### PR TITLE
[semconv] add 1.22.0 semantic conventions

### DIFF
--- a/.chloggen/codeboten_semconv1.22.yaml
+++ b/.chloggen/codeboten_semconv1.22.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: semconv
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Generated Semantic conventions 1.22.0.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8686]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/semconv/v1.22.0/doc.go
+++ b/semconv/v1.22.0/doc.go
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package semconv implements OpenTelemetry semantic conventions.
+//
+// OpenTelemetry semantic conventions are agreed standardized naming
+// patterns for OpenTelemetry things. This package represents the v1.22.0
+// version of the OpenTelemetry semantic conventions.
+package semconv // import "go.opentelemetry.io/collector/semconv/v1.22.0"

--- a/semconv/v1.22.0/generated_event.go
+++ b/semconv/v1.22.0/generated_event.go
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv
+
+// This semantic convention defines the attributes used to represent a feature
+// flag evaluation as an event.
+const (
+	// The unique identifier of the feature flag.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: 'logo-color'
+	AttributeFeatureFlagKey = "feature_flag.key"
+	// The name of the service provider that performs the flag evaluation.
+	//
+	// Type: string
+	// Requirement Level: Recommended
+	// Stability: experimental
+	// Examples: 'Flag Manager'
+	AttributeFeatureFlagProviderName = "feature_flag.provider_name"
+	// SHOULD be a semantic identifier for a value. If one is unavailable, a
+	// stringified version of the value can be used.
+	//
+	// Type: string
+	// Requirement Level: Recommended
+	// Stability: experimental
+	// Examples: 'red', 'true', 'on'
+	// Note: A semantic identifier, commonly referred to as a variant, provides a
+	// means
+	// for referring to a value without including the value itself. This can
+	// provide additional context for understanding the meaning behind a value.
+	// For example, the variant red maybe be used for the value #c05543.A stringified
+	// version of the value can be used in situations where a
+	// semantic identifier is unavailable. String representation of the value
+	// should be determined by the implementer.
+	AttributeFeatureFlagVariant = "feature_flag.variant"
+)
+
+// RPC received/sent message.
+const (
+	// Compressed size of the message in bytes.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeMessageCompressedSize = "message.compressed_size"
+	// MUST be calculated as two different counters starting from 1 one for sent
+	// messages and one for received message.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Note: This way we guarantee that the values will be consistent between
+	// different implementations.
+	AttributeMessageID = "message.id"
+	// Whether this is a received or sent message.
+	//
+	// Type: Enum
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeMessageType = "message.type"
+	// Uncompressed size of the message in bytes.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeMessageUncompressedSize = "message.uncompressed_size"
+)
+
+const (
+	// sent
+	AttributeMessageTypeSent = "SENT"
+	// received
+	AttributeMessageTypeReceived = "RECEIVED"
+)
+
+// The attributes used to report a single exception associated with a span.
+const (
+	// SHOULD be set to true if the exception event is recorded at a point where it is
+	// known that the exception is escaping the scope of the span.
+	//
+	// Type: boolean
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Note: An exception is considered to have escaped (or left) the scope of a span,
+	// if that span is ended while the exception is still logically &quot;in
+	// flight&quot;.
+	// This may be actually &quot;in flight&quot; in some languages (e.g. if the
+	// exception
+	// is passed to a Context manager's __exit__ method in Python) but will
+	// usually be caught at the point of recording the exception in most languages.It
+	// is usually not possible to determine at the point where an exception is thrown
+	// whether it will escape the scope of a span.
+	// However, it is trivial to know that an exception
+	// will escape, if one checks for an active exception just before ending the span,
+	// as done in the example above.It follows that an exception may still escape the
+	// scope of the span
+	// even if the exception.escaped attribute was not set or set to false,
+	// since the event might have been recorded at a time where it was not
+	// clear whether the exception will escape.
+	AttributeExceptionEscaped = "exception.escaped"
+)
+
+func GetEventSemanticConventionAttributeNames() []string {
+	return []string{
+		AttributeFeatureFlagKey,
+		AttributeFeatureFlagProviderName,
+		AttributeFeatureFlagVariant,
+		AttributeMessageCompressedSize,
+		AttributeMessageID,
+		AttributeMessageType,
+		AttributeMessageUncompressedSize,
+		AttributeExceptionEscaped,
+	}
+}

--- a/semconv/v1.22.0/generated_resource.go
+++ b/semconv/v1.22.0/generated_resource.go
@@ -1,0 +1,1473 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv
+
+// The Android platform on which the Android application is running.
+const (
+	// Uniquely identifies the framework API revision offered by a version
+	// (os.version) of the android operating system. More information can be found
+	// here.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '33', '32'
+	AttributeAndroidOSAPILevel = "android.os.api_level"
+)
+
+// The web browser in which the application represented by the resource is
+// running. The `browser.*` attributes MUST be used only for resources that
+// represent applications running in a web browser (regardless of whether
+// running on a mobile or desktop device).
+const (
+	// Array of brand name and version separated by a space
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: ' Not A;Brand 99', 'Chromium 99', 'Chrome 99'
+	// Note: This value is intended to be taken from the UA client hints API
+	// (navigator.userAgentData.brands).
+	AttributeBrowserBrands = "browser.brands"
+	// Preferred language of the user using the browser
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'en', 'en-US', 'fr', 'fr-FR'
+	// Note: This value is intended to be taken from the Navigator API
+	// navigator.language.
+	AttributeBrowserLanguage = "browser.language"
+	// A boolean that is true if the browser is running on a mobile device
+	//
+	// Type: boolean
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Note: This value is intended to be taken from the UA client hints API
+	// (navigator.userAgentData.mobile). If unavailable, this attribute SHOULD be left
+	// unset.
+	AttributeBrowserMobile = "browser.mobile"
+	// The platform on which the browser is running
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Windows', 'macOS', 'Android'
+	// Note: This value is intended to be taken from the UA client hints API
+	// (navigator.userAgentData.platform). If unavailable, the legacy
+	// navigator.platform API SHOULD NOT be used instead and this attribute SHOULD be
+	// left unset in order for the values to be consistent.
+	// The list of possible values is defined in the W3C User-Agent Client Hints
+	// specification. Note that some (but not all) of these values can overlap with
+	// values in the os.type and os.name attributes. However, for consistency, the
+	// values in the browser.platform attribute should capture the exact value that
+	// the user agent provides.
+	AttributeBrowserPlatform = "browser.platform"
+)
+
+// A cloud environment (e.g. GCP, Azure, AWS)
+const (
+	// The cloud account ID the resource is assigned to.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '111111111111', 'opentelemetry'
+	AttributeCloudAccountID = "cloud.account.id"
+	// Cloud regions often have multiple, isolated locations known as zones to
+	// increase availability. Availability zone represents the zone where the resource
+	// is running.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'us-east-1c'
+	// Note: Availability zones are called &quot;zones&quot; on Alibaba Cloud and
+	// Google Cloud.
+	AttributeCloudAvailabilityZone = "cloud.availability_zone"
+	// The cloud platform in use.
+	//
+	// Type: Enum
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Note: The prefix of the service SHOULD match the one specified in
+	// cloud.provider.
+	AttributeCloudPlatform = "cloud.platform"
+	// Name of the cloud provider.
+	//
+	// Type: Enum
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeCloudProvider = "cloud.provider"
+	// The geographical region the resource is running.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'us-central1', 'us-east-1'
+	// Note: Refer to your provider's docs to see the available regions, for example
+	// Alibaba Cloud regions, AWS regions, Azure regions, Google Cloud regions, or
+	// Tencent Cloud regions.
+	AttributeCloudRegion = "cloud.region"
+	// Cloud provider-specific native identifier of the monitored cloud resource (e.g.
+	// an ARN on AWS, a fully qualified resource ID on Azure, a full resource name on
+	// GCP)
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function', '//run.googl
+	// eapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID', '/sub
+	// scriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites
+	// /<FUNCAPP>/functions/<FUNC>'
+	// Note: On some cloud providers, it may not be possible to determine the full ID
+	// at startup,
+	// so it may be necessary to set cloud.resource_id as a span attribute instead.The
+	// exact value to use for cloud.resource_id depends on the cloud provider.
+	// The following well-known definitions MUST be used if you set this attribute and
+	// they apply:<ul>
+	// <li>AWS Lambda: The function ARN.
+	// Take care not to use the &quot;invoked ARN&quot; directly but replace any
+	// alias suffix
+	// with the resolved function version, as the same runtime instance may be
+	// invokable with
+	// multiple different aliases.</li>
+	// <li>GCP: The URI of the resource</li>
+	// <li>Azure: The Fully Qualified Resource ID of the invoked function,
+	// not the function app, having the form
+	// /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/s
+	// ites/<FUNCAPP>/functions/<FUNC>.
+	// This means that a span attribute MUST be used, as an Azure function app can
+	// host multiple functions that would usually share
+	// a TracerProvider.</li>
+	// </ul>
+	AttributeCloudResourceID = "cloud.resource_id"
+)
+
+const (
+	// Alibaba Cloud Elastic Compute Service
+	AttributeCloudPlatformAlibabaCloudECS = "alibaba_cloud_ecs"
+	// Alibaba Cloud Function Compute
+	AttributeCloudPlatformAlibabaCloudFc = "alibaba_cloud_fc"
+	// Red Hat OpenShift on Alibaba Cloud
+	AttributeCloudPlatformAlibabaCloudOpenshift = "alibaba_cloud_openshift"
+	// AWS Elastic Compute Cloud
+	AttributeCloudPlatformAWSEC2 = "aws_ec2"
+	// AWS Elastic Container Service
+	AttributeCloudPlatformAWSECS = "aws_ecs"
+	// AWS Elastic Kubernetes Service
+	AttributeCloudPlatformAWSEKS = "aws_eks"
+	// AWS Lambda
+	AttributeCloudPlatformAWSLambda = "aws_lambda"
+	// AWS Elastic Beanstalk
+	AttributeCloudPlatformAWSElasticBeanstalk = "aws_elastic_beanstalk"
+	// AWS App Runner
+	AttributeCloudPlatformAWSAppRunner = "aws_app_runner"
+	// Red Hat OpenShift on AWS (ROSA)
+	AttributeCloudPlatformAWSOpenshift = "aws_openshift"
+	// Azure Virtual Machines
+	AttributeCloudPlatformAzureVM = "azure_vm"
+	// Azure Container Instances
+	AttributeCloudPlatformAzureContainerInstances = "azure_container_instances"
+	// Azure Kubernetes Service
+	AttributeCloudPlatformAzureAKS = "azure_aks"
+	// Azure Functions
+	AttributeCloudPlatformAzureFunctions = "azure_functions"
+	// Azure App Service
+	AttributeCloudPlatformAzureAppService = "azure_app_service"
+	// Azure Red Hat OpenShift
+	AttributeCloudPlatformAzureOpenshift = "azure_openshift"
+	// Google Bare Metal Solution (BMS)
+	AttributeCloudPlatformGCPBareMetalSolution = "gcp_bare_metal_solution"
+	// Google Cloud Compute Engine (GCE)
+	AttributeCloudPlatformGCPComputeEngine = "gcp_compute_engine"
+	// Google Cloud Run
+	AttributeCloudPlatformGCPCloudRun = "gcp_cloud_run"
+	// Google Cloud Kubernetes Engine (GKE)
+	AttributeCloudPlatformGCPKubernetesEngine = "gcp_kubernetes_engine"
+	// Google Cloud Functions (GCF)
+	AttributeCloudPlatformGCPCloudFunctions = "gcp_cloud_functions"
+	// Google Cloud App Engine (GAE)
+	AttributeCloudPlatformGCPAppEngine = "gcp_app_engine"
+	// Red Hat OpenShift on Google Cloud
+	AttributeCloudPlatformGCPOpenshift = "gcp_openshift"
+	// Red Hat OpenShift on IBM Cloud
+	AttributeCloudPlatformIbmCloudOpenshift = "ibm_cloud_openshift"
+	// Tencent Cloud Cloud Virtual Machine (CVM)
+	AttributeCloudPlatformTencentCloudCvm = "tencent_cloud_cvm"
+	// Tencent Cloud Elastic Kubernetes Service (EKS)
+	AttributeCloudPlatformTencentCloudEKS = "tencent_cloud_eks"
+	// Tencent Cloud Serverless Cloud Function (SCF)
+	AttributeCloudPlatformTencentCloudScf = "tencent_cloud_scf"
+)
+
+const (
+	// Alibaba Cloud
+	AttributeCloudProviderAlibabaCloud = "alibaba_cloud"
+	// Amazon Web Services
+	AttributeCloudProviderAWS = "aws"
+	// Microsoft Azure
+	AttributeCloudProviderAzure = "azure"
+	// Google Cloud Platform
+	AttributeCloudProviderGCP = "gcp"
+	// Heroku Platform as a Service
+	AttributeCloudProviderHeroku = "heroku"
+	// IBM Cloud
+	AttributeCloudProviderIbmCloud = "ibm_cloud"
+	// Tencent Cloud
+	AttributeCloudProviderTencentCloud = "tencent_cloud"
+)
+
+// Resources used by AWS Elastic Container Service (ECS).
+const (
+	// The ARN of an ECS cluster.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AttributeAWSECSClusterARN = "aws.ecs.cluster.arn"
+	// The Amazon Resource Name (ARN) of an ECS container instance.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9'
+	AttributeAWSECSContainerARN = "aws.ecs.container.arn"
+	// The launch type for an ECS task.
+	//
+	// Type: Enum
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeAWSECSLaunchtype = "aws.ecs.launchtype"
+	// The ARN of an ECS task definition.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AttributeAWSECSTaskARN = "aws.ecs.task.arn"
+	// The task definition family this task definition is a member of.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry-family'
+	AttributeAWSECSTaskFamily = "aws.ecs.task.family"
+	// The revision for this task definition.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '8', '26'
+	AttributeAWSECSTaskRevision = "aws.ecs.task.revision"
+)
+
+const (
+	// ec2
+	AttributeAWSECSLaunchtypeEC2 = "ec2"
+	// fargate
+	AttributeAWSECSLaunchtypeFargate = "fargate"
+)
+
+// Resources used by AWS Elastic Kubernetes Service (EKS).
+const (
+	// The ARN of an EKS cluster.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AttributeAWSEKSClusterARN = "aws.eks.cluster.arn"
+)
+
+// Resources specific to Amazon Web Services.
+const (
+	// The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*'
+	// Note: See the log group ARN format documentation.
+	AttributeAWSLogGroupARNs = "aws.log.group.arns"
+	// The name(s) of the AWS log group(s) an application is writing to.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '/aws/lambda/my-function', 'opentelemetry-service'
+	// Note: Multiple log groups must be supported for cases like multi-container
+	// applications, where a single application has sidecar containers, and each write
+	// to their own log group.
+	AttributeAWSLogGroupNames = "aws.log.group.names"
+	// The ARN(s) of the AWS log stream(s).
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-
+	// stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	// Note: See the log stream ARN format documentation. One log group can contain
+	// several log streams, so these ARNs necessarily identify both a log group and a
+	// log stream.
+	AttributeAWSLogStreamARNs = "aws.log.stream.arns"
+	// The name(s) of the AWS log stream(s) an application is writing to.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AttributeAWSLogStreamNames = "aws.log.stream.names"
+)
+
+// Resource used by Google Cloud Run.
+const (
+	// The name of the Cloud Run execution being run for the Job, as set by the
+	// CLOUD_RUN_EXECUTION environment variable.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'job-name-xxxx', 'sample-job-mdw84'
+	AttributeGCPCloudRunJobExecution = "gcp.cloud_run.job.execution"
+	// The index for a task within an execution as provided by the
+	// CLOUD_RUN_TASK_INDEX environment variable.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 0, 1
+	AttributeGCPCloudRunJobTaskIndex = "gcp.cloud_run.job.task_index"
+)
+
+// Resources used by Google Compute Engine (GCE).
+const (
+	// The hostname of a GCE instance. This is the full value of the default or custom
+	// hostname.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'my-host1234.example.com', 'sample-vm.us-west1-b.c.my-
+	// project.internal'
+	AttributeGCPGceInstanceHostname = "gcp.gce.instance.hostname"
+	// The instance name of a GCE instance. This is the value provided by host.name,
+	// the visible name of the instance in the Cloud Console UI, and the prefix for
+	// the default hostname of the instance as defined by the default internal DNS
+	// name.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'instance-1', 'my-vm-name'
+	AttributeGCPGceInstanceName = "gcp.gce.instance.name"
+)
+
+// Heroku dyno metadata
+const (
+	// Unique identifier for the application
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '2daa2797-e42b-4624-9322-ec3f968df4da'
+	AttributeHerokuAppID = "heroku.app.id"
+	// Commit hash for the current release
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'e6134959463efd8966b20e75b913cafe3f5ec'
+	AttributeHerokuReleaseCommit = "heroku.release.commit"
+	// Time and date the release was created
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '2022-10-23T18:00:42Z'
+	AttributeHerokuReleaseCreationTimestamp = "heroku.release.creation_timestamp"
+)
+
+// A container instance.
+const (
+	// The command used to run the container (i.e. the command name).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'otelcontribcol'
+	// Note: If using embedded credentials or sensitive data, it is recommended to
+	// remove them to prevent potential leakage.
+	AttributeContainerCommand = "container.command"
+	// All the command arguments (including the command/executable itself) run by the
+	// container. [2]
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'otelcontribcol, --config, config.yaml'
+	AttributeContainerCommandArgs = "container.command_args"
+	// The full command run by the container as a single string representing the full
+	// command. [2]
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'otelcontribcol --config config.yaml'
+	AttributeContainerCommandLine = "container.command_line"
+	// Container ID. Usually a UUID, as for example used to identify Docker
+	// containers. The UUID might be abbreviated.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'a3bf90e006b2'
+	AttributeContainerID = "container.id"
+	// Runtime specific image identifier. Usually a hash algorithm followed by a UUID.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples:
+	// 'sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f'
+	// Note: Docker defines a sha256 of the image id; container.image.id corresponds
+	// to the Image field from the Docker container inspect API endpoint.
+	// K8S defines a link to the container registry repository with digest "imageID":
+	// "registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e
+	// 8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625".
+	// The ID is assinged by the container runtime and can vary in different
+	// environments. Consider using oci.manifest.digest if it is important to identify
+	// the same image in different environments/runtimes.
+	AttributeContainerImageID = "container.image.id"
+	// Name of the image the container was built on.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'gcr.io/opentelemetry/operator'
+	AttributeContainerImageName = "container.image.name"
+	// Repo digests of the container image as provided by the container runtime.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d7
+	// 02d249a0ccb', 'internal.registry.example.com:5000/example@sha256:b69959407d21e8
+	// a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578'
+	// Note: Docker and CRI report those under the RepoDigests field.
+	AttributeContainerImageRepoDigests = "container.image.repo_digests"
+	// Container image tags. An example can be found in Docker Image Inspect. Should
+	// be only the <tag> section of the full name for example from
+	// registry.example.com/my-org/my-image:<tag>.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'v1.27.1', '3.5.7-0'
+	AttributeContainerImageTags = "container.image.tags"
+	// Container name used by container runtime.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry-autoconf'
+	AttributeContainerName = "container.name"
+	// The container runtime managing this container.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'docker', 'containerd', 'rkt'
+	AttributeContainerRuntime = "container.runtime"
+)
+
+// The software deployment.
+const (
+	// Name of the deployment environment (aka deployment tier).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'staging', 'production'
+	AttributeDeploymentEnvironment = "deployment.environment"
+)
+
+// The device on which the process represented by this resource is running.
+const (
+	// A unique identifier representing the device
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '2ab2916d-a51f-4ac8-80ee-45ac31a28092'
+	// Note: The device identifier MUST only be defined using the values outlined
+	// below. This value is not an advertising identifier and MUST NOT be used as
+	// such. On iOS (Swift or Objective-C), this value MUST be equal to the vendor
+	// identifier. On Android (Java or Kotlin), this value MUST be equal to the
+	// Firebase Installation ID or a globally unique UUID which is persisted across
+	// sessions in your application. More information can be found here on best
+	// practices and exact implementation details. Caution should be taken when
+	// storing personal data or anything which can identify a user. GDPR and data
+	// protection laws may apply, ensure you do your own due diligence.
+	AttributeDeviceID = "device.id"
+	// The name of the device manufacturer
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Apple', 'Samsung'
+	// Note: The Android OS provides this field via Build. iOS apps SHOULD hardcode
+	// the value Apple.
+	AttributeDeviceManufacturer = "device.manufacturer"
+	// The model identifier for the device
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'iPhone3,4', 'SM-G920F'
+	// Note: It's recommended this value represents a machine readable version of the
+	// model identifier rather than the market or consumer-friendly name of the
+	// device.
+	AttributeDeviceModelIdentifier = "device.model.identifier"
+	// The marketing name for the device model
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'iPhone 6s Plus', 'Samsung Galaxy S6'
+	// Note: It's recommended this value represents a human readable version of the
+	// device model rather than a machine readable alternative.
+	AttributeDeviceModelName = "device.model.name"
+)
+
+// A serverless instance.
+const (
+	// The execution environment ID as a string, that will be potentially reused for
+	// other invocations to the same function/function version.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de'
+	// Note: <ul>
+	// <li>AWS Lambda: Use the (full) log stream name.</li>
+	// </ul>
+	AttributeFaaSInstance = "faas.instance"
+	// The amount of memory available to the serverless function converted to Bytes.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 134217728
+	// Note: It's recommended to set this attribute since e.g. too little memory can
+	// easily stop a Java AWS Lambda function from working correctly. On AWS Lambda,
+	// the environment variable AWS_LAMBDA_FUNCTION_MEMORY_SIZE provides this
+	// information (which must be multiplied by 1,048,576).
+	AttributeFaaSMaxMemory = "faas.max_memory"
+	// The name of the single function that this runtime instance executes.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: 'my-function', 'myazurefunctionapp/some-function-name'
+	// Note: This is the name of the function as configured/deployed on the FaaS
+	// platform and is usually different from the name of the callback
+	// function (which may be stored in the
+	// code.namespace/code.function
+	// span attributes).For some cloud providers, the above definition is ambiguous.
+	// The following
+	// definition of function name MUST be used for this attribute
+	// (and consequently the span name) for the listed cloud providers/products:<ul>
+	// <li>Azure:  The full name <FUNCAPP>/<FUNC>, i.e., function app name
+	// followed by a forward slash followed by the function name (this form
+	// can also be seen in the resource JSON for the function).
+	// This means that a span attribute MUST be used, as an Azure function
+	// app can host multiple functions that would usually share
+	// a TracerProvider (see also the cloud.resource_id attribute).</li>
+	// </ul>
+	AttributeFaaSName = "faas.name"
+	// The immutable version of the function being executed.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '26', 'pinkfroid-00002'
+	// Note: Depending on the cloud provider and platform, use:<ul>
+	// <li>AWS Lambda: The function version
+	// (an integer represented as a decimal string).</li>
+	// <li>Google Cloud Run (Services): The revision
+	// (i.e., the function name plus the revision suffix).</li>
+	// <li>Google Cloud Functions: The value of the
+	// K_REVISION environment variable.</li>
+	// <li>Azure Functions: Not applicable. Do not set this attribute.</li>
+	// </ul>
+	AttributeFaaSVersion = "faas.version"
+)
+
+// A host is defined as a computing instance. For example, physical servers,
+// virtual machines, switches or disk array.
+const (
+	// The CPU architecture the host system is running on.
+	//
+	// Type: Enum
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeHostArch = "host.arch"
+	// Unique host ID. For Cloud, this must be the instance_id assigned by the cloud
+	// provider. For non-containerized systems, this should be the machine-id. See the
+	// table below for the sources to use to determine the machine-id based on
+	// operating system.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'fdbf79e8af94cb7f9e8df36789187052'
+	AttributeHostID = "host.id"
+	// VM image ID or host OS image ID. For Cloud, this value is from the provider.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'ami-07b06b442921831e5'
+	AttributeHostImageID = "host.image.id"
+	// Name of the VM image or OS install the host was instantiated from.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'infra-ami-eks-worker-node-7d4ec78312', 'CentOS-8-x86_64-1905'
+	AttributeHostImageName = "host.image.name"
+	// The version string of the VM image or host OS as defined in Version Attributes.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '0.1'
+	AttributeHostImageVersion = "host.image.version"
+	// Available IP addresses of the host, excluding loopback interfaces.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '192.168.1.140', 'fe80::abc2:4a28:737a:609e'
+	// Note: IPv4 Addresses MUST be specified in dotted-quad notation. IPv6 addresses
+	// MUST be specified in the RFC 5952 format.
+	AttributeHostIP = "host.ip"
+	// Name of the host. On Unix systems, it may contain what the hostname command
+	// returns, or the fully qualified hostname, or another name specified by the
+	// user.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry-test'
+	AttributeHostName = "host.name"
+	// Type of host. For Cloud, this must be the machine type.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'n1-standard-1'
+	AttributeHostType = "host.type"
+)
+
+const (
+	// AMD64
+	AttributeHostArchAMD64 = "amd64"
+	// ARM32
+	AttributeHostArchARM32 = "arm32"
+	// ARM64
+	AttributeHostArchARM64 = "arm64"
+	// Itanium
+	AttributeHostArchIA64 = "ia64"
+	// 32-bit PowerPC
+	AttributeHostArchPPC32 = "ppc32"
+	// 64-bit PowerPC
+	AttributeHostArchPPC64 = "ppc64"
+	// IBM z/Architecture
+	AttributeHostArchS390x = "s390x"
+	// 32-bit x86
+	AttributeHostArchX86 = "x86"
+)
+
+// A host's CPU information
+const (
+	// The amount of level 2 memory cache available to the processor (in Bytes).
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 12288000
+	AttributeHostCPUCacheL2Size = "host.cpu.cache.l2.size"
+	// Numeric value specifying the family or generation of the CPU.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 6
+	AttributeHostCPUFamily = "host.cpu.family"
+	// Model identifier. It provides more granular information about the CPU,
+	// distinguishing it from other CPUs within the same family.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 6
+	AttributeHostCPUModelID = "host.cpu.model.id"
+	// Model designation of the processor.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz'
+	AttributeHostCPUModelName = "host.cpu.model.name"
+	// Stepping or core revisions.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 1
+	AttributeHostCPUStepping = "host.cpu.stepping"
+	// Processor manufacturer identifier. A maximum 12-character string.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'GenuineIntel'
+	// Note: CPUID command returns the vendor ID string in EBX, EDX and ECX registers.
+	// Writing these to memory in this order results in a 12-character string.
+	AttributeHostCPUVendorID = "host.cpu.vendor.id"
+)
+
+// A Kubernetes Cluster.
+const (
+	// The name of the cluster.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry-cluster'
+	AttributeK8SClusterName = "k8s.cluster.name"
+	// A pseudo-ID for the cluster, set to the UID of the kube-system namespace.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '218fc5a9-a5f1-4b54-aa05-46717d0ab26d'
+	// Note: K8S does not have support for obtaining a cluster ID. If this is ever
+	// added, we will recommend collecting the k8s.cluster.uid through the
+	// official APIs. In the meantime, we are able to use the uid of the
+	// kube-system namespace as a proxy for cluster ID. Read on for the
+	// rationale.Every object created in a K8S cluster is assigned a distinct UID. The
+	// kube-system namespace is used by Kubernetes itself and will exist
+	// for the lifetime of the cluster. Using the uid of the kube-system
+	// namespace is a reasonable proxy for the K8S ClusterID as it will only
+	// change if the cluster is rebuilt. Furthermore, Kubernetes UIDs are
+	// UUIDs as standardized by
+	// ISO/IEC 9834-8 and ITU-T X.667.
+	// Which states:<blockquote>
+	// If generated according to one of the mechanisms defined in Rec.</blockquote>
+	// ITU-T X.667 | ISO/IEC 9834-8, a UUID is either guaranteed to be
+	//   different from all other UUIDs generated before 3603 A.D., or is
+	//   extremely likely to be different (depending on the mechanism
+	// chosen).Therefore, UIDs between clusters should be extremely unlikely to
+	// conflict.
+	AttributeK8SClusterUID = "k8s.cluster.uid"
+)
+
+// A Kubernetes Node object.
+const (
+	// The name of the Node.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'node-1'
+	AttributeK8SNodeName = "k8s.node.name"
+	// The UID of the Node.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2'
+	AttributeK8SNodeUID = "k8s.node.uid"
+)
+
+// A Kubernetes Namespace.
+const (
+	// The name of the namespace that the pod is running in.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'default'
+	AttributeK8SNamespaceName = "k8s.namespace.name"
+)
+
+// A Kubernetes Pod object.
+const (
+	// The name of the Pod.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry-pod-autoconf'
+	AttributeK8SPodName = "k8s.pod.name"
+	// The UID of the Pod.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SPodUID = "k8s.pod.uid"
+)
+
+// A container in a
+// [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
+const (
+	// The name of the Container from Pod specification, must be unique within a Pod.
+	// Container runtime usually uses different globally unique name (container.name).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'redis'
+	AttributeK8SContainerName = "k8s.container.name"
+	// Number of times the container was restarted. This attribute can be used to
+	// identify a particular container (running or stopped) within a container spec.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 0, 2
+	AttributeK8SContainerRestartCount = "k8s.container.restart_count"
+)
+
+// A Kubernetes ReplicaSet object.
+const (
+	// The name of the ReplicaSet.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry'
+	AttributeK8SReplicaSetName = "k8s.replicaset.name"
+	// The UID of the ReplicaSet.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SReplicaSetUID = "k8s.replicaset.uid"
+)
+
+// A Kubernetes Deployment object.
+const (
+	// The name of the Deployment.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry'
+	AttributeK8SDeploymentName = "k8s.deployment.name"
+	// The UID of the Deployment.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SDeploymentUID = "k8s.deployment.uid"
+)
+
+// A Kubernetes StatefulSet object.
+const (
+	// The name of the StatefulSet.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry'
+	AttributeK8SStatefulSetName = "k8s.statefulset.name"
+	// The UID of the StatefulSet.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SStatefulSetUID = "k8s.statefulset.uid"
+)
+
+// A Kubernetes DaemonSet object.
+const (
+	// The name of the DaemonSet.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry'
+	AttributeK8SDaemonSetName = "k8s.daemonset.name"
+	// The UID of the DaemonSet.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SDaemonSetUID = "k8s.daemonset.uid"
+)
+
+// A Kubernetes Job object.
+const (
+	// The name of the Job.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry'
+	AttributeK8SJobName = "k8s.job.name"
+	// The UID of the Job.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SJobUID = "k8s.job.uid"
+)
+
+// A Kubernetes CronJob object.
+const (
+	// The name of the CronJob.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'opentelemetry'
+	AttributeK8SCronJobName = "k8s.cronjob.name"
+	// The UID of the CronJob.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SCronJobUID = "k8s.cronjob.uid"
+)
+
+// An OCI image manifest.
+const (
+	// The digest of the OCI image manifest. For container images specifically is the
+	// digest by which the container image is known.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples:
+	// 'sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4'
+	// Note: Follows OCI Image Manifest Specification, and specifically the Digest
+	// property.
+	// An example can be found in Example Image Manifest.
+	AttributeOciManifestDigest = "oci.manifest.digest"
+)
+
+// The operating system (OS) on which the process represented by this resource
+// is running.
+const (
+	// Unique identifier for a particular build or compilation of the operating
+	// system.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'TQ3C.230805.001.B2', '20E247', '22621'
+	AttributeOSBuildID = "os.build_id"
+	// Human readable (not intended to be parsed) OS version information, like e.g.
+	// reported by ver or lsb_release -a commands.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Microsoft Windows [Version 10.0.18363.778]', 'Ubuntu 18.04.1 LTS'
+	AttributeOSDescription = "os.description"
+	// Human readable operating system name.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'iOS', 'Android', 'Ubuntu'
+	AttributeOSName = "os.name"
+	// The operating system type.
+	//
+	// Type: Enum
+	// Requirement Level: Required
+	// Stability: experimental
+	AttributeOSType = "os.type"
+	// The version string of the operating system as defined in Version Attributes.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '14.2.1', '18.04.1'
+	AttributeOSVersion = "os.version"
+)
+
+const (
+	// Microsoft Windows
+	AttributeOSTypeWindows = "windows"
+	// Linux
+	AttributeOSTypeLinux = "linux"
+	// Apple Darwin
+	AttributeOSTypeDarwin = "darwin"
+	// FreeBSD
+	AttributeOSTypeFreeBSD = "freebsd"
+	// NetBSD
+	AttributeOSTypeNetBSD = "netbsd"
+	// OpenBSD
+	AttributeOSTypeOpenBSD = "openbsd"
+	// DragonFly BSD
+	AttributeOSTypeDragonflyBSD = "dragonflybsd"
+	// HP-UX (Hewlett Packard Unix)
+	AttributeOSTypeHPUX = "hpux"
+	// AIX (Advanced Interactive eXecutive)
+	AttributeOSTypeAIX = "aix"
+	// SunOS, Oracle Solaris
+	AttributeOSTypeSolaris = "solaris"
+	// IBM z/OS
+	AttributeOSTypeZOS = "z_os"
+)
+
+// An operating system process.
+const (
+	// The command used to launch the process (i.e. the command name). On Linux based
+	// systems, can be set to the zeroth string in proc/[pid]/cmdline. On Windows, can
+	// be set to the first parameter extracted from GetCommandLineW.
+	//
+	// Type: string
+	// Requirement Level: Conditionally Required - See alternative attributes below.
+	// Stability: experimental
+	// Examples: 'cmd/otelcol'
+	AttributeProcessCommand = "process.command"
+	// All the command arguments (including the command/executable itself) as received
+	// by the process. On Linux-based systems (and some other Unixoid systems
+	// supporting procfs), can be set according to the list of null-delimited strings
+	// extracted from proc/[pid]/cmdline. For libc-based executables, this would be
+	// the full argv vector passed to main.
+	//
+	// Type: string[]
+	// Requirement Level: Conditionally Required - See alternative attributes below.
+	// Stability: experimental
+	// Examples: 'cmd/otecol', '--config=config.yaml'
+	AttributeProcessCommandArgs = "process.command_args"
+	// The full command used to launch the process as a single string representing the
+	// full command. On Windows, can be set to the result of GetCommandLineW. Do not
+	// set this if you have to assemble it just for monitoring; use
+	// process.command_args instead.
+	//
+	// Type: string
+	// Requirement Level: Conditionally Required - See alternative attributes below.
+	// Stability: experimental
+	// Examples: 'C:\\cmd\\otecol --config="my directory\\config.yaml"'
+	AttributeProcessCommandLine = "process.command_line"
+	// The name of the process executable. On Linux based systems, can be set to the
+	// Name in proc/[pid]/status. On Windows, can be set to the base name of
+	// GetProcessImageFileNameW.
+	//
+	// Type: string
+	// Requirement Level: Conditionally Required - See alternative attributes below.
+	// Stability: experimental
+	// Examples: 'otelcol'
+	AttributeProcessExecutableName = "process.executable.name"
+	// The full path to the process executable. On Linux based systems, can be set to
+	// the target of proc/[pid]/exe. On Windows, can be set to the result of
+	// GetProcessImageFileNameW.
+	//
+	// Type: string
+	// Requirement Level: Conditionally Required - See alternative attributes below.
+	// Stability: experimental
+	// Examples: '/usr/bin/cmd/otelcol'
+	AttributeProcessExecutablePath = "process.executable.path"
+	// The username of the user that owns the process.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'root'
+	AttributeProcessOwner = "process.owner"
+	// Parent Process identifier (PID).
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 111
+	AttributeProcessParentPID = "process.parent_pid"
+	// Process identifier (PID).
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 1234
+	AttributeProcessPID = "process.pid"
+)
+
+// The single (language) runtime instance which is monitored.
+const (
+	// An additional description about the runtime of the process, for example a
+	// specific vendor customization of the runtime environment.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0'
+	AttributeProcessRuntimeDescription = "process.runtime.description"
+	// The name of the runtime of this process. For compiled native binaries, this
+	// SHOULD be the name of the compiler.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'OpenJDK Runtime Environment'
+	AttributeProcessRuntimeName = "process.runtime.name"
+	// The version of the runtime of this process, as returned by the runtime without
+	// modification.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '14.0.2'
+	AttributeProcessRuntimeVersion = "process.runtime.version"
+)
+
+// A service instance.
+const (
+	// Logical name of the service.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: 'shoppingcart'
+	// Note: MUST be the same for all instances of horizontally scaled services. If
+	// the value was not specified, SDKs MUST fallback to unknown_service:
+	// concatenated with process.executable.name, e.g. unknown_service:bash. If
+	// process.executable.name is not available, the value MUST be set to
+	// unknown_service.
+	AttributeServiceName = "service.name"
+	// The version string of the service API or implementation. The format is not
+	// defined by these conventions.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '2.0.0', 'a01dbef8a'
+	AttributeServiceVersion = "service.version"
+)
+
+// A service instance.
+const (
+	// The string ID of the service instance.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'my-k8s-pod-deployment-1', '627cc493-f310-47de-96bd-71410b7dec09'
+	// Note: MUST be unique for each instance of the same
+	// service.namespace,service.name pair (in other words
+	// service.namespace,service.name,service.instance.id triplet MUST be globally
+	// unique). The ID helps to distinguish instances of the same service that exist
+	// at the same time (e.g. instances of a horizontally scaled service). It is
+	// preferable for the ID to be persistent and stay the same for the lifetime of
+	// the service instance, however it is acceptable that the ID is ephemeral and
+	// changes during important lifetime events for the service (e.g. service
+	// restarts). If the service has no inherent unique ID that can be used as the
+	// value of this attribute it is recommended to generate a random Version 1 or
+	// Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use
+	// Version 5, see RFC 4122 for more recommendations).
+	AttributeServiceInstanceID = "service.instance.id"
+	// A namespace for service.name.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Shop'
+	// Note: A string value having a meaning that helps to distinguish a group of
+	// services, for example the team name that owns a group of services. service.name
+	// is expected to be unique within the same namespace. If service.namespace is not
+	// specified in the Resource then service.name is expected to be unique for all
+	// services that have no explicit namespace defined (so the empty/unspecified
+	// namespace is simply one more valid namespace). Zero-length namespace string is
+	// assumed equal to unspecified namespace.
+	AttributeServiceNamespace = "service.namespace"
+)
+
+// The telemetry SDK used to capture data recorded by the instrumentation
+// libraries.
+const (
+	// The language of the telemetry SDK.
+	//
+	// Type: Enum
+	// Requirement Level: Required
+	// Stability: experimental
+	AttributeTelemetrySDKLanguage = "telemetry.sdk.language"
+	// The name of the telemetry SDK as defined above.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: 'opentelemetry'
+	// Note: The OpenTelemetry SDK MUST set the telemetry.sdk.name attribute to
+	// opentelemetry.
+	// If another SDK, like a fork or a vendor-provided implementation, is used, this
+	// SDK MUST set the
+	// telemetry.sdk.name attribute to the fully-qualified class or module name of
+	// this SDK's main entry point
+	// or another suitable identifier depending on the language.
+	// The identifier opentelemetry is reserved and MUST NOT be used in this case.
+	// All custom identifiers SHOULD be stable across different versions of an
+	// implementation.
+	AttributeTelemetrySDKName = "telemetry.sdk.name"
+	// The version string of the telemetry SDK.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: '1.2.3'
+	AttributeTelemetrySDKVersion = "telemetry.sdk.version"
+)
+
+const (
+	// cpp
+	AttributeTelemetrySDKLanguageCPP = "cpp"
+	// dotnet
+	AttributeTelemetrySDKLanguageDotnet = "dotnet"
+	// erlang
+	AttributeTelemetrySDKLanguageErlang = "erlang"
+	// go
+	AttributeTelemetrySDKLanguageGo = "go"
+	// java
+	AttributeTelemetrySDKLanguageJava = "java"
+	// nodejs
+	AttributeTelemetrySDKLanguageNodejs = "nodejs"
+	// php
+	AttributeTelemetrySDKLanguagePHP = "php"
+	// python
+	AttributeTelemetrySDKLanguagePython = "python"
+	// ruby
+	AttributeTelemetrySDKLanguageRuby = "ruby"
+	// rust
+	AttributeTelemetrySDKLanguageRust = "rust"
+	// swift
+	AttributeTelemetrySDKLanguageSwift = "swift"
+	// webjs
+	AttributeTelemetrySDKLanguageWebjs = "webjs"
+)
+
+// The telemetry SDK used to capture data recorded by the instrumentation
+// libraries.
+const (
+	// The name of the auto instrumentation agent or distribution, if used.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'parts-unlimited-java'
+	// Note: Official auto instrumentation agents and distributions SHOULD set the
+	// telemetry.distro.name attribute to
+	// a string starting with opentelemetry-, e.g. opentelemetry-java-instrumentation.
+	AttributeTelemetryDistroName = "telemetry.distro.name"
+	// The version string of the auto instrumentation agent or distribution, if used.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '1.2.3'
+	AttributeTelemetryDistroVersion = "telemetry.distro.version"
+)
+
+// Resource describing the packaged software running the application code. Web
+// engines are typically executed using process.runtime.
+const (
+	// Additional description of the web engine (e.g. detailed version and edition
+	// information).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final'
+	AttributeWebEngineDescription = "webengine.description"
+	// The name of the web engine.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: 'WildFly'
+	AttributeWebEngineName = "webengine.name"
+	// The version of the web engine.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '21.0.0'
+	AttributeWebEngineVersion = "webengine.version"
+)
+
+// Attributes used by non-OTLP exporters to represent OpenTelemetry Scope's
+// concepts.
+const (
+	// The name of the instrumentation scope - (InstrumentationScope.Name in OTLP).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'io.opentelemetry.contrib.mongodb'
+	AttributeOTelScopeName = "otel.scope.name"
+	// The version of the instrumentation scope - (InstrumentationScope.Version in
+	// OTLP).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '1.0.0'
+	AttributeOTelScopeVersion = "otel.scope.version"
+)
+
+// Span attributes used by non-OTLP exporters to represent OpenTelemetry
+// Scope's concepts.
+const (
+	// Deprecated, use the otel.scope.name attribute.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: deprecated
+	// Examples: 'io.opentelemetry.contrib.mongodb'
+	AttributeOTelLibraryName = "otel.library.name"
+	// Deprecated, use the otel.scope.version attribute.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: deprecated
+	// Examples: '1.0.0'
+	AttributeOTelLibraryVersion = "otel.library.version"
+)
+
+func GetResourceSemanticConventionAttributeNames() []string {
+	return []string{
+		AttributeAndroidOSAPILevel,
+		AttributeBrowserBrands,
+		AttributeBrowserLanguage,
+		AttributeBrowserMobile,
+		AttributeBrowserPlatform,
+		AttributeCloudAccountID,
+		AttributeCloudAvailabilityZone,
+		AttributeCloudPlatform,
+		AttributeCloudProvider,
+		AttributeCloudRegion,
+		AttributeCloudResourceID,
+		AttributeAWSECSClusterARN,
+		AttributeAWSECSContainerARN,
+		AttributeAWSECSLaunchtype,
+		AttributeAWSECSTaskARN,
+		AttributeAWSECSTaskFamily,
+		AttributeAWSECSTaskRevision,
+		AttributeAWSEKSClusterARN,
+		AttributeAWSLogGroupARNs,
+		AttributeAWSLogGroupNames,
+		AttributeAWSLogStreamARNs,
+		AttributeAWSLogStreamNames,
+		AttributeGCPCloudRunJobExecution,
+		AttributeGCPCloudRunJobTaskIndex,
+		AttributeGCPGceInstanceHostname,
+		AttributeGCPGceInstanceName,
+		AttributeHerokuAppID,
+		AttributeHerokuReleaseCommit,
+		AttributeHerokuReleaseCreationTimestamp,
+		AttributeContainerCommand,
+		AttributeContainerCommandArgs,
+		AttributeContainerCommandLine,
+		AttributeContainerID,
+		AttributeContainerImageID,
+		AttributeContainerImageName,
+		AttributeContainerImageRepoDigests,
+		AttributeContainerImageTags,
+		AttributeContainerName,
+		AttributeContainerRuntime,
+		AttributeDeploymentEnvironment,
+		AttributeDeviceID,
+		AttributeDeviceManufacturer,
+		AttributeDeviceModelIdentifier,
+		AttributeDeviceModelName,
+		AttributeFaaSInstance,
+		AttributeFaaSMaxMemory,
+		AttributeFaaSName,
+		AttributeFaaSVersion,
+		AttributeHostArch,
+		AttributeHostID,
+		AttributeHostImageID,
+		AttributeHostImageName,
+		AttributeHostImageVersion,
+		AttributeHostIP,
+		AttributeHostName,
+		AttributeHostType,
+		AttributeHostCPUCacheL2Size,
+		AttributeHostCPUFamily,
+		AttributeHostCPUModelID,
+		AttributeHostCPUModelName,
+		AttributeHostCPUStepping,
+		AttributeHostCPUVendorID,
+		AttributeK8SClusterName,
+		AttributeK8SClusterUID,
+		AttributeK8SNodeName,
+		AttributeK8SNodeUID,
+		AttributeK8SNamespaceName,
+		AttributeK8SPodName,
+		AttributeK8SPodUID,
+		AttributeK8SContainerName,
+		AttributeK8SContainerRestartCount,
+		AttributeK8SReplicaSetName,
+		AttributeK8SReplicaSetUID,
+		AttributeK8SDeploymentName,
+		AttributeK8SDeploymentUID,
+		AttributeK8SStatefulSetName,
+		AttributeK8SStatefulSetUID,
+		AttributeK8SDaemonSetName,
+		AttributeK8SDaemonSetUID,
+		AttributeK8SJobName,
+		AttributeK8SJobUID,
+		AttributeK8SCronJobName,
+		AttributeK8SCronJobUID,
+		AttributeOciManifestDigest,
+		AttributeOSBuildID,
+		AttributeOSDescription,
+		AttributeOSName,
+		AttributeOSType,
+		AttributeOSVersion,
+		AttributeProcessCommand,
+		AttributeProcessCommandArgs,
+		AttributeProcessCommandLine,
+		AttributeProcessExecutableName,
+		AttributeProcessExecutablePath,
+		AttributeProcessOwner,
+		AttributeProcessParentPID,
+		AttributeProcessPID,
+		AttributeProcessRuntimeDescription,
+		AttributeProcessRuntimeName,
+		AttributeProcessRuntimeVersion,
+		AttributeServiceName,
+		AttributeServiceVersion,
+		AttributeServiceInstanceID,
+		AttributeServiceNamespace,
+		AttributeTelemetrySDKLanguage,
+		AttributeTelemetrySDKName,
+		AttributeTelemetrySDKVersion,
+		AttributeTelemetryDistroName,
+		AttributeTelemetryDistroVersion,
+		AttributeWebEngineDescription,
+		AttributeWebEngineName,
+		AttributeWebEngineVersion,
+		AttributeOTelScopeName,
+		AttributeOTelScopeVersion,
+		AttributeOTelLibraryName,
+		AttributeOTelLibraryVersion,
+	}
+}

--- a/semconv/v1.22.0/generated_trace.go
+++ b/semconv/v1.22.0/generated_trace.go
@@ -1,0 +1,1471 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv
+
+// The shared attributes used to report a single exception associated with a
+// span or log.
+const (
+	// The exception message.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Division by zero', "Can't convert 'int' object to str implicitly"
+	AttributeExceptionMessage = "exception.message"
+	// A stacktrace as a string in the natural representation for the language
+	// runtime. The representation is to be determined and documented by each language
+	// SIG.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Exception in thread "main" java.lang.RuntimeException: Test
+	// exception\\n at '
+	//  'com.example.GenerateTrace.methodB(GenerateTrace.java:13)\\n at '
+	//  'com.example.GenerateTrace.methodA(GenerateTrace.java:9)\\n at '
+	//  'com.example.GenerateTrace.main(GenerateTrace.java:5)'
+	AttributeExceptionStacktrace = "exception.stacktrace"
+	// The type of the exception (its fully-qualified class name, if applicable). The
+	// dynamic type of the exception should be preferred over the static type in
+	// languages that support it.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'java.net.ConnectException', 'OSError'
+	AttributeExceptionType = "exception.type"
+)
+
+// Operations that access some remote service.
+const (
+	// The service.name of the remote service. SHOULD be equal to the actual
+	// service.name resource attribute of the remote service if any.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'AuthTokenCache'
+	AttributePeerService = "peer.service"
+)
+
+// These attributes may be used for any operation with an authenticated and/or
+// authorized enduser.
+const (
+	// Username or client_id extracted from the access token or Authorization header
+	// in the inbound request from outside the system.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'username'
+	AttributeEnduserID = "enduser.id"
+	// Actual/assumed role the client is making the request under extracted from token
+	// or application security context.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'admin'
+	AttributeEnduserRole = "enduser.role"
+	// Scopes or granted authorities the client currently possesses extracted from
+	// token or application security context. The value would come from the scope
+	// associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0
+	// Assertion.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'read:message, write:files'
+	AttributeEnduserScope = "enduser.scope"
+)
+
+// These attributes may be used for any operation to store information about a
+// thread that started a span.
+const (
+	// Whether the thread is daemon or not.
+	//
+	// Type: boolean
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeThreadDaemon = "thread.daemon"
+	// Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 42
+	AttributeThreadID = "thread.id"
+	// Current thread name.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'main'
+	AttributeThreadName = "thread.name"
+)
+
+// These attributes allow to report this unit of code and therefore to provide
+// more context about the span.
+const (
+	// The column number in code.filepath best representing the operation. It SHOULD
+	// point within the code unit named in code.function.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 16
+	AttributeCodeColumn = "code.column"
+	// The source code file name that identifies the code unit as uniquely as possible
+	// (preferably an absolute file path).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '/usr/local/MyApplication/content_root/app/index.php'
+	AttributeCodeFilepath = "code.filepath"
+	// The method or function name, or equivalent (usually rightmost part of the code
+	// unit's name).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'serveRequest'
+	AttributeCodeFunction = "code.function"
+	// The line number in code.filepath best representing the operation. It SHOULD
+	// point within the code unit named in code.function.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 42
+	AttributeCodeLineNumber = "code.lineno"
+	// The &quot;namespace&quot; within which code.function is defined. Usually the
+	// qualified class or module name, such that code.namespace + some separator +
+	// code.function form a unique identifier for the code unit.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'com.example.MyHTTPService'
+	AttributeCodeNamespace = "code.namespace"
+)
+
+// Span attributes used by AWS Lambda (in addition to general `faas`
+// attributes).
+const (
+	// The full invoked ARN as provided on the Context passed to the function (Lambda-
+	// Runtime-Invoked-Function-ARN header on the /runtime/invocation/next
+	// applicable).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'arn:aws:lambda:us-east-1:123456:function:myfunction:myalias'
+	// Note: This may be different from cloud.resource_id if an alias is involved.
+	AttributeAWSLambdaInvokedARN = "aws.lambda.invoked_arn"
+)
+
+// Attributes for CloudEvents. CloudEvents is a specification on how to define
+// event data in a standard way. These attributes can be attached to spans when
+// performing operations with CloudEvents, regardless of the protocol being
+// used.
+const (
+	// The event_id uniquely identifies the event.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: '123e4567-e89b-12d3-a456-426614174000', '0001'
+	AttributeCloudeventsEventID = "cloudevents.event_id"
+	// The source identifies the context in which an event happened.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: 'https://github.com/cloudevents', '/cloudevents/spec/pull/123', 'my-
+	// service'
+	AttributeCloudeventsEventSource = "cloudevents.event_source"
+	// The version of the CloudEvents specification which the event uses.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '1.0'
+	AttributeCloudeventsEventSpecVersion = "cloudevents.event_spec_version"
+	// The subject of the event in the context of the event producer (identified by
+	// source).
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'mynewfile.jpg'
+	AttributeCloudeventsEventSubject = "cloudevents.event_subject"
+	// The event_type contains a value describing the type of event related to the
+	// originating occurrence.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'com.github.pull_request.opened', 'com.example.object.deleted.v2'
+	AttributeCloudeventsEventType = "cloudevents.event_type"
+)
+
+// Semantic conventions for the OpenTracing Shim
+const (
+	// Parent-child Reference type
+	//
+	// Type: Enum
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Note: The causal relationship between a child Span and a parent Span.
+	AttributeOpentracingRefType = "opentracing.ref_type"
+)
+
+const (
+	// The parent Span depends on the child Span in some capacity
+	AttributeOpentracingRefTypeChildOf = "child_of"
+	// The parent Span does not depend in any way on the result of the child Span
+	AttributeOpentracingRefTypeFollowsFrom = "follows_from"
+)
+
+// The attributes used to perform database client calls.
+const (
+	// The connection string used to connect to the database. It is recommended to
+	// remove embedded credentials.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Server=(localdb)\\v11.0;Integrated Security=true;'
+	AttributeDBConnectionString = "db.connection_string"
+	// The fully-qualified class name of the Java Database Connectivity (JDBC) driver
+	// used to connect.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'org.postgresql.Driver',
+	// 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
+	AttributeDBJDBCDriverClassname = "db.jdbc.driver_classname"
+	// This attribute is used to report the name of the database being accessed. For
+	// commands that switch the database, this should be set to the target database
+	// (even if the command fails).
+	//
+	// Type: string
+	// Requirement Level: Conditionally Required - If applicable.
+	// Stability: experimental
+	// Examples: 'customers', 'main'
+	// Note: In some SQL databases, the database name to be used is called
+	// &quot;schema name&quot;. In case there are multiple layers that could be
+	// considered for database name (e.g. Oracle instance name and schema name), the
+	// database name to be used is the more specific layer (e.g. Oracle schema name).
+	AttributeDBName = "db.name"
+	// The name of the operation being executed, e.g. the MongoDB command name such as
+	// findAndModify, or the SQL keyword.
+	//
+	// Type: string
+	// Requirement Level: Conditionally Required - If `db.statement` is not
+	// applicable.
+	// Stability: experimental
+	// Examples: 'findAndModify', 'HMSET', 'SELECT'
+	// Note: When setting this to an SQL keyword, it is not recommended to attempt any
+	// client-side parsing of db.statement just to get this property, but it should be
+	// set if the operation name is provided by the library being instrumented. If the
+	// SQL statement has an ambiguous operation, or performs more than one operation,
+	// this value may be omitted.
+	AttributeDBOperation = "db.operation"
+	// The database statement being executed.
+	//
+	// Type: string
+	// Requirement Level: Recommended - Should be collected by default only if there
+	// is sanitization that excludes sensitive information.
+	// Stability: experimental
+	// Examples: 'SELECT * FROM wuser_table', 'SET mykey "WuValue"'
+	AttributeDBStatement = "db.statement"
+	// An identifier for the database management system (DBMS) product being used. See
+	// below for a list of well-known identifiers.
+	//
+	// Type: Enum
+	// Requirement Level: Required
+	// Stability: experimental
+	AttributeDBSystem = "db.system"
+	// Username for accessing the database.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'readonly_user', 'reporting_user'
+	AttributeDBUser = "db.user"
+)
+
+const (
+	// Some other SQL database. Fallback only. See notes
+	AttributeDBSystemOtherSQL = "other_sql"
+	// Microsoft SQL Server
+	AttributeDBSystemMSSQL = "mssql"
+	// Microsoft SQL Server Compact
+	AttributeDBSystemMssqlcompact = "mssqlcompact"
+	// MySQL
+	AttributeDBSystemMySQL = "mysql"
+	// Oracle Database
+	AttributeDBSystemOracle = "oracle"
+	// IBM DB2
+	AttributeDBSystemDB2 = "db2"
+	// PostgreSQL
+	AttributeDBSystemPostgreSQL = "postgresql"
+	// Amazon Redshift
+	AttributeDBSystemRedshift = "redshift"
+	// Apache Hive
+	AttributeDBSystemHive = "hive"
+	// Cloudscape
+	AttributeDBSystemCloudscape = "cloudscape"
+	// HyperSQL DataBase
+	AttributeDBSystemHSQLDB = "hsqldb"
+	// Progress Database
+	AttributeDBSystemProgress = "progress"
+	// SAP MaxDB
+	AttributeDBSystemMaxDB = "maxdb"
+	// SAP HANA
+	AttributeDBSystemHanaDB = "hanadb"
+	// Ingres
+	AttributeDBSystemIngres = "ingres"
+	// FirstSQL
+	AttributeDBSystemFirstSQL = "firstsql"
+	// EnterpriseDB
+	AttributeDBSystemEDB = "edb"
+	// InterSystems Caché
+	AttributeDBSystemCache = "cache"
+	// Adabas (Adaptable Database System)
+	AttributeDBSystemAdabas = "adabas"
+	// Firebird
+	AttributeDBSystemFirebird = "firebird"
+	// Apache Derby
+	AttributeDBSystemDerby = "derby"
+	// FileMaker
+	AttributeDBSystemFilemaker = "filemaker"
+	// Informix
+	AttributeDBSystemInformix = "informix"
+	// InstantDB
+	AttributeDBSystemInstantDB = "instantdb"
+	// InterBase
+	AttributeDBSystemInterbase = "interbase"
+	// MariaDB
+	AttributeDBSystemMariaDB = "mariadb"
+	// Netezza
+	AttributeDBSystemNetezza = "netezza"
+	// Pervasive PSQL
+	AttributeDBSystemPervasive = "pervasive"
+	// PointBase
+	AttributeDBSystemPointbase = "pointbase"
+	// SQLite
+	AttributeDBSystemSqlite = "sqlite"
+	// Sybase
+	AttributeDBSystemSybase = "sybase"
+	// Teradata
+	AttributeDBSystemTeradata = "teradata"
+	// Vertica
+	AttributeDBSystemVertica = "vertica"
+	// H2
+	AttributeDBSystemH2 = "h2"
+	// ColdFusion IMQ
+	AttributeDBSystemColdfusion = "coldfusion"
+	// Apache Cassandra
+	AttributeDBSystemCassandra = "cassandra"
+	// Apache HBase
+	AttributeDBSystemHBase = "hbase"
+	// MongoDB
+	AttributeDBSystemMongoDB = "mongodb"
+	// Redis
+	AttributeDBSystemRedis = "redis"
+	// Couchbase
+	AttributeDBSystemCouchbase = "couchbase"
+	// CouchDB
+	AttributeDBSystemCouchDB = "couchdb"
+	// Microsoft Azure Cosmos DB
+	AttributeDBSystemCosmosDB = "cosmosdb"
+	// Amazon DynamoDB
+	AttributeDBSystemDynamoDB = "dynamodb"
+	// Neo4j
+	AttributeDBSystemNeo4j = "neo4j"
+	// Apache Geode
+	AttributeDBSystemGeode = "geode"
+	// Elasticsearch
+	AttributeDBSystemElasticsearch = "elasticsearch"
+	// Memcached
+	AttributeDBSystemMemcached = "memcached"
+	// CockroachDB
+	AttributeDBSystemCockroachdb = "cockroachdb"
+	// OpenSearch
+	AttributeDBSystemOpensearch = "opensearch"
+	// ClickHouse
+	AttributeDBSystemClickhouse = "clickhouse"
+	// Cloud Spanner
+	AttributeDBSystemSpanner = "spanner"
+	// Trino
+	AttributeDBSystemTrino = "trino"
+)
+
+// Connection-level attributes for Microsoft SQL Server
+const (
+	// The Microsoft SQL Server instance name connecting to. This name is used to
+	// determine the port of a named instance.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'MSSQLSERVER'
+	// Note: If setting a db.mssql.instance_name, server.port is no longer required
+	// (but still recommended if non-standard).
+	AttributeDBMSSQLInstanceName = "db.mssql.instance_name"
+)
+
+// Call-level attributes for Cassandra
+const (
+	// The consistency level of the query. Based on consistency values from CQL.
+	//
+	// Type: Enum
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeDBCassandraConsistencyLevel = "db.cassandra.consistency_level"
+	// The data center of the coordinating node for a query.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'us-west-2'
+	AttributeDBCassandraCoordinatorDC = "db.cassandra.coordinator.dc"
+	// The ID of the coordinating node for a query.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'be13faa2-8574-4d71-926d-27f16cf8a7af'
+	AttributeDBCassandraCoordinatorID = "db.cassandra.coordinator.id"
+	// Whether or not the query is idempotent.
+	//
+	// Type: boolean
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeDBCassandraIdempotence = "db.cassandra.idempotence"
+	// The fetch size used for paging, i.e. how many rows will be returned at once.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 5000
+	AttributeDBCassandraPageSize = "db.cassandra.page_size"
+	// The number of times a query was speculatively executed. Not set or 0 if the
+	// query was not executed speculatively.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 0, 2
+	AttributeDBCassandraSpeculativeExecutionCount = "db.cassandra.speculative_execution_count"
+	// The name of the primary table that the operation is acting upon, including the
+	// keyspace name (if applicable).
+	//
+	// Type: string
+	// Requirement Level: Recommended
+	// Stability: experimental
+	// Examples: 'mytable'
+	// Note: This mirrors the db.sql.table attribute but references cassandra rather
+	// than sql. It is not recommended to attempt any client-side parsing of
+	// db.statement just to get this property, but it should be set if it is provided
+	// by the library being instrumented. If the operation is acting upon an anonymous
+	// table, or more than one table, this value MUST NOT be set.
+	AttributeDBCassandraTable = "db.cassandra.table"
+)
+
+const (
+	// all
+	AttributeDBCassandraConsistencyLevelAll = "all"
+	// each_quorum
+	AttributeDBCassandraConsistencyLevelEachQuorum = "each_quorum"
+	// quorum
+	AttributeDBCassandraConsistencyLevelQuorum = "quorum"
+	// local_quorum
+	AttributeDBCassandraConsistencyLevelLocalQuorum = "local_quorum"
+	// one
+	AttributeDBCassandraConsistencyLevelOne = "one"
+	// two
+	AttributeDBCassandraConsistencyLevelTwo = "two"
+	// three
+	AttributeDBCassandraConsistencyLevelThree = "three"
+	// local_one
+	AttributeDBCassandraConsistencyLevelLocalOne = "local_one"
+	// any
+	AttributeDBCassandraConsistencyLevelAny = "any"
+	// serial
+	AttributeDBCassandraConsistencyLevelSerial = "serial"
+	// local_serial
+	AttributeDBCassandraConsistencyLevelLocalSerial = "local_serial"
+)
+
+// Call-level attributes for Redis
+const (
+	// The index of the database being accessed as used in the SELECT command,
+	// provided as an integer. To be used instead of the generic db.name attribute.
+	//
+	// Type: int
+	// Requirement Level: Conditionally Required - If other than the default database
+	// (`0`).
+	// Stability: experimental
+	// Examples: 0, 1, 15
+	AttributeDBRedisDBIndex = "db.redis.database_index"
+)
+
+// Call-level attributes for MongoDB
+const (
+	// The collection being accessed within the database stated in db.name.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: 'customers', 'products'
+	AttributeDBMongoDBCollection = "db.mongodb.collection"
+)
+
+// Call-level attributes for Elasticsearch
+const (
+	// Represents the identifier of an Elasticsearch cluster.
+	//
+	// Type: string
+	// Requirement Level: Recommended - When communicating with an Elastic Cloud
+	// deployment, this should be collected from the "X-Found-Handling-Cluster" HTTP
+	// response header.
+	// Stability: experimental
+	// Examples: 'e9106fc68e3044f0b1475b04bf4ffd5f'
+	AttributeDBElasticsearchClusterName = "db.elasticsearch.cluster.name"
+	// Represents the human-readable identifier of the node/instance to which a
+	// request was routed.
+	//
+	// Type: string
+	// Requirement Level: Recommended - When communicating with an Elastic Cloud
+	// deployment, this should be collected from the "X-Found-Handling-Instance" HTTP
+	// response header.
+	// Stability: experimental
+	// Examples: 'instance-0000000001'
+	AttributeDBElasticsearchNodeName = "db.elasticsearch.node.name"
+)
+
+// Call-level attributes for SQL databases
+const (
+	// The name of the primary table that the operation is acting upon, including the
+	// database name (if applicable).
+	//
+	// Type: string
+	// Requirement Level: Recommended
+	// Stability: experimental
+	// Examples: 'public.users', 'customers'
+	// Note: It is not recommended to attempt any client-side parsing of db.statement
+	// just to get this property, but it should be set if it is provided by the
+	// library being instrumented. If the operation is acting upon an anonymous table,
+	// or more than one table, this value MUST NOT be set.
+	AttributeDBSQLTable = "db.sql.table"
+)
+
+// Call-level attributes for Cosmos DB.
+const (
+	// Unique Cosmos client instance id.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '3ba4827d-4422-483f-b59f-85b74211c11d'
+	AttributeDBCosmosDBClientID = "db.cosmosdb.client_id"
+	// Cosmos client connection mode.
+	//
+	// Type: Enum
+	// Requirement Level: Conditionally Required - if not `direct` (or pick gw as
+	// default)
+	// Stability: experimental
+	AttributeDBCosmosDBConnectionMode = "db.cosmosdb.connection_mode"
+	// Cosmos DB container name.
+	//
+	// Type: string
+	// Requirement Level: Conditionally Required - if available
+	// Stability: experimental
+	// Examples: 'anystring'
+	AttributeDBCosmosDBContainer = "db.cosmosdb.container"
+	// CosmosDB Operation Type.
+	//
+	// Type: Enum
+	// Requirement Level: Conditionally Required - when performing one of the
+	// operations in this list
+	// Stability: experimental
+	AttributeDBCosmosDBOperationType = "db.cosmosdb.operation_type"
+	// RU consumed for that operation
+	//
+	// Type: double
+	// Requirement Level: Conditionally Required - when available
+	// Stability: experimental
+	// Examples: 46.18, 1.0
+	AttributeDBCosmosDBRequestCharge = "db.cosmosdb.request_charge"
+	// Request payload size in bytes
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeDBCosmosDBRequestContentLength = "db.cosmosdb.request_content_length"
+	// Cosmos DB status code.
+	//
+	// Type: int
+	// Requirement Level: Conditionally Required - if response was received
+	// Stability: experimental
+	// Examples: 200, 201
+	AttributeDBCosmosDBStatusCode = "db.cosmosdb.status_code"
+	// Cosmos DB sub status code.
+	//
+	// Type: int
+	// Requirement Level: Conditionally Required - when response was received and
+	// contained sub-code.
+	// Stability: experimental
+	// Examples: 1000, 1002
+	AttributeDBCosmosDBSubStatusCode = "db.cosmosdb.sub_status_code"
+)
+
+const (
+	// Gateway (HTTP) connections mode
+	AttributeDBCosmosDBConnectionModeGateway = "gateway"
+	// Direct connection
+	AttributeDBCosmosDBConnectionModeDirect = "direct"
+)
+
+const (
+	// invalid
+	AttributeDBCosmosDBOperationTypeInvalid = "Invalid"
+	// create
+	AttributeDBCosmosDBOperationTypeCreate = "Create"
+	// patch
+	AttributeDBCosmosDBOperationTypePatch = "Patch"
+	// read
+	AttributeDBCosmosDBOperationTypeRead = "Read"
+	// read_feed
+	AttributeDBCosmosDBOperationTypeReadFeed = "ReadFeed"
+	// delete
+	AttributeDBCosmosDBOperationTypeDelete = "Delete"
+	// replace
+	AttributeDBCosmosDBOperationTypeReplace = "Replace"
+	// execute
+	AttributeDBCosmosDBOperationTypeExecute = "Execute"
+	// query
+	AttributeDBCosmosDBOperationTypeQuery = "Query"
+	// head
+	AttributeDBCosmosDBOperationTypeHead = "Head"
+	// head_feed
+	AttributeDBCosmosDBOperationTypeHeadFeed = "HeadFeed"
+	// upsert
+	AttributeDBCosmosDBOperationTypeUpsert = "Upsert"
+	// batch
+	AttributeDBCosmosDBOperationTypeBatch = "Batch"
+	// query_plan
+	AttributeDBCosmosDBOperationTypeQueryPlan = "QueryPlan"
+	// execute_javascript
+	AttributeDBCosmosDBOperationTypeExecuteJavascript = "ExecuteJavaScript"
+)
+
+// Span attributes used by non-OTLP exporters to represent OpenTelemetry Span's
+// concepts.
+const (
+	// Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set
+	// if the status code is UNSET.
+	//
+	// Type: Enum
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeOTelStatusCode = "otel.status_code"
+	// Description of the Status if it has a value, otherwise not set.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'resource not found'
+	AttributeOTelStatusDescription = "otel.status_description"
+)
+
+const (
+	// The operation has been validated by an Application developer or Operator to have completed successfully
+	AttributeOTelStatusCodeOk = "OK"
+	// The operation contains an error
+	AttributeOTelStatusCodeError = "ERROR"
+)
+
+// This semantic convention describes an instance of a function that runs
+// without provisioning or managing of servers (also known as serverless
+// functions or Function as a Service (FaaS)) with spans.
+const (
+	// The invocation ID of the current function invocation.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28'
+	AttributeFaaSInvocationID = "faas.invocation_id"
+)
+
+// Semantic Convention for FaaS triggered as a response to some data source
+// operation such as a database or filesystem read/write.
+const (
+	// The name of the source on which the triggering operation was performed. For
+	// example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos
+	// DB to the database name.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: 'myBucketName', 'myDBName'
+	AttributeFaaSDocumentCollection = "faas.document.collection"
+	// The document name/table subjected to the operation. For example, in Cloud
+	// Storage or S3 is the name of the file, and in Cosmos DB the table name.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'myFile.txt', 'myTableName'
+	AttributeFaaSDocumentName = "faas.document.name"
+	// Describes the type of the operation that was performed on the data.
+	//
+	// Type: Enum
+	// Requirement Level: Required
+	// Stability: experimental
+	AttributeFaaSDocumentOperation = "faas.document.operation"
+	// A string containing the time when the data was accessed in the ISO 8601 format
+	// expressed in UTC.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '2020-01-23T13:47:06Z'
+	AttributeFaaSDocumentTime = "faas.document.time"
+)
+
+const (
+	// When a new object is created
+	AttributeFaaSDocumentOperationInsert = "insert"
+	// When an object is modified
+	AttributeFaaSDocumentOperationEdit = "edit"
+	// When an object is deleted
+	AttributeFaaSDocumentOperationDelete = "delete"
+)
+
+// Semantic Convention for FaaS scheduled to be executed regularly.
+const (
+	// A string containing the schedule period as Cron Expression.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '0/5 * * * ? *'
+	AttributeFaaSCron = "faas.cron"
+	// A string containing the function invocation time in the ISO 8601 format
+	// expressed in UTC.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '2020-01-23T13:47:06Z'
+	AttributeFaaSTime = "faas.time"
+)
+
+// Contains additional attributes for incoming FaaS spans.
+const (
+	// A boolean that is true if the serverless function is executed for the first
+	// time (aka cold-start).
+	//
+	// Type: boolean
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeFaaSColdstart = "faas.coldstart"
+)
+
+// The `aws` conventions apply to operations using the AWS SDK. They map
+// request or response parameters in AWS SDK API calls to attributes on a Span.
+// The conventions have been collected over time based on feedback from AWS
+// users of tracing and will continue to evolve as new interesting conventions
+// are found.
+// Some descriptions are also provided for populating general OpenTelemetry
+// semantic conventions based on these APIs.
+const (
+	// The AWS request ID as returned in the response headers x-amz-request-id or
+	// x-amz-requestid.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '79b9da39-b7ae-508a-a6bc-864b2829c622', 'C9ER4AJX75574TDJ'
+	AttributeAWSRequestID = "aws.request_id"
+)
+
+// Attributes that exist for multiple DynamoDB request types.
+const (
+	// The value of the AttributesToGet request parameter.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'lives', 'id'
+	AttributeAWSDynamoDBAttributesToGet = "aws.dynamodb.attributes_to_get"
+	// The value of the ConsistentRead request parameter.
+	//
+	// Type: boolean
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeAWSDynamoDBConsistentRead = "aws.dynamodb.consistent_read"
+	// The JSON-serialized value of each item in the ConsumedCapacity response field.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : {
+	// "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number } },
+	// "ReadCapacityUnits": number, "Table": { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName":
+	// "string", "WriteCapacityUnits": number }'
+	AttributeAWSDynamoDBConsumedCapacity = "aws.dynamodb.consumed_capacity"
+	// The value of the IndexName request parameter.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'name_to_group'
+	AttributeAWSDynamoDBIndexName = "aws.dynamodb.index_name"
+	// The JSON-serialized value of the ItemCollectionMetrics response field.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob,
+	// "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" :
+	// "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S":
+	// "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }'
+	AttributeAWSDynamoDBItemCollectionMetrics = "aws.dynamodb.item_collection_metrics"
+	// The value of the Limit request parameter.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 10
+	AttributeAWSDynamoDBLimit = "aws.dynamodb.limit"
+	// The value of the ProjectionExpression request parameter.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Title', 'Title, Price, Color', 'Title, Description, RelatedItems,
+	// ProductReviews'
+	AttributeAWSDynamoDBProjection = "aws.dynamodb.projection"
+	// The value of the ProvisionedThroughput.ReadCapacityUnits request parameter.
+	//
+	// Type: double
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 1.0, 2.0
+	AttributeAWSDynamoDBProvisionedReadCapacity = "aws.dynamodb.provisioned_read_capacity"
+	// The value of the ProvisionedThroughput.WriteCapacityUnits request parameter.
+	//
+	// Type: double
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 1.0, 2.0
+	AttributeAWSDynamoDBProvisionedWriteCapacity = "aws.dynamodb.provisioned_write_capacity"
+	// The value of the Select request parameter.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'ALL_ATTRIBUTES', 'COUNT'
+	AttributeAWSDynamoDBSelect = "aws.dynamodb.select"
+	// The keys in the RequestItems object field.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Users', 'Cats'
+	AttributeAWSDynamoDBTableNames = "aws.dynamodb.table_names"
+)
+
+// DynamoDB.CreateTable
+const (
+	// The JSON-serialized value of each item of the GlobalSecondaryIndexes request
+	// field
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits":
+	// number, "WriteCapacityUnits": number } }'
+	AttributeAWSDynamoDBGlobalSecondaryIndexes = "aws.dynamodb.global_secondary_indexes"
+	// The JSON-serialized value of each item of the LocalSecondaryIndexes request
+	// field.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '{ "IndexARN": "string", "IndexName": "string", "IndexSizeBytes":
+	// number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" } }'
+	AttributeAWSDynamoDBLocalSecondaryIndexes = "aws.dynamodb.local_secondary_indexes"
+)
+
+// DynamoDB.ListTables
+const (
+	// The value of the ExclusiveStartTableName request parameter.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Users', 'CatsTable'
+	AttributeAWSDynamoDBExclusiveStartTable = "aws.dynamodb.exclusive_start_table"
+	// The the number of items in the TableNames response parameter.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 20
+	AttributeAWSDynamoDBTableCount = "aws.dynamodb.table_count"
+)
+
+// DynamoDB.Query
+const (
+	// The value of the ScanIndexForward request parameter.
+	//
+	// Type: boolean
+	// Requirement Level: Optional
+	// Stability: experimental
+	AttributeAWSDynamoDBScanForward = "aws.dynamodb.scan_forward"
+)
+
+// DynamoDB.Scan
+const (
+	// The value of the Count response parameter.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 10
+	AttributeAWSDynamoDBCount = "aws.dynamodb.count"
+	// The value of the ScannedCount response parameter.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 50
+	AttributeAWSDynamoDBScannedCount = "aws.dynamodb.scanned_count"
+	// The value of the Segment request parameter.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 10
+	AttributeAWSDynamoDBSegment = "aws.dynamodb.segment"
+	// The value of the TotalSegments request parameter.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 100
+	AttributeAWSDynamoDBTotalSegments = "aws.dynamodb.total_segments"
+)
+
+// DynamoDB.UpdateTable
+const (
+	// The JSON-serialized value of each item in the AttributeDefinitions request
+	// field.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '{ "AttributeName": "string", "AttributeType": "string" }'
+	AttributeAWSDynamoDBAttributeDefinitions = "aws.dynamodb.attribute_definitions"
+	// The JSON-serialized value of each item in the the GlobalSecondaryIndexUpdates
+	// request field.
+	//
+	// Type: string[]
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '{ "Create": { "IndexName": "string", "KeySchema": [ {
+	// "AttributeName": "string", "KeyType": "string" } ], "Projection": {
+	// "NonKeyAttributes": [ "string" ], "ProjectionType": "string" },
+	// "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }'
+	AttributeAWSDynamoDBGlobalSecondaryIndexUpdates = "aws.dynamodb.global_secondary_index_updates"
+)
+
+// Attributes that exist for S3 request types.
+const (
+	// The S3 bucket name the request refers to. Corresponds to the --bucket parameter
+	// of the S3 API operations.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'some-bucket-name'
+	// Note: The bucket attribute is applicable to all S3 operations that reference a
+	// bucket, i.e. that require the bucket name as a mandatory parameter.
+	// This applies to almost all S3 operations except list-buckets.
+	AttributeAWSS3Bucket = "aws.s3.bucket"
+	// The source object (in the form bucket/key) for the copy operation.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'someFile.yml'
+	// Note: The copy_source attribute applies to S3 copy operations and corresponds
+	// to the --copy-source parameter
+	// of the copy-object operation within the S3 API.
+	// This applies in particular to the following operations:<ul>
+	// <li>copy-object</li>
+	// <li>upload-part-copy</li>
+	// </ul>
+	AttributeAWSS3CopySource = "aws.s3.copy_source"
+	// The delete request container that specifies the objects to be deleted.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Objects=[{Key=string,VersionID=string},{Key=string,VersionID=string}
+	// ],Quiet=boolean'
+	// Note: The delete attribute is only applicable to the delete-object operation.
+	// The delete attribute corresponds to the --delete parameter of the
+	// delete-objects operation within the S3 API.
+	AttributeAWSS3Delete = "aws.s3.delete"
+	// The S3 object key the request refers to. Corresponds to the --key parameter of
+	// the S3 API operations.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'someFile.yml'
+	// Note: The key attribute is applicable to all object-related S3 operations, i.e.
+	// that require the object key as a mandatory parameter.
+	// This applies in particular to the following operations:<ul>
+	// <li>copy-object</li>
+	// <li>delete-object</li>
+	// <li>get-object</li>
+	// <li>head-object</li>
+	// <li>put-object</li>
+	// <li>restore-object</li>
+	// <li>select-object-content</li>
+	// <li>abort-multipart-upload</li>
+	// <li>complete-multipart-upload</li>
+	// <li>create-multipart-upload</li>
+	// <li>list-parts</li>
+	// <li>upload-part</li>
+	// <li>upload-part-copy</li>
+	// </ul>
+	AttributeAWSS3Key = "aws.s3.key"
+	// The part number of the part being uploaded in a multipart-upload operation.
+	// This is a positive integer between 1 and 10,000.
+	//
+	// Type: int
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 3456
+	// Note: The part_number attribute is only applicable to the upload-part
+	// and upload-part-copy operations.
+	// The part_number attribute corresponds to the --part-number parameter of the
+	// upload-part operation within the S3 API.
+	AttributeAWSS3PartNumber = "aws.s3.part_number"
+	// Upload ID that identifies the multipart upload.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'dfRtDYWFbkRONycy.Yxwh66Yjlx.cph0gtNBtJ'
+	// Note: The upload_id attribute applies to S3 multipart-upload operations and
+	// corresponds to the --upload-id parameter
+	// of the S3 API multipart operations.
+	// This applies in particular to the following operations:<ul>
+	// <li>abort-multipart-upload</li>
+	// <li>complete-multipart-upload</li>
+	// <li>list-parts</li>
+	// <li>upload-part</li>
+	// <li>upload-part-copy</li>
+	// </ul>
+	AttributeAWSS3UploadID = "aws.s3.upload_id"
+)
+
+// Semantic conventions to apply when instrumenting the GraphQL implementation.
+// They map GraphQL operations to attributes on a Span.
+const (
+	// The GraphQL document being executed.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'query findBookByID { bookByID(id: ?) { name } }'
+	// Note: The value may be sanitized to exclude sensitive information.
+	AttributeGraphqlDocument = "graphql.document"
+	// The name of the operation being executed.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'findBookByID'
+	AttributeGraphqlOperationName = "graphql.operation.name"
+	// The type of the operation being executed.
+	//
+	// Type: Enum
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'query', 'mutation', 'subscription'
+	AttributeGraphqlOperationType = "graphql.operation.type"
+)
+
+const (
+	// GraphQL query
+	AttributeGraphqlOperationTypeQuery = "query"
+	// GraphQL mutation
+	AttributeGraphqlOperationTypeMutation = "mutation"
+	// GraphQL subscription
+	AttributeGraphqlOperationTypeSubscription = "subscription"
+)
+
+// General attributes used in messaging systems.
+const (
+	// The number of messages sent, received, or processed in the scope of the
+	// batching operation.
+	//
+	// Type: int
+	// Requirement Level: Conditionally Required - If the span describes an operation
+	// on a batch of messages.
+	// Stability: experimental
+	// Examples: 0, 1, 2
+	// Note: Instrumentations SHOULD NOT set messaging.batch.message_count on spans
+	// that operate with a single message. When a messaging client library supports
+	// both batch and single-message API for the same operation, instrumentations
+	// SHOULD use messaging.batch.message_count for batching APIs and SHOULD NOT use
+	// it for single-message APIs.
+	AttributeMessagingBatchMessageCount = "messaging.batch.message_count"
+	// A unique identifier for the client that consumes or produces a message.
+	//
+	// Type: string
+	// Requirement Level: Recommended - If a client id is available
+	// Stability: experimental
+	// Examples: 'client-5', 'myhost@8742@s8083jm'
+	AttributeMessagingClientID = "messaging.client_id"
+	// A string identifying the kind of messaging operation as defined in the
+	// Operation names section above.
+	//
+	// Type: Enum
+	// Requirement Level: Required
+	// Stability: experimental
+	// Note: If a custom value is used, it MUST be of low cardinality.
+	AttributeMessagingOperation = "messaging.operation"
+	// A string identifying the messaging system.
+	//
+	// Type: string
+	// Requirement Level: Required
+	// Stability: experimental
+	// Examples: 'kafka', 'rabbitmq', 'rocketmq', 'activemq', 'AmazonSQS'
+	AttributeMessagingSystem = "messaging.system"
+)
+
+const (
+	// publish
+	AttributeMessagingOperationPublish = "publish"
+	// receive
+	AttributeMessagingOperationReceive = "receive"
+	// process
+	AttributeMessagingOperationProcess = "process"
+)
+
+// Semantic conventions for remote procedure calls.
+const (
+	// The name of the (logical) method being called, must be equal to the $method
+	// part in the span name.
+	//
+	// Type: string
+	// Requirement Level: Recommended
+	// Stability: experimental
+	// Examples: 'exampleMethod'
+	// Note: This is the logical name of the method from the RPC interface
+	// perspective, which can be different from the name of any implementing
+	// method/function. The code.function attribute may be used to store the latter
+	// (e.g., method actually executing the call on the server side, RPC client stub
+	// method on the client side).
+	AttributeRPCMethod = "rpc.method"
+	// The full (logical) name of the service being called, including its package
+	// name, if applicable.
+	//
+	// Type: string
+	// Requirement Level: Recommended
+	// Stability: experimental
+	// Examples: 'myservice.EchoService'
+	// Note: This is the logical name of the service from the RPC interface
+	// perspective, which can be different from the name of any implementing class.
+	// The code.namespace attribute may be used to store the latter (despite the
+	// attribute name, it may include a class name; e.g., class with method actually
+	// executing the call on the server side, RPC client stub class on the client
+	// side).
+	AttributeRPCService = "rpc.service"
+	// A string identifying the remoting system. See below for a list of well-known
+	// identifiers.
+	//
+	// Type: Enum
+	// Requirement Level: Required
+	// Stability: experimental
+	AttributeRPCSystem = "rpc.system"
+)
+
+const (
+	// gRPC
+	AttributeRPCSystemGRPC = "grpc"
+	// Java RMI
+	AttributeRPCSystemJavaRmi = "java_rmi"
+	// .NET WCF
+	AttributeRPCSystemDotnetWcf = "dotnet_wcf"
+	// Apache Dubbo
+	AttributeRPCSystemApacheDubbo = "apache_dubbo"
+	// Connect RPC
+	AttributeRPCSystemConnectRPC = "connect_rpc"
+)
+
+// Tech-specific attributes for gRPC.
+const (
+	// The numeric status code of the gRPC request.
+	//
+	// Type: Enum
+	// Requirement Level: Required
+	// Stability: experimental
+	AttributeRPCGRPCStatusCode = "rpc.grpc.status_code"
+)
+
+const (
+	// OK
+	AttributeRPCGRPCStatusCodeOk = "0"
+	// CANCELLED
+	AttributeRPCGRPCStatusCodeCancelled = "1"
+	// UNKNOWN
+	AttributeRPCGRPCStatusCodeUnknown = "2"
+	// INVALID_ARGUMENT
+	AttributeRPCGRPCStatusCodeInvalidArgument = "3"
+	// DEADLINE_EXCEEDED
+	AttributeRPCGRPCStatusCodeDeadlineExceeded = "4"
+	// NOT_FOUND
+	AttributeRPCGRPCStatusCodeNotFound = "5"
+	// ALREADY_EXISTS
+	AttributeRPCGRPCStatusCodeAlreadyExists = "6"
+	// PERMISSION_DENIED
+	AttributeRPCGRPCStatusCodePermissionDenied = "7"
+	// RESOURCE_EXHAUSTED
+	AttributeRPCGRPCStatusCodeResourceExhausted = "8"
+	// FAILED_PRECONDITION
+	AttributeRPCGRPCStatusCodeFailedPrecondition = "9"
+	// ABORTED
+	AttributeRPCGRPCStatusCodeAborted = "10"
+	// OUT_OF_RANGE
+	AttributeRPCGRPCStatusCodeOutOfRange = "11"
+	// UNIMPLEMENTED
+	AttributeRPCGRPCStatusCodeUnimplemented = "12"
+	// INTERNAL
+	AttributeRPCGRPCStatusCodeInternal = "13"
+	// UNAVAILABLE
+	AttributeRPCGRPCStatusCodeUnavailable = "14"
+	// DATA_LOSS
+	AttributeRPCGRPCStatusCodeDataLoss = "15"
+	// UNAUTHENTICATED
+	AttributeRPCGRPCStatusCodeUnauthenticated = "16"
+)
+
+// Tech-specific attributes for [JSON RPC](https://www.jsonrpc.org/).
+const (
+	// error.code property of response if it is an error response.
+	//
+	// Type: int
+	// Requirement Level: Conditionally Required - If response is not successful.
+	// Stability: experimental
+	// Examples: -32700, 100
+	AttributeRPCJsonrpcErrorCode = "rpc.jsonrpc.error_code"
+	// error.message property of response if it is an error response.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: 'Parse error', 'User already exists'
+	AttributeRPCJsonrpcErrorMessage = "rpc.jsonrpc.error_message"
+	// id property of request or response. Since protocol allows id to be int, string,
+	// null or missing (for notifications), value is expected to be cast to string for
+	// simplicity. Use empty string in case of null value. Omit entirely if this is a
+	// notification.
+	//
+	// Type: string
+	// Requirement Level: Optional
+	// Stability: experimental
+	// Examples: '10', 'request-7', ''
+	AttributeRPCJsonrpcRequestID = "rpc.jsonrpc.request_id"
+	// Protocol version as in jsonrpc property of request/response. Since JSON-RPC 1.0
+	// does not specify this, the value can be omitted.
+	//
+	// Type: string
+	// Requirement Level: Conditionally Required - If other than the default version
+	// (`1.0`)
+	// Stability: experimental
+	// Examples: '2.0', '1.0'
+	AttributeRPCJsonrpcVersion = "rpc.jsonrpc.version"
+)
+
+// Tech-specific attributes for Connect RPC.
+const (
+	// The error codes of the Connect request. Error codes are always string values.
+	//
+	// Type: Enum
+	// Requirement Level: Conditionally Required - If response is not successful and
+	// if error code available.
+	// Stability: experimental
+	AttributeRPCConnectRPCErrorCode = "rpc.connect_rpc.error_code"
+)
+
+const (
+	// cancelled
+	AttributeRPCConnectRPCErrorCodeCancelled = "cancelled"
+	// unknown
+	AttributeRPCConnectRPCErrorCodeUnknown = "unknown"
+	// invalid_argument
+	AttributeRPCConnectRPCErrorCodeInvalidArgument = "invalid_argument"
+	// deadline_exceeded
+	AttributeRPCConnectRPCErrorCodeDeadlineExceeded = "deadline_exceeded"
+	// not_found
+	AttributeRPCConnectRPCErrorCodeNotFound = "not_found"
+	// already_exists
+	AttributeRPCConnectRPCErrorCodeAlreadyExists = "already_exists"
+	// permission_denied
+	AttributeRPCConnectRPCErrorCodePermissionDenied = "permission_denied"
+	// resource_exhausted
+	AttributeRPCConnectRPCErrorCodeResourceExhausted = "resource_exhausted"
+	// failed_precondition
+	AttributeRPCConnectRPCErrorCodeFailedPrecondition = "failed_precondition"
+	// aborted
+	AttributeRPCConnectRPCErrorCodeAborted = "aborted"
+	// out_of_range
+	AttributeRPCConnectRPCErrorCodeOutOfRange = "out_of_range"
+	// unimplemented
+	AttributeRPCConnectRPCErrorCodeUnimplemented = "unimplemented"
+	// internal
+	AttributeRPCConnectRPCErrorCodeInternal = "internal"
+	// unavailable
+	AttributeRPCConnectRPCErrorCodeUnavailable = "unavailable"
+	// data_loss
+	AttributeRPCConnectRPCErrorCodeDataLoss = "data_loss"
+	// unauthenticated
+	AttributeRPCConnectRPCErrorCodeUnauthenticated = "unauthenticated"
+)
+
+func GetTraceSemanticConventionAttributeNames() []string {
+	return []string{
+		AttributeExceptionMessage,
+		AttributeExceptionStacktrace,
+		AttributeExceptionType,
+		AttributePeerService,
+		AttributeEnduserID,
+		AttributeEnduserRole,
+		AttributeEnduserScope,
+		AttributeThreadDaemon,
+		AttributeThreadID,
+		AttributeThreadName,
+		AttributeCodeColumn,
+		AttributeCodeFilepath,
+		AttributeCodeFunction,
+		AttributeCodeLineNumber,
+		AttributeCodeNamespace,
+		AttributeAWSLambdaInvokedARN,
+		AttributeCloudeventsEventID,
+		AttributeCloudeventsEventSource,
+		AttributeCloudeventsEventSpecVersion,
+		AttributeCloudeventsEventSubject,
+		AttributeCloudeventsEventType,
+		AttributeOpentracingRefType,
+		AttributeDBConnectionString,
+		AttributeDBJDBCDriverClassname,
+		AttributeDBName,
+		AttributeDBOperation,
+		AttributeDBStatement,
+		AttributeDBSystem,
+		AttributeDBUser,
+		AttributeDBMSSQLInstanceName,
+		AttributeDBCassandraConsistencyLevel,
+		AttributeDBCassandraCoordinatorDC,
+		AttributeDBCassandraCoordinatorID,
+		AttributeDBCassandraIdempotence,
+		AttributeDBCassandraPageSize,
+		AttributeDBCassandraSpeculativeExecutionCount,
+		AttributeDBCassandraTable,
+		AttributeDBRedisDBIndex,
+		AttributeDBMongoDBCollection,
+		AttributeDBElasticsearchClusterName,
+		AttributeDBElasticsearchNodeName,
+		AttributeDBSQLTable,
+		AttributeDBCosmosDBClientID,
+		AttributeDBCosmosDBConnectionMode,
+		AttributeDBCosmosDBContainer,
+		AttributeDBCosmosDBOperationType,
+		AttributeDBCosmosDBRequestCharge,
+		AttributeDBCosmosDBRequestContentLength,
+		AttributeDBCosmosDBStatusCode,
+		AttributeDBCosmosDBSubStatusCode,
+		AttributeOTelStatusCode,
+		AttributeOTelStatusDescription,
+		AttributeFaaSInvocationID,
+		AttributeFaaSDocumentCollection,
+		AttributeFaaSDocumentName,
+		AttributeFaaSDocumentOperation,
+		AttributeFaaSDocumentTime,
+		AttributeFaaSCron,
+		AttributeFaaSTime,
+		AttributeFaaSColdstart,
+		AttributeAWSRequestID,
+		AttributeAWSDynamoDBAttributesToGet,
+		AttributeAWSDynamoDBConsistentRead,
+		AttributeAWSDynamoDBConsumedCapacity,
+		AttributeAWSDynamoDBIndexName,
+		AttributeAWSDynamoDBItemCollectionMetrics,
+		AttributeAWSDynamoDBLimit,
+		AttributeAWSDynamoDBProjection,
+		AttributeAWSDynamoDBProvisionedReadCapacity,
+		AttributeAWSDynamoDBProvisionedWriteCapacity,
+		AttributeAWSDynamoDBSelect,
+		AttributeAWSDynamoDBTableNames,
+		AttributeAWSDynamoDBGlobalSecondaryIndexes,
+		AttributeAWSDynamoDBLocalSecondaryIndexes,
+		AttributeAWSDynamoDBExclusiveStartTable,
+		AttributeAWSDynamoDBTableCount,
+		AttributeAWSDynamoDBScanForward,
+		AttributeAWSDynamoDBCount,
+		AttributeAWSDynamoDBScannedCount,
+		AttributeAWSDynamoDBSegment,
+		AttributeAWSDynamoDBTotalSegments,
+		AttributeAWSDynamoDBAttributeDefinitions,
+		AttributeAWSDynamoDBGlobalSecondaryIndexUpdates,
+		AttributeAWSS3Bucket,
+		AttributeAWSS3CopySource,
+		AttributeAWSS3Delete,
+		AttributeAWSS3Key,
+		AttributeAWSS3PartNumber,
+		AttributeAWSS3UploadID,
+		AttributeGraphqlDocument,
+		AttributeGraphqlOperationName,
+		AttributeGraphqlOperationType,
+		AttributeMessagingBatchMessageCount,
+		AttributeMessagingClientID,
+		AttributeMessagingOperation,
+		AttributeMessagingSystem,
+		AttributeRPCMethod,
+		AttributeRPCService,
+		AttributeRPCSystem,
+		AttributeRPCGRPCStatusCode,
+		AttributeRPCJsonrpcErrorCode,
+		AttributeRPCJsonrpcErrorMessage,
+		AttributeRPCJsonrpcRequestID,
+		AttributeRPCJsonrpcVersion,
+		AttributeRPCConnectRPCErrorCode,
+	}
+}

--- a/semconv/v1.22.0/schema.go
+++ b/semconv/v1.22.0/schema.go
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package semconv // import "go.opentelemetry.io/collector/semconv/v1.22.0"
+
+// SchemaURL is the schema URL that matches the version of the semantic conventions
+// that this package defines. Semconv packages starting from v1.4.0 must declare
+// non-empty schema URL in the form https://opentelemetry.io/schemas/<version>
+const SchemaURL = "https://opentelemetry.io/schemas/1.22.0"


### PR DESCRIPTION
Generated with the following:

```
make gensemconv SPECPATH=/tmp/semantic-conventions SPECTAG=v1.22.0
```

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/8686
