### PR TITLE
record a metric with open census to ensure backwards compat

### DIFF
--- a/.chloggen/codeboten_use-otel-with-healthcheck-view.yaml
+++ b/.chloggen/codeboten_use-otel-with-healthcheck-view.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: telemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add OpenCensus view to useOtelForInternalMetrics path
+
+# One or more tracking issues or pull requests related to the change
+issues: [9065]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This ensures the healthcheck extension which relies on an OpenCensus
+  view continues to work as it does today when a user enables useOtelForInternalMetrics.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -222,6 +222,15 @@ func (or *ObsReport) recordWithOtel(ctx context.Context, dataType component.Data
 
 	sentMeasure.Add(ctx, sent, metric.WithAttributes(or.otelAttrs...))
 	failedMeasure.Add(ctx, failed, metric.WithAttributes(or.otelAttrs...))
+	// This is here to ensure the current healthcheck extension continues
+	// to work even when using OpenTelemetry for collector metrics
+	if failed > 0 {
+		_ = stats.RecordWithTags(
+			ctx,
+			or.mutators,
+			obsmetrics.ExporterFailedToSendSpans.M(failed))
+	}
+
 }
 
 func (or *ObsReport) recordWithOC(ctx context.Context, dataType component.DataType, sent int64, failed int64) {

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -33,6 +33,7 @@ import (
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/service/internal/proctelemetry"
 	"go.opentelemetry.io/collector/service/internal/servicetelemetry"
 	"go.opentelemetry.io/collector/service/telemetry"
@@ -169,6 +170,19 @@ func (tel *telemetryInitializer) initMetrics(res *resource.Resource, logger *zap
 	if err != nil {
 		return err
 	}
+
+	// This is here to ensure the current healthcheck extension continues
+	// to work even when using OpenTelemetry for collector metrics
+	healthcheckView := &view.View{
+		Name:        obsmetrics.ExporterPrefix + "send_failed_requests",
+		Description: "number of times exporters failed to send requests to the destination",
+		Measure:     obsmetrics.ExporterFailedToSendSpans,
+		Aggregation: view.Count(),
+	}
+	if err := view.Register(healthcheckView); err != nil {
+		return err
+	}
+
 	tel.mp = mp
 	return nil
 }


### PR DESCRIPTION
The healthcheck extension currently relies on an OpenCensus view to determine the health of the collector. This behaviour is not great as it only looks at span exports, but it exists today. To avoid breaking it, I suggest this PR that adds the same OC view even on the otel path, and records the same metric.

Note to reviewers: This is only a hack that's needed until the new healthcheck extension that uses component status is ready to go. cc @mwear 
