### PR TITLE
[chore] [makefile] Update check-changes and prepare-release targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,11 +384,7 @@ push-tags: $(MULTIMOD)
 
 .PHONY: check-changes
 check-changes: $(MULTIMOD)
-	# NOTE: ! inverses the return code of multimod diff. This is
-	# because prepare-release expects a 0 if there are diffs and
-	# non-0 if there are no diffs, which is the inverse of most
-	# diff tools
-	! $(MULTIMOD) diff -p $(PREVIOUS_VERSION) -m $(MODSET)
+	$(MULTIMOD) diff -p $(PREVIOUS_VERSION) -m $(MODSET)
 
 .PHONY: prepare-release
 prepare-release:
@@ -413,8 +409,6 @@ else
 endif
 	# ensure a clean branch
 	git diff -s --exit-code || (echo "local repository not clean"; exit 1)
-	# check if any modules have changed since the previous release
-	$(MAKE) check-changes
 	# update files with new version
 	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' versions.yaml
 	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' ./cmd/builder/internal/builder/config.go


### PR DESCRIPTION
Relax requirements for prepare-release by removing check-changes. Currently, even if it fails, the prepare-release target isn't canceled.

check-changes should be used separately by a release manager

Related to https://github.com/open-telemetry/opentelemetry-collector/pull/9081