### PR TITLE
[chore] [exporterhelper] Remove redundant flaky test

### DIFF
--- a/exporter/exporterhelper/internal/bounded_memory_queue_test.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue_test.go
@@ -233,17 +233,6 @@ func (s *consumerState) assertConsumed(expected map[string]bool) {
 	assert.Equal(s.t, expected, s.snapshot())
 }
 
-func TestZeroSizeWithConsumers(t *testing.T) {
-	q := NewBoundedMemoryQueue[string](0)
-
-	consumers := NewQueueConsumers(q, 1, func(context.Context, string) bool { return true })
-	assert.NoError(t, consumers.Start(context.Background(), componenttest.NewNopHost()))
-
-	assert.NoError(t, q.Offer(context.Background(), "a")) // in process
-
-	assert.NoError(t, consumers.Shutdown(context.Background()))
-}
-
 func TestZeroSizeNoConsumers(t *testing.T) {
 	q := NewBoundedMemoryQueue[string](0)
 


### PR DESCRIPTION
The test checks the behavior that is not available for the user. Zero queue size is not allowed.

With the given input, the test is running in a race condition and fails when `Offer` is called before `Consume`.

```
--- FAIL: TestZeroSizeWithConsumers (0.00s)
    bounded_memory_queue_test.go:242:
        	Error Trace:	/home/runner/work/opentelemetry-collector/opentelemetry-collector/exporter/exporterhelper/internal/bounded_memory_queue_test.go:242
        	Error:      	Received unexpected error:
        	            	sending queue is full
        	Test:       	TestZeroSizeWithConsumers
FAIL
```

A recent example: https://github.com/open-telemetry/opentelemetry-collector/actions/runs/7187787264/job/19576154676