### PR TITLE
[chore] remove unused CI link

### DIFF
--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -1,5 +1,4 @@
 # OpenTelemetry Collector Builder (ocb)
-[![CI](https://github.com/open-telemetry/opentelemetry-collector-builder/actions/workflows/go.yaml/badge.svg)](https://github.com/open-telemetry/opentelemetry-collector-builder/actions/workflows/go.yaml?query=branch%3Amain)
 
 This program generates a custom OpenTelemetry Collector binary based on a given configuration.
 


### PR DESCRIPTION
Deletes a link that does not match any CI status.