### PR TITLE
[chore] remove exemptions for builder

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -7,8 +7,6 @@
 name: "Inform Incompatible PRs"
 on:
   pull_request:
-    paths-ignore:
-      - 'cmd/builder/**'
     branches:
       - main
 

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -2,11 +2,7 @@ name: check-links
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - 'cmd/builder/**'
   pull_request:
-    paths-ignore:
-      - 'cmd/builder/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
I seem to recall these were placed here during the initial transition of the repo, they're no longer needed.

This is a follow up to @atoulme's PR which led me to wonder why exemptions were there in the first place 😄 