### PR TITLE
[chore] remove TODO from confighttp tests

### DIFF
--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -817,13 +817,14 @@ func TestHttpCors(t *testing.T) {
 				}))
 			require.NoError(t, err)
 
+			waitStart := make(chan struct{})
 			go func() {
+				close(waitStart)
 				_ = s.Serve(ln)
 			}()
 
-			// TODO: make starting server deterministic
 			// Wait for the servers to start
-			<-time.After(10 * time.Millisecond)
+			<-waitStart
 
 			url := fmt.Sprintf("http://%s", ln.Addr().String())
 
@@ -937,13 +938,14 @@ func TestHttpServerHeaders(t *testing.T) {
 				}))
 			require.NoError(t, err)
 
+			startChan := make(chan struct{})
 			go func() {
+				close(startChan)
 				_ = s.Serve(ln)
 			}()
 
-			// TODO: make starting server deterministic
 			// Wait for the servers to start
-			<-time.After(10 * time.Millisecond)
+			<-startChan
 
 			url := fmt.Sprintf("http://%s", ln.Addr().String())
 


### PR DESCRIPTION
Since the listener is already listening, the Serve call will not introduce a delay in processing requests.
It is then fair to block the main thread on waiting the goroutine to be started, and unblock before Serve is called.