### PR TITLE
[chore] remove confighttp TODO

### DIFF
--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -358,7 +358,6 @@ func (hss *HTTPServerSettings) ToServer(host component.Host, settings component.
 	}
 
 	// Enable OpenTelemetry observability plugin.
-	// TODO: Consider to use component ID string as prefix for all the operations.
 	handler = otelhttp.NewHandler(
 		handler,
 		"",


### PR DESCRIPTION
Remove a TODO recommending to look at set the operation name prefix as the component ID.
We already set the exporter ID as the name of the tracer in [receiverhelper](https://github.com/open-telemetry/opentelemetry-collector/blob/b5635a7a90d204453915db36e4e29182ee2dddb2/receiver/receiverhelper/obsreport.go#L79).
The component ID is also not available in this section of the code.