### PR TITLE
[exporter/otlp] add error message when no spans can be read from JSON

### DIFF
--- a/.chloggen/fix_no_error_when_no_spans_read.yaml
+++ b/.chloggen/fix_no_error_when_no_spans_read.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: If no spans can be read from the JSON payload, return an error message.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6320]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/otlpreceiver/internal/trace/otlp.go
+++ b/receiver/otlpreceiver/internal/trace/otlp.go
@@ -11,7 +11,10 @@ import (
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 )
 
-const dataFormatProtobuf = "protobuf"
+const (
+	dataFormatProtobuf = "protobuf"
+	noSpans            = "no spans read in payload"
+)
 
 // Receiver is the type used to handle spans from OpenTelemetry exporters.
 type Receiver struct {
@@ -34,7 +37,9 @@ func (r *Receiver) Export(ctx context.Context, req ptraceotlp.ExportRequest) (pt
 	// We need to ensure that it propagates the receiver name as a tag
 	numSpans := td.SpanCount()
 	if numSpans == 0 {
-		return ptraceotlp.NewExportResponse(), nil
+		resp := ptraceotlp.NewExportResponse()
+		resp.PartialSuccess().SetErrorMessage(noSpans)
+		return resp, nil
 	}
 
 	ctx = r.obsreport.StartTracesOp(ctx)


### PR DESCRIPTION
**Description:**
If no spans can be read from the JSON payload, return an error message.

**Link to tracking Issue:**
Fixes #6320

**Testing:**
Unit test.

