### PR TITLE
[component] deprecate component.UnmarshalConfig

### DIFF
--- a/.chloggen/deprecate_UnmarshalConfig.yaml
+++ b/.chloggen/deprecate_UnmarshalConfig.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: config
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate component.UnmarshalConfig. Prefer `conf.Unmarshal(cfg)` instead
+
+# One or more tracking issues or pull requests related to the change
+issues: [7102]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/component/config.go
+++ b/component/config.go
@@ -27,12 +27,9 @@ var configValidatorType = reflect.TypeOf((*ConfigValidator)(nil)).Elem()
 // UnmarshalConfig helper function to UnmarshalConfig a Config.
 // It checks if the config implements confmap.Unmarshaler and uses that if available,
 // otherwise uses Map.UnmarshalExact, erroring if a field is nonexistent.
+// Deprecated: Use `conf.Unmarshal(cfg)` instead.
 func UnmarshalConfig(conf *confmap.Conf, intoCfg Config) error {
-	if cu, ok := intoCfg.(confmap.Unmarshaler); ok {
-		return cu.Unmarshal(conf)
-	}
-
-	return conf.Unmarshal(intoCfg, confmap.WithErrorUnused())
+	return conf.Unmarshal(intoCfg)
 }
 
 // ConfigValidator defines an optional interface for configurations to implement to do validation.

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -51,15 +51,24 @@ type UnmarshalOption interface {
 }
 
 type unmarshalOption struct {
-	errorUnused bool
+	ignoreErrorUnused bool
 }
 
 // WithErrorUnused sets an option to error when there are existing
 // keys in the original Conf that were unused in the decoding process
-// (extra keys).
+// (extra keys). This option is enabled by default and can be disabled with `WithIgnoreErrorUnused`.
 func WithErrorUnused() UnmarshalOption {
 	return unmarshalOptionFunc(func(uo *unmarshalOption) {
-		uo.errorUnused = true
+		uo.ignoreErrorUnused = false
+	})
+}
+
+// WithIgnoreErrorUnused sets an option to ignore errors if existing
+// keys in the original Conf were unused in the decoding process
+// (extra keys).
+func WithIgnoreErrorUnused() UnmarshalOption {
+	return unmarshalOptionFunc(func(uo *unmarshalOption) {
+		uo.ignoreErrorUnused = true
 	})
 }
 
@@ -76,7 +85,7 @@ func (l *Conf) Unmarshal(result any, opts ...UnmarshalOption) error {
 	for _, opt := range opts {
 		opt.apply(&set)
 	}
-	return decodeConfig(l, result, set.errorUnused)
+	return decodeConfig(l, result, !set.ignoreErrorUnused)
 }
 
 type marshalOption struct{}

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -150,6 +150,8 @@ func TestUnmarshalWithErrorUnused(t *testing.T) {
 	}
 	conf := NewFromStringMap(stringMap)
 	assert.Error(t, conf.Unmarshal(&TestIDConfig{}, WithErrorUnused()))
+	assert.Error(t, conf.Unmarshal(&TestIDConfig{}))
+	assert.NoError(t, conf.Unmarshal(&TestIDConfig{}, WithIgnoreErrorUnused()))
 }
 
 type TestConfig struct {

--- a/exporter/debugexporter/config_test.go
+++ b/exporter/debugexporter/config_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -19,7 +18,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -49,7 +48,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			require.NoError(t, err)
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
-			err = component.UnmarshalConfig(cm, cfg)
+			err = cm.Unmarshal(&cfg)
 			if tt.expectedErr != "" {
 				assert.EqualError(t, err, tt.expectedErr)
 			} else {
@@ -91,7 +90,7 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 
 			outCfg := &Config{}
 
-			err = component.UnmarshalConfig(conf, outCfg)
+			err = conf.Unmarshal(&outCfg)
 
 			if tc.expectedErr == "" {
 				assert.NoError(t, err)

--- a/exporter/loggingexporter/config.go
+++ b/exporter/loggingexporter/config.go
@@ -65,7 +65,7 @@ func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
 		return fmt.Errorf("'loglevel' and 'verbosity' are incompatible. Use only 'verbosity' instead")
 	}
 
-	if err := conf.Unmarshal(cfg, confmap.WithErrorUnused()); err != nil {
+	if err := conf.Unmarshal(cfg); err != nil {
 		return err
 	}
 

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -20,7 +19,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -61,11 +60,11 @@ func TestUnmarshalConfig(t *testing.T) {
 		},
 		{
 			filename:    "invalid_verbosity_loglevel.yaml",
-			expectedErr: "'loglevel' and 'verbosity' are incompatible. Use only 'verbosity' instead",
+			expectedErr: "error decoding '': 'loglevel' and 'verbosity' are incompatible. Use only 'verbosity' instead",
 		},
 		{
 			filename:    "config_loglevel_typo.yaml",
-			expectedErr: "1 error(s) decoding:\n\n* '' has invalid keys: logLevel",
+			expectedErr: "error decoding '': 1 error(s) decoding:\n\n* '' has invalid keys: logLevel",
 		},
 	}
 
@@ -75,7 +74,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			require.NoError(t, err)
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
-			err = component.UnmarshalConfig(cm, cfg)
+			err = cm.Unmarshal(&cfg)
 			if tt.expectedErr != "" {
 				assert.EqualError(t, err, tt.expectedErr)
 			} else {
@@ -120,7 +119,7 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 				LogLevel:  zapcore.DebugLevel,
 				Verbosity: configtelemetry.LevelNormal,
 			},
-			expectedErr: "'loglevel' and 'verbosity' are incompatible. Use only 'verbosity' instead",
+			expectedErr: "error decoding '': 'loglevel' and 'verbosity' are incompatible. Use only 'verbosity' instead",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -135,7 +134,7 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 
 			outCfg := &Config{}
 
-			err = component.UnmarshalConfig(conf, outCfg)
+			err = conf.Unmarshal(&outCfg)
 
 			if tc.expectedErr == "" {
 				assert.NoError(t, err)

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -25,7 +25,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -34,7 +34,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			TimeoutSettings: exporterhelper.TimeoutSettings{

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -24,7 +24,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 	// Default/Empty config is invalid.
 	assert.Error(t, component.ValidateConfig(cfg))
@@ -35,7 +35,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			RetryConfig: configretry.BackOffConfig{

--- a/extension/ballastextension/config_test.go
+++ b/extension/ballastextension/config_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -18,7 +17,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -27,7 +26,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			SizeMiB:          123,

--- a/extension/zpagesextension/config_test.go
+++ b/extension/zpagesextension/config_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -19,7 +18,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -28,7 +27,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			TCPAddr: confignet.TCPAddr{

--- a/otelcol/internal/configunmarshaler/configs.go
+++ b/otelcol/internal/configunmarshaler/configs.go
@@ -23,7 +23,7 @@ func NewConfigs[F component.Factory](factories map[component.Type]F) *Configs[F]
 
 func (c *Configs[F]) Unmarshal(conf *confmap.Conf) error {
 	rawCfgs := make(map[component.ID]map[string]any)
-	if err := conf.Unmarshal(&rawCfgs, confmap.WithErrorUnused()); err != nil {
+	if err := conf.Unmarshal(&rawCfgs); err != nil {
 		return err
 	}
 
@@ -42,7 +42,7 @@ func (c *Configs[F]) Unmarshal(conf *confmap.Conf) error {
 
 		// Now that the default config struct is created we can Unmarshal into it,
 		// and it will apply user-defined config on top of the default.
-		if err := component.UnmarshalConfig(confmap.NewFromStringMap(value), cfg); err != nil {
+		if err := confmap.NewFromStringMap(value).Unmarshal(&cfg); err != nil {
 			return errorUnmarshalError(id, err)
 		}
 

--- a/otelcol/unmarshaler.go
+++ b/otelcol/unmarshaler.go
@@ -66,5 +66,5 @@ func unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
 		},
 	}
 
-	return cfg, v.Unmarshal(&cfg, confmap.WithErrorUnused())
+	return cfg, v.Unmarshal(&cfg)
 }

--- a/otelcol/unmarshaler_test.go
+++ b/otelcol/unmarshaler_test.go
@@ -135,7 +135,7 @@ func TestPipelineConfigUnmarshalError(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			pips := new(pipelines.Config)
-			err := tt.conf.Unmarshal(&pips, confmap.WithErrorUnused())
+			err := tt.conf.Unmarshal(&pips)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectError)
 		})
@@ -203,7 +203,7 @@ func TestServiceUnmarshalError(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.conf.Unmarshal(&service.Config{}, confmap.WithErrorUnused())
+			err := tt.conf.Unmarshal(&service.Config{})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectError)
 		})

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -19,7 +18,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -28,7 +27,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			SendBatchSize:            uint32(10000),

--- a/processor/memorylimiterprocessor/config_test.go
+++ b/processor/memorylimiterprocessor/config_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -19,7 +18,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -28,7 +27,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			CheckInterval:       5 * time.Second,

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -60,7 +60,7 @@ func (cfg *Config) Validate() error {
 // Unmarshal a confmap.Conf into the config struct.
 func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
 	// first load the config normally
-	err := conf.Unmarshal(cfg, confmap.WithErrorUnused())
+	err := conf.Unmarshal(cfg)
 	if err != nil {
 		return err
 	}

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -25,7 +25,7 @@ func TestUnmarshalDefaultConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -34,7 +34,7 @@ func TestUnmarshalConfigOnlyGRPC(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyGRPC := factory.CreateDefaultConfig().(*Config)
 	defaultOnlyGRPC.HTTP = nil
@@ -46,7 +46,7 @@ func TestUnmarshalConfigOnlyHTTP(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyHTTP := factory.CreateDefaultConfig().(*Config)
 	defaultOnlyHTTP.GRPC = nil
@@ -58,7 +58,7 @@ func TestUnmarshalConfigOnlyHTTPNull(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyHTTP := factory.CreateDefaultConfig().(*Config)
 	defaultOnlyHTTP.GRPC = nil
@@ -70,7 +70,7 @@ func TestUnmarshalConfigOnlyHTTPEmptyMap(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyHTTP := factory.CreateDefaultConfig().(*Config)
 	defaultOnlyHTTP.GRPC = nil
@@ -82,7 +82,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			Protocols: Protocols{
@@ -143,7 +143,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			Protocols: Protocols{
@@ -171,7 +171,7 @@ func TestUnmarshalConfigTypoDefaultProtocol(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.EqualError(t, component.UnmarshalConfig(cm, cfg), "1 error(s) decoding:\n\n* 'protocols' has invalid keys: htttp")
+	assert.EqualError(t, cm.Unmarshal(&cfg), "1 error(s) decoding:\n\n* 'protocols' has invalid keys: htttp")
 }
 
 func TestUnmarshalConfigInvalidProtocol(t *testing.T) {
@@ -179,7 +179,7 @@ func TestUnmarshalConfigInvalidProtocol(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.EqualError(t, component.UnmarshalConfig(cm, cfg), "1 error(s) decoding:\n\n* 'protocols' has invalid keys: thrift")
+	assert.EqualError(t, cm.Unmarshal(&cfg), "1 error(s) decoding:\n\n* 'protocols' has invalid keys: thrift")
 }
 
 func TestUnmarshalConfigEmptyProtocols(t *testing.T) {
@@ -187,7 +187,7 @@ func TestUnmarshalConfigEmptyProtocols(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.EqualError(t, component.ValidateConfig(cfg), "must specify at least one protocol when using the OTLP receiver")
 }
 
@@ -216,7 +216,7 @@ func TestUnmarshalConfigInvalidSignalPath(t *testing.T) {
 			require.NoError(t, err)
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
-			assert.EqualError(t, component.UnmarshalConfig(cm, cfg), "invalid HTTP URL path set for signal: parse \":invalid\": missing protocol scheme")
+			assert.EqualError(t, cm.Unmarshal(&cfg), "invalid HTTP URL path set for signal: parse \":invalid\": missing protocol scheme")
 		})
 	}
 }
@@ -224,6 +224,6 @@ func TestUnmarshalConfigInvalidSignalPath(t *testing.T) {
 func TestUnmarshalConfigEmpty(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, component.UnmarshalConfig(confmap.New(), cfg))
+	assert.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.EqualError(t, component.ValidateConfig(cfg), "must specify at least one protocol when using the OTLP receiver")
 }


### PR DESCRIPTION
**Description:**
Deprecate component.UnmarshalConfig. Prefer `conf.Unmarshal(cfg)` instead
This PR also makes the `WithErrorUnused()` option enabled by default.

**Link to tracking Issue:**
Fixes #7102

**Documentation:**
Added deprecation information