### PR TITLE
[configtls] add include_system_ca_certs_pool

### DIFF
--- a/.chloggen/UseSystemCACerts.yaml
+++ b/.chloggen/UseSystemCACerts.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: configtls
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `use_system_ca_certs` to configtls, allowing to load system certs and additional custom certs.
+note: Add `include_system_ca_certs_pool` to configtls, allowing to load system certs and additional custom certs.
 
 # One or more tracking issues or pull requests related to the change
 issues: [7774]

--- a/.chloggen/UseSystemCACerts.yaml
+++ b/.chloggen/UseSystemCACerts.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configtls
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `use_system_ca_certs` to configtls, allowing to load system certs and additional custom certs.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7774]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -31,12 +31,18 @@ A certificate authority may also need to be defined:
   system root CA. Should only be used if `insecure` is set to false.
   - `ca_pem`: Alternative to `ca_file`. Provide the CA cert contents as a string instead of a filepath.
 
+You can also combine defining a certificate authority with the system certificate authorities.
+
+- `use_system_ca_certs` (default = false): whether to load the system certificate authorities
+  alongside the certificate authority.
+
 Additionally you can configure TLS to be enabled but skip verifying the server's
 certificate chain. This cannot be combined with `insecure` since `insecure`
 won't use TLS at all.
 
 - `insecure_skip_verify` (default = false): whether to skip verifying the
   certificate or not.
+
 
 Minimum and maximum TLS version can be set:
 

--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -33,7 +33,7 @@ A certificate authority may also need to be defined:
 
 You can also combine defining a certificate authority with the system certificate authorities.
 
-- `use_system_ca_certs` (default = false): whether to load the system certificate authorities
+- `include_system_ca_certs_pool` (default = false): whether to load the system certificate authorities pool
   alongside the certificate authority.
 
 Additionally you can configure TLS to be enabled but skip verifying the server's
@@ -42,7 +42,6 @@ won't use TLS at all.
 
 - `insecure_skip_verify` (default = false): whether to skip verifying the
   certificate or not.
-
 
 Minimum and maximum TLS version can be set:
 

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -29,9 +29,6 @@ var systemCertPool = x509.SystemCertPool
 // Note: Since there isn't anything specific to a server connection. Components
 // with server connections should use TLSSetting.
 type TLSSetting struct {
-	// If true, load system CA certificates pool in addition to the certificates
-	// configured in this struct.
-	IncludeSystemCACertsPool bool `mapstructure:"include_system_ca_certs_pool"`
 	// Path to the CA cert. For a client this verifies the server certificate.
 	// For a server this verifies client certificates. If empty uses system root CA.
 	// (optional)
@@ -39,6 +36,10 @@ type TLSSetting struct {
 
 	// In memory PEM encoded cert. (optional)
 	CAPem configopaque.String `mapstructure:"ca_pem"`
+
+	// If true, load system CA certificates pool in addition to the certificates
+	// configured in this struct.
+	IncludeSystemCACertsPool bool `mapstructure:"include_system_ca_certs_pool"`
 
 	// Path to the TLS cert to use for TLS required connections. (optional)
 	CertFile string `mapstructure:"cert_file"`

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -27,9 +27,9 @@ const defaultMaxTLSVersion = 0
 // Note: Since there isn't anything specific to a server connection. Components
 // with server connections should use TLSSetting.
 type TLSSetting struct {
-	// If true, load system certificates in addition to the certificates
+	// If true, load system CA certificates pool in addition to the certificates
 	// configured in this struct.
-	UseSystemCACerts bool `mapstructure:"use_system_ca_certs"`
+	IncludeSystemCACertsPool bool `mapstructure:"include_system_ca_certs_pool"`
 	// Path to the CA cert. For a client this verifies the server certificate.
 	// For a server this verifies client certificates. If empty uses system root CA.
 	// (optional)
@@ -308,7 +308,7 @@ func (c TLSSetting) loadCert(caPath string) (*x509.CertPool, error) {
 	}
 
 	var certPool *x509.CertPool
-	if c.UseSystemCACerts {
+	if c.IncludeSystemCACertsPool {
 		if certPool, err = x509.SystemCertPool(); err != nil {
 			return nil, err
 		}

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -312,7 +312,8 @@ func (c TLSSetting) loadCert(caPath string) (*x509.CertPool, error) {
 		if certPool, err = x509.SystemCertPool(); err != nil {
 			return nil, err
 		}
-	} else {
+	}
+	if certPool == nil {
 		certPool = x509.NewCertPool()
 	}
 	if !certPool.AppendCertsFromPEM(caPEM) {

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -23,6 +23,8 @@ const defaultMinTLSVersion = tls.VersionTLS12
 // Uses the default MaxVersion from "crypto/tls" which is the maximum supported version
 const defaultMaxTLSVersion = 0
 
+var systemCertPool = x509.SystemCertPool
+
 // TLSSetting exposes the common client and server TLS configurations.
 // Note: Since there isn't anything specific to a server connection. Components
 // with server connections should use TLSSetting.
@@ -309,7 +311,7 @@ func (c TLSSetting) loadCert(caPath string) (*x509.CertPool, error) {
 
 	var certPool *x509.CertPool
 	if c.IncludeSystemCACertsPool {
-		if certPool, err = x509.SystemCertPool(); err != nil {
+		if certPool, err = systemCertPool(); err != nil {
 			return nil, err
 		}
 	}

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -35,7 +35,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name:    "should load system CA and custom CA",
-			options: TLSSetting{UseSystemCACerts: true, CAFile: filepath.Join("testdata", "ca-1.crt")},
+			options: TLSSetting{IncludeSystemCACertsPool: true, CAFile: filepath.Join("testdata", "ca-1.crt")},
 		},
 		{
 			name:        "should fail with invalid CA file path",

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -34,6 +34,10 @@ func TestOptionsToConfig(t *testing.T) {
 			options: TLSSetting{CAFile: filepath.Join("testdata", "ca-1.crt")},
 		},
 		{
+			name:    "should load system CA and custom CA",
+			options: TLSSetting{UseSystemCACerts: true, CAFile: filepath.Join("testdata", "ca-1.crt")},
+		},
+		{
 			name:        "should fail with invalid CA file path",
 			options:     TLSSetting{CAFile: filepath.Join("testdata", "not/valid")},
 			expectError: "failed to load CA",


### PR DESCRIPTION
**Description:**
Add `include_system_ca_certs_pool` to configtls, allowing to load system certs and additional custom certs.

**Link to tracking Issue:**
Fixes #7774

**Testing:**
UTs

**Documentation:**
Added to README
