### PR TITLE
[chore] [exporterhelper] Add an option for items based queue sizing

### DIFF
--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -16,35 +16,40 @@ import (
 // the producer are dropped.
 type boundedMemoryQueue[T any] struct {
 	component.StartFunc
-	items chan queueRequest[T]
+	QueueCapacityLimiter[T]
+	inCh  chan<- queueRequest[T]
+	outCh <-chan queueRequest[T]
 }
 
 // NewBoundedMemoryQueue constructs the new queue of specified capacity, and with an optional
 // callback for dropped items (e.g. useful to emit metrics).
-func NewBoundedMemoryQueue[T any](capacity int) Queue[T] {
+func NewBoundedMemoryQueue[T any](capacityLimiter QueueCapacityLimiter[T]) Queue[T] {
+	inCh, outCh := newUnboundedChannel[queueRequest[T]]()
 	return &boundedMemoryQueue[T]{
-		items: make(chan queueRequest[T], capacity),
+		QueueCapacityLimiter: capacityLimiter,
+		inCh:                 inCh,
+		outCh:                outCh,
 	}
 }
 
 // Offer is used by the producer to submit new item to the queue. Calling this method on a stopped queue will panic.
 func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
-	select {
-	case q.items <- queueRequest[T]{ctx: ctx, req: req}:
-		return nil
-	default:
+	if !q.QueueCapacityLimiter.claim(req) {
 		return ErrQueueIsFull
 	}
+	q.inCh <- queueRequest[T]{ctx: ctx, req: req}
+	return nil
 }
 
 // Consume applies the provided function on the head of queue.
 // The call blocks until there is an item available or the queue is stopped.
 // The function returns true when an item is consumed or false if the queue is stopped and emptied.
 func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T) error) bool {
-	item, ok := <-q.items
+	item, ok := <-q.outCh
 	if !ok {
 		return false
 	}
+	q.QueueCapacityLimiter.release(item.req)
 	// the memory queue doesn't handle consume errors
 	_ = consumeFunc(item.ctx, item.req)
 	return true
@@ -52,17 +57,8 @@ func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T) err
 
 // Shutdown closes the queue channel to initiate draining of the queue.
 func (q *boundedMemoryQueue[T]) Shutdown(context.Context) error {
-	close(q.items)
+	close(q.inCh)
 	return nil
-}
-
-// Size returns the current size of the queue
-func (q *boundedMemoryQueue[T]) Size() int {
-	return len(q.items)
-}
-
-func (q *boundedMemoryQueue[T]) Capacity() int {
-	return cap(q.items)
 }
 
 type queueRequest[T any] struct {

--- a/exporter/exporterhelper/internal/queue_capacity.go
+++ b/exporter/exporterhelper/internal/queue_capacity.go
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+
+import (
+	"sync/atomic"
+)
+
+type itemsCounter interface {
+	ItemsCount() int
+}
+
+// QueueCapacityLimiter is an interface to control the capacity of the queue.
+type QueueCapacityLimiter[T any] interface {
+	// Capacity is the maximum capacity of the queue.
+	Capacity() int
+	// Size returns the current size of the queue.
+	Size() int
+	// claim tries to claim capacity for the given element. If the capacity is not available, it returns false.
+	claim(T) bool
+	// release releases capacity for the given queue element.
+	release(T)
+	// sizeOf returns the size of the given element.
+	sizeOf(T) uint64
+}
+
+type baseCapacityLimiter[T any] struct {
+	used *atomic.Uint64
+	cap  uint64
+}
+
+func newBaseCapacityLimiter[T any](capacity int) baseCapacityLimiter[T] {
+	return baseCapacityLimiter[T]{
+		used: &atomic.Uint64{},
+		cap:  uint64(capacity),
+	}
+}
+
+func (bcl *baseCapacityLimiter[T]) Capacity() int {
+	return int(bcl.cap)
+}
+
+func (bcl *baseCapacityLimiter[T]) Size() int {
+	return int(bcl.used.Load())
+}
+
+// nolint:unused false positive https://github.com/dominikh/go-tools/issues/1440
+func (bcl *baseCapacityLimiter[T]) claim(size uint64) bool {
+	if bcl.used.Add(size) > bcl.cap {
+		bcl.release(size)
+		return false
+	}
+	return true
+}
+
+// nolint:unused false positive https://github.com/dominikh/go-tools/issues/1440
+func (bcl *baseCapacityLimiter[T]) release(size uint64) {
+	bcl.used.Add(^(size - 1))
+}
+
+// itemsCapacityLimiter is a capacity limiter that limits the queue based on the number of items (e.g. spans, log records).
+type itemsCapacityLimiter[T itemsCounter] struct {
+	baseCapacityLimiter[T]
+}
+
+func NewItemsCapacityLimiter[T itemsCounter](capacity int) QueueCapacityLimiter[T] {
+	return &itemsCapacityLimiter[T]{baseCapacityLimiter: newBaseCapacityLimiter[T](capacity)}
+}
+
+func (icl *itemsCapacityLimiter[T]) claim(el T) bool {
+	return icl.baseCapacityLimiter.claim(uint64(el.ItemsCount()))
+}
+
+// nolint:unused false positive https://github.com/dominikh/go-tools/issues/1440
+func (icl *itemsCapacityLimiter[T]) release(el T) {
+	icl.baseCapacityLimiter.release(uint64(el.ItemsCount()))
+}
+
+// nolint:unused false positive https://github.com/dominikh/go-tools/issues/1440
+func (icl *itemsCapacityLimiter[T]) sizeOf(el T) uint64 {
+	return uint64(el.ItemsCount())
+}
+
+// requestsCapacityLimiter is a capacity limiter that limits the queue based on the number of requests.
+type requestsCapacityLimiter[T any] struct {
+	baseCapacityLimiter[T]
+}
+
+func NewRequestsCapacityLimiter[T any](capacity int) QueueCapacityLimiter[T] {
+	return &requestsCapacityLimiter[T]{baseCapacityLimiter: newBaseCapacityLimiter[T](capacity)}
+}
+
+// nolint:unused false positive https://github.com/dominikh/go-tools/issues/1440
+func (rcl *requestsCapacityLimiter[T]) claim(T) bool {
+	return rcl.baseCapacityLimiter.claim(1)
+}
+
+// nolint:unused false positive https://github.com/dominikh/go-tools/issues/1440
+func (rcl *requestsCapacityLimiter[T]) release(T) {
+	rcl.baseCapacityLimiter.release(1)
+}
+
+// nolint:unused false positive https://github.com/dominikh/go-tools/issues/1440
+func (rcl *requestsCapacityLimiter[T]) sizeOf(T) uint64 {
+	return 1
+}

--- a/exporter/exporterhelper/internal/queue_capacity_test.go
+++ b/exporter/exporterhelper/internal/queue_capacity_test.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestsCapacityLimiter(t *testing.T) {
+	rl := NewRequestsCapacityLimiter[fakeReq](2)
+	assert.Equal(t, 0, rl.Size())
+	assert.Equal(t, 2, rl.Capacity())
+
+	req := fakeReq{itemsCount: 5}
+
+	assert.True(t, rl.claim(req))
+	assert.Equal(t, 1, rl.Size())
+
+	assert.True(t, rl.claim(req))
+	assert.Equal(t, 2, rl.Size())
+
+	assert.False(t, rl.claim(req))
+	assert.Equal(t, 2, rl.Size())
+
+	rl.release(req)
+	assert.Equal(t, 1, rl.Size())
+}
+
+func TestItemsCapacityLimiter(t *testing.T) {
+	rl := NewItemsCapacityLimiter[fakeReq](7)
+	assert.Equal(t, 0, rl.Size())
+	assert.Equal(t, 7, rl.Capacity())
+
+	req := fakeReq{itemsCount: 3}
+
+	assert.True(t, rl.claim(req))
+	assert.Equal(t, 3, rl.Size())
+
+	assert.True(t, rl.claim(req))
+	assert.Equal(t, 6, rl.Size())
+
+	assert.False(t, rl.claim(req))
+	assert.Equal(t, 6, rl.Size())
+
+	rl.release(req)
+	assert.Equal(t, 3, rl.Size())
+}
+
+type fakeReq struct {
+	itemsCount int
+}
+
+func (r fakeReq) ItemsCount() int {
+	return r.itemsCount
+}

--- a/exporter/exporterhelper/internal/unbounded_channel.go
+++ b/exporter/exporterhelper/internal/unbounded_channel.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+
+// newUnboundedChannel creates a pair of buffered channels with no cap.
+// Caller should close the input channel when done. That will trigger draining of the output channel.
+// Closing the output channel by client will panic.
+func newUnboundedChannel[T any]() (chan<- T, <-chan T) {
+	in, out := make(chan T), make(chan T)
+	go func() {
+		var queue []T
+		for len(queue) > 0 || in != nil {
+			var outCh chan T
+			var curVal T
+			if len(queue) > 0 {
+				outCh = out
+				curVal = queue[0]
+			}
+			select {
+			case v, ok := <-in:
+				if !ok {
+					in = nil
+				} else {
+					queue = append(queue, v)
+				}
+			case outCh <- curVal:
+				queue = queue[1:]
+			}
+		}
+		close(out)
+	}()
+	return in, out
+}

--- a/exporter/exporterhelper/internal/unbounded_channel_test.go
+++ b/exporter/exporterhelper/internal/unbounded_channel_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewUnboundedChannel(t *testing.T) {
+	in, out := newUnboundedChannel[int]()
+	assert.NotNil(t, in)
+	assert.NotNil(t, out)
+
+	in <- 1
+	in <- 2
+
+	assert.Equal(t, 1, <-out)
+	in <- 3
+	assert.Equal(t, 2, <-out)
+	assert.Equal(t, 3, <-out)
+	in <- 4
+	assert.Equal(t, 4, <-out)
+}

--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -90,11 +90,11 @@ func newQueueSender(config QueueSettings, set exporter.CreateSettings, signal co
 
 	isPersistent := config.StorageID != nil
 	var queue internal.Queue[Request]
+	capLimiter := internal.NewRequestsCapacityLimiter[Request](config.QueueSize)
 	if isPersistent {
-		queue = internal.NewPersistentQueue[Request](
-			config.QueueSize, signal, *config.StorageID, marshaler, unmarshaler, set)
+		queue = internal.NewPersistentQueue[Request](capLimiter, signal, *config.StorageID, marshaler, unmarshaler, set)
 	} else {
-		queue = internal.NewBoundedMemoryQueue[Request](config.QueueSize)
+		queue = internal.NewBoundedMemoryQueue[Request](capLimiter)
 	}
 	qs := &queueSender{
 		fullName:       set.ID.String(),


### PR DESCRIPTION
Introduce an option to limit the queue size by the number of items instead of number of requests. This is preliminary step for having the exporter helper v2 with a batcher sender placed after the queue sender. Otherwise, it'll be hard for the users to estimate the queue size based on the number of requests without batch processor in front of it.

This change doesn't effect the existing functionality and the items based queue limiting cannot be utilized yet.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/8122