### PR TITLE
[chore] Fix PR template so that comments aren't seen in markdown

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,16 +3,16 @@ We are currently preparing for the upcoming 1.0 GA release. Pull requests that a
 the current roadmap and are not aimed at stabilizing and preparing the Collector for the release will
 not be accepted.
 
-_Delete this paragraph before submitting._
+_Delete the preceding paragraph before submitting._
 
-**Description:** <Describe what has changed. 
-Ex. Fixing a bug - Describe the bug and how this fixes the issue.
-Ex. Adding a feature - Explain what this achieves.>
+**Description:** <Describe what has changed.>
+<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
+Ex. Adding a feature - Explain what this achieves.-->
 
 **Link to tracking Issue:** <Issue number if applicable>
 
-**Testing:** < Describe what testing was performed and which tests were added.>
+**Testing:** <Describe what testing was performed and which tests were added.>
 
-**Documentation:** < Describe the documentation added.>
+**Documentation:** <Describe the documentation added.>
 
 _Please delete paragraphs that you did not use before submitting._


### PR DESCRIPTION
**Description:**
Currently when submitting a PR the section descriptions will be shown in the markdown view when they should be hidden. This now follows [contrib's template formatting](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/pull_request_template.md?plain=1).