### PR TITLE
[chore] polish sharedcomponent API

### DIFF
--- a/internal/sharedcomponent/sharedcomponent.go
+++ b/internal/sharedcomponent/sharedcomponent.go
@@ -13,24 +13,20 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-// Map keeps reference of all created instances for a given shared key such as a component configuration.
-type Map[K comparable, V component.Component] interface {
-	// LoadOrStore returns the already created instance if exists, otherwise creates a new instance
-	// and adds it to the map of references.
-	LoadOrStore(key K, create func() (V, error), telemetrySettings *component.TelemetrySettings) (*Component[V], error)
-}
-
-func NewMap[K comparable, V component.Component]() Map[K, V] {
-	return &mapImpl[K, V]{
+func NewMap[K comparable, V component.Component]() *Map[K, V] {
+	return &Map[K, V]{
 		components: map[K]*Component[V]{},
 	}
 }
 
-type mapImpl[K comparable, V component.Component] struct {
+// Map keeps reference of all created instances for a given shared key such as a component configuration.
+type Map[K comparable, V component.Component] struct {
 	components map[K]*Component[V]
 }
 
-func (m *mapImpl[K, V]) LoadOrStore(key K, create func() (V, error), telemetrySettings *component.TelemetrySettings) (*Component[V], error) {
+// LoadOrStore returns the already created instance if exists, otherwise creates a new instance
+// and adds it to the map of references.
+func (m *Map[K, V]) LoadOrStore(key K, create func() (V, error), telemetrySettings *component.TelemetrySettings) (*Component[V], error) {
 	if c, ok := m.components[key]; ok {
 		// If we haven't already seen this telemetry settings, this shared component represents
 		// another instance. Wrap ReportComponentStatus to report for all instances this shared

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -25,11 +25,11 @@ type baseComponent struct {
 
 func TestNewMap(t *testing.T) {
 	comps := NewMap[component.ID, *baseComponent]()
-	assert.Len(t, comps.(*mapImpl[component.ID, *baseComponent]).components, 0)
+	assert.Len(t, comps.components, 0)
 }
 
 func TestNewSharedComponentsCreateError(t *testing.T) {
-	comps := NewMap[component.ID, *baseComponent]().(*mapImpl[component.ID, *baseComponent])
+	comps := NewMap[component.ID, *baseComponent]()
 	assert.Len(t, comps.components, 0)
 	myErr := errors.New("my error")
 	_, err := comps.LoadOrStore(
@@ -51,7 +51,7 @@ func TestSharedComponentsLoadOrStore(t *testing.T) {
 		newNopTelemetrySettings(),
 	)
 	require.NoError(t, err)
-	assert.Len(t, comps.(*mapImpl[component.ID, *baseComponent]).components, 1)
+	assert.Len(t, comps.components, 1)
 	assert.Same(t, nop, got.Unwrap())
 	gotSecond, err := comps.LoadOrStore(
 		id,
@@ -64,7 +64,7 @@ func TestSharedComponentsLoadOrStore(t *testing.T) {
 
 	// Shutdown nop will remove
 	assert.NoError(t, got.Shutdown(context.Background()))
-	assert.Len(t, comps.(*mapImpl[component.ID, *baseComponent]).components, 0)
+	assert.Len(t, comps.components, 0)
 	gotThird, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return nop, nil },
@@ -141,7 +141,7 @@ func TestSharedComponentsReportStatus(t *testing.T) {
 			telemetrySettings,
 		)
 		require.NoError(t, err)
-		assert.Len(t, comps.(*mapImpl[component.ID, *baseComponent]).components, 1)
+		assert.Len(t, comps.components, 1)
 		assert.Same(t, comp, got.Unwrap())
 	}
 

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -286,7 +286,7 @@ func TestReportStatusOnStartShutdown(t *testing.T) {
 				}
 			}
 			comps := Map[component.ID, *baseComponent]{}
-			var comp *SharedComponent[*baseComponent]
+			var comp *Component[*baseComponent]
 			var err error
 			for i := 0; i < 3; i++ {
 				telemetrySettings := newNopTelemetrySettings()

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -141,4 +141,4 @@ func createLog(
 // create separate objects, they must use one otlpReceiver object per configuration.
 // When the receiver is shutdown it should be removed from this map so the same configuration
 // can be recreated successfully.
-var receivers = sharedcomponent.Map[*Config, *otlpReceiver]{}
+var receivers = sharedcomponent.NewMap[*Config, *otlpReceiver]()

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -68,7 +68,7 @@ func createTraces(
 	nextConsumer consumer.Traces,
 ) (receiver.Traces, error) {
 	oCfg := cfg.(*Config)
-	r, err := receivers.GetOrAdd(
+	r, err := receivers.LoadOrStore(
 		oCfg,
 		func() (*otlpReceiver, error) {
 			return newOtlpReceiver(oCfg, &set)
@@ -93,7 +93,7 @@ func createMetrics(
 	consumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	oCfg := cfg.(*Config)
-	r, err := receivers.GetOrAdd(
+	r, err := receivers.LoadOrStore(
 		oCfg,
 		func() (*otlpReceiver, error) {
 			return newOtlpReceiver(oCfg, &set)
@@ -118,7 +118,7 @@ func createLog(
 	consumer consumer.Logs,
 ) (receiver.Logs, error) {
 	oCfg := cfg.(*Config)
-	r, err := receivers.GetOrAdd(
+	r, err := receivers.LoadOrStore(
 		oCfg,
 		func() (*otlpReceiver, error) {
 			return newOtlpReceiver(oCfg, &set)
@@ -141,4 +141,4 @@ func createLog(
 // create separate objects, they must use one otlpReceiver object per configuration.
 // When the receiver is shutdown it should be removed from this map so the same configuration
 // can be recreated successfully.
-var receivers = sharedcomponent.NewSharedComponents[*Config, *otlpReceiver]()
+var receivers = sharedcomponent.Map[*Config, *otlpReceiver]{}


### PR DESCRIPTION
Attempt to simplify as much as possible the API exposed by the sharedcomponent package ahead of exposing it as part of a published module.

Relates to #9156 

Changes:
* Remove the map field in the struct, make the struct a map
* Remove the `NewSharedComponents` function, just initialize the map instead.
* Rename GetOrAdd to LoadOrStore 