### PR TITLE
[confignet] Add new functions that take Context

### DIFF
--- a/.chloggen/confignet-now-with-ctx.yaml
+++ b/.chloggen/confignet-now-with-ctx.yaml
@@ -22,4 +22,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [api]

--- a/.chloggen/confignet-now-with-ctx.yaml
+++ b/.chloggen/confignet-now-with-ctx.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confignet
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecates the `Dial` and `Listen` functions in favor of `DialContext` and `ListenContext`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9163]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -4,6 +4,7 @@
 package confignet // import "go.opentelemetry.io/collector/config/confignet"
 
 import (
+	"context"
 	"net"
 	"time"
 )
@@ -33,13 +34,27 @@ type NetAddr struct {
 }
 
 // Dial equivalent with net.Dial for this address.
+// Deprecated: [v0.92.0] use DialContext instead.
 func (na *NetAddr) Dial() (net.Conn, error) {
 	return net.DialTimeout(na.Transport, na.Endpoint, na.DialerConfig.Timeout)
 }
 
 // Listen equivalent with net.Listen for this address.
+// Deprecated: [v0.92.0] use ListenContext instead.
 func (na *NetAddr) Listen() (net.Listener, error) {
 	return net.Listen(na.Transport, na.Endpoint)
+}
+
+// DialContext equivalent with net.Dialer's DialContext for this address.
+func (na *NetAddr) DialContext(ctx context.Context) (net.Conn, error) {
+	d := net.Dialer{Timeout: na.DialerConfig.Timeout}
+	return d.DialContext(ctx, na.Transport, na.Endpoint)
+}
+
+// ListenContext equivalent with net.ListenConfig's Listen for this address.
+func (na *NetAddr) ListenContext(ctx context.Context) (net.Listener, error) {
+	lc := net.ListenConfig{}
+	return lc.Listen(ctx, na.Transport, na.Endpoint)
 }
 
 // TCPAddr represents a TCP endpoint address.
@@ -56,11 +71,25 @@ type TCPAddr struct {
 }
 
 // Dial equivalent with net.Dial for this address.
+// Deprecated: [v0.92.0] use DialContext instead.
 func (na *TCPAddr) Dial() (net.Conn, error) {
 	return net.DialTimeout("tcp", na.Endpoint, na.DialerConfig.Timeout)
 }
 
 // Listen equivalent with net.Listen for this address.
+// Deprecated: [v0.92.0] use ListenContext instead.
 func (na *TCPAddr) Listen() (net.Listener, error) {
 	return net.Listen("tcp", na.Endpoint)
+}
+
+// DialContext equivalent with net.Dialer's DialContext for this address.
+func (na *TCPAddr) DialContext(ctx context.Context) (net.Conn, error) {
+	d := net.Dialer{Timeout: na.DialerConfig.Timeout}
+	return d.DialContext(ctx, "tcp", na.Endpoint)
+}
+
+// ListenContext equivalent with net.ListenConfig's Listen for this address.
+func (na *TCPAddr) ListenContext(ctx context.Context) (net.Listener, error) {
+	lc := net.ListenConfig{}
+	return lc.Listen(ctx, "tcp", na.Endpoint)
 }

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -4,6 +4,7 @@
 package confignet
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
@@ -52,7 +53,7 @@ func TestNetAddr(t *testing.T) {
 		Endpoint:  "localhost:0",
 		Transport: "tcp",
 	}
-	ln, err := nas.Listen()
+	ln, err := nas.ListenContext(context.Background())
 	assert.NoError(t, err)
 	done := make(chan bool, 1)
 
@@ -73,7 +74,7 @@ func TestNetAddr(t *testing.T) {
 		Transport: "tcp",
 	}
 	var conn net.Conn
-	conn, err = nac.Dial()
+	conn, err = nac.DialContext(context.Background())
 	assert.NoError(t, err)
 	_, err = conn.Write([]byte("test"))
 	assert.NoError(t, err)
@@ -86,7 +87,7 @@ func TestTCPAddr(t *testing.T) {
 	nas := &TCPAddr{
 		Endpoint: "localhost:0",
 	}
-	ln, err := nas.Listen()
+	ln, err := nas.ListenContext(context.Background())
 	assert.NoError(t, err)
 	done := make(chan bool, 1)
 
@@ -106,7 +107,7 @@ func TestTCPAddr(t *testing.T) {
 		Endpoint: ln.Addr().String(),
 	}
 	var conn net.Conn
-	conn, err = nac.Dial()
+	conn, err = nac.DialContext(context.Background())
 	assert.NoError(t, err)
 	_, err = conn.Write([]byte("test"))
 	assert.NoError(t, err)


### PR DESCRIPTION
**Description:** 
Deprecates the `Dial` and `Listen` functions in favor of `DialContext` and `ListenContext`.

**Link to tracking Issue:**
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9105

**Testing:** 
Updated unit tests

**Documentation:**
Added godoc comments