### PR TITLE
[chore] [exporterhelper] Items based queue sizing with bounded channel

### DIFF
--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -16,25 +16,26 @@ import (
 // the producer are dropped.
 type boundedMemoryQueue[T any] struct {
 	component.StartFunc
+	*queueCapacityLimiter[T]
 	items chan queueRequest[T]
 }
 
 // NewBoundedMemoryQueue constructs the new queue of specified capacity, and with an optional
 // callback for dropped items (e.g. useful to emit metrics).
-func NewBoundedMemoryQueue[T any](capacity int) Queue[T] {
+func NewBoundedMemoryQueue[T any](sizer Sizer[T], capacity int) Queue[T] {
 	return &boundedMemoryQueue[T]{
-		items: make(chan queueRequest[T], capacity),
+		queueCapacityLimiter: newQueueCapacityLimiter[T](sizer, capacity),
+		items:                make(chan queueRequest[T], capacity),
 	}
 }
 
 // Offer is used by the producer to submit new item to the queue. Calling this method on a stopped queue will panic.
 func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
-	select {
-	case q.items <- queueRequest[T]{ctx: ctx, req: req}:
-		return nil
-	default:
+	if !q.queueCapacityLimiter.claim(req) {
 		return ErrQueueIsFull
 	}
+	q.items <- queueRequest[T]{ctx: ctx, req: req}
+	return nil
 }
 
 // Consume applies the provided function on the head of queue.
@@ -45,6 +46,7 @@ func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T) err
 	if !ok {
 		return false
 	}
+	q.queueCapacityLimiter.release(item.req)
 	// the memory queue doesn't handle consume errors
 	_ = consumeFunc(item.ctx, item.req)
 	return true
@@ -54,15 +56,6 @@ func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T) err
 func (q *boundedMemoryQueue[T]) Shutdown(context.Context) error {
 	close(q.items)
 	return nil
-}
-
-// Size returns the current size of the queue
-func (q *boundedMemoryQueue[T]) Size() int {
-	return len(q.items)
-}
-
-func (q *boundedMemoryQueue[T]) Capacity() int {
-	return cap(q.items)
 }
 
 type queueRequest[T any] struct {

--- a/exporter/exporterhelper/internal/bounded_memory_queue_test.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue_test.go
@@ -8,7 +8,6 @@ package internal
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -23,7 +22,7 @@ import (
 // We want to test the overflow behavior, so we block the consumer
 // by holding a startLock before submitting items to the queue.
 func TestBoundedQueue(t *testing.T) {
-	q := NewBoundedMemoryQueue[string](1)
+	q := NewBoundedMemoryQueue[string](&RequestSizer[string]{}, 1)
 
 	assert.NoError(t, q.Offer(context.Background(), "a"))
 
@@ -73,7 +72,7 @@ func TestBoundedQueue(t *testing.T) {
 // only after Stop will mean the consumers are still locked while
 // trying to perform the final consumptions.
 func TestShutdownWhileNotEmpty(t *testing.T) {
-	q := NewBoundedMemoryQueue[string](1000)
+	q := NewBoundedMemoryQueue[string](&RequestSizer[string]{}, 1000)
 
 	assert.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
 	for i := 0; i < 10; i++ {
@@ -98,75 +97,70 @@ func TestShutdownWhileNotEmpty(t *testing.T) {
 	}))
 }
 
-func Benchmark_QueueUsage_10000_1_50000(b *testing.B) {
-	benchmarkQueueUsage(b, 10000, 1, 50000)
+func Benchmark_QueueUsage_10000_requests_1_50000(b *testing.B) {
+	benchmarkQueueUsage(b, &RequestSizer[fakeReq]{}, 10000, 1, 50000)
 }
 
-func Benchmark_QueueUsage_10000_2_50000(b *testing.B) {
-	benchmarkQueueUsage(b, 10000, 2, 50000)
-}
-func Benchmark_QueueUsage_10000_5_50000(b *testing.B) {
-	benchmarkQueueUsage(b, 10000, 5, 50000)
-}
-func Benchmark_QueueUsage_10000_10_50000(b *testing.B) {
-	benchmarkQueueUsage(b, 10000, 10, 50000)
+func Benchmark_QueueUsage_10000_requests_10_50000(b *testing.B) {
+	benchmarkQueueUsage(b, &RequestSizer[fakeReq]{}, 10000, 10, 50000)
 }
 
-func Benchmark_QueueUsage_50000_1_50000(b *testing.B) {
-	benchmarkQueueUsage(b, 50000, 1, 50000)
+func Benchmark_QueueUsage_50000_requests_1_50000(b *testing.B) {
+	benchmarkQueueUsage(b, &RequestSizer[fakeReq]{}, 50000, 1, 50000)
 }
 
-func Benchmark_QueueUsage_50000_2_50000(b *testing.B) {
-	benchmarkQueueUsage(b, 50000, 2, 50000)
-}
-func Benchmark_QueueUsage_50000_5_50000(b *testing.B) {
-	benchmarkQueueUsage(b, 50000, 5, 50000)
-}
-func Benchmark_QueueUsage_50000_10_50000(b *testing.B) {
-	benchmarkQueueUsage(b, 50000, 10, 50000)
+func Benchmark_QueueUsage_50000_requests_10_50000(b *testing.B) {
+	benchmarkQueueUsage(b, &RequestSizer[fakeReq]{}, 50000, 10, 50000)
 }
 
-func Benchmark_QueueUsage_10000_1_250000(b *testing.B) {
-	benchmarkQueueUsage(b, 10000, 1, 250000)
+func Benchmark_QueueUsage_10000_requests_1_250000(b *testing.B) {
+	benchmarkQueueUsage(b, &RequestSizer[fakeReq]{}, 10000, 1, 250000)
 }
 
-func Benchmark_QueueUsage_10000_2_250000(b *testing.B) {
-	benchmarkQueueUsage(b, 10000, 2, 250000)
+func Benchmark_QueueUsage_10000_requests_10_250000(b *testing.B) {
+	benchmarkQueueUsage(b, &RequestSizer[fakeReq]{}, 10000, 10, 250000)
 }
-func Benchmark_QueueUsage_10000_5_250000(b *testing.B) {
-	benchmarkQueueUsage(b, 10000, 5, 250000)
+
+func Benchmark_QueueUsage_1M_items_10_250k(b *testing.B) {
+	benchmarkQueueUsage(b, &ItemsSizer[fakeReq]{}, 1000000, 10, 250000)
 }
-func Benchmark_QueueUsage_10000_10_250000(b *testing.B) {
-	benchmarkQueueUsage(b, 10000, 10, 250000)
+
+func Benchmark_QueueUsage_1M_items_10_1M(b *testing.B) {
+	benchmarkQueueUsage(b, &ItemsSizer[fakeReq]{}, 1000000, 10, 1000000)
+}
+
+func Benchmark_QueueUsage_100M_items_10_10M(b *testing.B) {
+	benchmarkQueueUsage(b, &ItemsSizer[fakeReq]{}, 100000000, 10, 10000000)
 }
 
 func TestQueueUsage(t *testing.T) {
 	t.Run("with enough workers", func(t *testing.T) {
-		queueUsage(t, 10000, 5, 1000)
+		queueUsage(t, &RequestSizer[fakeReq]{}, 10000, 5, 1000)
 	})
 	t.Run("past capacity", func(t *testing.T) {
-		queueUsage(t, 10000, 2, 50000)
+		queueUsage(t, &RequestSizer[fakeReq]{}, 10000, 2, 50000)
 	})
 }
 
-func benchmarkQueueUsage(b *testing.B, capacity int, numConsumers int, numberOfItems int) {
+func benchmarkQueueUsage(b *testing.B, sizer Sizer[fakeReq], capacity int, numConsumers int,
+	numberOfItems int) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		queueUsage(b, capacity, numConsumers, numberOfItems)
+		queueUsage(b, sizer, capacity, numConsumers, numberOfItems)
 	}
 }
 
-func queueUsage(tb testing.TB, capacity int, numConsumers int, numberOfItems int) {
+func queueUsage(tb testing.TB, sizer Sizer[fakeReq], capacity int, numConsumers int, numberOfItems int) {
 	var wg sync.WaitGroup
 	wg.Add(numberOfItems)
-	q := NewBoundedMemoryQueue[string](capacity)
-	consumers := NewQueueConsumers(q, numConsumers, func(context.Context, string) error {
+	q := NewBoundedMemoryQueue[fakeReq](sizer, capacity)
+	consumers := NewQueueConsumers(q, numConsumers, func(context.Context, fakeReq) error {
 		wg.Done()
 		return nil
 	})
 	require.NoError(tb, consumers.Start(context.Background(), componenttest.NewNopHost()))
 	for j := 0; j < numberOfItems; j++ {
-		if err := q.Offer(context.Background(), fmt.Sprintf("%d", j)); errors.Is(err, ErrQueueIsFull) {
+		if err := q.Offer(context.Background(), fakeReq{10}); errors.Is(err, ErrQueueIsFull) {
 			wg.Done()
 		}
 	}
@@ -176,7 +170,7 @@ func queueUsage(tb testing.TB, capacity int, numConsumers int, numberOfItems int
 }
 
 func TestZeroSizeNoConsumers(t *testing.T) {
-	q := NewBoundedMemoryQueue[string](0)
+	q := NewBoundedMemoryQueue[string](&RequestSizer[string]{}, 0)
 
 	err := q.Start(context.Background(), componenttest.NewNopHost())
 	assert.NoError(t, err)

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -41,6 +43,8 @@ import (
 //	 index          index   x
 //	                        xxxx deleted
 type persistentQueue[T any] struct {
+	*queueCapacityLimiter[T]
+
 	set         exporter.CreateSettings
 	storageID   component.ID
 	dataType    component.DataType
@@ -48,13 +52,17 @@ type persistentQueue[T any] struct {
 	unmarshaler func(data []byte) (T, error)
 	marshaler   func(req T) ([]byte, error)
 
-	putChan  chan struct{}
-	capacity uint64
+	// isRequestSized indicates whether the queue is sized by the number of requests.
+	isRequestSized bool
+
+	putChan chan struct{}
 
 	// mu guards everything declared below.
 	mu                       sync.Mutex
 	readIndex                uint64
 	writeIndex               uint64
+	initIndexSize            uint64
+	initQueueSize            *atomic.Uint64
 	currentlyDispatchedItems []uint64
 	refClient                int64
 	stopped                  bool
@@ -68,6 +76,7 @@ const (
 	readIndexKey                = "ri"
 	writeIndexKey               = "wi"
 	currentlyDispatchedItemsKey = "di"
+	queueSizeKey                = "si"
 )
 
 var (
@@ -78,15 +87,19 @@ var (
 )
 
 // NewPersistentQueue creates a new queue backed by file storage; name and signal must be a unique combination that identifies the queue storage
-func NewPersistentQueue[T any](capacity int, dataType component.DataType, storageID component.ID, marshaler func(req T) ([]byte, error), unmarshaler func([]byte) (T, error), set exporter.CreateSettings) Queue[T] {
+func NewPersistentQueue[T any](sizer Sizer[T], capacity int, dataType component.DataType, storageID component.ID,
+	marshaler func(req T) ([]byte, error), unmarshaler func([]byte) (T, error), set exporter.CreateSettings) Queue[T] {
+	_, isRequestSized := sizer.(*RequestSizer[T])
 	return &persistentQueue[T]{
-		set:         set,
-		storageID:   storageID,
-		dataType:    dataType,
-		unmarshaler: unmarshaler,
-		marshaler:   marshaler,
-		capacity:    uint64(capacity),
-		putChan:     make(chan struct{}, capacity),
+		queueCapacityLimiter: newQueueCapacityLimiter[T](sizer, capacity),
+		set:                  set,
+		storageID:            storageID,
+		dataType:             dataType,
+		unmarshaler:          unmarshaler,
+		marshaler:            marshaler,
+		initQueueSize:        &atomic.Uint64{},
+		isRequestSized:       isRequestSized,
+		putChan:              make(chan struct{}, capacity),
 	}
 }
 
@@ -107,12 +120,6 @@ func (pq *persistentQueue[T]) initClient(ctx context.Context, client storage.Cli
 	pq.initPersistentContiguousStorage(ctx)
 	// Make sure the leftover requests are handled
 	pq.retrieveAndEnqueueNotDispatchedReqs(ctx)
-
-	// Ensure the communication channel has the same size as the queue
-	// We might already have items here from requeueing non-dispatched requests
-	for len(pq.putChan) < int(pq.size()) {
-		pq.putChan <- struct{}{}
-	}
 }
 
 func (pq *persistentQueue[T]) initPersistentContiguousStorage(ctx context.Context) {
@@ -137,6 +144,39 @@ func (pq *persistentQueue[T]) initPersistentContiguousStorage(ctx context.Contex
 		pq.readIndex = 0
 		pq.writeIndex = 0
 	}
+	pq.initIndexSize = pq.writeIndex - pq.readIndex
+
+	// Ensure the communication channel has the same size as the queue
+	for i := 0; i < int(pq.initIndexSize); i++ {
+		pq.putChan <- struct{}{}
+	}
+
+	// Read snapshot of the queue size from storage. It's not a problem if the value cannot be fetched,
+	// or it's not accurate. The queue size will be corrected once the recovered queue is drained.
+	if pq.initIndexSize > 0 {
+		// If the queue is sized by the number of requests, no need to read the queue size from storage.
+		if pq.isRequestSized {
+			pq.initQueueSize.Store(pq.initIndexSize)
+			return
+		}
+
+		res, err := pq.client.Get(ctx, queueSizeKey)
+		if err == nil {
+			var restoredQueueSize uint64
+			restoredQueueSize, err = bytesToItemIndex(res)
+			pq.initQueueSize.Store(restoredQueueSize)
+		}
+		if err != nil {
+			if errors.Is(err, errValueNotSet) {
+				pq.set.Logger.Warn("Cannot read the queue size snapshot from storage. "+
+					"The reported queue size will be inaccurate until the initial queue is drained. "+
+					"It's expected when the items sized queue enabled for the first time", zap.Error(err))
+			} else {
+				pq.set.Logger.Error("Failed to read the queue size snapshot from storage. "+
+					"The reported queue size will be inaccurate until the initial queue is drained.", zap.Error(err))
+			}
+		}
+	}
 }
 
 // Consume applies the provided function on the head of queue.
@@ -159,20 +199,9 @@ func (pq *persistentQueue[T]) Consume(consumeFunc func(context.Context, T) error
 	}
 }
 
-func (pq *persistentQueue[T]) size() uint64 {
-	return pq.writeIndex - pq.readIndex
-}
-
-// Size returns the number of currently available items, which were not picked by consumers yet
+// Size returns the current size of the queue.
 func (pq *persistentQueue[T]) Size() int {
-	pq.mu.Lock()
-	defer pq.mu.Unlock()
-	return int(pq.size())
-}
-
-// Capacity returns the number of currently available items, which were not picked by consumers yet
-func (pq *persistentQueue[T]) Capacity() int {
-	return int(pq.capacity)
+	return int(pq.initQueueSize.Load()) + pq.queueCapacityLimiter.Size()
 }
 
 func (pq *persistentQueue[T]) Shutdown(ctx context.Context) error {
@@ -181,7 +210,27 @@ func (pq *persistentQueue[T]) Shutdown(ctx context.Context) error {
 	defer pq.mu.Unlock()
 	// Mark this queue as stopped, so consumer don't start any more work.
 	pq.stopped = true
-	return pq.unrefClient(ctx)
+	return multierr.Combine(
+		pq.backupQueueSize(ctx),
+		pq.unrefClient(ctx),
+	)
+}
+
+// backupQueueSize writes the current queue size to storage. The value is used to recover the queue size
+// in case if the collector is killed.
+func (pq *persistentQueue[T]) backupQueueSize(ctx context.Context) error {
+	// Client can be nil if the queue is not initialized yet.
+	if pq.client == nil {
+		return nil
+	}
+
+	// No need to write the queue size if the queue is sized by the number of requests.
+	// That information is already stored as difference between read and write indexes.
+	if pq.isRequestSized {
+		return nil
+	}
+
+	return pq.client.Set(ctx, queueSizeKey, itemIndexToBytes(uint64(pq.Size())))
 }
 
 // unrefClient unrefs the client, and closes if no more references. Callers MUST hold the mutex.
@@ -205,7 +254,7 @@ func (pq *persistentQueue[T]) Offer(ctx context.Context, req T) error {
 
 // putInternal is the internal version that requires caller to hold the mutex lock.
 func (pq *persistentQueue[T]) putInternal(ctx context.Context, req T) error {
-	if pq.size() >= pq.capacity {
+	if !pq.queueCapacityLimiter.claim(req) {
 		pq.set.Logger.Warn("Maximum queue capacity reached")
 		return ErrQueueIsFull
 	}
@@ -215,6 +264,7 @@ func (pq *persistentQueue[T]) putInternal(ctx context.Context, req T) error {
 
 	reqBuf, err := pq.marshaler(req)
 	if err != nil {
+		pq.queueCapacityLimiter.release(req)
 		return err
 	}
 
@@ -224,12 +274,21 @@ func (pq *persistentQueue[T]) putInternal(ctx context.Context, req T) error {
 		storage.SetOperation(itemKey, reqBuf),
 	}
 	if storageErr := pq.client.Batch(ctx, ops...); storageErr != nil {
+		pq.queueCapacityLimiter.release(req)
 		return storageErr
 	}
 
 	pq.writeIndex = newIndex
 	// Inform the loop that there's some data to process
 	pq.putChan <- struct{}{}
+
+	// Back up the queue size to storage every 10 writes. The stored value is used to recover the queue size
+	// in case if the collector is killed. The recovered queue size is allowed to be inaccurate.
+	if (pq.writeIndex % 10) == 5 {
+		if err := pq.backupQueueSize(ctx); err != nil {
+			pq.set.Logger.Error("Error writing queue size to storage", zap.Error(err))
+		}
+	}
 
 	return nil
 }
@@ -274,6 +333,16 @@ func (pq *persistentQueue[T]) getNextItem(ctx context.Context) (T, func(error), 
 		return request, nil, false
 	}
 
+	pq.releaseCapacity(request)
+
+	// Back up the queue size to storage on every 10 reads. The stored value is used to recover the queue size
+	// in case if the collector is killed. The recovered queue size is allowed to be inaccurate.
+	if (pq.writeIndex % 10) == 0 {
+		if qsErr := pq.backupQueueSize(ctx); qsErr != nil {
+			pq.set.Logger.Error("Error writing queue size to storage", zap.Error(err))
+		}
+	}
+
 	// Increase the reference count, so the client is not closed while the request is being processed.
 	// The client cannot be closed because we hold the lock since last we checked `stopped`.
 	pq.refClient++
@@ -299,6 +368,28 @@ func (pq *persistentQueue[T]) getNextItem(ctx context.Context) (T, func(error), 
 		}
 
 	}, true
+}
+
+// releaseCapacity releases the capacity of the queue. The caller must hold the mutex.
+func (pq *persistentQueue[T]) releaseCapacity(req T) {
+	// If the recovered queue size is not emptied yet, decrease it first.
+	if pq.initIndexSize > 0 {
+		pq.initIndexSize--
+		if pq.initIndexSize == 0 {
+			pq.initQueueSize.Store(0)
+			return
+		}
+		reqSize := pq.queueCapacityLimiter.sizeOf(req)
+		if pq.initQueueSize.Load() < reqSize {
+			pq.initQueueSize.Store(0)
+			return
+		}
+		pq.initQueueSize.Add(^(reqSize - 1))
+		return
+	}
+
+	// Otherwise, decrease the current queue size.
+	pq.queueCapacityLimiter.release(req)
 }
 
 // retrieveAndEnqueueNotDispatchedReqs gets the items for which sending was not finished, cleans the storage

--- a/exporter/exporterhelper/internal/persistent_queue_test.go
+++ b/exporter/exporterhelper/internal/persistent_queue_test.go
@@ -24,10 +24,24 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-var (
-	marshaler   = ptrace.ProtoMarshaler{}
-	unmarshaler = ptrace.ProtoUnmarshaler{}
-)
+type tracesRequest struct {
+	traces ptrace.Traces
+}
+
+func (tr tracesRequest) ItemsCount() int {
+	return tr.traces.SpanCount()
+}
+
+func marshalTracesRequest(tr tracesRequest) ([]byte, error) {
+	marshaler := &ptrace.ProtoMarshaler{}
+	return marshaler.MarshalTraces(tr.traces)
+}
+
+func unmarshalTracesRequest(bytes []byte) (tracesRequest, error) {
+	unmarshaler := &ptrace.ProtoUnmarshaler{}
+	traces, err := unmarshaler.UnmarshalTraces(bytes)
+	return tracesRequest{traces: traces}, err
+}
 
 type mockHost struct {
 	component.Host
@@ -39,9 +53,10 @@ func (nh *mockHost) GetExtensions() map[component.ID]component.Component {
 }
 
 // createAndStartTestPersistentQueue creates and starts a fake queue with the given capacity and number of consumers.
-func createAndStartTestPersistentQueue(t *testing.T, capacity, numConsumers int, consumeFunc func(_ context.Context, item ptrace.Traces) error) Queue[ptrace.Traces] {
-	pq := NewPersistentQueue[ptrace.Traces](capacity, component.DataTypeTraces, component.ID{}, marshaler.MarshalTraces,
-		unmarshaler.UnmarshalTraces, exportertest.NewNopCreateSettings())
+func createAndStartTestPersistentQueue(t *testing.T, sizer Sizer[tracesRequest], capacity int, numConsumers int,
+	consumeFunc func(_ context.Context, item tracesRequest) error) Queue[tracesRequest] {
+	pq := NewPersistentQueue[tracesRequest](sizer, capacity, component.DataTypeTraces, component.ID{},
+		marshalTracesRequest, unmarshalTracesRequest, exportertest.NewNopCreateSettings())
 	host := &mockHost{ext: map[component.ID]component.Component{
 		{}: NewMockStorageExtension(nil),
 	}}
@@ -53,58 +68,87 @@ func createAndStartTestPersistentQueue(t *testing.T, capacity, numConsumers int,
 	return pq
 }
 
-func createTestPersistentQueueWithClient(client storage.Client) *persistentQueue[ptrace.Traces] {
-	pq := NewPersistentQueue[ptrace.Traces](1000, component.DataTypeTraces, component.ID{}, marshaler.MarshalTraces,
-		unmarshaler.UnmarshalTraces, exportertest.NewNopCreateSettings()).(*persistentQueue[ptrace.Traces])
-
+func createTestPersistentQueueWithClient(client storage.Client) *persistentQueue[tracesRequest] {
+	pq := NewPersistentQueue[tracesRequest](&RequestSizer[tracesRequest]{}, 1000, component.DataTypeTraces,
+		component.ID{}, marshalTracesRequest, unmarshalTracesRequest, exportertest.NewNopCreateSettings()).(*persistentQueue[tracesRequest])
 	pq.initClient(context.Background(), client)
 	return pq
 }
 
-func createTestPersistentQueueWithCapacity(t testing.TB, ext storage.Extension, capacity int) *persistentQueue[ptrace.Traces] {
-	pq := NewPersistentQueue[ptrace.Traces](capacity, component.DataTypeTraces, component.ID{}, marshaler.MarshalTraces,
-		unmarshaler.UnmarshalTraces, exportertest.NewNopCreateSettings()).(*persistentQueue[ptrace.Traces])
+func createTestPersistentQueueWithRequestsCapacity(t testing.TB, ext storage.Extension, capacity int) *persistentQueue[tracesRequest] {
+	return createTestPersistentQueueWithCapacityLimiter(t, ext, &RequestSizer[tracesRequest]{}, capacity)
+}
 
+func createTestPersistentQueueWithItemsCapacity(t testing.TB, ext storage.Extension, capacity int) *persistentQueue[tracesRequest] {
+	return createTestPersistentQueueWithCapacityLimiter(t, ext, &ItemsSizer[tracesRequest]{}, capacity)
+}
+
+func createTestPersistentQueueWithCapacityLimiter(t testing.TB, ext storage.Extension, sizer Sizer[tracesRequest],
+	capacity int) *persistentQueue[tracesRequest] {
+	pq := NewPersistentQueue[tracesRequest](sizer, capacity, component.DataTypeTraces, component.ID{},
+		marshalTracesRequest, unmarshalTracesRequest, exportertest.NewNopCreateSettings()).(*persistentQueue[tracesRequest])
 	require.NoError(t, pq.Start(context.Background(), &mockHost{ext: map[component.ID]component.Component{{}: ext}}))
 	return pq
 }
 
-func createTestPersistentQueue(t testing.TB, ext storage.Extension) *persistentQueue[ptrace.Traces] {
-	return createTestPersistentQueueWithCapacity(t, ext, 1000)
-}
-
 func TestPersistentQueue_FullCapacity(t *testing.T) {
-	start := make(chan struct{})
-	done := make(chan struct{})
-	pq := createAndStartTestPersistentQueue(t, 5, 1, func(context.Context, ptrace.Traces) error {
-		<-start
-		<-done
-		return nil
-	})
-	assert.Equal(t, 0, pq.Size())
-
-	req := newTraces(1, 10)
-
-	// First request is picked by the consumer. Wait until the consumer is blocked on done.
-	assert.NoError(t, pq.Offer(context.Background(), req))
-	start <- struct{}{}
-	close(start)
-
-	for i := 0; i < 10; i++ {
-		result := pq.Offer(context.Background(), newTraces(1, 10))
-		if i < 5 {
-			assert.NoError(t, result)
-		} else {
-			assert.ErrorIs(t, result, ErrQueueIsFull)
-		}
+	tests := []struct {
+		name           string
+		sizer          Sizer[tracesRequest]
+		capacity       int
+		sizeMultiplier int
+	}{
+		{
+			name:           "requests_capacity",
+			sizer:          &RequestSizer[tracesRequest]{},
+			capacity:       5,
+			sizeMultiplier: 1,
+		},
+		{
+			name:           "items_capacity",
+			sizer:          &ItemsSizer[tracesRequest]{},
+			capacity:       55,
+			sizeMultiplier: 10,
+		},
 	}
-	assert.Equal(t, 5, pq.Size())
-	close(done)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := make(chan struct{})
+			done := make(chan struct{})
+			pq := createAndStartTestPersistentQueue(t, tt.sizer, tt.capacity, 1, func(context.Context, tracesRequest) error {
+				<-start
+				<-done
+				return nil
+			})
+			assert.Equal(t, 0, pq.Size())
+
+			req := newTracesRequest(1, 10)
+
+			// First request is picked by the consumer. Wait until the consumer is blocked on done.
+			assert.NoError(t, pq.Offer(context.Background(), req))
+			start <- struct{}{}
+			close(start)
+
+			for i := 0; i < 10; i++ {
+				result := pq.Offer(context.Background(), newTracesRequest(1, 10))
+				if i < 5 {
+					assert.NoError(t, result)
+				} else {
+					assert.ErrorIs(t, result, ErrQueueIsFull)
+				}
+			}
+			assert.Equal(t, 5*tt.sizeMultiplier, pq.Size())
+			close(done)
+		})
+	}
 }
 
 func TestPersistentQueue_Shutdown(t *testing.T) {
-	pq := createAndStartTestPersistentQueue(t, 1001, 100, func(context.Context, ptrace.Traces) error { return nil })
-	req := newTraces(1, 10)
+	pq := createAndStartTestPersistentQueue(t, &RequestSizer[tracesRequest]{}, 1001, 100, func(context.Context,
+		tracesRequest) error {
+		return nil
+	})
+	req := newTracesRequest(1, 10)
 
 	for i := 0; i < 1000; i++ {
 		assert.NoError(t, pq.Offer(context.Background(), req))
@@ -141,13 +185,15 @@ func TestPersistentQueue_ConsumersProducers(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("#messages: %d #consumers: %d", c.numMessagesProduced, c.numConsumers), func(t *testing.T) {
-			req := newTraces(1, 10)
+			req := newTracesRequest(1, 10)
 
 			numMessagesConsumed := &atomic.Int32{}
-			pq := createAndStartTestPersistentQueue(t, 1000, c.numConsumers, func(context.Context, ptrace.Traces) error {
-				numMessagesConsumed.Add(int32(1))
-				return nil
-			})
+			pq := createAndStartTestPersistentQueue(t, &RequestSizer[tracesRequest]{}, 1000, c.numConsumers,
+				func(context.Context,
+					tracesRequest) error {
+					numMessagesConsumed.Add(int32(1))
+					return nil
+				})
 
 			for i := 0; i < c.numMessagesProduced; i++ {
 				assert.NoError(t, pq.Offer(context.Background(), req))
@@ -160,7 +206,7 @@ func TestPersistentQueue_ConsumersProducers(t *testing.T) {
 	}
 }
 
-func newTraces(numTraces int, numSpans int) ptrace.Traces {
+func newTracesRequest(numTraces int, numSpans int) tracesRequest {
 	traces := ptrace.NewTraces()
 	batch := traces.ResourceSpans().AppendEmpty()
 	batch.Resource().Attributes().PutStr("resource-attr", "some-resource")
@@ -184,7 +230,7 @@ func newTraces(numTraces int, numSpans int) ptrace.Traces {
 		}
 	}
 
-	return traces
+	return tracesRequest{traces: traces}
 }
 
 func TestToStorageClient(t *testing.T) {
@@ -274,13 +320,14 @@ func TestInvalidStorageExtensionType(t *testing.T) {
 }
 
 func TestPersistentQueue_StopAfterBadStart(t *testing.T) {
-	pq := NewPersistentQueue[ptrace.Traces](1, component.DataTypeTraces, component.ID{}, marshaler.MarshalTraces, unmarshaler.UnmarshalTraces, exportertest.NewNopCreateSettings())
+	pq := NewPersistentQueue[tracesRequest](&RequestSizer[tracesRequest]{}, 1, component.DataTypeTraces, component.ID{},
+		marshalTracesRequest, unmarshalTracesRequest, exportertest.NewNopCreateSettings())
 	// verify that stopping a un-start/started w/error queue does not panic
 	assert.NoError(t, pq.Shutdown(context.Background()))
 }
 
 func TestPersistentQueue_CorruptedData(t *testing.T) {
-	req := newTraces(5, 10)
+	req := newTracesRequest(5, 10)
 
 	cases := []struct {
 		name                               string
@@ -335,7 +382,7 @@ func TestPersistentQueue_CorruptedData(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ext := NewMockStorageExtension(nil)
-			ps := createTestPersistentQueue(t, ext)
+			ps := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
 
 			// Put some items, make sure they are loaded and shutdown the storage...
 			for i := 0; i < 3; i++ {
@@ -343,7 +390,7 @@ func TestPersistentQueue_CorruptedData(t *testing.T) {
 				require.NoError(t, err)
 			}
 			assert.Equal(t, 3, ps.Size())
-			require.True(t, ps.Consume(func(ctx context.Context, traces ptrace.Traces) error {
+			require.True(t, ps.Consume(func(ctx context.Context, traces tracesRequest) error {
 				return NewShutdownErr(nil)
 			}))
 			assert.Equal(t, 2, ps.Size())
@@ -373,17 +420,17 @@ func TestPersistentQueue_CorruptedData(t *testing.T) {
 			assert.NoError(t, ps.Shutdown(context.Background()))
 
 			// Reload
-			newPs := createTestPersistentQueue(t, ext)
+			newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
 			assert.Equal(t, c.desiredQueueSize, newPs.Size())
 		})
 	}
 }
 
 func TestPersistentQueue_CurrentlyProcessedItems(t *testing.T) {
-	req := newTraces(5, 10)
+	req := newTracesRequest(5, 10)
 
 	ext := NewMockStorageExtension(nil)
-	ps := createTestPersistentQueue(t, ext)
+	ps := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
 
 	for i := 0; i < 5; i++ {
 		err := ps.Offer(context.Background(), req)
@@ -410,13 +457,13 @@ func TestPersistentQueue_CurrentlyProcessedItems(t *testing.T) {
 
 	// Reload the storage. Since items 0 was not finished, this should be re-enqueued at the end.
 	// The queue should be essentially {3,4,0,2}.
-	newPs := createTestPersistentQueue(t, ext)
+	newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
 	assert.Equal(t, 4, newPs.Size())
 	requireCurrentlyDispatchedItemsEqual(t, newPs, []uint64{})
 
 	// We should be able to pull all remaining items now
 	for i := 0; i < 4; i++ {
-		newPs.Consume(func(ctx context.Context, traces ptrace.Traces) error {
+		newPs.Consume(func(ctx context.Context, traces tracesRequest) error {
 			assert.Equal(t, req, traces)
 			return nil
 		})
@@ -439,10 +486,10 @@ func TestPersistentQueue_CurrentlyProcessedItems(t *testing.T) {
 // this test attempts to check if all the invariants are kept if the queue is recreated while
 // close to full and with some items dispatched
 func TestPersistentQueueStartWithNonDispatched(t *testing.T) {
-	req := newTraces(5, 10)
+	req := newTracesRequest(5, 10)
 
 	ext := NewMockStorageExtension(nil)
-	ps := createTestPersistentQueueWithCapacity(t, ext, 5)
+	ps := createTestPersistentQueueWithRequestsCapacity(t, ext, 5)
 
 	// Put in items up to capacity
 	for i := 0; i < 5; i++ {
@@ -452,7 +499,7 @@ func TestPersistentQueueStartWithNonDispatched(t *testing.T) {
 
 	// get one item out, but don't mark it as processed
 	<-ps.putChan
-	require.True(t, ps.Consume(func(ctx context.Context, traces ptrace.Traces) error {
+	require.True(t, ps.Consume(func(ctx context.Context, traces tracesRequest) error {
 		// put one more item in
 		require.NoError(t, ps.Offer(context.Background(), req))
 		require.Equal(t, 5, ps.Size())
@@ -461,14 +508,14 @@ func TestPersistentQueueStartWithNonDispatched(t *testing.T) {
 	assert.NoError(t, ps.Shutdown(context.Background()))
 
 	// Reload with extra capacity to make sure we re-enqueue in-progress items.
-	newPs := createTestPersistentQueueWithCapacity(t, ext, 6)
+	newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 6)
 	require.Equal(t, 6, newPs.Size())
 }
 
 func TestPersistentQueue_PutCloseReadClose(t *testing.T) {
-	req := newTraces(5, 10)
+	req := newTracesRequest(5, 10)
 	ext := NewMockStorageExtension(nil)
-	ps := createTestPersistentQueue(t, ext)
+	ps := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
 	assert.Equal(t, 0, ps.Size())
 
 	// Put two elements and close the extension
@@ -479,17 +526,17 @@ func TestPersistentQueue_PutCloseReadClose(t *testing.T) {
 	_, _, _ = ps.getNextItem(context.Background())
 	assert.NoError(t, ps.Shutdown(context.Background()))
 
-	newPs := createTestPersistentQueue(t, ext)
+	newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
 	require.Equal(t, 2, newPs.Size())
 
 	// Let's read both of the elements we put
-	newPs.Consume(func(ctx context.Context, traces ptrace.Traces) error {
+	newPs.Consume(func(ctx context.Context, traces tracesRequest) error {
 		require.Equal(t, req, traces)
 		return nil
 	})
 	assert.Equal(t, 1, newPs.Size())
 
-	newPs.Consume(func(ctx context.Context, traces ptrace.Traces) error {
+	newPs.Consume(func(ctx context.Context, traces tracesRequest) error {
 		require.Equal(t, req, traces)
 		return nil
 	})
@@ -519,9 +566,9 @@ func BenchmarkPersistentQueue_TraceSpans(b *testing.B) {
 	for _, c := range cases {
 		b.Run(fmt.Sprintf("#traces: %d #spansPerTrace: %d", c.numTraces, c.numSpansPerTrace), func(bb *testing.B) {
 			ext := NewMockStorageExtension(nil)
-			ps := createTestPersistentQueueWithCapacity(b, ext, 10000000)
+			ps := createTestPersistentQueueWithRequestsCapacity(b, ext, 10000000)
 
-			req := newTraces(c.numTraces, c.numSpansPerTrace)
+			req := newTracesRequest(c.numTraces, c.numSpansPerTrace)
 
 			bb.ResetTimer()
 
@@ -530,7 +577,7 @@ func BenchmarkPersistentQueue_TraceSpans(b *testing.B) {
 			}
 
 			for i := 0; i < bb.N; i++ {
-				require.True(bb, ps.Consume(func(context.Context, ptrace.Traces) error { return nil }))
+				require.True(bb, ps.Consume(func(context.Context, tracesRequest) error { return nil }))
 			}
 			require.NoError(b, ext.Shutdown(context.Background()))
 		})
@@ -596,12 +643,12 @@ func TestItemIndexArrayMarshaling(t *testing.T) {
 }
 
 func TestPersistentQueue_ShutdownWhileConsuming(t *testing.T) {
-	ps := createTestPersistentQueue(t, NewMockStorageExtension(nil))
+	ps := createTestPersistentQueueWithRequestsCapacity(t, NewMockStorageExtension(nil), 1000)
 
 	assert.Equal(t, 0, ps.Size())
 	assert.False(t, ps.client.(*mockStorageClient).isClosed())
 
-	assert.NoError(t, ps.Offer(context.Background(), newTraces(5, 10)))
+	assert.NoError(t, ps.Offer(context.Background(), newTracesRequest(5, 10)))
 
 	_, onProcessingFinished, ok := ps.getNextItem(context.Background())
 	require.True(t, ok)
@@ -613,8 +660,8 @@ func TestPersistentQueue_ShutdownWhileConsuming(t *testing.T) {
 }
 
 func TestPersistentQueue_StorageFull(t *testing.T) {
-	req := newTraces(5, 10)
-	marshaled, err := marshaler.MarshalTraces(req)
+	req := newTracesRequest(5, 10)
+	marshaled, err := marshalTracesRequest(req)
 	require.NoError(t, err)
 	maxSizeInBytes := len(marshaled) * 5 // arbitrary small number
 	freeSpaceInBytes := 1
@@ -648,7 +695,7 @@ func TestPersistentQueue_StorageFull(t *testing.T) {
 	// Subsequent items succeed, as deleting the first item frees enough space for the state update
 	reqCount--
 	for i := reqCount; i > 0; i-- {
-		require.True(t, ps.Consume(func(context.Context, ptrace.Traces) error { return nil }))
+		require.True(t, ps.Consume(func(context.Context, tracesRequest) error { return nil }))
 	}
 
 	// We should be able to put a new item in
@@ -708,7 +755,107 @@ func TestPersistentQueue_ItemDispatchingFinish_ErrorHandling(t *testing.T) {
 	}
 }
 
-func requireCurrentlyDispatchedItemsEqual(t *testing.T, pq *persistentQueue[ptrace.Traces], compare []uint64) {
+func TestPersistentQueue_ItemsCapacityUsageRestoredOnShutdown(t *testing.T) {
+	ext := NewMockStorageExtension(nil)
+	pq := createTestPersistentQueueWithItemsCapacity(t, ext, 100)
+
+	assert.Equal(t, 0, pq.Size())
+
+	// Fill the queue up to the capacity.
+	assert.NoError(t, pq.Offer(context.Background(), newTracesRequest(4, 10)))
+	assert.NoError(t, pq.Offer(context.Background(), newTracesRequest(4, 10)))
+	assert.NoError(t, pq.Offer(context.Background(), newTracesRequest(2, 10)))
+	assert.Equal(t, 100, pq.Size())
+
+	assert.ErrorIs(t, pq.Offer(context.Background(), newTracesRequest(5, 5)), ErrQueueIsFull)
+	assert.Equal(t, 100, pq.Size())
+
+	assert.True(t, pq.Consume(func(ctx context.Context, traces tracesRequest) error {
+		assert.Equal(t, 40, traces.traces.SpanCount())
+		return nil
+	}))
+	assert.Equal(t, 60, pq.Size())
+
+	assert.NoError(t, pq.Shutdown(context.Background()))
+
+	newPQ := createTestPersistentQueueWithItemsCapacity(t, ext, 100)
+
+	// The queue should be restored to the previous size.
+	assert.Equal(t, 60, newPQ.Size())
+
+	assert.NoError(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
+
+	// Check the combined queue size.
+	assert.Equal(t, 70, newPQ.Size())
+
+	assert.True(t, newPQ.Consume(func(ctx context.Context, traces tracesRequest) error {
+		assert.Equal(t, 40, traces.traces.SpanCount())
+		return nil
+	}))
+	assert.Equal(t, 30, newPQ.Size())
+
+	assert.True(t, newPQ.Consume(func(ctx context.Context, traces tracesRequest) error {
+		assert.Equal(t, 20, traces.traces.SpanCount())
+		return nil
+	}))
+	assert.Equal(t, 10, newPQ.Size())
+
+	assert.NoError(t, newPQ.Shutdown(context.Background()))
+}
+
+// This test covers the case when the items capacity queue is enabled for the first time.
+func TestPersistentQueue_ItemsCapacityUsageIsNotPreserved(t *testing.T) {
+	ext := NewMockStorageExtension(nil)
+	pq := createTestPersistentQueueWithRequestsCapacity(t, ext, 100)
+
+	assert.Equal(t, 0, pq.Size())
+
+	assert.NoError(t, pq.Offer(context.Background(), newTracesRequest(4, 10)))
+	assert.NoError(t, pq.Offer(context.Background(), newTracesRequest(2, 10)))
+	assert.NoError(t, pq.Offer(context.Background(), newTracesRequest(5, 5)))
+	assert.Equal(t, 3, pq.Size())
+
+	assert.True(t, pq.Consume(func(ctx context.Context, traces tracesRequest) error {
+		assert.Equal(t, 40, traces.traces.SpanCount())
+		return nil
+	}))
+	assert.Equal(t, 2, pq.Size())
+
+	assert.NoError(t, pq.Shutdown(context.Background()))
+
+	newPQ := createTestPersistentQueueWithItemsCapacity(t, ext, 100)
+
+	// The queue items size cannot be restored to the previous size. Falls back to 0.
+	assert.Equal(t, 0, newPQ.Size())
+
+	assert.NoError(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
+
+	// Only new items are reflected
+	assert.Equal(t, 10, newPQ.Size())
+
+	// Consuming old items should does not affect the size.
+	assert.True(t, newPQ.Consume(func(ctx context.Context, traces tracesRequest) error {
+		assert.Equal(t, 20, traces.traces.SpanCount())
+		return nil
+	}))
+	assert.Equal(t, 10, newPQ.Size())
+
+	assert.True(t, newPQ.Consume(func(ctx context.Context, traces tracesRequest) error {
+		assert.Equal(t, 25, traces.traces.SpanCount())
+		return nil
+	}))
+	assert.Equal(t, 10, newPQ.Size())
+
+	assert.True(t, newPQ.Consume(func(ctx context.Context, traces tracesRequest) error {
+		assert.Equal(t, 10, traces.traces.SpanCount())
+		return nil
+	}))
+	assert.Equal(t, 0, newPQ.Size())
+
+	assert.NoError(t, newPQ.Shutdown(context.Background()))
+}
+
+func requireCurrentlyDispatchedItemsEqual(t *testing.T, pq *persistentQueue[tracesRequest], compare []uint64) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	assert.ElementsMatch(t, compare, pq.currentlyDispatchedItems)

--- a/exporter/exporterhelper/internal/queue_capacity.go
+++ b/exporter/exporterhelper/internal/queue_capacity.go
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+
+import (
+	"sync/atomic"
+)
+
+type itemsCounter interface {
+	ItemsCount() int
+}
+
+// Sizer is an interface that returns the size of the given element.
+type Sizer[T any] interface {
+	SizeOf(T) uint64
+}
+
+// ItemsSizer is a Sizer implementation that returns the size of a queue element as the number of items it contains.
+type ItemsSizer[T itemsCounter] struct{}
+
+func (is *ItemsSizer[T]) SizeOf(el T) uint64 {
+	return uint64(el.ItemsCount())
+}
+
+// RequestSizer is a Sizer implementation that returns the size of a queue element as one request.
+type RequestSizer[T any] struct{}
+
+func (rs *RequestSizer[T]) SizeOf(T) uint64 {
+	return 1
+}
+
+type queueCapacityLimiter[T any] struct {
+	used *atomic.Uint64
+	cap  uint64
+	sz   Sizer[T]
+}
+
+func (bcl queueCapacityLimiter[T]) Capacity() int {
+	return int(bcl.cap)
+}
+
+func (bcl queueCapacityLimiter[T]) Size() int {
+	return int(bcl.used.Load())
+}
+
+func (bcl queueCapacityLimiter[T]) claim(el T) bool {
+	size := bcl.sizeOf(el)
+	if bcl.used.Add(size) > bcl.cap {
+		bcl.releaseSize(size)
+		return false
+	}
+	return true
+}
+
+func (bcl queueCapacityLimiter[T]) release(el T) {
+	bcl.releaseSize(bcl.sizeOf(el))
+}
+
+func (bcl queueCapacityLimiter[T]) releaseSize(size uint64) {
+	bcl.used.Add(^(size - 1))
+}
+
+func (bcl queueCapacityLimiter[T]) sizeOf(el T) uint64 {
+	return bcl.sz.SizeOf(el)
+}
+
+func newQueueCapacityLimiter[T any](sizer Sizer[T], capacity int) *queueCapacityLimiter[T] {
+	return &queueCapacityLimiter[T]{
+		used: &atomic.Uint64{},
+		cap:  uint64(capacity),
+		sz:   sizer,
+	}
+}

--- a/exporter/exporterhelper/internal/queue_capacity_test.go
+++ b/exporter/exporterhelper/internal/queue_capacity_test.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestsCapacityLimiter(t *testing.T) {
+	rl := newQueueCapacityLimiter[fakeReq](&RequestSizer[fakeReq]{}, 2)
+	assert.Equal(t, 0, rl.Size())
+	assert.Equal(t, 2, rl.Capacity())
+
+	req := fakeReq{itemsCount: 5}
+
+	assert.True(t, rl.claim(req))
+	assert.Equal(t, 1, rl.Size())
+
+	assert.True(t, rl.claim(req))
+	assert.Equal(t, 2, rl.Size())
+
+	assert.False(t, rl.claim(req))
+	assert.Equal(t, 2, rl.Size())
+
+	rl.release(req)
+	assert.Equal(t, 1, rl.Size())
+}
+
+func TestItemsCapacityLimiter(t *testing.T) {
+	rl := newQueueCapacityLimiter[fakeReq](&ItemsSizer[fakeReq]{}, 7)
+	assert.Equal(t, 0, rl.Size())
+	assert.Equal(t, 7, rl.Capacity())
+
+	req := fakeReq{itemsCount: 3}
+
+	assert.True(t, rl.claim(req))
+	assert.Equal(t, 3, rl.Size())
+
+	assert.True(t, rl.claim(req))
+	assert.Equal(t, 6, rl.Size())
+
+	assert.False(t, rl.claim(req))
+	assert.Equal(t, 6, rl.Size())
+
+	rl.release(req)
+	assert.Equal(t, 3, rl.Size())
+}
+
+type fakeReq struct {
+	itemsCount int
+}
+
+func (r fakeReq) ItemsCount() int {
+	return r.itemsCount
+}

--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -90,11 +90,12 @@ func newQueueSender(config QueueSettings, set exporter.CreateSettings, signal co
 
 	isPersistent := config.StorageID != nil
 	var queue internal.Queue[Request]
+	queueSizer := &internal.RequestSizer[Request]{}
 	if isPersistent {
-		queue = internal.NewPersistentQueue[Request](
-			config.QueueSize, signal, *config.StorageID, marshaler, unmarshaler, set)
+		queue = internal.NewPersistentQueue[Request](queueSizer, config.QueueSize, signal, *config.StorageID, marshaler,
+			unmarshaler, set)
 	} else {
-		queue = internal.NewBoundedMemoryQueue[Request](config.QueueSize)
+		queue = internal.NewBoundedMemoryQueue[Request](queueSizer, config.QueueSize)
 	}
 	qs := &queueSender{
 		fullName:       set.ID.String(),


### PR DESCRIPTION
Introduce an option to limit the queue size by the number of items instead of number of requests. This is preliminary step for having the exporter helper v2 with a batcher sender placed after the queue sender. Otherwise, it'll be hard for the users to estimate the queue size based on the number of requests without batch processor in front of it.

This change doesn't effect the existing functionality and the items based queue limiting cannot be utilized yet.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/8122

Alternative to https://github.com/open-telemetry/opentelemetry-collector/pull/9147