### PR TITLE
[configtls] support setting cipher suites

### DIFF
--- a/.chloggen/cipher_suites.yaml
+++ b/.chloggen/cipher_suites.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configtls
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add `cipher_suites` to configtls.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8105]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Users can specify a list of cipher suites to pick from. If left blank, a safe default list is used.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -48,6 +48,17 @@ __IMPORTANT__: TLS 1.0 and 1.1 are deprecated due to known vulnerabilities and s
 - `max_version` (default = "" handled by [crypto/tls](https://github.com/golang/go/blob/ed9db1d36ad6ef61095d5941ad9ee6da7ab6d05a/src/crypto/tls/common.go#L700) - currently TLS 1.3): Maximum acceptable TLS version.
   - options: ["1.0", "1.1", "1.2", "1.3"]
 
+Explicit cipher suites can be set. If left blank, a safe default list is used. See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.
+- `cipher_suites`: (default = []): List of cipher suites to use.
+
+Example:
+```
+  cipher_suites:
+    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+```
+
 Additionally certificates may be reloaded by setting the below configuration.
 
 - `reload_interval` (optional) : ReloadInterval specifies the duration after which the certificate will be reloaded.

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -6,6 +6,7 @@ package configtls // import "go.opentelemetry.io/collector/config/configtls"
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -197,6 +198,7 @@ func (c TLSSetting) loadTLSConfig() (*tls.Config, error) {
 
 func convertCipherSuites(cipherSuites []string) ([]uint16, error) {
 	var result []uint16
+	var errs []error
 	for _, suite := range cipherSuites {
 		found := false
 		for _, supported := range tls.CipherSuites() {
@@ -207,8 +209,11 @@ func convertCipherSuites(cipherSuites []string) ([]uint16, error) {
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("invalid TLS cipher suite: %q", suite)
+			errs = append(errs, fmt.Errorf("invalid TLS cipher suite: %q", suite))
 		}
+	}
+	if len(errs) != 0 {
+		return nil, errors.Join(errs...)
 	}
 	return result, nil
 }

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -212,10 +212,7 @@ func convertCipherSuites(cipherSuites []string) ([]uint16, error) {
 			errs = append(errs, fmt.Errorf("invalid TLS cipher suite: %q", suite))
 		}
 	}
-	if len(errs) != 0 {
-		return nil, errors.Join(errs...)
-	}
-	return result, nil
+	return result, errors.Join(errs...)
 }
 
 func (c TLSSetting) loadCACertPool() (*x509.CertPool, error) {


### PR DESCRIPTION
**Description:**
Add `cipher_suites` to configtls:
Users can specify a list of cipher suites to pick from. If left blank, a safe default list is used.

**Link to tracking Issue:**
Fixes #8105

**Testing:**
Unit tests

**Documentation:**
godoc and README