### PR TITLE
[chore] remove fieldalignment linter TODO

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,8 +69,11 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
 
     enable-all: true
-    # TODO: Enable this and fix the alignment issues.
     disable:
+      # We want to order fields according to readability and grouping them by use cases.
+      # This linter does not offer a discernible performance improvement as the structs
+      # defined in this repository are not in the execution hot path.
+      # See https://github.com/open-telemetry/opentelemetry-collector/issues/2789
       - fieldalignment
 
   revive:


### PR DESCRIPTION
**Description:** 
Removes a TODO for the fieldalignment linter, offering a reasoning to keep it disabled moving forward.

**Link to tracking Issue:**
Fixes #2789
