### PR TITLE
Move error out of `ReportComponentStatus` function signature, use `ReportStatus` instead

### DIFF
--- a/.chloggen/statuschange_invalidtransition.yaml
+++ b/.chloggen/statuschange_invalidtransition.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: status
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `ReportComponentStatus` in favor of `ReportStatus`. This new function does not return an error.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9148]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/component/componenttest/nop_telemetry.go
+++ b/component/componenttest/nop_telemetry.go
@@ -21,7 +21,7 @@ func NewNopTelemetrySettings() component.TelemetrySettings {
 		MeterProvider:  noopmetric.NewMeterProvider(),
 		MetricsLevel:   configtelemetry.LevelNone,
 		Resource:       pcommon.NewResource(),
-		ReportComponentStatus: func(*component.StatusEvent) {
+		ReportStatus: func(*component.StatusEvent) {
 		},
 	}
 }

--- a/component/componenttest/nop_telemetry.go
+++ b/component/componenttest/nop_telemetry.go
@@ -21,8 +21,7 @@ func NewNopTelemetrySettings() component.TelemetrySettings {
 		MeterProvider:  noopmetric.NewMeterProvider(),
 		MetricsLevel:   configtelemetry.LevelNone,
 		Resource:       pcommon.NewResource(),
-		ReportComponentStatus: func(*component.StatusEvent) error {
-			return nil
+		ReportComponentStatus: func(*component.StatusEvent) {
 		},
 	}
 }

--- a/component/telemetry.go
+++ b/component/telemetry.go
@@ -37,13 +37,6 @@ type TelemetrySettings struct {
 
 	// ReportComponentStatus allows a component to report runtime changes in status. The service
 	// will automatically report status for a component during startup and shutdown. Components can
-	// use this method to report status after start and before shutdown. ReportComponentStatus
-	// will only return errors if the API used incorrectly. The two scenarios where an error will
-	// be returned are:
-	//
-	//   - An illegal state transition
-	//   - Calling this method before component startup
-	//
-	// If the API is being used properly, these errors are safe to ignore.
-	ReportComponentStatus func(*StatusEvent) error
+	// use this method to report status after start and before shutdown.
+	ReportComponentStatus func(*StatusEvent)
 }

--- a/component/telemetry.go
+++ b/component/telemetry.go
@@ -38,5 +38,12 @@ type TelemetrySettings struct {
 	// ReportComponentStatus allows a component to report runtime changes in status. The service
 	// will automatically report status for a component during startup and shutdown. Components can
 	// use this method to report status after start and before shutdown.
-	ReportComponentStatus func(*StatusEvent)
+	// Deprecated: [v0.92.0] This function will be removed in a future release.
+	// Use ReportStatus instead.
+	ReportComponentStatus func(*StatusEvent) error
+
+	// ReportStatus allows a component to report runtime changes in status. The service
+	// will automatically report status for a component during startup and shutdown. Components can
+	// use this method to report status after start and before shutdown.
+	ReportStatus func(*StatusEvent)
 }

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -126,10 +126,10 @@ func TestSharedComponentsReportStatus(t *testing.T) {
 	// make a shared component that represents three instances
 	for i := 0; i < 3; i++ {
 		telemetrySettings = newNopTelemetrySettings()
-		telemetrySettings.ReportComponentStatus = newStatusFunc()
+		telemetrySettings.ReportStatus = newStatusFunc()
 		// The initial settings for the shared component need to match the ones passed to the first
 		// invocation of LoadOrStore so that underlying telemetry settings reference can be used to
-		// wrap ReportComponentStatus for subsequently added "instances".
+		// wrap ReportStatus for subsequently added "instances".
 		if i == 0 {
 			comp.telemetry = telemetrySettings
 		}
@@ -150,18 +150,18 @@ func TestSharedComponentsReportStatus(t *testing.T) {
 		telemetrySettings,
 	)
 
-	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusStarting))
+	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusStarting))
 
-	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
+	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusOK))
 
 	// simulate an error
-	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusNone))
+	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusNone))
 
 	// stopping
-	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusStopping))
+	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusStopping))
 
 	// stopped
-	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusStopped))
+	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusStopped))
 
 	// The shared component represents 3 component instances. Reporting status for the shared
 	// component should report status for each of the instances it represents.
@@ -241,7 +241,7 @@ func TestReportStatusOnStartShutdown(t *testing.T) {
 			var err error
 			for i := 0; i < 3; i++ {
 				telemetrySettings := newNopTelemetrySettings()
-				telemetrySettings.ReportComponentStatus = newStatusFunc()
+				telemetrySettings.ReportStatus = newStatusFunc()
 				if i == 0 {
 					base.telemetry = telemetrySettings
 				}
@@ -257,7 +257,7 @@ func TestReportStatusOnStartShutdown(t *testing.T) {
 			require.Equal(t, tc.startErr, err)
 
 			if tc.startErr == nil {
-				comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
+				comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusOK))
 
 				err = comp.Shutdown(context.Background())
 				require.Equal(t, tc.shutdownErr, err)

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -109,15 +109,13 @@ func TestSharedComponent(t *testing.T) {
 }
 func TestSharedComponentsReportStatus(t *testing.T) {
 	reportedStatuses := make(map[*component.InstanceID][]component.Status)
-	newStatusFunc := func() func(*component.StatusEvent) error {
+	newStatusFunc := func() func(*component.StatusEvent) {
 		instanceID := &component.InstanceID{}
-		return func(ev *component.StatusEvent) error {
-			// Use an event with component.StatusNone to simulate an error.
+		return func(ev *component.StatusEvent) {
 			if ev.Status() == component.StatusNone {
-				return assert.AnError
+				return
 			}
 			reportedStatuses[instanceID] = append(reportedStatuses[instanceID], ev.Status())
-			return nil
 		}
 	}
 
@@ -152,24 +150,18 @@ func TestSharedComponentsReportStatus(t *testing.T) {
 		telemetrySettings,
 	)
 
-	err := comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusStarting))
-	require.NoError(t, err)
+	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusStarting))
 
-	// ok
-	err = comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
-	require.NoError(t, err)
+	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
 
 	// simulate an error
-	err = comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusNone))
-	require.ErrorIs(t, err, assert.AnError)
+	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusNone))
 
 	// stopping
-	err = comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusStopping))
-	require.NoError(t, err)
+	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusStopping))
 
 	// stopped
-	err = comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusStopped))
-	require.NoError(t, err)
+	comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusStopped))
 
 	// The shared component represents 3 component instances. Reporting status for the shared
 	// component should report status for each of the instances it represents.
@@ -227,11 +219,10 @@ func TestReportStatusOnStartShutdown(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			reportedStatuses := make(map[*component.InstanceID][]component.Status)
-			newStatusFunc := func() func(*component.StatusEvent) error {
+			newStatusFunc := func() func(*component.StatusEvent) {
 				instanceID := &component.InstanceID{}
-				return func(ev *component.StatusEvent) error {
+				return func(ev *component.StatusEvent) {
 					reportedStatuses[instanceID] = append(reportedStatuses[instanceID], ev.Status())
-					return nil
 				}
 			}
 			base := &baseComponent{}
@@ -266,8 +257,7 @@ func TestReportStatusOnStartShutdown(t *testing.T) {
 			require.Equal(t, tc.startErr, err)
 
 			if tc.startErr == nil {
-				err = comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
-				require.NoError(t, err)
+				comp.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
 
 				err = comp.Shutdown(context.Background())
 				require.Equal(t, tc.shutdownErr, err)

--- a/processor/processortest/unhealthy_processor.go
+++ b/processor/processortest/unhealthy_processor.go
@@ -64,7 +64,7 @@ type unhealthyProcessor struct {
 
 func (p unhealthyProcessor) Start(_ context.Context, _ component.Host) error {
 	go func() {
-		_ = p.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusRecoverableError))
+		p.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusRecoverableError))
 	}()
 	return nil
 }

--- a/processor/processortest/unhealthy_processor.go
+++ b/processor/processortest/unhealthy_processor.go
@@ -64,7 +64,7 @@ type unhealthyProcessor struct {
 
 func (p unhealthyProcessor) Start(_ context.Context, _ component.Host) error {
 	go func() {
-		p.telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusRecoverableError))
+		p.telemetry.ReportStatus(component.NewStatusEvent(component.StatusRecoverableError))
 	}()
 	return nil
 }

--- a/service/extensions/extensions.go
+++ b/service/extensions/extensions.go
@@ -37,18 +37,18 @@ func (bes *Extensions) Start(ctx context.Context, host component.Host) error {
 		extLogger.Info("Extension is starting...")
 		instanceID := bes.instanceIDs[extID]
 		ext := bes.extMap[extID]
-		_ = bes.telemetry.Status.ReportComponentStatus(
+		bes.telemetry.Status.ReportComponentStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStarting),
 		)
 		if err := ext.Start(ctx, components.NewHostWrapper(host, extLogger)); err != nil {
-			_ = bes.telemetry.Status.ReportComponentStatus(
+			bes.telemetry.Status.ReportComponentStatus(
 				instanceID,
 				component.NewPermanentErrorEvent(err),
 			)
 			return err
 		}
-		_ = bes.telemetry.Status.ReportComponentOKIfStarting(instanceID)
+		bes.telemetry.Status.ReportComponentOKIfStarting(instanceID)
 		extLogger.Info("Extension started.")
 	}
 	return nil
@@ -62,19 +62,19 @@ func (bes *Extensions) Shutdown(ctx context.Context) error {
 		extID := bes.extensionIDs[i]
 		instanceID := bes.instanceIDs[extID]
 		ext := bes.extMap[extID]
-		_ = bes.telemetry.Status.ReportComponentStatus(
+		bes.telemetry.Status.ReportComponentStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStopping),
 		)
 		if err := ext.Shutdown(ctx); err != nil {
-			_ = bes.telemetry.Status.ReportComponentStatus(
+			bes.telemetry.Status.ReportComponentStatus(
 				instanceID,
 				component.NewPermanentErrorEvent(err),
 			)
 			errs = multierr.Append(errs, err)
 			continue
 		}
-		_ = bes.telemetry.Status.ReportComponentStatus(
+		bes.telemetry.Status.ReportComponentStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStopped),
 		)

--- a/service/extensions/extensions.go
+++ b/service/extensions/extensions.go
@@ -37,18 +37,18 @@ func (bes *Extensions) Start(ctx context.Context, host component.Host) error {
 		extLogger.Info("Extension is starting...")
 		instanceID := bes.instanceIDs[extID]
 		ext := bes.extMap[extID]
-		bes.telemetry.Status.ReportComponentStatus(
+		bes.telemetry.Status.ReportStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStarting),
 		)
 		if err := ext.Start(ctx, components.NewHostWrapper(host, extLogger)); err != nil {
-			bes.telemetry.Status.ReportComponentStatus(
+			bes.telemetry.Status.ReportStatus(
 				instanceID,
 				component.NewPermanentErrorEvent(err),
 			)
 			return err
 		}
-		bes.telemetry.Status.ReportComponentOKIfStarting(instanceID)
+		bes.telemetry.Status.ReportOKIfStarting(instanceID)
 		extLogger.Info("Extension started.")
 	}
 	return nil
@@ -62,19 +62,19 @@ func (bes *Extensions) Shutdown(ctx context.Context) error {
 		extID := bes.extensionIDs[i]
 		instanceID := bes.instanceIDs[extID]
 		ext := bes.extMap[extID]
-		bes.telemetry.Status.ReportComponentStatus(
+		bes.telemetry.Status.ReportStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStopping),
 		)
 		if err := ext.Shutdown(ctx); err != nil {
-			bes.telemetry.Status.ReportComponentStatus(
+			bes.telemetry.Status.ReportStatus(
 				instanceID,
 				component.NewPermanentErrorEvent(err),
 			)
 			errs = multierr.Append(errs, err)
 			continue
 		}
-		bes.telemetry.Status.ReportComponentStatus(
+		bes.telemetry.Status.ReportStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStopped),
 		)

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -434,6 +434,8 @@ func TestStatusReportedOnStartupShutdown(t *testing.T) {
 			var actualStatuses []*component.StatusEvent
 			rep := status.NewReporter(func(id *component.InstanceID, ev *component.StatusEvent) {
 				actualStatuses = append(actualStatuses, ev)
+			}, func(err error) {
+				require.NoError(t, err)
 			})
 			extensions.telemetry.Status = rep
 			rep.Ready()

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -388,20 +388,20 @@ func (g *Graph) StartAll(ctx context.Context, host component.Host) error {
 		}
 
 		instanceID := g.instanceIDs[node.ID()]
-		g.telemetry.Status.ReportComponentStatus(
+		g.telemetry.Status.ReportStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStarting),
 		)
 
 		if compErr := comp.Start(ctx, host); compErr != nil {
-			g.telemetry.Status.ReportComponentStatus(
+			g.telemetry.Status.ReportStatus(
 				instanceID,
 				component.NewPermanentErrorEvent(compErr),
 			)
 			return compErr
 		}
 
-		g.telemetry.Status.ReportComponentOKIfStarting(instanceID)
+		g.telemetry.Status.ReportOKIfStarting(instanceID)
 	}
 	return nil
 }
@@ -427,21 +427,21 @@ func (g *Graph) ShutdownAll(ctx context.Context) error {
 		}
 
 		instanceID := g.instanceIDs[node.ID()]
-		g.telemetry.Status.ReportComponentStatus(
+		g.telemetry.Status.ReportStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStopping),
 		)
 
 		if compErr := comp.Shutdown(ctx); compErr != nil {
 			errs = multierr.Append(errs, compErr)
-			g.telemetry.Status.ReportComponentStatus(
+			g.telemetry.Status.ReportStatus(
 				instanceID,
 				component.NewPermanentErrorEvent(compErr),
 			)
 			continue
 		}
 
-		g.telemetry.Status.ReportComponentStatus(
+		g.telemetry.Status.ReportStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStopped),
 		)

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -388,20 +388,20 @@ func (g *Graph) StartAll(ctx context.Context, host component.Host) error {
 		}
 
 		instanceID := g.instanceIDs[node.ID()]
-		_ = g.telemetry.Status.ReportComponentStatus(
+		g.telemetry.Status.ReportComponentStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStarting),
 		)
 
 		if compErr := comp.Start(ctx, host); compErr != nil {
-			_ = g.telemetry.Status.ReportComponentStatus(
+			g.telemetry.Status.ReportComponentStatus(
 				instanceID,
 				component.NewPermanentErrorEvent(compErr),
 			)
 			return compErr
 		}
 
-		_ = g.telemetry.Status.ReportComponentOKIfStarting(instanceID)
+		g.telemetry.Status.ReportComponentOKIfStarting(instanceID)
 	}
 	return nil
 }
@@ -427,21 +427,21 @@ func (g *Graph) ShutdownAll(ctx context.Context) error {
 		}
 
 		instanceID := g.instanceIDs[node.ID()]
-		_ = g.telemetry.Status.ReportComponentStatus(
+		g.telemetry.Status.ReportComponentStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStopping),
 		)
 
 		if compErr := comp.Shutdown(ctx); compErr != nil {
 			errs = multierr.Append(errs, compErr)
-			_ = g.telemetry.Status.ReportComponentStatus(
+			g.telemetry.Status.ReportComponentStatus(
 				instanceID,
 				component.NewPermanentErrorEvent(compErr),
 			)
 			continue
 		}
 
-		_ = g.telemetry.Status.ReportComponentStatus(
+		g.telemetry.Status.ReportComponentStatus(
 			instanceID,
 			component.NewStatusEvent(component.StatusStopped),
 		)

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -2337,6 +2337,7 @@ func TestStatusReportedOnStartupShutdown(t *testing.T) {
 			actualStatuses := make(map[*component.InstanceID][]*component.StatusEvent)
 			rep := status.NewReporter(func(id *component.InstanceID, ev *component.StatusEvent) {
 				actualStatuses[id] = append(actualStatuses[id], ev)
+			}, func(err error) {
 			})
 
 			pg.telemetry.Status = rep

--- a/service/internal/servicetelemetry/nop_telemetry_settings.go
+++ b/service/internal/servicetelemetry/nop_telemetry_settings.go
@@ -22,6 +22,6 @@ func NewNopTelemetrySettings() TelemetrySettings {
 		MeterProvider:  noopmetric.NewMeterProvider(),
 		MetricsLevel:   configtelemetry.LevelNone,
 		Resource:       pcommon.NewResource(),
-		Status:         status.NewReporter(func(*component.InstanceID, *component.StatusEvent) {}),
+		Status:         status.NewReporter(func(*component.InstanceID, *component.StatusEvent) {}, func(err error) {}),
 	}
 }

--- a/service/internal/servicetelemetry/nop_telemetry_settings_test.go
+++ b/service/internal/servicetelemetry/nop_telemetry_settings_test.go
@@ -26,10 +26,10 @@ func TestNewNopSettings(t *testing.T) {
 	require.Equal(t, noopmetric.NewMeterProvider(), set.MeterProvider)
 	require.Equal(t, configtelemetry.LevelNone, set.MetricsLevel)
 	require.Equal(t, pcommon.NewResource(), set.Resource)
-	set.Status.ReportComponentStatus(
+	set.Status.ReportStatus(
 		&component.InstanceID{},
 		component.NewStatusEvent(component.StatusStarting),
 	)
-	set.Status.ReportComponentOKIfStarting(&component.InstanceID{})
+	set.Status.ReportOKIfStarting(&component.InstanceID{})
 
 }

--- a/service/internal/servicetelemetry/nop_telemetry_settings_test.go
+++ b/service/internal/servicetelemetry/nop_telemetry_settings_test.go
@@ -26,11 +26,10 @@ func TestNewNopSettings(t *testing.T) {
 	require.Equal(t, noopmetric.NewMeterProvider(), set.MeterProvider)
 	require.Equal(t, configtelemetry.LevelNone, set.MetricsLevel)
 	require.Equal(t, pcommon.NewResource(), set.Resource)
-	require.NoError(t,
-		set.Status.ReportComponentStatus(
-			&component.InstanceID{},
-			component.NewStatusEvent(component.StatusStarting),
-		),
+	set.Status.ReportComponentStatus(
+		&component.InstanceID{},
+		component.NewStatusEvent(component.StatusStarting),
 	)
-	require.NoError(t, set.Status.ReportComponentOKIfStarting(&component.InstanceID{}))
+	set.Status.ReportComponentOKIfStarting(&component.InstanceID{})
+
 }

--- a/service/internal/servicetelemetry/telemetry_settings.go
+++ b/service/internal/servicetelemetry/telemetry_settings.go
@@ -43,7 +43,7 @@ type TelemetrySettings struct {
 // ToComponentTelemetrySettings returns a TelemetrySettings for a specific component derived from
 // this service level Settings object.
 func (s TelemetrySettings) ToComponentTelemetrySettings(id *component.InstanceID) component.TelemetrySettings {
-	status := status.NewComponentStatusFunc(id, s.Status.ReportStatus)
+	statusFunc := status.NewReportStatusFunc(id, s.Status.ReportStatus)
 	return component.TelemetrySettings{
 		Logger:         s.Logger,
 		TracerProvider: s.TracerProvider,
@@ -51,9 +51,9 @@ func (s TelemetrySettings) ToComponentTelemetrySettings(id *component.InstanceID
 		MetricsLevel:   s.MetricsLevel,
 		Resource:       s.Resource,
 		ReportComponentStatus: func(event *component.StatusEvent) error {
-			status(event)
+			statusFunc(event)
 			return nil
 		},
-		ReportStatus: status,
+		ReportStatus: statusFunc,
 	}
 }

--- a/service/internal/servicetelemetry/telemetry_settings.go
+++ b/service/internal/servicetelemetry/telemetry_settings.go
@@ -43,12 +43,17 @@ type TelemetrySettings struct {
 // ToComponentTelemetrySettings returns a TelemetrySettings for a specific component derived from
 // this service level Settings object.
 func (s TelemetrySettings) ToComponentTelemetrySettings(id *component.InstanceID) component.TelemetrySettings {
+	status := status.NewComponentStatusFunc(id, s.Status.ReportStatus)
 	return component.TelemetrySettings{
-		Logger:                s.Logger,
-		TracerProvider:        s.TracerProvider,
-		MeterProvider:         s.MeterProvider,
-		MetricsLevel:          s.MetricsLevel,
-		Resource:              s.Resource,
-		ReportComponentStatus: status.NewComponentStatusFunc(id, s.Status.ReportComponentStatus),
+		Logger:         s.Logger,
+		TracerProvider: s.TracerProvider,
+		MeterProvider:  s.MeterProvider,
+		MetricsLevel:   s.MetricsLevel,
+		Resource:       s.Resource,
+		ReportComponentStatus: func(event *component.StatusEvent) error {
+			status(event)
+			return nil
+		},
+		ReportStatus: status,
 	}
 }

--- a/service/internal/servicetelemetry/telemetry_settings_test.go
+++ b/service/internal/servicetelemetry/telemetry_settings_test.go
@@ -24,17 +24,17 @@ func TestSettings(t *testing.T) {
 		MeterProvider:  noopmetric.NewMeterProvider(),
 		MetricsLevel:   configtelemetry.LevelNone,
 		Resource:       pcommon.NewResource(),
-		Status:         status.NewReporter(func(*component.InstanceID, *component.StatusEvent) {}),
+		Status: status.NewReporter(
+			func(*component.InstanceID, *component.StatusEvent) {},
+			func(err error) { require.NoError(t, err) }),
 	}
 	set.Status.Ready()
-	require.NoError(t,
-		set.Status.ReportComponentStatus(
-			&component.InstanceID{},
-			component.NewStatusEvent(component.StatusStarting),
-		),
+	set.Status.ReportComponentStatus(
+		&component.InstanceID{},
+		component.NewStatusEvent(component.StatusStarting),
 	)
-	require.NoError(t, set.Status.ReportComponentOKIfStarting(&component.InstanceID{}))
+	set.Status.ReportComponentOKIfStarting(&component.InstanceID{})
 
 	compSet := set.ToComponentTelemetrySettings(&component.InstanceID{})
-	require.NoError(t, compSet.ReportComponentStatus(component.NewStatusEvent(component.StatusStarting)))
+	compSet.ReportComponentStatus(component.NewStatusEvent(component.StatusStarting))
 }

--- a/service/internal/servicetelemetry/telemetry_settings_test.go
+++ b/service/internal/servicetelemetry/telemetry_settings_test.go
@@ -29,12 +29,12 @@ func TestSettings(t *testing.T) {
 			func(err error) { require.NoError(t, err) }),
 	}
 	set.Status.Ready()
-	set.Status.ReportComponentStatus(
+	set.Status.ReportStatus(
 		&component.InstanceID{},
 		component.NewStatusEvent(component.StatusStarting),
 	)
-	set.Status.ReportComponentOKIfStarting(&component.InstanceID{})
+	set.Status.ReportOKIfStarting(&component.InstanceID{})
 
 	compSet := set.ToComponentTelemetrySettings(&component.InstanceID{})
-	compSet.ReportComponentStatus(component.NewStatusEvent(component.StatusStarting))
+	compSet.ReportStatus(component.NewStatusEvent(component.StatusStarting))
 }

--- a/service/internal/status/status.go
+++ b/service/internal/status/status.go
@@ -180,10 +180,10 @@ func (r *Reporter) componentFSM(id *component.InstanceID) *fsm {
 	return fsm
 }
 
-// NewComponentStatusFunc returns a function to be used as ReportStatus for
+// NewReportStatusFunc returns a function to be used as ReportStatus for
 // component.TelemetrySettings, which differs from servicetelemetry.Settings in that
 // the component version is tied to specific component instance.
-func NewComponentStatusFunc(
+func NewReportStatusFunc(
 	id *component.InstanceID,
 	srvStatus ServiceStatusFunc,
 ) func(*component.StatusEvent) {

--- a/service/internal/status/status.go
+++ b/service/internal/status/status.go
@@ -89,7 +89,7 @@ type NotifyStatusFunc func(*component.InstanceID, *component.StatusEvent)
 // InvalidTransitionFunc is the receiver of invalid transition errors
 type InvalidTransitionFunc func(error)
 
-// ServiceStatusFunc is the expected type of ReportComponentStatus for servicetelemetry.Settings
+// ServiceStatusFunc is the expected type of ReportStatus for servicetelemetry.Settings
 type ServiceStatusFunc func(*component.InstanceID, *component.StatusEvent)
 
 // ErrStatusNotReady is returned when trying to report status before service start
@@ -122,7 +122,18 @@ func (r *Reporter) Ready() {
 }
 
 // ReportComponentStatus reports status for the given InstanceID
+// Deprecated: [v0.92.0] This function will be removed in a future release.
+// Use ReportStatus instead.
 func (r *Reporter) ReportComponentStatus(
+	id *component.InstanceID,
+	ev *component.StatusEvent,
+) error {
+	r.ReportStatus(id, ev)
+	return nil
+}
+
+// ReportStatus reports status for the given InstanceID
+func (r *Reporter) ReportStatus(
 	id *component.InstanceID,
 	ev *component.StatusEvent,
 ) {
@@ -138,7 +149,14 @@ func (r *Reporter) ReportComponentStatus(
 }
 
 // ReportComponentOkIfStarting reports StatusOK if the component's current status is Starting
-func (r *Reporter) ReportComponentOKIfStarting(id *component.InstanceID) {
+// Deprecated: [v0.92.0] This function will be removed in a future release.
+// Use ReportOKIfStarting instead.
+func (r *Reporter) ReportComponentOKIfStarting(id *component.InstanceID) error {
+	r.ReportOKIfStarting(id)
+	return nil
+}
+
+func (r *Reporter) ReportOKIfStarting(id *component.InstanceID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if !r.ready {
@@ -162,7 +180,7 @@ func (r *Reporter) componentFSM(id *component.InstanceID) *fsm {
 	return fsm
 }
 
-// NewComponentStatusFunc returns a function to be used as ReportComponentStatus for
+// NewComponentStatusFunc returns a function to be used as ReportStatus for
 // component.TelemetrySettings, which differs from servicetelemetry.Settings in that
 // the component version is tied to specific component instance.
 func NewComponentStatusFunc(

--- a/service/internal/status/status.go
+++ b/service/internal/status/status.go
@@ -92,8 +92,8 @@ type InvalidTransitionFunc func(error)
 // ServiceStatusFunc is the expected type of ReportComponentStatus for servicetelemetry.Settings
 type ServiceStatusFunc func(*component.InstanceID, *component.StatusEvent)
 
-// errStatusNotReady is returned when trying to report status before service start
-var errStatusNotReady = errors.New("report component status is not ready until service start")
+// ErrStatusNotReady is returned when trying to report status before service start
+var ErrStatusNotReady = errors.New("report component status is not ready until service start")
 
 // Reporter handles component status reporting
 type Reporter struct {
@@ -129,7 +129,7 @@ func (r *Reporter) ReportComponentStatus(
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if !r.ready {
-		r.onInvalidTransition(errStatusNotReady)
+		r.onInvalidTransition(ErrStatusNotReady)
 	} else {
 		if err := r.componentFSM(id).transition(ev); err != nil {
 			r.onInvalidTransition(err)
@@ -142,7 +142,7 @@ func (r *Reporter) ReportComponentOKIfStarting(id *component.InstanceID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if !r.ready {
-		r.onInvalidTransition(errStatusNotReady)
+		r.onInvalidTransition(ErrStatusNotReady)
 	}
 	fsm := r.componentFSM(id)
 	if fsm.current.Status() == component.StatusStarting {

--- a/service/internal/status/status_test.go
+++ b/service/internal/status/status_test.go
@@ -269,7 +269,7 @@ func TestReporterReady(t *testing.T) {
 	id := &component.InstanceID{}
 
 	rep.ReportComponentStatus(id, component.NewStatusEvent(component.StatusStarting))
-	require.ErrorIs(t, err, errStatusNotReady)
+	require.ErrorIs(t, err, ErrStatusNotReady)
 	rep.Ready()
 
 	err = nil

--- a/service/internal/status/status_test.go
+++ b/service/internal/status/status_test.go
@@ -212,8 +212,8 @@ func TestStatusFuncs(t *testing.T) {
 		func(err error) {
 			require.NoError(t, err)
 		})
-	comp1Func := NewComponentStatusFunc(id1, rep.ReportComponentStatus)
-	comp2Func := NewComponentStatusFunc(id2, rep.ReportComponentStatus)
+	comp1Func := NewComponentStatusFunc(id1, rep.ReportStatus)
+	comp2Func := NewComponentStatusFunc(id2, rep.ReportStatus)
 	rep.Ready()
 
 	for _, st := range statuses1 {
@@ -245,7 +245,7 @@ func TestStatusFuncsConcurrent(t *testing.T) {
 	for _, id := range ids {
 		id := id
 		go func() {
-			compFn := NewComponentStatusFunc(id, rep.ReportComponentStatus)
+			compFn := NewComponentStatusFunc(id, rep.ReportStatus)
 			compFn(component.NewStatusEvent(component.StatusStarting))
 			for i := 0; i < 1000; i++ {
 				compFn(component.NewStatusEvent(component.StatusRecoverableError))
@@ -268,12 +268,12 @@ func TestReporterReady(t *testing.T) {
 		})
 	id := &component.InstanceID{}
 
-	rep.ReportComponentStatus(id, component.NewStatusEvent(component.StatusStarting))
+	rep.ReportStatus(id, component.NewStatusEvent(component.StatusStarting))
 	require.ErrorIs(t, err, ErrStatusNotReady)
 	rep.Ready()
 
 	err = nil
-	rep.ReportComponentStatus(id, component.NewStatusEvent(component.StatusStarting))
+	rep.ReportStatus(id, component.NewStatusEvent(component.StatusStarting))
 	require.NoError(t, err)
 }
 
@@ -342,10 +342,10 @@ func TestReportComponentOKIfStarting(t *testing.T) {
 
 			id := &component.InstanceID{}
 			for _, status := range tc.initialStatuses {
-				rep.ReportComponentStatus(id, component.NewStatusEvent(status))
+				rep.ReportStatus(id, component.NewStatusEvent(status))
 			}
 
-			rep.ReportComponentOKIfStarting(id)
+			rep.ReportOKIfStarting(id)
 
 			require.Equal(t, tc.expectedStatuses, receivedStatuses)
 		})

--- a/service/internal/status/status_test.go
+++ b/service/internal/status/status_test.go
@@ -212,8 +212,8 @@ func TestStatusFuncs(t *testing.T) {
 		func(err error) {
 			require.NoError(t, err)
 		})
-	comp1Func := NewComponentStatusFunc(id1, rep.ReportStatus)
-	comp2Func := NewComponentStatusFunc(id2, rep.ReportStatus)
+	comp1Func := NewReportStatusFunc(id1, rep.ReportStatus)
+	comp2Func := NewReportStatusFunc(id2, rep.ReportStatus)
 	rep.Ready()
 
 	for _, st := range statuses1 {
@@ -245,7 +245,7 @@ func TestStatusFuncsConcurrent(t *testing.T) {
 	for _, id := range ids {
 		id := id
 		go func() {
-			compFn := NewComponentStatusFunc(id, rep.ReportStatus)
+			compFn := NewReportStatusFunc(id, rep.ReportStatus)
 			compFn(component.NewStatusEvent(component.StatusStarting))
 			for i := 0; i < 1000; i++ {
 				compFn(component.NewStatusEvent(component.StatusRecoverableError))

--- a/service/service.go
+++ b/service/service.go
@@ -113,7 +113,9 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		MetricsLevel:   cfg.Telemetry.Metrics.Level,
 		// Construct telemetry attributes from build info and config's resource attributes.
 		Resource: pcommonRes,
-		Status:   status.NewReporter(srv.host.notifyComponentStatusChange),
+		Status: status.NewReporter(srv.host.notifyComponentStatusChange, func(err error) {
+			srv.telemetry.Logger().Debug("Invalid transition", zap.Error(err))
+		}),
 	}
 
 	if err = srv.telemetryInitializer.init(res, srv.telemetrySettings, cfg.Telemetry, set.AsyncErrorChannel); err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -5,6 +5,7 @@ package service // import "go.opentelemetry.io/collector/service"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 
@@ -114,7 +115,11 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		// Construct telemetry attributes from build info and config's resource attributes.
 		Resource: pcommonRes,
 		Status: status.NewReporter(srv.host.notifyComponentStatusChange, func(err error) {
-			srv.telemetry.Logger().Debug("Invalid transition", zap.Error(err))
+			if errors.Is(err, status.ErrStatusNotReady) {
+				srv.telemetry.Logger().Warn("Invalid transition", zap.Error(err))
+			} else {
+				srv.telemetry.Logger().Debug("Invalid transition", zap.Error(err))
+			}
 		}),
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -117,9 +117,8 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		Status: status.NewReporter(srv.host.notifyComponentStatusChange, func(err error) {
 			if errors.Is(err, status.ErrStatusNotReady) {
 				srv.telemetry.Logger().Warn("Invalid transition", zap.Error(err))
-			} else {
-				srv.telemetry.Logger().Debug("Invalid transition", zap.Error(err))
 			}
+			// ignore other errors as they represent invalid state transitions and are considered benign.
 		}),
 	}
 


### PR DESCRIPTION
Fixes #9148