### PR TITLE
[chore] update codecov to ignore third_party

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,3 +19,4 @@ coverage:
 
 ignore:
   - "pdata/internal/data/protogen/**/*"
+  - "cmd/mdatagen/third_party/**/*"


### PR DESCRIPTION
This is the same rule that was used in contrib, ignores third_party dir under mdatagen.
