### PR TITLE
[chore][CI/CD] Add make gotidy check in build-and-test.yml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -107,6 +107,11 @@ jobs:
         run: make misspell
       - name: checkdoc
         run: make checkdoc
+      - name: Check for go mod dependency changes
+        run: |
+          make gotidy
+          git diff --exit-code || (echo 'go.mod/go.sum deps changes detected, please run "make gotidy" and commit the changes in this PR.' && exit 1)
+          - name: Gen genotelcontribcol
       - name: go:porto
         run: |
           make goporto

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,7 +111,6 @@ jobs:
         run: |
           make gotidy
           git diff --exit-code || (echo 'go.mod/go.sum deps changes detected, please run "make gotidy" and commit the changes in this PR.' && exit 1)
-          - name: Gen genotelcontribcol
       - name: go:porto
         run: |
           make goporto


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Every PR should be checked to make sure `make gotidy` can run successfully against its contents. I want to add this because as shown in #9212, I recently broke some dependencies on `main`.

[Logic lifted from contrib.](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/0c27a3bccfd1b1f7418cc1ac05a535ce29a5a736/.github/workflows/build-and-test.yml#L198-L201)