### PR TITLE
[chore] [extension/memory_ballast] Move ballast size calculation to the init step

### DIFF
--- a/.chloggen/change-memory-balast-init.yaml
+++ b/.chloggen/change-memory-balast-init.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: 'extension/memory_ballast'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Move memory ballast initialization to from the start to the build step"
+
+# One or more tracking issues or pull requests related to the change
+issues: [9218]

--- a/extension/ballastextension/factory.go
+++ b/extension/ballastextension/factory.go
@@ -27,5 +27,5 @@ func createDefaultConfig() component.Config {
 }
 
 func createExtension(_ context.Context, set extension.CreateSettings, cfg component.Config) (extension.Extension, error) {
-	return newMemoryBallast(cfg.(*Config), set.TelemetrySettings.Logger, memHandler), nil
+	return newMemoryBallast(cfg.(*Config), set.TelemetrySettings.Logger, memHandler)
 }


### PR DESCRIPTION
This is needed to unblock moving `memory_limiter` from the processor to the extension.

`memory_limiter` uses the ballast size to accurately calculate the memory usage. Even if the memory_ballast extension is deprecated, the user can still use it. In order to make them work together, we need to make sure that the ballast is calculated before the `memory_limiter` extension is started. This change moves the ballast calculation in the ballast extension from the Start to the Init step.

Alternatively, we could make the new `memory_limiter` extension fail if `memory_ballast` is found. But that would:
1. make the logic of memory_limiter processors and extension split more complicated;
2. force users to handle the ballast deprecation before trying the new `memory_limiter` extension.
