### PR TITLE
[chore][cmd/mdatagen] Properly test bytes attribute type

### DIFF
--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -194,7 +194,7 @@ func (a attribute) TestValue() string {
 	case pcommon.ValueTypeSlice:
 		return fmt.Sprintf(`[]any{"%s-item1", "%s-item2"}`, a.FullName, a.FullName)
 	case pcommon.ValueTypeBytes:
-		return fmt.Sprintf(`bytes("%s-val")`, a.FullName)
+		return fmt.Sprintf(`[]byte("%s-val")`, a.FullName)
 	}
 	return ""
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As described in the [issue opened in the contrib repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29923), mdatagen was originally generating tests for byte arrays incorrectly. This tests byte arrays in their proper format.

As [requested](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30106#issuecomment-1879321401), this ports the [contrib fix ](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30106 )into core. 

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29923

**Testing:** <Describe what testing was performed and which tests were added.>
I added a fake attribute and fake metric that used it, then generated tests.
Fake attribute and metric:
```
attributes:
  # Added a fake attribute in a metadata.yaml file
  fake:
    description: "Fake attribute for testing"
    type: bytes

metrics:
  container.cpu.usage.percpu:
    enabled: false
    description: "Per-core CPU usage by the container (Only available with cgroups v1)."
    unit: ns
    sum:
      value_type: int
      monotonic: true
      aggregation_temporality: cumulative
    attributes:
      - fake
```
Generated tests:
```
// First test reference:
			mb.RecordContainerCPUUsagePercpuDataPoint(ts, 1, []byte("fake-val"))
// Second test reference:
					attrVal, ok := dp.Attributes().Get("fake")
					assert.True(t, ok)
					assert.EqualValues(t, []byte("fake-val"), attrVal.Bytes())
```