### PR TITLE
[confignet] Remove deprecated confignet functions

### DIFF
--- a/.chloggen/confignet-remove-deprecated-functions.yaml
+++ b/.chloggen/confignet-remove-deprecated-functions.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confignet
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecates `DialContext` and `ListenContext` functions. Use `Dial` and `Listen` instead.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9258]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Unlike the previous `Dial` and `Listen` functions, the new `Dial` and `Listen` functions take a `context.Context` like `DialContext` and `ListenContext`.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -270,7 +270,7 @@ func validateBalancerName(balancerName string) bool {
 
 // ToListener returns the net.Listener constructed from the settings.
 func (gss *GRPCServerSettings) ToListener() (net.Listener, error) {
-	return gss.NetAddr.Listen()
+	return gss.NetAddr.Listen(context.Background())
 }
 
 func (gss *GRPCServerSettings) ToServer(host component.Host, settings component.TelemetrySettings, extraOpts ...grpc.ServerOption) (*grpc.Server, error) {

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -33,18 +33,6 @@ type NetAddr struct {
 	DialerConfig DialerConfig `mapstructure:"dialer"`
 }
 
-// Dial equivalent with net.Dial for this address.
-// Deprecated: [v0.92.0] use DialContext instead.
-func (na *NetAddr) Dial() (net.Conn, error) {
-	return net.DialTimeout(na.Transport, na.Endpoint, na.DialerConfig.Timeout)
-}
-
-// Listen equivalent with net.Listen for this address.
-// Deprecated: [v0.92.0] use ListenContext instead.
-func (na *NetAddr) Listen() (net.Listener, error) {
-	return net.Listen(na.Transport, na.Endpoint)
-}
-
 // DialContext equivalent with net.Dialer's DialContext for this address.
 func (na *NetAddr) DialContext(ctx context.Context) (net.Conn, error) {
 	d := net.Dialer{Timeout: na.DialerConfig.Timeout}
@@ -68,18 +56,6 @@ type TCPAddr struct {
 
 	// DialerConfig contains options for connecting to an address.
 	DialerConfig DialerConfig `mapstructure:"dialer"`
-}
-
-// Dial equivalent with net.Dial for this address.
-// Deprecated: [v0.92.0] use DialContext instead.
-func (na *TCPAddr) Dial() (net.Conn, error) {
-	return net.DialTimeout("tcp", na.Endpoint, na.DialerConfig.Timeout)
-}
-
-// Listen equivalent with net.Listen for this address.
-// Deprecated: [v0.92.0] use ListenContext instead.
-func (na *TCPAddr) Listen() (net.Listener, error) {
-	return net.Listen("tcp", na.Endpoint)
 }
 
 // DialContext equivalent with net.Dialer's DialContext for this address.

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -33,16 +33,28 @@ type NetAddr struct {
 	DialerConfig DialerConfig `mapstructure:"dialer"`
 }
 
-// DialContext equivalent with net.Dialer's DialContext for this address.
-func (na *NetAddr) DialContext(ctx context.Context) (net.Conn, error) {
+// Dial equivalent with net.Dialer's DialContext for this address.
+func (na *NetAddr) Dial(ctx context.Context) (net.Conn, error) {
 	d := net.Dialer{Timeout: na.DialerConfig.Timeout}
 	return d.DialContext(ctx, na.Transport, na.Endpoint)
 }
 
-// ListenContext equivalent with net.ListenConfig's Listen for this address.
-func (na *NetAddr) ListenContext(ctx context.Context) (net.Listener, error) {
+// Listen equivalent with net.ListenConfig's Listen for this address.
+func (na *NetAddr) Listen(ctx context.Context) (net.Listener, error) {
 	lc := net.ListenConfig{}
 	return lc.Listen(ctx, na.Transport, na.Endpoint)
+}
+
+// DialContext equivalent with net.Dialer's DialContext for this address.
+// Deprecated: [v0.93.0] use Dial instead.
+func (na *NetAddr) DialContext(ctx context.Context) (net.Conn, error) {
+	return na.Dial(ctx)
+}
+
+// ListenContext equivalent with net.ListenConfig's Listen for this address.
+// Deprecated: [v0.93.0] use Listen instead.
+func (na *NetAddr) ListenContext(ctx context.Context) (net.Listener, error) {
+	return na.Listen(ctx)
 }
 
 // TCPAddr represents a TCP endpoint address.
@@ -58,14 +70,26 @@ type TCPAddr struct {
 	DialerConfig DialerConfig `mapstructure:"dialer"`
 }
 
-// DialContext equivalent with net.Dialer's DialContext for this address.
-func (na *TCPAddr) DialContext(ctx context.Context) (net.Conn, error) {
+// Dial equivalent with net.Dialer's DialContext for this address.
+func (na *TCPAddr) Dial(ctx context.Context) (net.Conn, error) {
 	d := net.Dialer{Timeout: na.DialerConfig.Timeout}
 	return d.DialContext(ctx, "tcp", na.Endpoint)
 }
 
-// ListenContext equivalent with net.ListenConfig's Listen for this address.
-func (na *TCPAddr) ListenContext(ctx context.Context) (net.Listener, error) {
+// Listen equivalent with net.ListenConfig's Listen for this address.
+func (na *TCPAddr) Listen(ctx context.Context) (net.Listener, error) {
 	lc := net.ListenConfig{}
 	return lc.Listen(ctx, "tcp", na.Endpoint)
+}
+
+// DialContext equivalent with net.Dialer's DialContext for this address.
+// Deprecated: [v0.93.0] use Dial instead.
+func (na *TCPAddr) DialContext(ctx context.Context) (net.Conn, error) {
+	return na.Dial(ctx)
+}
+
+// ListenContext equivalent with net.ListenConfig's Listen for this address.
+// Deprecated: [v0.93.0] use Listen instead.
+func (na *TCPAddr) ListenContext(ctx context.Context) (net.Listener, error) {
+	return na.Listen(ctx)
 }

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -21,7 +21,7 @@ func TestNetAddrTimeout(t *testing.T) {
 			Timeout: -1 * time.Second,
 		},
 	}
-	_, err := nac.Dial()
+	_, err := nac.Dial(context.Background())
 	assert.Error(t, err)
 	var netErr net.Error
 	if errors.As(err, &netErr) {
@@ -38,7 +38,7 @@ func TestTCPAddrTimeout(t *testing.T) {
 			Timeout: -1 * time.Second,
 		},
 	}
-	_, err := nac.Dial()
+	_, err := nac.Dial(context.Background())
 	assert.Error(t, err)
 	var netErr net.Error
 	if errors.As(err, &netErr) {
@@ -53,7 +53,7 @@ func TestNetAddr(t *testing.T) {
 		Endpoint:  "localhost:0",
 		Transport: "tcp",
 	}
-	ln, err := nas.ListenContext(context.Background())
+	ln, err := nas.Listen(context.Background())
 	assert.NoError(t, err)
 	done := make(chan bool, 1)
 
@@ -74,7 +74,7 @@ func TestNetAddr(t *testing.T) {
 		Transport: "tcp",
 	}
 	var conn net.Conn
-	conn, err = nac.DialContext(context.Background())
+	conn, err = nac.Dial(context.Background())
 	assert.NoError(t, err)
 	_, err = conn.Write([]byte("test"))
 	assert.NoError(t, err)
@@ -87,7 +87,7 @@ func TestTCPAddr(t *testing.T) {
 	nas := &TCPAddr{
 		Endpoint: "localhost:0",
 	}
-	ln, err := nas.ListenContext(context.Background())
+	ln, err := nas.Listen(context.Background())
 	assert.NoError(t, err)
 	done := make(chan bool, 1)
 
@@ -107,7 +107,7 @@ func TestTCPAddr(t *testing.T) {
 		Endpoint: ln.Addr().String(),
 	}
 	var conn net.Conn
-	conn, err = nac.DialContext(context.Background())
+	conn, err = nac.Dial(context.Background())
 	assert.NoError(t, err)
 	_, err = conn.Write([]byte("test"))
 	assert.NoError(t, err)

--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -67,7 +67,7 @@ func (zpe *zpagesExtension) Start(_ context.Context, host component.Host) error 
 
 	// Start the listener here so we can have earlier failure if port is
 	// already in use.
-	ln, err := zpe.config.TCPAddr.Listen()
+	ln, err := zpe.config.TCPAddr.Listen(context.Background())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:** 
Instead of completely removing `Dial` and `Listen`, renames `DialContext` and `ListenContext` to `Dial` and `Listen` and deprecates `DialContext` and `ListenContext`.

**Link to tracking Issue:**
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9105

**Testing:**
Updated tests
