### PR TITLE
[chore][bug_report.md] Comment out header descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,26 +8,26 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **Steps to reproduce**
-If possible, provide a recipe for reproducing the error.
+<!-- If possible, provide a recipe for reproducing the error. -->
 
 **What did you expect to see?**
-A clear and concise description of what you expected to see.
+<!-- A clear and concise description of what you expected to see. -->
 
 **What did you see instead?**
-A clear and concise description of what you saw instead.
+<!-- A clear and concise description of what you saw instead. -->
 
 **What version did you use?**
-Version: (e.g., `v0.4.0`, `1eb551b`, etc)
+<!-- Version: (e.g., `v0.4.0`, `1eb551b`, etc) -->
 
 **What config did you use?**
-Config: (e.g. the yaml config file)
+<!-- Config: (e.g. the yaml config file) -->
 
 **Environment**
-OS: (e.g., "Ubuntu 20.04")
-Compiler(if manually compiled): (e.g., "go 14.2")
+<!-- OS: (e.g., "Ubuntu 20.04") -->
+<!-- Compiler(if manually compiled): (e.g., "go 14.2") -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
**Documentation:** <Describe the documentation added.>
The descriptions for each header when reporting bugs is useful for the person filing the bug, but not useful to those reading and reviewing. I think it makes sense for these to be included as comments in the bug report, so they're hidden in the rendered report.