### PR TITLE
Mark configopaque change as a breaking change

### DIFF
--- a/.chloggen/configopaque_stringer.yaml
+++ b/.chloggen/configopaque_stringer.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: configopaque
@@ -15,7 +15,9 @@ issues: [9213]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: | 
+  This may break applications that rely on the previous behavior of opaque strings with `fmt.Sprintf` to e.g. build URLs or headers.
+  Explicitly cast the opaque string to a string before using it in `fmt.Sprintf` to restore the previous behavior.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/.chloggen/configopaque_stringer.yaml
+++ b/.chloggen/configopaque_stringer.yaml
@@ -24,4 +24,4 @@ subtext: |
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [api]
+change_logs: [user, api]


### PR DESCRIPTION
**Description:** 

Follow up to #9214.

I think marking this as breaking is warranted since we have found 6 instances of breakage in contrib (fixed by open-telemetry/opentelemetry-collector-contrib#30304, open-telemetry/opentelemetry-collector-contrib#30402 and open-telemetry/opentelemetry-collector-contrib#30405).

I am also:

- Adding subtext explicitly stating how to fix this
- Adding this to the user changelog, since it has user-facing implications.
