### PR TITLE
[exporterhelper] Log errors even if retry is not used

### DIFF
--- a/.chloggen/eh_logerrors.yaml
+++ b/.chloggen/eh_logerrors.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: log errors even if component does not use exporter helper retry
+
+# One or more tracking issues or pull requests related to the change
+issues: [9219]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -163,9 +163,10 @@ func newBaseExporter(set exporter.CreateSettings, signal component.DataType, req
 		unmarshaler:     unmarshaler,
 		signal:          signal,
 
-		queueSender:   &baseRequestSender{},
-		obsrepSender:  osf(obsReport),
-		retrySender:   &baseRequestSender{},
+		queueSender:  &baseRequestSender{},
+		obsrepSender: osf(obsReport),
+		// this is required so that exporters that don't use WithRetry() still get error logs on export failure
+		retrySender:   &errorLoggingRequestSender{logger: set.Logger},
 		timeoutSender: &timeoutSender{cfg: NewDefaultTimeoutSettings()},
 
 		set:    set,

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -166,7 +166,7 @@ func newBaseExporter(set exporter.CreateSettings, signal component.DataType, req
 		queueSender:  &baseRequestSender{},
 		obsrepSender: osf(obsReport),
 		// this is required so that exporters that don't use WithRetry() still get error logs on export failure
-		retrySender:   &errorLoggingRequestSender{logger: set.Logger},
+		retrySender:   &errorLoggingRequestSender{logger: set.Logger, message: "Exporting failed"},
 		timeoutSender: &timeoutSender{cfg: NewDefaultTimeoutSettings()},
 
 		set:    set,

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -86,11 +86,11 @@ func TestQueueRetryOptionsWithRequestExporter(t *testing.T) {
 func TestBaseExporterLogging(t *testing.T) {
 	tests := []struct {
 		name            string
-		exporterOptions func() []Option
+		exporterOptions []Option
 	}{
 		{
 			"no options",
-			func() []Option { return nil },
+			nil,
 		},
 		{
 			"with retry",
@@ -98,7 +98,7 @@ func TestBaseExporterLogging(t *testing.T) {
 				rCfg := configretry.NewDefaultBackOffConfig()
 				rCfg.Enabled = false
 				return []Option{WithRetry(rCfg)}
-			},
+			}(),
 		},
 	}
 	for _, test := range tests {
@@ -106,7 +106,7 @@ func TestBaseExporterLogging(t *testing.T) {
 		logger, observed := observer.New(zap.DebugLevel)
 		set.Logger = zap.New(logger)
 
-		bs, err := newBaseExporter(set, "", true, nil, nil, newNoopObsrepSender, test.exporterOptions()...)
+		bs, err := newBaseExporter(set, "", true, nil, nil, newNoopObsrepSender, test.exporterOptions...)
 		require.Nil(t, err)
 		require.True(t, bs.requestExporter)
 		sendErr := bs.send(context.Background(), newErrorRequest())


### PR DESCRIPTION
**Description:** Fixes regression of #8792. Test was changed in #8862 to use `WithRetry()` which removed the assertion that an error is still logged. 

**Link to tracking Issue:** #9219

_Please delete paragraphs that you did not use before submitting._
