### PR TITLE
[configopaque] Implement encoding.BinaryMarshaler interface for String

### DIFF
--- a/.chloggen/configopaque-implement-BinaryMarshaler.yaml
+++ b/.chloggen/configopaque-implement-BinaryMarshaler.yaml
@@ -22,4 +22,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [api]

--- a/.chloggen/configopaque-implement-BinaryMarshaler.yaml
+++ b/.chloggen/configopaque-implement-BinaryMarshaler.yaml
@@ -4,7 +4,7 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: configopaque
+component: bug_fix
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Implement `encoding.BinaryMarshaler` interface to prevent `configopaque` -> `[]byte` -> `string` conversions from leaking the value

--- a/.chloggen/configopaque-implement-BinaryMarshaler.yaml
+++ b/.chloggen/configopaque-implement-BinaryMarshaler.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configopaque
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Implement `encoding.BinaryMarshaler` interface to prevent `configopaque` -> `[]byte` -> `string` conversions from leaking the value
+
+# One or more tracking issues or pull requests related to the change
+issues: [9279]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configopaque/opaque.go
+++ b/config/configopaque/opaque.go
@@ -35,3 +35,10 @@ var _ fmt.GoStringer = String("")
 func (s String) GoString() string {
 	return fmt.Sprintf("%#v", maskedString)
 }
+
+var _ encoding.BinaryMarshaler = String("")
+
+// MarshalBinary marshals the string `[REDACTED]` as []byte.
+func (s String) MarshalBinary() (text []byte, err error) {
+	return []byte(maskedString), nil
+}

--- a/config/configopaque/opaque_test.go
+++ b/config/configopaque/opaque_test.go
@@ -80,3 +80,12 @@ func TestStringFmt(t *testing.T) {
 		}
 	}
 }
+
+func TestStringMarshalBinary(t *testing.T) {
+	examples := []String{"opaque", "s", "veryveryveryveryveryveryveryveryveryverylong"}
+	for _, example := range examples {
+		opaque, err := example.MarshalBinary()
+		require.NoError(t, err)
+		assert.Equal(t, []byte("[REDACTED]"), opaque)
+	}
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Implements the `encoding.BinaryMarshaler` interface for `String`.  This prevents the situation `configopaque` -> `[]byte` -> `string` from leaking the `String` value.

**Link to tracking Issue:** <Issue number if applicable>
Closes https://github.com/open-telemetry/opentelemetry-collector/issues/9272

**Testing:** 
Added unit test
