### PR TITLE
[exporterhelper] Cleanup logging for export failures

### DIFF
--- a/.chloggen/exporter-helper-cleanup-error-logs.yaml
+++ b/.chloggen/exporter-helper-cleanup-error-logs.yaml
@@ -1,0 +1,27 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporters
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Cleanup log messages for export failures
+
+# One or more tracking issues or pull requests related to the change
+issues: [9219]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  1. Ensure an error message is logged every time and only once when data is dropped/rejected due to export failure.
+  2. Update the wording. Specifically, don't use "dropped" term when an error is reported back to the pipeline.
+     Keep the "dropped" wording for failures happened after the enabled queue.
+  3. Properly report any error reported by a queue. For example, a persistent storage error must be reported as a storage error, not as "queue overflow".
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -93,19 +93,14 @@ func (rs *retrySender) send(ctx context.Context, req Request) error {
 
 		// Immediately drop data on permanent errors.
 		if consumererror.IsPermanent(err) {
-			rs.logger.Error(
-				"Exporting failed. The error is not retryable. Dropping data.",
-				zap.Error(err),
-				zap.Int("dropped_items", req.ItemsCount()),
-			)
-			return err
+			return fmt.Errorf("not retryable error: %w", err)
 		}
 
 		req = extractPartialRequest(req, err)
 
 		backoffDelay := expBackoff.NextBackOff()
 		if backoffDelay == backoff.Stop {
-			return fmt.Errorf("max elapsed time expired %w", err)
+			return fmt.Errorf("no more retries left: %w", err)
 		}
 
 		throttleErr := throttleRetry{}


### PR DESCRIPTION
This change makes the logging of the exported error failures cleaner.
1. Ensure an error message is logged every time and only once when data is dropped/rejected due to export failure.
2. Update the wording. Specifically, don't use "dropped" term when an error is reported back to the pipeline. If there is no queue configured, the exporter doesn't drop data by itself but rather rejects it. Keep the "dropped" wording for failures after the enabled queue.
3. Properly report any error reported by a queue. For example, a persistent storage error must be reported as a storage error, not as "queue overflow".

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/9219