### PR TITLE
[otelcol] Add unit test for implicit config use case

### DIFF
--- a/otelcol/command_test.go
+++ b/otelcol/command_test.go
@@ -29,7 +29,7 @@ func TestNewCommandNoConfigURI(t *testing.T) {
 
 // This test emulates usage of Collector in Jaeger all-in-one, which
 // allows running the binary with no explicit configuration.
-func TestNewCommandImplicitConfig(t *testing.T) {
+func TestNewCommandProgrammaticallyPassedConfig(t *testing.T) {
 	cmd := NewCommand(CollectorSettings{Factories: nopFactories})
 	otelRunE := cmd.RunE
 	cmd.RunE = func(c *cobra.Command, args []string) error {

--- a/otelcol/command_test.go
+++ b/otelcol/command_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -24,6 +25,26 @@ func TestNewCommandVersion(t *testing.T) {
 func TestNewCommandNoConfigURI(t *testing.T) {
 	cmd := NewCommand(CollectorSettings{Factories: nopFactories})
 	require.Error(t, cmd.Execute())
+}
+
+// This test emulates usage of Collector in Jaeger all-in-one, which
+// allows running the binary with no explicit configuration.
+func TestNewCommandImplicitConfig(t *testing.T) {
+	cmd := NewCommand(CollectorSettings{Factories: nopFactories})
+	otelRunE := cmd.RunE
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		configFlag := c.Flag("config")
+		cfg := `
+service:
+  extensions: [invalid_component_name]
+receivers:
+  invalid_component_name:
+`
+		configFlag.Value.Set("yaml:" + cfg)
+		return otelRunE(cmd, args)
+	}
+	// verify that cmd.Execute was run with the implicitly provided config.
+	require.ErrorContains(t, cmd.Execute(), "invalid_component_name")
 }
 
 func TestNewCommandInvalidComponent(t *testing.T) {

--- a/otelcol/command_test.go
+++ b/otelcol/command_test.go
@@ -40,7 +40,7 @@ service:
 receivers:
   invalid_component_name:
 `
-		configFlag.Value.Set("yaml:" + cfg)
+		require.NoError(t, configFlag.Value.Set("yaml:"+cfg))
 		return otelRunE(cmd, args)
 	}
 	// verify that cmd.Execute was run with the implicitly provided config.


### PR DESCRIPTION
**Description:** 
* Add unit test that illustrates running the command without an external config
* This models how Jaeger all-in-one uses collector because all-in-one can be run without arguments, for maximum user friendliness
