### PR TITLE
Fixed indentation in YAML for deployment at otel-config.yaml

### DIFF
--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -206,7 +206,7 @@ spec:
                 apiVersion: v1
                 fieldPath: status.podIP
           - name: GOMEMLIMIT
-              value: 1600MiB
+            value: 1600MiB
         volumeMounts:
         - name: otel-collector-config-vol
           mountPath: /conf


### PR DESCRIPTION
The name/value entry had an incorrect indentation that made the documented process fail (Document ref: https://opentelemetry.io/docs/collector/installation/)

## Important (read before submitting)
We are currently preparing for the upcoming 1.0 GA release. Pull requests that are not aligned with
the current roadmap and are not aimed at stabilizing and preparing the Collector for the release will
not be accepted.

_Delete the preceding paragraph before submitting._

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>

_Please delete paragraphs that you did not use before submitting._
