### PR TITLE
[chore] remove waits as start is now deterministic

### DIFF
--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -101,10 +101,6 @@ func TestJsonHttp(t *testing.T) {
 	require.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()), "Failed to start trace receiver")
 	t.Cleanup(func() { require.NoError(t, recv.Shutdown(context.Background())) })
 
-	// TODO(nilebox): make starting server deterministic
-	// Wait for the servers to start
-	<-time.After(10 * time.Millisecond)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sink.Reset()
@@ -139,10 +135,6 @@ func TestHandleInvalidRequests(t *testing.T) {
 	recv := newHTTPReceiver(t, componenttest.NewNopTelemetrySettings(), addr, sink)
 	require.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()), "Failed to start trace receiver")
 	t.Cleanup(func() { require.NoError(t, recv.Shutdown(context.Background())) })
-
-	// TODO(nilebox): make starting server deterministic
-	// Wait for the servers to start
-	<-time.After(10 * time.Millisecond)
 
 	tests := []struct {
 		name        string
@@ -346,10 +338,6 @@ func TestProtoHttp(t *testing.T) {
 	require.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()), "Failed to start trace receiver")
 	t.Cleanup(func() { require.NoError(t, recv.Shutdown(context.Background())) })
 
-	// TODO(nilebox): make starting server deterministic
-	// Wait for the servers to start
-	<-time.After(10 * time.Millisecond)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sink.Reset()
@@ -432,9 +420,6 @@ func TestOTLPReceiverInvalidContentEncoding(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, recv.Shutdown(context.Background())) })
 
 	url := fmt.Sprintf("http://%s%s", addr, defaultTracesURLPath)
-
-	// Wait for the servers to start
-	<-time.After(10 * time.Millisecond)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:**
This PR removes 3 TODOs and time.Sleep statements as otlp receiver start is now deterministic.

This change is similar to https://github.com/open-telemetry/opentelemetry-collector/pull/9121

For good measure, I ran the tests 10,000 each (each test runs multiple sub-tests) and didn't have any failures.