### PR TITLE
[chore][extension/zpages] ReportFatalError -> ReportStatus

### DIFF
--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -79,7 +79,7 @@ func (zpe *zpagesExtension) Start(_ context.Context, host component.Host) error 
 		defer close(zpe.stopCh)
 
 		if errHTTP := zpe.server.Serve(ln); errHTTP != nil && !errors.Is(errHTTP, http.ErrServerClosed) {
-			host.ReportFatalError(errHTTP)
+			zpe.telemetry.ReportStatus(component.NewFatalErrorEvent(errHTTP))
 		}
 	}()
 


### PR DESCRIPTION
**Description:**
Remove use of the deprecated method `ReportFatalError` in favor of using `ReportStatus`.