### PR TITLE
[docs] Add owner for darwin/amd64

### DIFF
--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -58,7 +58,7 @@ Tier 3 platforms are _guaranteed to build_. Precompiled binaries are made availa
 Tier 3 platforms are currently:
 | Platform      | Owner(s)                                                                                                    |
 |---------------|-------------------------------------------------------------------------------------------------------------|
-| darwin/amd64  | [@h0cheung](https://github.com/h0cheung)                                                                     |
+| darwin/amd64  | [@h0cheung](https://github.com/h0cheung)                                                                    |
 | darwin/arm64  | [@MovieStoreGuy](https://github.com/MovieStoreGuy)                                                          |
 | linux/arm64   | [@atoulme](https://github.com/atoulme)                                                                      |
 | linux/386     |                                                                                                             |

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -58,7 +58,7 @@ Tier 3 platforms are _guaranteed to build_. Precompiled binaries are made availa
 Tier 3 platforms are currently:
 | Platform      | Owner(s)                                                                                                    |
 |---------------|-------------------------------------------------------------------------------------------------------------|
-| darwin/amd64  | [h0cheung](https://github.com/h0cheung)                                                                     |
+| darwin/amd64  | [@h0cheung](https://github.com/h0cheung)                                                                     |
 | darwin/arm64  | [@MovieStoreGuy](https://github.com/MovieStoreGuy)                                                          |
 | linux/arm64   | [@atoulme](https://github.com/atoulme)                                                                      |
 | linux/386     |                                                                                                             |

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -58,7 +58,7 @@ Tier 3 platforms are _guaranteed to build_. Precompiled binaries are made availa
 Tier 3 platforms are currently:
 | Platform      | Owner(s)                                                                                                    |
 |---------------|-------------------------------------------------------------------------------------------------------------|
-| darwin/amd64  |                                                                                                             |
+| darwin/amd64  | [h0cheung](https://github.com/h0cheung)                                                                     |
 | darwin/arm64  | [@MovieStoreGuy](https://github.com/MovieStoreGuy)                                                          |
 | linux/arm64   | [@atoulme](https://github.com/atoulme)                                                                      |
 | linux/386     |                                                                                                             |


### PR DESCRIPTION
**Description:** 

Adds owner for darwin/amd64 platform based on https://github.com/open-telemetry/opentelemetry-collector/issues/8526#issuecomment-1905979165.

**Link to tracking Issue:** Fixes #9114
