### PR TITLE
[service] fix opencensus bridge in periodic readers

### DIFF
--- a/.chloggen/codeboten_fix-census-bridge.yaml
+++ b/.chloggen/codeboten_fix-census-bridge.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix opencensus bridge configuration in periodic readers
+
+# One or more tracking issues or pull requests related to the change
+issues: [9361]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/service/internal/proctelemetry/config.go
+++ b/service/internal/proctelemetry/config.go
@@ -71,7 +71,9 @@ func InitMetricReader(ctx context.Context, reader config.MetricReader, asyncErro
 		return initPullExporter(reader.Pull.Exporter, asyncErrorChannel)
 	}
 	if reader.Periodic != nil {
-		opts := []sdkmetric.PeriodicReaderOption{}
+		opts := []sdkmetric.PeriodicReaderOption{
+			sdkmetric.WithProducer(opencensus.NewMetricProducer()),
+		}
 		if reader.Periodic.Interval != nil {
 			opts = append(opts, sdkmetric.WithInterval(time.Duration(*reader.Periodic.Interval)*time.Millisecond))
 		}


### PR DESCRIPTION
The periodic metric readers were not connecting to the opencensus bridge prior to this change, meaning anyone trying to emit metrics via the console or OTLP from components that used opencensus were failing to do so.
