### PR TITLE
[config/configgrpc] introduce toListenerContext, deprecate toListener

### DIFF
--- a/.chloggen/deprecate_toListener.yaml
+++ b/.chloggen/deprecate_toListener.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `ToListener` function in favor of `ToListenerContext`
+
+# One or more tracking issues or pull requests related to the change
+issues: [9389]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -268,9 +268,15 @@ func validateBalancerName(balancerName string) bool {
 	return balancer.Get(balancerName) != nil
 }
 
+// ToListenerContext returns the net.Listener constructed from the settings.
+func (gss *GRPCServerSettings) ToListenerContext(ctx context.Context) (net.Listener, error) {
+	return gss.NetAddr.Listen(ctx)
+}
+
 // ToListener returns the net.Listener constructed from the settings.
+// Deprecated: [v0.94.0] use ToListenerContext instead.
 func (gss *GRPCServerSettings) ToListener() (net.Listener, error) {
-	return gss.NetAddr.Listen(context.Background())
+	return gss.ToListenerContext(context.Background())
 }
 
 func (gss *GRPCServerSettings) ToServer(host component.Host, settings component.TelemetrySettings, extraOpts ...grpc.ServerOption) (*grpc.Server, error) {

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -493,7 +493,7 @@ func TestGRPCServerSettings_ToListener_Error(t *testing.T) {
 		},
 		Keepalive: nil,
 	}
-	_, err := settings.ToListener()
+	_, err := settings.ToListenerContext(context.Background())
 	assert.Error(t, err)
 }
 
@@ -615,7 +615,7 @@ func TestHttpReception(t *testing.T) {
 				},
 				TLSSetting: test.tlsServerCreds,
 			}
-			ln, err := gss.ToListener()
+			ln, err := gss.ToListenerContext(context.Background())
 			assert.NoError(t, err)
 			s, err := gss.ToServer(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
@@ -661,7 +661,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 			Transport: "unix",
 		},
 	}
-	ln, err := gss.ToListener()
+	ln, err := gss.ToListenerContext(context.Background())
 	assert.NoError(t, err)
 	srv, err := gss.ToServer(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	assert.NoError(t, err)
@@ -862,7 +862,7 @@ func TestClientInfoInterceptors(t *testing.T) {
 
 				defer srv.Stop()
 
-				l, err = gss.ToListener()
+				l, err = gss.ToListenerContext(context.Background())
 				require.NoError(t, err)
 
 				go func() {

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -101,7 +101,7 @@ func (r *otlpReceiver) startGRPCServer(host component.Host) error {
 
 	r.settings.Logger.Info("Starting GRPC server", zap.String("endpoint", r.cfg.GRPC.NetAddr.Endpoint))
 	var gln net.Listener
-	if gln, err = r.cfg.GRPC.ToListener(); err != nil {
+	if gln, err = r.cfg.GRPC.ToListenerContext(context.Background()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**Description:**
Introduce `ToListenerContext` and deprecate `ToListener`.

**Link to tracking Issue:**
#9389
