### PR TITLE
[config/confighttp] add memorylimiterextension to confighttp

### DIFF
--- a/.chloggen/timn_memorylimiterextension-HTTPServerConfig.yaml
+++ b/.chloggen/timn_memorylimiterextension-HTTPServerConfig.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add an option to setup MemoryLimiter extension in to HTTPServerConfig
+
+# One or more tracking issues or pull requests related to the change
+issues: [8632]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -44,6 +44,7 @@ replaces:
   - go.opentelemetry.io/collector/exporter/loggingexporter => ${WORKSPACE_DIR}/exporter/loggingexporter
   - go.opentelemetry.io/collector/extension => ${WORKSPACE_DIR}/extension
   - go.opentelemetry.io/collector/extension/auth => ${WORKSPACE_DIR}/extension/auth
+  - go.opentelemetry.io/collector/extension/memorylimiterextension => ${WORKSPACE_DIR}/extension/memorylimiterextension
   - go.opentelemetry.io/collector/extension/zpagesextension => ${WORKSPACE_DIR}/extension/zpagesextension
   - go.opentelemetry.io/collector/featuregate => ${WORKSPACE_DIR}/featuregate
   - go.opentelemetry.io/collector/otelcol => ${WORKSPACE_DIR}/otelcol

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -78,6 +78,8 @@ will not be enabled.
 - [`tls`](../configtls/README.md)
 - [`auth`](../configauth/README.md)
 
+`memory_limiter`: [Memory limiter extension](../../extension/memorylimiterextension/README.md) that will reject incoming requests once the memory utilization grows above configured limits.
+
 You can enable [`attribute processor`][attribute-processor] to append any http header to span's attribute using custom key. You also need to enable the "include_metadata"
 
 Example:

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -77,8 +77,7 @@ will not be enabled.
 - `max_request_body_size`: configures the maximum allowed body size in bytes for a single request. Default: `0` (no restriction)
 - [`tls`](../configtls/README.md)
 - [`auth`](../configauth/README.md)
-
-`memory_limiter`: [Memory limiter extension](../../extension/memorylimiterextension/README.md) that will reject incoming requests once the memory utilization grows above configured limits.
+- [`memory_limiter`](../../extension/memorylimiterextension/README.md) that will reject incoming requests once the memory utilization grows above configured limits.
 
 You can enable [`attribute processor`][attribute-processor] to append any http header to span's attribute using custom key. You also need to enable the "include_metadata"
 

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -1341,13 +1341,19 @@ func TestMemoryLimiterInterceptor(t *testing.T) {
 }
 
 func TestGetMemoryLimiterExtension(t *testing.T) {
+	fakeID := component.NewID("memoryLimiterFake")
 	mle := &mockMemoryLimiterExtension{}
 	nopExt, err := extensiontest.NewNopFactory().CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), CORSConfig{})
 	assert.NoError(t, err)
 
 	extList := map[component.ID]component.Component{
-		component.NewID("memoryLimiter"):     mle,
-		component.NewID("memoryLimiterFake"): nopExt,
+		component.NewID("memoryLimiter"): mle,
+		fakeID:                           nopExt,
+	}
+
+	hss := ServerConfig{
+		Endpoint:      "localhost:0",
+		MemoryLimiter: &fakeID,
 	}
 
 	// valid extension
@@ -1360,10 +1366,17 @@ func TestGetMemoryLimiterExtension(t *testing.T) {
 	_, err = getMemoryLimiterExtension(&comID, extList)
 	assert.EqualError(t, err, "requested MemoryLimiter, memoryLimiterFake, is not a memoryLimiterExtension")
 
+	// invalid through toServer
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+	host := &mockHost{ext: extList}
+	_, err = hss.ToServer(host, componenttest.NewNopTelemetrySettings(), handler)
+	require.Error(t, err, "requested MemoryLimiter, memoryLimiterFake, is not a memoryLimiterExtension")
+
 	// not found
 	comID = component.NewID("notfound")
 	_, err = getMemoryLimiterExtension(&comID, extList)
 	assert.EqualError(t, err, "failed to resolve memoryLimiterExtension \"notfound\": memory limiter extension not found")
+
 }
 
 type mockHost struct {

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.0
 	go.opentelemetry.io/collector/config/configtls v0.96.0
 	go.opentelemetry.io/collector/config/internal v0.96.0
+	go.opentelemetry.io/collector/extension v0.96.0
 	go.opentelemetry.io/collector/extension/auth v0.96.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0
 	go.opentelemetry.io/otel v1.24.0
@@ -46,7 +47,6 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.0 // indirect
-	go.opentelemetry.io/collector/extension v0.96.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

integrate MemoryLimiterExtension with confighttp. The line of thinking is if there is a limiter extension all http servers would be restricted based on that memory requirement in order to not crash the collector from OOM. 

**Link to tracking Issue:** [8632](https://github.com/open-telemetry/opentelemetry-collector/issues/8632)

**Testing:** <Describe what testing was performed and which tests were added.>

unit test

**Documentation:** <Describe the documentation added.>

confighttp README linking to memorylimiterextension.

