### PR TITLE
[configgrpc] Deprecate GRPCClientSettings, use ClientConfig instead

### DIFF
--- a/.chloggen/grpcclientsettings_grpcclientconfig-otlpreceiver.yaml
+++ b/.chloggen/grpcclientsettings_grpcclientconfig-otlpreceiver.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: otlpexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Config struct is moving from embedding the deprecated GRPCClientSettings struct to using GRPCClientConfig instead.
+note: Config struct is moving from embedding the deprecated GRPCClientSettings struct to using ClientConfig instead.
 
 # One or more tracking issues or pull requests related to the change
 issues: [6767]

--- a/.chloggen/grpcclientsettings_grpcclientconfig-otlpreceiver.yaml
+++ b/.chloggen/grpcclientsettings_grpcclientconfig-otlpreceiver.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Config struct is moving from embedding the deprecated GRPCClientSettings struct to using GRPCClientConfig instead.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6767]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/grpcclientsettings_grpcclientconfig.yaml
+++ b/.chloggen/grpcclientsettings_grpcclientconfig.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate GRPCClientSettings, use GRPCClientConfig instead
+
+# One or more tracking issues or pull requests related to the change
+issues: [6767]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/grpcclientsettings_grpcclientconfig.yaml
+++ b/.chloggen/grpcclientsettings_grpcclientconfig.yaml
@@ -7,7 +7,7 @@ change_type: deprecation
 component: configgrpc
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecate GRPCClientSettings, use GRPCClientConfig instead
+note: Deprecate GRPCClientSettings, use ClientConfig instead
 
 # One or more tracking issues or pull requests related to the change
 issues: [6767]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -48,11 +48,11 @@ type KeepaliveClientConfig struct {
 }
 
 // GRPCClientSettings defines common settings for a gRPC client configuration.
-// Deprecated: [v0.94.0] Use GRPCClientConfig instead
-type GRPCClientSettings = GRPCClientConfig
+// Deprecated: [v0.94.0] Use ClientConfig instead
+type GRPCClientSettings = ClientConfig
 
-// GRPCClientConfig defines common settings for a gRPC client configuration.
-type GRPCClientConfig struct {
+// ClientConfig defines common settings for a gRPC client configuration.
+type ClientConfig struct {
 	// The target to which the exporter is going to send traces or metrics,
 	// using the gRPC protocol. The valid syntax is described at
 	// https://github.com/grpc/grpc/blob/master/doc/naming.md.
@@ -155,8 +155,8 @@ type GRPCServerSettings struct {
 	IncludeMetadata bool `mapstructure:"include_metadata"`
 }
 
-// SanitizedEndpoint strips the prefix of either http:// or https:// from configgrpc.GRPCClientConfig.Endpoint.
-func (gcs *GRPCClientConfig) SanitizedEndpoint() string {
+// SanitizedEndpoint strips the prefix of either http:// or https:// from configgrpc.ClientConfig.Endpoint.
+func (gcs *ClientConfig) SanitizedEndpoint() string {
 	switch {
 	case gcs.isSchemeHTTP():
 		return strings.TrimPrefix(gcs.Endpoint, "http://")
@@ -167,11 +167,11 @@ func (gcs *GRPCClientConfig) SanitizedEndpoint() string {
 	}
 }
 
-func (gcs *GRPCClientConfig) isSchemeHTTP() bool {
+func (gcs *ClientConfig) isSchemeHTTP() bool {
 	return strings.HasPrefix(gcs.Endpoint, "http://")
 }
 
-func (gcs *GRPCClientConfig) isSchemeHTTPS() bool {
+func (gcs *ClientConfig) isSchemeHTTPS() bool {
 	return strings.HasPrefix(gcs.Endpoint, "https://")
 }
 
@@ -179,7 +179,7 @@ func (gcs *GRPCClientConfig) isSchemeHTTPS() bool {
 // a non-blocking dial (the function won't wait for connections to be
 // established, and connecting happens in the background). To make it a blocking
 // dial, use grpc.WithBlock() dial option.
-func (gcs *GRPCClientConfig) ToClientConn(ctx context.Context, host component.Host, settings component.TelemetrySettings, extraOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+func (gcs *ClientConfig) ToClientConn(ctx context.Context, host component.Host, settings component.TelemetrySettings, extraOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	opts, err := gcs.toDialOptions(host, settings)
 	if err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func (gcs *GRPCClientConfig) ToClientConn(ctx context.Context, host component.Ho
 	return grpc.DialContext(ctx, gcs.SanitizedEndpoint(), opts...)
 }
 
-func (gcs *GRPCClientConfig) toDialOptions(host component.Host, settings component.TelemetrySettings) ([]grpc.DialOption, error) {
+func (gcs *ClientConfig) toDialOptions(host component.Host, settings component.TelemetrySettings) ([]grpc.DialOption, error) {
 	var opts []grpc.DialOption
 	if configcompression.IsCompressed(gcs.Compression) {
 		cp, err := getGRPCCompressionName(gcs.Compression)

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -48,7 +48,11 @@ type KeepaliveClientConfig struct {
 }
 
 // GRPCClientSettings defines common settings for a gRPC client configuration.
-type GRPCClientSettings struct {
+// Deprecated: [v0.94.0] Use GRPCClientConfig instead
+type GRPCClientSettings = GRPCClientConfig
+
+// GRPCClientConfig defines common settings for a gRPC client configuration.
+type GRPCClientConfig struct {
 	// The target to which the exporter is going to send traces or metrics,
 	// using the gRPC protocol. The valid syntax is described at
 	// https://github.com/grpc/grpc/blob/master/doc/naming.md.
@@ -151,8 +155,8 @@ type GRPCServerSettings struct {
 	IncludeMetadata bool `mapstructure:"include_metadata"`
 }
 
-// SanitizedEndpoint strips the prefix of either http:// or https:// from configgrpc.GRPCClientSettings.Endpoint.
-func (gcs *GRPCClientSettings) SanitizedEndpoint() string {
+// SanitizedEndpoint strips the prefix of either http:// or https:// from configgrpc.GRPCClientConfig.Endpoint.
+func (gcs *GRPCClientConfig) SanitizedEndpoint() string {
 	switch {
 	case gcs.isSchemeHTTP():
 		return strings.TrimPrefix(gcs.Endpoint, "http://")
@@ -163,11 +167,11 @@ func (gcs *GRPCClientSettings) SanitizedEndpoint() string {
 	}
 }
 
-func (gcs *GRPCClientSettings) isSchemeHTTP() bool {
+func (gcs *GRPCClientConfig) isSchemeHTTP() bool {
 	return strings.HasPrefix(gcs.Endpoint, "http://")
 }
 
-func (gcs *GRPCClientSettings) isSchemeHTTPS() bool {
+func (gcs *GRPCClientConfig) isSchemeHTTPS() bool {
 	return strings.HasPrefix(gcs.Endpoint, "https://")
 }
 
@@ -175,7 +179,7 @@ func (gcs *GRPCClientSettings) isSchemeHTTPS() bool {
 // a non-blocking dial (the function won't wait for connections to be
 // established, and connecting happens in the background). To make it a blocking
 // dial, use grpc.WithBlock() dial option.
-func (gcs *GRPCClientSettings) ToClientConn(ctx context.Context, host component.Host, settings component.TelemetrySettings, extraOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+func (gcs *GRPCClientConfig) ToClientConn(ctx context.Context, host component.Host, settings component.TelemetrySettings, extraOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	opts, err := gcs.toDialOptions(host, settings)
 	if err != nil {
 		return nil, err
@@ -184,7 +188,7 @@ func (gcs *GRPCClientSettings) ToClientConn(ctx context.Context, host component.
 	return grpc.DialContext(ctx, gcs.SanitizedEndpoint(), opts...)
 }
 
-func (gcs *GRPCClientSettings) toDialOptions(host component.Host, settings component.TelemetrySettings) ([]grpc.DialOption, error) {
+func (gcs *GRPCClientConfig) toDialOptions(host component.Host, settings component.TelemetrySettings) ([]grpc.DialOption, error) {
 	var opts []grpc.DialOption
 	if configcompression.IsCompressed(gcs.Compression) {
 		cp, err := getGRPCCompressionName(gcs.Compression)

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -55,7 +55,7 @@ func TestDefaultGrpcClientSettings(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	gcs := &GRPCClientConfig{
+	gcs := &ClientConfig{
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
 		},
@@ -71,13 +71,13 @@ func TestAllGrpcClientSettings(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	tests := []struct {
-		settings GRPCClientConfig
+		settings ClientConfig
 		name     string
 		host     component.Host
 	}{
 		{
 			name: "test all with gzip compression",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Headers: map[string]configopaque.String{
 					"test": "test",
 				},
@@ -106,7 +106,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 		},
 		{
 			name: "test all with snappy compression",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Headers: map[string]configopaque.String{
 					"test": "test",
 				},
@@ -135,7 +135,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 		},
 		{
 			name: "test all with zstd compression",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Headers: map[string]configopaque.String{
 					"test": "test",
 				},
@@ -241,13 +241,13 @@ func TestGRPCClientSettingsError(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	tests := []struct {
-		settings GRPCClientConfig
+		settings ClientConfig
 		err      string
 		host     component.Host
 	}{
 		{
 			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Headers:     nil,
 				Endpoint:    "",
 				Compression: "",
@@ -263,7 +263,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Headers:     nil,
 				Endpoint:    "",
 				Compression: "",
@@ -279,7 +279,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "invalid balancer_name: test",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Headers: map[string]configopaque.String{
 					"test": "test",
 				},
@@ -301,7 +301,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "failed to resolve authenticator \"doesntexist\": authenticator not found",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("doesntexist")},
 			},
@@ -309,7 +309,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "no extensions configuration available",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("doesntexist")},
 			},
@@ -317,7 +317,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "unsupported compression type \"zlib\"",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: true,
@@ -328,7 +328,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "unsupported compression type \"deflate\"",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: true,
@@ -339,7 +339,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "unsupported compression type \"bad\"",
-			settings: GRPCClientConfig{
+			settings: ClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: true,
@@ -363,7 +363,7 @@ func TestUseSecure(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	gcs := &GRPCClientConfig{
+	gcs := &ClientConfig{
 		Headers:     nil,
 		Endpoint:    "",
 		Compression: "",
@@ -625,7 +625,7 @@ func TestHttpReception(t *testing.T) {
 				_ = s.Serve(ln)
 			}()
 
-			gcs := &GRPCClientConfig{
+			gcs := &ClientConfig{
 				Endpoint:   ln.Addr().String(),
 				TLSSetting: *test.tlsClientCreds,
 			}
@@ -671,7 +671,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 		_ = srv.Serve(ln)
 	}()
 
-	gcs := &GRPCClientConfig{
+	gcs := &ClientConfig{
 		Endpoint: "unix://" + ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -872,7 +872,7 @@ func TestClientInfoInterceptors(t *testing.T) {
 
 			// prepare the client and execute a RPC
 			{
-				gcs := &GRPCClientConfig{
+				gcs := &ClientConfig{
 					Endpoint: l.Addr().String(),
 					TLSSetting: configtls.TLSClientSetting{
 						Insecure: true,

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -55,7 +55,7 @@ func TestDefaultGrpcClientSettings(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	gcs := &GRPCClientSettings{
+	gcs := &GRPCClientConfig{
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
 		},
@@ -71,13 +71,13 @@ func TestAllGrpcClientSettings(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	tests := []struct {
-		settings GRPCClientSettings
+		settings GRPCClientConfig
 		name     string
 		host     component.Host
 	}{
 		{
 			name: "test all with gzip compression",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Headers: map[string]configopaque.String{
 					"test": "test",
 				},
@@ -106,7 +106,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 		},
 		{
 			name: "test all with snappy compression",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Headers: map[string]configopaque.String{
 					"test": "test",
 				},
@@ -135,7 +135,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 		},
 		{
 			name: "test all with zstd compression",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Headers: map[string]configopaque.String{
 					"test": "test",
 				},
@@ -241,13 +241,13 @@ func TestGRPCClientSettingsError(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	tests := []struct {
-		settings GRPCClientSettings
+		settings GRPCClientConfig
 		err      string
 		host     component.Host
 	}{
 		{
 			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Headers:     nil,
 				Endpoint:    "",
 				Compression: "",
@@ -263,7 +263,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Headers:     nil,
 				Endpoint:    "",
 				Compression: "",
@@ -279,7 +279,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "invalid balancer_name: test",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Headers: map[string]configopaque.String{
 					"test": "test",
 				},
@@ -301,7 +301,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "failed to resolve authenticator \"doesntexist\": authenticator not found",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("doesntexist")},
 			},
@@ -309,7 +309,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "no extensions configuration available",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("doesntexist")},
 			},
@@ -317,7 +317,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "unsupported compression type \"zlib\"",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: true,
@@ -328,7 +328,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "unsupported compression type \"deflate\"",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: true,
@@ -339,7 +339,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "unsupported compression type \"bad\"",
-			settings: GRPCClientSettings{
+			settings: GRPCClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: true,
@@ -363,7 +363,7 @@ func TestUseSecure(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	gcs := &GRPCClientSettings{
+	gcs := &GRPCClientConfig{
 		Headers:     nil,
 		Endpoint:    "",
 		Compression: "",
@@ -625,7 +625,7 @@ func TestHttpReception(t *testing.T) {
 				_ = s.Serve(ln)
 			}()
 
-			gcs := &GRPCClientSettings{
+			gcs := &GRPCClientConfig{
 				Endpoint:   ln.Addr().String(),
 				TLSSetting: *test.tlsClientCreds,
 			}
@@ -671,7 +671,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 		_ = srv.Serve(ln)
 	}()
 
-	gcs := &GRPCClientSettings{
+	gcs := &GRPCClientConfig{
 		Endpoint: "unix://" + ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -872,7 +872,7 @@ func TestClientInfoInterceptors(t *testing.T) {
 
 			// prepare the client and execute a RPC
 			{
-				gcs := &GRPCClientSettings{
+				gcs := &GRPCClientConfig{
 					Endpoint: l.Addr().String(),
 					TLSSetting: configtls.TLSClientSetting{
 						Insecure: true,

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -12,7 +12,7 @@ import (
 
 // Config defines configuration for OTLP exporter.
 type Config struct {
-	exporterhelper.TimeoutSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	exporterhelper.TimeoutSettings `mapstructure:",squash"`     // squash ensures fields are correctly decoded in embedded struct.
 	QueueConfig                    exporterhelper.QueueSettings `mapstructure:"sending_queue"`
 	RetryConfig                    configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
 

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	QueueConfig                    exporterhelper.QueueSettings `mapstructure:"sending_queue"`
 	RetryConfig                    configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
 
-	configgrpc.GRPCClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	configgrpc.GRPCClientConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 }
 
 var _ component.Config = (*Config)(nil)

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -12,11 +12,11 @@ import (
 
 // Config defines configuration for OTLP exporter.
 type Config struct {
-	exporterhelper.TimeoutSettings `mapstructure:",squash"`     // squash ensures fields are correctly decoded in embedded struct.
+	exporterhelper.TimeoutSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	QueueConfig                    exporterhelper.QueueSettings `mapstructure:"sending_queue"`
 	RetryConfig                    configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
 
-	configgrpc.GRPCClientConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	configgrpc.ClientConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 }
 
 var _ component.Config = (*Config)(nil)

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -53,7 +53,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				NumConsumers: 2,
 				QueueSize:    10,
 			},
-			GRPCClientSettings: configgrpc.GRPCClientSettings{
+			GRPCClientConfig: configgrpc.GRPCClientConfig{
 				Headers: map[string]configopaque.String{
 					"can you have a . here?": "F0000000-0000-0000-0000-000000000000",
 					"header1":                "234",

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -53,7 +53,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				NumConsumers: 2,
 				QueueSize:    10,
 			},
-			GRPCClientConfig: configgrpc.GRPCClientConfig{
+			ClientConfig: configgrpc.ClientConfig{
 				Headers: map[string]configopaque.String{
 					"can you have a . here?": "F0000000-0000-0000-0000-000000000000",
 					"header1":                "234",

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -33,7 +33,7 @@ func createDefaultConfig() component.Config {
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
 		RetryConfig:     configretry.NewDefaultBackOffConfig(),
 		QueueConfig:     exporterhelper.NewDefaultQueueSettings(),
-		GRPCClientConfig: configgrpc.GRPCClientConfig{
+		ClientConfig: configgrpc.ClientConfig{
 			Headers: map[string]configopaque.String{},
 			// Default to gzip compression
 			Compression: configcompression.Gzip,

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -33,7 +33,7 @@ func createDefaultConfig() component.Config {
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
 		RetryConfig:     configretry.NewDefaultBackOffConfig(),
 		QueueConfig:     exporterhelper.NewDefaultQueueSettings(),
-		GRPCClientSettings: configgrpc.GRPCClientSettings{
+		GRPCClientConfig: configgrpc.GRPCClientConfig{
 			Headers: map[string]configopaque.String{},
 			// Default to gzip compression
 			Compression: configcompression.Gzip,

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -39,7 +39,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetricsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
@@ -58,7 +58,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NoEndpoint",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint: "",
 				},
 			},
@@ -67,7 +67,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "UseSecure",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
 						Insecure: false,
@@ -78,7 +78,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Keepalive",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint: endpoint,
 					Keepalive: &configgrpc.KeepaliveClientConfig{
 						Time:                30 * time.Second,
@@ -91,7 +91,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NoneCompression",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint:    endpoint,
 					Compression: "none",
 				},
@@ -100,7 +100,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "GzipCompression",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint:    endpoint,
 					Compression: configcompression.Gzip,
 				},
@@ -109,7 +109,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "SnappyCompression",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint:    endpoint,
 					Compression: configcompression.Snappy,
 				},
@@ -118,7 +118,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "ZstdCompression",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint:    endpoint,
 					Compression: configcompression.Zstd,
 				},
@@ -127,7 +127,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Headers",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint: endpoint,
 					Headers: map[string]configopaque.String{
 						"hdr1": "val1",
@@ -139,7 +139,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NumConsumers",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint: endpoint,
 				},
 			},
@@ -147,7 +147,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CaCert",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -160,7 +160,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CertPemFileError",
 			config: &Config{
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
+				GRPCClientConfig: configgrpc.GRPCClientConfig{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -204,7 +204,7 @@ func TestCreateTracesExporter(t *testing.T) {
 func TestCreateLogsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -39,7 +39,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetricsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.ClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
@@ -58,7 +58,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NoEndpoint",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: "",
 				},
 			},
@@ -67,7 +67,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "UseSecure",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
 						Insecure: false,
@@ -78,7 +78,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Keepalive",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
 					Keepalive: &configgrpc.KeepaliveClientConfig{
 						Time:                30 * time.Second,
@@ -91,7 +91,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NoneCompression",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
 					Compression: "none",
 				},
@@ -100,7 +100,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "GzipCompression",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
 					Compression: configcompression.Gzip,
 				},
@@ -109,7 +109,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "SnappyCompression",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
 					Compression: configcompression.Snappy,
 				},
@@ -118,7 +118,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "ZstdCompression",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
 					Compression: configcompression.Zstd,
 				},
@@ -127,7 +127,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Headers",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
 					Headers: map[string]configopaque.String{
 						"hdr1": "val1",
@@ -139,7 +139,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NumConsumers",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
 				},
 			},
@@ -147,7 +147,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CaCert",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -160,7 +160,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CertPemFileError",
 			config: &Config{
-				GRPCClientConfig: configgrpc.GRPCClientConfig{
+				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -204,7 +204,7 @@ func TestCreateTracesExporter(t *testing.T) {
 func TestCreateLogsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.ClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -64,19 +64,19 @@ func newExporter(cfg component.Config, set exporter.CreateSettings) (*baseExport
 // start actually creates the gRPC connection. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *baseExporter) start(ctx context.Context, host component.Host) (err error) {
-	if e.clientConn, err = e.config.GRPCClientSettings.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+	if e.clientConn, err = e.config.GRPCClientConfig.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
 		return err
 	}
 	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)
 	e.metricExporter = pmetricotlp.NewGRPCClient(e.clientConn)
 	e.logExporter = plogotlp.NewGRPCClient(e.clientConn)
 	headers := map[string]string{}
-	for k, v := range e.config.GRPCClientSettings.Headers {
+	for k, v := range e.config.GRPCClientConfig.Headers {
 		headers[k] = string(v)
 	}
 	e.metadata = metadata.New(headers)
 	e.callOptions = []grpc.CallOption{
-		grpc.WaitForReady(e.config.GRPCClientSettings.WaitForReady),
+		grpc.WaitForReady(e.config.GRPCClientConfig.WaitForReady),
 	}
 
 	return

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -64,19 +64,19 @@ func newExporter(cfg component.Config, set exporter.CreateSettings) (*baseExport
 // start actually creates the gRPC connection. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *baseExporter) start(ctx context.Context, host component.Host) (err error) {
-	if e.clientConn, err = e.config.GRPCClientConfig.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+	if e.clientConn, err = e.config.ClientConfig.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
 		return err
 	}
 	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)
 	e.metricExporter = pmetricotlp.NewGRPCClient(e.clientConn)
 	e.logExporter = plogotlp.NewGRPCClient(e.clientConn)
 	headers := map[string]string{}
-	for k, v := range e.config.GRPCClientConfig.Headers {
+	for k, v := range e.config.ClientConfig.Headers {
 		headers[k] = string(v)
 	}
 	e.metadata = metadata.New(headers)
 	e.callOptions = []grpc.CallOption{
-		grpc.WaitForReady(e.config.GRPCClientConfig.WaitForReady),
+		grpc.WaitForReady(e.config.ClientConfig.WaitForReady),
 	}
 
 	return

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -235,7 +235,7 @@ func TestSendTraces(t *testing.T) {
 	// Disable queuing to ensure that we execute the request when calling ConsumeTraces
 	// otherwise we will not see any errors.
 	cfg.QueueConfig.Enabled = false
-	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
+	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -318,19 +318,19 @@ func TestSendTracesWhenEndpointHasHttpScheme(t *testing.T) {
 		name               string
 		useTLS             bool
 		scheme             string
-		gRPCClientSettings configgrpc.GRPCClientSettings
+		gRPCClientSettings configgrpc.GRPCClientConfig
 	}{
 		{
 			name:               "Use https scheme",
 			useTLS:             true,
 			scheme:             "https://",
-			gRPCClientSettings: configgrpc.GRPCClientSettings{},
+			gRPCClientSettings: configgrpc.GRPCClientConfig{},
 		},
 		{
 			name:   "Use http scheme",
 			useTLS: false,
 			scheme: "http://",
-			gRPCClientSettings: configgrpc.GRPCClientSettings{
+			gRPCClientSettings: configgrpc.GRPCClientConfig{
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: true,
 				},
@@ -351,10 +351,10 @@ func TestSendTracesWhenEndpointHasHttpScheme(t *testing.T) {
 			// Start an OTLP exporter and point to the receiver.
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig().(*Config)
-			cfg.GRPCClientSettings = test.gRPCClientSettings
-			cfg.GRPCClientSettings.Endpoint = test.scheme + ln.Addr().String()
+			cfg.GRPCClientConfig = test.gRPCClientSettings
+			cfg.GRPCClientConfig.Endpoint = test.scheme + ln.Addr().String()
 			if test.useTLS {
-				cfg.GRPCClientSettings.TLSSetting.InsecureSkipVerify = true
+				cfg.GRPCClientConfig.TLSSetting.InsecureSkipVerify = true
 			}
 			set := exportertest.NewNopCreateSettings()
 			exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
@@ -400,7 +400,7 @@ func TestSendMetrics(t *testing.T) {
 	// Disable queuing to ensure that we execute the request when calling ConsumeMetrics
 	// otherwise we will not see any errors.
 	cfg.QueueConfig.Enabled = false
-	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
+	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -498,7 +498,7 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 	// Disable queuing to ensure that we execute the request when calling ConsumeTraces
 	// otherwise we will not see the error.
 	cfg.QueueConfig.Enabled = false
-	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
+	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -558,7 +558,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 	// Start an OTLP exporter and point to the receiver.
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
+	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -609,7 +609,7 @@ func TestSendTracesOnResourceExhaustion(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.RetryConfig.InitialInterval = 0
-	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
+	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -690,7 +690,7 @@ func TestSendLogData(t *testing.T) {
 	// Disable queuing to ensure that we execute the request when calling ConsumeLogs
 	// otherwise we will not see any errors.
 	cfg.QueueConfig.Enabled = false
-	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
+	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -235,7 +235,7 @@ func TestSendTraces(t *testing.T) {
 	// Disable queuing to ensure that we execute the request when calling ConsumeTraces
 	// otherwise we will not see any errors.
 	cfg.QueueConfig.Enabled = false
-	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
+	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -318,19 +318,19 @@ func TestSendTracesWhenEndpointHasHttpScheme(t *testing.T) {
 		name               string
 		useTLS             bool
 		scheme             string
-		gRPCClientSettings configgrpc.GRPCClientConfig
+		gRPCClientSettings configgrpc.ClientConfig
 	}{
 		{
 			name:               "Use https scheme",
 			useTLS:             true,
 			scheme:             "https://",
-			gRPCClientSettings: configgrpc.GRPCClientConfig{},
+			gRPCClientSettings: configgrpc.ClientConfig{},
 		},
 		{
 			name:   "Use http scheme",
 			useTLS: false,
 			scheme: "http://",
-			gRPCClientSettings: configgrpc.GRPCClientConfig{
+			gRPCClientSettings: configgrpc.ClientConfig{
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: true,
 				},
@@ -351,10 +351,10 @@ func TestSendTracesWhenEndpointHasHttpScheme(t *testing.T) {
 			// Start an OTLP exporter and point to the receiver.
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig().(*Config)
-			cfg.GRPCClientConfig = test.gRPCClientSettings
-			cfg.GRPCClientConfig.Endpoint = test.scheme + ln.Addr().String()
+			cfg.ClientConfig = test.gRPCClientSettings
+			cfg.ClientConfig.Endpoint = test.scheme + ln.Addr().String()
 			if test.useTLS {
-				cfg.GRPCClientConfig.TLSSetting.InsecureSkipVerify = true
+				cfg.ClientConfig.TLSSetting.InsecureSkipVerify = true
 			}
 			set := exportertest.NewNopCreateSettings()
 			exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
@@ -400,7 +400,7 @@ func TestSendMetrics(t *testing.T) {
 	// Disable queuing to ensure that we execute the request when calling ConsumeMetrics
 	// otherwise we will not see any errors.
 	cfg.QueueConfig.Enabled = false
-	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
+	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -498,7 +498,7 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 	// Disable queuing to ensure that we execute the request when calling ConsumeTraces
 	// otherwise we will not see the error.
 	cfg.QueueConfig.Enabled = false
-	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
+	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -558,7 +558,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 	// Start an OTLP exporter and point to the receiver.
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
+	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -609,7 +609,7 @@ func TestSendTracesOnResourceExhaustion(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.RetryConfig.InitialInterval = 0
-	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
+	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
@@ -690,7 +690,7 @@ func TestSendLogData(t *testing.T) {
 	// Disable queuing to ensure that we execute the request when calling ConsumeLogs
 	// otherwise we will not see any errors.
 	cfg.QueueConfig.Enabled = false
-	cfg.GRPCClientConfig = configgrpc.GRPCClientConfig{
+	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,

--- a/internal/e2e/consume_contract_test.go
+++ b/internal/e2e/consume_contract_test.go
@@ -24,7 +24,7 @@ func testExporterConfig(endpoint string) component.Config {
 	return &otlpexporter.Config{
 		QueueConfig: exporterhelper.QueueSettings{Enabled: false},
 		RetryConfig: retryConfig,
-		GRPCClientSettings: configgrpc.GRPCClientSettings{
+		GRPCClientConfig: configgrpc.GRPCClientConfig{
 			Endpoint: endpoint,
 			TLSSetting: configtls.TLSClientSetting{
 				Insecure: true,

--- a/internal/e2e/consume_contract_test.go
+++ b/internal/e2e/consume_contract_test.go
@@ -24,7 +24,7 @@ func testExporterConfig(endpoint string) component.Config {
 	return &otlpexporter.Config{
 		QueueConfig: exporterhelper.QueueSettings{Enabled: false},
 		RetryConfig: retryConfig,
-		GRPCClientConfig: configgrpc.GRPCClientConfig{
+		ClientConfig: configgrpc.ClientConfig{
 			Endpoint: endpoint,
 			TLSSetting: configtls.TLSClientSetting{
 				Insecure: true,


### PR DESCRIPTION
**Description:**
Deprecate GRPCClientSettings, use ~GRPC~ClientConfig instead

**Link to tracking Issue:**
#6767
