### PR TITLE
[confighttp] Deprecate HTTPClientSettings, use HTTPClientConfig instead

### DIFF
--- a/.chloggen/httpclientsettings_httpclientconfig-breaking.yaml
+++ b/.chloggen/httpclientsettings_httpclientconfig-breaking.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlphttpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: otlphttpexporter.Config embeds the struct confighttp.HTTPClientConfig instead of confighttp.HTTPClientSettings
+
+# One or more tracking issues or pull requests related to the change
+issues: [6767]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/httpclientsettings_httpclientconfig.yaml
+++ b/.chloggen/httpclientsettings_httpclientconfig.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate HTTPClientSettings, use HTTPClientConfig instead
+
+# One or more tracking issues or pull requests related to the change
+issues: [6767]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -95,7 +95,7 @@ func TestHTTPClientCompression(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, srv.URL, reqBody)
 			require.NoError(t, err, "failed to create request to test handler")
 
-			clientSettings := HTTPClientSettings{
+			clientSettings := HTTPClientConfig{
 				Endpoint:    srv.URL,
 				Compression: tt.encoding,
 			}

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -30,7 +30,11 @@ import (
 const headerContentEncoding = "Content-Encoding"
 
 // HTTPClientSettings defines settings for creating an HTTP client.
-type HTTPClientSettings struct {
+// Deprecated: [v0.94.0] Use HTTPClientConfig instead
+type HTTPClientSettings = HTTPClientConfig
+
+// HTTPClientConfig defines settings for creating an HTTP client.
+type HTTPClientConfig struct {
 	// The target URL to send data to (e.g.: http://some.url:9411/v1/traces).
 	Endpoint string `mapstructure:"endpoint"`
 
@@ -103,19 +107,28 @@ type HTTPClientSettings struct {
 // the default values of 'MaxIdleConns' and 'IdleConnTimeout'.
 // Other config options are not added as they are initialized with 'zero value' by GoLang as default.
 // We encourage to use this function to create an object of HTTPClientSettings.
-func NewDefaultHTTPClientSettings() HTTPClientSettings {
+// Deprecated: [v0.94.0] Use NewDefaultHTTPClientConfig instead
+func NewDefaultHTTPClientSettings() HTTPClientConfig {
+	return NewDefaultHTTPClientConfig()
+}
+
+// NewDefaultHTTPClientConfig returns HTTPClientConfig type object with
+// the default values of 'MaxIdleConns' and 'IdleConnTimeout'.
+// Other config options are not added as they are initialized with 'zero value' by GoLang as default.
+// We encourage to use this function to create an object of HTTPClientConfig.
+func NewDefaultHTTPClientConfig() HTTPClientConfig {
 	// The default values are taken from the values of 'DefaultTransport' of 'http' package.
 	maxIdleConns := 100
 	idleConnTimeout := 90 * time.Second
 
-	return HTTPClientSettings{
+	return HTTPClientConfig{
 		MaxIdleConns:    &maxIdleConns,
 		IdleConnTimeout: &idleConnTimeout,
 	}
 }
 
 // ToClient creates an HTTP client.
-func (hcs *HTTPClientSettings) ToClient(host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
+func (hcs *HTTPClientConfig) ToClient(host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
 	tlsCfg, err := hcs.TLSSetting.LoadTLSConfig()
 	if err != nil {
 		return nil, err

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -56,12 +56,12 @@ func TestAllHTTPClientSettings(t *testing.T) {
 	http2PingTimeout := 5 * time.Second
 	tests := []struct {
 		name        string
-		settings    HTTPClientSettings
+		settings    HTTPClientConfig
 		shouldError bool
 	}{
 		{
 			name: "all_valid_settings",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: false,
@@ -82,7 +82,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 		},
 		{
 			name: "all_valid_settings_with_none_compression",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: false,
@@ -103,7 +103,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 		},
 		{
 			name: "all_valid_settings_with_gzip_compression",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: false,
@@ -124,7 +124,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 		},
 		{
 			name: "all_valid_settings_http2_health_check",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: false,
@@ -145,7 +145,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 		},
 		{
 			name: "error_round_tripper_returned",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: false,
@@ -193,12 +193,12 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		settings    HTTPClientSettings
+		settings    HTTPClientConfig
 		shouldError bool
 	}{
 		{
 			name: "valid_partial_settings",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: false,
@@ -231,7 +231,7 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 }
 
 func TestDefaultHTTPClientSettings(t *testing.T) {
-	httpClientSettings := NewDefaultHTTPClientSettings()
+	httpClientSettings := NewDefaultHTTPClientConfig()
 	assert.EqualValues(t, 100, *httpClientSettings.MaxIdleConns)
 	assert.EqualValues(t, 90*time.Second, *httpClientSettings.IdleConnTimeout)
 }
@@ -260,7 +260,7 @@ func TestProxyURL(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			s := NewDefaultHTTPClientSettings()
+			s := NewDefaultHTTPClientConfig()
 			s.ProxyURL = tC.proxyURL
 
 			tt := componenttest.NewNopTelemetrySettings()
@@ -296,12 +296,12 @@ func TestHTTPClientSettingsError(t *testing.T) {
 		ext: map[component.ID]component.Component{},
 	}
 	tests := []struct {
-		settings HTTPClientSettings
+		settings HTTPClientConfig
 		err      string
 	}{
 		{
 			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "",
 				TLSSetting: configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
@@ -314,7 +314,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "",
 				TLSSetting: configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
@@ -327,7 +327,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 		},
 		{
 			err: "failed to resolve authenticator \"dummy\": authenticator not found",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "https://localhost:1234/v1/traces",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("dummy")},
 			},
@@ -345,12 +345,12 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 	tests := []struct {
 		name      string
 		shouldErr bool
-		settings  HTTPClientSettings
+		settings  HTTPClientConfig
 		host      component.Host
 	}{
 		{
 			name: "no_auth_extension_enabled",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     nil,
 			},
@@ -365,7 +365,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with_auth_configuration_and_no_extension",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("dummy")},
 			},
@@ -378,7 +378,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with_auth_configuration_and_no_extension_map",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("dummy")},
 			},
@@ -387,7 +387,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with_auth_configuration_has_extension",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("mock")},
 			},
@@ -400,7 +400,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with_auth_configuration_has_extension_and_headers",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("mock")},
 				Headers:  map[string]configopaque.String{"foo": "bar"},
@@ -414,7 +414,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with_auth_configuration_has_extension_and_compression",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint:    "localhost:1234",
 				Auth:        &configauth.Authentication{AuthenticatorID: component.NewID("mock")},
 				Compression: configcompression.Gzip,
@@ -428,7 +428,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with_auth_configuration_has_err_extension",
-			settings: HTTPClientSettings{
+			settings: HTTPClientConfig{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("mock")},
 			},
@@ -713,7 +713,7 @@ func TestHttpReception(t *testing.T) {
 				expectedProto = "HTTP/1.1"
 			}
 
-			hcs := &HTTPClientSettings{
+			hcs := &HTTPClientConfig{
 				Endpoint:   prefix + ln.Addr().String(),
 				TLSSetting: *tt.tlsClientCreds,
 			}
@@ -1044,7 +1044,7 @@ func TestHttpClientHeaders(t *testing.T) {
 			}))
 			defer server.Close()
 			serverURL, _ := url.Parse(server.URL)
-			setting := HTTPClientSettings{
+			setting := HTTPClientConfig{
 				Endpoint:        serverURL.String(),
 				TLSSetting:      configtls.TLSClientSetting{},
 				ReadBufferSize:  0,
@@ -1336,7 +1336,7 @@ func BenchmarkHttpRequest(b *testing.B) {
 	}()
 
 	for _, bb := range tests {
-		hcs := &HTTPClientSettings{
+		hcs := &HTTPClientConfig{
 			Endpoint:   "https://" + ln.Addr().String(),
 			TLSSetting: *tlsClientCreds,
 		}

--- a/exporter/otlphttpexporter/config.go
+++ b/exporter/otlphttpexporter/config.go
@@ -14,9 +14,9 @@ import (
 
 // Config defines configuration for OTLP/HTTP exporter.
 type Config struct {
-	confighttp.HTTPClientSettings `mapstructure:",squash"`     // squash ensures fields are correctly decoded in embedded struct.
-	QueueConfig                   exporterhelper.QueueSettings `mapstructure:"sending_queue"`
-	RetryConfig                   configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	confighttp.HTTPClientConfig `mapstructure:",squash"`     // squash ensures fields are correctly decoded in embedded struct.
+	QueueConfig                 exporterhelper.QueueSettings `mapstructure:"sending_queue"`
+	RetryConfig                 configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
 
 	// The URL to send traces to. If omitted the Endpoint + "/v1/traces" will be used.
 	TracesEndpoint string `mapstructure:"traces_endpoint"`

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -51,7 +51,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				NumConsumers: 2,
 				QueueSize:    10,
 			},
-			HTTPClientSettings: confighttp.HTTPClientSettings{
+			HTTPClientConfig: confighttp.HTTPClientConfig{
 				Headers: map[string]configopaque.String{
 					"can you have a . here?": "F0000000-0000-0000-0000-000000000000",
 					"header1":                "234",

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -36,7 +36,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		RetryConfig: configretry.NewDefaultBackOffConfig(),
 		QueueConfig: exporterhelper.NewDefaultQueueSettings(),
-		HTTPClientSettings: confighttp.HTTPClientSettings{
+		HTTPClientConfig: confighttp.HTTPClientConfig{
 			Endpoint: "",
 			Timeout:  30 * time.Second,
 			Headers:  map[string]configopaque.String{},

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -28,8 +28,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
-	assert.Equal(t, ocfg.HTTPClientSettings.Endpoint, "")
-	assert.Equal(t, ocfg.HTTPClientSettings.Timeout, 30*time.Second, "default timeout is 30 second")
+	assert.Equal(t, ocfg.HTTPClientConfig.Endpoint, "")
+	assert.Equal(t, ocfg.HTTPClientConfig.Timeout, 30*time.Second, "default timeout is 30 second")
 	assert.Equal(t, ocfg.RetryConfig.Enabled, true, "default retry is enabled")
 	assert.Equal(t, ocfg.RetryConfig.MaxElapsedTime, 300*time.Second, "default retry MaxElapsedTime")
 	assert.Equal(t, ocfg.RetryConfig.InitialInterval, 5*time.Second, "default retry InitialInterval")
@@ -41,7 +41,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetricsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.HTTPClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
+	cfg.HTTPClientConfig.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
@@ -61,7 +61,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NoEndpoint",
 			config: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
+				HTTPClientConfig: confighttp.HTTPClientConfig{
 					Endpoint: "",
 				},
 			},
@@ -70,7 +70,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "UseSecure",
 			config: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
+				HTTPClientConfig: confighttp.HTTPClientConfig{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
 						Insecure: false,
@@ -81,7 +81,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Headers",
 			config: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
+				HTTPClientConfig: confighttp.HTTPClientConfig{
 					Endpoint: endpoint,
 					Headers: map[string]configopaque.String{
 						"hdr1": "val1",
@@ -93,7 +93,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CaCert",
 			config: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
+				HTTPClientConfig: confighttp.HTTPClientConfig{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -106,7 +106,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CertPemFileError",
 			config: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
+				HTTPClientConfig: confighttp.HTTPClientConfig{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -121,7 +121,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NoneCompression",
 			config: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
+				HTTPClientConfig: confighttp.HTTPClientConfig{
 					Endpoint:    endpoint,
 					Compression: "none",
 				},
@@ -130,7 +130,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "GzipCompression",
 			config: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
+				HTTPClientConfig: confighttp.HTTPClientConfig{
 					Endpoint:    endpoint,
 					Compression: configcompression.Gzip,
 				},
@@ -139,7 +139,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "SnappyCompression",
 			config: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
+				HTTPClientConfig: confighttp.HTTPClientConfig{
 					Endpoint:    endpoint,
 					Compression: configcompression.Snappy,
 				},
@@ -148,7 +148,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "ZstdCompression",
 			config: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
+				HTTPClientConfig: confighttp.HTTPClientConfig{
 					Endpoint:    endpoint,
 					Compression: configcompression.Zstd,
 				},
@@ -186,7 +186,7 @@ func TestCreateTracesExporter(t *testing.T) {
 func TestCreateLogsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.HTTPClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
+	cfg.HTTPClientConfig.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
@@ -199,13 +199,13 @@ func TestComposeSignalURL(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 
 	// Has slash at end
-	cfg.HTTPClientSettings.Endpoint = "http://localhost:4318/"
+	cfg.HTTPClientConfig.Endpoint = "http://localhost:4318/"
 	url, err := composeSignalURL(cfg, "", "traces")
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:4318/v1/traces", url)
 
 	// No slash at end
-	cfg.HTTPClientSettings.Endpoint = "http://localhost:4318"
+	cfg.HTTPClientConfig.Endpoint = "http://localhost:4318"
 	url, err = composeSignalURL(cfg, "", "traces")
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:4318/v1/traces", url)

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -77,7 +77,7 @@ func newExporter(cfg component.Config, set exporter.CreateSettings) (*baseExport
 // start actually creates the HTTP client. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *baseExporter) start(_ context.Context, host component.Host) error {
-	client, err := e.config.HTTPClientSettings.ToClient(host, e.settings)
+	client, err := e.config.HTTPClientConfig.ToClient(host, e.settings)
 	if err != nil {
 		return err
 	}

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -251,7 +251,7 @@ func TestUserAgent(t *testing.T) {
 
 				cfg := &Config{
 					TracesEndpoint: fmt.Sprintf("%s/v1/traces", srv.URL),
-					HTTPClientSettings: confighttp.HTTPClientSettings{
+					HTTPClientConfig: confighttp.HTTPClientConfig{
 						Headers: test.headers,
 					},
 				}
@@ -284,7 +284,7 @@ func TestUserAgent(t *testing.T) {
 
 				cfg := &Config{
 					MetricsEndpoint: fmt.Sprintf("%s/v1/metrics", srv.URL),
-					HTTPClientSettings: confighttp.HTTPClientSettings{
+					HTTPClientConfig: confighttp.HTTPClientConfig{
 						Headers: test.headers,
 					},
 				}
@@ -317,7 +317,7 @@ func TestUserAgent(t *testing.T) {
 
 				cfg := &Config{
 					LogsEndpoint: fmt.Sprintf("%s/v1/logs", srv.URL),
-					HTTPClientSettings: confighttp.HTTPClientSettings{
+					HTTPClientConfig: confighttp.HTTPClientConfig{
 						Headers: test.headers,
 					},
 				}
@@ -423,8 +423,8 @@ func TestPartialSuccess_logs(t *testing.T) {
 	defer srv.Close()
 
 	cfg := &Config{
-		LogsEndpoint:       fmt.Sprintf("%s/v1/logs", srv.URL),
-		HTTPClientSettings: confighttp.HTTPClientSettings{},
+		LogsEndpoint:     fmt.Sprintf("%s/v1/logs", srv.URL),
+		HTTPClientConfig: confighttp.HTTPClientConfig{},
 	}
 	exp, err := createLogsExporter(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 	require.NoError(t, err)
@@ -547,8 +547,8 @@ func TestPartialSuccess_traces(t *testing.T) {
 	defer srv.Close()
 
 	cfg := &Config{
-		TracesEndpoint:     fmt.Sprintf("%s/v1/traces", srv.URL),
-		HTTPClientSettings: confighttp.HTTPClientSettings{},
+		TracesEndpoint:   fmt.Sprintf("%s/v1/traces", srv.URL),
+		HTTPClientConfig: confighttp.HTTPClientConfig{},
 	}
 	exp, err := createTracesExporter(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 	require.NoError(t, err)
@@ -581,8 +581,8 @@ func TestPartialSuccess_metrics(t *testing.T) {
 	defer srv.Close()
 
 	cfg := &Config{
-		MetricsEndpoint:    fmt.Sprintf("%s/v1/metrics", srv.URL),
-		HTTPClientSettings: confighttp.HTTPClientSettings{},
+		MetricsEndpoint:  fmt.Sprintf("%s/v1/metrics", srv.URL),
+		HTTPClientConfig: confighttp.HTTPClientConfig{},
 	}
 	exp, err := createMetricsExporter(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 	require.NoError(t, err)

--- a/internal/e2e/otlphttp_test.go
+++ b/internal/e2e/otlphttp_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestInvalidConfig(t *testing.T) {
 	config := &otlphttpexporter.Config{
-		HTTPClientSettings: confighttp.HTTPClientSettings{
+		HTTPClientConfig: confighttp.HTTPClientConfig{
 			Endpoint: "",
 		},
 	}


### PR DESCRIPTION
**Description:**
Deprecate HTTPClientSettings, use HTTPClientConfig instead

**Link to tracking Issue:**
#6767