### PR TITLE
[confighttp] Deprecate HTTPServerSettings, use HTTPServerConfig instead

### DIFF
--- a/.chloggen/httpserversettings_httpserverconfig.yaml
+++ b/.chloggen/httpserversettings_httpserverconfig.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate HTTPServerSettings, use HTTPServerConfig instead
+
+# One or more tracking issues or pull requests related to the change
+issues: [6767]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -244,7 +244,11 @@ func (interceptor *headerRoundTripper) RoundTrip(req *http.Request) (*http.Respo
 }
 
 // HTTPServerSettings defines settings for creating an HTTP server.
-type HTTPServerSettings struct {
+// Deprecated: [v0.94.0] Use HTTPServerConfig instead
+type HTTPServerSettings = HTTPServerConfig
+
+// HTTPServerConfig defines settings for creating an HTTP server.
+type HTTPServerConfig struct {
 	// Endpoint configures the listening address for the server.
 	Endpoint string `mapstructure:"endpoint"`
 
@@ -270,7 +274,7 @@ type HTTPServerSettings struct {
 }
 
 // ToListener creates a net.Listener.
-func (hss *HTTPServerSettings) ToListener() (net.Listener, error) {
+func (hss *HTTPServerConfig) ToListener() (net.Listener, error) {
 	listener, err := net.Listen("tcp", hss.Endpoint)
 	if err != nil {
 		return nil, err
@@ -289,14 +293,14 @@ func (hss *HTTPServerSettings) ToListener() (net.Listener, error) {
 }
 
 // toServerOptions has options that change the behavior of the HTTP server
-// returned by HTTPServerSettings.ToServer().
+// returned by HTTPServerConfig.ToServer().
 type toServerOptions struct {
 	errHandler func(w http.ResponseWriter, r *http.Request, errorMsg string, statusCode int)
 	decoders   map[string]func(body io.ReadCloser) (io.ReadCloser, error)
 }
 
 // ToServerOption is an option to change the behavior of the HTTP server
-// returned by HTTPServerSettings.ToServer().
+// returned by HTTPServerConfig.ToServer().
 type ToServerOption func(opts *toServerOptions)
 
 // WithErrorHandler overrides the HTTP error handler that gets invoked
@@ -319,7 +323,7 @@ func WithDecoder(key string, dec func(body io.ReadCloser) (io.ReadCloser, error)
 }
 
 // ToServer creates an http.Server from settings object.
-func (hss *HTTPServerSettings) ToServer(host component.Host, settings component.TelemetrySettings, handler http.Handler, opts ...ToServerOption) (*http.Server, error) {
+func (hss *HTTPServerConfig) ToServer(host component.Host, settings component.TelemetrySettings, handler http.Handler, opts ...ToServerOption) (*http.Server, error) {
 	internal.WarnOnUnspecifiedHost(settings.Logger, hss.Endpoint)
 
 	serverOpts := &toServerOptions{}

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -479,12 +479,12 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 
 func TestHTTPServerSettingsError(t *testing.T) {
 	tests := []struct {
-		settings HTTPServerSettings
+		settings HTTPServerConfig
 		err      string
 	}{
 		{
 			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
-			settings: HTTPServerSettings{
+			settings: HTTPServerConfig{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{
 					TLSSetting: configtls.TLSSetting{
@@ -495,7 +495,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 		},
 		{
 			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
-			settings: HTTPServerSettings{
+			settings: HTTPServerConfig{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{
 					TLSSetting: configtls.TLSSetting{
@@ -506,7 +506,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 		},
 		{
 			err: "failed to load client CA CertPool: failed to load CA /doesnt/exist:",
-			settings: HTTPServerSettings{
+			settings: HTTPServerConfig{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{
 					ClientCAFile: "/doesnt/exist",
@@ -525,17 +525,17 @@ func TestHTTPServerSettingsError(t *testing.T) {
 func TestHTTPServerWarning(t *testing.T) {
 	tests := []struct {
 		name     string
-		settings HTTPServerSettings
+		settings HTTPServerConfig
 		len      int
 	}{
 		{
-			settings: HTTPServerSettings{
+			settings: HTTPServerConfig{
 				Endpoint: "0.0.0.0:0",
 			},
 			len: 1,
 		},
 		{
-			settings: HTTPServerSettings{
+			settings: HTTPServerConfig{
 				Endpoint: "127.0.0.1:0",
 			},
 			len: 0,
@@ -686,7 +686,7 @@ func TestHttpReception(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hss := &HTTPServerSettings{
+			hss := &HTTPServerConfig{
 				Endpoint:   "localhost:0",
 				TLSSetting: tt.tlsServerCreds,
 			}
@@ -798,7 +798,7 @@ func TestHttpCors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hss := &HTTPServerSettings{
+			hss := &HTTPServerConfig{
 				Endpoint: "localhost:0",
 				CORS:     tt.CORSConfig,
 			}
@@ -840,7 +840,7 @@ func TestHttpCors(t *testing.T) {
 }
 
 func TestHttpCorsInvalidSettings(t *testing.T) {
-	hss := &HTTPServerSettings{
+	hss := &HTTPServerConfig{
 		Endpoint: "localhost:0",
 		CORS:     &CORSConfig{AllowedHeaders: []string{"some-header"}},
 	}
@@ -856,7 +856,7 @@ func TestHttpCorsInvalidSettings(t *testing.T) {
 }
 
 func TestHttpCorsWithSettings(t *testing.T) {
-	hss := &HTTPServerSettings{
+	hss := &HTTPServerConfig{
 		Endpoint: "localhost:0",
 		CORS: &CORSConfig{
 			AllowedOrigins: []string{"*"},
@@ -914,7 +914,7 @@ func TestHttpServerHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hss := &HTTPServerSettings{
+			hss := &HTTPServerConfig{
 				Endpoint:        "localhost:0",
 				ResponseHeaders: tt.headers,
 			}
@@ -1002,7 +1002,7 @@ func verifyHeadersResp(t *testing.T, url string, expected map[string]configopaqu
 }
 
 func ExampleHTTPServerSettings() {
-	settings := HTTPServerSettings{
+	settings := HTTPServerConfig{
 		Endpoint: "localhost:443",
 	}
 	s, err := settings.ToServer(
@@ -1125,7 +1125,7 @@ func TestContextWithClient(t *testing.T) {
 func TestServerAuth(t *testing.T) {
 	// prepare
 	authCalled := false
-	hss := HTTPServerSettings{
+	hss := HTTPServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &configauth.Authentication{
 			AuthenticatorID: component.NewID("mock"),
@@ -1160,7 +1160,7 @@ func TestServerAuth(t *testing.T) {
 }
 
 func TestInvalidServerAuth(t *testing.T) {
-	hss := HTTPServerSettings{
+	hss := HTTPServerConfig{
 		Auth: &configauth.Authentication{
 			AuthenticatorID: component.NewID("non-existing"),
 		},
@@ -1173,7 +1173,7 @@ func TestInvalidServerAuth(t *testing.T) {
 
 func TestFailedServerAuth(t *testing.T) {
 	// prepare
-	hss := HTTPServerSettings{
+	hss := HTTPServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &configauth.Authentication{
 			AuthenticatorID: component.NewID("mock"),
@@ -1203,7 +1203,7 @@ func TestFailedServerAuth(t *testing.T) {
 
 func TestServerWithErrorHandler(t *testing.T) {
 	// prepare
-	hss := HTTPServerSettings{
+	hss := HTTPServerConfig{
 		Endpoint: "localhost:0",
 	}
 	eh := func(w http.ResponseWriter, r *http.Request, errorMsg string, statusCode int) {
@@ -1234,7 +1234,7 @@ func TestServerWithErrorHandler(t *testing.T) {
 
 func TestServerWithDecoder(t *testing.T) {
 	// prepare
-	hss := HTTPServerSettings{
+	hss := HTTPServerConfig{
 		Endpoint: "localhost:0",
 	}
 	decoder := func(body io.ReadCloser) (io.ReadCloser, error) {
@@ -1312,7 +1312,7 @@ func BenchmarkHttpRequest(b *testing.B) {
 		ServerName: "localhost",
 	}
 
-	hss := &HTTPServerSettings{
+	hss := &HTTPServerConfig{
 		Endpoint:   "localhost:0",
 		TLSSetting: tlsServerCreds,
 	}

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -22,7 +22,7 @@ const (
 )
 
 type HTTPConfig struct {
-	*confighttp.HTTPServerSettings `mapstructure:",squash"`
+	*confighttp.HTTPServerConfig `mapstructure:",squash"`
 
 	// The URL path to receive traces on. If omitted "/v1/traces" will be used.
 	TracesURLPath string `mapstructure:"traces_url_path,omitempty"`

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -116,7 +116,7 @@ func TestUnmarshalConfig(t *testing.T) {
 					},
 				},
 				HTTP: &HTTPConfig{
-					HTTPServerSettings: &confighttp.HTTPServerSettings{
+					HTTPServerConfig: &confighttp.HTTPServerConfig{
 						Endpoint: "0.0.0.0:4318",
 						TLSSetting: &configtls.TLSServerSetting{
 							TLSSetting: configtls.TLSSetting{
@@ -155,7 +155,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 					ReadBufferSize: 512 * 1024,
 				},
 				HTTP: &HTTPConfig{
-					HTTPServerSettings: &confighttp.HTTPServerSettings{
+					HTTPServerConfig: &confighttp.HTTPServerConfig{
 						Endpoint: "/tmp/http_otlp.sock",
 					},
 					TracesURLPath:  defaultTracesURLPath,

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -52,7 +52,7 @@ func createDefaultConfig() component.Config {
 				ReadBufferSize: 512 * 1024,
 			},
 			HTTP: &HTTPConfig{
-				HTTPServerSettings: &confighttp.HTTPServerSettings{
+				HTTPServerConfig: &confighttp.HTTPServerConfig{
 					Endpoint: localhostgate.EndpointForPort(httpPort),
 				},
 				TracesURLPath:  defaultTracesURLPath,

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -59,7 +59,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 		},
 	}
 	defaultHTTPSettings := &HTTPConfig{
-		HTTPServerSettings: &confighttp.HTTPServerSettings{
+		HTTPServerConfig: &confighttp.HTTPServerConfig{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
 		TracesURLPath:  defaultTracesURLPath,
@@ -106,7 +106,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
 					HTTP: &HTTPConfig{
-						HTTPServerSettings: &confighttp.HTTPServerSettings{
+						HTTPServerConfig: &confighttp.HTTPServerConfig{
 							Endpoint: "localhost:112233",
 						},
 						TracesURLPath: defaultTracesURLPath,
@@ -122,7 +122,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
 					HTTP: &HTTPConfig{
-						HTTPServerSettings: &confighttp.HTTPServerSettings{
+						HTTPServerConfig: &confighttp.HTTPServerConfig{
 							Endpoint: "127.0.0.1:1122",
 						},
 					},
@@ -169,7 +169,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 		},
 	}
 	defaultHTTPSettings := &HTTPConfig{
-		HTTPServerSettings: &confighttp.HTTPServerSettings{
+		HTTPServerConfig: &confighttp.HTTPServerConfig{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
 		TracesURLPath:  defaultTracesURLPath,
@@ -216,7 +216,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
 					HTTP: &HTTPConfig{
-						HTTPServerSettings: &confighttp.HTTPServerSettings{
+						HTTPServerConfig: &confighttp.HTTPServerConfig{
 							Endpoint: "327.0.0.1:1122",
 						},
 						MetricsURLPath: defaultMetricsURLPath,
@@ -232,7 +232,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
 					HTTP: &HTTPConfig{
-						HTTPServerSettings: &confighttp.HTTPServerSettings{
+						HTTPServerConfig: &confighttp.HTTPServerConfig{
 							Endpoint: "127.0.0.1:1122",
 						},
 					},
@@ -278,7 +278,7 @@ func TestCreateLogReceiver(t *testing.T) {
 		},
 	}
 	defaultHTTPSettings := &HTTPConfig{
-		HTTPServerSettings: &confighttp.HTTPServerSettings{
+		HTTPServerConfig: &confighttp.HTTPServerConfig{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
 		TracesURLPath:  defaultTracesURLPath,
@@ -325,7 +325,7 @@ func TestCreateLogReceiver(t *testing.T) {
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
 					HTTP: &HTTPConfig{
-						HTTPServerSettings: &confighttp.HTTPServerSettings{
+						HTTPServerConfig: &confighttp.HTTPServerConfig{
 							Endpoint: "327.0.0.1:1122",
 						},
 						LogsURLPath: defaultLogsURLPath,
@@ -341,7 +341,7 @@ func TestCreateLogReceiver(t *testing.T) {
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
 					HTTP: &HTTPConfig{
-						HTTPServerSettings: &confighttp.HTTPServerSettings{
+						HTTPServerConfig: &confighttp.HTTPServerConfig{
 							Endpoint: "127.0.0.1:1122",
 						},
 					},

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -149,9 +149,9 @@ func (r *otlpReceiver) startHTTPServer(host component.Host) error {
 		return err
 	}
 
-	r.settings.Logger.Info("Starting HTTP server", zap.String("endpoint", r.cfg.HTTP.HTTPServerSettings.Endpoint))
+	r.settings.Logger.Info("Starting HTTP server", zap.String("endpoint", r.cfg.HTTP.HTTPServerConfig.Endpoint))
 	var hln net.Listener
-	if hln, err = r.cfg.HTTP.HTTPServerSettings.ToListener(); err != nil {
+	if hln, err = r.cfg.HTTP.HTTPServerConfig.ToListener(); err != nil {
 		return err
 	}
 

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -699,7 +699,7 @@ func TestHTTPInvalidTLSCredentials(t *testing.T) {
 	cfg := &Config{
 		Protocols: Protocols{
 			HTTP: &HTTPConfig{
-				HTTPServerSettings: &confighttp.HTTPServerSettings{
+				HTTPServerConfig: &confighttp.HTTPServerConfig{
 					Endpoint: testutil.GetAvailableLocalAddress(t),
 					TLSSetting: &configtls.TLSServerSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -732,7 +732,7 @@ func testHTTPMaxRequestBodySize(t *testing.T, path string, contentType string, p
 	cfg := &Config{
 		Protocols: Protocols{
 			HTTP: &HTTPConfig{
-				HTTPServerSettings: &confighttp.HTTPServerSettings{
+				HTTPServerConfig: &confighttp.HTTPServerConfig{
 					Endpoint:           addr,
 					MaxRequestBodySize: int64(size),
 				},


### PR DESCRIPTION
**Description:**
Deprecate HTTPServerSettings, use HTTPServerConfig instead

**Link to tracking Issue:**
#6767