### PR TITLE
[service/telemetry] Deprecate telemetry.Settings in favor of telemetry.CreateSettings

### DIFF
--- a/.chloggen/mx-psi_createsettings.yaml
+++ b/.chloggen/mx-psi_createsettings.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service/telemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `telemetry.Settings` in favor of `telemetry.CreateSettings`
+
+# One or more tracking issues or pull requests related to the change
+issues: [9406]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/service/service.go
+++ b/service/service.go
@@ -91,7 +91,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		collectorConf:        set.CollectorConf,
 	}
 	var err error
-	srv.telemetry, err = telemetry.New(ctx, telemetry.Settings{ZapOptions: set.LoggingOptions}, cfg.Telemetry)
+	srv.telemetry, err = telemetry.New(ctx, telemetry.CreateSettings{ZapOptions: set.LoggingOptions}, cfg.Telemetry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get logger: %w", err)
 	}

--- a/service/telemetry/telemetry.go
+++ b/service/telemetry/telemetry.go
@@ -34,12 +34,16 @@ func (t *Telemetry) Shutdown(ctx context.Context) error {
 }
 
 // Settings holds configuration for building Telemetry.
-type Settings struct {
+// Deprecated [v0.94.0]: Use CreateSettings instead.
+type Settings = CreateSettings
+
+// CreateSettings holds configuration for building Telemetry.
+type CreateSettings struct {
 	ZapOptions []zap.Option
 }
 
 // New creates a new Telemetry from Config.
-func New(_ context.Context, set Settings, cfg Config) (*Telemetry, error) {
+func New(_ context.Context, set CreateSettings, cfg Config) (*Telemetry, error) {
 	logger, err := newLogger(cfg.Logs, set.ZapOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description:** Deprecate `telemetry.Settings` in favor of `telemetry.CreateSettings`. This is for consistency with how we name similar structs in exporters, receivers, processors, connectors and extensions.
