### PR TITLE
[chore] validate version format to prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Validate version format
         run: |
           validate_version() {
-              if [[ ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rcv[0-9]+)?$ ]]; then
-                  echo "Invalid $2 version format. It should be like 1.0.0 or 1.0.0-rcv0014."
-                  exit 1
-              fi
+             if [[ ! "$1" =~ ^[1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*(-rcv[0-9]+)?$ ]]; then
+                 echo "Invalid $2 version format. It should be like 1.0.0 or 1.0.0-rcv0014."
+                 exit 1
+             fi
           }
 
           validate_version "${{ inputs.candidate-stable }}" "candidate-stable"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,10 +26,17 @@ jobs:
       - name: Validate version format
         run: |
           validate_version() {
-             if [[ ! "$1" =~ ^[1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*(-rcv[0-9]+)?$ ]]; then
-                 echo "Invalid $2 version format. It should be like 1.0.0 or 1.0.0-rcv0014."
-                 exit 1
-             fi
+            local regex_pattern_stable='^[1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*$'
+            local regex_pattern_beta='^[0-9]+\.[1-9][0-9]*\.[1-9][0-9]*$'
+
+            if [[ "$1" =~ $regex_pattern_stable && ! "$1" =~ -rcv[0-9]+$ ]]; then
+                echo "Valid $2 version: $1"
+            elif [[ "$1" =~ $regex_pattern_beta && ! "$1" =~ -rcv[0-9]+$ ]]; then
+                echo "Valid $2 version: $1"
+            else
+                echo "Invalid $2 version format. For stable, it should be like 1.0.0, and for beta, it can be 0.1.0 or higher. No RC candidates allowed."
+                exit 1
+            fi
           }
 
           validate_version "${{ inputs.candidate-stable }}" "candidate-stable"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Validate version format
       run: |
         validate_version() {
-          local regex_pattern_beta='^[0-9]+\.[1-9][0-9]*\.[1-9][0-9]*$'
-          local regex_pattern_stable='^[1-9][0-9]*\.[0-9]+\.[0-9]+(-rcv[0-9]+)?$'
+          local regex_pattern_beta='^[0-9]+\.[0-9]+\.[0-9]+$'
+          local regex_pattern_stable='^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
 
           if [[ ! "$1" =~ $regex_pattern_beta ]]; then
             if [[ ! "$1" =~ $regex_pattern_stable ]]; then
-              echo "Invalid $2 version format. For beta, it can be 0.1.0 or higher. For stable, Major version must be greater than 1, and it can have an optional RC version."
+              echo "Invalid $2 version format. For beta, it can be 0.1.0 or higher. For stable, Major version must be greater than 1."
               exit 1
             fi
           fi

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,25 +24,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Validate version format
+     - name: Validate version format
       run: |
-        validate_version() {
+        validate_beta_version() {
           local regex_pattern_beta='^[0-9]+\.[0-9]+\.[0-9]+$'
-          local regex_pattern_stable='^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
-
           if [[ ! "$1" =~ $regex_pattern_beta ]]; then
-            if [[ ! "$1" =~ $regex_pattern_stable ]]; then
-              echo "Invalid $2 version format. For beta, it can be 0.1.0 or higher. For stable, Major version must be greater than 1."
-              exit 1
-            fi
+            echo "Invalid $2 version format. For beta, it can be 0.1.0 or higher"
+            exit 1
           fi
-          echo "Valid $2 version: $1"
         }
 
-        validate_version "${{ inputs.candidate-beta }}" "candidate-beta"
-        validate_version "${{ inputs.current-beta }}" "current-beta"
-        validate_version "${{ inputs.candidate-stable }}" "candidate-stable"
-        validate_version "${{ inputs.current-stable }}" "current-stable"
+        validate_stable_version() {
+          local regex_pattern_stable='^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
+          if [[ ! "$1" =~ $regex_pattern_stable ]]; then
+            echo "Invalid stable version format for $2. Major version must be greater than 1."
+            exit 1
+          fi
+        }
+
+        validate_beta_version "${{ inputs.candidate-beta }}" "candidate-beta"
+        validate_beta_version "${{ inputs.current-beta }}" "current-beta"
+        validate_stable_version "${{ inputs.candidate-stable }}" "candidate-stable"
+        validate_stable_version "${{ inputs.current-stable }}" "current-stable"
       shell: bash
   # Releasing opentelemetry-collector
   prepare-release:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,28 +25,21 @@ jobs:
     steps:
       - name: Validate version format
         run: |
-          if [[ ! "${{ inputs.candidate-stable }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rcv[0-9]+$ ]]; then
-            echo "Invalid candidate-stable version format. It should be like 1.0.0-rcv0014."
-            exit 1
-          fi
+          validate_version() {
+              if [[ ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rcv[0-9]+)?$ ]]; then
+                  echo "Invalid $2 version format. It should be like 1.0.0 or 1.0.0-rcv0014."
+                  exit 1
+              fi
+          }
 
-          if [[ ! "${{ inputs.current-stable }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rcv[0-9]+$ ]]; then
-            echo "Invalid current-stable version format. It should be like 1.0.0-rcv0014."
-            exit 1
-          fi
-
-          if [[ ! "${{ inputs.candidate-beta }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid candidate-beta version format. It should be like 0.70.0."
-            exit 1
-          fi
-
-          if [[ ! "${{ inputs.current-beta }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid current-beta version format. It should be like 0.69.1."
-            exit 1
-          fi
+          validate_version "${{ inputs.candidate-stable }}" "candidate-stable"
+          validate_version "${{ inputs.current-stable }}" "current-stable"
+          validate_version "${{ inputs.candidate-beta }}" "candidate-beta"
+          validate_version "${{ inputs.current-beta }}" "current-beta"
         shell: bash
   # Releasing opentelemetry-collector
   prepare-release:
+    needs: validate-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -39,7 +39,8 @@ jobs:
         shell: bash
   # Releasing opentelemetry-collector
   prepare-release:
-    needs: validate-version
+    needs: 
+      - validate-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -20,30 +20,30 @@ on:
         description: Current version (beta, like 0.69.1). Don't include `v`.
 jobs:
   #validate-version format
-  validate-version:
+  validate-versions:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Validate version format
-        run: |
-          validate_version() {
-            local regex_pattern_stable='^[1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*$'
-            local regex_pattern_beta='^[0-9]+\.[1-9][0-9]*\.[1-9][0-9]*$'
+    - name: Validate version format
+      run: |
+        validate_version() {
+          local regex_pattern_beta='^[0-9]+\.[1-9][0-9]*\.[1-9][0-9]*$'
+          local regex_pattern_stable='^[1-9][0-9]*\.[0-9]+\.[0-9]+(-rcv[0-9]+)?$'
 
-            if [[ "$1" =~ $regex_pattern_stable && ! "$1" =~ -rcv[0-9]+$ ]]; then
-                echo "Valid $2 version: $1"
-            elif [[ "$1" =~ $regex_pattern_beta && ! "$1" =~ -rcv[0-9]+$ ]]; then
-                echo "Valid $2 version: $1"
-            else
-                echo "Invalid $2 version format. For stable, it should be like 1.0.0, and for beta, it can be 0.1.0 or higher. No RC candidates allowed."
-                exit 1
+          if [[ ! "$1" =~ $regex_pattern_beta ]]; then
+            if [[ ! "$1" =~ $regex_pattern_stable ]]; then
+              echo "Invalid $2 version format. For beta, it can be 0.1.0 or higher. For stable, Major version must be greater than 1, and it can have an optional RC version."
+              exit 1
             fi
-          }
+          fi
+          echo "Valid $2 version: $1"
+        }
 
-          validate_version "${{ inputs.candidate-stable }}" "candidate-stable"
-          validate_version "${{ inputs.current-stable }}" "current-stable"
-          validate_version "${{ inputs.candidate-beta }}" "candidate-beta"
-          validate_version "${{ inputs.current-beta }}" "current-beta"
-        shell: bash
+        validate_version "${{ inputs.candidate-beta }}" "candidate-beta"
+        validate_version "${{ inputs.current-beta }}" "current-beta"
+        validate_version "${{ inputs.candidate-stable }}" "candidate-stable"
+        validate_version "${{ inputs.current-stable }}" "current-stable"
+      shell: bash
   # Releasing opentelemetry-collector
   prepare-release:
     needs: 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,6 +19,32 @@ on:
         required: true
         description: Current version (beta, like 0.69.1). Don't include `v`.
 jobs:
+  #validate-version format
+  validate-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.candidate-stable }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rcv[0-9]+$ ]]; then
+            echo "Invalid candidate-stable version format. It should be like 1.0.0-rcv0014."
+            exit 1
+          fi
+
+          if [[ ! "${{ inputs.current-stable }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rcv[0-9]+$ ]]; then
+            echo "Invalid current-stable version format. It should be like 1.0.0-rcv0014."
+            exit 1
+          fi
+
+          if [[ ! "${{ inputs.candidate-beta }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid candidate-beta version format. It should be like 0.70.0."
+            exit 1
+          fi
+
+          if [[ ! "${{ inputs.current-beta }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid current-beta version format. It should be like 0.69.1."
+            exit 1
+          fi
+        shell: bash
   # Releasing opentelemetry-collector
   prepare-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION

**Description:** <Describe what has changed.>
 enhance the "Automation - Prepare Release" GitHub Actions workflow by adding version format validation. The workflow now includes a new job, "validate-version," which checks whether the provided version inputs match the expected schema

**Link to tracking Issue:** <Issue number if applicable> #7627 