### PR TITLE
[mdatagen] Add checks for README.md and metadata.yaml files

### DIFF
--- a/.chloggen/add_generated_tests_mdatagen.yaml
+++ b/.chloggen/add_generated_tests_mdatagen.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add additional generated tests to check presence of metadata.yaml and README.md files in the component
+
+# One or more tracking issues or pull requests related to the change
+issues: [9437]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/templates/component_test.go.tmpl
@@ -53,6 +53,13 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
+func TestREADMEmdPresent(t *testing.T) {
+	require.FileExists(t, "README.md")
+}
+
+func TestMetadataYamlPresent(t *testing.T) {
+	require.FileExists(t, "metadata.yaml")
+}
 
 {{ if isExporter }}
 func Test_ComponentLifecycle(t *testing.T) {


### PR DESCRIPTION
**Description:**
Add checks for README.md and metadata.yaml files as part of the generated tests created by mdatagen.

These tests replace the Makefile targets https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/Makefile#L333-L341 executed through github here https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/build-and-test.yml#L187-L190.

Moving to generated tests removes the dependency on cmd/otelcontribcol.

**Testing:**
Tested manually in contrib.