### PR TITLE
[mdatagen] Remove use of ReportFatalError in generated tests

### DIFF
--- a/.chloggen/remove_assert_host.yaml
+++ b/.chloggen/remove_assert_host.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove use of ReportFatalError in generated tests
+
+# One or more tracking issues or pull requests related to the change
+issues: [9439]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/templates/component_test.go.tmpl
@@ -10,7 +10,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -41,26 +40,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 {{ end }}
 )
-
-// assertNoErrorHost implements a component.Host that asserts that there were no errors.
-type assertNoErrorHost struct {
-	component.Host
-	*testing.T
-}
-
-var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestCheckConfigStruct(t *testing.T) {
 	componenttest.CheckConfigStruct(NewFactory().CreateDefaultConfig())
@@ -122,10 +101,10 @@ func TestComponentLifecycle(t *testing.T) {
 			{{ end }}
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -148,7 +127,7 @@ func TestComponentLifecycle(t *testing.T) {
 				}
 			})
 			{{ if not expectConsumerError }}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			{{ end }}
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
@@ -213,10 +192,10 @@ func TestComponentLifecycle(t *testing.T) {
 			{{ end }}
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -238,7 +217,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
@@ -302,7 +281,7 @@ func TestComponentLifecycle(t *testing.T) {
 			{{ end }}
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))
@@ -340,12 +319,12 @@ func TestComponentLifecycle(t *testing.T) {
 		{{ end }}
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }


### PR DESCRIPTION
**Description:**
Remove use of ReportFatalError in generated tests

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30579
