### PR TITLE
[chore] Use `grep -E` in root Makefile to fix warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ALL_DOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) \
                                 -type f | sort)
 
 # ALL_MODULES includes ./* dirs (excludes . dir)
-ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./' )
+ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | grep -E  '^./' )
 
 CMD?=
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ALL_DOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) \
                                 -type f | sort)
 
 # ALL_MODULES includes ./* dirs (excludes . dir)
-ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | grep -E  '^./' )
+ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | grep -E '^./' )
 
 CMD?=
 


### PR DESCRIPTION
**Description:**

This removes a warning on recent GNU grep versions, but also works on other grep implementations. Contrib already is using the `-E` flag.
