### PR TITLE
Parallelizing contrib check

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -16,10 +16,22 @@ permissions:
   contents: read
 
 jobs:
-  contrib_tests:
+  contrib-tests-matrix:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Skip Contrib Tests') }}
-
+    strategy:
+      matrix:
+        group:
+          - receiver-0
+          - receiver-1
+          - processor
+          - exporter
+          - extension
+          - connector
+          - internal
+          - pkg
+          - cmd
+          - other
     steps:
       - name: Checkout Repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -32,4 +44,21 @@ jobs:
         run: |
           contrib_path=/tmp/opentelemetry-collector-contrib
           git clone --depth=1 https://github.com/open-telemetry/opentelemetry-collector-contrib.git $contrib_path
-          make CONTRIB_PATH=$contrib_path SKIP_RESTORE_CONTRIB=true check-contrib
+          make CONTRIB_PATH=$contrib_path SKIP_RESTORE_CONTRIB=true GROUP=${{ matrix.group }} check-contrib  
+
+  contrib_tests:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Skip Contrib Tests') }}
+    needs: [ contrib-tests-matrix ]
+    steps:
+      - name: Print result
+        run: echo ${{ needs.contrib-tests-matrix.result }}
+      - name: Interpret result
+        run: |
+          if [[ success == ${{ needs.contrib-tests-matrix.result }} ]]
+          then
+            echo "All matrix jobs passed!"
+          else
+            echo "One or more matrix jobs failed."
+            false
+          fi


### PR DESCRIPTION
**Description:**
Implements a job matrix for the contrib checks.  If we think it would be worth it, we could add a setup job to download the repo only 1 time.

**Link to tracking Issue:** <Issue number if applicable>

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30880
