### PR TITLE
[mdatagen] add CustomMetricName func

### DIFF
--- a/.chloggen/codeboten_mdatagen-custom-metric.yaml
+++ b/.chloggen/codeboten_mdatagen-custom-metric.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add convenience method to generate consistent custom metric names
+
+# One or more tracking issues or pull requests related to the change
+issues: [9455]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/metadata/generated_status.go
+++ b/cmd/mdatagen/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("file")
+	Type    = component.MustNewType("file")
+	nameSep = "/"
 )
 
 const (
@@ -25,4 +26,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol")
+}
+
+func CustomMetricName(name string) string {
+	return "receiver" + nameSep + "file" + nameSep + name
 }

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -366,7 +366,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("foo")
+	Type    = component.MustNewType("foo")
+	nameSep = "/"
 )
 
 const (
@@ -379,6 +380,10 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("")
+}
+
+func CustomMetricName(name string) string {
+	return "receiver" + nameSep + "foo" + nameSep + name
 }
 `,
 		},
@@ -403,7 +408,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("foo")
+	Type    = component.MustNewType("foo")
+	nameSep = "/"
 )
 
 const (
@@ -416,6 +422,10 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("")
+}
+
+func CustomMetricName(name string) string {
+	return "receiver" + nameSep + "foo" + nameSep + name
 }
 `,
 		},

--- a/cmd/mdatagen/templates/status.go.tmpl
+++ b/cmd/mdatagen/templates/status.go.tmpl
@@ -10,6 +10,7 @@ import (
 
 var (
 	Type = component.MustNewType("{{ .Type }}")
+	nameSep = "/"
 )
 
 const (
@@ -26,4 +27,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("{{ .ScopeName }}")
+}
+
+func CustomMetricName(name string) string {
+	return "{{ .Status.Class }}" + nameSep + "{{ .Type }}" + nameSep + name
 }

--- a/connector/forwardconnector/internal/metadata/generated_status.go
+++ b/connector/forwardconnector/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("forward")
+	Type    = component.MustNewType("forward")
+	nameSep = "/"
 )
 
 const (
@@ -25,4 +26,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/forward")
+}
+
+func CustomMetricName(name string) string {
+	return "connector" + nameSep + "forward" + nameSep + name
 }

--- a/exporter/debugexporter/internal/metadata/generated_status.go
+++ b/exporter/debugexporter/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("debug")
+	Type    = component.MustNewType("debug")
+	nameSep = "/"
 )
 
 const (
@@ -25,4 +26,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/debug")
+}
+
+func CustomMetricName(name string) string {
+	return "exporter" + nameSep + "debug" + nameSep + name
 }

--- a/exporter/loggingexporter/internal/metadata/generated_status.go
+++ b/exporter/loggingexporter/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("logging")
+	Type    = component.MustNewType("logging")
+	nameSep = "/"
 )
 
 const (
@@ -25,4 +26,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/logging")
+}
+
+func CustomMetricName(name string) string {
+	return "exporter" + nameSep + "logging" + nameSep + name
 }

--- a/exporter/otlpexporter/internal/metadata/generated_status.go
+++ b/exporter/otlpexporter/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("otlp")
+	Type    = component.MustNewType("otlp")
+	nameSep = "/"
 )
 
 const (
@@ -25,4 +26,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/otlp")
+}
+
+func CustomMetricName(name string) string {
+	return "exporter" + nameSep + "otlp" + nameSep + name
 }

--- a/exporter/otlphttpexporter/internal/metadata/generated_status.go
+++ b/exporter/otlphttpexporter/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("otlphttp")
+	Type    = component.MustNewType("otlphttp")
+	nameSep = "/"
 )
 
 const (
@@ -25,4 +26,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/otlphttp")
+}
+
+func CustomMetricName(name string) string {
+	return "exporter" + nameSep + "otlphttp" + nameSep + name
 }

--- a/extension/ballastextension/internal/metadata/generated_status.go
+++ b/extension/ballastextension/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("memory_ballast")
+	Type    = component.MustNewType("memory_ballast")
+	nameSep = "/"
 )
 
 const (
@@ -23,4 +24,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/ballast")
+}
+
+func CustomMetricName(name string) string {
+	return "extension" + nameSep + "memory_ballast" + nameSep + name
 }

--- a/extension/memorylimiterextension/internal/metadata/generated_status.go
+++ b/extension/memorylimiterextension/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("memory_limiter")
+	Type    = component.MustNewType("memory_limiter")
+	nameSep = "/"
 )
 
 const (
@@ -23,4 +24,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/memorylimiter")
+}
+
+func CustomMetricName(name string) string {
+	return "extension" + nameSep + "memory_limiter" + nameSep + name
 }

--- a/extension/zpagesextension/internal/metadata/generated_status.go
+++ b/extension/zpagesextension/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("zpages")
+	Type    = component.MustNewType("zpages")
+	nameSep = "/"
 )
 
 const (
@@ -23,4 +24,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/zpages")
+}
+
+func CustomMetricName(name string) string {
+	return "extension" + nameSep + "zpages" + nameSep + name
 }

--- a/processor/batchprocessor/internal/metadata/generated_status.go
+++ b/processor/batchprocessor/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("batch")
+	Type    = component.MustNewType("batch")
+	nameSep = "/"
 )
 
 const (
@@ -25,4 +26,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/batch")
+}
+
+func CustomMetricName(name string) string {
+	return "processor" + nameSep + "batch" + nameSep + name
 }

--- a/processor/memorylimiterprocessor/internal/metadata/generated_status.go
+++ b/processor/memorylimiterprocessor/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("memory_limiter")
+	Type    = component.MustNewType("memory_limiter")
+	nameSep = "/"
 )
 
 const (
@@ -25,4 +26,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/memorylimiter")
+}
+
+func CustomMetricName(name string) string {
+	return "processor" + nameSep + "memory_limiter" + nameSep + name
 }

--- a/receiver/otlpreceiver/internal/metadata/generated_status.go
+++ b/receiver/otlpreceiver/internal/metadata/generated_status.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("otlp")
+	Type    = component.MustNewType("otlp")
+	nameSep = "/"
 )
 
 const (
@@ -25,4 +26,8 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("otelcol/otlpreceiver")
+}
+
+func CustomMetricName(name string) string {
+	return "receiver" + nameSep + "otlp" + nameSep + name
 }


### PR DESCRIPTION
This allows components to generate a consistent metric name. Doing this in mdatagen will allow us to remove the need to export methods in helpers, for example `BuildCustomMetricName`.

Eventually we might want to define the custom metrics for each component's internal telemetry via metadata.yaml, at which point we can remove this func. For now it allows us to clean up some more code.
