### PR TITLE
[service] introduce otelFormat feature gate

### DIFF
--- a/.chloggen/codeboten_emit-otel-format-metrics.yaml
+++ b/.chloggen/codeboten_emit-otel-format-metrics.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "introduce feature gate `telemetry.useOtelFormat` to allow users a chance to migrate away from opencensus-formatted metrics"
+
+# One or more tracking issues or pull requests related to the change
+issues: [9467]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -30,3 +30,11 @@ var UseOtelWithSDKConfigurationForInternalTelemetryFeatureGate = featuregate.Glo
 	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("controls whether the collector supports extended OpenTelemetry"+
 		"configuration for internal telemetry"))
+
+// UseOtelFormat is the feature gate that controls whether the collector
+// emits metrics using the OpenTelemetry specified format
+var UseOtelFormat = featuregate.GlobalRegistry().MustRegister(
+	"telemetry.useOtelFormat",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("controls whether the collector emits metrics using the"+
+		"OpenTelemetry specified format."))


### PR DESCRIPTION
This feature gate will allow end users to migrate away from the telemetry produced to be opencensus compatible and over to the OpenTelemetry formatted metrics.
