### PR TITLE
[configretry] validate max_elapsed_time

### DIFF
--- a/.chloggen/check_max_elapsed_time.yaml
+++ b/.chloggen/check_max_elapsed_time.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configretry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Validate `max_elapsed_time`, ensure it is larger than `max_interval` and `initial_interval` respectively.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9489]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configretry/backoff.go
+++ b/config/configretry/backoff.go
@@ -59,7 +59,13 @@ func (bs *BackOffConfig) Validate() error {
 		return errors.New("'max_interval' must be non-negative")
 	}
 	if bs.MaxElapsedTime < 0 {
-		return errors.New("'max_elapsed' time must be non-negative")
+		return errors.New("'max_elapsed_time' must be non-negative")
+	}
+	if bs.MaxElapsedTime < bs.InitialInterval {
+		return errors.New("'max_elapsed_time' must be larger than 'initial_interval'")
+	}
+	if bs.MaxElapsedTime < bs.MaxInterval {
+		return errors.New("'max_elapsed_time' must be larger than 'max_interval'")
 	}
 	return nil
 }

--- a/config/configretry/backoff.go
+++ b/config/configretry/backoff.go
@@ -65,7 +65,7 @@ func (bs *BackOffConfig) Validate() error {
 		return errors.New("'max_elapsed_time' must be larger than 'initial_interval'")
 	}
 	if bs.MaxElapsedTime < bs.MaxInterval {
-		return errors.New("'max_elapsed_time' must be larger than 'max_interval'")
+		return errors.New("'max_elapsed_time' must not be less than 'max_interval'")
 	}
 	return nil
 }

--- a/config/configretry/backoff.go
+++ b/config/configretry/backoff.go
@@ -62,7 +62,7 @@ func (bs *BackOffConfig) Validate() error {
 		return errors.New("'max_elapsed_time' must be non-negative")
 	}
 	if bs.MaxElapsedTime < bs.InitialInterval {
-		return errors.New("'max_elapsed_time' must be larger than 'initial_interval'")
+		return errors.New("'max_elapsed_time' must not be less than 'initial_interval'")
 	}
 	if bs.MaxElapsedTime < bs.MaxInterval {
 		return errors.New("'max_elapsed_time' must not be less than 'max_interval'")

--- a/config/configretry/backoff_test.go
+++ b/config/configretry/backoff_test.go
@@ -66,6 +66,12 @@ func TestInvalidMaxElapsedTime(t *testing.T) {
 	assert.NoError(t, cfg.Validate())
 	cfg.MaxElapsedTime = -1
 	assert.Error(t, cfg.Validate())
+	cfg.MaxElapsedTime = 60
+	assert.Error(t, cfg.Validate())
+	cfg.InitialInterval = 0
+	assert.Error(t, cfg.Validate())
+	cfg.MaxInterval = 0
+	assert.NoError(t, cfg.Validate())
 }
 
 func TestDisabledWithInvalidValues(t *testing.T) {


### PR DESCRIPTION
**Description:** 
Validate `max_elapsed_time`, ensure it is larger than `max_interval` and `initial_interval` respectively.
