### PR TITLE
[configtls] Rename config structs for consistency

### DIFF
--- a/.chloggen/rename_configtls_structs.yaml
+++ b/.chloggen/rename_configtls_structs.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configtls
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename TLSClientSetting, TLSServerSetting, and TLSSetting based on the naming convention used in other config packages.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9474]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -57,7 +57,7 @@ type ClientConfig struct {
 	Compression configcompression.Type `mapstructure:"compression"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.TLSClientSetting `mapstructure:"tls"`
+	TLSSetting configtls.ClientConfig `mapstructure:"tls"`
 
 	// The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams.
 	// (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
@@ -122,7 +122,7 @@ type ServerConfig struct {
 
 	// Configures the protocol to use TLS.
 	// The default value is nil, which will cause the protocol to not use TLS.
-	TLSSetting *configtls.TLSServerSetting `mapstructure:"tls"`
+	TLSSetting *configtls.ServerConfig `mapstructure:"tls"`
 
 	// MaxRecvMsgSizeMiB sets the maximum size (in MiB) of messages accepted by the server.
 	MaxRecvMsgSizeMiB uint64 `mapstructure:"max_recv_msg_size_mib"`

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -63,7 +63,7 @@ func TestDefaultGrpcClientSettings(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	gcs := &ClientConfig{
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: configtls.ClientConfig{
 			Insecure: true,
 		},
 	}
@@ -90,7 +90,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				},
 				Endpoint:    "localhost:1234",
 				Compression: configcompression.TypeGzip,
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				Keepalive: &KeepaliveClientConfig{
@@ -119,7 +119,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				},
 				Endpoint:    "localhost:1234",
 				Compression: configcompression.TypeSnappy,
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				Keepalive: &KeepaliveClientConfig{
@@ -148,7 +148,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				},
 				Endpoint:    "localhost:1234",
 				Compression: configcompression.TypeZstd,
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				Keepalive: &KeepaliveClientConfig{
@@ -196,8 +196,8 @@ func TestAllGrpcServerSettingsExceptAuth(t *testing.T) {
 			Endpoint:  "localhost:1234",
 			Transport: "tcp",
 		},
-		TLSSetting: &configtls.TLSServerSetting{
-			TLSSetting:   configtls.TLSSetting{},
+		TLSSetting: &configtls.ServerConfig{
+			TLSSetting:   configtls.Config{},
 			ClientCAFile: "",
 		},
 		MaxRecvMsgSizeMiB:    1,
@@ -258,8 +258,8 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				Headers:     nil,
 				Endpoint:    "",
 				Compression: "",
-				TLSSetting: configtls.TLSClientSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: configtls.ClientConfig{
+					TLSSetting: configtls.Config{
 						CAFile: "/doesnt/exist",
 					},
 					Insecure:   false,
@@ -274,8 +274,8 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				Headers:     nil,
 				Endpoint:    "",
 				Compression: "",
-				TLSSetting: configtls.TLSClientSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: configtls.ClientConfig{
+					TLSSetting: configtls.Config{
 						CertFile: "/doesnt/exist",
 					},
 					Insecure:   false,
@@ -292,7 +292,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				},
 				Endpoint:    "localhost:1234",
 				Compression: "gzip",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				Keepalive: &KeepaliveClientConfig{
@@ -326,7 +326,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "unsupported compression type \"zlib\"",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: true,
 				},
 				Compression: "zlib",
@@ -337,7 +337,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "unsupported compression type \"deflate\"",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: true,
 				},
 				Compression: "deflate",
@@ -348,7 +348,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "unsupported compression type \"bad\"",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: true,
 				},
 				Compression: "bad",
@@ -374,7 +374,7 @@ func TestUseSecure(t *testing.T) {
 		Headers:     nil,
 		Endpoint:    "",
 		Compression: "",
-		TLSSetting:  configtls.TLSClientSetting{},
+		TLSSetting:  configtls.ClientConfig{},
 		Keepalive:   nil,
 	}
 	dialOpts, err := gcs.toDialOptions(componenttest.NewNopHost(), tt.TelemetrySettings())
@@ -445,8 +445,8 @@ func TestGRPCServerSettingsError(t *testing.T) {
 					Endpoint:  "127.0.0.1:1234",
 					Transport: "tcp",
 				},
-				TLSSetting: &configtls.TLSServerSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: &configtls.ServerConfig{
+					TLSSetting: configtls.Config{
 						CAFile: "/doesnt/exist",
 					},
 				},
@@ -459,8 +459,8 @@ func TestGRPCServerSettingsError(t *testing.T) {
 					Endpoint:  "127.0.0.1:1234",
 					Transport: "tcp",
 				},
-				TLSSetting: &configtls.TLSServerSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: &configtls.ServerConfig{
+					TLSSetting: configtls.Config{
 						CertFile: "/doesnt/exist",
 					},
 				},
@@ -473,7 +473,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 					Endpoint:  "127.0.0.1:1234",
 					Transport: "tcp",
 				},
-				TLSSetting: &configtls.TLSServerSetting{
+				TLSSetting: &configtls.ServerConfig{
 					ClientCAFile: "/doesnt/exist",
 				},
 			},
@@ -505,28 +505,28 @@ func TestHttpReception(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		tlsServerCreds *configtls.TLSServerSetting
-		tlsClientCreds *configtls.TLSClientSetting
+		tlsServerCreds *configtls.ServerConfig
+		tlsClientCreds *configtls.ClientConfig
 		hasError       bool
 	}{
 		{
 			name:           "noTLS",
 			tlsServerCreds: nil,
-			tlsClientCreds: &configtls.TLSClientSetting{
+			tlsClientCreds: &configtls.ClientConfig{
 				Insecure: true,
 			},
 		},
 		{
 			name: "TLS",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "server.crt"),
 					KeyFile:  filepath.Join("testdata", "server.key"),
 				},
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile: filepath.Join("testdata", "ca.crt"),
 				},
 				ServerName: "localhost",
@@ -534,13 +534,13 @@ func TestHttpReception(t *testing.T) {
 		},
 		{
 			name: "NoServerCertificates",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile: filepath.Join("testdata", "ca.crt"),
 				},
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile: filepath.Join("testdata", "ca.crt"),
 				},
 				ServerName: "localhost",
@@ -549,16 +549,16 @@ func TestHttpReception(t *testing.T) {
 		},
 		{
 			name: "mTLS",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "server.crt"),
 					KeyFile:  filepath.Join("testdata", "server.key"),
 				},
 				ClientCAFile: filepath.Join("testdata", "ca.crt"),
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "client.crt"),
 					KeyFile:  filepath.Join("testdata", "client.key"),
@@ -568,16 +568,16 @@ func TestHttpReception(t *testing.T) {
 		},
 		{
 			name: "NoClientCertificate",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "server.crt"),
 					KeyFile:  filepath.Join("testdata", "server.key"),
 				},
 				ClientCAFile: filepath.Join("testdata", "ca.crt"),
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile: filepath.Join("testdata", "ca.crt"),
 				},
 				ServerName: "localhost",
@@ -586,16 +586,16 @@ func TestHttpReception(t *testing.T) {
 		},
 		{
 			name: "WrongClientCA",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "server.crt"),
 					KeyFile:  filepath.Join("testdata", "server.key"),
 				},
 				ClientCAFile: filepath.Join("testdata", "server.crt"),
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "client.crt"),
 					KeyFile:  filepath.Join("testdata", "client.key"),
@@ -675,7 +675,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 
 	gcs := &ClientConfig{
 		Endpoint: "unix://" + ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: configtls.ClientConfig{
 			Insecure: true,
 		},
 	}
@@ -877,7 +877,7 @@ func TestClientInfoInterceptors(t *testing.T) {
 			{
 				gcs := &ClientConfig{
 					Endpoint: l.Addr().String(),
-					TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: configtls.ClientConfig{
 						Insecure: true,
 					},
 				}

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -38,7 +38,7 @@ type ClientConfig struct {
 	ProxyURL string `mapstructure:"proxy_url"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.TLSClientSetting `mapstructure:"tls"`
+	TLSSetting configtls.ClientConfig `mapstructure:"tls"`
 
 	// ReadBufferSize for HTTP client. See http.Transport.ReadBufferSize.
 	ReadBufferSize int `mapstructure:"read_buffer_size"`
@@ -256,7 +256,7 @@ type ServerConfig struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting *configtls.TLSServerSetting `mapstructure:"tls"`
+	TLSSetting *configtls.ServerConfig `mapstructure:"tls"`
 
 	// CORS configures the server for HTTP cross-origin resource sharing (CORS).
 	CORS *CORSConfig `mapstructure:"cors"`

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -70,7 +70,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 			name: "all_valid_settings",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				ReadBufferSize:       1024,
@@ -91,7 +91,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 			name: "all_valid_settings_with_none_compression",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				ReadBufferSize:       1024,
@@ -112,7 +112,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 			name: "all_valid_settings_with_gzip_compression",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				ReadBufferSize:       1024,
@@ -133,7 +133,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 			name: "all_valid_settings_http2_health_check",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				ReadBufferSize:       1024,
@@ -154,7 +154,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 			name: "error_round_tripper_returned",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				ReadBufferSize:     1024,
@@ -207,7 +207,7 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 			name: "valid_partial_settings",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: false,
 				},
 				ReadBufferSize:     1024,
@@ -310,8 +310,8 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: ClientConfig{
 				Endpoint: "",
-				TLSSetting: configtls.TLSClientSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: configtls.ClientConfig{
+					TLSSetting: configtls.Config{
 						CAFile: "/doesnt/exist",
 					},
 					Insecure:   false,
@@ -323,8 +323,8 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
 			settings: ClientConfig{
 				Endpoint: "",
-				TLSSetting: configtls.TLSClientSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: configtls.ClientConfig{
+					TLSSetting: configtls.Config{
 						CertFile: "/doesnt/exist",
 					},
 					Insecure:   false,
@@ -493,8 +493,8 @@ func TestHTTPServerSettingsError(t *testing.T) {
 			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: ServerConfig{
 				Endpoint: "localhost:0",
-				TLSSetting: &configtls.TLSServerSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: &configtls.ServerConfig{
+					TLSSetting: configtls.Config{
 						CAFile: "/doesnt/exist",
 					},
 				},
@@ -504,8 +504,8 @@ func TestHTTPServerSettingsError(t *testing.T) {
 			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
 			settings: ServerConfig{
 				Endpoint: "localhost:0",
-				TLSSetting: &configtls.TLSServerSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: &configtls.ServerConfig{
+					TLSSetting: configtls.Config{
 						CertFile: "/doesnt/exist",
 					},
 				},
@@ -515,7 +515,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 			err: "failed to load client CA CertPool: failed to load CA /doesnt/exist:",
 			settings: ServerConfig{
 				Endpoint: "localhost:0",
-				TLSSetting: &configtls.TLSServerSetting{
+				TLSSetting: &configtls.ServerConfig{
 					ClientCAFile: "/doesnt/exist",
 				},
 			},
@@ -571,29 +571,29 @@ func TestHTTPServerWarning(t *testing.T) {
 func TestHttpReception(t *testing.T) {
 	tests := []struct {
 		name           string
-		tlsServerCreds *configtls.TLSServerSetting
-		tlsClientCreds *configtls.TLSClientSetting
+		tlsServerCreds *configtls.ServerConfig
+		tlsClientCreds *configtls.ClientConfig
 		hasError       bool
 		forceHTTP1     bool
 	}{
 		{
 			name:           "noTLS",
 			tlsServerCreds: nil,
-			tlsClientCreds: &configtls.TLSClientSetting{
+			tlsClientCreds: &configtls.ClientConfig{
 				Insecure: true,
 			},
 		},
 		{
 			name: "TLS",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "server.crt"),
 					KeyFile:  filepath.Join("testdata", "server.key"),
 				},
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile: filepath.Join("testdata", "ca.crt"),
 				},
 				ServerName: "localhost",
@@ -601,15 +601,15 @@ func TestHttpReception(t *testing.T) {
 		},
 		{
 			name: "TLS (HTTP/1.1)",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "server.crt"),
 					KeyFile:  filepath.Join("testdata", "server.key"),
 				},
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile: filepath.Join("testdata", "ca.crt"),
 				},
 				ServerName: "localhost",
@@ -618,13 +618,13 @@ func TestHttpReception(t *testing.T) {
 		},
 		{
 			name: "NoServerCertificates",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile: filepath.Join("testdata", "ca.crt"),
 				},
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile: filepath.Join("testdata", "ca.crt"),
 				},
 				ServerName: "localhost",
@@ -633,16 +633,16 @@ func TestHttpReception(t *testing.T) {
 		},
 		{
 			name: "mTLS",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "server.crt"),
 					KeyFile:  filepath.Join("testdata", "server.key"),
 				},
 				ClientCAFile: filepath.Join("testdata", "ca.crt"),
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "client.crt"),
 					KeyFile:  filepath.Join("testdata", "client.key"),
@@ -652,16 +652,16 @@ func TestHttpReception(t *testing.T) {
 		},
 		{
 			name: "NoClientCertificate",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "server.crt"),
 					KeyFile:  filepath.Join("testdata", "server.key"),
 				},
 				ClientCAFile: filepath.Join("testdata", "ca.crt"),
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile: filepath.Join("testdata", "ca.crt"),
 				},
 				ServerName: "localhost",
@@ -670,16 +670,16 @@ func TestHttpReception(t *testing.T) {
 		},
 		{
 			name: "WrongClientCA",
-			tlsServerCreds: &configtls.TLSServerSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsServerCreds: &configtls.ServerConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "server.crt"),
 					KeyFile:  filepath.Join("testdata", "server.key"),
 				},
 				ClientCAFile: filepath.Join("testdata", "server.crt"),
 			},
-			tlsClientCreds: &configtls.TLSClientSetting{
-				TLSSetting: configtls.TLSSetting{
+			tlsClientCreds: &configtls.ClientConfig{
+				TLSSetting: configtls.Config{
 					CAFile:   filepath.Join("testdata", "ca.crt"),
 					CertFile: filepath.Join("testdata", "client.crt"),
 					KeyFile:  filepath.Join("testdata", "client.key"),
@@ -1053,7 +1053,7 @@ func TestHttpClientHeaders(t *testing.T) {
 			serverURL, _ := url.Parse(server.URL)
 			setting := ClientConfig{
 				Endpoint:        serverURL.String(),
-				TLSSetting:      configtls.TLSClientSetting{},
+				TLSSetting:      configtls.ClientConfig{},
 				ReadBufferSize:  0,
 				WriteBufferSize: 0,
 				Timeout:         0,
@@ -1339,15 +1339,15 @@ func BenchmarkHttpRequest(b *testing.B) {
 		},
 	}
 
-	tlsServerCreds := &configtls.TLSServerSetting{
-		TLSSetting: configtls.TLSSetting{
+	tlsServerCreds := &configtls.ServerConfig{
+		TLSSetting: configtls.Config{
 			CAFile:   filepath.Join("testdata", "ca.crt"),
 			CertFile: filepath.Join("testdata", "server.crt"),
 			KeyFile:  filepath.Join("testdata", "server.key"),
 		},
 	}
-	tlsClientCreds := &configtls.TLSClientSetting{
-		TLSSetting: configtls.TLSSetting{
+	tlsClientCreds := &configtls.ClientConfig{
+		TLSSetting: configtls.Config{
 			CAFile: filepath.Join("testdata", "ca.crt"),
 		},
 		ServerName: "localhost",

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -24,9 +24,13 @@ const defaultMinTLSVersion = tls.VersionTLS12
 const defaultMaxTLSVersion = 0
 
 // TLSSetting exposes the common client and server TLS configurations.
+// Deprecated: [v0.95.0] Use Config instead.
+type TLSSetting = Config
+
+// Config exposes the common client and server TLS configurations.
 // Note: Since there isn't anything specific to a server connection. Components
-// with server connections should use TLSSetting.
-type TLSSetting struct {
+// with server connections should use Config.
+type Config struct {
 	// Path to the CA cert. For a client this verifies the server certificate.
 	// For a server this verifies client certificates. If empty uses system root CA.
 	// (optional)
@@ -65,10 +69,15 @@ type TLSSetting struct {
 	ReloadInterval time.Duration `mapstructure:"reload_interval"`
 }
 
-// TLSClientSetting contains TLS configurations that are specific to client
+// TSLClientSetting contains TLS configurations that are specific to client
+// connections in addition to the common configurations.
+// Deprecated: [v0.95.0] Use ClientConfig instead.
+type TLSClientSetting = ClientConfig
+
+// ClientConfig contains TLS configurations that are specific to client
 // connections in addition to the common configurations. This should be used by
 // components configuring TLS client connections.
-type TLSClientSetting struct {
+type ClientConfig struct {
 	// squash ensures fields are correctly decoded in embedded struct.
 	TLSSetting `mapstructure:",squash"`
 
@@ -90,9 +99,14 @@ type TLSClientSetting struct {
 }
 
 // TLSServerSetting contains TLS configurations that are specific to server
+// connections in addition to the common configurations.
+// Deprecated: [v0.95.0] Use ServerConfig instead.
+type TLSServerSetting = ServerConfig
+
+// ServerConfig contains TLS configurations that are specific to server
 // connections in addition to the common configurations. This should be used by
 // components configuring TLS server connections.
-type TLSServerSetting struct {
+type ServerConfig struct {
 	// squash ensures fields are correctly decoded in embedded struct.
 	TLSSetting `mapstructure:",squash"`
 
@@ -115,10 +129,10 @@ type certReloader struct {
 	nextReload time.Time
 	cert       *tls.Certificate
 	lock       sync.RWMutex
-	tls        TLSSetting
+	tls        Config
 }
 
-func (c TLSSetting) newCertReloader() (*certReloader, error) {
+func (c Config) newCertReloader() (*certReloader, error) {
 	cert, err := c.loadCertificate()
 	if err != nil {
 		return nil, err
@@ -155,7 +169,7 @@ func (r *certReloader) GetCertificate() (*tls.Certificate, error) {
 
 // loadTLSConfig loads TLS certificates and returns a tls.Config.
 // This will set the RootCAs and Certificates of a tls.Config.
-func (c TLSSetting) loadTLSConfig() (*tls.Config, error) {
+func (c Config) loadTLSConfig() (*tls.Config, error) {
 	certPool, err := c.loadCACertPool()
 	if err != nil {
 		return nil, err
@@ -215,7 +229,7 @@ func convertCipherSuites(cipherSuites []string) ([]uint16, error) {
 	return result, errors.Join(errs...)
 }
 
-func (c TLSSetting) loadCACertPool() (*x509.CertPool, error) {
+func (c Config) loadCACertPool() (*x509.CertPool, error) {
 	// There is no need to load the System Certs for RootCAs because
 	// if the value is nil, it will default to checking against th System Certs.
 	var err error
@@ -241,7 +255,7 @@ func (c TLSSetting) loadCACertPool() (*x509.CertPool, error) {
 	return certPool, nil
 }
 
-func (c TLSSetting) loadCertFile(certPath string) (*x509.CertPool, error) {
+func (c Config) loadCertFile(certPath string) (*x509.CertPool, error) {
 	certPem, err := os.ReadFile(filepath.Clean(certPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load cert %s: %w", certPath, err)
@@ -250,7 +264,7 @@ func (c TLSSetting) loadCertFile(certPath string) (*x509.CertPool, error) {
 	return c.loadCertPem(certPem)
 }
 
-func (c TLSSetting) loadCertPem(certPem []byte) (*x509.CertPool, error) {
+func (c Config) loadCertPem(certPem []byte) (*x509.CertPool, error) {
 	certPool := x509.NewCertPool()
 	if !certPool.AppendCertsFromPEM(certPem) {
 		return nil, fmt.Errorf("failed to parse cert")
@@ -258,7 +272,7 @@ func (c TLSSetting) loadCertPem(certPem []byte) (*x509.CertPool, error) {
 	return certPool, nil
 }
 
-func (c TLSSetting) loadCertificate() (tls.Certificate, error) {
+func (c Config) loadCertificate() (tls.Certificate, error) {
 	switch {
 	case c.hasCert() != c.hasKey():
 		return tls.Certificate{}, fmt.Errorf("for auth via TLS, provide both certificate and key, or neither")
@@ -298,7 +312,7 @@ func (c TLSSetting) loadCertificate() (tls.Certificate, error) {
 	return certificate, err
 }
 
-func (c TLSSetting) loadCert(caPath string) (*x509.CertPool, error) {
+func (c Config) loadCert(caPath string) (*x509.CertPool, error) {
 	caPEM, err := os.ReadFile(filepath.Clean(caPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load CA %s: %w", caPath, err)
@@ -312,7 +326,7 @@ func (c TLSSetting) loadCert(caPath string) (*x509.CertPool, error) {
 }
 
 // LoadTLSConfig loads the TLS configuration.
-func (c TLSClientSetting) LoadTLSConfig() (*tls.Config, error) {
+func (c ClientConfig) LoadTLSConfig() (*tls.Config, error) {
 	if c.Insecure && !c.hasCA() {
 		return nil, nil
 	}
@@ -327,7 +341,7 @@ func (c TLSClientSetting) LoadTLSConfig() (*tls.Config, error) {
 }
 
 // LoadTLSConfig loads the TLS configuration.
-func (c TLSServerSetting) LoadTLSConfig() (*tls.Config, error) {
+func (c ServerConfig) LoadTLSConfig() (*tls.Config, error) {
 	tlsCfg, err := c.loadTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS config: %w", err)
@@ -350,22 +364,22 @@ func (c TLSServerSetting) LoadTLSConfig() (*tls.Config, error) {
 	return tlsCfg, nil
 }
 
-func (c TLSServerSetting) loadClientCAFile() (*x509.CertPool, error) {
+func (c ServerConfig) loadClientCAFile() (*x509.CertPool, error) {
 	return c.loadCert(c.ClientCAFile)
 }
 
-func (c TLSSetting) hasCA() bool   { return c.hasCAFile() || c.hasCAPem() }
-func (c TLSSetting) hasCert() bool { return c.hasCertFile() || c.hasCertPem() }
-func (c TLSSetting) hasKey() bool  { return c.hasKeyFile() || c.hasKeyPem() }
+func (c Config) hasCA() bool   { return c.hasCAFile() || c.hasCAPem() }
+func (c Config) hasCert() bool { return c.hasCertFile() || c.hasCertPem() }
+func (c Config) hasKey() bool  { return c.hasKeyFile() || c.hasKeyPem() }
 
-func (c TLSSetting) hasCAFile() bool { return c.CAFile != "" }
-func (c TLSSetting) hasCAPem() bool  { return len(c.CAPem) != 0 }
+func (c Config) hasCAFile() bool { return c.CAFile != "" }
+func (c Config) hasCAPem() bool  { return len(c.CAPem) != 0 }
 
-func (c TLSSetting) hasCertFile() bool { return c.CertFile != "" }
-func (c TLSSetting) hasCertPem() bool  { return len(c.CertPem) != 0 }
+func (c Config) hasCertFile() bool { return c.CertFile != "" }
+func (c Config) hasCertPem() bool  { return len(c.CertPem) != 0 }
 
-func (c TLSSetting) hasKeyFile() bool { return c.KeyFile != "" }
-func (c TLSSetting) hasKeyPem() bool  { return len(c.KeyPem) != 0 }
+func (c Config) hasKeyFile() bool { return c.KeyFile != "" }
+func (c Config) hasKeyPem() bool  { return len(c.KeyPem) != 0 }
 
 func convertVersion(v string, defaultVersion uint16) (uint16, error) {
 	// Use a default that is explicitly defined

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -24,7 +24,7 @@ const defaultMinTLSVersion = tls.VersionTLS12
 const defaultMaxTLSVersion = 0
 
 // TLSSetting exposes the common client and server TLS configurations.
-// Deprecated: [v0.95.0] Use Config instead.
+// Deprecated: [v0.96.0] Use Config instead.
 type TLSSetting = Config
 
 // Config exposes the common client and server TLS configurations.
@@ -71,7 +71,7 @@ type Config struct {
 
 // TSLClientSetting contains TLS configurations that are specific to client
 // connections in addition to the common configurations.
-// Deprecated: [v0.95.0] Use ClientConfig instead.
+// Deprecated: [v0.96.0] Use ClientConfig instead.
 type TLSClientSetting = ClientConfig
 
 // ClientConfig contains TLS configurations that are specific to client
@@ -100,7 +100,7 @@ type ClientConfig struct {
 
 // TLSServerSetting contains TLS configurations that are specific to server
 // connections in addition to the common configurations.
-// Deprecated: [v0.95.0] Use ServerConfig instead.
+// Deprecated: [v0.96.0] Use ServerConfig instead.
 type TLSServerSetting = ServerConfig
 
 // ServerConfig contains TLS configurations that are specific to server

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -22,30 +22,30 @@ import (
 func TestOptionsToConfig(t *testing.T) {
 	tests := []struct {
 		name        string
-		options     TLSSetting
+		options     Config
 		expectError string
 	}{
 		{
 			name:    "should load system CA",
-			options: TLSSetting{CAFile: ""},
+			options: Config{CAFile: ""},
 		},
 		{
 			name:    "should load custom CA",
-			options: TLSSetting{CAFile: filepath.Join("testdata", "ca-1.crt")},
+			options: Config{CAFile: filepath.Join("testdata", "ca-1.crt")},
 		},
 		{
 			name:        "should fail with invalid CA file path",
-			options:     TLSSetting{CAFile: filepath.Join("testdata", "not/valid")},
+			options:     Config{CAFile: filepath.Join("testdata", "not/valid")},
 			expectError: "failed to load CA",
 		},
 		{
 			name:        "should fail with invalid CA file content",
-			options:     TLSSetting{CAFile: filepath.Join("testdata", "testCA-bad.txt")},
+			options:     Config{CAFile: filepath.Join("testdata", "testCA-bad.txt")},
 			expectError: "failed to parse cert",
 		},
 		{
 			name: "should load valid TLS  settings",
-			options: TLSSetting{
+			options: Config{
 				CAFile:   filepath.Join("testdata", "ca-1.crt"),
 				CertFile: filepath.Join("testdata", "server-1.crt"),
 				KeyFile:  filepath.Join("testdata", "server-1.key"),
@@ -53,7 +53,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail with missing TLS KeyFile",
-			options: TLSSetting{
+			options: Config{
 				CAFile:   filepath.Join("testdata", "ca-1.crt"),
 				CertFile: filepath.Join("testdata", "server-1.crt"),
 			},
@@ -61,7 +61,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail with invalid TLS KeyFile",
-			options: TLSSetting{
+			options: Config{
 				CAFile:   filepath.Join("testdata", "ca-1.crt"),
 				CertFile: filepath.Join("testdata", "server-1.crt"),
 				KeyFile:  filepath.Join("testdata", "not/valid"),
@@ -70,7 +70,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail with missing TLS Cert",
-			options: TLSSetting{
+			options: Config{
 				CAFile:  filepath.Join("testdata", "ca-1.crt"),
 				KeyFile: filepath.Join("testdata", "server-1.key"),
 			},
@@ -78,7 +78,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail with invalid TLS Cert",
-			options: TLSSetting{
+			options: Config{
 				CAFile:   filepath.Join("testdata", "ca-1.crt"),
 				CertFile: filepath.Join("testdata", "not/valid"),
 				KeyFile:  filepath.Join("testdata", "server-1.key"),
@@ -87,52 +87,52 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail with invalid TLS CA",
-			options: TLSSetting{
+			options: Config{
 				CAFile: filepath.Join("testdata", "not/valid"),
 			},
 			expectError: "failed to load CA",
 		},
 		{
 			name: "should fail with invalid CA pool",
-			options: TLSSetting{
+			options: Config{
 				CAFile: filepath.Join("testdata", "testCA-bad.txt"),
 			},
 			expectError: "failed to parse cert",
 		},
 		{
 			name: "should pass with valid CA pool",
-			options: TLSSetting{
+			options: Config{
 				CAFile: filepath.Join("testdata", "ca-1.crt"),
 			},
 		},
 		{
 			name: "should pass with valid min and max version",
-			options: TLSSetting{
+			options: Config{
 				MinVersion: "1.1",
 				MaxVersion: "1.2",
 			},
 		},
 		{
 			name: "should pass with invalid min",
-			options: TLSSetting{
+			options: Config{
 				MinVersion: "1.7",
 			},
 			expectError: "invalid TLS min_",
 		},
 		{
 			name: "should pass with invalid max",
-			options: TLSSetting{
+			options: Config{
 				MaxVersion: "1.7",
 			},
 			expectError: "invalid TLS max_",
 		},
 		{
 			name:    "should load custom CA PEM",
-			options: TLSSetting{CAPem: readFilePanics("testdata/ca-1.crt")},
+			options: Config{CAPem: readFilePanics("testdata/ca-1.crt")},
 		},
 		{
 			name: "should load valid TLS settings with PEMs",
-			options: TLSSetting{
+			options: Config{
 				CAPem:   readFilePanics("testdata/ca-1.crt"),
 				CertPem: readFilePanics("testdata/server-1.crt"),
 				KeyPem:  readFilePanics("testdata/server-1.key"),
@@ -140,26 +140,26 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "mix Cert file and Key PEM provided",
-			options: TLSSetting{
+			options: Config{
 				CertFile: "testdata/server-1.crt",
 				KeyPem:   readFilePanics("testdata/server-1.key"),
 			},
 		},
 		{
 			name: "mix Cert PEM and Key File provided",
-			options: TLSSetting{
+			options: Config{
 				CertPem: readFilePanics("testdata/server-1.crt"),
 				KeyFile: "testdata/server-1.key",
 			},
 		},
 		{
 			name:        "should fail with invalid CA PEM",
-			options:     TLSSetting{CAPem: readFilePanics("testdata/testCA-bad.txt")},
+			options:     Config{CAPem: readFilePanics("testdata/testCA-bad.txt")},
 			expectError: "failed to parse cert",
 		},
 		{
 			name: "should fail CA file and PEM both provided",
-			options: TLSSetting{
+			options: Config{
 				CAFile: "testdata/ca-1.crt",
 				CAPem:  readFilePanics("testdata/ca-1.crt"),
 			},
@@ -167,7 +167,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail Cert file and PEM both provided",
-			options: TLSSetting{
+			options: Config{
 				CertFile: "testdata/server-1.crt",
 				CertPem:  readFilePanics("testdata/server-1.crt"),
 				KeyFile:  "testdata/server-1.key",
@@ -176,7 +176,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail Key file and PEM both provided",
-			options: TLSSetting{
+			options: Config{
 				CertFile: "testdata/server-1.crt",
 				KeyFile:  "testdata/ca-1.crt",
 				KeyPem:   readFilePanics("testdata/server-1.key"),
@@ -185,7 +185,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail to load valid TLS settings with bad Cert PEM",
-			options: TLSSetting{
+			options: Config{
 				CAPem:   readFilePanics("testdata/ca-1.crt"),
 				CertPem: readFilePanics("testdata/testCA-bad.txt"),
 				KeyPem:  readFilePanics("testdata/server-1.key"),
@@ -194,7 +194,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail to load valid TLS settings with bad Key PEM",
-			options: TLSSetting{
+			options: Config{
 				CAPem:   readFilePanics("testdata/ca-1.crt"),
 				CertPem: readFilePanics("testdata/server-1.crt"),
 				KeyPem:  readFilePanics("testdata/testCA-bad.txt"),
@@ -203,7 +203,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail with missing TLS KeyPem",
-			options: TLSSetting{
+			options: Config{
 				CAPem:   readFilePanics("testdata/ca-1.crt"),
 				CertPem: readFilePanics("testdata/server-1.crt"),
 			},
@@ -211,7 +211,7 @@ func TestOptionsToConfig(t *testing.T) {
 		},
 		{
 			name: "should fail with missing TLS Cert PEM",
-			options: TLSSetting{
+			options: Config{
 				CAPem:  readFilePanics("testdata/ca-1.crt"),
 				KeyPem: readFilePanics("testdata/server-1.key"),
 			},
@@ -243,8 +243,8 @@ func readFilePanics(filePath string) configopaque.String {
 }
 
 func TestLoadTLSClientConfigError(t *testing.T) {
-	tlsSetting := TLSClientSetting{
-		TLSSetting: TLSSetting{
+	tlsSetting := ClientConfig{
+		TLSSetting: Config{
 			CertFile: "doesnt/exist",
 			KeyFile:  "doesnt/exist",
 		},
@@ -254,19 +254,19 @@ func TestLoadTLSClientConfigError(t *testing.T) {
 }
 
 func TestLoadTLSClientConfig(t *testing.T) {
-	tlsSetting := TLSClientSetting{
+	tlsSetting := ClientConfig{
 		Insecure: true,
 	}
 	tlsCfg, err := tlsSetting.LoadTLSConfig()
 	assert.NoError(t, err)
 	assert.Nil(t, tlsCfg)
 
-	tlsSetting = TLSClientSetting{}
+	tlsSetting = ClientConfig{}
 	tlsCfg, err = tlsSetting.LoadTLSConfig()
 	assert.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 
-	tlsSetting = TLSClientSetting{
+	tlsSetting = ClientConfig{
 		InsecureSkipVerify: true,
 	}
 	tlsCfg, err = tlsSetting.LoadTLSConfig()
@@ -276,8 +276,8 @@ func TestLoadTLSClientConfig(t *testing.T) {
 }
 
 func TestLoadTLSServerConfigError(t *testing.T) {
-	tlsSetting := TLSServerSetting{
-		TLSSetting: TLSSetting{
+	tlsSetting := ServerConfig{
+		TLSSetting: Config{
 			CertFile: "doesnt/exist",
 			KeyFile:  "doesnt/exist",
 		},
@@ -285,7 +285,7 @@ func TestLoadTLSServerConfigError(t *testing.T) {
 	_, err := tlsSetting.LoadTLSConfig()
 	assert.Error(t, err)
 
-	tlsSetting = TLSServerSetting{
+	tlsSetting = ServerConfig{
 		ClientCAFile: "doesnt/exist",
 	}
 	_, err = tlsSetting.LoadTLSConfig()
@@ -293,7 +293,7 @@ func TestLoadTLSServerConfigError(t *testing.T) {
 }
 
 func TestLoadTLSServerConfig(t *testing.T) {
-	tlsSetting := TLSServerSetting{}
+	tlsSetting := ServerConfig{}
 	tlsCfg, err := tlsSetting.LoadTLSConfig()
 	assert.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
@@ -305,7 +305,7 @@ func TestLoadTLSServerConfigReload(t *testing.T) {
 
 	overwriteClientCA(t, tmpCaPath, "ca-1.crt")
 
-	tlsSetting := TLSServerSetting{
+	tlsSetting := ServerConfig{
 		ClientCAFile:       tmpCaPath,
 		ReloadClientCAFile: true,
 	}
@@ -336,7 +336,7 @@ func TestLoadTLSServerConfigFailingReload(t *testing.T) {
 
 	overwriteClientCA(t, tmpCaPath, "ca-1.crt")
 
-	tlsSetting := TLSServerSetting{
+	tlsSetting := ServerConfig{
 		ClientCAFile:       tmpCaPath,
 		ReloadClientCAFile: true,
 	}
@@ -367,7 +367,7 @@ func TestLoadTLSServerConfigFailingInitialLoad(t *testing.T) {
 
 	overwriteClientCA(t, tmpCaPath, "testCA-bad.txt")
 
-	tlsSetting := TLSServerSetting{
+	tlsSetting := ServerConfig{
 		ClientCAFile:       tmpCaPath,
 		ReloadClientCAFile: true,
 	}
@@ -381,7 +381,7 @@ func TestLoadTLSServerConfigWrongPath(t *testing.T) {
 
 	tmpCaPath := createTempClientCaFile(t)
 
-	tlsSetting := TLSServerSetting{
+	tlsSetting := ServerConfig{
 		ClientCAFile:       tmpCaPath + "wrong-path",
 		ReloadClientCAFile: true,
 	}
@@ -397,7 +397,7 @@ func TestLoadTLSServerConfigFailing(t *testing.T) {
 
 	overwriteClientCA(t, tmpCaPath, "ca-1.crt")
 
-	tlsSetting := TLSServerSetting{
+	tlsSetting := ServerConfig{
 		ClientCAFile:       tmpCaPath,
 		ReloadClientCAFile: true,
 	}
@@ -443,7 +443,7 @@ func createTempClientCaFile(t *testing.T) string {
 }
 
 func TestEagerlyLoadCertificate(t *testing.T) {
-	options := TLSSetting{
+	options := Config{
 		CertFile: filepath.Join("testdata", "client-1.crt"),
 		KeyFile:  filepath.Join("testdata", "client-1.key"),
 	}
@@ -530,7 +530,7 @@ func TestCertificateReload(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NoError(t, fdk.Close())
 
-			options := TLSSetting{
+			options := Config{
 				CertFile:       certFile.Name(),
 				KeyFile:        keyFile.Name(),
 				ReloadInterval: test.reloadInterval,
@@ -611,7 +611,7 @@ func TestMinMaxTLSVersions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			setting := TLSSetting{
+			setting := Config{
 				MinVersion: test.minVersion,
 				MaxVersion: test.maxVersion,
 			}
@@ -631,32 +631,32 @@ func TestMinMaxTLSVersions(t *testing.T) {
 func TestCipherSuites(t *testing.T) {
 	tests := []struct {
 		name       string
-		tlsSetting TLSSetting
+		tlsSetting Config
 		wantErr    string
 		result     []uint16
 	}{
 		{
 			name:       "no suites set",
-			tlsSetting: TLSSetting{},
+			tlsSetting: Config{},
 			result:     nil,
 		},
 		{
 			name: "one cipher suite set",
-			tlsSetting: TLSSetting{
+			tlsSetting: Config{
 				CipherSuites: []string{"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"},
 			},
 			result: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
 		},
 		{
 			name: "invalid cipher suite set",
-			tlsSetting: TLSSetting{
+			tlsSetting: Config{
 				CipherSuites: []string{"FOO"},
 			},
 			wantErr: `invalid TLS cipher suite: "FOO"`,
 		},
 		{
 			name: "multiple invalid cipher suites set",
-			tlsSetting: TLSSetting{
+			tlsSetting: Config{
 				CipherSuites: []string{"FOO", "BAR"},
 			},
 			wantErr: `invalid TLS cipher suite: "FOO"

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -61,8 +61,8 @@ func TestUnmarshalConfig(t *testing.T) {
 				},
 				Endpoint:    "1.2.3.4:1234",
 				Compression: "gzip",
-				TLSSetting: configtls.TLSClientSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: configtls.ClientConfig{
+					TLSSetting: configtls.Config{
 						CAFile: "/var/lib/mycert.pem",
 					},
 					Insecure: false,

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -59,7 +59,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: &Config{
 				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: configtls.ClientConfig{
 						Insecure: false,
 					},
 				},
@@ -139,8 +139,8 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: &Config{
 				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
-						TLSSetting: configtls.TLSSetting{
+					TLSSetting: configtls.ClientConfig{
+						TLSSetting: configtls.Config{
 							CAFile: filepath.Join("testdata", "test_cert.pem"),
 						},
 					},
@@ -152,8 +152,8 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: &Config{
 				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
-						TLSSetting: configtls.TLSSetting{
+					TLSSetting: configtls.ClientConfig{
+						TLSSetting: configtls.Config{
 							CAFile: "nosuchfile",
 						},
 					},

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -239,7 +239,7 @@ func TestSendTraces(t *testing.T) {
 	cfg.QueueConfig.Enabled = false
 	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: configtls.ClientConfig{
 			Insecure: true,
 		},
 		Headers: map[string]configopaque.String{
@@ -340,7 +340,7 @@ func TestSendTracesWhenEndpointHasHttpScheme(t *testing.T) {
 			useTLS: false,
 			scheme: "http://",
 			gRPCClientSettings: configgrpc.ClientConfig{
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: configtls.ClientConfig{
 					Insecure: true,
 				},
 			},
@@ -411,7 +411,7 @@ func TestSendMetrics(t *testing.T) {
 	cfg.QueueConfig.Enabled = false
 	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: configtls.ClientConfig{
 			Insecure: true,
 		},
 		Headers: map[string]configopaque.String{
@@ -516,7 +516,7 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 	cfg.QueueConfig.Enabled = false
 	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: configtls.ClientConfig{
 			Insecure: true,
 		},
 		// Need to wait for every request blocking until either request timeouts or succeed.
@@ -576,7 +576,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: configtls.ClientConfig{
 			Insecure: true,
 		},
 	}
@@ -627,7 +627,7 @@ func TestSendTracesOnResourceExhaustion(t *testing.T) {
 	cfg.RetryConfig.InitialInterval = 0
 	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: configtls.ClientConfig{
 			Insecure: true,
 		},
 	}
@@ -708,7 +708,7 @@ func TestSendLogData(t *testing.T) {
 	cfg.QueueConfig.Enabled = false
 	cfg.ClientConfig = configgrpc.ClientConfig{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: configtls.ClientConfig{
 			Insecure: true,
 		},
 	}

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -59,8 +59,8 @@ func TestUnmarshalConfig(t *testing.T) {
 					"another":                "somevalue",
 				},
 				Endpoint: "https://1.2.3.4:1234",
-				TLSSetting: configtls.TLSClientSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: configtls.ClientConfig{
+					TLSSetting: configtls.Config{
 						CAFile:   "/var/lib/mycert.pem",
 						CertFile: "certfile",
 						KeyFile:  "keyfile",

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -73,7 +73,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: &Config{
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: configtls.ClientConfig{
 						Insecure: false,
 					},
 				},
@@ -96,8 +96,8 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: &Config{
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
-						TLSSetting: configtls.TLSSetting{
+					TLSSetting: configtls.ClientConfig{
+						TLSSetting: configtls.Config{
 							CAFile: filepath.Join("testdata", "test_cert.pem"),
 						},
 					},
@@ -109,8 +109,8 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: &Config{
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
-						TLSSetting: configtls.TLSSetting{
+					TLSSetting: configtls.ClientConfig{
+						TLSSetting: configtls.Config{
 							CAFile: "nosuchfile",
 						},
 					},

--- a/internal/e2e/consume_contract_test.go
+++ b/internal/e2e/consume_contract_test.go
@@ -26,7 +26,7 @@ func testExporterConfig(endpoint string) component.Config {
 		RetryConfig: retryConfig,
 		ClientConfig: configgrpc.ClientConfig{
 			Endpoint: endpoint,
-			TLSSetting: configtls.TLSClientSetting{
+			TLSSetting: configtls.ClientConfig{
 				Insecure: true,
 			},
 		},

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -91,8 +91,8 @@ func TestUnmarshalConfig(t *testing.T) {
 						Endpoint:  "0.0.0.0:4317",
 						Transport: "tcp",
 					},
-					TLSSetting: &configtls.TLSServerSetting{
-						TLSSetting: configtls.TLSSetting{
+					TLSSetting: &configtls.ServerConfig{
+						TLSSetting: configtls.Config{
 							CertFile: "test.crt",
 							KeyFile:  "test.key",
 						},
@@ -118,8 +118,8 @@ func TestUnmarshalConfig(t *testing.T) {
 				HTTP: &HTTPConfig{
 					ServerConfig: &confighttp.ServerConfig{
 						Endpoint: "0.0.0.0:4318",
-						TLSSetting: &configtls.TLSServerSetting{
-							TLSSetting: configtls.TLSSetting{
+						TLSSetting: &configtls.ServerConfig{
+							TLSSetting: configtls.Config{
 								CertFile: "test.crt",
 								KeyFile:  "test.key",
 							},

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -638,8 +638,8 @@ func TestGRPCInvalidTLSCredentials(t *testing.T) {
 					Endpoint:  testutil.GetAvailableLocalAddress(t),
 					Transport: "tcp",
 				},
-				TLSSetting: &configtls.TLSServerSetting{
-					TLSSetting: configtls.TLSSetting{
+				TLSSetting: &configtls.ServerConfig{
+					TLSSetting: configtls.Config{
 						CertFile: "willfail",
 					},
 				},
@@ -701,8 +701,8 @@ func TestHTTPInvalidTLSCredentials(t *testing.T) {
 			HTTP: &HTTPConfig{
 				ServerConfig: &confighttp.ServerConfig{
 					Endpoint: testutil.GetAvailableLocalAddress(t),
-					TLSSetting: &configtls.TLSServerSetting{
-						TLSSetting: configtls.TLSSetting{
+					TLSSetting: &configtls.ServerConfig{
+						TLSSetting: configtls.Config{
 							CertFile: "willfail",
 						},
 					},


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Simply renames a few structs in the `configtls` package for consistence.

`TLSClientSetting` to `ClientConfig`
`TLSServerSetting` to `ServerConfig`
`TLSSetting` to `Config`

**Link to tracking Issue:** <Issue number if applicable>

Fixes #9474 
