### PR TITLE
[cmd/builder] Allow configuring confmap providers

### DIFF
--- a/.chloggen/builder-confmap-providers.yaml
+++ b/.chloggen/builder-confmap-providers.yaml
@@ -16,7 +16,7 @@ issues: [4759]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  If no providers or converters are specified, the defaults are used.
+  If no providers are specified, the defaults are used.
   The default providers are: env, file, http, https, and yaml.
 
   To configure providers, use the `providers` key in your OCB build

--- a/.chloggen/builder-confmap-providers.yaml
+++ b/.chloggen/builder-confmap-providers.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: cmd/builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow configuring `confmap.Provider`s in the builder.
+
+# One or more tracking issues or pull requests related to the change
+issues: [4759]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  If no providers or converters are specified, the defaults are used.
+  The default providers are: env, file, http, https, and yaml.
+
+  To configure providers, use the `providers` key in your OCB build
+  manifest with a list of Go modules for your providers.
+  The modules will work the same as other Collector components.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -12,20 +12,20 @@ dist:
   description: Local OpenTelemetry Collector binary
   output_path: /tmp/dist
 exporters:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.96.0
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.96.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.97.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.97.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.97.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.96.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.97.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.97.0
 
 converters:
-  - gomod: go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.0
+  - gomod: go.opentelemetry.io/collector/confmap/converter/expandconverter v0.97.0
 EOF
 $ builder --config=otelcol-builder.yaml
 $ cat > /tmp/otelcol.yaml <<EOF

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -12,20 +12,20 @@ dist:
   description: Local OpenTelemetry Collector binary
   output_path: /tmp/dist
 exporters:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.97.0
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.97.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.99.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.99.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.97.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.99.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.97.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.99.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.97.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.99.0
 
 converters:
-  - gomod: go.opentelemetry.io/collector/confmap/converter/expandconverter v0.97.0
+  - gomod: go.opentelemetry.io/collector/confmap/converter/expandconverter v0.99.0
 EOF
 $ builder --config=otelcol-builder.yaml
 $ cat > /tmp/otelcol.yaml <<EOF

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -12,14 +12,20 @@ dist:
   description: Local OpenTelemetry Collector binary
   output_path: /tmp/dist
 exporters:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.86.0
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.86.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.96.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.96.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.86.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.86.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.96.0
+
+providers:
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.0
+
+converters:
+  - gomod: go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.0
 EOF
 $ builder --config=otelcol-builder.yaml
 $ cat > /tmp/otelcol.yaml <<EOF

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -23,7 +23,9 @@ var ErrInvalidGoMod = errors.New("invalid gomod specification for module")
 
 // Config holds the builder's configuration
 type Config struct {
-	Logger               *zap.Logger
+	Logger                         *zap.Logger
+	SupportsConfigProviderSettings bool
+
 	SkipGenerate         bool   `mapstructure:"-"`
 	SkipCompilation      bool   `mapstructure:"-"`
 	SkipGetModules       bool   `mapstructure:"-"`

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -23,8 +23,8 @@ var ErrInvalidGoMod = errors.New("invalid gomod specification for module")
 
 // Config holds the builder's configuration
 type Config struct {
-	Logger                         *zap.Logger
-	SupportsConfigProviderSettings bool
+	Logger                   *zap.Logger
+	SupportsConfmapFactories bool
 
 	SkipGenerate         bool   `mapstructure:"-"`
 	SkipCompilation      bool   `mapstructure:"-"`

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -90,7 +90,7 @@ func NewDefaultConfig() Config {
 
 // Validate checks whether the current configuration is valid
 func (c *Config) Validate() error {
-	var providersError, convertersError error
+	var providersError error
 	if c.Providers != nil {
 		providersError = validateModules(*c.Providers)
 	}
@@ -101,7 +101,6 @@ func (c *Config) Validate() error {
 		validateModules(c.Processors),
 		validateModules(c.Connectors),
 		providersError,
-		convertersError,
 	)
 }
 

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -220,8 +220,76 @@ func TestRequireOtelColModule(t *testing.T) {
 		t.Run(tt.Version, func(t *testing.T) {
 			cfg := NewDefaultConfig()
 			cfg.Distribution.OtelColVersion = tt.Version
-			require.NoError(t, cfg.SetRequireOtelColModule())
+			require.NoError(t, cfg.SetBackwardsCompatibility())
 			assert.Equal(t, tt.ExpectedRequireOtelColModule, cfg.Distribution.RequireOtelColModule)
+		})
+	}
+}
+
+func TestConfmapFactoryVersions(t *testing.T) {
+	testCases := []struct {
+		version   string
+		supported bool
+		err       bool
+	}{
+		{
+			version:   "x.0.0",
+			supported: false,
+			err:       true,
+		},
+		{
+			version:   "0.x.0",
+			supported: false,
+			err:       true,
+		},
+		{
+			version:   "0.0.0",
+			supported: false,
+		},
+		{
+			version:   "0.98.0",
+			supported: false,
+		},
+		{
+			version:   "0.98.1",
+			supported: false,
+		},
+		{
+			version:   "0.99.0",
+			supported: true,
+		},
+		{
+			version:   "0.99.7",
+			supported: true,
+		},
+		{
+			version:   "0.100.0",
+			supported: true,
+		},
+		{
+			version:   "0.100.1",
+			supported: true,
+		},
+		{
+			version:   "1.0",
+			supported: true,
+		},
+		{
+			version:   "1.0.0",
+			supported: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.version, func(t *testing.T) {
+			cfg := NewDefaultConfig()
+			cfg.Distribution.OtelColVersion = tt.version
+			if !tt.err {
+				require.NoError(t, cfg.SetBackwardsCompatibility())
+				assert.Equal(t, tt.supported, cfg.Distribution.SupportsConfmapFactories)
+			} else {
+				require.Error(t, cfg.SetBackwardsCompatibility())
+			}
 		})
 	}
 }

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -225,3 +225,16 @@ func TestRequireOtelColModule(t *testing.T) {
 		})
 	}
 }
+
+func TestAddsDefaultProviders(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.Providers = nil
+	assert.NoError(t, cfg.ParseModules())
+	assert.Len(t, *cfg.Providers, 5)
+}
+
+func TestSkipsNilFieldValidation(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.Providers = nil
+	assert.NoError(t, cfg.Validate())
+}

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -79,7 +79,6 @@ func Generate(cfg Config) error {
 		}
 		cfg.Logger.Info("You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API", zap.String("builder-version", defaultOtelColVersion))
 	}
-
 	// if the file does not exist, try to create it
 	if _, err := os.Stat(cfg.Distribution.OutputPath); os.IsNotExist(err) {
 		if err = os.Mkdir(cfg.Distribution.OutputPath, 0750); err != nil {

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -80,7 +80,7 @@ func Generate(cfg Config) error {
 		}
 		cfg.Logger.Info("You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API", zap.String("builder-version", defaultOtelColVersion))
 	}
-	cfg.SupportsConfigProviderSettings = supportsConfigProviderSettings(cfg)
+	cfg.SupportsConfmapFactories = supportsConfmapFactories(cfg)
 	// if the file does not exist, try to create it
 	if _, err := os.Stat(cfg.Distribution.OutputPath); os.IsNotExist(err) {
 		if err = os.Mkdir(cfg.Distribution.OutputPath, 0750); err != nil {
@@ -265,7 +265,7 @@ func (c *Config) readGoModFile() (string, map[string]string, error) {
 	return modPath, dependencies, nil
 }
 
-func supportsConfigProviderSettings(cfg Config) bool {
+func supportsConfmapFactories(cfg Config) bool {
 	splitVersion := strings.Split(cfg.Distribution.OtelColVersion, ".")
 
 	if len(splitVersion) != 3 {
@@ -288,7 +288,8 @@ func supportsConfigProviderSettings(cfg Config) bool {
 		return true
 	}
 
-	if majorVer == 0 && minorVer >= 95 {
+	// confmap factories were introduced in v0.99.0.
+	if majorVer == 0 && minorVer >= 99 {
 		return true
 	}
 

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -239,7 +239,8 @@ func (c *Config) allComponents() []Module {
 		append(c.Receivers,
 			append(c.Processors,
 				append(c.Extensions,
-					c.Connectors...)...)...)...)
+					append(c.Connectors,
+						*c.Providers...)...)...)...)...)
 }
 
 func (c *Config) readGoModFile() (string, map[string]string, error) {

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -16,7 +16,6 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/mod/modfile"
-	"golang.org/x/mod/semver"
 )
 
 var (
@@ -81,8 +80,6 @@ func Generate(cfg Config) error {
 		cfg.Logger.Info("You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API", zap.String("builder-version", defaultOtelColVersion))
 	}
 
-	// confmap factories were introduced in v0.99.0.
-	cfg.SupportsConfmapFactories = semver.Compare("v"+cfg.Distribution.OtelColVersion, "v0.99.0") > -1
 	// if the file does not exist, try to create it
 	if _, err := os.Stat(cfg.Distribution.OutputPath); os.IsNotExist(err) {
 		if err = os.Mkdir(cfg.Distribution.OutputPath, 0750); err != nil {

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -38,7 +38,7 @@ func newInitializedConfig(t *testing.T) Config {
 	// Validate and ParseModules will be called before the config is
 	// given to Generate.
 	assert.NoError(t, cfg.Validate())
-	assert.NoError(t, cfg.SetRequireOtelColModule())
+	assert.NoError(t, cfg.SetBackwardsCompatibility())
 	assert.NoError(t, cfg.ParseModules())
 
 	return cfg

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -38,6 +38,7 @@ func newInitializedConfig(t *testing.T) Config {
 	// Validate and ParseModules will be called before the config is
 	// given to Generate.
 	assert.NoError(t, cfg.Validate())
+	assert.NoError(t, cfg.SetRequireOtelColModule())
 	assert.NoError(t, cfg.ParseModules())
 
 	return cfg

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -322,7 +322,7 @@ func TestGenerateAndCompile(t *testing.T) {
 	}
 }
 
-func TestConfigProviderVersions(t *testing.T) {
+func TestConfmapFactoryVersions(t *testing.T) {
 	testCases := []struct {
 		version   string
 		supported bool
@@ -352,19 +352,19 @@ func TestConfigProviderVersions(t *testing.T) {
 			supported: false,
 		},
 		{
-			version:   "0.95.0",
+			version:   "0.99.0",
 			supported: true,
 		},
 		{
-			version:   "0.95.7",
-			supported: true,
-		},
-		{
-			version:   "0.96.0",
+			version:   "0.99.7",
 			supported: true,
 		},
 		{
 			version:   "0.100.0",
+			supported: true,
+		},
+		{
+			version:   "0.100.1",
 			supported: true,
 		},
 		{
@@ -380,7 +380,7 @@ func TestConfigProviderVersions(t *testing.T) {
 			},
 		}
 
-		shouldSupport := supportsConfigProviderSettings(cfg)
+		shouldSupport := supportsConfmapFactories(cfg)
 		require.Equal(t, tt.supported, shouldSupport)
 	}
 }

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -322,6 +322,69 @@ func TestGenerateAndCompile(t *testing.T) {
 	}
 }
 
+func TestConfigProviderVersions(t *testing.T) {
+	testCases := []struct {
+		version   string
+		supported bool
+	}{
+		{
+			version:   "1.0",
+			supported: false,
+		},
+		{
+			version:   "x.0.0",
+			supported: false,
+		},
+		{
+			version:   "0.x.0",
+			supported: false,
+		},
+		{
+			version:   "0.0.0",
+			supported: false,
+		},
+		{
+			version:   "0.94.0",
+			supported: false,
+		},
+		{
+			version:   "0.94.1",
+			supported: false,
+		},
+		{
+			version:   "0.95.0",
+			supported: true,
+		},
+		{
+			version:   "0.95.7",
+			supported: true,
+		},
+		{
+			version:   "0.96.0",
+			supported: true,
+		},
+		{
+			version:   "0.100.0",
+			supported: true,
+		},
+		{
+			version:   "1.0.0",
+			supported: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		cfg := Config{
+			Distribution: Distribution{
+				OtelColVersion: tt.version,
+			},
+		}
+
+		shouldSupport := supportsConfigProviderSettings(cfg)
+		require.Equal(t, tt.supported, shouldSupport)
+	}
+}
+
 func makeModule(dir string, fileContents []byte) error {
 	// if the file does not exist, try to create it
 	if _, err := os.Stat(dir); os.IsNotExist(err) {

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -47,13 +47,6 @@ func TestGenerateDefault(t *testing.T) {
 	require.NoError(t, Generate(newInitializedConfig(t)))
 }
 
-func TestGenerateInvalidCollectorVersion(t *testing.T) {
-	cfg := newInitializedConfig(t)
-	cfg.Distribution.OtelColVersion = "invalid"
-	err := Generate(cfg)
-	require.NoError(t, err)
-}
-
 func TestGenerateInvalidOutputPath(t *testing.T) {
 	cfg := newInitializedConfig(t)
 	cfg.Distribution.OutputPath = "/:invalid"
@@ -71,7 +64,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "defaults",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Distribution.Go = "go"
 				return cfg
 			},
@@ -80,7 +73,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "require otelcol",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Distribution.Go = "go"
 				cfg.Distribution.RequireOtelColModule = true
 				return cfg
@@ -90,7 +83,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "only gomod file, skip generate",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				tempDir := t.TempDir()
 				err := makeModule(tempDir, goModTestFile)
 				require.NoError(t, err)
@@ -104,7 +97,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "old otel version",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Distribution.OtelColVersion = "0.90.0"
 				return cfg
 			},
@@ -113,7 +106,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "old otel version without strict mode",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Verbose = true
 				cfg.Distribution.Go = "go"
 				cfg.SkipStrictVersioning = true
@@ -125,7 +118,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "invalid collector version",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Distribution.OtelColVersion = "invalid"
 				return cfg
 			},
@@ -134,7 +127,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "invalid collector version without strict mode, only generate",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Distribution.OtelColVersion = "invalid"
 				cfg.SkipGetModules = true
 				cfg.SkipCompilation = true
@@ -146,7 +139,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "invalid collector version without strict mode",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Distribution.OtelColVersion = "invalid"
 				cfg.SkipStrictVersioning = true
 				return cfg
@@ -156,7 +149,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "old component version",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Distribution.Go = "go"
 				cfg.Exporters = []Module{
 					{
@@ -171,7 +164,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "old component version without strict mode",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Distribution.Go = "go"
 				cfg.SkipStrictVersioning = true
 				cfg.Exporters = []Module{
@@ -187,7 +180,7 @@ func TestVersioning(t *testing.T) {
 		{
 			description: "invalid component version",
 			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
+				cfg := newInitializedConfig(t)
 				cfg.Distribution.Go = "go"
 				cfg.Exporters = []Module{
 					{

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -302,6 +302,28 @@ func TestGenerateAndCompile(t *testing.T) {
 				return cfg
 			},
 		},
+		{
+			testCase: "Pre-confmap factories",
+			cfgBuilder: func(t *testing.T) Config {
+				cfg := NewDefaultConfig()
+				cfg.Distribution.OutputPath = t.TempDir()
+				cfg.Replaces = append(cfg.Replaces, replaces...)
+				cfg.Distribution.OtelColVersion = "0.98.0"
+				cfg.SkipStrictVersioning = true
+				return cfg
+			},
+		},
+		{
+			testCase: "With confmap factories",
+			cfgBuilder: func(t *testing.T) Config {
+				cfg := NewDefaultConfig()
+				cfg.Distribution.OutputPath = t.TempDir()
+				cfg.Replaces = append(cfg.Replaces, replaces...)
+				cfg.Distribution.OtelColVersion = "0.99.0"
+				cfg.SkipStrictVersioning = true
+				return cfg
+			},
+		},
 	}
 
 	for _, tt := range testCases {
@@ -312,69 +334,6 @@ func TestGenerateAndCompile(t *testing.T) {
 			assert.NoError(t, cfg.ParseModules())
 			require.NoError(t, GenerateAndCompile(cfg))
 		})
-	}
-}
-
-func TestConfmapFactoryVersions(t *testing.T) {
-	testCases := []struct {
-		version   string
-		supported bool
-	}{
-		{
-			version:   "1.0",
-			supported: false,
-		},
-		{
-			version:   "x.0.0",
-			supported: false,
-		},
-		{
-			version:   "0.x.0",
-			supported: false,
-		},
-		{
-			version:   "0.0.0",
-			supported: false,
-		},
-		{
-			version:   "0.94.0",
-			supported: false,
-		},
-		{
-			version:   "0.94.1",
-			supported: false,
-		},
-		{
-			version:   "0.99.0",
-			supported: true,
-		},
-		{
-			version:   "0.99.7",
-			supported: true,
-		},
-		{
-			version:   "0.100.0",
-			supported: true,
-		},
-		{
-			version:   "0.100.1",
-			supported: true,
-		},
-		{
-			version:   "1.0.0",
-			supported: true,
-		},
-	}
-
-	for _, tt := range testCases {
-		cfg := Config{
-			Distribution: Distribution{
-				OtelColVersion: tt.version,
-			},
-		}
-
-		shouldSupport := supportsConfmapFactories(cfg)
-		require.Equal(t, tt.supported, shouldSupport)
 	}
 }
 

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -5,7 +5,7 @@ module {{.Distribution.Module}}
 go 1.21
 
 require (
-	{{if .SupportsConfmapFactories -}}
+	{{if .Distribution.SupportsConfmapFactories -}}
 	go.opentelemetry.io/collector/confmap/converter/expandconverter v{{.Distribution.OtelColVersion}}
 	{{- range .Providers}}
 	{{if .GoMod}}{{.GoMod}}{{end}}

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -5,9 +5,11 @@ module {{.Distribution.Module}}
 go 1.21
 
 require (
+	{{if .SupportsConfigProviderSettings -}}
 	go.opentelemetry.io/collector/confmap/converter/expandconverter v{{.Distribution.OtelColVersion}}
 	{{- range .Providers}}
 	{{if .GoMod}}{{.GoMod}}{{end}}
+	{{- end}}
 	{{- end}}
 	{{- range .Connectors}}
 	{{if .GoMod}}{{.GoMod}}{{end}}

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -5,7 +5,7 @@ module {{.Distribution.Module}}
 go 1.21
 
 require (
-	{{if .SupportsConfigProviderSettings -}}
+	{{if .SupportsConfmapFactories -}}
 	go.opentelemetry.io/collector/confmap/converter/expandconverter v{{.Distribution.OtelColVersion}}
 	{{- range .Providers}}
 	{{if .GoMod}}{{.GoMod}}{{end}}

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -5,6 +5,10 @@ module {{.Distribution.Module}}
 go 1.21
 
 require (
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v{{.Distribution.OtelColVersion}}
+	{{- range .Providers}}
+	{{if .GoMod}}{{.GoMod}}{{end}}
+	{{- end}}
 	{{- range .Connectors}}
 	{{if .GoMod}}{{.GoMod}}{{end}}
 	{{- end}}

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"log"
 
 	"go.opentelemetry.io/collector/component"
-	{{- if .SupportsConfmapFactories}}
+	{{- if .Distribution.SupportsConfmapFactories}}
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
 	{{- range .Providers}}
@@ -27,7 +27,7 @@ func main() {
 	set := otelcol.CollectorSettings{
 		BuildInfo: info,
 		Factories: components,
-		{{- if .SupportsConfmapFactories}}
+		{{- if .Distribution.SupportsConfmapFactories}}
 		ConfigProviderSettings: otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
 				ProviderFactories: []confmap.ProviderFactory{

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -21,14 +21,17 @@ func main() {
 		Description: "{{ .Distribution.Description }}",
 		Version:     "{{ .Distribution.Version }}",
 	}
+	{{if .SupportsConfigProviderSettings -}}
 	providers := []confmap.Provider{
 		{{- range .Providers}}
 		{{.Name}}.NewWithSettings(confmap.ProviderSettings{}),
 		{{- end}}
 	}
+	{{end}}
 	set := otelcol.CollectorSettings{
 		BuildInfo: info,
 		Factories: components,
+		{{if .SupportsConfigProviderSettings -}}
 		ConfigProviderSettings: otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
 				Providers:  makeMapProvidersMap(providers...),
@@ -37,6 +40,7 @@ func main() {
 				},
 			},
 		},
+		{{end}}
 	}
 
 	if err := run(set); err != nil {
@@ -53,6 +57,7 @@ func runInteractive(params otelcol.CollectorSettings) error {
 	return nil
 }
 
+{{if .SupportsConfigProviderSettings -}}
 func makeMapProvidersMap(providers ...confmap.Provider) map[string]confmap.Provider {
 	ret := make(map[string]confmap.Provider, len(providers))
 	for _, provider := range providers {
@@ -60,3 +65,4 @@ func makeMapProvidersMap(providers ...confmap.Provider) map[string]confmap.Provi
 	}
 	return ret
 }
+{{end}}

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"log"
 
 	"go.opentelemetry.io/collector/component"
-	{{- if .SupportsConfigProviderSettings}}
+	{{- if .SupportsConfmapFactories}}
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
 	{{- range .Providers}}
@@ -23,22 +23,20 @@ func main() {
 		Description: "{{ .Distribution.Description }}",
 		Version:     "{{ .Distribution.Version }}",
 	}
-	{{- if .SupportsConfigProviderSettings}}
-	providers := []confmap.Provider{
-		{{- range .Providers}}
-		{{.Name}}.NewWithSettings(confmap.ProviderSettings{}),
-		{{- end}}
-	}
-	{{- end}}
+
 	set := otelcol.CollectorSettings{
 		BuildInfo: info,
 		Factories: components,
-		{{- if .SupportsConfigProviderSettings}}
+		{{- if .SupportsConfmapFactories}}
 		ConfigProviderSettings: otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
-				Providers:  makeMapProvidersMap(providers...),
-				Converters: []confmap.Converter{
-					expandconverter.New(confmap.ConverterSettings{}),
+				ProviderFactories: []confmap.ProviderFactory{
+					{{- range .Providers}}
+					{{.Name}}.NewFactory(),
+					{{- end}}
+				},
+				ConverterFactories: []confmap.ConverterFactory{
+					expandconverter.NewFactory(),
 				},
 			},
 		},
@@ -58,13 +56,3 @@ func runInteractive(params otelcol.CollectorSettings) error {
 
 	return nil
 }
-
-{{if .SupportsConfigProviderSettings}}
-func makeMapProvidersMap(providers ...confmap.Provider) map[string]confmap.Provider {
-	ret := make(map[string]confmap.Provider, len(providers))
-	for _, provider := range providers {
-		ret[provider.Scheme()] = provider
-	}
-	return ret
-}
-{{- end}}

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -7,10 +7,12 @@ import (
 	"log"
 
 	"go.opentelemetry.io/collector/component"
+	{{- if .SupportsConfigProviderSettings}}
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
 	{{- range .Providers}}
 	{{.Name}} "{{.Import}}"
+	{{- end}}
 	{{- end}}
 	"go.opentelemetry.io/collector/otelcol"
 )
@@ -21,17 +23,17 @@ func main() {
 		Description: "{{ .Distribution.Description }}",
 		Version:     "{{ .Distribution.Version }}",
 	}
-	{{if .SupportsConfigProviderSettings -}}
+	{{- if .SupportsConfigProviderSettings}}
 	providers := []confmap.Provider{
 		{{- range .Providers}}
 		{{.Name}}.NewWithSettings(confmap.ProviderSettings{}),
 		{{- end}}
 	}
-	{{end}}
+	{{- end}}
 	set := otelcol.CollectorSettings{
 		BuildInfo: info,
 		Factories: components,
-		{{if .SupportsConfigProviderSettings -}}
+		{{- if .SupportsConfigProviderSettings}}
 		ConfigProviderSettings: otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
 				Providers:  makeMapProvidersMap(providers...),
@@ -40,7 +42,7 @@ func main() {
 				},
 			},
 		},
-		{{end}}
+		{{- end}}
 	}
 
 	if err := run(set); err != nil {
@@ -57,7 +59,7 @@ func runInteractive(params otelcol.CollectorSettings) error {
 	return nil
 }
 
-{{if .SupportsConfigProviderSettings -}}
+{{if .SupportsConfigProviderSettings}}
 func makeMapProvidersMap(providers ...confmap.Provider) map[string]confmap.Provider {
 	ret := make(map[string]confmap.Provider, len(providers))
 	for _, provider := range providers {
@@ -65,4 +67,4 @@ func makeMapProvidersMap(providers ...confmap.Provider) map[string]confmap.Provi
 	}
 	return ret
 }
-{{end}}
+{{- end}}

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -7,6 +7,11 @@ import (
 	"log"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
+	{{- range .Providers}}
+	{{.Name}} "{{.Import}}"
+	{{- end}}
 	"go.opentelemetry.io/collector/otelcol"
 )
 
@@ -16,8 +21,25 @@ func main() {
 		Description: "{{ .Distribution.Description }}",
 		Version:     "{{ .Distribution.Version }}",
 	}
+	providers := []confmap.Provider{
+		{{- range .Providers}}
+		{{.Name}}.NewWithSettings(confmap.ProviderSettings{}),
+		{{- end}}
+	}
+	set := otelcol.CollectorSettings{
+		BuildInfo: info,
+		Factories: components,
+		ConfigProviderSettings: otelcol.ConfigProviderSettings{
+			ResolverSettings: confmap.ResolverSettings{
+				Providers:  makeMapProvidersMap(providers...),
+				Converters: []confmap.Converter{
+					expandconverter.New(confmap.ConverterSettings{}),
+				},
+			},
+		},
+	}
 
-	if err := run(otelcol.CollectorSettings{BuildInfo: info, Factories: components}); err != nil {
+	if err := run(set); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -29,4 +51,12 @@ func runInteractive(params otelcol.CollectorSettings) error {
 	}
 
 	return nil
+}
+
+func makeMapProvidersMap(providers ...confmap.Provider) map[string]confmap.Provider {
+	ret := make(map[string]confmap.Provider, len(providers))
+	for _, provider := range providers {
+		ret[provider.Scheme()] = provider
+	}
+	return ret
 }

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -170,6 +170,7 @@ func applyCfgFromFile(flags *flag.FlagSet, cfgFromFile builder.Config) {
 	cfg.Receivers = cfgFromFile.Receivers
 	cfg.Processors = cfgFromFile.Processors
 	cfg.Connectors = cfgFromFile.Connectors
+	cfg.Providers = cfgFromFile.Providers
 	cfg.Replaces = cfgFromFile.Replaces
 	cfg.Excludes = cfgFromFile.Excludes
 

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -66,7 +66,7 @@ configuration is provided, ocb will generate a default Collector.
 				return fmt.Errorf("go not found: %w", err)
 			}
 
-			if err := cfg.SetRequireOtelColModule(); err != nil {
+			if err := cfg.SetBackwardsCompatibility(); err != nil {
 				return fmt.Errorf("unable to compare otelcol version: %w", err)
 			}
 

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -25,9 +25,9 @@ connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.98.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v0.95.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.95.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.95.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.95.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.95.0
 

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -24,3 +24,10 @@ processors:
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.98.0
 
+providers:
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.0
+

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -25,11 +25,11 @@ connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.98.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v0.95.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.95.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.95.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.95.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.95.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v0.97.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.97.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.97.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.97.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.97.0
 
 replaces:
   - go.opentelemetry.io/collector => ../../

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -24,6 +24,13 @@ processors:
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.98.0
 
+providers:
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v0.95.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.95.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.95.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.95.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.95.0
+
 replaces:
   - go.opentelemetry.io/collector => ../../
   - go.opentelemetry.io/collector/otelcol => ../../otelcol

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -25,11 +25,11 @@ connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.98.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v0.97.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.97.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.97.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.97.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.97.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v0.98.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v0.98.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.98.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.98.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.98.0
 
 replaces:
   - go.opentelemetry.io/collector => ../../

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -6,13 +6,6 @@ go 1.21
 
 require (
 	go.opentelemetry.io/collector/component v0.98.0
-	go.opentelemetry.io/collector/confmap v0.98.0
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.98.0
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.98.0
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.98.0
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.98.0
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.98.0
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.98.0
 	go.opentelemetry.io/collector/connector v0.98.0
 	go.opentelemetry.io/collector/connector/forwardconnector v0.98.0
 	go.opentelemetry.io/collector/exporter v0.98.0
@@ -89,6 +82,13 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.98.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.98.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.98.0 // indirect
+	go.opentelemetry.io/collector/confmap v0.98.0 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.98.0 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.98.0 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.98.0 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.98.0 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.98.0 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.98.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.98.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.98.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.5.0 // indirect

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -6,6 +6,13 @@ go 1.21
 
 require (
 	go.opentelemetry.io/collector/component v0.98.0
+	go.opentelemetry.io/collector/confmap v0.98.0
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.98.0
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.98.0
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.98.0
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.98.0
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.98.0
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.98.0
 	go.opentelemetry.io/collector/connector v0.98.0
 	go.opentelemetry.io/collector/connector/forwardconnector v0.98.0
 	go.opentelemetry.io/collector/exporter v0.98.0
@@ -82,13 +89,6 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.98.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.98.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.98.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.98.0 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.98.0 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.98.0 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.98.0 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.98.0 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.98.0 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.98.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.98.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.98.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.5.0 // indirect

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -7,13 +7,6 @@ import (
 	"log"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/confmap"
-	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
-	envprovider "go.opentelemetry.io/collector/confmap/provider/envprovider"
-	fileprovider "go.opentelemetry.io/collector/confmap/provider/fileprovider"
-	httpprovider "go.opentelemetry.io/collector/confmap/provider/httpprovider"
-	httpsprovider "go.opentelemetry.io/collector/confmap/provider/httpsprovider"
-	yamlprovider "go.opentelemetry.io/collector/confmap/provider/yamlprovider"
 	"go.opentelemetry.io/collector/otelcol"
 )
 
@@ -27,20 +20,6 @@ func main() {
 	set := otelcol.CollectorSettings{
 		BuildInfo: info,
 		Factories: components,
-		ConfigProviderSettings: otelcol.ConfigProviderSettings{
-			ResolverSettings: confmap.ResolverSettings{
-				ProviderFactories: []confmap.ProviderFactory{
-					envprovider.NewFactory(),
-					fileprovider.NewFactory(),
-					httpprovider.NewFactory(),
-					httpsprovider.NewFactory(),
-					yamlprovider.NewFactory(),
-				},
-				ConverterFactories: []confmap.ConverterFactory{
-					expandconverter.NewFactory(),
-				},
-			},
-		},
 	}
 
 	if err := run(set); err != nil {

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -23,21 +23,21 @@ func main() {
 		Description: "Local OpenTelemetry Collector binary, testing only.",
 		Version:     "0.98.0-dev",
 	}
-	providers := []confmap.Provider{
-		envprovider.NewWithSettings(confmap.ProviderSettings{}),
-		fileprovider.NewWithSettings(confmap.ProviderSettings{}),
-		httpprovider.NewWithSettings(confmap.ProviderSettings{}),
-		httpsprovider.NewWithSettings(confmap.ProviderSettings{}),
-		yamlprovider.NewWithSettings(confmap.ProviderSettings{}),
-	}
+
 	set := otelcol.CollectorSettings{
 		BuildInfo: info,
 		Factories: components,
 		ConfigProviderSettings: otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
-				Providers: makeMapProvidersMap(providers...),
-				Converters: []confmap.Converter{
-					expandconverter.New(confmap.ConverterSettings{}),
+				ProviderFactories: []confmap.ProviderFactory{
+					envprovider.NewFactory(),
+					fileprovider.NewFactory(),
+					httpprovider.NewFactory(),
+					httpsprovider.NewFactory(),
+					yamlprovider.NewFactory(),
+				},
+				ConverterFactories: []confmap.ConverterFactory{
+					expandconverter.NewFactory(),
 				},
 			},
 		},
@@ -55,12 +55,4 @@ func runInteractive(params otelcol.CollectorSettings) error {
 	}
 
 	return nil
-}
-
-func makeMapProvidersMap(providers ...confmap.Provider) map[string]confmap.Provider {
-	ret := make(map[string]confmap.Provider, len(providers))
-	for _, provider := range providers {
-		ret[provider.Scheme()] = provider
-	}
-	return ret
 }


### PR DESCRIPTION
**Description:**

Allow configuring confmap providers in the builder's config. If the field isn't set, the default set of providers is used.

**Link to tracking Issue:**

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/4759.

**Testing:**

Extended unit tests.

**Documentation:**

Updated the readme to include the new options in the example manifest file.

cc @mx-psi
