### PR TITLE
[chore] remove comment

### DIFF
--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -47,8 +47,6 @@ type baseExporter struct {
 	userAgent string
 }
 
-// Crete new exporter and start it. The exporter will begin connecting but
-// this function may return before the connection is established.
 func newExporter(cfg component.Config, set exporter.CreateSettings) (*baseExporter, error) {
 	oCfg := cfg.(*Config)
 


### PR DESCRIPTION
This comment has a typo and is invalid: we do not start the exporter in this function.