### PR TITLE
Offer a way to deal with status report with sharedcomponent.Map

### DIFF
--- a/.chloggen/simplify_sharedcomponent.yaml
+++ b/.chloggen/simplify_sharedcomponent.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: internal/sharedcomponents
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Start shared components on first usage, stop shared components when the last use is stopped.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9155]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -31,7 +31,7 @@ func TestNewSharedComponentsCreateError(t *testing.T) {
 	comps := NewMap[component.ID, *baseComponent]()
 	assert.Len(t, comps.components, 0)
 	myErr := errors.New("my error")
-	_, err := comps.LoadOrStore(
+	_, _, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return nil, myErr },
 	)
@@ -43,27 +43,28 @@ func TestSharedComponentsLoadOrStore(t *testing.T) {
 	nop := &baseComponent{}
 
 	comps := NewMap[component.ID, *baseComponent]()
-	got, err := comps.LoadOrStore(
+	got, comp, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return nop, nil },
 	)
 	require.NoError(t, err)
 	assert.Len(t, comps.components, 1)
-	assert.Same(t, nop, got.Unwrap())
-	gotSecond, err := comps.LoadOrStore(
+	assert.Same(t, nop, comp)
+	gotSecond, comp2, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { panic("should not be called") },
 	)
 
 	require.NoError(t, err)
 	assert.Same(t, got, gotSecond)
+	assert.Same(t, comp, comp2)
 
 	assert.NoError(t, got.Start(context.Background(), componenttest.NewNopHost()))
 
 	// Shutdown nop will remove
 	assert.NoError(t, got.Shutdown(context.Background()))
 	assert.Len(t, comps.components, 0)
-	gotThird, err := comps.LoadOrStore(
+	gotThird, _, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return nop, nil },
 	)
@@ -86,7 +87,7 @@ func TestSharedComponent(t *testing.T) {
 		}}
 
 	comps := NewMap[component.ID, *baseComponent]()
-	got, err := comps.LoadOrStore(
+	got, _, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return comp, nil },
 	)

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -20,7 +20,6 @@ var id = component.MustNewID("test")
 type baseComponent struct {
 	component.StartFunc
 	component.ShutdownFunc
-	telemetry *component.TelemetrySettings
 }
 
 func TestNewMap(t *testing.T) {
@@ -35,7 +34,6 @@ func TestNewSharedComponentsCreateError(t *testing.T) {
 	_, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return nil, myErr },
-		newNopTelemetrySettings(),
 	)
 	assert.ErrorIs(t, err, myErr)
 	assert.Len(t, comps.components, 0)
@@ -48,7 +46,6 @@ func TestSharedComponentsLoadOrStore(t *testing.T) {
 	got, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return nop, nil },
-		newNopTelemetrySettings(),
 	)
 	require.NoError(t, err)
 	assert.Len(t, comps.components, 1)
@@ -56,11 +53,12 @@ func TestSharedComponentsLoadOrStore(t *testing.T) {
 	gotSecond, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { panic("should not be called") },
-		newNopTelemetrySettings(),
 	)
 
 	require.NoError(t, err)
 	assert.Same(t, got, gotSecond)
+
+	assert.NoError(t, got.Start(context.Background(), componenttest.NewNopHost()))
 
 	// Shutdown nop will remove
 	assert.NoError(t, got.Shutdown(context.Background()))
@@ -68,7 +66,6 @@ func TestSharedComponentsLoadOrStore(t *testing.T) {
 	gotThird, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return nop, nil },
-		newNopTelemetrySettings(),
 	)
 	require.NoError(t, err)
 	assert.NotSame(t, got, gotThird)
@@ -92,188 +89,17 @@ func TestSharedComponent(t *testing.T) {
 	got, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return comp, nil },
-		newNopTelemetrySettings(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, wantErr, got.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Equal(t, 1, calledStart)
 	// Second time is not called anymore.
-	assert.NoError(t, got.Start(context.Background(), componenttest.NewNopHost()))
+	assert.Equal(t, wantErr, got.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Equal(t, 1, calledStart)
-	// first time, shutdown is called.
+	// first time, shutdown is not called.
+	assert.Equal(t, nil, got.Shutdown(context.Background()))
+	assert.Equal(t, 0, calledStop)
+	// Second time shutdown is called.
 	assert.Equal(t, wantErr, got.Shutdown(context.Background()))
 	assert.Equal(t, 1, calledStop)
-	// Second time is not called anymore.
-	assert.NoError(t, got.Shutdown(context.Background()))
-	assert.Equal(t, 1, calledStop)
-}
-func TestSharedComponentsReportStatus(t *testing.T) {
-	reportedStatuses := make(map[*component.InstanceID][]component.Status)
-	newStatusFunc := func() func(*component.StatusEvent) {
-		instanceID := &component.InstanceID{}
-		return func(ev *component.StatusEvent) {
-			if ev.Status() == component.StatusNone {
-				return
-			}
-			reportedStatuses[instanceID] = append(reportedStatuses[instanceID], ev.Status())
-		}
-	}
-
-	comp := &baseComponent{}
-	comps := NewMap[component.ID, *baseComponent]()
-	var telemetrySettings *component.TelemetrySettings
-
-	// make a shared component that represents three instances
-	for i := 0; i < 3; i++ {
-		telemetrySettings = newNopTelemetrySettings()
-		telemetrySettings.ReportStatus = newStatusFunc()
-		// The initial settings for the shared component need to match the ones passed to the first
-		// invocation of LoadOrStore so that underlying telemetry settings reference can be used to
-		// wrap ReportStatus for subsequently added "instances".
-		if i == 0 {
-			comp.telemetry = telemetrySettings
-		}
-		got, err := comps.LoadOrStore(
-			id,
-			func() (*baseComponent, error) { return comp, nil },
-			telemetrySettings,
-		)
-		require.NoError(t, err)
-		assert.Len(t, comps.components, 1)
-		assert.Same(t, comp, got.Unwrap())
-	}
-
-	// make sure we don't try to represent a fourth instance if we reuse a telemetrySettings
-	_, _ = comps.LoadOrStore(
-		id,
-		func() (*baseComponent, error) { return comp, nil },
-		telemetrySettings,
-	)
-
-	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusStarting))
-
-	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusOK))
-
-	// simulate an error
-	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusNone))
-
-	// stopping
-	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusStopping))
-
-	// stopped
-	comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusStopped))
-
-	// The shared component represents 3 component instances. Reporting status for the shared
-	// component should report status for each of the instances it represents.
-	expectedStatuses := []component.Status{
-		component.StatusStarting,
-		component.StatusOK,
-		component.StatusStopping,
-		component.StatusStopped,
-	}
-
-	require.Equal(t, 3, len(reportedStatuses))
-
-	for _, actualStatuses := range reportedStatuses {
-		require.Equal(t, expectedStatuses, actualStatuses)
-	}
-}
-
-func TestReportStatusOnStartShutdown(t *testing.T) {
-	for _, tc := range []struct {
-		name             string
-		startErr         error
-		shutdownErr      error
-		expectedStatuses []component.Status
-	}{
-		{
-			name:        "successful start/stop",
-			startErr:    nil,
-			shutdownErr: nil,
-			expectedStatuses: []component.Status{
-				component.StatusStarting,
-				component.StatusOK,
-				component.StatusStopping,
-				component.StatusStopped,
-			},
-		},
-		{
-			name:        "start error",
-			startErr:    assert.AnError,
-			shutdownErr: nil,
-			expectedStatuses: []component.Status{
-				component.StatusStarting,
-				component.StatusPermanentError,
-			},
-		},
-		{
-			name:        "shutdown error",
-			shutdownErr: assert.AnError,
-			expectedStatuses: []component.Status{
-				component.StatusStarting,
-				component.StatusOK,
-				component.StatusStopping,
-				component.StatusPermanentError,
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			reportedStatuses := make(map[*component.InstanceID][]component.Status)
-			newStatusFunc := func() func(*component.StatusEvent) {
-				instanceID := &component.InstanceID{}
-				return func(ev *component.StatusEvent) {
-					reportedStatuses[instanceID] = append(reportedStatuses[instanceID], ev.Status())
-				}
-			}
-			base := &baseComponent{}
-			if tc.startErr != nil {
-				base.StartFunc = func(context.Context, component.Host) error {
-					return tc.startErr
-				}
-			}
-			if tc.shutdownErr != nil {
-				base.ShutdownFunc = func(context.Context) error {
-					return tc.shutdownErr
-				}
-			}
-			comps := NewMap[component.ID, *baseComponent]()
-			var comp *Component[*baseComponent]
-			var err error
-			for i := 0; i < 3; i++ {
-				telemetrySettings := newNopTelemetrySettings()
-				telemetrySettings.ReportStatus = newStatusFunc()
-				if i == 0 {
-					base.telemetry = telemetrySettings
-				}
-				comp, err = comps.LoadOrStore(
-					id,
-					func() (*baseComponent, error) { return base, nil },
-					telemetrySettings,
-				)
-				require.NoError(t, err)
-			}
-
-			err = comp.Start(context.Background(), componenttest.NewNopHost())
-			require.Equal(t, tc.startErr, err)
-
-			if tc.startErr == nil {
-				comp.telemetry.ReportStatus(component.NewStatusEvent(component.StatusOK))
-
-				err = comp.Shutdown(context.Background())
-				require.Equal(t, tc.shutdownErr, err)
-			}
-
-			require.Equal(t, 3, len(reportedStatuses))
-
-			for _, actualStatuses := range reportedStatuses {
-				require.Equal(t, tc.expectedStatuses, actualStatuses)
-			}
-		})
-	}
-}
-
-// newNopTelemetrySettings streamlines getting a pointer to a NopTelemetrySettings
-func newNopTelemetrySettings() *component.TelemetrySettings {
-	set := componenttest.NewNopTelemetrySettings()
-	return &set
 }

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -23,12 +23,12 @@ type baseComponent struct {
 }
 
 func TestNewMap(t *testing.T) {
-	comps := NewMap[component.ID, *baseComponent]()
+	comps := NewMap[component.ID, *baseComponent](true)
 	assert.Len(t, comps.components, 0)
 }
 
 func TestNewSharedComponentsCreateError(t *testing.T) {
-	comps := NewMap[component.ID, *baseComponent]()
+	comps := NewMap[component.ID, *baseComponent](true)
 	assert.Len(t, comps.components, 0)
 	myErr := errors.New("my error")
 	_, _, err := comps.LoadOrStore(
@@ -42,7 +42,7 @@ func TestNewSharedComponentsCreateError(t *testing.T) {
 func TestSharedComponentsLoadOrStore(t *testing.T) {
 	nop := &baseComponent{}
 
-	comps := NewMap[component.ID, *baseComponent]()
+	comps := NewMap[component.ID, *baseComponent](true)
 	got, comp, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return nop, nil },
@@ -86,7 +86,7 @@ func TestSharedComponent(t *testing.T) {
 			return wantErr
 		}}
 
-	comps := NewMap[component.ID, *baseComponent]()
+	comps := NewMap[component.ID, *baseComponent](true)
 	got, _, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return comp, nil },

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -71,7 +71,7 @@ func createTraces(
 	nextConsumer consumer.Traces,
 ) (receiver.Traces, error) {
 	oCfg := cfg.(*Config)
-	r, err := receivers.LoadOrStore(
+	shared, r, err := receivers.LoadOrStore(
 		oCfg,
 		func() (*otlpReceiver, error) {
 			return newOtlpReceiver(oCfg, &set)
@@ -81,10 +81,10 @@ func createTraces(
 		return nil, err
 	}
 
-	if err = r.Unwrap().registerTraceConsumer(nextConsumer); err != nil {
+	if err = r.registerTraceConsumer(nextConsumer); err != nil {
 		return nil, err
 	}
-	return r, nil
+	return shared, nil
 }
 
 // createMetrics creates a metrics receiver based on provided config.
@@ -95,7 +95,7 @@ func createMetrics(
 	consumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	oCfg := cfg.(*Config)
-	r, err := receivers.LoadOrStore(
+	shared, r, err := receivers.LoadOrStore(
 		oCfg,
 		func() (*otlpReceiver, error) {
 			return newOtlpReceiver(oCfg, &set)
@@ -105,10 +105,10 @@ func createMetrics(
 		return nil, err
 	}
 
-	if err = r.Unwrap().registerMetricsConsumer(consumer); err != nil {
+	if err = r.registerMetricsConsumer(consumer); err != nil {
 		return nil, err
 	}
-	return r, nil
+	return shared, nil
 }
 
 // createLog creates a log receiver based on provided config.
@@ -119,7 +119,7 @@ func createLog(
 	consumer consumer.Logs,
 ) (receiver.Logs, error) {
 	oCfg := cfg.(*Config)
-	r, err := receivers.LoadOrStore(
+	shared, r, err := receivers.LoadOrStore(
 		oCfg,
 		func() (*otlpReceiver, error) {
 			return newOtlpReceiver(oCfg, &set)
@@ -129,10 +129,10 @@ func createLog(
 		return nil, err
 	}
 
-	if err = r.Unwrap().registerLogsConsumer(consumer); err != nil {
+	if err = r.registerLogsConsumer(consumer); err != nil {
 		return nil, err
 	}
-	return r, nil
+	return shared, nil
 }
 
 // This is the map of already created OTLP receivers for particular configurations.

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -76,7 +76,6 @@ func createTraces(
 		func() (*otlpReceiver, error) {
 			return newOtlpReceiver(oCfg, &set)
 		},
-		&set.TelemetrySettings,
 	)
 	if err != nil {
 		return nil, err
@@ -101,7 +100,6 @@ func createMetrics(
 		func() (*otlpReceiver, error) {
 			return newOtlpReceiver(oCfg, &set)
 		},
-		&set.TelemetrySettings,
 	)
 	if err != nil {
 		return nil, err
@@ -126,7 +124,6 @@ func createLog(
 		func() (*otlpReceiver, error) {
 			return newOtlpReceiver(oCfg, &set)
 		},
-		&set.TelemetrySettings,
 	)
 	if err != nil {
 		return nil, err

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -141,4 +141,4 @@ func createLog(
 // create separate objects, they must use one otlpReceiver object per configuration.
 // When the receiver is shutdown it should be removed from this map so the same configuration
 // can be recreated successfully.
-var receivers = sharedcomponent.NewMap[*Config, *otlpReceiver]()
+var receivers = sharedcomponent.NewMap[*Config, *otlpReceiver](false)


### PR DESCRIPTION
**Description:**
Given that we start and stop components of a shared component map once, but want to have idempotence, this PR changes the way it handles telemetry status report by removing explicit handling of report status entirely.

Rather, we rely on errors returned by Start and Shutdown.

For Start, we cache the error and return it on any subsequent runs.

For Shutdown, we only run the underlying Shutdown on the last call and return the error if any. Any previous calls return nil.

This change in approach allows to be closer to the lifecycle of a normal component and doesn't have the overhead of dealing with status reporting, which is handled like every other component by the service.

**Link to tracking Issue:**
Fixes #9155

**Testing:**
Unit tests
