### PR TITLE
[otlpexporter] change handling of https:// endpoints

### DIFF
--- a/.chloggen/remove_https_special_treatment.yaml
+++ b/.chloggen/remove_https_special_treatment.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove special treatment of TLS for https endpoints
+
+# One or more tracking issues or pull requests related to the change
+issues: [9535]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The OTLP exporter README mentions that endpoints using https:// will override TLS credentials:
+  > -If a scheme of `https` is used then client transport security is enabled and overrides the `insecure` setting.
+  
+  This change removes this override and instead abides by the TLS configuration.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
@@ -185,7 +186,10 @@ func (gcs *ClientConfig) toDialOptions(host component.Host, settings component.T
 	if err != nil {
 		return nil, err
 	}
-	cred := credentials.NewTLS(tlsCfg)
+	cred := insecure.NewCredentials()
+	if tlsCfg != nil {
+		cred = credentials.NewTLS(tlsCfg)
+	}
 	opts = append(opts, grpc.WithTransportCredentials(cred))
 
 	if gcs.ReadBufferSize > 0 {

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -5,7 +5,6 @@ package configgrpc // import "go.opentelemetry.io/collector/config/configgrpc"
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -19,7 +18,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
@@ -159,26 +157,6 @@ type ServerConfig struct {
 	IncludeMetadata bool `mapstructure:"include_metadata"`
 }
 
-// SanitizedEndpoint strips the prefix of either http:// or https:// from configgrpc.ClientConfig.Endpoint.
-func (gcs *ClientConfig) SanitizedEndpoint() string {
-	switch {
-	case gcs.isSchemeHTTP():
-		return strings.TrimPrefix(gcs.Endpoint, "http://")
-	case gcs.isSchemeHTTPS():
-		return strings.TrimPrefix(gcs.Endpoint, "https://")
-	default:
-		return gcs.Endpoint
-	}
-}
-
-func (gcs *ClientConfig) isSchemeHTTP() bool {
-	return strings.HasPrefix(gcs.Endpoint, "http://")
-}
-
-func (gcs *ClientConfig) isSchemeHTTPS() bool {
-	return strings.HasPrefix(gcs.Endpoint, "https://")
-}
-
 // ToClientConn creates a client connection to the given target. By default, it's
 // a non-blocking dial (the function won't wait for connections to be
 // established, and connecting happens in the background). To make it a blocking
@@ -189,7 +167,8 @@ func (gcs *ClientConfig) ToClientConn(ctx context.Context, host component.Host, 
 		return nil, err
 	}
 	opts = append(opts, extraOpts...)
-	return grpc.DialContext(ctx, gcs.SanitizedEndpoint(), opts...)
+	endpointWithoutHTTPSCheme := strings.TrimPrefix(strings.TrimPrefix(gcs.Endpoint, "https://"), "http://")
+	return grpc.DialContext(ctx, endpointWithoutHTTPSCheme, opts...)
 }
 
 func (gcs *ClientConfig) toDialOptions(host component.Host, settings component.TelemetrySettings) ([]grpc.DialOption, error) {
@@ -206,12 +185,7 @@ func (gcs *ClientConfig) toDialOptions(host component.Host, settings component.T
 	if err != nil {
 		return nil, err
 	}
-	cred := insecure.NewCredentials()
-	if tlsCfg != nil {
-		cred = credentials.NewTLS(tlsCfg)
-	} else if gcs.isSchemeHTTPS() {
-		cred = credentials.NewTLS(&tls.Config{})
-	}
+	cred := credentials.NewTLS(tlsCfg)
 	opts = append(opts, grpc.WithTransportCredentials(cred))
 
 	if gcs.ReadBufferSize > 0 {

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -1102,3 +1102,37 @@ type mockHost struct {
 func (nh *mockHost) GetExtensions() map[component.ID]component.Component {
 	return nh.ext
 }
+
+func TestSanitizedEndpoint(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		endpoint  string
+		sanitized string
+	}{
+		{
+			"no changes",
+			"example.com:443",
+			"example.com:443",
+		},
+		{
+			"empty string",
+			"",
+			"",
+		},
+		{
+			"http",
+			"http://example.com:443",
+			"example.com:443",
+		},
+		{
+			"https",
+			"https://example.com:443",
+			"example.com:443",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := ClientConfig{Endpoint: test.endpoint}
+			assert.Equal(t, test.sanitized, c.SanitizedEndpoint())
+		})
+	}
+}

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -1102,37 +1102,3 @@ type mockHost struct {
 func (nh *mockHost) GetExtensions() map[component.ID]component.Component {
 	return nh.ext
 }
-
-func TestSanitizedEndpoint(t *testing.T) {
-	for _, test := range []struct {
-		name      string
-		endpoint  string
-		sanitized string
-	}{
-		{
-			"no changes",
-			"example.com:443",
-			"example.com:443",
-		},
-		{
-			"empty string",
-			"",
-			"",
-		},
-		{
-			"http",
-			"http://example.com:443",
-			"example.com:443",
-		},
-		{
-			"https",
-			"https://example.com:443",
-			"example.com:443",
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			c := ClientConfig{Endpoint: test.endpoint}
-			assert.Equal(t, test.sanitized, c.SanitizedEndpoint())
-		})
-	}
-}

--- a/exporter/otlpexporter/README.md
+++ b/exporter/otlpexporter/README.md
@@ -25,7 +25,6 @@ The following settings are required:
 - `endpoint` (no default): host:port to which the exporter is going to send OTLP trace data,
 using the gRPC protocol. The valid syntax is described
 [here](https://github.com/grpc/grpc/blob/master/doc/naming.md).
-If a scheme of `https` is used then client transport security is enabled and overrides the `insecure` setting.
 - `tls`: see [TLS Configuration Settings](../../config/configtls/README.md) for the full set of available options.
 
 Example:


### PR DESCRIPTION
**Description:**
Remove special treatment of TLS for https endpoints.

The OTLP exporter README mentions that endpoints using https:// will override TLS credentials:
  > -If a scheme of `https` is used then client transport security is enabled and overrides the `insecure` setting.
  
This change removes this override and instead abides by the TLS configuration.

