### PR TITLE
[configgrpc] Deprecate configgrpc.SanitizedEndpoint

### DIFF
--- a/.chloggen/deprecate_sanitizedEndpoint.yaml
+++ b/.chloggen/deprecate_sanitizedEndpoint.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate configgrpc.SanitizedEndpoint
+
+# One or more tracking issues or pull requests related to the change
+issues: [9537]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -160,19 +160,9 @@ type ServerConfig struct {
 }
 
 // SanitizedEndpoint strips the prefix of either http:// or https:// from configgrpc.ClientConfig.Endpoint.
+// Deprecated: [v0.95.0] This function is unused and will be removed in a future release.
 func (gcs *ClientConfig) SanitizedEndpoint() string {
-	switch {
-	case gcs.isSchemeHTTP():
-		return strings.TrimPrefix(gcs.Endpoint, "http://")
-	case gcs.isSchemeHTTPS():
-		return strings.TrimPrefix(gcs.Endpoint, "https://")
-	default:
-		return gcs.Endpoint
-	}
-}
-
-func (gcs *ClientConfig) isSchemeHTTP() bool {
-	return strings.HasPrefix(gcs.Endpoint, "http://")
+	return strings.TrimPrefix(strings.TrimPrefix(gcs.Endpoint, "https://"), "http://")
 }
 
 func (gcs *ClientConfig) isSchemeHTTPS() bool {
@@ -189,7 +179,8 @@ func (gcs *ClientConfig) ToClientConn(ctx context.Context, host component.Host, 
 		return nil, err
 	}
 	opts = append(opts, extraOpts...)
-	return grpc.DialContext(ctx, gcs.SanitizedEndpoint(), opts...)
+	endpointWithoutHTTPSCheme := strings.TrimPrefix(strings.TrimPrefix(gcs.Endpoint, "https://"), "http://")
+	return grpc.DialContext(ctx, endpointWithoutHTTPSCheme, opts...)
 }
 
 func (gcs *ClientConfig) toDialOptions(host component.Host, settings component.TelemetrySettings) ([]grpc.DialOption, error) {


### PR DESCRIPTION
**Description:**
Deprecate the public function `SanitizedEndpoint`. It will be removed in a future release.
