### PR TITLE
[confignet] Rename Addr and TCP config structs

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -127,7 +127,7 @@ type GRPCServerSettings = ServerConfig
 // ServerConfig defines common settings for a gRPC server configuration.
 type ServerConfig struct {
 	// Server net.Addr config. For transport only "tcp" and "unix" are valid options.
-	NetAddr confignet.NetAddr `mapstructure:",squash"`
+	NetAddr confignet.AddrConfig `mapstructure:",squash"`
 
 	// Configures the protocol to use TLS.
 	// The default value is nil, which will cause the protocol to not use TLS.

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -181,7 +181,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 
 func TestDefaultGrpcServerSettings(t *testing.T) {
 	gss := &ServerConfig{
-		NetAddr: confignet.NetAddr{
+		NetAddr: confignet.AddrConfig{
 			Endpoint: "0.0.0.0:1234",
 		},
 	}
@@ -192,7 +192,7 @@ func TestDefaultGrpcServerSettings(t *testing.T) {
 
 func TestAllGrpcServerSettingsExceptAuth(t *testing.T) {
 	gss := &ServerConfig{
-		NetAddr: confignet.NetAddr{
+		NetAddr: confignet.AddrConfig{
 			Endpoint:  "localhost:1234",
 			Transport: "tcp",
 		},
@@ -225,7 +225,7 @@ func TestAllGrpcServerSettingsExceptAuth(t *testing.T) {
 
 func TestGrpcServerAuthSettings(t *testing.T) {
 	gss := &ServerConfig{
-		NetAddr: confignet.NetAddr{
+		NetAddr: confignet.AddrConfig{
 			Endpoint: "0.0.0.0:1234",
 		},
 	}
@@ -390,7 +390,7 @@ func TestGRPCServerWarning(t *testing.T) {
 	}{
 		{
 			settings: ServerConfig{
-				NetAddr: confignet.NetAddr{
+				NetAddr: confignet.AddrConfig{
 					Endpoint:  "0.0.0.0:1234",
 					Transport: "tcp",
 				},
@@ -399,7 +399,7 @@ func TestGRPCServerWarning(t *testing.T) {
 		},
 		{
 			settings: ServerConfig{
-				NetAddr: confignet.NetAddr{
+				NetAddr: confignet.AddrConfig{
 					Endpoint:  "127.0.0.1:1234",
 					Transport: "tcp",
 				},
@@ -408,7 +408,7 @@ func TestGRPCServerWarning(t *testing.T) {
 		},
 		{
 			settings: ServerConfig{
-				NetAddr: confignet.NetAddr{
+				NetAddr: confignet.AddrConfig{
 					Endpoint:  "0.0.0.0:1234",
 					Transport: "unix",
 				},
@@ -441,7 +441,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 		{
 			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: ServerConfig{
-				NetAddr: confignet.NetAddr{
+				NetAddr: confignet.AddrConfig{
 					Endpoint:  "127.0.0.1:1234",
 					Transport: "tcp",
 				},
@@ -455,7 +455,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 		{
 			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
 			settings: ServerConfig{
-				NetAddr: confignet.NetAddr{
+				NetAddr: confignet.AddrConfig{
 					Endpoint:  "127.0.0.1:1234",
 					Transport: "tcp",
 				},
@@ -469,7 +469,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 		{
 			err: "^failed to load client CA CertPool: failed to load CA /doesnt/exist:",
 			settings: ServerConfig{
-				NetAddr: confignet.NetAddr{
+				NetAddr: confignet.AddrConfig{
 					Endpoint:  "127.0.0.1:1234",
 					Transport: "tcp",
 				},
@@ -489,7 +489,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 
 func TestGRPCServerSettings_ToListener_Error(t *testing.T) {
 	settings := ServerConfig{
-		NetAddr: confignet.NetAddr{
+		NetAddr: confignet.AddrConfig{
 			Endpoint:  "127.0.0.1:1234567",
 			Transport: "tcp",
 		},
@@ -616,7 +616,7 @@ func TestHttpReception(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			gss := &ServerConfig{
-				NetAddr: confignet.NetAddr{
+				NetAddr: confignet.AddrConfig{
 					Endpoint:  "localhost:0",
 					Transport: "tcp",
 				},
@@ -664,7 +664,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 
 	socketName := tempSocketName(t)
 	gss := &ServerConfig{
-		NetAddr: confignet.NetAddr{
+		NetAddr: confignet.AddrConfig{
 			Endpoint:  socketName,
 			Transport: "unix",
 		},
@@ -860,7 +860,7 @@ func TestClientInfoInterceptors(t *testing.T) {
 			// prepare the server
 			{
 				gss := &ServerConfig{
-					NetAddr: confignet.NetAddr{
+					NetAddr: confignet.AddrConfig{
 						Endpoint:  "localhost:0",
 						Transport: "tcp",
 					},

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -17,7 +17,11 @@ type DialerConfig struct {
 }
 
 // NetAddr represents a network endpoint address.
-type NetAddr struct {
+// Deprecated: [v0.95.0] Use AddrConfig instead.
+type NetAddr = AddrConfig
+
+// AddrConfig represents a network endpoint address.
+type AddrConfig struct {
 	// Endpoint configures the address for this network connection.
 	// For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address,
 	// or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name.
@@ -34,19 +38,23 @@ type NetAddr struct {
 }
 
 // Dial equivalent with net.Dialer's DialContext for this address.
-func (na *NetAddr) Dial(ctx context.Context) (net.Conn, error) {
+func (na *AddrConfig) Dial(ctx context.Context) (net.Conn, error) {
 	d := net.Dialer{Timeout: na.DialerConfig.Timeout}
 	return d.DialContext(ctx, na.Transport, na.Endpoint)
 }
 
 // Listen equivalent with net.ListenConfig's Listen for this address.
-func (na *NetAddr) Listen(ctx context.Context) (net.Listener, error) {
+func (na *AddrConfig) Listen(ctx context.Context) (net.Listener, error) {
 	lc := net.ListenConfig{}
 	return lc.Listen(ctx, na.Transport, na.Endpoint)
 }
 
-// TCPAddr represents a TCP endpoint address.
-type TCPAddr struct {
+// TCPAddr represents a TCP endpoint address configuration.
+// Deprecated: [v0.95.0] Use TCPConfig instead.
+type TCPAddr = TCPConfig
+
+// TCPConfig represents a TCP endpoint address configuration.
+type TCPConfig struct {
 	// Endpoint configures the address for this network connection.
 	// The address has the form "host:port". The host must be a literal IP address, or a host name that can be
 	// resolved to IP addresses. The port must be a literal port number or a service name.
@@ -59,13 +67,13 @@ type TCPAddr struct {
 }
 
 // Dial equivalent with net.Dialer's DialContext for this address.
-func (na *TCPAddr) Dial(ctx context.Context) (net.Conn, error) {
+func (na *TCPConfig) Dial(ctx context.Context) (net.Conn, error) {
 	d := net.Dialer{Timeout: na.DialerConfig.Timeout}
 	return d.DialContext(ctx, "tcp", na.Endpoint)
 }
 
 // Listen equivalent with net.ListenConfig's Listen for this address.
-func (na *TCPAddr) Listen(ctx context.Context) (net.Listener, error) {
+func (na *TCPConfig) Listen(ctx context.Context) (net.Listener, error) {
 	lc := net.ListenConfig{}
 	return lc.Listen(ctx, "tcp", na.Endpoint)
 }

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNetAddrTimeout(t *testing.T) {
-	nac := &NetAddr{
+	nac := &AddrConfig{
 		Endpoint:  "localhost:0",
 		Transport: "tcp",
 		DialerConfig: DialerConfig{
@@ -32,7 +32,7 @@ func TestNetAddrTimeout(t *testing.T) {
 }
 
 func TestTCPAddrTimeout(t *testing.T) {
-	nac := &TCPAddr{
+	nac := &TCPConfig{
 		Endpoint: "localhost:0",
 		DialerConfig: DialerConfig{
 			Timeout: -1 * time.Second,
@@ -49,7 +49,7 @@ func TestTCPAddrTimeout(t *testing.T) {
 }
 
 func TestNetAddr(t *testing.T) {
-	nas := &NetAddr{
+	nas := &AddrConfig{
 		Endpoint:  "localhost:0",
 		Transport: "tcp",
 	}
@@ -69,7 +69,7 @@ func TestNetAddr(t *testing.T) {
 		done <- true
 	}()
 
-	nac := &NetAddr{
+	nac := &AddrConfig{
 		Endpoint:  ln.Addr().String(),
 		Transport: "tcp",
 	}
@@ -84,7 +84,7 @@ func TestNetAddr(t *testing.T) {
 }
 
 func TestTCPAddr(t *testing.T) {
-	nas := &TCPAddr{
+	nas := &TCPConfig{
 		Endpoint: "localhost:0",
 	}
 	ln, err := nas.Listen(context.Background())
@@ -103,7 +103,7 @@ func TestTCPAddr(t *testing.T) {
 		done <- true
 	}()
 
-	nac := &TCPAddr{
+	nac := &TCPConfig{
 		Endpoint: ln.Addr().String(),
 	}
 	var conn net.Conn

--- a/extension/zpagesextension/config.go
+++ b/extension/zpagesextension/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	// TCPAddr is the address and port in which the zPages will be listening to.
 	// Use localhost:<port> to make it available only locally, or ":<port>" to
 	// make it available on all network interfaces.
-	TCPAddr confignet.TCPAddr `mapstructure:",squash"`
+	TCPAddr confignet.TCPConfig `mapstructure:",squash"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/extension/zpagesextension/config_test.go
+++ b/extension/zpagesextension/config_test.go
@@ -31,7 +31,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
 	assert.Equal(t,
 		&Config{
-			TCPAddr: confignet.TCPAddr{
+			TCPAddr: confignet.TCPConfig{
 				Endpoint: "localhost:56888",
 			},
 		}, cfg)

--- a/extension/zpagesextension/factory.go
+++ b/extension/zpagesextension/factory.go
@@ -23,7 +23,7 @@ func NewFactory() extension.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		TCPAddr: confignet.TCPAddr{
+		TCPAddr: confignet.TCPConfig{
 			Endpoint: defaultEndpoint,
 		},
 	}

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -19,7 +19,7 @@ import (
 func TestFactory_CreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
 	assert.Equal(t, &Config{
-		TCPAddr: confignet.TCPAddr{
+		TCPAddr: confignet.TCPConfig{
 			Endpoint: "localhost:55679",
 		},
 	},

--- a/extension/zpagesextension/zpagesextension_test.go
+++ b/extension/zpagesextension/zpagesextension_test.go
@@ -48,7 +48,7 @@ func newZpagesTelemetrySettings() component.TelemetrySettings {
 
 func TestZPagesExtensionUsage(t *testing.T) {
 	cfg := &Config{
-		TCPAddr: confignet.TCPAddr{
+		TCPAddr: confignet.TCPConfig{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
 	}
@@ -80,7 +80,7 @@ func TestZPagesExtensionPortAlreadyInUse(t *testing.T) {
 	defer ln.Close()
 
 	cfg := &Config{
-		TCPAddr: confignet.TCPAddr{
+		TCPAddr: confignet.TCPConfig{
 			Endpoint: endpoint,
 		},
 	}
@@ -92,7 +92,7 @@ func TestZPagesExtensionPortAlreadyInUse(t *testing.T) {
 
 func TestZPagesMultipleStarts(t *testing.T) {
 	cfg := &Config{
-		TCPAddr: confignet.TCPAddr{
+		TCPAddr: confignet.TCPConfig{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
 	}
@@ -109,7 +109,7 @@ func TestZPagesMultipleStarts(t *testing.T) {
 
 func TestZPagesMultipleShutdowns(t *testing.T) {
 	cfg := &Config{
-		TCPAddr: confignet.TCPAddr{
+		TCPAddr: confignet.TCPConfig{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
 	}
@@ -124,7 +124,7 @@ func TestZPagesMultipleShutdowns(t *testing.T) {
 
 func TestZPagesShutdownWithoutStart(t *testing.T) {
 	cfg := &Config{
-		TCPAddr: confignet.TCPAddr{
+		TCPAddr: confignet.TCPConfig{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
 	}

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -87,7 +87,7 @@ func TestUnmarshalConfig(t *testing.T) {
 		&Config{
 			Protocols: Protocols{
 				GRPC: &configgrpc.ServerConfig{
-					NetAddr: confignet.NetAddr{
+					NetAddr: confignet.AddrConfig{
 						Endpoint:  "0.0.0.0:4317",
 						Transport: "tcp",
 					},
@@ -148,7 +148,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 		&Config{
 			Protocols: Protocols{
 				GRPC: &configgrpc.ServerConfig{
-					NetAddr: confignet.NetAddr{
+					NetAddr: confignet.AddrConfig{
 						Endpoint:  "/tmp/grpc_otlp.sock",
 						Transport: "unix",
 					},

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -44,7 +44,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		Protocols: Protocols{
 			GRPC: &configgrpc.ServerConfig{
-				NetAddr: confignet.NetAddr{
+				NetAddr: confignet.AddrConfig{
 					Endpoint:  localhostgate.EndpointForPort(grpcPort),
 					Transport: "tcp",
 				},

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -53,7 +53,7 @@ func TestCreateSameReceiver(t *testing.T) {
 func TestCreateTracesReceiver(t *testing.T) {
 	factory := NewFactory()
 	defaultGRPCSettings := &configgrpc.ServerConfig{
-		NetAddr: confignet.NetAddr{
+		NetAddr: confignet.AddrConfig{
 			Endpoint:  testutil.GetAvailableLocalAddress(t),
 			Transport: "tcp",
 		},
@@ -89,7 +89,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 			cfg: &Config{
 				Protocols: Protocols{
 					GRPC: &configgrpc.ServerConfig{
-						NetAddr: confignet.NetAddr{
+						NetAddr: confignet.AddrConfig{
 							Endpoint:  "localhost:112233",
 							Transport: "tcp",
 						},
@@ -162,7 +162,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 func TestCreateMetricReceiver(t *testing.T) {
 	factory := NewFactory()
 	defaultGRPCSettings := &configgrpc.ServerConfig{
-		NetAddr: confignet.NetAddr{
+		NetAddr: confignet.AddrConfig{
 			Endpoint:  testutil.GetAvailableLocalAddress(t),
 			Transport: "tcp",
 		},
@@ -198,7 +198,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 			cfg: &Config{
 				Protocols: Protocols{
 					GRPC: &configgrpc.ServerConfig{
-						NetAddr: confignet.NetAddr{
+						NetAddr: confignet.AddrConfig{
 							Endpoint:  "327.0.0.1:1122",
 							Transport: "tcp",
 						},
@@ -271,7 +271,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 func TestCreateLogReceiver(t *testing.T) {
 	factory := NewFactory()
 	defaultGRPCSettings := &configgrpc.ServerConfig{
-		NetAddr: confignet.NetAddr{
+		NetAddr: confignet.AddrConfig{
 			Endpoint:  testutil.GetAvailableLocalAddress(t),
 			Transport: "tcp",
 		},
@@ -307,7 +307,7 @@ func TestCreateLogReceiver(t *testing.T) {
 			cfg: &Config{
 				Protocols: Protocols{
 					GRPC: &configgrpc.ServerConfig{
-						NetAddr: confignet.NetAddr{
+						NetAddr: confignet.AddrConfig{
 							Endpoint:  "327.0.0.1:1122",
 							Transport: "tcp",
 						},

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -634,7 +634,7 @@ func TestGRPCInvalidTLSCredentials(t *testing.T) {
 	cfg := &Config{
 		Protocols: Protocols{
 			GRPC: &configgrpc.ServerConfig{
-				NetAddr: confignet.NetAddr{
+				NetAddr: confignet.AddrConfig{
 					Endpoint:  testutil.GetAvailableLocalAddress(t),
 					Transport: "tcp",
 				},

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -275,7 +275,7 @@ func testCollectorStartHelper(t *testing.T, tc ownMetricsTestCase) {
 	set := newNopSettings()
 	set.BuildInfo = component.BuildInfo{Version: "test version", Command: otelCommand}
 	set.Extensions = extension.NewBuilder(
-		map[component.ID]component.Config{component.MustNewID("zpages"): &zpagesextension.Config{TCPAddr: confignet.TCPAddr{Endpoint: zpagesAddr}}},
+		map[component.ID]component.Config{component.MustNewID("zpages"): &zpagesextension.Config{TCPAddr: confignet.TCPConfig{Endpoint: zpagesAddr}}},
 		map[component.Type]extension.Factory{component.MustNewType("zpages"): zpagesextension.NewFactory()})
 	set.LoggingOptions = []zap.Option{zap.Hooks(hook)}
 


### PR DESCRIPTION
This commit renames the following structs:

* `NetAddr` to `AddrConfig`
* `TCPAddr` to `TCPConfig`

Fixes #9509