### PR TITLE
[chore] [scrapererror] Remove nil check from IsPartialScrapeError

### DIFF
--- a/receiver/scrapererror/partialscrapeerror.go
+++ b/receiver/scrapererror/partialscrapeerror.go
@@ -23,10 +23,6 @@ func NewPartialScrapeError(err error, failed int) PartialScrapeError {
 
 // IsPartialScrapeError checks if an error was wrapped with PartialScrapeError.
 func IsPartialScrapeError(err error) bool {
-	if err == nil {
-		return false
-	}
-
 	var partialScrapeErr PartialScrapeError
 	return errors.As(err, &partialScrapeErr)
 }


### PR DESCRIPTION
Remove the nil check from `IsPartialScrapeError` as redundant, `errors.As` has the same condition
