### PR TITLE
[config/configgrpc] [chore] Remove usage of deprecated ToListenerContext

### DIFF
--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -489,7 +489,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 
 func TestGRPCServerSettings_ToListener_Error(t *testing.T) {
 	settings := ServerConfig{
-		NetAddr: confignet.AddrConfig{
+		NetAddr: confignet.NetAddr{
 			Endpoint:  "127.0.0.1:1234567",
 			Transport: "tcp",
 		},
@@ -622,7 +622,7 @@ func TestHttpReception(t *testing.T) {
 				},
 				TLSSetting: test.tlsServerCreds,
 			}
-			ln, err := gss.ToListenerContext(context.Background())
+			ln, err := gss.NetAddr.Listen(context.Background())
 			assert.NoError(t, err)
 			s, err := gss.ToServer(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
@@ -669,7 +669,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 			Transport: "unix",
 		},
 	}
-	ln, err := gss.ToListenerContext(context.Background())
+	ln, err := gss.NetAddr.Listen(context.Background())
 	assert.NoError(t, err)
 	srv, err := gss.ToServer(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	assert.NoError(t, err)
@@ -871,7 +871,7 @@ func TestClientInfoInterceptors(t *testing.T) {
 
 				defer srv.Stop()
 
-				l, err = gss.ToListenerContext(context.Background())
+				l, err = gss.NetAddr.Listen(context.Background())
 				require.NoError(t, err)
 
 				go func() {

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -101,7 +101,7 @@ func (r *otlpReceiver) startGRPCServer(host component.Host) error {
 
 	r.settings.Logger.Info("Starting GRPC server", zap.String("endpoint", r.cfg.GRPC.NetAddr.Endpoint))
 	var gln net.Listener
-	if gln, err = r.cfg.GRPC.ToListenerContext(context.Background()); err != nil {
+	if gln, err = r.cfg.GRPC.NetAddr.Listen(context.Background()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Not sure why the linter doesn't catch it