### PR TITLE
[confighttp] Remove deprecated items

### DIFF
--- a/.chloggen/confighttp-remove-deprecated-items.yaml
+++ b/.chloggen/confighttp-remove-deprecated-items.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `HTTPClientSettings`, `NewDefaultHTTPClientSettings`, and `CORSSettings`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9625]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -29,10 +29,6 @@ import (
 
 const headerContentEncoding = "Content-Encoding"
 
-// HTTPClientSettings defines settings for creating an HTTP client.
-// Deprecated: [v0.94.0] Use ClientConfig instead
-type HTTPClientSettings = ClientConfig
-
 // ClientConfig defines settings for creating an HTTP client.
 type ClientConfig struct {
 	// The target URL to send data to (e.g.: http://some.url:9411/v1/traces).
@@ -101,15 +97,6 @@ type ClientConfig struct {
 	// HTTP2PingTimeout if there's no response to the ping within the configured value, the connection will be closed.
 	// If not set or set to 0, it defaults to 15s.
 	HTTP2PingTimeout time.Duration `mapstructure:"http2_ping_timeout"`
-}
-
-// NewDefaultHTTPClientSettings returns HTTPClientSettings type object with
-// the default values of 'MaxIdleConns' and 'IdleConnTimeout'.
-// Other config options are not added as they are initialized with 'zero value' by GoLang as default.
-// We encourage to use this function to create an object of HTTPClientSettings.
-// Deprecated: [v0.94.0] Use NewDefaultClientConfig instead
-func NewDefaultHTTPClientSettings() ClientConfig {
-	return NewDefaultClientConfig()
 }
 
 // NewDefaultClientConfig returns ClientConfig type object with
@@ -263,10 +250,6 @@ func (interceptor *headerRoundTripper) RoundTrip(req *http.Request) (*http.Respo
 	return interceptor.transport.RoundTrip(req)
 }
 
-// HTTPServerSettings defines settings for creating an HTTP server.
-// Deprecated: [v0.94.0] Use ServerConfig instead
-type HTTPServerSettings = ServerConfig
-
 // ServerConfig defines settings for creating an HTTP server.
 type ServerConfig struct {
 	// Endpoint configures the listening address for the server.
@@ -418,11 +401,6 @@ func responseHeadersHandler(handler http.Handler, headers map[string]configopaqu
 		handler.ServeHTTP(w, r)
 	})
 }
-
-// CORSSettings configures a receiver for HTTP cross-origin resource sharing (CORS).
-// See the underlying https://github.com/rs/cors package for details.
-// Deprecated: [v0.94.0] Use CORSConfig instead
-type CORSSettings = CORSConfig
 
 // CORSConfig configures a receiver for HTTP cross-origin resource sharing (CORS).
 // See the underlying https://github.com/rs/cors package for details.

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -1087,7 +1087,7 @@ func TestHttpClientHostHeader(t *testing.T) {
 		}))
 		defer server.Close()
 		serverURL, _ := url.Parse(server.URL)
-		setting := HTTPClientSettings{
+		setting := ClientConfig{
 			Endpoint:        serverURL.String(),
 			TLSSetting:      configtls.TLSClientSetting{},
 			ReadBufferSize:  0,

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -1008,7 +1008,7 @@ func verifyHeadersResp(t *testing.T, url string, expected map[string]configopaqu
 	}
 }
 
-func ExampleHTTPServerSettings() {
+func ExampleServerConfig() {
 	settings := ServerConfig{
 		Endpoint: "localhost:443",
 	}


### PR DESCRIPTION
**Description:** 
Removes deprecated items from `confighttp` 

**Link to tracking Issue:** <Issue number if applicable>
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/6767