### PR TITLE
add openssf badge to read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
   <a href="https://github.com/open-telemetry/opentelemetry-collector/releases">
     <img alt="GitHub release (latest by date including pre-releases)" src="https://img.shields.io/github/v/release/open-telemetry/opentelemetry-collector?include_prereleases&style=for-the-badge">
   </a>
+  <a href="https://www.bestpractices.dev/projects/8404"><img src="https://www.bestpractices.dev/projects/8404/badge">
+  </a> 
 </p>
 
 <p align="center">


### PR DESCRIPTION
The OpenSSF badge is a required part of CNCF project graduation. The self reporting has been completed already and this is to demonstrate publicly we have done the required step. 

Relevant issue: https://github.com/open-telemetry/community/issues/1942