### PR TITLE
[otlp exporter] Validate exporter endpoint has port

### DIFF
--- a/.chloggen/validate-otlpexporter-port.yaml
+++ b/.chloggen/validate-otlpexporter-port.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Checks for port in the config validation for the otlpexporter
+
+# One or more tracking issues or pull requests related to the change
+issues: [9505]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -5,6 +5,9 @@ package otlpexporter // import "go.opentelemetry.io/collector/exporter/otlpexpor
 
 import (
 	"errors"
+	"fmt"
+	"net"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/collector/component"
@@ -23,9 +26,20 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-	if c.sanitizedEndpoint() == "" {
+	endpoint := c.sanitizedEndpoint()
+	if endpoint == "" {
 		return errors.New(`requires a non-empty "endpoint"`)
 	}
+
+	// Validate that the port is in the address
+	_, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return err
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return fmt.Errorf(`invalid port "%s"`, port)
+	}
+
 	return nil
 }
 

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -111,6 +111,14 @@ func TestUnmarshalInvalidConfig(t *testing.T) {
 			name:     "invalid_tls",
 			errorMsg: `invalid TLS min_version: unsupported TLS version: "asd"`,
 		},
+		{
+			name:     "missing_port",
+			errorMsg: `missing port in address`,
+		},
+		{
+			name:     "invalid_port",
+			errorMsg: `invalid port "port"`,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := factory.CreateDefaultConfig()

--- a/exporter/otlpexporter/testdata/invalid_configs.yaml
+++ b/exporter/otlpexporter/testdata/invalid_configs.yaml
@@ -71,3 +71,33 @@ invalid_tls:
     multiplier: 1.3
     max_interval: 60s
     max_elapsed_time: 10m
+missing_port:
+  endpoint: example.com
+  timeout: 10s
+  sending_queue:
+    enabled: true
+    num_consumers: 2
+    queue_size: 10
+  retry_on_failure:
+    enabled: true
+    initial_interval: 10s
+    randomization_factor: 0.7
+    multiplier: 1.3
+    max_interval: 60s
+    max_elapsed_time: 10m
+invalid_port:
+  endpoint: example.com:port
+  timeout: 10s
+  sending_queue:
+    enabled: true
+    num_consumers: 2
+    queue_size: 10
+  retry_on_failure:
+    enabled: true
+    initial_interval: 10s
+    randomization_factor: 0.7
+    multiplier: 1.3
+    max_interval: 60s
+    max_elapsed_time: 10m
+  
+


### PR DESCRIPTION
**Description:** This PR updates the otlp exporter config validation to ensure that the "endpoint" specified for the exporter includes a port. The goal of this is to fail fast if the configuration is invalid instead of waiting for an error to arise. The PR adds a function to the ClientConfig defined in configgrpc that parses the port defined in the endpoint. The otlp exporter uses this port parsing to validate that 

**Link to tracking Issue:** [Issue 9505](https://github.com/open-telemetry/opentelemetry-collector/issues/9505)

**Testing:** 

configgrpc:
- Add unit tests to validate ports are correctly parsed in configrpc and that an error is returned if the port is omitted

otlpexporter:
- Add unit test for conifg validation function to ensure that the validation fails for missing endpoint or missing port and that a well-formed endpoint does not fail
