### PR TITLE
[chore] Add rules for `NewDefault*` pattern

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,6 +278,11 @@ and should be followed.
 
 Within the project, there are some packages that are yet to follow the recommendations and are being address, however, any new code should adhere to the recommendations.
 
+### Default Configuration
+
+To guarantee backwards compatible behavior, all configuration packages should supply a `NewDefault[config name]` functions that create a default version of the config. The package does not need to guarantee that `NewDefault[config name]` returns a usable configuration, only that default values will be set. For example, if the configuration requires that a field, such as `Endpoint` be set, but there is no valid default value, then `NewDefault[config name]` may set that value to `""` with the expectation that the user will set a valid value.
+
+Users should always initialize the config struct with this function and overwrite anything as needed.
 
 ### Startup Error Handling
 


### PR DESCRIPTION
**Description:** 
Adds new rules for configuration packages and a `NewDefault*` function to enable backwards-compatible use of the configuration.

**Link to tracking Issue:** 
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9508