### PR TITLE
[configretry] Allow max_elapsed_time to be set to 0

### DIFF
--- a/.chloggen/configretry-validation-fix.yaml
+++ b/.chloggen/configretry-validation-fix.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configretry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow max_elapsed_time to be set to 0 for indefinite retries
+
+# One or more tracking issues or pull requests related to the change
+issues: [9641]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configretry/backoff.go
+++ b/config/configretry/backoff.go
@@ -61,11 +61,14 @@ func (bs *BackOffConfig) Validate() error {
 	if bs.MaxElapsedTime < 0 {
 		return errors.New("'max_elapsed_time' must be non-negative")
 	}
-	if bs.MaxElapsedTime < bs.InitialInterval {
-		return errors.New("'max_elapsed_time' must not be less than 'initial_interval'")
-	}
-	if bs.MaxElapsedTime < bs.MaxInterval {
-		return errors.New("'max_elapsed_time' must not be less than 'max_interval'")
+	if bs.MaxElapsedTime > 0 {
+		if bs.MaxElapsedTime < bs.InitialInterval {
+			return errors.New("'max_elapsed_time' must not be less than 'initial_interval'")
+		}
+		if bs.MaxElapsedTime < bs.MaxInterval {
+			return errors.New("'max_elapsed_time' must not be less than 'max_interval'")
+		}
+
 	}
 	return nil
 }

--- a/config/configretry/backoff_test.go
+++ b/config/configretry/backoff_test.go
@@ -67,10 +67,16 @@ func TestInvalidMaxElapsedTime(t *testing.T) {
 	cfg.MaxElapsedTime = -1
 	assert.Error(t, cfg.Validate())
 	cfg.MaxElapsedTime = 60
+	// MaxElapsedTime is 60, InitialInterval is 5s, so it should be invalid
 	assert.Error(t, cfg.Validate())
 	cfg.InitialInterval = 0
+	// MaxElapsedTime is 60, MaxInterval is 30s, so it should be invalid
 	assert.Error(t, cfg.Validate())
 	cfg.MaxInterval = 0
+	assert.NoError(t, cfg.Validate())
+	cfg.InitialInterval = 50
+	// MaxElapsedTime is 0, so it should be valid
+	cfg.MaxElapsedTime = 0
 	assert.NoError(t, cfg.Validate())
 }
 

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -12,7 +12,7 @@ The following configuration options can be modified:
   - `enabled` (default = true)
   - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`
   - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
-  - `max_elapsed_time` (default = 300s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`
+  - `max_elapsed_time` (default = 300s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`. If set to 0, the retries are never stopped.
 - `sending_queue`
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`


### PR DESCRIPTION

**Description:** <Describe what has changed.>
[configretry] Allow max_elapsed_time to be set to 0

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/9641

