### PR TITLE
use generated meter

### DIFF
--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -10,14 +10,12 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/multierr"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/batchprocessor/internal/metadata"
 	"go.opentelemetry.io/collector/processor/processorhelper"
-)
-
-const (
-	scopeName = "go.opentelemetry.io/collector/processor/batchprocessor"
 )
 
 type trigger int
@@ -50,16 +48,16 @@ func newBatchProcessorTelemetry(set processor.CreateSettings, currentMetadataCar
 		detailed:      set.MetricsLevel == configtelemetry.LevelDetailed,
 	}
 
-	if err := bpt.createOtelMetrics(set.MeterProvider, currentMetadataCardinality); err != nil {
+	if err := bpt.createOtelMetrics(set.TelemetrySettings, currentMetadataCardinality); err != nil {
 		return nil, err
 	}
 
 	return bpt, nil
 }
 
-func (bpt *batchProcessorTelemetry) createOtelMetrics(mp metric.MeterProvider, currentMetadataCardinality func() int) error {
+func (bpt *batchProcessorTelemetry) createOtelMetrics(set component.TelemetrySettings, currentMetadataCardinality func() int) error {
 	var errors, err error
-	meter := mp.Meter(scopeName)
+	meter := metadata.Meter(set)
 
 	bpt.batchSizeTriggerSend, err = meter.Int64Counter(
 		processorhelper.BuildCustomMetricName(typeStr, "batch_size_trigger_send"),


### PR DESCRIPTION
This follows #9556 and uses the Meter func instead of managing the scope in the batch processor manually. Replaces #9581
