### PR TITLE
(configgrpc): configure memorylimiterextension when setting up grpc servers

### DIFF
--- a/.chloggen/configgrpc-configure-memory-limiter-extension.yaml
+++ b/.chloggen/configgrpc-configure-memory-limiter-extension.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds option to configure a memory limiter extension within grpc servers.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9591]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configgrpc/README.md
+++ b/config/configgrpc/README.md
@@ -27,6 +27,7 @@ README](../configtls/README.md).
 - [`read_buffer_size`](https://godoc.org/google.golang.org/grpc#ReadBufferSize)
 - [`write_buffer_size`](https://godoc.org/google.golang.org/grpc#WriteBufferSize)
 - [`auth`](../configauth/README.md)
+- [`memory_limiter`](../../extension/memorylimiterextension/README.md) rejects incoming requests once the memory utilization grows above configured limits.
 
 Please note that [`per_rpc_auth`](https://pkg.go.dev/google.golang.org/grpc#PerRPCCredentials) which allows the credentials to send for every RPC is now moved to become an [extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/bearertokenauthextension). Note that this feature isn't about sending the headers only during the initial connection as an `authorization` header under the `headers` would do: this is sent for every RPC performed during an established connection.
 

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	errMetadataNotFound = errors.New("no request metadata found")
+	errMetadataNotFound   = errors.New("no request metadata found")
 	errMemoryLimitReached = status.Error(codes.ResourceExhausted, "Memory limit has been reached, too many requests.")
 )
 
@@ -418,7 +418,6 @@ func memoryLimiterStreamServerInterceptor(srv any, stream grpc.ServerStream, _ *
 
 	return handler(srv, wrapServerStream(ctx, stream))
 }
-
 
 func getMemoryLimiterExtension(extID *component.ID, extensions map[component.ID]component.Component) (memoryLimiterExtension, error) {
 	if ext, found := extensions[*extID]; found {

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -284,7 +284,9 @@ func TestGrpcServerMemoryLimiterSettings(t *testing.T) {
 		name     string
 		refused  bool
 		componentID component.ID
+		// getExtErr refers to whether the requested memory limiter extension was successfully found.
 		getExtErr error
+		// interceptErr refers to whether memorylimiterextension allowed the request.
 		interceptErr error
 	}{
 		{
@@ -302,14 +304,14 @@ func TestGrpcServerMemoryLimiterSettings(t *testing.T) {
 			interceptErr: errMemoryLimitReached,
 		},
 		{
-			name: "memory limiter refused, bad ID",
+			name: "not a memory limiter extension",
 			refused: true,
 			componentID: badID,
 			getExtErr: notMLExtensionErr,
 			interceptErr: nil,
 		},
 		{
-			name: "memory limiter refused, missing ID",
+			name: "memory limiter extension not found",
 			refused: true,
 			componentID: missingID,
 			getExtErr: missingMLExtensionErr,

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/config/configopaque v1.3.0
 	go.opentelemetry.io/collector/config/configtls v0.96.0
 	go.opentelemetry.io/collector/config/internal v0.96.0
+	go.opentelemetry.io/collector/extension v0.96.0
 	go.opentelemetry.io/collector/extension/auth v0.96.0
 	go.opentelemetry.io/collector/pdata v1.3.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0
@@ -51,7 +52,6 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.0 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.0 // indirect
-	go.opentelemetry.io/collector/extension v0.96.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect


### PR DESCRIPTION
**Description:**

This PR adds a new configgrpc option to configure a memory limiter extension to use. This allows users to leverage the new [memorylimiterextension](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/memorylimiterextension) within receivers that set up a gRPC server.

**Link to tracking Issue:**

This is part of https://github.com/open-telemetry/opentelemetry-collector/issues/9591 and relates to https://github.com/open-telemetry/opentelemetry-collector/issues/8632

**Testing:**

Added new unit tests that cover the added code.

