### PR TITLE
[chore] Fix prepare-release.yml

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -51,7 +51,7 @@ jobs:
   # Releasing opentelemetry-collector
   prepare-release:
     needs: 
-      - validate-version
+      - validate-versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
**Description:** 

Fixes https://github.com/open-telemetry/opentelemetry-collector/actions/runs/8139621131/workflow

```
The workflow is not valid. .github/workflows/prepare-release.yml (Line: 54, Col: 9): 
Job 'prepare-release' depends on unknown job 'validate-version'.
```

#9409 introduced some errors because the workflow is not tested on PRs, #9668 partly fixed them and I mistakenly believed Github would notify me of further errors in the workflow, the same way it did with this one, but it did not.
