### PR TITLE
[chore] Update prepare release examples

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -6,18 +6,18 @@ on:
     # the minor version number and set the patch number to 0.
     inputs:
       candidate-stable:
-        description: Release candidate version (stable, like 1.0.0-rcv0014). Don't include a leading `v`.
+        description: Release candidate version (stable, like 1.3.0). Don't include a leading `v`.
 
       current-stable:
         required: true
-        description: Current version (stable, like 1.0.0-rcv0014). Don't include a leading `v`.
+        description: Current version (stable, like 1.2.0). Don't include a leading `v`.
 
       candidate-beta:
-        description: Release candidate version (beta, like 0.70.0). Don't include `v`.
+        description: Release candidate version (beta, like 0.96.0). Don't include `v`.
 
       current-beta:
         required: true
-        description: Current version (beta, like 0.69.1). Don't include `v`.
+        description: Current version (beta, like 0.95.1). Don't include `v`.
 jobs:
   #validate-version format
   validate-versions:


### PR DESCRIPTION
**Description:** 

After #8975 we decided to not do any more explicit release candidates so we can update the examples.

Note that due to #9676 this is not tested until we explicitly run the workflow on the next release, but the change is small enough to seem safe to merge.
