### PR TITLE
[chore] Update release schedule

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -155,12 +155,12 @@ Once a module is ready to be released under the `1.x` version scheme, file a PR 
 
 ## Release schedule
 
-| Date       | Version | Release manager |
-|------------|---------|-----------------|
-| 2024-02-19 | v0.95.0 | @jpkrohling     |
-| 2024-03-04 | v0.96.0 | @mx-psi         |
-| 2024-03-18 | v0.97.0 | @djaglowski     |
-| 2024-04-01 | v0.98.0 | @dmitryax       |
-| 2024-04-15 | v0.99.0 | @codeboten      |
-| 2024-04-29 | v0.100.0 | @bogdandrutu    |
-| 2024-05-13 | v0.101.0 | @Aneurysm9      |
+| Date       | Version  | Release manager |
+|------------|----------|-----------------|
+| 2024-03-25 | v0.97.0  | @djaglowski     |
+| 2024-04-08 | v0.98.0  | @dmitryax       |
+| 2024-04-22 | v0.99.0  | @codeboten      |
+| 2024-05-06 | v0.100.0 | @bogdandrutu    |
+| 2024-05-20 | v0.101.0 | @Aneurysm9      |
+| 2024-06-03 | v0.102.0 | @jpkrohling     |
+| 2024-06-17 | v0.103.0 | @mx-psi         |


### PR DESCRIPTION
**Description:** 

Updates release schedule. The March 18th release overlaps with KubeCon EU, so I am shifting everything by one week starting with that release. This means the next release cycle will have three weeks.
