### PR TITLE
[chore] fix type in confighttp readme

### DIFF
--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -39,7 +39,7 @@ Example:
 
 ```yaml
 exporter:
-  otlp:
+  otlphttp:
     endpoint: otelcol2:55690
     auth:
       authenticator: some-authenticator-extension


### PR DESCRIPTION
This doc incorrectly uses the otlp exporter as an example of using confighttp. That exporter doesn't use confighttp
