### PR TITLE
[chore] [cmd/mdatagen] Update status.go template

### DIFF
--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_status.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("sample")
-	scopeName = "go.opentelemetry.io/collector/internal/receiver/samplereceiver"
+	Type = component.MustNewType("sample")
 )
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/internal/receiver/samplereceiver")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/internal/receiver/samplereceiver")
 }

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -390,8 +390,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("foo")
-	scopeName = ""
+	Type = component.MustNewType("foo")
 )
 
 const (
@@ -399,11 +398,11 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("")
 }
 `,
 		},
@@ -430,8 +429,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("foo")
-	scopeName = ""
+	Type = component.MustNewType("foo")
 )
 
 const (
@@ -439,11 +437,11 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("")
 }
 `,
 		},

--- a/cmd/mdatagen/templates/status.go.tmpl
+++ b/cmd/mdatagen/templates/status.go.tmpl
@@ -10,7 +10,6 @@ import (
 
 var (
 	Type = component.MustNewType("{{ .Type }}")
-	scopeName = "{{ .ScopeName }}"
 )
 
 const (
@@ -22,9 +21,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("{{ .ScopeName }}")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("{{ .ScopeName }}")
 }

--- a/connector/forwardconnector/internal/metadata/generated_status.go
+++ b/connector/forwardconnector/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("forward")
-	scopeName = "go.opentelemetry.io/collector/connector/forwardconnector"
+	Type = component.MustNewType("forward")
 )
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/connector/forwardconnector")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/connector/forwardconnector")
 }

--- a/exporter/debugexporter/internal/metadata/generated_status.go
+++ b/exporter/debugexporter/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("debug")
-	scopeName = "go.opentelemetry.io/collector/exporter/debugexporter"
+	Type = component.MustNewType("debug")
 )
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/exporter/debugexporter")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/exporter/debugexporter")
 }

--- a/exporter/loggingexporter/internal/metadata/generated_status.go
+++ b/exporter/loggingexporter/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("logging")
-	scopeName = "go.opentelemetry.io/collector/exporter/loggingexporter"
+	Type = component.MustNewType("logging")
 )
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/exporter/loggingexporter")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/exporter/loggingexporter")
 }

--- a/exporter/otlpexporter/internal/metadata/generated_status.go
+++ b/exporter/otlpexporter/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("otlp")
-	scopeName = "go.opentelemetry.io/collector/exporter/otlpexporter"
+	Type = component.MustNewType("otlp")
 )
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/exporter/otlpexporter")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/exporter/otlpexporter")
 }

--- a/exporter/otlphttpexporter/internal/metadata/generated_status.go
+++ b/exporter/otlphttpexporter/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("otlphttp")
-	scopeName = "go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	Type = component.MustNewType("otlphttp")
 )
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/exporter/otlphttpexporter")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/exporter/otlphttpexporter")
 }

--- a/extension/ballastextension/internal/metadata/generated_status.go
+++ b/extension/ballastextension/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("memory_ballast")
-	scopeName = "go.opentelemetry.io/collector/extension/ballastextension"
+	Type = component.MustNewType("memory_ballast")
 )
 
 const (
@@ -19,9 +18,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/extension/ballastextension")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/extension/ballastextension")
 }

--- a/extension/memorylimiterextension/internal/metadata/generated_status.go
+++ b/extension/memorylimiterextension/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("memory_limiter")
-	scopeName = "go.opentelemetry.io/collector/extension/memorylimiterextension"
+	Type = component.MustNewType("memory_limiter")
 )
 
 const (
@@ -19,9 +18,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/extension/memorylimiterextension")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/extension/memorylimiterextension")
 }

--- a/extension/zpagesextension/internal/metadata/generated_status.go
+++ b/extension/zpagesextension/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("zpages")
-	scopeName = "go.opentelemetry.io/collector/extension/zpagesextension"
+	Type = component.MustNewType("zpages")
 )
 
 const (
@@ -19,9 +18,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/extension/zpagesextension")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/extension/zpagesextension")
 }

--- a/processor/batchprocessor/internal/metadata/generated_status.go
+++ b/processor/batchprocessor/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("batch")
-	scopeName = "go.opentelemetry.io/collector/processor/batchprocessor"
+	Type = component.MustNewType("batch")
 )
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/processor/batchprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/processor/batchprocessor")
 }

--- a/processor/memorylimiterprocessor/internal/metadata/generated_status.go
+++ b/processor/memorylimiterprocessor/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("memory_limiter")
-	scopeName = "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
+	Type = component.MustNewType("memory_limiter")
 )
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/processor/memorylimiterprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/processor/memorylimiterprocessor")
 }

--- a/receiver/otlpreceiver/internal/metadata/generated_status.go
+++ b/receiver/otlpreceiver/internal/metadata/generated_status.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("otlp")
-	scopeName = "go.opentelemetry.io/collector/receiver/otlpreceiver"
+	Type = component.MustNewType("otlp")
 )
 
 const (
@@ -21,9 +20,9 @@ const (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(scopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/receiver/otlpreceiver")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(scopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/receiver/otlpreceiver")
 }


### PR DESCRIPTION
To produce the same output as mdatagen in contrib. It makes it easy to compare the diff for the mdatagen migration.
