### PR TITLE
[chore] Fix an incorrect automatic replace made by a bot in `otel-config.yml`

### DIFF
--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -195,7 +195,7 @@ spec:
         ports:
         - containerPort: 55679 # Default endpoint for ZPages.
         - containerPort: 4317 # Default endpoint for OpenTelemetry receiver.
-        - containerPort: 1.3.0 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
         - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
         - containerPort: 9411 # Default endpoint for Zipkin receiver.
         - containerPort: 8888  # Default endpoint for querying metrics.


### PR DESCRIPTION
This PR fixes an incorrect automatic replace made in the `otel-config.yml` file in this [pull request](https://github.com/open-telemetry/opentelemetry-collector/pull/9680/files#diff-c7c8156618a7f8126b25ca1bdfde3e172a0d2cb75c533d63a71617ae2a5c54ae) by a bot. I've taken the previous value which seems right. 

