### PR TITLE
[chore] Remove `telemetry.useOtelForInternalMetrics` stable feature gate

### DIFF
--- a/.chloggen/remove_stable_featuregate.yaml
+++ b/.chloggen/remove_stable_featuregate.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: telemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove telemetry.useOtelForInternalMetrics stable feature gate
+
+# One or more tracking issues or pull requests related to the change
+issues: [9752]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -7,14 +7,6 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 )
 
-// UseOtelForInternalMetricsfeatureGate is the feature gate that controls whether the collector uses open
-// telemetrySettings for internal metrics.
-var UseOtelForInternalMetricsfeatureGate = featuregate.GlobalRegistry().MustRegister(
-	"telemetry.useOtelForInternalMetrics",
-	featuregate.StageStable,
-	featuregate.WithRegisterDescription("controls whether the collector uses OpenTelemetry for internal metrics"),
-	featuregate.WithRegisterToVersion("0.95.0"))
-
 // DisableHighCardinalityMetricsfeatureGate is the feature gate that controls whether the collector should enable
 // potentially high cardinality metrics. The gate will be removed when the collector allows for view configuration.
 var DisableHighCardinalityMetricsfeatureGate = featuregate.GlobalRegistry().MustRegister(


### PR DESCRIPTION
**Description:**
Remove the stable feature gate `telemetry.useOtelForInternalMetrics`. It was declared stable in 0.95.0.