### PR TITLE
update all metrics to include otelcol_ prefix

### DIFF
--- a/.chloggen/codeboten_update-all-metrics-with-prefix.yaml
+++ b/.chloggen/codeboten_update-all-metrics-with-prefix.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update all metrics to include `otelcol_` prefix to ensure consistency across OTLP and Prometheus metrics"
+
+# One or more tracking issues or pull requests related to the change
+issues: [9759]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change is marked as a breaking change as anyone that was using OTLP for metrics will
+  see the new prefix which was not present before. Prometheus generated metrics remain
+  unchanged.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/samplereceiver/documentation.md
+++ b/cmd/mdatagen/internal/samplereceiver/documentation.md
@@ -117,7 +117,7 @@ metrics:
 
 The following telemetry is emitted by this component.
 
-### batch_size_trigger_send
+### otelcol_batch_size_trigger_send
 
 Number of times the batch was sent due to a size trigger
 
@@ -125,7 +125,7 @@ Number of times the batch was sent due to a size trigger
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### process_runtime_total_alloc_bytes
+### otelcol_process_runtime_total_alloc_bytes
 
 Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
 
@@ -133,7 +133,7 @@ Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalA
 | ---- | ----------- | ---------- | --------- |
 | By | Sum | Int | true |
 
-### queue_length
+### otelcol_queue_length
 
 This metric is optional and therefore not initialized in NewTelemetryBuilder.
 
@@ -143,7 +143,7 @@ For example this metric only exists if feature A is enabled.
 | ---- | ----------- | ---------- |
 | 1 | Gauge | Int |
 
-### request_duration
+### otelcol_request_duration
 
 Duration of request
 

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -64,7 +64,7 @@ func WithProcessRuntimeTotalAllocBytesCallback(cb func() int64) telemetryBuilder
 func (builder *TelemetryBuilder) InitQueueLength(cb func() int64) error {
 	var err error
 	builder.QueueLength, err = builder.meter.Int64ObservableGauge(
-		"queue_length",
+		"otelcol_queue_length",
 		metric.WithDescription("This metric is optional and therefore not initialized in NewTelemetryBuilder."),
 		metric.WithUnit("1"),
 	)
@@ -92,13 +92,13 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		builder.meter = noop.Meter{}
 	}
 	builder.BatchSizeTriggerSend, err = builder.meter.Int64Counter(
-		"batch_size_trigger_send",
+		"otelcol_batch_size_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a size trigger"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeTotalAllocBytes, err = builder.meter.Int64ObservableCounter(
-		"process_runtime_total_alloc_bytes",
+		"otelcol_process_runtime_total_alloc_bytes",
 		metric.WithDescription("Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')"),
 		metric.WithUnit("By"),
 	)
@@ -109,7 +109,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	}, builder.ProcessRuntimeTotalAllocBytes)
 	errs = errors.Join(errs, err)
 	builder.RequestDuration, err = builder.meter.Float64Histogram(
-		"request_duration",
+		"otelcol_request_duration",
 		metric.WithDescription("Duration of request"),
 		metric.WithUnit("s"), metric.WithExplicitBucketBoundaries([]float64{1, 10, 100}...),
 	)

--- a/cmd/mdatagen/internal/samplereceiver/metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/metrics_test.go
@@ -30,7 +30,7 @@ func TestComponentTelemetry(t *testing.T) {
 	require.NoError(t, err)
 	tt.assertMetrics(t, []metricdata.Metrics{
 		{
-			Name:        "batch_size_trigger_send",
+			Name:        "otelcol_batch_size_trigger_send",
 			Description: "Number of times the batch was sent due to a size trigger",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -44,7 +44,7 @@ func TestComponentTelemetry(t *testing.T) {
 			},
 		},
 		{
-			Name:        "process_runtime_total_alloc_bytes",
+			Name:        "otelcol_process_runtime_total_alloc_bytes",
 			Description: "Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')",
 			Unit:        "By",
 			Data: metricdata.Sum[int64]{
@@ -63,7 +63,7 @@ func TestComponentTelemetry(t *testing.T) {
 	rcv.initOptionalMetric()
 	tt.assertMetrics(t, []metricdata.Metrics{
 		{
-			Name:        "batch_size_trigger_send",
+			Name:        "otelcol_batch_size_trigger_send",
 			Description: "Number of times the batch was sent due to a size trigger",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -77,7 +77,7 @@ func TestComponentTelemetry(t *testing.T) {
 			},
 		},
 		{
-			Name:        "process_runtime_total_alloc_bytes",
+			Name:        "otelcol_process_runtime_total_alloc_bytes",
 			Description: "Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')",
 			Unit:        "By",
 			Data: metricdata.Sum[int64]{
@@ -91,7 +91,7 @@ func TestComponentTelemetry(t *testing.T) {
 			},
 		},
 		{
-			Name:        "queue_length",
+			Name:        "otelcol_queue_length",
 			Description: "This metric is optional and therefore not initialized in NewTelemetryBuilder.",
 			Unit:        "1",
 			Data: metricdata.Gauge[int64]{

--- a/cmd/mdatagen/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/templates/documentation.md.tmpl
@@ -38,7 +38,7 @@
 {{- $metricName := . }}
 {{- $metric := $metricName | telemetryInfo -}}
 
-### {{ $metricName }}
+### otelcol_{{ $metricName }}
 
 {{ $metric.Description }}
 

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -65,7 +65,7 @@ func WithAttributeSet(set attribute.Set) telemetryBuilderOption {
 func (builder *TelemetryBuilder) Init{{ $name.Render }}({{ if $metric.Data.Async -}}cb func() {{ $metric.Data.BasicType }}{{- end }}) error {
     var err error
     builder.{{ $name.Render }}, err = builder.meter.{{ $metric.Data.Instrument }}(
-        "{{ $name }}",
+        "otelcol_{{ $name }}",
         metric.WithDescription("{{ $metric.Description }}"),
         metric.WithUnit("{{ $metric.Unit }}"),
         {{- if eq $metric.Data.Type "Histogram" -}}
@@ -114,7 +114,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
     {{- range $name, $metric := .Telemetry.Metrics }}
     {{- if not $metric.Optional }}
     builder.{{ $name.Render }}, err = builder.meter.{{ $metric.Data.Instrument }}(
-        "{{ $name }}",
+        "otelcol_{{ $name }}",
         metric.WithDescription("{{ $metric.Description }}"),
         metric.WithUnit("{{ $metric.Unit }}"),
         {{- if eq $metric.Data.Type "Histogram" -}}

--- a/component/componenttest/otelprometheuschecker.go
+++ b/component/componenttest/otelprometheuschecker.go
@@ -117,8 +117,7 @@ func (pc *prometheusChecker) checkExporterMetricGauge(exporter component.ID, met
 }
 
 func (pc *prometheusChecker) checkCounter(expectedMetric string, value int64, attrs []attribute.KeyValue) error {
-
-	ts, err := pc.getMetric(expectedMetric, io_prometheus_client.MetricType_COUNTER, attrs)
+	ts, err := pc.getMetric(fmt.Sprintf("otelcol_%s", expectedMetric), io_prometheus_client.MetricType_COUNTER, attrs)
 	if err != nil {
 		return err
 	}

--- a/component/componenttest/testdata/prometheus_response
+++ b/component/componenttest/testdata/prometheus_response
@@ -1,81 +1,81 @@
-# HELP exporter_send_failed_spans Number of spans in failed attempts to send to destination.
-# TYPE exporter_send_failed_spans counter
-exporter_send_failed_spans{exporter="fakeExporter"} 14
-# HELP exporter_sent_spans Number of spans successfully sent to destination.
-# TYPE exporter_sent_spans counter
-exporter_sent_spans{exporter="fakeExporter"} 43
-# HELP exporter_send_failed_metric_points Number of metrics in failed attempts to send to destination.
-# TYPE exporter_send_failed_metric_points counter
-exporter_send_failed_metric_points{exporter="fakeExporter"} 42
-# HELP exporter_sent_metric_points Number of metrics successfully sent to destination.
-# TYPE exporter_sent_metric_points counter
-exporter_sent_metric_points{exporter="fakeExporter"} 8
-# HELP exporter_send_failed_log_records Number of logs in failed attempts to send to destination.
-# TYPE exporter_send_failed_log_records counter
-exporter_send_failed_log_records{exporter="fakeExporter"} 36
-# HELP exporter_sent_log_records Number of logs successfully sent to destination.
-# TYPE exporter_sent_log_records counter
-exporter_sent_log_records{exporter="fakeExporter"} 103
-# HELP processor_accepted_spans Number of spans successfully pushed into the next component in the pipeline.
-# TYPE processor_accepted_spans counter
-processor_accepted_spans{processor="fakeProcessor"} 42
-# HELP processor_refused_spans Number of spans that were rejected by the next component in the pipeline.
-# TYPE processor_refused_spans counter
-processor_refused_spans{processor="fakeProcessor"} 13
-# HELP processor_dropped_spans Number of spans that were dropped.
-# TYPE processor_dropped_spans counter
-processor_dropped_spans{processor="fakeProcessor"} 7
-# HELP processor_inserted_spans Number of spans that were inserted.
-# TYPE processor_inserted_spans counter
-processor_inserted_spans{processor="fakeProcessor"} 5
-# HELP processor_accepted_metric_points Number of metric points successfully pushed into the next component in the pipeline.
-# TYPE processor_accepted_metric_points counter
-processor_accepted_metric_points{processor="fakeProcessor"} 7
-# HELP processor_refused_metric_points Number of metric points that were rejected by the next component in the pipeline.
-# TYPE processor_refused_metric_points counter
-processor_refused_metric_points{processor="fakeProcessor"} 41
-# HELP processor_dropped_metric_points Number of metric points that were dropped.
-# TYPE processor_dropped_metric_points counter
-processor_dropped_metric_points{processor="fakeProcessor"} 13
-# HELP processor_inserted_metric_points Number of metric points that were inserted.
-# TYPE processor_inserted_metric_points counter
-processor_inserted_metric_points{processor="fakeProcessor"} 4
-# HELP processor_accepted_log_records Number of log records successfully pushed into the next component in the pipeline.
-# TYPE processor_accepted_log_records counter
-processor_accepted_log_records{processor="fakeProcessor"} 102
-# HELP processor_refused_log_records Number of log records that were rejected by the next component in the pipeline.
-# TYPE processor_refused_log_records counter
-processor_refused_log_records{processor="fakeProcessor"} 35
-# HELP processor_dropped_log_records Number of log records that were dropped.
-# TYPE processor_dropped_log_records counter
-processor_dropped_log_records{processor="fakeProcessor"} 14
-# HELP processor_inserted_log_records Number of log records that were inserted.
-# TYPE processor_inserted_log_records counter
-processor_inserted_log_records{processor="fakeProcessor"} 3
-# HELP receiver_accepted_log_records Number of log records successfully pushed into the pipeline.
-# TYPE receiver_accepted_log_records counter
-receiver_accepted_log_records{receiver="fakeReceiver",transport="fakeTransport"} 102
-# HELP receiver_accepted_metric_points Number of metric points successfully pushed into the pipeline.
-# TYPE receiver_accepted_metric_points counter
-receiver_accepted_metric_points{receiver="fakeReceiver",transport="fakeTransport"} 7
-# HELP receiver_accepted_spans Number of spans successfully pushed into the pipeline.
-# TYPE receiver_accepted_spans counter
-receiver_accepted_spans{receiver="fakeReceiver",transport="fakeTransport"} 42
-# HELP receiver_refused_log_records Number of log records that could not be pushed into the pipeline.
-# TYPE receiver_refused_log_records counter
-receiver_refused_log_records{receiver="fakeReceiver",transport="fakeTransport"} 35
-# HELP receiver_refused_metric_points Number of metric points that could not be pushed into the pipeline.
-# TYPE receiver_refused_metric_points counter
-receiver_refused_metric_points{receiver="fakeReceiver",transport="fakeTransport"} 41
-# HELP receiver_refused_spans Number of spans that could not be pushed into the pipeline.
-# TYPE receiver_refused_spans counter
-receiver_refused_spans{receiver="fakeReceiver",transport="fakeTransport"} 13
-# HELP scraper_scraped_metric_points Number of metric points successfully scraped.
-# TYPE scraper_scraped_metric_points counter
-scraper_scraped_metric_points{receiver="fakeReceiver",scraper="fakeScraper"} 7
-# HELP scraper_errored_metric_points Number of metric points that were unable to be scraped.
-# TYPE scraper_errored_metric_points counter
-scraper_errored_metric_points{receiver="fakeReceiver",scraper="fakeScraper"} 41
+# HELP otelcol_exporter_send_failed_spans Number of spans in failed attempts to send to destination.
+# TYPE otelcol_exporter_send_failed_spans counter
+otelcol_exporter_send_failed_spans{exporter="fakeExporter"} 14
+# HELP otelcol_exporter_sent_spans Number of spans successfully sent to destination.
+# TYPE otelcol_exporter_sent_spans counter
+otelcol_exporter_sent_spans{exporter="fakeExporter"} 43
+# HELP otelcol_exporter_send_failed_metric_points Number of metrics in failed attempts to send to destination.
+# TYPE otelcol_exporter_send_failed_metric_points counter
+otelcol_exporter_send_failed_metric_points{exporter="fakeExporter"} 42
+# HELP otelcol_exporter_sent_metric_points Number of metrics successfully sent to destination.
+# TYPE otelcol_exporter_sent_metric_points counter
+otelcol_exporter_sent_metric_points{exporter="fakeExporter"} 8
+# HELP otelcol_exporter_send_failed_log_records Number of logs in failed attempts to send to destination.
+# TYPE otelcol_exporter_send_failed_log_records counter
+otelcol_exporter_send_failed_log_records{exporter="fakeExporter"} 36
+# HELP otelcol_exporter_sent_log_records Number of logs successfully sent to destination.
+# TYPE otelcol_exporter_sent_log_records counter
+otelcol_exporter_sent_log_records{exporter="fakeExporter"} 103
+# HELP otelcol_processor_accepted_spans Number of spans successfully pushed into the next component in the pipeline.
+# TYPE otelcol_processor_accepted_spans counter
+otelcol_processor_accepted_spans{processor="fakeProcessor"} 42
+# HELP otelcol_processor_refused_spans Number of spans that were rejected by the next component in the pipeline.
+# TYPE otelcol_processor_refused_spans counter
+otelcol_processor_refused_spans{processor="fakeProcessor"} 13
+# HELP otelcol_processor_dropped_spans Number of spans that were dropped.
+# TYPE otelcol_processor_dropped_spans counter
+otelcol_processor_dropped_spans{processor="fakeProcessor"} 7
+# HELP otelcol_processor_inserted_spans Number of spans that were inserted.
+# TYPE otelcol_processor_inserted_spans counter
+otelcol_processor_inserted_spans{processor="fakeProcessor"} 5
+# HELP otelcol_processor_accepted_metric_points Number of metric points successfully pushed into the next component in the pipeline.
+# TYPE otelcol_processor_accepted_metric_points counter
+otelcol_processor_accepted_metric_points{processor="fakeProcessor"} 7
+# HELP otelcol_processor_refused_metric_points Number of metric points that were rejected by the next component in the pipeline.
+# TYPE otelcol_processor_refused_metric_points counter
+otelcol_processor_refused_metric_points{processor="fakeProcessor"} 41
+# HELP otelcol_processor_dropped_metric_points Number of metric points that were dropped.
+# TYPE otelcol_processor_dropped_metric_points counter
+otelcol_processor_dropped_metric_points{processor="fakeProcessor"} 13
+# HELP otelcol_processor_inserted_metric_points Number of metric points that were inserted.
+# TYPE otelcol_processor_inserted_metric_points counter
+otelcol_processor_inserted_metric_points{processor="fakeProcessor"} 4
+# HELP otelcol_processor_accepted_log_records Number of log records successfully pushed into the next component in the pipeline.
+# TYPE otelcol_processor_accepted_log_records counter
+otelcol_processor_accepted_log_records{processor="fakeProcessor"} 102
+# HELP otelcol_processor_refused_log_records Number of log records that were rejected by the next component in the pipeline.
+# TYPE otelcol_processor_refused_log_records counter
+otelcol_processor_refused_log_records{processor="fakeProcessor"} 35
+# HELP otelcol_processor_dropped_log_records Number of log records that were dropped.
+# TYPE otelcol_processor_dropped_log_records counter
+otelcol_processor_dropped_log_records{processor="fakeProcessor"} 14
+# HELP otelcol_processor_inserted_log_records Number of log records that were inserted.
+# TYPE otelcol_processor_inserted_log_records counter
+otelcol_processor_inserted_log_records{processor="fakeProcessor"} 3
+# HELP otelcol_receiver_accepted_log_records Number of log records successfully pushed into the pipeline.
+# TYPE otelcol_receiver_accepted_log_records counter
+otelcol_receiver_accepted_log_records{receiver="fakeReceiver",transport="fakeTransport"} 102
+# HELP otelcol_receiver_accepted_metric_points Number of metric points successfully pushed into the pipeline.
+# TYPE otelcol_receiver_accepted_metric_points counter
+otelcol_receiver_accepted_metric_points{receiver="fakeReceiver",transport="fakeTransport"} 7
+# HELP otelcol_receiver_accepted_spans Number of spans successfully pushed into the pipeline.
+# TYPE otelcol_receiver_accepted_spans counter
+otelcol_receiver_accepted_spans{receiver="fakeReceiver",transport="fakeTransport"} 42
+# HELP otelcol_receiver_refused_log_records Number of log records that could not be pushed into the pipeline.
+# TYPE otelcol_receiver_refused_log_records counter
+otelcol_receiver_refused_log_records{receiver="fakeReceiver",transport="fakeTransport"} 35
+# HELP otelcol_receiver_refused_metric_points Number of metric points that could not be pushed into the pipeline.
+# TYPE otelcol_receiver_refused_metric_points counter
+otelcol_receiver_refused_metric_points{receiver="fakeReceiver",transport="fakeTransport"} 41
+# HELP otelcol_receiver_refused_spans Number of spans that could not be pushed into the pipeline.
+# TYPE otelcol_receiver_refused_spans counter
+otelcol_receiver_refused_spans{receiver="fakeReceiver",transport="fakeTransport"} 13
+# HELP otelcol_scraper_scraped_metric_points Number of metric points successfully scraped.
+# TYPE otelcol_scraper_scraped_metric_points counter
+otelcol_scraper_scraped_metric_points{receiver="fakeReceiver",scraper="fakeScraper"} 7
+# HELP otelcol_scraper_errored_metric_points Number of metric points that were unable to be scraped.
+# TYPE otelcol_scraper_errored_metric_points counter
+otelcol_scraper_errored_metric_points{receiver="fakeReceiver",scraper="fakeScraper"} 41
 # HELP gauge_metric A simple gauge metric
 # TYPE gauge_metric gauge
 gauge_metric 49

--- a/exporter/exporterhelper/documentation.md
+++ b/exporter/exporterhelper/documentation.md
@@ -6,7 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### exporter_enqueue_failed_log_records
+### otelcol_exporter_enqueue_failed_log_records
 
 Number of log records failed to be added to the sending queue.
 
@@ -14,7 +14,7 @@ Number of log records failed to be added to the sending queue.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### exporter_enqueue_failed_metric_points
+### otelcol_exporter_enqueue_failed_metric_points
 
 Number of metric points failed to be added to the sending queue.
 
@@ -22,7 +22,7 @@ Number of metric points failed to be added to the sending queue.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### exporter_enqueue_failed_spans
+### otelcol_exporter_enqueue_failed_spans
 
 Number of spans failed to be added to the sending queue.
 
@@ -30,7 +30,7 @@ Number of spans failed to be added to the sending queue.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### exporter_queue_capacity
+### otelcol_exporter_queue_capacity
 
 Fixed capacity of the retry queue (in batches)
 
@@ -38,7 +38,7 @@ Fixed capacity of the retry queue (in batches)
 | ---- | ----------- | ---------- |
 | 1 | Gauge | Int |
 
-### exporter_queue_size
+### otelcol_exporter_queue_size
 
 Current size of the retry queue (in batches)
 
@@ -46,7 +46,7 @@ Current size of the retry queue (in batches)
 | ---- | ----------- | ---------- |
 | 1 | Gauge | Int |
 
-### exporter_send_failed_log_records
+### otelcol_exporter_send_failed_log_records
 
 Number of log records in failed attempts to send to destination.
 
@@ -54,7 +54,7 @@ Number of log records in failed attempts to send to destination.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### exporter_send_failed_metric_points
+### otelcol_exporter_send_failed_metric_points
 
 Number of metric points in failed attempts to send to destination.
 
@@ -62,7 +62,7 @@ Number of metric points in failed attempts to send to destination.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### exporter_send_failed_spans
+### otelcol_exporter_send_failed_spans
 
 Number of spans in failed attempts to send to destination.
 
@@ -70,7 +70,7 @@ Number of spans in failed attempts to send to destination.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### exporter_sent_log_records
+### otelcol_exporter_sent_log_records
 
 Number of log record successfully sent to destination.
 
@@ -78,7 +78,7 @@ Number of log record successfully sent to destination.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### exporter_sent_metric_points
+### otelcol_exporter_sent_metric_points
 
 Number of metric points successfully sent to destination.
 
@@ -86,7 +86,7 @@ Number of metric points successfully sent to destination.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### exporter_sent_spans
+### otelcol_exporter_sent_spans
 
 Number of spans successfully sent to destination.
 

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -63,7 +63,7 @@ func WithAttributeSet(set attribute.Set) telemetryBuilderOption {
 func (builder *TelemetryBuilder) InitExporterQueueCapacity(cb func() int64) error {
 	var err error
 	builder.ExporterQueueCapacity, err = builder.meter.Int64ObservableGauge(
-		"exporter_queue_capacity",
+		"otelcol_exporter_queue_capacity",
 		metric.WithDescription("Fixed capacity of the retry queue (in batches)"),
 		metric.WithUnit("1"),
 	)
@@ -81,7 +81,7 @@ func (builder *TelemetryBuilder) InitExporterQueueCapacity(cb func() int64) erro
 func (builder *TelemetryBuilder) InitExporterQueueSize(cb func() int64) error {
 	var err error
 	builder.ExporterQueueSize, err = builder.meter.Int64ObservableGauge(
-		"exporter_queue_size",
+		"otelcol_exporter_queue_size",
 		metric.WithDescription("Current size of the retry queue (in batches)"),
 		metric.WithUnit("1"),
 	)
@@ -109,55 +109,55 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		builder.meter = noop.Meter{}
 	}
 	builder.ExporterEnqueueFailedLogRecords, err = builder.meter.Int64Counter(
-		"exporter_enqueue_failed_log_records",
+		"otelcol_exporter_enqueue_failed_log_records",
 		metric.WithDescription("Number of log records failed to be added to the sending queue."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterEnqueueFailedMetricPoints, err = builder.meter.Int64Counter(
-		"exporter_enqueue_failed_metric_points",
+		"otelcol_exporter_enqueue_failed_metric_points",
 		metric.WithDescription("Number of metric points failed to be added to the sending queue."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterEnqueueFailedSpans, err = builder.meter.Int64Counter(
-		"exporter_enqueue_failed_spans",
+		"otelcol_exporter_enqueue_failed_spans",
 		metric.WithDescription("Number of spans failed to be added to the sending queue."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSendFailedLogRecords, err = builder.meter.Int64Counter(
-		"exporter_send_failed_log_records",
+		"otelcol_exporter_send_failed_log_records",
 		metric.WithDescription("Number of log records in failed attempts to send to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSendFailedMetricPoints, err = builder.meter.Int64Counter(
-		"exporter_send_failed_metric_points",
+		"otelcol_exporter_send_failed_metric_points",
 		metric.WithDescription("Number of metric points in failed attempts to send to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSendFailedSpans, err = builder.meter.Int64Counter(
-		"exporter_send_failed_spans",
+		"otelcol_exporter_send_failed_spans",
 		metric.WithDescription("Number of spans in failed attempts to send to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSentLogRecords, err = builder.meter.Int64Counter(
-		"exporter_sent_log_records",
+		"otelcol_exporter_sent_log_records",
 		metric.WithDescription("Number of log record successfully sent to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSentMetricPoints, err = builder.meter.Int64Counter(
-		"exporter_sent_metric_points",
+		"otelcol_exporter_sent_metric_points",
 		metric.WithDescription("Number of metric points successfully sent to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSentSpans, err = builder.meter.Int64Counter(
-		"exporter_sent_spans",
+		"otelcol_exporter_sent_spans",
 		metric.WithDescription("Number of spans successfully sent to destination."),
 		metric.WithUnit("1"),
 	)

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -216,12 +216,12 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	require.NoError(t, tt.CheckExporterMetricGauge("exporter_queue_capacity", int64(defaultQueueSize)))
+	require.NoError(t, tt.CheckExporterMetricGauge("otelcol_exporter_queue_capacity", int64(defaultQueueSize)))
 
 	for i := 0; i < 7; i++ {
 		require.NoError(t, be.send(context.Background(), newErrorRequest()))
 	}
-	require.NoError(t, tt.CheckExporterMetricGauge("exporter_queue_size", int64(7)))
+	require.NoError(t, tt.CheckExporterMetricGauge("otelcol_exporter_queue_size", int64(7)))
 
 	assert.NoError(t, be.Shutdown(context.Background()))
 }

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -213,7 +213,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 
 	tel.assertMetrics(t, []metricdata.Metrics{
 		{
-			Name:        "processor_batch_batch_send_size_bytes",
+			Name:        "otelcol_processor_batch_batch_send_size_bytes",
 			Description: "Number of bytes in batch that was sent",
 			Unit:        "By",
 			Data: metricdata.Histogram[int64]{
@@ -234,7 +234,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_batch_send_size",
+			Name:        "otelcol_processor_batch_batch_send_size",
 			Description: "Number of units in the batch",
 			Unit:        "1",
 			Data: metricdata.Histogram[int64]{
@@ -253,7 +253,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_batch_size_trigger_send",
+			Name:        "otelcol_processor_batch_batch_size_trigger_send",
 			Description: "Number of times the batch was sent due to a size trigger",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -268,7 +268,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_metadata_cardinality",
+			Name:        "otelcol_processor_batch_metadata_cardinality",
 			Description: "Number of distinct metadata value combinations being processed",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -339,7 +339,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 
 	tel.assertMetrics(t, []metricdata.Metrics{
 		{
-			Name:        "processor_batch_batch_send_size_bytes",
+			Name:        "otelcol_processor_batch_batch_send_size_bytes",
 			Description: "Number of bytes in batch that was sent",
 			Unit:        "By",
 			Data: metricdata.Histogram[int64]{
@@ -360,7 +360,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_batch_send_size",
+			Name:        "otelcol_processor_batch_batch_send_size",
 			Description: "Number of units in the batch",
 			Unit:        "1",
 			Data: metricdata.Histogram[int64]{
@@ -379,7 +379,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_batch_size_trigger_send",
+			Name:        "otelcol_processor_batch_batch_size_trigger_send",
 			Description: "Number of times the batch was sent due to a size trigger",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -394,7 +394,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_timeout_trigger_send",
+			Name:        "otelcol_processor_batch_timeout_trigger_send",
 			Description: "Number of times the batch was sent due to a timeout trigger",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -409,7 +409,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_metadata_cardinality",
+			Name:        "otelcol_processor_batch_metadata_cardinality",
 			Description: "Number of distinct metadata value combinations being processed",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -602,7 +602,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 
 	tel.assertMetrics(t, []metricdata.Metrics{
 		{
-			Name:        "processor_batch_batch_send_size_bytes",
+			Name:        "otelcol_processor_batch_batch_send_size_bytes",
 			Description: "Number of bytes in batch that was sent",
 			Unit:        "By",
 			Data: metricdata.Histogram[int64]{
@@ -623,7 +623,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_batch_send_size",
+			Name:        "otelcol_processor_batch_batch_send_size",
 			Description: "Number of units in the batch",
 			Unit:        "1",
 			Data: metricdata.Histogram[int64]{
@@ -642,7 +642,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_batch_size_trigger_send",
+			Name:        "otelcol_processor_batch_batch_size_trigger_send",
 			Description: "Number of times the batch was sent due to a size trigger",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -657,7 +657,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_metadata_cardinality",
+			Name:        "otelcol_processor_batch_metadata_cardinality",
 			Description: "Number of distinct metadata value combinations being processed",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -982,7 +982,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 
 	tel.assertMetrics(t, []metricdata.Metrics{
 		{
-			Name:        "processor_batch_batch_send_size_bytes",
+			Name:        "otelcol_processor_batch_batch_send_size_bytes",
 			Description: "Number of bytes in batch that was sent",
 			Unit:        "By",
 			Data: metricdata.Histogram[int64]{
@@ -1003,7 +1003,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_batch_send_size",
+			Name:        "otelcol_processor_batch_batch_send_size",
 			Description: "Number of units in the batch",
 			Unit:        "1",
 			Data: metricdata.Histogram[int64]{
@@ -1022,7 +1022,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_batch_size_trigger_send",
+			Name:        "otelcol_processor_batch_batch_size_trigger_send",
 			Description: "Number of times the batch was sent due to a size trigger",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -1037,7 +1037,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 			},
 		},
 		{
-			Name:        "processor_batch_metadata_cardinality",
+			Name:        "otelcol_processor_batch_metadata_cardinality",
 			Description: "Number of distinct metadata value combinations being processed",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{

--- a/processor/batchprocessor/documentation.md
+++ b/processor/batchprocessor/documentation.md
@@ -6,7 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### processor_batch_batch_send_size
+### otelcol_processor_batch_batch_send_size
 
 Number of units in the batch
 
@@ -14,7 +14,7 @@ Number of units in the batch
 | ---- | ----------- | ---------- |
 | 1 | Histogram | Int |
 
-### processor_batch_batch_send_size_bytes
+### otelcol_processor_batch_batch_send_size_bytes
 
 Number of bytes in batch that was sent
 
@@ -22,7 +22,7 @@ Number of bytes in batch that was sent
 | ---- | ----------- | ---------- |
 | By | Histogram | Int |
 
-### processor_batch_batch_size_trigger_send
+### otelcol_processor_batch_batch_size_trigger_send
 
 Number of times the batch was sent due to a size trigger
 
@@ -30,7 +30,7 @@ Number of times the batch was sent due to a size trigger
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_batch_metadata_cardinality
+### otelcol_processor_batch_metadata_cardinality
 
 Number of distinct metadata value combinations being processed
 
@@ -38,7 +38,7 @@ Number of distinct metadata value combinations being processed
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | false |
 
-### processor_batch_timeout_trigger_send
+### otelcol_processor_batch_timeout_trigger_send
 
 Number of times the batch was sent due to a timeout trigger
 

--- a/processor/batchprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/batchprocessor/internal/metadata/generated_telemetry.go
@@ -75,25 +75,25 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		builder.meter = noop.Meter{}
 	}
 	builder.ProcessorBatchBatchSendSize, err = builder.meter.Int64Histogram(
-		"processor_batch_batch_send_size",
+		"otelcol_processor_batch_batch_send_size",
 		metric.WithDescription("Number of units in the batch"),
 		metric.WithUnit("1"), metric.WithExplicitBucketBoundaries([]float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000}...),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorBatchBatchSendSizeBytes, err = builder.meter.Int64Histogram(
-		"processor_batch_batch_send_size_bytes",
+		"otelcol_processor_batch_batch_send_size_bytes",
 		metric.WithDescription("Number of bytes in batch that was sent"),
 		metric.WithUnit("By"), metric.WithExplicitBucketBoundaries([]float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000, 200000, 300000, 400000, 500000, 600000, 700000, 800000, 900000, 1e+06, 2e+06, 3e+06, 4e+06, 5e+06, 6e+06, 7e+06, 8e+06, 9e+06}...),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorBatchBatchSizeTriggerSend, err = builder.meter.Int64Counter(
-		"processor_batch_batch_size_trigger_send",
+		"otelcol_processor_batch_batch_size_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a size trigger"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorBatchMetadataCardinality, err = builder.meter.Int64ObservableUpDownCounter(
-		"processor_batch_metadata_cardinality",
+		"otelcol_processor_batch_metadata_cardinality",
 		metric.WithDescription("Number of distinct metadata value combinations being processed"),
 		metric.WithUnit("1"),
 	)
@@ -104,7 +104,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	}, builder.ProcessorBatchMetadataCardinality)
 	errs = errors.Join(errs, err)
 	builder.ProcessorBatchTimeoutTriggerSend, err = builder.meter.Int64Counter(
-		"processor_batch_timeout_trigger_send",
+		"otelcol_processor_batch_timeout_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a timeout trigger"),
 		metric.WithUnit("1"),
 	)

--- a/processor/processorhelper/documentation.md
+++ b/processor/processorhelper/documentation.md
@@ -6,7 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### processor_accepted_log_records
+### otelcol_processor_accepted_log_records
 
 Number of log records successfully pushed into the next component in the pipeline.
 
@@ -14,7 +14,7 @@ Number of log records successfully pushed into the next component in the pipelin
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_accepted_metric_points
+### otelcol_processor_accepted_metric_points
 
 Number of metric points successfully pushed into the next component in the pipeline.
 
@@ -22,7 +22,7 @@ Number of metric points successfully pushed into the next component in the pipel
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_accepted_spans
+### otelcol_processor_accepted_spans
 
 Number of spans successfully pushed into the next component in the pipeline.
 
@@ -30,7 +30,7 @@ Number of spans successfully pushed into the next component in the pipeline.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_dropped_log_records
+### otelcol_processor_dropped_log_records
 
 Number of log records that were dropped.
 
@@ -38,7 +38,7 @@ Number of log records that were dropped.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_dropped_metric_points
+### otelcol_processor_dropped_metric_points
 
 Number of metric points that were dropped.
 
@@ -46,7 +46,7 @@ Number of metric points that were dropped.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_dropped_spans
+### otelcol_processor_dropped_spans
 
 Number of spans that were dropped.
 
@@ -54,7 +54,7 @@ Number of spans that were dropped.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_inserted_log_records
+### otelcol_processor_inserted_log_records
 
 Number of log records that were inserted.
 
@@ -62,7 +62,7 @@ Number of log records that were inserted.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_inserted_metric_points
+### otelcol_processor_inserted_metric_points
 
 Number of metric points that were inserted.
 
@@ -70,7 +70,7 @@ Number of metric points that were inserted.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_inserted_spans
+### otelcol_processor_inserted_spans
 
 Number of spans that were inserted.
 
@@ -78,7 +78,7 @@ Number of spans that were inserted.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_refused_log_records
+### otelcol_processor_refused_log_records
 
 Number of log records that were rejected by the next component in the pipeline.
 
@@ -86,7 +86,7 @@ Number of log records that were rejected by the next component in the pipeline.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_refused_metric_points
+### otelcol_processor_refused_metric_points
 
 Number of metric points that were rejected by the next component in the pipeline.
 
@@ -94,7 +94,7 @@ Number of metric points that were rejected by the next component in the pipeline
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### processor_refused_spans
+### otelcol_processor_refused_spans
 
 Number of spans that were rejected by the next component in the pipeline.
 

--- a/processor/processorhelper/internal/metadata/generated_telemetry.go
+++ b/processor/processorhelper/internal/metadata/generated_telemetry.go
@@ -64,73 +64,73 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		builder.meter = noop.Meter{}
 	}
 	builder.ProcessorAcceptedLogRecords, err = builder.meter.Int64Counter(
-		"processor_accepted_log_records",
+		"otelcol_processor_accepted_log_records",
 		metric.WithDescription("Number of log records successfully pushed into the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorAcceptedMetricPoints, err = builder.meter.Int64Counter(
-		"processor_accepted_metric_points",
+		"otelcol_processor_accepted_metric_points",
 		metric.WithDescription("Number of metric points successfully pushed into the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorAcceptedSpans, err = builder.meter.Int64Counter(
-		"processor_accepted_spans",
+		"otelcol_processor_accepted_spans",
 		metric.WithDescription("Number of spans successfully pushed into the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorDroppedLogRecords, err = builder.meter.Int64Counter(
-		"processor_dropped_log_records",
+		"otelcol_processor_dropped_log_records",
 		metric.WithDescription("Number of log records that were dropped."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorDroppedMetricPoints, err = builder.meter.Int64Counter(
-		"processor_dropped_metric_points",
+		"otelcol_processor_dropped_metric_points",
 		metric.WithDescription("Number of metric points that were dropped."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorDroppedSpans, err = builder.meter.Int64Counter(
-		"processor_dropped_spans",
+		"otelcol_processor_dropped_spans",
 		metric.WithDescription("Number of spans that were dropped."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorInsertedLogRecords, err = builder.meter.Int64Counter(
-		"processor_inserted_log_records",
+		"otelcol_processor_inserted_log_records",
 		metric.WithDescription("Number of log records that were inserted."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorInsertedMetricPoints, err = builder.meter.Int64Counter(
-		"processor_inserted_metric_points",
+		"otelcol_processor_inserted_metric_points",
 		metric.WithDescription("Number of metric points that were inserted."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorInsertedSpans, err = builder.meter.Int64Counter(
-		"processor_inserted_spans",
+		"otelcol_processor_inserted_spans",
 		metric.WithDescription("Number of spans that were inserted."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedLogRecords, err = builder.meter.Int64Counter(
-		"processor_refused_log_records",
+		"otelcol_processor_refused_log_records",
 		metric.WithDescription("Number of log records that were rejected by the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedMetricPoints, err = builder.meter.Int64Counter(
-		"processor_refused_metric_points",
+		"otelcol_processor_refused_metric_points",
 		metric.WithDescription("Number of metric points that were rejected by the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedSpans, err = builder.meter.Int64Counter(
-		"processor_refused_spans",
+		"otelcol_processor_refused_spans",
 		metric.WithDescription("Number of spans that were rejected by the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)

--- a/receiver/receiverhelper/documentation.md
+++ b/receiver/receiverhelper/documentation.md
@@ -6,7 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### receiver_accepted_log_records
+### otelcol_receiver_accepted_log_records
 
 Number of log records successfully pushed into the pipeline.
 
@@ -14,7 +14,7 @@ Number of log records successfully pushed into the pipeline.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### receiver_accepted_metric_points
+### otelcol_receiver_accepted_metric_points
 
 Number of metric points successfully pushed into the pipeline.
 
@@ -22,7 +22,7 @@ Number of metric points successfully pushed into the pipeline.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### receiver_accepted_spans
+### otelcol_receiver_accepted_spans
 
 Number of spans successfully pushed into the pipeline.
 
@@ -30,7 +30,7 @@ Number of spans successfully pushed into the pipeline.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### receiver_refused_log_records
+### otelcol_receiver_refused_log_records
 
 Number of log records that could not be pushed into the pipeline.
 
@@ -38,7 +38,7 @@ Number of log records that could not be pushed into the pipeline.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### receiver_refused_metric_points
+### otelcol_receiver_refused_metric_points
 
 Number of metric points that could not be pushed into the pipeline.
 
@@ -46,7 +46,7 @@ Number of metric points that could not be pushed into the pipeline.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### receiver_refused_spans
+### otelcol_receiver_refused_spans
 
 Number of spans that could not be pushed into the pipeline.
 

--- a/receiver/receiverhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/receiverhelper/internal/metadata/generated_telemetry.go
@@ -58,37 +58,37 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		builder.meter = noop.Meter{}
 	}
 	builder.ReceiverAcceptedLogRecords, err = builder.meter.Int64Counter(
-		"receiver_accepted_log_records",
+		"otelcol_receiver_accepted_log_records",
 		metric.WithDescription("Number of log records successfully pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverAcceptedMetricPoints, err = builder.meter.Int64Counter(
-		"receiver_accepted_metric_points",
+		"otelcol_receiver_accepted_metric_points",
 		metric.WithDescription("Number of metric points successfully pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverAcceptedSpans, err = builder.meter.Int64Counter(
-		"receiver_accepted_spans",
+		"otelcol_receiver_accepted_spans",
 		metric.WithDescription("Number of spans successfully pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverRefusedLogRecords, err = builder.meter.Int64Counter(
-		"receiver_refused_log_records",
+		"otelcol_receiver_refused_log_records",
 		metric.WithDescription("Number of log records that could not be pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverRefusedMetricPoints, err = builder.meter.Int64Counter(
-		"receiver_refused_metric_points",
+		"otelcol_receiver_refused_metric_points",
 		metric.WithDescription("Number of metric points that could not be pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverRefusedSpans, err = builder.meter.Int64Counter(
-		"receiver_refused_spans",
+		"otelcol_receiver_refused_spans",
 		metric.WithDescription("Number of spans that could not be pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)

--- a/receiver/scraperhelper/documentation.md
+++ b/receiver/scraperhelper/documentation.md
@@ -6,7 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### scraper_errored_metric_points
+### otelcol_scraper_errored_metric_points
 
 Number of metric points that were unable to be scraped.
 
@@ -14,7 +14,7 @@ Number of metric points that were unable to be scraped.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### scraper_scraped_metric_points
+### otelcol_scraper_scraped_metric_points
 
 Number of metric points successfully scraped.
 

--- a/receiver/scraperhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/scraperhelper/internal/metadata/generated_telemetry.go
@@ -54,13 +54,13 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		builder.meter = noop.Meter{}
 	}
 	builder.ScraperErroredMetricPoints, err = builder.meter.Int64Counter(
-		"scraper_errored_metric_points",
+		"otelcol_scraper_errored_metric_points",
 		metric.WithDescription("Number of metric points that were unable to be scraped."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ScraperScrapedMetricPoints, err = builder.meter.Int64Counter(
-		"scraper_scraped_metric_points",
+		"otelcol_scraper_scraped_metric_points",
 		metric.WithDescription("Number of metric points successfully scraped."),
 		metric.WithUnit("1"),
 	)

--- a/service/documentation.md
+++ b/service/documentation.md
@@ -6,7 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### process_cpu_seconds
+### otelcol_process_cpu_seconds
 
 Total CPU user and system time in seconds
 
@@ -14,7 +14,7 @@ Total CPU user and system time in seconds
 | ---- | ----------- | ---------- | --------- |
 | s | Sum | Double | true |
 
-### process_memory_rss
+### otelcol_process_memory_rss
 
 Total physical memory (resident set size)
 
@@ -22,7 +22,7 @@ Total physical memory (resident set size)
 | ---- | ----------- | ---------- |
 | By | Gauge | Int |
 
-### process_runtime_heap_alloc_bytes
+### otelcol_process_runtime_heap_alloc_bytes
 
 Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')
 
@@ -30,7 +30,7 @@ Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')
 | ---- | ----------- | ---------- |
 | By | Gauge | Int |
 
-### process_runtime_total_alloc_bytes
+### otelcol_process_runtime_total_alloc_bytes
 
 Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
 
@@ -38,7 +38,7 @@ Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalA
 | ---- | ----------- | ---------- | --------- |
 | By | Sum | Int | true |
 
-### process_runtime_total_sys_memory_bytes
+### otelcol_process_runtime_total_sys_memory_bytes
 
 Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')
 
@@ -46,7 +46,7 @@ Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')
 | ---- | ----------- | ---------- |
 | By | Gauge | Int |
 
-### process_uptime
+### otelcol_process_uptime
 
 Uptime of the process
 

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -116,7 +116,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		builder.meter = noop.Meter{}
 	}
 	builder.ProcessCPUSeconds, err = builder.meter.Float64ObservableCounter(
-		"process_cpu_seconds",
+		"otelcol_process_cpu_seconds",
 		metric.WithDescription("Total CPU user and system time in seconds"),
 		metric.WithUnit("s"),
 	)
@@ -127,7 +127,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	}, builder.ProcessCPUSeconds)
 	errs = errors.Join(errs, err)
 	builder.ProcessMemoryRss, err = builder.meter.Int64ObservableGauge(
-		"process_memory_rss",
+		"otelcol_process_memory_rss",
 		metric.WithDescription("Total physical memory (resident set size)"),
 		metric.WithUnit("By"),
 	)
@@ -138,7 +138,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	}, builder.ProcessMemoryRss)
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeHeapAllocBytes, err = builder.meter.Int64ObservableGauge(
-		"process_runtime_heap_alloc_bytes",
+		"otelcol_process_runtime_heap_alloc_bytes",
 		metric.WithDescription("Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')"),
 		metric.WithUnit("By"),
 	)
@@ -149,7 +149,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	}, builder.ProcessRuntimeHeapAllocBytes)
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeTotalAllocBytes, err = builder.meter.Int64ObservableCounter(
-		"process_runtime_total_alloc_bytes",
+		"otelcol_process_runtime_total_alloc_bytes",
 		metric.WithDescription("Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')"),
 		metric.WithUnit("By"),
 	)
@@ -160,7 +160,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	}, builder.ProcessRuntimeTotalAllocBytes)
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeTotalSysMemoryBytes, err = builder.meter.Int64ObservableGauge(
-		"process_runtime_total_sys_memory_bytes",
+		"otelcol_process_runtime_total_sys_memory_bytes",
 		metric.WithDescription("Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')"),
 		metric.WithUnit("By"),
 	)
@@ -171,7 +171,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	}, builder.ProcessRuntimeTotalSysMemoryBytes)
 	errs = errors.Join(errs, err)
 	builder.ProcessUptime, err = builder.meter.Float64ObservableCounter(
-		"process_uptime",
+		"otelcol_process_uptime",
 		metric.WithDescription("Uptime of the process"),
 		metric.WithUnit("s"),
 	)

--- a/service/internal/proctelemetry/config.go
+++ b/service/internal/proctelemetry/config.go
@@ -172,7 +172,6 @@ func initPrometheusExporter(prometheusConfig *config.Prometheus, asyncErrorChann
 		otelprom.WithoutScopeInfo(),
 		// This allows us to produce metrics that are backwards compatible w/ opencensus
 		otelprom.WithoutCounterSuffixes(),
-		otelprom.WithNamespace("otelcol"),
 		otelprom.WithResourceAsConstantLabels(attribute.NewDenyKeysFilter()),
 	}
 	if !featuregates.DisableOpenCensusBridge.IsEnabled() {

--- a/service/internal/proctelemetry/process_telemetry_test.go
+++ b/service/internal/proctelemetry/process_telemetry_test.go
@@ -31,12 +31,12 @@ type testTelemetry struct {
 }
 
 var expectedMetrics = []string{
-	"process_uptime",
-	"process_runtime_heap_alloc_bytes",
-	"process_runtime_total_alloc_bytes",
-	"process_runtime_total_sys_memory_bytes",
-	"process_cpu_seconds",
-	"process_memory_rss",
+	"otelcol_process_uptime",
+	"otelcol_process_runtime_heap_alloc_bytes",
+	"otelcol_process_runtime_total_alloc_bytes",
+	"otelcol_process_runtime_total_sys_memory_bytes",
+	"otelcol_process_cpu_seconds",
+	"otelcol_process_memory_rss",
 }
 
 func setupTelemetry(t *testing.T) testTelemetry {
@@ -93,7 +93,7 @@ func TestProcessTelemetry(t *testing.T) {
 		} else {
 			metricValue = metric.Metric[0].GetGauge().GetValue()
 		}
-		if strings.HasPrefix(metricName, "process_uptime") || strings.HasPrefix(metricName, "process_cpu_seconds") {
+		if strings.HasPrefix(metricName, "otelcol_process_uptime") || strings.HasPrefix(metricName, "otelcol_process_cpu_seconds") {
 			// This likely will still be zero when running the test.
 			assert.GreaterOrEqual(t, metricValue, float64(0), metricName)
 			continue

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -329,22 +329,22 @@ func TestTelemetryInit(t *testing.T) {
 
 func createTestMetrics(t *testing.T, mp metric.MeterProvider) *view.View {
 	// Creates a OTel Go counter
-	counter, err := mp.Meter("collector_test").Int64Counter(otelPrefix+counterName, metric.WithUnit("ms"))
+	counter, err := mp.Meter("collector_test").Int64Counter(metricPrefix+otelPrefix+counterName, metric.WithUnit("ms"))
 	require.NoError(t, err)
 	counter.Add(context.Background(), 13)
 
-	grpcExampleCounter, err := mp.Meter(proctelemetry.GRPCInstrumentation).Int64Counter(grpcPrefix + counterName)
+	grpcExampleCounter, err := mp.Meter(proctelemetry.GRPCInstrumentation).Int64Counter(metricPrefix + grpcPrefix + counterName)
 	require.NoError(t, err)
 	grpcExampleCounter.Add(context.Background(), 11, metric.WithAttributes(proctelemetry.GRPCUnacceptableKeyValues...))
 
-	httpExampleCounter, err := mp.Meter(proctelemetry.HTTPInstrumentation).Int64Counter(httpPrefix + counterName)
+	httpExampleCounter, err := mp.Meter(proctelemetry.HTTPInstrumentation).Int64Counter(metricPrefix + httpPrefix + counterName)
 	require.NoError(t, err)
 	httpExampleCounter.Add(context.Background(), 10, metric.WithAttributes(proctelemetry.HTTPUnacceptableKeyValues...))
 
 	// Creates a OpenCensus measure
-	ocCounter := stats.Int64(ocPrefix+counterName, counterName, stats.UnitDimensionless)
+	ocCounter := stats.Int64(metricPrefix+ocPrefix+counterName, counterName, stats.UnitDimensionless)
 	v := &view.View{
-		Name:        ocPrefix + counterName,
+		Name:        metricPrefix + ocPrefix + counterName,
 		Description: ocCounter.Description(),
 		Measure:     ocCounter,
 		Aggregation: view.Sum(),
@@ -352,10 +352,10 @@ func createTestMetrics(t *testing.T, mp metric.MeterProvider) *view.View {
 	err = view.Register(v)
 	require.NoError(t, err)
 
-	stats.Record(context.Background(), stats.Int64(ocPrefix+counterName, counterName, stats.UnitDimensionless).M(13))
+	stats.Record(context.Background(), stats.Int64(metricPrefix+ocPrefix+counterName, counterName, stats.UnitDimensionless).M(13))
 
 	// Forces a flush for the view data.
-	_, _ = view.RetrieveData(ocPrefix + counterName)
+	_, _ = view.RetrieveData(metricPrefix + ocPrefix + counterName)
 
 	return v
 }


### PR DESCRIPTION
This ensures the consistency for folks emitting metrics w/ OTLP until the OTEP to specify pipeline telemetry is completed.

Waiting on https://github.com/open-telemetry/opentelemetry-collector/pull/9775 before moving this forward

Fixes #9315
