### PR TITLE
[chore] Remove the top level error if it indicates an empty name

### DIFF
--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -5,8 +5,10 @@ package confmap // import "go.opentelemetry.io/collector/confmap"
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/knadh/koanf/maps"
@@ -167,7 +169,13 @@ func decodeConfig(m *Conf, result any, errorUnused bool) error {
 	if err != nil {
 		return err
 	}
-	return decoder.Decode(m.ToStringMap())
+	if err = decoder.Decode(m.ToStringMap()); err != nil {
+		if strings.HasPrefix(err.Error(), "error decoding ''") {
+			return errors.Unwrap(err)
+		}
+		return err
+	}
+	return nil
 }
 
 // encoderConfig returns a default encoder.EncoderConfig that includes

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -450,7 +450,7 @@ func TestEmbeddedUnmarshalerError(t *testing.T) {
 	})
 
 	tc := &testConfigWithEmbeddedError{}
-	assert.EqualError(t, cfgMap.Unmarshal(tc), "error decoding '': embedded error")
+	assert.EqualError(t, cfgMap.Unmarshal(tc), "embedded error")
 }
 
 func TestEmbeddedMarshalerError(t *testing.T) {
@@ -462,7 +462,7 @@ func TestEmbeddedMarshalerError(t *testing.T) {
 	})
 
 	tc := &testConfigWithMarshalError{}
-	assert.EqualError(t, cfgMap.Unmarshal(tc), "error decoding '': error running encode hook: marshaling error")
+	assert.EqualError(t, cfgMap.Unmarshal(tc), "error running encode hook: marshaling error")
 }
 
 func TestUnmarshalerKeepAlreadyInitialized(t *testing.T) {


### PR DESCRIPTION
This is a split of #9750 that tries to work around mapstructure, which wraps an error around a decoding error.

In the case when an error is returned from a top level construct, we get a not so helpful message that says:
```
error decoding '': error running encode hook: marshaling error
```

With this change, the error is unwrapped, giving the following string representation:
```
error running encode hook: marshaling error
```

Because #9750 enforces going through mapstructure, it would change errors returned with this not-so-helpful preamble. Adding this removes the problem.