### PR TITLE
[cmd/mdatagen] optimize mdatagen for batchprocessor failed test

### DIFF
--- a/.chloggen/optimize-mdatagen-for-batchprocessor.yaml
+++ b/.chloggen/optimize-mdatagen-for-batchprocessor.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: optimiz the mdatagen for the case like batchprocessor which use a common struct to implement consumer.Traces, consumer.Metrics, consumer.Logs in the meantime.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9688]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/templates/component_test.go.tmpl
@@ -108,20 +108,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
-				switch e := c.(type) {
-				case exporter.Logs:
+				switch test.name {
+				case "logs":
+					e, ok := c.(exporter.Logs)
+					require.True(t, ok)				
 					logs := generateLifecycleTestLogs()
 					if !e.Capabilities().MutatesData {
 						logs.MarkReadOnly()
 					}
 					err = e.ConsumeLogs(context.Background(), logs)
-				case exporter.Metrics:
+				case "metrics":
+					e, ok := c.(exporter.Metrics)
+					require.True(t, ok)
 					metrics := generateLifecycleTestMetrics()
 					if !e.Capabilities().MutatesData {
 						metrics.MarkReadOnly()
 					}
 					err = e.ConsumeMetrics(context.Background(), metrics)
-				case exporter.Traces:
+				case "traces":
+					e, ok := c.(exporter.Traces)
+					require.True(t, ok)
 					traces := generateLifecycleTestTraces()
 					if !e.Capabilities().MutatesData {
 						traces.MarkReadOnly()
@@ -199,20 +205,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
-				switch e := c.(type) {
-				case processor.Logs:
+				switch test.name {
+				case "logs":
+					e, ok := c.(processor.Logs)
+					require.True(t, ok)
 					logs := generateLifecycleTestLogs()
 					if !e.Capabilities().MutatesData {
 						logs.MarkReadOnly()
 					}
 					err = e.ConsumeLogs(context.Background(), logs)
-				case processor.Metrics:
+				case "metrics":
+					e, ok := c.(processor.Metrics)
+					require.True(t, ok)
 					metrics := generateLifecycleTestMetrics()
 					if !e.Capabilities().MutatesData {
 						metrics.MarkReadOnly()
 					}
 					err = e.ConsumeMetrics(context.Background(), metrics)
-				case processor.Traces:
+				case "traces":
+					e, ok := c.(processor.Traces)
+					require.True(t, ok)
 					traces := generateLifecycleTestTraces()
 					if !e.Capabilities().MutatesData {
 						traces.MarkReadOnly()

--- a/exporter/debugexporter/generated_component_test.go
+++ b/exporter/debugexporter/generated_component_test.go
@@ -71,20 +71,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
-				switch e := c.(type) {
-				case exporter.Logs:
+				switch test.name {
+				case "logs":
+					e, ok := c.(exporter.Logs)
+					require.True(t, ok)
 					logs := generateLifecycleTestLogs()
 					if !e.Capabilities().MutatesData {
 						logs.MarkReadOnly()
 					}
 					err = e.ConsumeLogs(context.Background(), logs)
-				case exporter.Metrics:
+				case "metrics":
+					e, ok := c.(exporter.Metrics)
+					require.True(t, ok)
 					metrics := generateLifecycleTestMetrics()
 					if !e.Capabilities().MutatesData {
 						metrics.MarkReadOnly()
 					}
 					err = e.ConsumeMetrics(context.Background(), metrics)
-				case exporter.Traces:
+				case "traces":
+					e, ok := c.(exporter.Traces)
+					require.True(t, ok)
 					traces := generateLifecycleTestTraces()
 					if !e.Capabilities().MutatesData {
 						traces.MarkReadOnly()

--- a/exporter/loggingexporter/generated_component_test.go
+++ b/exporter/loggingexporter/generated_component_test.go
@@ -71,20 +71,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
-				switch e := c.(type) {
-				case exporter.Logs:
+				switch test.name {
+				case "logs":
+					e, ok := c.(exporter.Logs)
+					require.True(t, ok)
 					logs := generateLifecycleTestLogs()
 					if !e.Capabilities().MutatesData {
 						logs.MarkReadOnly()
 					}
 					err = e.ConsumeLogs(context.Background(), logs)
-				case exporter.Metrics:
+				case "metrics":
+					e, ok := c.(exporter.Metrics)
+					require.True(t, ok)
 					metrics := generateLifecycleTestMetrics()
 					if !e.Capabilities().MutatesData {
 						metrics.MarkReadOnly()
 					}
 					err = e.ConsumeMetrics(context.Background(), metrics)
-				case exporter.Traces:
+				case "traces":
+					e, ok := c.(exporter.Traces)
+					require.True(t, ok)
 					traces := generateLifecycleTestTraces()
 					if !e.Capabilities().MutatesData {
 						traces.MarkReadOnly()

--- a/exporter/nopexporter/generated_component_test.go
+++ b/exporter/nopexporter/generated_component_test.go
@@ -71,20 +71,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
-				switch e := c.(type) {
-				case exporter.Logs:
+				switch test.name {
+				case "logs":
+					e, ok := c.(exporter.Logs)
+					require.True(t, ok)
 					logs := generateLifecycleTestLogs()
 					if !e.Capabilities().MutatesData {
 						logs.MarkReadOnly()
 					}
 					err = e.ConsumeLogs(context.Background(), logs)
-				case exporter.Metrics:
+				case "metrics":
+					e, ok := c.(exporter.Metrics)
+					require.True(t, ok)
 					metrics := generateLifecycleTestMetrics()
 					if !e.Capabilities().MutatesData {
 						metrics.MarkReadOnly()
 					}
 					err = e.ConsumeMetrics(context.Background(), metrics)
-				case exporter.Traces:
+				case "traces":
+					e, ok := c.(exporter.Traces)
+					require.True(t, ok)
 					traces := generateLifecycleTestTraces()
 					if !e.Capabilities().MutatesData {
 						traces.MarkReadOnly()

--- a/exporter/otlpexporter/generated_component_test.go
+++ b/exporter/otlpexporter/generated_component_test.go
@@ -71,20 +71,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
-				switch e := c.(type) {
-				case exporter.Logs:
+				switch test.name {
+				case "logs":
+					e, ok := c.(exporter.Logs)
+					require.True(t, ok)
 					logs := generateLifecycleTestLogs()
 					if !e.Capabilities().MutatesData {
 						logs.MarkReadOnly()
 					}
 					err = e.ConsumeLogs(context.Background(), logs)
-				case exporter.Metrics:
+				case "metrics":
+					e, ok := c.(exporter.Metrics)
+					require.True(t, ok)
 					metrics := generateLifecycleTestMetrics()
 					if !e.Capabilities().MutatesData {
 						metrics.MarkReadOnly()
 					}
 					err = e.ConsumeMetrics(context.Background(), metrics)
-				case exporter.Traces:
+				case "traces":
+					e, ok := c.(exporter.Traces)
+					require.True(t, ok)
 					traces := generateLifecycleTestTraces()
 					if !e.Capabilities().MutatesData {
 						traces.MarkReadOnly()

--- a/exporter/otlphttpexporter/generated_component_test.go
+++ b/exporter/otlphttpexporter/generated_component_test.go
@@ -71,20 +71,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
-				switch e := c.(type) {
-				case exporter.Logs:
+				switch test.name {
+				case "logs":
+					e, ok := c.(exporter.Logs)
+					require.True(t, ok)
 					logs := generateLifecycleTestLogs()
 					if !e.Capabilities().MutatesData {
 						logs.MarkReadOnly()
 					}
 					err = e.ConsumeLogs(context.Background(), logs)
-				case exporter.Metrics:
+				case "metrics":
+					e, ok := c.(exporter.Metrics)
+					require.True(t, ok)
 					metrics := generateLifecycleTestMetrics()
 					if !e.Capabilities().MutatesData {
 						metrics.MarkReadOnly()
 					}
 					err = e.ConsumeMetrics(context.Background(), metrics)
-				case exporter.Traces:
+				case "traces":
+					e, ok := c.(exporter.Traces)
+					require.True(t, ok)
 					traces := generateLifecycleTestTraces()
 					if !e.Capabilities().MutatesData {
 						traces.MarkReadOnly()

--- a/processor/batchprocessor/generated_component_test.go
+++ b/processor/batchprocessor/generated_component_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -60,6 +61,44 @@ func TestComponentLifecycle(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
+			require.NoError(t, err)
+			err = c.Shutdown(context.Background())
+			require.NoError(t, err)
+		})
+		t.Run(test.name+"-lifecycle", func(t *testing.T) {
+			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
+			require.NoError(t, err)
+			host := componenttest.NewNopHost()
+			err = c.Start(context.Background(), host)
+			require.NoError(t, err)
+			require.NotPanics(t, func() {
+				switch test.name {
+				case "logs":
+					e, ok := c.(processor.Logs)
+					require.True(t, ok)
+					logs := generateLifecycleTestLogs()
+					if !e.Capabilities().MutatesData {
+						logs.MarkReadOnly()
+					}
+					err = e.ConsumeLogs(context.Background(), logs)
+				case "metrics":
+					e, ok := c.(processor.Metrics)
+					require.True(t, ok)
+					metrics := generateLifecycleTestMetrics()
+					if !e.Capabilities().MutatesData {
+						metrics.MarkReadOnly()
+					}
+					err = e.ConsumeMetrics(context.Background(), metrics)
+				case "traces":
+					e, ok := c.(processor.Traces)
+					require.True(t, ok)
+					traces := generateLifecycleTestTraces()
+					if !e.Capabilities().MutatesData {
+						traces.MarkReadOnly()
+					}
+					err = e.ConsumeTraces(context.Background(), traces)
+				}
+			})
 			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)

--- a/processor/batchprocessor/metadata.yaml
+++ b/processor/batchprocessor/metadata.yaml
@@ -7,5 +7,3 @@ status:
   distributions: [core, contrib]
 
 tests:
-  # TODO: https://github.com/open-telemetry/opentelemetry-collector/issues/9688
-  skip_lifecycle: true

--- a/processor/memorylimiterprocessor/generated_component_test.go
+++ b/processor/memorylimiterprocessor/generated_component_test.go
@@ -66,20 +66,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
-				switch e := c.(type) {
-				case processor.Logs:
+				switch test.name {
+				case "logs":
+					e, ok := c.(processor.Logs)
+					require.True(t, ok)
 					logs := generateLifecycleTestLogs()
 					if !e.Capabilities().MutatesData {
 						logs.MarkReadOnly()
 					}
 					err = e.ConsumeLogs(context.Background(), logs)
-				case processor.Metrics:
+				case "metrics":
+					e, ok := c.(processor.Metrics)
+					require.True(t, ok)
 					metrics := generateLifecycleTestMetrics()
 					if !e.Capabilities().MutatesData {
 						metrics.MarkReadOnly()
 					}
 					err = e.ConsumeMetrics(context.Background(), metrics)
-				case processor.Traces:
+				case "traces":
+					e, ok := c.(processor.Traces)
+					require.True(t, ok)
 					traces := generateLifecycleTestTraces()
 					if !e.Capabilities().MutatesData {
 						traces.MarkReadOnly()


### PR DESCRIPTION
**Description:** 
fix #9688

The batchprocessor use a `batchProcessor` as a common struct which implements `consumer.Traces`, `consumer.Metrics`, `consumer.Logs` in the meantime.

As a result, the generated lifecycle test will fail, since when it create a metrics, traces processor object, it will still fall to the case `consumer.Logs` and panic. 
```
=== RUN   TestComponentLifecycle/metrics-shutdown
=== RUN   TestComponentLifecycle/metrics-lifecycle
panic: interface conversion: interface {} is plog.Logs, not pmetric.Metrics

goroutine 37 [running]:
go.opentelemetry.io/collector/processor/batchprocessor.(*batchMetrics).add(0x14000208120?, {0x10572aae0?, 0x1400029c3f0?})
	/Users/zhaoziqi/Documents/go/src/go.opentelemetry.io/opentelemetry-collector/processor/batchprocessor/batch_processor.go:450 +0x208
go.opentelemetry.io/collector/processor/batchprocessor.(*shard).processItem(0x14000292200, {0x10572aae0?, 0x1400029c3f0?})
	/Users/zhaoziqi/Documents/go/src/go.opentelemetry.io/opentelemetry-collector/processor/batchprocessor/batch_processor.go:226 +0x38
go.opentelemetry.io/collector/processor/batchprocessor.(*shard).start(0x14000292200)
	/Users/zhaoziqi/Documents/go/src/go.opentelemetry.io/opentelemetry-collector/processor/batchprocessor/batch_processor.go:199 +0x1a0
created by go.opentelemetry.io/collector/processor/batchprocessor.(*batchProcessor).newShard in goroutine 36
	/Users/zhaoziqi/Documents/go/src/go.opentelemetry.io/opentelemetry-collector/processor/batchprocessor/batch_processor.go:160 +0x1a4
exit status 2
FAIL	go.opentelemetry.io/collector/processor/batchprocessor	0.594s
```

**Link to tracking Issue:** <Issue number if applicable>
fix #9688

