### PR TITLE
Revert "[chore] change the way we unmarshal the config in tests"

### DIFF
--- a/cmd/mdatagen/internal/samplereceiver/generated_component_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/generated_component_test.go
@@ -51,7 +51,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {

--- a/cmd/mdatagen/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/templates/component_test.go.tmpl
@@ -88,7 +88,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		{{- if not .Tests.SkipShutdown }}
@@ -185,7 +185,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		{{- if not .Tests.SkipShutdown }}
@@ -280,7 +280,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		{{- if not .Tests.SkipShutdown }}
@@ -319,7 +319,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	{{- if not .Tests.SkipShutdown }}
 	t.Run("shutdown", func(t *testing.T) {
@@ -433,7 +433,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		{{- if not .Tests.SkipShutdown }}

--- a/connector/forwardconnector/generated_component_test.go
+++ b/connector/forwardconnector/generated_component_test.go
@@ -51,7 +51,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {

--- a/exporter/debugexporter/generated_component_test.go
+++ b/exporter/debugexporter/generated_component_test.go
@@ -55,7 +55,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {

--- a/exporter/loggingexporter/generated_component_test.go
+++ b/exporter/loggingexporter/generated_component_test.go
@@ -55,7 +55,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {

--- a/exporter/nopexporter/generated_component_test.go
+++ b/exporter/nopexporter/generated_component_test.go
@@ -55,7 +55,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {

--- a/exporter/otlpexporter/generated_component_test.go
+++ b/exporter/otlpexporter/generated_component_test.go
@@ -55,7 +55,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {

--- a/exporter/otlphttpexporter/generated_component_test.go
+++ b/exporter/otlphttpexporter/generated_component_test.go
@@ -55,7 +55,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {

--- a/extension/ballastextension/generated_component_test.go
+++ b/extension/ballastextension/generated_component_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
@@ -21,7 +22,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 	t.Run("shutdown", func(t *testing.T) {
 		e, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)

--- a/extension/memorylimiterextension/generated_component_test.go
+++ b/extension/memorylimiterextension/generated_component_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
@@ -21,7 +22,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 	t.Run("lifecycle", func(t *testing.T) {
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)

--- a/extension/zpagesextension/generated_component_test.go
+++ b/extension/zpagesextension/generated_component_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
@@ -21,7 +22,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 	t.Run("shutdown", func(t *testing.T) {
 		e, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)

--- a/processor/batchprocessor/generated_component_test.go
+++ b/processor/batchprocessor/generated_component_test.go
@@ -56,7 +56,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {

--- a/processor/memorylimiterprocessor/generated_component_test.go
+++ b/processor/memorylimiterprocessor/generated_component_test.go
@@ -56,7 +56,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-lifecycle", func(t *testing.T) {

--- a/receiver/nopreceiver/generated_component_test.go
+++ b/receiver/nopreceiver/generated_component_test.go
@@ -51,7 +51,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {

--- a/receiver/otlpreceiver/generated_component_test.go
+++ b/receiver/otlpreceiver/generated_component_test.go
@@ -51,7 +51,7 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector#9765

We need to revert those changes as contrib has issues with them in isolation from #9750. 