### PR TITLE
[connector] Remove deprecated interfaces LogsRouter, MetricsRouter and TracesRouter

### DIFF
--- a/.chloggen/remove_deprecated_interfaces_connector.yaml
+++ b/.chloggen/remove_deprecated_interfaces_connector.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: connector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `LogsRouter`, `MetricsRouter` and `TracesRouter`. Use `LogsRouterAndConsumer`, `MetricsRouterAndConsumer`, `TracesRouterAndConsumer` respectively instead.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9095]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/connector/logs_router.go
+++ b/connector/logs_router.go
@@ -13,12 +13,6 @@ import (
 	"go.opentelemetry.io/collector/internal/fanoutconsumer"
 )
 
-// Deprecated: [v0.92.0] use LogsRouterAndConsumer
-type LogsRouter interface {
-	Consumer(...component.ID) (consumer.Logs, error)
-	PipelineIDs() []component.ID
-}
-
 // LogsRouterAndConsumer feeds the first consumer.Logs in each of the specified pipelines.
 type LogsRouterAndConsumer interface {
 	consumer.Logs

--- a/connector/metrics_router.go
+++ b/connector/metrics_router.go
@@ -13,12 +13,6 @@ import (
 	"go.opentelemetry.io/collector/internal/fanoutconsumer"
 )
 
-// Deprecated: [v0.92.0] use MetricsRouterAndConsumer.
-type MetricsRouter interface {
-	Consumer(...component.ID) (consumer.Metrics, error)
-	PipelineIDs() []component.ID
-}
-
 // MetricsRouterAndConsumer feeds the first consumer.Metrics in each of the specified pipelines.
 type MetricsRouterAndConsumer interface {
 	consumer.Metrics

--- a/connector/traces_router.go
+++ b/connector/traces_router.go
@@ -13,12 +13,6 @@ import (
 	"go.opentelemetry.io/collector/internal/fanoutconsumer"
 )
 
-// Deprecated: [v0.92.0] use TracesRouterAndConsumer
-type TracesRouter interface {
-	Consumer(...component.ID) (consumer.Traces, error)
-	PipelineIDs() []component.ID
-}
-
 // TracesRouterAndConsumer feeds the first consumer.Traces in each of the specified pipelines.
 type TracesRouterAndConsumer interface {
 	consumer.Traces


### PR DESCRIPTION
**Description:**
Remove deprecated interfaces LogsRouter, MetricsRouter and TracesRouter.

**Link to tracking Issue:**
Follow up to #9095