### PR TITLE
[receiver] Remove deprecated `ScraperControllerSettings` and `NewDefaultScraperControllerSettings`

### DIFF
--- a/.chloggen/remove_deprecated_scrapercontrollersettings.yaml
+++ b/.chloggen/remove_deprecated_scrapercontrollersettings.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: receiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated struct `ScraperControllerSettings` and function `NewDefaultScraperControllerSettings`
+
+# One or more tracking issues or pull requests related to the change
+issues: [6767]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/scraperhelper/config.go
+++ b/receiver/scraperhelper/config.go
@@ -9,19 +9,11 @@ import (
 	"time"
 
 	"go.uber.org/multierr"
-
-	"go.opentelemetry.io/collector/component"
 )
 
 var (
 	errNonPositiveInterval = errors.New("requires positive value")
 )
-
-// ScraperControllerSettings defines common settings for a scraper controller
-// configuration. Scraper controller receivers can embed this struct, instead
-// of receiver.Settings, and extend it with more fields if needed.
-// Deprecated: [v0.95.0] Use ControllerConfig instead
-type ScraperControllerSettings = ControllerConfig
 
 // ControllerConfig defines common settings for a scraper controller
 // configuration. Scraper controller receivers can embed this struct, instead
@@ -36,13 +28,6 @@ type ControllerConfig struct {
 	InitialDelay time.Duration `mapstructure:"initial_delay"`
 	// Timeout is an optional value used to set scraper's context deadline.
 	Timeout time.Duration `mapstructure:"timeout"`
-}
-
-// NewDefaultScraperControllerSettings returns default scraper controller
-// settings with a collection interval of one minute.
-// Deprecated: [v0.95.0] Use NewDefaultControllerConfig instead
-func NewDefaultScraperControllerSettings(component.Type) ControllerConfig {
-	return NewDefaultControllerConfig()
 }
 
 // NewDefaultControllerConfig returns default scraper controller


### PR DESCRIPTION
**Description:** 
Remove deprecated `ScraperControllerSettings` and `NewDefaultScraperControllerSettings`

**Link to tracking Issue:**
#6767