### PR TITLE
[configgrpc] Deprecate SanitizedEndpoint

### DIFF
--- a/.chloggen/deprecate-SanatizedEndpoints.yaml
+++ b/.chloggen/deprecate-SanatizedEndpoints.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `SanitizedEndpoint`
+
+# One or more tracking issues or pull requests related to the change
+issues: [9788]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -151,6 +151,7 @@ type ServerConfig struct {
 }
 
 // SanitizedEndpoint strips the prefix of either http:// or https:// from configgrpc.ClientConfig.Endpoint.
+// Deprecated: [v0.97.0]
 func (gcs *ClientConfig) SanitizedEndpoint() string {
 	switch {
 	case gcs.isSchemeHTTP():

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -5,6 +5,7 @@ package otlpexporter // import "go.opentelemetry.io/collector/exporter/otlpexpor
 
 import (
 	"errors"
+	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -22,10 +23,21 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-	if c.SanitizedEndpoint() == "" {
+	if c.sanitizedEndpoint() == "" {
 		return errors.New(`requires a non-empty "endpoint"`)
 	}
 	return nil
+}
+
+func (c *Config) sanitizedEndpoint() string {
+	switch {
+	case strings.HasPrefix(c.Endpoint, "http://"):
+		return strings.TrimPrefix(c.Endpoint, "http://")
+	case strings.HasPrefix(c.Endpoint, "https://"):
+		return strings.TrimPrefix(c.Endpoint, "https://")
+	default:
+		return c.Endpoint
+	}
 }
 
 var _ component.Config = (*Config)(nil)

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -92,6 +92,10 @@ func TestUnmarshalInvalidConfig(t *testing.T) {
 			errorMsg: `requires a non-empty "endpoint"`,
 		},
 		{
+			name:     "https_endpoint",
+			errorMsg: `requires a non-empty "endpoint"`,
+		},
+		{
 			name:     "http_endpoint",
 			errorMsg: `requires a non-empty "endpoint"`,
 		},

--- a/exporter/otlpexporter/testdata/invalid_configs.yaml
+++ b/exporter/otlpexporter/testdata/invalid_configs.yaml
@@ -11,6 +11,8 @@ no_endpoint:
     multiplier: 1.3
     max_interval: 60s
     max_elapsed_time: 10m
+https_endpoint:
+  endpoint: https://
 http_endpoint:
   endpoint: http://
   timeout: 10s


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Deprecates `configgrpc.SanitizedEndpoint()`.

**Link to tracking Issue:** <Issue number if applicable>
Works towards: https://github.com/open-telemetry/opentelemetry-collector/issues/9482
