### PR TITLE
[WIP][exporterhelper] Fix batchSender to always produce correct batch size

### DIFF
--- a/.chloggen/carsonip_batchsender-active-requests-scheduling.yaml
+++ b/.chloggen/carsonip_batchsender-active-requests-scheduling.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix batchSender to always produce correct batch size regardless of goroutine scheduling.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9793]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/batch_sender_test.go
+++ b/exporter/exporterhelper/batch_sender_test.go
@@ -294,6 +294,14 @@ func TestBatchSender_ConcurrencyLimitReached(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return sink.requestsCount.Load() == 1 && sink.itemsCount.Load() == 16
 	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	// do it a few more times to ensure it produces the correct batch size regardless of goroutine scheduling.
+	for i := 0; i < 4; i++ {
+		assert.NoError(t, be.send(context.Background(), &fakeRequest{items: 8, sink: sink}))
+	}
+	assert.Eventually(t, func() bool {
+		return sink.requestsCount.Load() == 3 && sink.itemsCount.Load() == 48
+	}, 100*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestBatchSender_BatchBlocking(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fix batchSender batching such that it produces batches containing the
right size regardless of goroutine scheduling in case of concurrency
limit reached.

**Testing:**

Manual testing shows that it now always produce the correct size, in contrast to the previous non-deterministic batching due to goroutine scheduling since #9761  


WIP: FIXME: does not handle mergeSplitBatch yet

