### PR TITLE
[configtls] Update IncludeSystemCACertsPool to be used in server and client RootCAs

### DIFF
--- a/.chloggen/configtls-fix-IncludeSystemCACertsPool-bug.yaml
+++ b/.chloggen/configtls-fix-IncludeSystemCACertsPool-bug.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configtls
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where `IncludeSystemCACertsPool` was not consistently used between `ServerConfig` and `ClientConfig`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9835]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -174,6 +174,10 @@ func (r *certReloader) GetCertificate() (*tls.Certificate, error) {
 }
 
 func (c TLSSetting) Validate() error {
+	if c.hasCAFile() && c.hasCAPem() {
+		return fmt.Errorf("provide either a CA file or the PEM-encoded string, but not both")
+	}
+
 	minTLS, err := convertVersion(c.MinVersion, defaultMinTLSVersion)
 	if err != nil {
 		return fmt.Errorf("invalid TLS min_version: %w", err)
@@ -290,6 +294,15 @@ func (c Config) loadCertFile(certPath string) (*x509.CertPool, error) {
 
 func (c Config) loadCertPem(certPem []byte) (*x509.CertPool, error) {
 	certPool := x509.NewCertPool()
+	if c.IncludeSystemCACertsPool {
+		scp, err := systemCertPool()
+		if err != nil {
+			return nil, err
+		}
+		if scp != nil {
+			certPool = scp
+		}
+	}
 	if !certPool.AppendCertsFromPEM(certPem) {
 		return nil, fmt.Errorf("failed to parse cert")
 	}

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -635,30 +635,25 @@ func TestMinMaxTLSVersions(t *testing.T) {
 
 func TestTLSSettingValidate(t *testing.T) {
 	tests := []struct {
-		name       string
-		minVersion string
-		maxVersion string
-		errorTxt   string
+		name      string
+		tlsConfig TLSSetting
+		errorTxt  string
 	}{
-		{name: `TLS Config ["", ""] to be valid`, minVersion: "", maxVersion: ""},
-		{name: `TLS Config ["", "1.3"] to be valid`, minVersion: "", maxVersion: "1.3"},
-		{name: `TLS Config ["1.2", ""] to be valid`, minVersion: "1.2", maxVersion: ""},
-		{name: `TLS Config ["1.3", "1.3"] to be valid`, minVersion: "1.3", maxVersion: "1.3"},
-		{name: `TLS Config ["1.0", "1.1"] to be valid`, minVersion: "1.0", maxVersion: "1.1"},
-		{name: `TLS Config ["asd", ""] to give [Error]`, minVersion: "asd", maxVersion: "", errorTxt: `invalid TLS min_version: unsupported TLS version: "asd"`},
-		{name: `TLS Config ["", "asd"] to give [Error]`, minVersion: "", maxVersion: "asd", errorTxt: `invalid TLS max_version: unsupported TLS version: "asd"`},
-		{name: `TLS Config ["0.4", ""] to give [Error]`, minVersion: "0.4", maxVersion: "", errorTxt: `invalid TLS min_version: unsupported TLS version: "0.4"`},
-		{name: `TLS Config ["1.2", "1.1"] to give [Error]`, minVersion: "1.2", maxVersion: "1.1", errorTxt: `invalid TLS configuration: min_version cannot be greater than max_version`},
+		{name: `TLS Config ["", ""] to be valid`, tlsConfig: Config{MinVersion: "", MaxVersion: ""}},
+		{name: `TLS Config ["", "1.3"] to be valid`, tlsConfig: Config{MinVersion: "", MaxVersion: "1.3"}},
+		{name: `TLS Config ["1.2", ""] to be valid`, tlsConfig: Config{MinVersion: "1.2", MaxVersion: ""}},
+		{name: `TLS Config ["1.3", "1.3"] to be valid`, tlsConfig: Config{MinVersion: "1.3", MaxVersion: "1.3"}},
+		{name: `TLS Config ["1.0", "1.1"] to be valid`, tlsConfig: Config{MinVersion: "1.0", MaxVersion: "1.1"}},
+		{name: `TLS Config ["asd", ""] to give [Error]`, tlsConfig: Config{MinVersion: "asd", MaxVersion: ""}, errorTxt: `invalid TLS min_version: unsupported TLS version: "asd"`},
+		{name: `TLS Config ["", "asd"] to give [Error]`, tlsConfig: Config{MinVersion: "", MaxVersion: "asd"}, errorTxt: `invalid TLS max_version: unsupported TLS version: "asd"`},
+		{name: `TLS Config ["0.4", ""] to give [Error]`, tlsConfig: Config{MinVersion: "0.4", MaxVersion: ""}, errorTxt: `invalid TLS min_version: unsupported TLS version: "0.4"`},
+		{name: `TLS Config ["1.2", "1.1"] to give [Error]`, tlsConfig: Config{MinVersion: "1.2", MaxVersion: "1.1"}, errorTxt: `invalid TLS configuration: min_version cannot be greater than max_version`},
+		{name: `TLS Config with both CA File and PEM`, tlsConfig: Config{CAFile: "test", CAPem: "test"}, errorTxt: `provide either a CA file or the PEM-encoded string, but not both`},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			setting := TLSSetting{
-				MinVersion: test.minVersion,
-				MaxVersion: test.maxVersion,
-			}
-
-			err := setting.Validate()
+			err := test.tlsConfig.Validate()
 
 			if test.errorTxt == "" {
 				assert.Nil(t, err)


### PR DESCRIPTION
**Description:** 
Updates `ServerConfig` and `ClientConfig` to use `IncludeSystemCACertsPool` when doing `LoadTLSConfig`. Previously `IncludeSystemCACertsPool` was only used for `ServerConfig`'s `ClientCAs` via `newClientCAsReloader`.

**Link to tracking Issue:** 
Closes https://github.com/open-telemetry/opentelemetry-collector/issues/9789

**Testing:** 
Added more tests