### PR TITLE
[collector-telemetry] Ensure correct behavior for the sampler returne

### DIFF
--- a/service/telemetry/otel_trace_sampler.go
+++ b/service/telemetry/otel_trace_sampler.go
@@ -24,5 +24,5 @@ func alwaysRecord() sdktrace.Sampler {
 		sdktrace.WithRemoteParentSampled(sdktrace.AlwaysSample()),
 		sdktrace.WithRemoteParentNotSampled(rs),
 		sdktrace.WithLocalParentSampled(sdktrace.AlwaysSample()),
-		sdktrace.WithRemoteParentSampled(rs))
+		sdktrace.WithLocalParentNotSampled(rs))
 }


### PR DESCRIPTION
 Fixing a bug：Use the correct parameter when calling sdktrace.ParentBased function in the alwaysRecord function.
