### PR TITLE
Updated public methods to accept context.context in `configretry`

### DIFF
--- a/.chloggen/configretry-add-context-to-public-funcs.yaml
+++ b/.chloggen/configretry-add-context-to-public-funcs.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configretry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `NewDefaultBackOffConfig`, use `NewDefaultBackOffConfigContext` instead.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9809]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configretry/backoff.go
+++ b/config/configretry/backoff.go
@@ -4,6 +4,7 @@
 package configretry // import "go.opentelemetry.io/collector/config/configretry"
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -11,7 +12,8 @@ import (
 )
 
 // NewDefaultBackOffConfig returns the default settings for RetryConfig.
-func NewDefaultBackOffConfig() BackOffConfig {
+// Deprecated: [v0.97.0] Use NewDefaultBackOffConfigContext instead.
+func NewDefaultBackOffConfigContext(_ context.Context) BackOffConfig {
 	return BackOffConfig{
 		Enabled:             true,
 		InitialInterval:     5 * time.Second,

--- a/config/configretry/backoff_test.go
+++ b/config/configretry/backoff_test.go
@@ -4,6 +4,7 @@
 package configretry
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 )
 
 func TestNewDefaultBackOffSettings(t *testing.T) {
-	cfg := NewDefaultBackOffConfig()
+	cfg := NewDefaultBackOffConfigContext(context.Background())
 	assert.NoError(t, cfg.Validate())
 	assert.Equal(t,
 		BackOffConfig{
@@ -25,14 +26,14 @@ func TestNewDefaultBackOffSettings(t *testing.T) {
 }
 
 func TestInvalidInitialInterval(t *testing.T) {
-	cfg := NewDefaultBackOffConfig()
+	cfg := NewDefaultBackOffConfigContext(context.Background())
 	assert.NoError(t, cfg.Validate())
 	cfg.InitialInterval = -1
 	assert.Error(t, cfg.Validate())
 }
 
 func TestInvalidRandomizationFactor(t *testing.T) {
-	cfg := NewDefaultBackOffConfig()
+	cfg := NewDefaultBackOffConfigContext(context.Background())
 	assert.NoError(t, cfg.Validate())
 	cfg.RandomizationFactor = -1
 	assert.Error(t, cfg.Validate())
@@ -41,28 +42,28 @@ func TestInvalidRandomizationFactor(t *testing.T) {
 }
 
 func TestInvalidMultiplier(t *testing.T) {
-	cfg := NewDefaultBackOffConfig()
+	cfg := NewDefaultBackOffConfigContext(context.Background())
 	assert.NoError(t, cfg.Validate())
 	cfg.Multiplier = -1
 	assert.Error(t, cfg.Validate())
 }
 
 func TestZeroMultiplierIsValid(t *testing.T) {
-	cfg := NewDefaultBackOffConfig()
+	cfg := NewDefaultBackOffConfigContext(context.Background())
 	assert.NoError(t, cfg.Validate())
 	cfg.Multiplier = 0
 	assert.NoError(t, cfg.Validate())
 }
 
 func TestInvalidMaxInterval(t *testing.T) {
-	cfg := NewDefaultBackOffConfig()
+	cfg := NewDefaultBackOffConfigContext(context.Background())
 	assert.NoError(t, cfg.Validate())
 	cfg.MaxInterval = -1
 	assert.Error(t, cfg.Validate())
 }
 
 func TestInvalidMaxElapsedTime(t *testing.T) {
-	cfg := NewDefaultBackOffConfig()
+	cfg := NewDefaultBackOffConfigContext(context.Background())
 	assert.NoError(t, cfg.Validate())
 	cfg.MaxElapsedTime = -1
 	assert.Error(t, cfg.Validate())

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -67,17 +67,17 @@ func checkStatus(t *testing.T, sd sdktrace.ReadOnlySpan, err error) {
 
 func TestQueueOptionsWithRequestExporter(t *testing.T) {
 	bs, err := newBaseExporter(exportertest.NewNopCreateSettings(), defaultType, newNoopObsrepSender,
-		WithRetry(configretry.NewDefaultBackOffConfig()))
+		WithRetry(configretry.NewDefaultBackOffConfigContext(context.Background())))
 	require.Nil(t, err)
 	require.Nil(t, bs.marshaler)
 	require.Nil(t, bs.unmarshaler)
 	_, err = newBaseExporter(exportertest.NewNopCreateSettings(), defaultType, newNoopObsrepSender,
-		WithRetry(configretry.NewDefaultBackOffConfig()), WithQueue(NewDefaultQueueSettings()))
+		WithRetry(configretry.NewDefaultBackOffConfigContext(context.Background())), WithQueue(NewDefaultQueueSettings()))
 	require.Error(t, err)
 
 	_, err = newBaseExporter(exportertest.NewNopCreateSettings(), defaultType, newNoopObsrepSender,
 		withMarshaler(mockRequestMarshaler), withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
-		WithRetry(configretry.NewDefaultBackOffConfig()),
+		WithRetry(configretry.NewDefaultBackOffConfigContext(context.Background())),
 		WithRequestQueue(exporterqueue.NewDefaultConfig(), exporterqueue.NewMemoryQueueFactory[Request]()))
 	require.Error(t, err)
 }
@@ -86,7 +86,7 @@ func TestBaseExporterLogging(t *testing.T) {
 	set := exportertest.NewNopCreateSettings()
 	logger, observed := observer.New(zap.DebugLevel)
 	set.Logger = zap.New(logger)
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	rCfg.Enabled = false
 	bs, err := newBaseExporter(set, defaultType, newNoopObsrepSender, WithRetry(rCfg))
 	require.Nil(t, err)

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -159,7 +159,7 @@ func TestLogsExporter_WithPersistentQueue(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	ts := consumertest.LogsSink{}
 	set := exportertest.NewNopCreateSettings()
 	set.ID = component.MustNewIDWithName("test_logs", "with_persistent_queue")
@@ -237,7 +237,7 @@ func TestLogsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 2

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -160,7 +160,7 @@ func TestMetricsExporter_WithPersistentQueue(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	ms := consumertest.MetricsSink{}
 	set := exportertest.NewNopCreateSettings()
 	set.ID = component.MustNewIDWithName("test_metrics", "with_persistent_queue")
@@ -239,7 +239,7 @@ func TestMetricsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 2

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -26,7 +26,7 @@ import (
 func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	be, err := newBaseExporter(defaultSettings, defaultType, newObservabilityConsumerSender,
 		withMarshaler(mockRequestMarshaler), withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
 		WithRetry(rCfg), WithQueue(qCfg))
@@ -60,7 +60,7 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	be, err := newBaseExporter(defaultSettings, defaultType, newObservabilityConsumerSender,
 		withMarshaler(mockRequestMarshaler), withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
 		WithRetry(rCfg), WithQueue(qCfg))
@@ -122,7 +122,7 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 					QueueSize:    10,
 					NumConsumers: 1,
 				}),
-				WithRetry(configretry.NewDefaultBackOffConfig()),
+				WithRetry(configretry.NewDefaultBackOffConfigContext(context.Background())),
 			},
 		},
 		{
@@ -133,7 +133,7 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 					QueueSize:    10,
 					NumConsumers: 1,
 				}, exporterqueue.NewMemoryQueueFactory[Request]()),
-				WithRetry(configretry.NewDefaultBackOffConfig()),
+				WithRetry(configretry.NewDefaultBackOffConfigContext(context.Background())),
 			},
 		},
 		{
@@ -144,7 +144,7 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 					QueueSize:    10,
 					NumConsumers: 1,
 				}, exporterqueue.NewPersistentQueueFactory[Request](nil, exporterqueue.PersistentQueueSettings[Request]{})),
-				WithRetry(configretry.NewDefaultBackOffConfig()),
+				WithRetry(configretry.NewDefaultBackOffConfigContext(context.Background())),
 			},
 		},
 		{
@@ -155,7 +155,7 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 					QueueSize:    10,
 					NumConsumers: 1,
 				}, exporterqueue.NewPersistentQueueFactory[Request](nil, exporterqueue.PersistentQueueSettings[Request]{})),
-				WithRetry(configretry.NewDefaultBackOffConfig()),
+				WithRetry(configretry.NewDefaultBackOffConfigContext(context.Background())),
 			},
 		},
 	}
@@ -207,7 +207,7 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 0 // to make every request go straight to the queue
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	set := exporter.CreateSettings{ID: defaultID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}
 	be, err := newBaseExporter(set, defaultType, newObservabilityConsumerSender,
 		withMarshaler(mockRequestMarshaler), withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
@@ -336,7 +336,7 @@ func TestQueuedRetryPersistenceEnabled(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID // enable persistence
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	set := exporter.CreateSettings{ID: defaultID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}
 	be, err := newBaseExporter(set, defaultType, newObservabilityConsumerSender,
 		withMarshaler(mockRequestMarshaler), withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
@@ -362,7 +362,7 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID // enable persistence
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	set := exporter.CreateSettings{ID: defaultID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}
 	be, err := newBaseExporter(set, defaultType, newObservabilityConsumerSender, withMarshaler(mockRequestMarshaler),
 		withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})), WithRetry(rCfg), WithQueue(qCfg))
@@ -383,7 +383,7 @@ func TestQueuedRetryPersistentEnabled_NoDataLossOnShutdown(t *testing.T) {
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID // enable persistence to ensure data is re-queued on shutdown
 
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 0 // retry infinitely so shutdown can be triggered
 

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -37,7 +37,7 @@ func mockRequestMarshaler(Request) ([]byte, error) {
 
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	mockR := newMockRequest(2, consumererror.NewPermanent(errors.New("bad data")))
 	be, err := newBaseExporter(defaultSettings, defaultType, newObservabilityConsumerSender,
 		withMarshaler(mockRequestMarshaler), withUnmarshaler(mockRequestUnmarshaler(mockR)), WithRetry(rCfg), WithQueue(qCfg))
@@ -61,7 +61,7 @@ func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 
 func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	rCfg.Enabled = false
 	be, err := newBaseExporter(defaultSettings, defaultType, newObservabilityConsumerSender, withMarshaler(mockRequestMarshaler),
 		withUnmarshaler(mockRequestUnmarshaler(newMockRequest(2, errors.New("transient error")))),
@@ -88,7 +88,7 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 func TestQueuedRetry_OnError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	rCfg.InitialInterval = 0
 	be, err := newBaseExporter(defaultSettings, defaultType, newObservabilityConsumerSender,
 		withMarshaler(mockRequestMarshaler), withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
@@ -117,7 +117,7 @@ func TestQueuedRetry_OnError(t *testing.T) {
 func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 100 * time.Millisecond
 	be, err := newBaseExporter(defaultSettings, defaultType, newObservabilityConsumerSender,
@@ -166,7 +166,7 @@ func (e wrappedError) Unwrap() error {
 func TestQueuedRetry_ThrottleError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	rCfg.InitialInterval = 10 * time.Millisecond
 	be, err := newBaseExporter(defaultSettings, defaultType, newObservabilityConsumerSender,
 		withMarshaler(mockRequestMarshaler), withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
@@ -200,7 +200,7 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 1
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	rCfg.InitialInterval = 0
 	be, err := newBaseExporter(defaultSettings, defaultType, newObservabilityConsumerSender,
 		withMarshaler(mockRequestMarshaler), withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
@@ -227,7 +227,7 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 }
 
 func TestQueueRetryWithNoQueue(t *testing.T) {
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	rCfg.MaxElapsedTime = time.Nanosecond // fail fast
 	be, err := newBaseExporter(exportertest.NewNopCreateSettings(), component.DataTypeLogs, newObservabilityConsumerSender, WithRetry(rCfg))
 	require.NoError(t, err)
@@ -245,7 +245,7 @@ func TestQueueRetryWithNoQueue(t *testing.T) {
 }
 
 func TestQueueRetryWithDisabledRetires(t *testing.T) {
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	rCfg.Enabled = false
 	set := exportertest.NewNopCreateSettings()
 	logger, observed := observer.New(zap.ErrorLevel)

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -157,7 +157,7 @@ func TestTracesExporter_WithPersistentQueue(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	ts := consumertest.TracesSink{}
 	set := exportertest.NewNopCreateSettings()
 	set.ID = component.MustNewIDWithName("test_traces", "with_persistent_queue")
@@ -236,7 +236,7 @@ func TestTracesExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg := configretry.NewDefaultBackOffConfigContext(context.Background())
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 2

--- a/exporter/exportertest/contract_checker_test.go
+++ b/exporter/exportertest/contract_checker_test.go
@@ -18,7 +18,7 @@ import (
 
 // retryConfig is a configuration to quickly retry failed exports.
 var retryConfig = func() configretry.BackOffConfig {
-	c := configretry.NewDefaultBackOffConfig()
+	c := configretry.NewDefaultBackOffConfigContext(context.Background())
 	c.InitialInterval = time.Millisecond
 	return c
 }()

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -31,7 +31,7 @@ func NewFactory() exporter.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
-		RetryConfig:     configretry.NewDefaultBackOffConfig(),
+		RetryConfig:     configretry.NewDefaultBackOffConfigContext(context.Background()),
 		QueueConfig:     exporterhelper.NewDefaultQueueSettings(),
 		ClientConfig: configgrpc.ClientConfig{
 			Headers: map[string]configopaque.String{},

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -30,7 +30,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
-	assert.Equal(t, ocfg.RetryConfig, configretry.NewDefaultBackOffConfig())
+	assert.Equal(t, ocfg.RetryConfig, configretry.NewDefaultBackOffConfigContext(context.Background()))
 	assert.Equal(t, ocfg.QueueConfig, exporterhelper.NewDefaultQueueSettings())
 	assert.Equal(t, ocfg.TimeoutSettings, exporterhelper.NewDefaultTimeoutSettings())
 	assert.Equal(t, ocfg.Compression, configcompression.TypeGzip)

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -34,7 +34,7 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		RetryConfig: configretry.NewDefaultBackOffConfig(),
+		RetryConfig: configretry.NewDefaultBackOffConfigContext(context.Background()),
 		QueueConfig: exporterhelper.NewDefaultQueueSettings(),
 		Encoding:    EncodingProto,
 		ClientConfig: confighttp.ClientConfig{

--- a/internal/e2e/consume_contract_test.go
+++ b/internal/e2e/consume_contract_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -19,7 +20,7 @@ import (
 )
 
 func testExporterConfig(endpoint string) component.Config {
-	retryConfig := configretry.NewDefaultBackOffConfig()
+	retryConfig := configretry.NewDefaultBackOffConfigContext(context.Background())
 	retryConfig.InitialInterval = time.Millisecond // interval is short for the test purposes
 	return &otlpexporter.Config{
 		QueueConfig: exporterhelper.QueueSettings{Enabled: false},


### PR DESCRIPTION
Deprecate `NewDefaultBackOffConfig` and use `NewDefaultBackOffConfigContext` instead.

Link: https://github.com/open-telemetry/opentelemetry-collector/issues/9809