### PR TITLE
[collector-telemetry] Ensure correct behavior for the sampler returne

### DIFF
--- a/service/telemetry/otel_trace_sampler.go
+++ b/service/telemetry/otel_trace_sampler.go
@@ -24,5 +24,5 @@ func alwaysRecord() sdktrace.Sampler {
 		sdktrace.WithRemoteParentSampled(sdktrace.AlwaysSample()),
 		sdktrace.WithRemoteParentNotSampled(rs),
 		sdktrace.WithLocalParentSampled(sdktrace.AlwaysSample()),
-		sdktrace.WithRemoteParentSampled(rs))
+		sdktrace.WithLocalParentNotSampled(rs))
 }

--- a/unreleased/9806-fix-telemetry-sampler-bug.yaml
+++ b/unreleased/9806-fix-telemetry-sampler-bug.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: telemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure correct behavior for the sampler returner
+
+# One or more tracking issues related to the change
+issues: [9806]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
Fixing a bug：Use the correct parameter when calling sdktrace.ParentBased function in the alwaysRecord function.