### PR TITLE
[receiver/otlp] Refactor http error handling

### DIFF
--- a/receiver/otlpreceiver/internal/errors/errors_test.go
+++ b/receiver/otlpreceiver/internal/errors/errors_test.go
@@ -48,33 +48,98 @@ func Test_GetStatusFromError(t *testing.T) {
 func Test_GetHTTPStatusCodeFromStatus(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    error
+		input    *status.Status
 		expected int
 	}{
 		{
-			name:     "Not a Status",
-			input:    fmt.Errorf("not a status error"),
-			expected: http.StatusInternalServerError,
-		},
-		{
 			name:     "Retryable Status",
-			input:    status.New(codes.Unavailable, "test").Err(),
+			input:    status.New(codes.Unavailable, "test"),
 			expected: http.StatusServiceUnavailable,
 		},
 		{
 			name:     "Non-retryable Status",
-			input:    status.New(codes.InvalidArgument, "test").Err(),
+			input:    status.New(codes.InvalidArgument, "test"),
 			expected: http.StatusInternalServerError,
 		},
 		{
 			name:     "Specifically 429",
-			input:    status.New(codes.ResourceExhausted, "test").Err(),
+			input:    status.New(codes.ResourceExhausted, "test"),
 			expected: http.StatusTooManyRequests,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GetHTTPStatusCodeFromStatus(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_ErrorMsgAndHTTPCodeToStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		errMsg     string
+		statusCode int
+		expected   *status.Status
+	}{
+		{
+			name:       "Bad Request",
+			errMsg:     "test",
+			statusCode: http.StatusBadRequest,
+			expected:   status.New(codes.InvalidArgument, "test"),
+		},
+		{
+			name:       "Unauthorized",
+			errMsg:     "test",
+			statusCode: http.StatusUnauthorized,
+			expected:   status.New(codes.Unauthenticated, "test"),
+		},
+		{
+			name:       "Forbidden",
+			errMsg:     "test",
+			statusCode: http.StatusForbidden,
+			expected:   status.New(codes.PermissionDenied, "test"),
+		},
+		{
+			name:       "Not Found",
+			errMsg:     "test",
+			statusCode: http.StatusNotFound,
+			expected:   status.New(codes.Unimplemented, "test"),
+		},
+		{
+			name:       "Too Many Requests",
+			errMsg:     "test",
+			statusCode: http.StatusTooManyRequests,
+			expected:   status.New(codes.ResourceExhausted, "test"),
+		},
+		{
+			name:       "Bad Gateway",
+			errMsg:     "test",
+			statusCode: http.StatusBadGateway,
+			expected:   status.New(codes.Unavailable, "test"),
+		},
+		{
+			name:       "Service Unavailable",
+			errMsg:     "test",
+			statusCode: http.StatusServiceUnavailable,
+			expected:   status.New(codes.Unavailable, "test"),
+		},
+		{
+			name:       "Gateway Timeout",
+			errMsg:     "test",
+			statusCode: http.StatusGatewayTimeout,
+			expected:   status.New(codes.Unavailable, "test"),
+		},
+		{
+			name:       "Unsupported Media Type",
+			errMsg:     "test",
+			statusCode: http.StatusUnsupportedMediaType,
+			expected:   status.New(codes.Unknown, "test"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewStatusFromMsgAndHTTPCode(tt.errMsg, tt.statusCode)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/receiver/otlpreceiver/otlphttp.go
+++ b/receiver/otlpreceiver/otlphttp.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	spb "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"go.opentelemetry.io/collector/receiver/otlpreceiver/internal/errors"
@@ -43,7 +42,7 @@ func handleTraces(resp http.ResponseWriter, req *http.Request, tracesReceiver *t
 
 	otlpResp, err := tracesReceiver.Export(req.Context(), otlpReq)
 	if err != nil {
-		writeError(resp, enc, err, errors.GetHTTPStatusCodeFromStatus(err))
+		writeError(resp, enc, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -74,7 +73,7 @@ func handleMetrics(resp http.ResponseWriter, req *http.Request, metricsReceiver 
 
 	otlpResp, err := metricsReceiver.Export(req.Context(), otlpReq)
 	if err != nil {
-		writeError(resp, enc, err, errors.GetHTTPStatusCodeFromStatus(err))
+		writeError(resp, enc, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -105,7 +104,7 @@ func handleLogs(resp http.ResponseWriter, req *http.Request, logsReceiver *logs.
 
 	otlpResp, err := logsReceiver.Export(req.Context(), otlpReq)
 	if err != nil {
-		writeError(resp, enc, err, errors.GetHTTPStatusCodeFromStatus(err))
+		writeError(resp, enc, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -150,8 +149,10 @@ func readAndCloseBody(resp http.ResponseWriter, req *http.Request, enc encoder) 
 // writeError encodes the HTTP error inside a rpc.Status message as required by the OTLP protocol.
 func writeError(w http.ResponseWriter, encoder encoder, err error, statusCode int) {
 	s, ok := status.FromError(err)
-	if !ok {
-		s = errorMsgToStatus(err.Error(), statusCode)
+	if ok {
+		statusCode = errors.GetHTTPStatusCodeFromStatus(s)
+	} else {
+		s = errors.NewStatusFromMsgAndHTTPCode(err.Error(), statusCode)
 	}
 	writeStatusResponse(w, encoder, statusCode, s.Proto())
 }
@@ -159,7 +160,7 @@ func writeError(w http.ResponseWriter, encoder encoder, err error, statusCode in
 // errorHandler encodes the HTTP error message inside a rpc.Status message as required
 // by the OTLP protocol.
 func errorHandler(w http.ResponseWriter, r *http.Request, errMsg string, statusCode int) {
-	s := errorMsgToStatus(errMsg, statusCode)
+	s := errors.NewStatusFromMsgAndHTTPCode(errMsg, statusCode)
 	switch getMimeTypeFromContentType(r.Header.Get("Content-Type")) {
 	case pbContentType:
 		writeStatusResponse(w, pbEncoder, statusCode, s.Proto())
@@ -186,13 +187,6 @@ func writeResponse(w http.ResponseWriter, contentType string, statusCode int, ms
 	w.WriteHeader(statusCode)
 	// Nothing we can do with the error if we cannot write to the response.
 	_, _ = w.Write(msg)
-}
-
-func errorMsgToStatus(errMsg string, statusCode int) *status.Status {
-	if statusCode == http.StatusBadRequest {
-		return status.New(codes.InvalidArgument, errMsg)
-	}
-	return status.New(codes.Unknown, errMsg)
 }
 
 func getMimeTypeFromContentType(contentType string) string {


### PR DESCRIPTION
**Description:** 
This PR slightly refactors the otlp receiver's HTTP error handling. The result is a few less calls to `status.FromError`, increased accuracy in the grpc code included in the body of the response, and centralizing http<->grpc mapping in the `internal/errors` package.

This PR intentionally changes how we map from HTTP status code to grpc `Status.code`. I don't consider this to be a breaking change, or even worthy of a changelog, since the specification states that `"The clients are not expected to alter their behavior based on Status.code field but MAY record it for troubleshooting purposes."` Honestly, I'd be ok if we chose to stop including the `Status.code` entirely as it leads to more confusion in the code and payload in my opinion.

**Link to tracking Issue:** 
Closes https://github.com/open-telemetry/opentelemetry-collector/issues/9864

**Testing:** 
Added new tests