### PR TITLE
PoC implementation for replaying startup logs once logger is initialized

### DIFF
--- a/confmap/confmaptest/provider_settings.go
+++ b/confmap/confmaptest/provider_settings.go
@@ -5,10 +5,17 @@ package confmaptest // import "go.opentelemetry.io/collector/confmap/confmaptest
 
 import (
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"go.opentelemetry.io/collector/confmap"
 )
 
 func NewNopProviderSettings() confmap.ProviderSettings {
 	return confmap.ProviderSettings{Logger: zap.NewNop()}
+}
+
+func NewLoggingProviderSettings() (confmap.ProviderSettings, *observer.ObservedLogs) {
+	core, ol := observer.New(zap.InfoLevel) // todo how do i get an appropriate logging level in here?
+	return confmap.ProviderSettings{Logger: zap.New(core)}, ol
+
 }

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"go.uber.org/multierr"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // follows drive-letter specification:
@@ -39,6 +40,8 @@ type ResolverSettings struct {
 
 	// MapConverters is a slice of Converter.
 	Converters []Converter
+
+	Ol *observer.ObservedLogs
 }
 
 // NewResolver returns a new Resolver that resolves configuration from multiple URIs.

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -198,6 +198,10 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	logger := col.service.Logger()
+	for _, log := range col.set.ConfigProviderSettings.ResolverSettings.Ol.All() {
+		logger.Log(log.Level, log.Message)
+	}
 
 	if !col.set.SkipSettingGRPCLogger {
 		grpclog.SetLogger(col.service.Logger(), cfg.Service.Telemetry.Logs.Level)

--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -134,7 +134,7 @@ func (cm *configProvider) GetConfmap(ctx context.Context) (*confmap.Conf, error)
 
 func newDefaultConfigProviderSettings(uris []string) ConfigProviderSettings {
 	converterSet := confmap.ConverterSettings{}
-	providerSet := confmaptest.NewNopProviderSettings()
+	providerSet, ol := confmaptest.NewLoggingProviderSettings()
 	return ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
 			URIs: uris,
@@ -146,6 +146,7 @@ func newDefaultConfigProviderSettings(uris []string) ConfigProviderSettings {
 				httpsprovider.NewWithSettings(providerSet),
 			),
 			Converters: []confmap.Converter{expandconverter.New(converterSet)},
+			Ol:         ol,
 		},
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Replaying previously stored provider logs once logger is initialized

**Link to tracking Issue:** [5615](https://github.com/open-telemetry/opentelemetry-collector/issues/5615)

**Testing:** None yet
