### PR TITLE
Move arm64 to platform support tier 2

### DIFF
--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -50,6 +50,8 @@ Tier 2 platforms are currently:
 | Platform      | Owner(s)                                                                                                    |
 |---------------|-------------------------------------------------------------------------------------------------------------|
 | windows/amd64 | [OpenTelemetry Collector approvers](https://github.com/open-telemetry/opentelemetry-collector#contributing) |
+| linux/arm64   | [@atoulme](https://github.com/atoulme)                                                                      |
+
 
 ### Tier 3 - Community Support
 
@@ -60,7 +62,6 @@ Tier 3 platforms are currently:
 |---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | darwin/amd64  | [@h0cheung](https://github.com/h0cheung)                                                                                                                        |
 | darwin/arm64  | [@MovieStoreGuy](https://github.com/MovieStoreGuy)                                                                                                              |
-| linux/arm64   | [@atoulme](https://github.com/atoulme)                                                                                                                          |
 | linux/386     | [@astencel-sumo](https://github.com/astencel-sumo)                                                                                                              |
 | linux/arm     | [@Wal8800](https://github.com/Wal8800), [@atoulme](https://github.com/atoulme)                                                                                  |
 | linux/ppc64le | [@IBM-Currency-Helper](https://github.com/IBM-Currency-Helper), [@adilhusain-s](https://github.com/adilhusain-s), [@seth-priya](https://github.com/seth-priya)  |


### PR DESCRIPTION
This is a documentation change reflecting the progress we have made in supporting Linux ARM64 type machines.

We now run both core and contrib builds on Ampere machines, supported by the CNCF, through Actuated github action runners.

This PR fixes #9731