### PR TITLE
[chore][CI/CD] Fix broken check-contrib tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,8 @@ check-contrib:
 		-replace go.opentelemetry.io/collector/receiver/nopreceiver=$(CURDIR)/receiver/nopreceiver  \
 		-replace go.opentelemetry.io/collector/receiver/otlpreceiver=$(CURDIR)/receiver/otlpreceiver  \
 		-replace go.opentelemetry.io/collector/semconv=$(CURDIR)/semconv  \
-		-replace go.opentelemetry.io/collector/service=$(CURDIR)/service"
+		-replace go.opentelemetry.io/collector/service=$(CURDIR)/service \
+		-replace go.opentelemetry.io/collector/pdata/testdata=$(CURDIR)/pdata/testdata"
 	@$(MAKE) -C $(CONTRIB_PATH) gotidy
 	@$(MAKE) -C $(CONTRIB_PATH) gotest
 	@if [ -z "$(SKIP_RESTORE_CONTRIB)" ]; then \


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
I noticed all of the [`contrib-tests` workflow runs](https://github.com/open-telemetry/opentelemetry-collector/actions/workflows/contrib-tests.yml) have been failing today, most of which are unrelated to contrib imports. Here are some sample failure runs and outputs:
[Example 1:](https://github.com/open-telemetry/opentelemetry-collector/actions/runs/8607209066/job/23587285578#step:4:792)
```
go: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter imports
	go.opentelemetry.io/collector/exporter/exporterhelper tested by
	go.opentelemetry.io/collector/exporter/exporterhelper.test imports
	go.opentelemetry.io/collector/pdata/testdata: go.opentelemetry.io/collector/pdata/testdata@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
make[3]: *** [../../Makefile.Common:208: tidy] Error 1
```
[Example 2:](https://github.com/open-telemetry/opentelemetry-collector/actions/runs/8607209066/job/23587284125)
```
go: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver tested by
	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver.test imports
	go.opentelemetry.io/collector/consumer/consumertest tested by
	go.opentelemetry.io/collector/consumer/consumertest.test imports
	go.opentelemetry.io/collector/pdata/testdata: go.opentelemetry.io/collector/pdata/testdata@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
make[3]: *** [../../Makefile.Common:208: tidy] Error 1
```

I believe this is a result of https://github.com/open-telemetry/opentelemetry-collector/pull/9885. The fix is simply add another replace in the `check-contrib` makefile directive.

**Testing:** <Describe what testing was performed and which tests were added.>
Tested locally, `make check-contrib` successfully got past the `make gotidy` check and started running tests successfully. In failing CI/CD runs (and locally as well) the `make gotidy` command was failing.