### PR TITLE
[chore][CI/CD] Fix failing codecov uploads

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -218,11 +218,12 @@ jobs:
       - name: Upload coverage report
         uses: Wandalen/wretry.action@1b2dcdbf61a2b96c52858ce7c24c5db099d58e77 # v3.0.1
         with:
-          action: codecov/codecov-action@v3
+          action: codecov/codecov-action@v4
           with: |
             file: ./coverage.txt
             fail_ci_if_error: true
             verbose: true
+            token: ${{ secrets.CODECOV_TOKEN }}
           attempt_limit: 10
           attempt_delay: 15000
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The `build-and-test` workflow has been failing consistently the last few days on the upload coverage step. The reason is outlined in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32259.

**Link to tracking Issue:** <Issue number if applicable>
Contrib issue, but same underlying cause: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32259

**Testing:** <Describe what testing was performed and which tests were added.>
None yet, the CI/CD tests on this PR should be successful if this works.
