### PR TITLE
[confighttp] deprecate ToClientContext, ToServerContext, ToListenerContext

### DIFF
--- a/.chloggen/codeboten_dep-context-methods.yaml
+++ b/.chloggen/codeboten_dep-context-methods.yaml
@@ -1,10 +1,10 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: deprecate
+component: confighttp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: deprecate ToClientContext, ToServerContext, ToListenerContext, replaced by ToClient, ToServer, ToListener

--- a/.chloggen/codeboten_dep-context-methods.yaml
+++ b/.chloggen/codeboten_dep-context-methods.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: deprecate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: deprecate ToClientContext, ToServerContext, ToListenerContext, replaced by ToClient, ToServer, ToListener
+
+# One or more tracking issues or pull requests related to the change
+issues: [9807]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -100,7 +100,7 @@ func TestHTTPClientCompression(t *testing.T) {
 				Endpoint:    srv.URL,
 				Compression: tt.encoding,
 			}
-			client, err := clientSettings.ToClientContext(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
+			client, err := clientSettings.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 			res, err := client.Do(req)
 			if tt.shouldError {

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -115,13 +115,8 @@ func NewDefaultClientConfig() ClientConfig {
 	}
 }
 
-// Deprecated: [v0.98.0] Use ToClientContext instead.
-func (hcs *ClientConfig) ToClient(host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
-	return hcs.ToClientContext(context.Background(), host, settings)
-}
-
-// ToClientContext creates an HTTP client.
-func (hcs *ClientConfig) ToClientContext(ctx context.Context, host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
+// ToClient creates an HTTP client.
+func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
 	tlsCfg, err := hcs.TLSSetting.LoadTLSConfigContext(ctx)
 	if err != nil {
 		return nil, err
@@ -234,6 +229,11 @@ func (hcs *ClientConfig) ToClientContext(ctx context.Context, host component.Hos
 	}, nil
 }
 
+// Deprecated: [v0.99.0] Use ToClient instead.
+func (hcs *ClientConfig) ToClientContext(ctx context.Context, host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
+	return hcs.ToClient(ctx, host, settings)
+}
+
 // Custom RoundTripper that adds headers.
 type headerRoundTripper struct {
 	transport http.RoundTripper
@@ -282,13 +282,13 @@ type ServerConfig struct {
 	ResponseHeaders map[string]configopaque.String `mapstructure:"response_headers"`
 }
 
-// Deprecated: [v0.98.0] Use ToListenerContext instead.
-func (hss *ServerConfig) ToListener() (net.Listener, error) {
-	return hss.ToListenerContext(context.Background())
+// Deprecated: [v0.99.0] Use ToListener instead.
+func (hss *ServerConfig) ToListenerContext(ctx context.Context) (net.Listener, error) {
+	return hss.ToListener(ctx)
 }
 
-// ToListenerContext creates a net.Listener.
-func (hss *ServerConfig) ToListenerContext(ctx context.Context) (net.Listener, error) {
+// ToListener creates a net.Listener.
+func (hss *ServerConfig) ToListener(ctx context.Context) (net.Listener, error) {
 	listener, err := net.Listen("tcp", hss.Endpoint)
 	if err != nil {
 		return nil, err
@@ -337,13 +337,13 @@ func WithDecoder(key string, dec func(body io.ReadCloser) (io.ReadCloser, error)
 	}
 }
 
-// Deprecated: [v0.98.0] Use ToServerContext instead.
-func (hss *ServerConfig) ToServer(host component.Host, settings component.TelemetrySettings, handler http.Handler, opts ...ToServerOption) (*http.Server, error) {
-	return hss.ToServerContext(context.Background(), host, settings, handler, opts...)
+// Deprecated: [v0.99.0] Use ToServer instead.
+func (hss *ServerConfig) ToServerContext(ctx context.Context, host component.Host, settings component.TelemetrySettings, handler http.Handler, opts ...ToServerOption) (*http.Server, error) {
+	return hss.ToServer(ctx, host, settings, handler, opts...)
 }
 
-// ToServerContext creates an http.Server from settings object.
-func (hss *ServerConfig) ToServerContext(_ context.Context, host component.Host, settings component.TelemetrySettings, handler http.Handler, opts ...ToServerOption) (*http.Server, error) {
+// ToServer creates an http.Server from settings object.
+func (hss *ServerConfig) ToServer(_ context.Context, host component.Host, settings component.TelemetrySettings, handler http.Handler, opts ...ToServerOption) (*http.Server, error) {
 	internal.WarnOnUnspecifiedHost(settings.Logger, hss.Endpoint)
 
 	serverOpts := &toServerOptions{}

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -169,7 +169,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tt := componenttest.NewNopTelemetrySettings()
 			tt.TracerProvider = nil
-			client, err := test.settings.ToClientContext(context.Background(), host, tt)
+			client, err := test.settings.ToClient(context.Background(), host, tt)
 			if test.shouldError {
 				assert.Error(t, err)
 				return
@@ -222,7 +222,7 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tt := componenttest.NewNopTelemetrySettings()
 			tt.TracerProvider = nil
-			client, err := test.settings.ToClientContext(context.Background(), host, tt)
+			client, err := test.settings.ToClient(context.Background(), host, tt)
 			assert.NoError(t, err)
 			transport := client.Transport.(*http.Transport)
 			assert.EqualValues(t, 1024, transport.ReadBufferSize)
@@ -272,7 +272,7 @@ func TestProxyURL(t *testing.T) {
 
 			tt := componenttest.NewNopTelemetrySettings()
 			tt.TracerProvider = nil
-			client, err := s.ToClientContext(context.Background(), componenttest.NewNopHost(), tt)
+			client, err := s.ToClient(context.Background(), componenttest.NewNopHost(), tt)
 
 			if tC.err {
 				require.Error(t, err)
@@ -342,7 +342,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.err, func(t *testing.T) {
-			_, err := test.settings.ToClientContext(context.Background(), host, componenttest.NewNopTelemetrySettings())
+			_, err := test.settings.ToClient(context.Background(), host, componenttest.NewNopTelemetrySettings())
 			assert.Regexp(t, test.err, err)
 		})
 	}
@@ -451,7 +451,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Omit TracerProvider and MeterProvider in TelemetrySettings as otelhttp.Transport cannot be introspected
-			client, err := test.settings.ToClientContext(context.Background(), test.host, component.TelemetrySettings{Logger: zap.NewNop(), MetricsLevel: configtelemetry.LevelNone})
+			client, err := test.settings.ToClient(context.Background(), test.host, component.TelemetrySettings{Logger: zap.NewNop(), MetricsLevel: configtelemetry.LevelNone})
 			if test.shouldErr {
 				assert.Error(t, err)
 				return
@@ -523,7 +523,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.err, func(t *testing.T) {
-			_, err := test.settings.ToListenerContext(context.Background())
+			_, err := test.settings.ToListener(context.Background())
 			assert.Regexp(t, test.err, err)
 		})
 	}
@@ -554,7 +554,7 @@ func TestHTTPServerWarning(t *testing.T) {
 			logger, observed := observer.New(zap.DebugLevel)
 			set.Logger = zap.New(logger)
 
-			_, err := test.settings.ToServerContext(
+			_, err := test.settings.ToServer(
 				context.Background(),
 				componenttest.NewNopHost(),
 				set,
@@ -698,10 +698,10 @@ func TestHttpReception(t *testing.T) {
 				Endpoint:   "localhost:0",
 				TLSSetting: tt.tlsServerCreds,
 			}
-			ln, err := hss.ToListenerContext(context.Background())
+			ln, err := hss.ToListener(context.Background())
 			require.NoError(t, err)
 
-			s, err := hss.ToServerContext(
+			s, err := hss.ToServer(
 				context.Background(),
 				componenttest.NewNopHost(),
 				componenttest.NewNopTelemetrySettings(),
@@ -733,7 +733,7 @@ func TestHttpReception(t *testing.T) {
 					return rt, nil
 				}
 			}
-			client, errClient := hcs.ToClientContext(context.Background(), componenttest.NewNopHost(), component.TelemetrySettings{})
+			client, errClient := hcs.ToClient(context.Background(), componenttest.NewNopHost(), component.TelemetrySettings{})
 			require.NoError(t, errClient)
 
 			resp, errResp := client.Get(hcs.Endpoint)
@@ -812,10 +812,10 @@ func TestHttpCors(t *testing.T) {
 				CORS:     tt.CORSConfig,
 			}
 
-			ln, err := hss.ToListenerContext(context.Background())
+			ln, err := hss.ToListener(context.Background())
 			require.NoError(t, err)
 
-			s, err := hss.ToServerContext(
+			s, err := hss.ToServer(
 				context.Background(),
 				componenttest.NewNopHost(),
 				componenttest.NewNopTelemetrySettings(),
@@ -856,7 +856,7 @@ func TestHttpCorsInvalidSettings(t *testing.T) {
 	}
 
 	// This effectively does not enable CORS but should also not cause an error
-	s, err := hss.ToServerContext(
+	s, err := hss.ToServer(
 		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
@@ -887,7 +887,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 		},
 	}
 
-	srv, err := hss.ToServerContext(context.Background(), host, componenttest.NewNopTelemetrySettings(), nil)
+	srv, err := hss.ToServer(context.Background(), host, componenttest.NewNopTelemetrySettings(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 
@@ -930,10 +930,10 @@ func TestHttpServerHeaders(t *testing.T) {
 				ResponseHeaders: tt.headers,
 			}
 
-			ln, err := hss.ToListenerContext(context.Background())
+			ln, err := hss.ToListener(context.Background())
 			require.NoError(t, err)
 
-			s, err := hss.ToServerContext(
+			s, err := hss.ToServer(
 				context.Background(),
 				componenttest.NewNopHost(),
 				componenttest.NewNopTelemetrySettings(),
@@ -1017,7 +1017,7 @@ func ExampleServerConfig() {
 	settings := ServerConfig{
 		Endpoint: "localhost:443",
 	}
-	s, err := settings.ToServerContext(
+	s, err := settings.ToServer(
 		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
@@ -1026,7 +1026,7 @@ func ExampleServerConfig() {
 		panic(err)
 	}
 
-	l, err := settings.ToListenerContext(context.Background())
+	l, err := settings.ToListener(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -1065,7 +1065,7 @@ func TestHttpClientHeaders(t *testing.T) {
 				Timeout:         0,
 				Headers:         tt.headers,
 			}
-			client, _ := setting.ToClientContext(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
+			client, _ := setting.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			req, err := http.NewRequest(http.MethodGet, setting.Endpoint, nil)
 			assert.NoError(t, err)
 			_, err = client.Do(req)
@@ -1101,7 +1101,7 @@ func TestHttpClientHostHeader(t *testing.T) {
 			Timeout:         0,
 			Headers:         tt.headers,
 		}
-		client, _ := setting.ToClientContext(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
+		client, _ := setting.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 		req, err := http.NewRequest(http.MethodGet, setting.Endpoint, nil)
 		assert.NoError(t, err)
 		_, err = client.Do(req)
@@ -1196,7 +1196,7 @@ func TestServerAuth(t *testing.T) {
 		handlerCalled = true
 	})
 
-	srv, err := hss.ToServerContext(context.Background(), host, componenttest.NewNopTelemetrySettings(), handler)
+	srv, err := hss.ToServer(context.Background(), host, componenttest.NewNopTelemetrySettings(), handler)
 	require.NoError(t, err)
 
 	// test
@@ -1214,7 +1214,7 @@ func TestInvalidServerAuth(t *testing.T) {
 		},
 	}
 
-	srv, err := hss.ToServerContext(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), http.NewServeMux())
+	srv, err := hss.ToServer(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), http.NewServeMux())
 	require.Error(t, err)
 	require.Nil(t, srv)
 }
@@ -1237,7 +1237,7 @@ func TestFailedServerAuth(t *testing.T) {
 		},
 	}
 
-	srv, err := hss.ToServerContext(context.Background(), host, componenttest.NewNopTelemetrySettings(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv, err := hss.ToServer(context.Background(), host, componenttest.NewNopTelemetrySettings(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	require.NoError(t, err)
 
 	// test
@@ -1260,7 +1260,7 @@ func TestServerWithErrorHandler(t *testing.T) {
 		http.Error(w, "invalid request", http.StatusInternalServerError)
 	}
 
-	srv, err := hss.ToServerContext(
+	srv, err := hss.ToServer(
 		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
@@ -1289,7 +1289,7 @@ func TestServerWithDecoder(t *testing.T) {
 		return body, nil
 	}
 
-	srv, err := hss.ToServerContext(
+	srv, err := hss.ToServer(
 		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
@@ -1366,7 +1366,7 @@ func BenchmarkHttpRequest(b *testing.B) {
 		TLSSetting: tlsServerCreds,
 	}
 
-	s, err := hss.ToServerContext(
+	s, err := hss.ToServer(
 		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
@@ -1375,7 +1375,7 @@ func BenchmarkHttpRequest(b *testing.B) {
 			require.NoError(b, errWrite)
 		}))
 	require.NoError(b, err)
-	ln, err := hss.ToListenerContext(context.Background())
+	ln, err := hss.ToListener(context.Background())
 	require.NoError(b, err)
 
 	go func() {
@@ -1399,12 +1399,12 @@ func BenchmarkHttpRequest(b *testing.B) {
 		b.Run(bb.name, func(b *testing.B) {
 			var c *http.Client
 			if !bb.clientPerThread {
-				c, err = hcs.ToClientContext(context.Background(), componenttest.NewNopHost(), component.TelemetrySettings{})
+				c, err = hcs.ToClient(context.Background(), componenttest.NewNopHost(), component.TelemetrySettings{})
 				require.NoError(b, err)
 			}
 			b.RunParallel(func(pb *testing.PB) {
 				if c == nil {
-					c, err = hcs.ToClientContext(context.Background(), componenttest.NewNopHost(), component.TelemetrySettings{})
+					c, err = hcs.ToClient(context.Background(), componenttest.NewNopHost(), component.TelemetrySettings{})
 					require.NoError(b, err)
 				}
 				for pb.Next() {

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -78,7 +78,7 @@ func newExporter(cfg component.Config, set exporter.CreateSettings) (*baseExport
 // start actually creates the HTTP client. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *baseExporter) start(ctx context.Context, host component.Host) error {
-	client, err := e.config.ClientConfig.ToClientContext(ctx, host, e.settings)
+	client, err := e.config.ClientConfig.ToClient(ctx, host, e.settings)
 	if err != nil {
 		return err
 	}

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -145,13 +145,13 @@ func (r *otlpReceiver) startHTTPServer(ctx context.Context, host component.Host)
 	}
 
 	var err error
-	if r.serverHTTP, err = r.cfg.HTTP.ToServerContext(ctx, host, r.settings.TelemetrySettings, httpMux, confighttp.WithErrorHandler(errorHandler)); err != nil {
+	if r.serverHTTP, err = r.cfg.HTTP.ToServer(ctx, host, r.settings.TelemetrySettings, httpMux, confighttp.WithErrorHandler(errorHandler)); err != nil {
 		return err
 	}
 
 	r.settings.Logger.Info("Starting HTTP server", zap.String("endpoint", r.cfg.HTTP.ServerConfig.Endpoint))
 	var hln net.Listener
-	if hln, err = r.cfg.HTTP.ServerConfig.ToListenerContext(ctx); err != nil {
+	if hln, err = r.cfg.HTTP.ServerConfig.ToListener(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Replaced by ToClient, ToServer, ToListener

Related to #9807 