### PR TITLE
[chore] fix deprecation godoc

### DIFF
--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -373,6 +373,7 @@ func (c ClientConfig) LoadTLSConfigContext(_ context.Context) (*tls.Config, erro
 }
 
 // LoadTLSConfig loads the TLS configuration.
+//
 // Deprecated: [v0.97.0] Use LoadTLSConfigContext instead.
 func (c ClientConfig) LoadTLSConfig() (*tls.Config, error) {
 	return c.LoadTLSConfigContext(context.Background())
@@ -403,6 +404,7 @@ func (c ServerConfig) LoadTLSConfigContext(_ context.Context) (*tls.Config, erro
 }
 
 // LoadTLSConfig loads the TLS configuration.
+//
 // Deprecated: [v0.97.0] Use LoadTLSConfigContext instead.
 func (c ServerConfig) LoadTLSConfig() (*tls.Config, error) {
 	return c.LoadTLSConfigContext(context.Background())

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -33,10 +33,12 @@ type RequestErrorHandler interface {
 }
 
 // RequestMarshaler is a function that can marshal a Request into bytes.
+//
 // Deprecated: [v0.94.0] Use exporterqueue.Marshaler[Request] instead.
 type RequestMarshaler func(req Request) ([]byte, error)
 
 // RequestUnmarshaler is a function that can unmarshal bytes into a Request.
+//
 // Deprecated: [v0.94.0] Use exporterqueue.Unmarshaler[Request] instead.
 type RequestUnmarshaler func(data []byte) (Request, error)
 


### PR DESCRIPTION
Not prefixing the Deprecated godoc with a newline (or it being the only godoc) appears to cause intellisense/linters some pain.
