### PR TITLE
[mdatagen] Rename include/exclude config options

### DIFF
--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
@@ -57,9 +57,14 @@ func DefaultMetricsConfig() MetricsConfig {
 
 // ResourceAttributeConfig provides common config for a particular resource attribute.
 type ResourceAttributeConfig struct {
-	Enabled bool            `mapstructure:"enabled"`
-	Include []filter.Config `mapstructure:"include"`
-	Exclude []filter.Config `mapstructure:"exclude"`
+	Enabled bool `mapstructure:"enabled"`
+	// Experimental: MetricsInclude defines a list of filters for attribute values.
+	// If the list is not empty, only metrics with matching resource attribute values will be emitted.
+	MetricsInclude []filter.Config `mapstructure:"metrics_include"`
+	// Experimental: MetricsExclude defines a list of filters for attribute values.
+	// If the list is not empty, metrics with matching resource attribute values will not be emitted.
+	// MetricsInclude has higher priority than MetricsExclude.
+	MetricsExclude []filter.Config `mapstructure:"metrics_exclude"`
 
 	enabledSetByUser bool
 }

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
@@ -357,7 +357,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 	if !mbc.ResourceAttributes.StringResourceAttrDisableWarning.enabledSetByUser {
 		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `string.resource.attr_disable_warning`: This resource_attribute will be disabled by default soon.")
 	}
-	if mbc.ResourceAttributes.StringResourceAttrRemoveWarning.enabledSetByUser || mbc.ResourceAttributes.StringResourceAttrRemoveWarning.Include != nil || mbc.ResourceAttributes.StringResourceAttrRemoveWarning.Exclude != nil {
+	if mbc.ResourceAttributes.StringResourceAttrRemoveWarning.enabledSetByUser || mbc.ResourceAttributes.StringResourceAttrRemoveWarning.MetricsInclude != nil || mbc.ResourceAttributes.StringResourceAttrRemoveWarning.MetricsExclude != nil {
 		settings.Logger.Warn("[WARNING] `string.resource.attr_remove_warning` should not be configured: This resource_attribute is deprecated and will be removed soon.")
 	}
 	if mbc.ResourceAttributes.StringResourceAttrToBeRemoved.Enabled {
@@ -376,53 +376,53 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		resourceAttributeIncludeFilter: make(map[string]filter.Filter),
 		resourceAttributeExcludeFilter: make(map[string]filter.Filter),
 	}
-	if mbc.ResourceAttributes.MapResourceAttr.Include != nil {
-		mb.resourceAttributeIncludeFilter["map.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.MapResourceAttr.Include)
+	if mbc.ResourceAttributes.MapResourceAttr.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["map.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.MapResourceAttr.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.MapResourceAttr.Exclude != nil {
-		mb.resourceAttributeExcludeFilter["map.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.MapResourceAttr.Exclude)
+	if mbc.ResourceAttributes.MapResourceAttr.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["map.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.MapResourceAttr.MetricsExclude)
 	}
-	if mbc.ResourceAttributes.OptionalResourceAttr.Include != nil {
-		mb.resourceAttributeIncludeFilter["optional.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.OptionalResourceAttr.Include)
+	if mbc.ResourceAttributes.OptionalResourceAttr.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["optional.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.OptionalResourceAttr.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.OptionalResourceAttr.Exclude != nil {
-		mb.resourceAttributeExcludeFilter["optional.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.OptionalResourceAttr.Exclude)
+	if mbc.ResourceAttributes.OptionalResourceAttr.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["optional.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.OptionalResourceAttr.MetricsExclude)
 	}
-	if mbc.ResourceAttributes.SliceResourceAttr.Include != nil {
-		mb.resourceAttributeIncludeFilter["slice.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.SliceResourceAttr.Include)
+	if mbc.ResourceAttributes.SliceResourceAttr.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["slice.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.SliceResourceAttr.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.SliceResourceAttr.Exclude != nil {
-		mb.resourceAttributeExcludeFilter["slice.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.SliceResourceAttr.Exclude)
+	if mbc.ResourceAttributes.SliceResourceAttr.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["slice.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.SliceResourceAttr.MetricsExclude)
 	}
-	if mbc.ResourceAttributes.StringEnumResourceAttr.Include != nil {
-		mb.resourceAttributeIncludeFilter["string.enum.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.StringEnumResourceAttr.Include)
+	if mbc.ResourceAttributes.StringEnumResourceAttr.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["string.enum.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.StringEnumResourceAttr.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.StringEnumResourceAttr.Exclude != nil {
-		mb.resourceAttributeExcludeFilter["string.enum.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.StringEnumResourceAttr.Exclude)
+	if mbc.ResourceAttributes.StringEnumResourceAttr.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["string.enum.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.StringEnumResourceAttr.MetricsExclude)
 	}
-	if mbc.ResourceAttributes.StringResourceAttr.Include != nil {
-		mb.resourceAttributeIncludeFilter["string.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttr.Include)
+	if mbc.ResourceAttributes.StringResourceAttr.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["string.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttr.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.StringResourceAttr.Exclude != nil {
-		mb.resourceAttributeExcludeFilter["string.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttr.Exclude)
+	if mbc.ResourceAttributes.StringResourceAttr.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["string.resource.attr"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttr.MetricsExclude)
 	}
-	if mbc.ResourceAttributes.StringResourceAttrDisableWarning.Include != nil {
-		mb.resourceAttributeIncludeFilter["string.resource.attr_disable_warning"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrDisableWarning.Include)
+	if mbc.ResourceAttributes.StringResourceAttrDisableWarning.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["string.resource.attr_disable_warning"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrDisableWarning.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.StringResourceAttrDisableWarning.Exclude != nil {
-		mb.resourceAttributeExcludeFilter["string.resource.attr_disable_warning"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrDisableWarning.Exclude)
+	if mbc.ResourceAttributes.StringResourceAttrDisableWarning.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["string.resource.attr_disable_warning"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrDisableWarning.MetricsExclude)
 	}
-	if mbc.ResourceAttributes.StringResourceAttrRemoveWarning.Include != nil {
-		mb.resourceAttributeIncludeFilter["string.resource.attr_remove_warning"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrRemoveWarning.Include)
+	if mbc.ResourceAttributes.StringResourceAttrRemoveWarning.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["string.resource.attr_remove_warning"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrRemoveWarning.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.StringResourceAttrRemoveWarning.Exclude != nil {
-		mb.resourceAttributeExcludeFilter["string.resource.attr_remove_warning"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrRemoveWarning.Exclude)
+	if mbc.ResourceAttributes.StringResourceAttrRemoveWarning.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["string.resource.attr_remove_warning"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrRemoveWarning.MetricsExclude)
 	}
-	if mbc.ResourceAttributes.StringResourceAttrToBeRemoved.Include != nil {
-		mb.resourceAttributeIncludeFilter["string.resource.attr_to_be_removed"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrToBeRemoved.Include)
+	if mbc.ResourceAttributes.StringResourceAttrToBeRemoved.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["string.resource.attr_to_be_removed"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrToBeRemoved.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.StringResourceAttrToBeRemoved.Exclude != nil {
-		mb.resourceAttributeExcludeFilter["string.resource.attr_to_be_removed"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrToBeRemoved.Exclude)
+	if mbc.ResourceAttributes.StringResourceAttrToBeRemoved.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["string.resource.attr_to_be_removed"] = filter.CreateFilter(mbc.ResourceAttributes.StringResourceAttrToBeRemoved.MetricsExclude)
 	}
 
 	for _, op := range options {

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/testdata/config.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/testdata/config.yaml
@@ -61,67 +61,67 @@ filter_set_include:
   resource_attributes:
     map.resource.attr:
       enabled: true
-      include:
+      metrics_include:
         - regexp: ".*"
     optional.resource.attr:
       enabled: true
-      include:
+      metrics_include:
         - regexp: ".*"
     slice.resource.attr:
       enabled: true
-      include:
+      metrics_include:
         - regexp: ".*"
     string.enum.resource.attr:
       enabled: true
-      include:
+      metrics_include:
         - regexp: ".*"
     string.resource.attr:
       enabled: true
-      include:
+      metrics_include:
         - regexp: ".*"
     string.resource.attr_disable_warning:
       enabled: true
-      include:
+      metrics_include:
         - regexp: ".*"
     string.resource.attr_remove_warning:
       enabled: true
-      include:
+      metrics_include:
         - regexp: ".*"
     string.resource.attr_to_be_removed:
       enabled: true
-      include:
+      metrics_include:
         - regexp: ".*"
 filter_set_exclude:
   resource_attributes:
     map.resource.attr:
       enabled: true
-      exclude:
+      metrics_exclude:
         - regexp: ".*"
     optional.resource.attr:
       enabled: true
-      exclude:
+      metrics_exclude:
         - strict: "optional.resource.attr-val"
     slice.resource.attr:
       enabled: true
-      exclude:
+      metrics_exclude:
         - regexp: ".*"
     string.enum.resource.attr:
       enabled: true
-      exclude:
+      metrics_exclude:
         - strict: "one"
     string.resource.attr:
       enabled: true
-      exclude:
+      metrics_exclude:
         - strict: "string.resource.attr-val"
     string.resource.attr_disable_warning:
       enabled: true
-      exclude:
+      metrics_exclude:
         - strict: "string.resource.attr_disable_warning-val"
     string.resource.attr_remove_warning:
       enabled: true
-      exclude:
+      metrics_exclude:
         - strict: "string.resource.attr_remove_warning-val"
     string.resource.attr_to_be_removed:
       enabled: true
-      exclude:
+      metrics_exclude:
         - strict: "string.resource.attr_to_be_removed-val"

--- a/cmd/mdatagen/templates/config.go.tmpl
+++ b/cmd/mdatagen/templates/config.go.tmpl
@@ -52,8 +52,13 @@ func DefaultMetricsConfig() MetricsConfig {
 type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 	{{- if .Metrics }}
-	Include []filter.Config `mapstructure:"include"`
-	Exclude []filter.Config `mapstructure:"exclude"`
+	// Experimental: MetricsInclude defines a list of filters for attribute values.
+	// If the list is not empty, only metrics with matching resource attribute values will be emitted.
+	MetricsInclude []filter.Config `mapstructure:"metrics_include"`
+	// Experimental: MetricsExclude defines a list of filters for attribute values.
+	// If the list is not empty, metrics with matching resource attribute values will not be emitted.
+	// MetricsInclude has higher priority than MetricsExclude.
+	MetricsExclude []filter.Config `mapstructure:"metrics_exclude"`
 	{{- end }}
 
 	enabledSetByUser bool

--- a/cmd/mdatagen/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/templates/metrics.go.tmpl
@@ -184,7 +184,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 	}
 	{{- end }}
 	{{- if $attr.Warnings.IfConfigured }}
-	if mbc.ResourceAttributes.{{ $name.Render }}.enabledSetByUser || mbc.ResourceAttributes.{{ $name.Render }}.Include != nil || mbc.ResourceAttributes.{{ $name.Render }}.Exclude != nil {
+	if mbc.ResourceAttributes.{{ $name.Render }}.enabledSetByUser || mbc.ResourceAttributes.{{ $name.Render }}.MetricsInclude != nil || mbc.ResourceAttributes.{{ $name.Render }}.MetricsExclude != nil {
 		settings.Logger.Warn("[WARNING] `{{ $name }}` should not be configured: {{ $attr.Warnings.IfConfigured }}")
 	}
 	{{- end }}
@@ -203,11 +203,11 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		{{- end }}
 	}
 	{{- range $name, $attr := .ResourceAttributes }}
-	if mbc.ResourceAttributes.{{ $name.Render }}.Include != nil {
-		mb.resourceAttributeIncludeFilter["{{ $name }}"] = filter.CreateFilter(mbc.ResourceAttributes.{{ $name.Render }}.Include)
+	if mbc.ResourceAttributes.{{ $name.Render }}.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["{{ $name }}"] = filter.CreateFilter(mbc.ResourceAttributes.{{ $name.Render }}.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.{{ $name.Render }}.Exclude != nil {
-		mb.resourceAttributeExcludeFilter["{{ $name }}"] = filter.CreateFilter(mbc.ResourceAttributes.{{ $name.Render }}.Exclude)
+	if mbc.ResourceAttributes.{{ $name.Render }}.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["{{ $name }}"] = filter.CreateFilter(mbc.ResourceAttributes.{{ $name.Render }}.MetricsExclude)
 	}
 	{{- end }}
 

--- a/cmd/mdatagen/templates/testdata/config.yaml.tmpl
+++ b/cmd/mdatagen/templates/testdata/config.yaml.tmpl
@@ -35,7 +35,7 @@ filter_set_include:
     {{- range $name, $attr := .ResourceAttributes }}
     {{ $name }}:
       enabled: true
-      include:
+      metrics_include:
         - regexp: ".*"
     {{- end }}
 filter_set_exclude:
@@ -43,7 +43,7 @@ filter_set_exclude:
     {{- range $name, $attr := .ResourceAttributes }}
     {{ $name }}:
       enabled: true
-      exclude:
+      metrics_exclude:
         {{- if eq $attr.Type.String "Str" }}
         - strict: {{ $attr.TestValue }}
         {{- else }}


### PR DESCRIPTION
The `include` and `exclude ` options in the resource attributes group sound confusing. It's easy to assume that matching filters will include or exclude resource attributes themselves while they control emitted resource metrics.

The proposal is to change the include/exclude options to `metrics_include`/`metrics_exclude` with detailed comments. These names make it cleaner that matching rules limit the emitted metrics, not resource attributes.

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25134