### PR TITLE
[featuregate] add Gate.featureGateEnableFunc for --feature-gates registered

### DIFF
--- a/featuregate/gate.go
+++ b/featuregate/gate.go
@@ -13,13 +13,14 @@ import (
 // Gate is an immutable object that is owned by the Registry and represents an individual feature that
 // may be enabled or disabled based on the lifecycle state of the feature and CLI flags specified by the user.
 type Gate struct {
-	id           string
-	description  string
-	referenceURL string
-	fromVersion  *version.Version
-	toVersion    *version.Version
-	stage        Stage
-	enabled      *atomic.Bool
+	id                    string
+	description           string
+	referenceURL          string
+	fromVersion           *version.Version
+	toVersion             *version.Version
+	stage                 Stage
+	enabled               *atomic.Bool
+	featureGateEnableFunc func()
 }
 
 // ID returns the id of the Gate.

--- a/featuregate/registry_test.go
+++ b/featuregate/registry_test.go
@@ -207,3 +207,9 @@ func TestRegisterGateLifecycle(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistryFeatureGateEnableFunc(t *testing.T) {
+	r := NewRegistry()
+	fooGate := r.MustRegister("foo", StageAlpha, WithRegisterFeatureGateEnableFunc(func() {}))
+	assert.NotNil(t, fooGate.featureGateEnableFunc)
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>

fix bug: collector start fail with '--feature-gates=logs.jsonParserArray'

how to fix: add Gate.featureGateEnableFunc,  called when --feature-gates registered

**Link to tracking Issue:** <Issue number if applicable>
[#32313
](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32313)
**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>

_Please delete paragraphs that you did not use before submitting._
