### PR TITLE
[service] fix bug in sampler

### DIFF
--- a/.chloggen/codeboten_fix-sampler-typo.yaml
+++ b/.chloggen/codeboten_fix-sampler-typo.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix record sampler configuration
+
+# One or more tracking issues or pull requests related to the change
+issues: [9968]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/service/telemetry/otel_trace_sampler.go
+++ b/service/telemetry/otel_trace_sampler.go
@@ -24,5 +24,5 @@ func alwaysRecord() sdktrace.Sampler {
 		sdktrace.WithRemoteParentSampled(sdktrace.AlwaysSample()),
 		sdktrace.WithRemoteParentNotSampled(rs),
 		sdktrace.WithLocalParentSampled(sdktrace.AlwaysSample()),
-		sdktrace.WithRemoteParentSampled(rs))
+		sdktrace.WithLocalParentNotSampled(rs))
 }


### PR DESCRIPTION
The configuration for the recordSampler has multiple configurations for the RemoteParentSampler which doesn't appear to make any sense. I suspect the original intent was to configure both local and remote samplers with sampled and not sampled.
