### PR TITLE
Memoize the result of Resolve to avoid duplicate read operations to the config

### DIFF
--- a/.chloggen/ms-hujia_enhance-collector.yaml
+++ b/.chloggen/ms-hujia_enhance-collector.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: Collector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Memoize the result of Get() for GetConfmap(), to avoid a duplicate call to Resolve() in ConfmapProvider.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9982]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -174,7 +174,6 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	var conf *confmap.Conf
 
 	if cp, ok := col.set.ConfigProvider.(ConfmapProvider); ok {
-		var err error
 		conf, err = cp.GetConfmap()
 
 		if err != nil {

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -162,17 +162,6 @@ func (col *Collector) Shutdown() {
 func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	col.setCollectorState(StateStarting)
 
-	var conf *confmap.Conf
-
-	if cp, ok := col.configProvider.(ConfmapProvider); ok {
-		var err error
-		conf, err = cp.GetConfmap(ctx)
-
-		if err != nil {
-			return fmt.Errorf("failed to resolve config: %w", err)
-		}
-	}
-
 	factories, err := col.set.Factories()
 	if err != nil {
 		return fmt.Errorf("failed to initialize factories: %w", err)
@@ -180,6 +169,17 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	cfg, err := col.configProvider.Get(ctx, factories)
 	if err != nil {
 		return fmt.Errorf("failed to get config: %w", err)
+	}
+
+	var conf *confmap.Conf
+
+	if cp, ok := col.set.ConfigProvider.(ConfmapProvider); ok {
+		var err error
+		conf, err = cp.GetConfmap()
+
+		if err != nil {
+			return fmt.Errorf("failed to resolve config: %w", err)
+		}
 	}
 
 	if err = cfg.Validate(); err != nil {

--- a/otelcol/configprovider_test.go
+++ b/otelcol/configprovider_test.go
@@ -119,7 +119,19 @@ func TestGetConfmap(t *testing.T) {
 	cmp, ok := cp.(ConfmapProvider)
 	require.True(t, ok)
 
-	cmap, err := cmp.GetConfmap(context.Background())
+	// Fail as no previous call to Get()
+	cmap, err := cmp.GetConfmap()
+	require.Nil(t, cmap)
+	require.Error(t, err)
+
+	// Succeed after call Get() first
+	factories, err := nopFactories()
+	require.NoError(t, err)
+
+	_, err = cp.Get(context.Background(), factories)
+	require.NoError(t, err)
+
+	cmap, err = cmp.GetConfmap()
 	require.NoError(t, err)
 
 	assert.EqualValues(t, yamlMap, cmap.ToStringMap())


### PR DESCRIPTION
**Description:** <Describe what has changed.>

For the implementation of `ConfigProvider`, the result of `Resolve` is memoized to avoid duplicate read operations to the config. The benefits include:
1. It could optimize the initialization of OTEL Collector. For `Collector`, the existing code will perform another extra read operation to the config right after the first one.
1. It could avoid missing change notification from `Watch()` in some rare corner case. This could happen after the watch is tear down and before new watch is setup in the second invocation to `Resolve()`. 

**Link to tracking Issue:** <Issue number if applicable>
N/A.

**Testing:** <Describe what testing was performed and which tests were added.>
No change to the interface and behavior, so all existing tests should be enough.

**Documentation:** <Describe the documentation added.>
N/A.