### PR TITLE
[featuregate] add Gate.operatorType for operator register

### DIFF
--- a/.chloggen/fix-featuregate-for-operator.yaml
+++ b/.chloggen/fix-featuregate-for-operator.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "add `Gate.operatorType` field. Check operator state in featuregate, when collector launch `--feature-gates=foo`"
+
+# One or more tracking issues or pull requests related to the change
+issues: [32313]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/featuregate/gate.go
+++ b/featuregate/gate.go
@@ -20,6 +20,7 @@ type Gate struct {
 	toVersion    *version.Version
 	stage        Stage
 	enabled      *atomic.Bool
+	operatorType string
 }
 
 // ID returns the id of the Gate.
@@ -55,4 +56,9 @@ func (g *Gate) FromVersion() string {
 // ToVersion returns the version information when Gate's in StageStable.
 func (g *Gate) ToVersion() string {
 	return fmt.Sprintf("v%s", g.toVersion)
+}
+
+// OperatorType returns the operator_type when Gate for operator.
+func (g *Gate) OperatorType() string {
+	return g.operatorType
 }

--- a/featuregate/gate_test.go
+++ b/featuregate/gate_test.go
@@ -22,6 +22,7 @@ func TestGate(t *testing.T) {
 
 	g := &Gate{
 		id:           "test",
+		operatorType: "test_type",
 		description:  "test gate",
 		enabled:      enabled,
 		stage:        StageAlpha,
@@ -37,4 +38,5 @@ func TestGate(t *testing.T) {
 	assert.Equal(t, "http://example.com", g.ReferenceURL())
 	assert.Equal(t, "v0.61.0", g.FromVersion())
 	assert.Equal(t, "v0.64.0", g.ToVersion())
+	assert.Equal(t, "test_type", g.OperatorType())
 }

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -107,6 +107,19 @@ func WithRegisterToVersion(toVersion string) RegisterOption {
 	})
 }
 
+// WithRegisterOperatorType is used to set the Gate "operatorType".
+// Optional, when you register Gate for operator, you should call this method to set the "operatorType".
+func WithRegisterOperatorType(operatorType string) RegisterOption {
+	return registerOptionFunc(func(g *Gate) error {
+		if len(operatorType) == 0 {
+			return fmt.Errorf("WithRegisterOperatorType: empty operator_type: %s", operatorType)
+		}
+
+		g.operatorType = operatorType
+		return nil
+	})
+}
+
 // MustRegister like Register but panics if an invalid ID or gate options are provided.
 func (r *Registry) MustRegister(id string, stage Stage, opts ...RegisterOption) *Gate {
 	g, err := r.Register(id, stage, opts...)


### PR DESCRIPTION
*Description:** <Describe what has changed.>
bug:  collector launch fail with '--feature-gates=logs.jsonParserArray'

how to fix: 
1. `func init()`always register operator to `operator.DefaultRegistry`.
2. use `Gate.operatorType` double check operator state in `featuregate.globalRegistry` when unmarshal configuration. Because id and operatorType are not the same string. (id: "logs.jsonParserArray", operatorType: "json_array_parser")

relevancy: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32478

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32313