### PR TITLE
[chore] Double Windows unit tests timeout

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -34,7 +34,7 @@ jobs:
             ~\AppData\Local\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
-        run: make gotest
+        run: make gotest GOTEST_TIMEOUT=240s
 
   windows-service-test:
     runs-on: windows-latest

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -4,7 +4,8 @@ ALL_PKGS := $(sort $(shell go list ./...))
 # COVER_PKGS is the list of packages to include in the coverage
 COVER_PKGS := $(shell go list ./... | tr "\n" ",")
 
-GOTEST_OPT?= -race -timeout 120s
+GOTEST_TIMEOUT?=120s
+GOTEST_OPT?= -race -timeout $(GOTEST_TIMEOUT)
 GOCMD?= go
 GOTEST=$(GOCMD) test
 GOOS := $(shell $(GOCMD) env GOOS)


### PR DESCRIPTION
**Description:**

Bump the timeout for the Windows unit tests from 120s to 240s. The tests currently are brushing up very close to this limit and are becoming flaky as a result.

[Example run](https://github.com/open-telemetry/opentelemetry-collector/actions/runs/8739137193/job/23984602883?pr=9516#step:5:19):

```
 ok  	go.opentelemetry.io/collector/cmd/builder/internal/builder	116.086s
```
