### PR TITLE
[builder] only compare major and minor versions from gomod

### DIFF
--- a/.chloggen/builder-strict-versioning.yaml
+++ b/.chloggen/builder-strict-versioning.yaml
@@ -15,7 +15,11 @@ issues: [9896]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:  Strict version checking will error on mismatches between the `otelcol_version` configured and the builder version or versions in the go.mod. This check can be temporarily disabled by using the `--skip-strict-versioning` flag. This flag will be removed in a future minor version.
+subtext:  |
+  Strict version checking will error on major and minor version mismatches 
+  between the `otelcol_version` configured and the builder version or versions 
+  in the go.mod. This check can be temporarily disabled by using the `--skip-strict-versioning` 
+  flag. This flag will be removed in a future minor version.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -152,13 +152,13 @@ The builder checks the relevant `go.mod`
 file for the following things after `go get`ing all components and calling 
 `go mod tidy`:
 
-1. The `dist::otelcol_version` field in the build configuration must
-   match the core library version calculated by the Go toolchain,
-   considering all components.  A mismatch could happen, for example,
-   when one of the components depends on a newer release of the core
-   collector library.
-2. For each component in the build configuration, the version included
-   in the `gomod` module specifier must match the one calculated by
+1. The `dist::otelcol_version` field in the build configuration must have 
+   matching major and minor versions as the core library version calculated by 
+   the Go toolchain, considering all components.  A mismatch could happen, for 
+   example, when the builder or one of the components depends on a newer release 
+   of the core collector library.
+2. For each component in the build configuration, the major and minor versions 
+   included in the `gomod` module specifier must match the one calculated by
    the Go toolchain, considering all components.  A mismatch could
    happen, for example, when the enclosing Go module uses a newer
    release of the core collector library.

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -16,6 +16,7 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
 )
 
 var (
@@ -167,7 +168,7 @@ func GetModules(cfg Config) error {
 	if !ok {
 		return fmt.Errorf("core collector %w: '%s'. %s", ErrDepNotFound, corePath, skipStrictMsg)
 	}
-	if coreDepVersion != coreVersion {
+	if semver.MajorMinor(coreDepVersion) != semver.MajorMinor(coreVersion) {
 		return fmt.Errorf(
 			"%w: core collector version calculated by component dependencies %q does not match configured version %q. %s",
 			ErrVersionMismatch, coreDepVersion, coreVersion, skipStrictMsg)
@@ -185,7 +186,7 @@ func GetModules(cfg Config) error {
 		if !ok {
 			return fmt.Errorf("component %w: '%s'. %s", ErrDepNotFound, module, skipStrictMsg)
 		}
-		if moduleDepVersion != version {
+		if semver.MajorMinor(moduleDepVersion) != semver.MajorMinor(version) {
 			return fmt.Errorf(
 				"%w: component %q version calculated by dependencies %q does not match configured version %q. %s",
 				ErrVersionMismatch, module, moduleDepVersion, version, skipStrictMsg)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When building from a commit hash, I got this error:
```
Error: mismatch in go.mod and builder configuration versions: core collector version calculated by component dependencies "v0.98.1-0.20240416174005-d0f15e2463f8" does not match configured version "v0.98.0". Use --skip-strict-versioning to temporarily disable this check. This flag will be removed in a future minor version
```
It may be more useful to only compare the major and minor versions

<!-- Issue number if applicable -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector/issues/9896
Found in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32544

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation
updated readme