### PR TITLE
[cmd/builder] Remove undocumented strictness check

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -34,7 +34,7 @@ jobs:
             ~\AppData\Local\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
-        run: make gotest GOTEST_TIMEOUT=240s
+        run: make gotest
 
   windows-service-test:
     runs-on: windows-latest

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -4,7 +4,7 @@ ALL_PKGS := $(sort $(shell go list ./...))
 # COVER_PKGS is the list of packages to include in the coverage
 COVER_PKGS := $(shell go list ./... | tr "\n" ",")
 
-GOTEST_TIMEOUT?=120s
+GOTEST_TIMEOUT?=240s
 GOTEST_OPT?= -race -timeout $(GOTEST_TIMEOUT)
 GOCMD?= go
 GOTEST=$(GOCMD) test

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -74,9 +74,6 @@ func Generate(cfg Config) error {
 	}
 	// create a warning message for non-aligned builder and collector base
 	if cfg.Distribution.OtelColVersion != defaultOtelColVersion {
-		if !cfg.SkipStrictVersioning {
-			return fmt.Errorf("builder version %q does not match build configuration version %q: %w", cfg.Distribution.OtelColVersion, defaultOtelColVersion, ErrVersionMismatch)
-		}
 		cfg.Logger.Info("You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API", zap.String("builder-version", defaultOtelColVersion))
 	}
 	// if the file does not exist, try to create it

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -90,18 +90,18 @@ func TestVersioning(t *testing.T) {
 				cfg := NewDefaultConfig()
 				cfg.Verbose = true
 				cfg.Distribution.Go = "go"
-				cfg.Distribution.OutputPath = "/tmp/otelcol-distribution"
-				cfg.Distribution.OtelColVersion = "0.96.0"
+				cfg.Distribution.OtelColVersion = "0.97.0"
+				cfg.Distribution.RequireOtelColModule = true
 				var err error
 				cfg.Exporters, err = parseModules([]Module{
 					{
-						GoMod: "go.opentelemetry.io/collector/exporter/otlpexporter v0.96.0",
+						GoMod: "go.opentelemetry.io/collector/exporter/otlpexporter v0.97.0",
 					},
 				})
 				require.NoError(t, err)
 				cfg.Receivers, err = parseModules([]Module{
 					{
-						GoMod: "go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.0",
+						GoMod: "go.opentelemetry.io/collector/receiver/otlpreceiver v0.97.0",
 					},
 				})
 				require.NoError(t, err)

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -90,19 +90,24 @@ func TestVersioning(t *testing.T) {
 				cfg := NewDefaultConfig()
 				cfg.Verbose = true
 				cfg.Distribution.Go = "go"
-				cfg.Distribution.OtelColVersion = "0.90.0"
+				cfg.Distribution.OutputPath = "/tmp/otelcol-distribution"
+				cfg.Distribution.OtelColVersion = "0.96.0"
+				var err error
+				cfg.Exporters, err = parseModules([]Module{
+					{
+						GoMod: "go.opentelemetry.io/collector/exporter/otlpexporter v0.96.0",
+					},
+				})
+				require.NoError(t, err)
+				cfg.Receivers, err = parseModules([]Module{
+					{
+						GoMod: "go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.0",
+					},
+				})
+				require.NoError(t, err)
 				return cfg
 			},
 			expectedErr: nil,
-		},
-		{
-			description: "invalid collector version",
-			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
-				cfg.Distribution.OtelColVersion = "invalid"
-				return cfg
-			},
-			expectedErr: ErrVersionMismatch,
 		},
 		{
 			description: "invalid collector version without strict mode, only generate",

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -88,18 +88,8 @@ func TestVersioning(t *testing.T) {
 			description: "old otel version",
 			cfgBuilder: func() Config {
 				cfg := NewDefaultConfig()
-				cfg.Distribution.OtelColVersion = "0.90.0"
-				return cfg
-			},
-			expectedErr: ErrVersionMismatch,
-		},
-		{
-			description: "old otel version without strict mode",
-			cfgBuilder: func() Config {
-				cfg := NewDefaultConfig()
 				cfg.Verbose = true
 				cfg.Distribution.Go = "go"
-				cfg.SkipStrictVersioning = true
 				cfg.Distribution.OtelColVersion = "0.90.0"
 				return cfg
 			},


### PR DESCRIPTION
#### Description
<!-- Issue number if applicable -->

Partially reverts #9897. This was not documented on the original PR and is IMO too strict. 
We likely want to allow for some skew between versions.

Mentioned on https://github.com/open-telemetry/opentelemetry-collector/pull/9513#issuecomment-2065586307
