### PR TITLE
Support metric.metadata in pdata/pmetric

### DIFF
--- a/.chloggen/metric-metadata.yaml
+++ b/.chloggen/metric-metadata.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pmetric
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support metric.metadata in pdata/pmetric
+
+# One or more tracking issues or pull requests related to the change
+issues: [10006]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pdata/internal/cmd/pdatagen/internal/pmetric_package.go
+++ b/pdata/internal/cmd/pdatagen/internal/pmetric_package.go
@@ -115,6 +115,10 @@ var metric = &messageValueStruct{
 			defaultVal: `""`,
 			testVal:    `"1"`,
 		},
+		&sliceField{
+			fieldName:   "Metadata",
+			returnSlice: mapStruct,
+		},
 		&oneOfField{
 			typeName:                   "MetricType",
 			originFieldName:            "Data",

--- a/pdata/pmetric/generated_metric.go
+++ b/pdata/pmetric/generated_metric.go
@@ -9,6 +9,7 @@ package pmetric
 import (
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 // Metric represents one metric as a collection of datapoints.
@@ -77,6 +78,11 @@ func (ms Metric) Unit() string {
 func (ms Metric) SetUnit(v string) {
 	ms.state.AssertMutable()
 	ms.orig.Unit = v
+}
+
+// Metadata returns the Metadata associated with this Metric.
+func (ms Metric) Metadata() pcommon.Map {
+	return pcommon.Map(internal.NewMap(&ms.orig.Metadata, ms.state))
 }
 
 // Type returns the type of the data for this Metric.
@@ -233,6 +239,7 @@ func (ms Metric) CopyTo(dest Metric) {
 	dest.SetName(ms.Name())
 	dest.SetDescription(ms.Description())
 	dest.SetUnit(ms.Unit())
+	ms.Metadata().CopyTo(dest.Metadata())
 	switch ms.Type() {
 	case MetricTypeGauge:
 		ms.Gauge().CopyTo(dest.SetEmptyGauge())

--- a/pdata/pmetric/generated_metric_test.go
+++ b/pdata/pmetric/generated_metric_test.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 func TestMetric_MoveTo(t *testing.T) {
@@ -63,6 +64,13 @@ func TestMetric_Unit(t *testing.T) {
 	assert.Equal(t, "1", ms.Unit())
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).SetUnit("1") })
+}
+
+func TestMetric_Metadata(t *testing.T) {
+	ms := NewMetric()
+	assert.Equal(t, pcommon.NewMap(), ms.Metadata())
+	internal.FillTestMap(internal.Map(ms.Metadata()))
+	assert.Equal(t, pcommon.Map(internal.GenerateTestMap()), ms.Metadata())
 }
 
 func TestMetric_Type(t *testing.T) {
@@ -175,6 +183,7 @@ func fillTestMetric(tv Metric) {
 	tv.orig.Name = "test_name"
 	tv.orig.Description = "test_description"
 	tv.orig.Unit = "1"
+	internal.FillTestMap(internal.NewMap(&tv.orig.Metadata, tv.state))
 	tv.orig.Data = &otlpmetrics.Metric_Sum{Sum: &otlpmetrics.Sum{}}
 	fillTestSum(newSum(tv.orig.GetSum(), tv.state))
 }


### PR DESCRIPTION
#### Description

After https://github.com/open-telemetry/opentelemetry-collector/pull/9985, add support for the new metric.metadata field in the pmetric package.

I plan to use the metric.metadata field to support additional prometheus types per https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata