### PR TITLE
Support parsing metric.metadata from OTLP JSON

### DIFF
--- a/.chloggen/json-metric-metadata.yaml
+++ b/.chloggen/json-metric-metadata.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pmetric
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support parsing metric.metadata from OTLP JSON.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10026]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pdata/pmetric/json.go
+++ b/pdata/pmetric/json.go
@@ -106,6 +106,11 @@ func (ms Metric) unmarshalJsoniter(iter *jsoniter.Iterator) {
 			ms.orig.Description = iter.ReadString()
 		case "unit":
 			ms.orig.Unit = iter.ReadString()
+		case "metadata":
+			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
+				ms.orig.Metadata = append(ms.orig.Metadata, json.ReadAttribute(iter))
+				return true
+			})
 		case "sum":
 			ms.SetEmptySum().unmarshalJsoniter(iter)
 		case "gauge":

--- a/pdata/pmetric/json_test.go
+++ b/pdata/pmetric/json_test.go
@@ -21,11 +21,13 @@ var metricsOTLP = func() Metrics {
 	il := rm.ScopeMetrics().AppendEmpty()
 	il.Scope().SetName("name")
 	il.Scope().SetVersion("version")
-	il.Metrics().AppendEmpty().SetName("testMetric")
+	m := il.Metrics().AppendEmpty()
+	m.SetName("testMetric")
+	m.Metadata().PutStr("metadatakey", "metadatavalue")
 	return md
 }()
 
-var metricsJSON = `{"resourceMetrics":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"testHost"}}]},"scopeMetrics":[{"scope":{"name":"name","version":"version"},"metrics":[{"name":"testMetric"}]}]}]}`
+var metricsJSON = `{"resourceMetrics":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"testHost"}}]},"scopeMetrics":[{"scope":{"name":"name","version":"version"},"metrics":[{"name":"testMetric","metadata":[{"key":"metadatakey","value":{"stringValue":"metadatavalue"}}]}]}]}]}`
 
 func TestMetricsJSON(t *testing.T) {
 	encoder := &JSONMarshaler{}


### PR DESCRIPTION
#### Description
Follow-up to https://github.com/open-telemetry/opentelemetry-collector/pull/10006, which added metric.metadata to pmetric.

I forgot to add support for parsing the field from JSON in that PR.  This PR adds the missing support.

#### Testing

Unit tests
