### PR TITLE
[chore] Remove GO111MODULE references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,10 +206,7 @@ before merging (but see above paragraph about writing good commit messages in th
 
 This project uses Go 1.21.* and [Github Actions.](https://github.com/features/actions)
 
-It is recommended to run `make gofmt all` before submitting your PR
-
-The dependencies are managed with `go mod` if you work with the sources under your
-`$GOPATH` you need to set the environment variable `GO111MODULE=on`.
+It is recommended to run `make gofmt all` before submitting your PR.
 
 ## Coding Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ endif
 # Build the Collector executable.
 .PHONY: otelcorecol
 otelcorecol:
-	pushd cmd/otelcorecol && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/otelcorecol_$(GOOS)_$(GOARCH) \
+	pushd cmd/otelcorecol && CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/otelcorecol_$(GOOS)_$(GOARCH) \
 		-tags $(GO_BUILD_TAGS) ./cmd/otelcorecol && popd
 
 .PHONY: genotelcorecol

--- a/cmd/builder/Makefile
+++ b/cmd/builder/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.Common
 
 .PHONY: ocb
 ocb:
-	GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/ocb_$(GOOS)_$(GOARCH) .
+	CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/ocb_$(GOOS)_$(GOARCH) .
 
 # Generate the default build config from otelcorecol, by removing the
 # "replaces" stanza, which is assumed to be at the end of the file.

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -5,7 +5,7 @@ This program generates a custom OpenTelemetry Collector binary based on a given 
 ## TL;DR
 
 ```console
-$ GO111MODULE=on go install go.opentelemetry.io/collector/cmd/builder@latest
+$ go install go.opentelemetry.io/collector/cmd/builder@latest
 $ cat > otelcol-builder.yaml <<EOF
 dist:
   name: otelcol-custom


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This has been set to `on` by default since Go 1.16: https://go.dev/doc/go1.16#go-command.