### PR TITLE
[cmd/builder] Disable cgo by default

### DIFF
--- a/.chloggen/builder-cgo.yaml
+++ b/.chloggen/builder-cgo.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable cgo by default
+
+# One or more tracking issues or pull requests related to the change
+issues: [10028]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  Most Collector builds do not use cgo, and all upstream distributions explicitly disable it.
+  Set `distribution::cgo_enabled` to `true` to allow use of cgo. Note that setting `cgo_enabled`
+  will only not set the `CGO_ENABLED` variable, and may not necessarily enable cgo.
+  See the [cgo package docs](https://pkg.go.dev/cmd/cgo) for more information.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -121,6 +121,7 @@ dist:
     version: "1.0.0" # the version for your custom OpenTelemetry Collector. Optional.
     go: "/usr/bin/go" # which Go binary to use to compile the generated sources. Optional.
     debug_compilation: false # enabling this causes the builder to keep the debug symbols in the resulting binary. Optional.
+    cgo_enabled: false # If false, sets `CGO_ENABLED=0` for compilation. Otherwise does not set any environment variable. Optional, disabled by default.
 exporters:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.40.0" # the Go module for the component. Required.
     import: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter" # the import path for the component. Optional.

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -48,6 +48,7 @@ type Distribution struct {
 	Module                   string `mapstructure:"module"`
 	Name                     string `mapstructure:"name"`
 	Go                       string `mapstructure:"go"`
+	CgoEnabled               bool   `mapstructure:"cgo_enabled"`
 	Description              string `mapstructure:"description"`
 	OtelColVersion           string `mapstructure:"otelcol_version"`
 	RequireOtelColModule     bool   `mapstructure:"-"` // required for backwards-compatibility with builds older than 0.86.0


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Disables cgo by default in the builder. I'm proposing this as a breaking change because I doubt it will affect many users, most of whom I expect to be using `CGO_ENABLED=0` already, or at a minimum prefer cgo to be disabled. If we would like to have a transition period for this, I can adjust the PR and plan for that.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10028 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

I can't find a good way to directly test this that doesn't involve either setting up a lot of scaffolding to either create a mock `go` cli or injects the necessary code into a top-level function. To keep things simple I have just relied on the existing test suite. I had thought of trying to test the output binary, but Go disables cgo if no compiler is detected on the system, so the test wouldn't be reliable across developer machines.

In the future, if we emit a Dockerfile from the builder, we can test that leaving the option as a default runs inside a `scratch` image.

<!--Describe the documentation added.-->
#### Documentation

Updated the builder readme.

<!--Please delete paragraphs that you did not use before submitting.-->
