### PR TITLE
[chore] group contrib packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,8 +35,10 @@
       },
       {
         "matchManagers": ["gomod"],
-        "matchSourceUrlPrefixes": ["https://go.opentelemetry.io/contrib"],
-        "groupName": "All go.opentelemetry.io/contrib packages"
+        "matchSourceUrls": [
+          "https://github.com/open-telemetry/opentelemetry-go-contrib"
+        ],
+        "groupName": "All opentelemetry-go-contrib packages"
       },
       {
         "matchManagers": ["gomod"],


### PR DESCRIPTION
This follows the monorepo preset pattern here: https://docs.renovatebot.com/presets-monorepo/#monorepoopentelemetry-go