### PR TITLE
[mdatagen] use mdatagen to produce component internal telemetry

### DIFF
--- a/.chloggen/codeboten_mdatagen-for-batch-metrics.yaml
+++ b/.chloggen/codeboten_mdatagen-for-batch-metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add ability to use metadata.yaml to automatically generate instruments for components
+
+# One or more tracking issues or pull requests related to the change
+issues: [10054]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `telemetry` section in metadata.yaml is used to generate
+  instruments for components to measure telemetry about themselves.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -3,9 +3,10 @@
 package metadata
 
 import (
+	"errors"
+
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/multierr"
 
 	"go.opentelemetry.io/collector/component"
 )
@@ -32,19 +33,19 @@ type telemetryBuilderOption func(*TelemetryBuilder)
 // for a component
 func NewTelemetryBuilder(settings component.TelemetrySettings, options ...telemetryBuilderOption) (*TelemetryBuilder, error) {
 	builder := TelemetryBuilder{}
-	var err, errors error
+	var err, errs error
 	meter := Meter(settings)
 	builder.BatchSizeTriggerSend, err = meter.Int64Counter(
 		"batch_size_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a size trigger"),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errs = errors.Join(errs, err)
 	builder.RequestDuration, err = meter.Float64Histogram(
 		"request_duration",
 		metric.WithDescription("Duration of request"),
 		metric.WithUnit("s"),
 	)
-	errors = multierr.Append(errors, err)
-	return &builder, errors
+	errs = errors.Join(errs, err)
+	return &builder, errs
 }

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -156,7 +156,7 @@ telemetry:
       enabled: true
       description: Number of times the batch was sent due to a size trigger
       unit: 1
-      counter:
+      sum:
         value_type: int
         monotonic: true
     request_duration:

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -149,3 +149,19 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     attributes: [ string_attr, overridden_int_attr, enum_attr, slice_attr, map_attr ]
+
+telemetry:
+  metrics:
+    batch_size_trigger_send:
+      enabled: true
+      description: Number of times the batch was sent due to a size trigger
+      unit: 1
+      counter:
+        value_type: int
+        monotonic: true
+    request_duration:
+      enabled: true
+      description: Duration of request
+      unit: s
+      histogram:
+        value_type: double

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -117,6 +117,8 @@ type metric struct {
 	Sum *sum `mapstructure:"sum,omitempty"`
 	// Gauge stores metadata for gauge metric type
 	Gauge *gauge `mapstructure:"gauge,omitempty"`
+	// Gauge stores metadata for gauge metric type
+	Histogram *histogram `mapstructure:"histogram,omitempty"`
 
 	// Attributes is the list of attributes that the metric emits.
 	Attributes []attributeName `mapstructure:"attributes"`
@@ -134,6 +136,9 @@ func (m metric) Data() MetricData {
 	}
 	if m.Gauge != nil {
 		return m.Gauge
+	}
+	if m.Histogram != nil {
+		return m.Histogram
 	}
 	return nil
 }
@@ -221,69 +226,8 @@ type tests struct {
 	ExpectConsumerError bool   `mapstructure:"expect_consumer_error"`
 }
 
-type counter struct {
-	ValueType   string `mapstructure:"value_type"`
-	Monotonic   bool   `mapstructure:"monotonic"`
-	Synchronous bool   `mapstructure:"synchronous"`
-}
-
-type histogram struct {
-	ValueType string `mapstructure:"value_type"`
-}
-
-func (m *internalMetric) Unmarshal(parser *confmap.Conf) error {
-	if !parser.IsSet("enabled") {
-		return errors.New("missing required field: `enabled`")
-	}
-	return parser.Unmarshal(m)
-}
-
-func (m internalMetric) Type() string {
-	typeStr := ""
-	if m.Counter != nil {
-		switch m.Counter.ValueType {
-		case "int":
-			typeStr += "Int64"
-		case "double":
-			typeStr += "Float64"
-		}
-
-		if !m.Counter.Monotonic {
-			typeStr += "UpDown"
-		}
-		typeStr += "Counter"
-		return typeStr
-	}
-	if m.Histogram != nil {
-		switch m.Histogram.ValueType {
-		case "int":
-			return "Int64Histogram"
-		case "double":
-			return "Float64Histogram"
-		}
-	}
-	return typeStr
-}
-
-type internalMetric struct {
-	// Enabled defines whether the metric is enabled by default.
-	Enabled bool `mapstructure:"enabled"`
-
-	// Description of the metric.
-	Description string `mapstructure:"description"`
-
-	// Unit of the metric.
-	Unit string `mapstructure:"unit"`
-
-	// Counter stores metadata for counter metric type
-	Counter *counter `mapstructure:"counter,omitempty"`
-
-	// Histogram stores metadata for histogram metric type
-	Histogram *histogram `mapstructure:"histogram,omitempty"`
-}
-
 type telemetry struct {
-	Metrics map[metricName]internalMetric `mapstructure:"metrics"`
+	Metrics map[metricName]metric `mapstructure:"metrics"`
 }
 
 type metadata struct {

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -232,22 +232,22 @@ func TestLoadMetadata(t *testing.T) {
 					},
 				},
 				Telemetry: telemetry{
-					Metrics: map[metricName]internalMetric{
+					Metrics: map[metricName]metric{
 						"batch_size_trigger_send": {
 							Enabled:     true,
 							Description: "Number of times the batch was sent due to a size trigger",
-							Unit:        "1",
-							Counter: &counter{
-								ValueType: "int",
-								Monotonic: true,
+							Unit:        strPtr("1"),
+							Sum: &sum{
+								MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeInt},
+								Mono:            Mono{Monotonic: true},
 							},
 						},
 						"request_duration": {
 							Enabled:     true,
 							Description: "Duration of request",
-							Unit:        "s",
+							Unit:        strPtr("s"),
 							Histogram: &histogram{
-								ValueType: "double",
+								MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeDouble},
 							},
 						},
 					},
@@ -284,11 +284,6 @@ func TestLoadMetadata(t *testing.T) {
 		{
 			name:    "testdata/unknown_value_type.yaml",
 			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[system.cpu.time]': 1 error(s) decoding:\n\n* error decoding 'sum': 1 error(s) decoding:\n\n* error decoding 'value_type': invalid value_type: \"unknown\"",
-		},
-		{
-			name:    "testdata/no_aggregation.yaml",
-			want:    metadata{},
-			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[default.metric]': 1 error(s) decoding:\n\n* error decoding 'sum': missing required field: `aggregation_temporality`",
 		},
 		{
 			name:    "testdata/invalid_aggregation.yaml",

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -231,6 +231,27 @@ func TestLoadMetadata(t *testing.T) {
 						Attributes: []attributeName{"string_attr", "overridden_int_attr", "enum_attr", "slice_attr", "map_attr"},
 					},
 				},
+				Telemetry: telemetry{
+					Metrics: map[metricName]internalMetric{
+						"batch_size_trigger_send": {
+							Enabled:     true,
+							Description: "Number of times the batch was sent due to a size trigger",
+							Unit:        "1",
+							Counter: &counter{
+								ValueType: "int",
+								Monotonic: true,
+							},
+						},
+						"request_duration": {
+							Enabled:     true,
+							Description: "Duration of request",
+							Unit:        "s",
+							Histogram: &histogram{
+								ValueType: "double",
+							},
+						},
+					},
+				},
 				ScopeName:       "go.opentelemetry.io/collector/internal/receiver/samplereceiver",
 				ShortFolderName: "sample",
 			},

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -125,3 +125,42 @@ tests:
     ignore:
       top: [string] # Optional: array of strings representing functions that should be ignore via IgnoreTopFunction
       any: [string] # Optional: array of strings representing functions that should be ignore via IgnoreAnyFunction
+
+
+# Optional: map of metric names with the key being the metric name and value
+# being described below.
+telemetry:
+  <metric.name>:
+    # Required: whether the metric is collected by default.
+    enabled: bool
+    # Required: metric description.
+    description:
+    # Optional: extended documentation of the metric.
+    extended_documentation:
+    # Optional: warnings that will be shown to user under specified conditions.
+    warnings:
+      # A warning that will be displayed if the metric is enabled in user config.
+      # Should be used for deprecated default metrics that will be removed soon.
+      if_enabled:
+      # A warning that will be displayed if `enabled` field is not set explicitly in user config.
+      # Should be used for metrics that will be turned from default to optional or vice versa.
+      if_enabled_not_set:
+      # A warning that will be displayed if the metrics is configured by user in any way.
+      # Should be used for deprecated optional metrics that will be removed soon.
+      if_configured:
+    # Required: metric unit as defined by https://ucum.org/ucum.html.
+    unit:
+    # Required: metric type with its settings.
+    <sum|gauge|histogram>:
+      # Required for sum and gauge metrics: type of number data point values.
+      value_type: <int|double>
+      # Required for sum metric: whether the metric is monotonic (no negative delta values).
+      monotonic: bool
+      # Required for sum metric: whether reported values incorporate previous measurements
+      # (cumulative) or not (delta).
+      aggregation_temporality: <delta|cumulative>
+       # Optional: Indicates the type the metric needs to be parsed from. If set, the generated
+       # functions will parse the value from string to value_type.
+      input_type: string
+    # Optional: array of attributes that were defined in the attributes section that are emitted by this metric.
+    attributes: [string]

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -156,11 +156,5 @@ telemetry:
       value_type: <int|double>
       # Required for sum metric: whether the metric is monotonic (no negative delta values).
       monotonic: bool
-      # Required for sum metric: whether reported values incorporate previous measurements
-      # (cumulative) or not (delta).
-      aggregation_temporality: <delta|cumulative>
-       # Optional: Indicates the type the metric needs to be parsed from. If set, the generated
-       # functions will parse the value from string to value_type.
-      input_type: string
     # Optional: array of attributes that were defined in the attributes section that are emitted by this metric.
     attributes: [string]

--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -158,9 +158,6 @@ type sum struct {
 
 // Unmarshal is a custom unmarshaler for sum. Needed mostly to avoid MetricValueType.Unmarshal inheritance.
 func (d *sum) Unmarshal(parser *confmap.Conf) error {
-	// if !parser.IsSet("aggregation_temporality") {
-	// 	return errors.New("missing required field: `aggregation_temporality`")
-	// }
 	if err := d.MetricValueType.Unmarshal(parser); err != nil {
 		return err
 	}

--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -7,6 +7,9 @@ import (
 	"errors"
 	"fmt"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
@@ -14,6 +17,7 @@ import (
 var (
 	_ MetricData = &gauge{}
 	_ MetricData = &sum{}
+	_ MetricData = &histogram{}
 )
 
 // MetricData is generic interface for all metric datatypes.
@@ -22,6 +26,7 @@ type MetricData interface {
 	HasMonotonic() bool
 	HasAggregated() bool
 	HasMetricInputType() bool
+	Instrument() string
 }
 
 // AggregationTemporality defines a metric aggregation type.
@@ -140,6 +145,10 @@ func (d gauge) HasAggregated() bool {
 	return false
 }
 
+func (d gauge) Instrument() string {
+	return ""
+}
+
 type sum struct {
 	AggregationTemporality `mapstructure:"aggregation_temporality"`
 	Mono                   `mapstructure:",squash"`
@@ -149,9 +158,9 @@ type sum struct {
 
 // Unmarshal is a custom unmarshaler for sum. Needed mostly to avoid MetricValueType.Unmarshal inheritance.
 func (d *sum) Unmarshal(parser *confmap.Conf) error {
-	if !parser.IsSet("aggregation_temporality") {
-		return errors.New("missing required field: `aggregation_temporality`")
-	}
+	// if !parser.IsSet("aggregation_temporality") {
+	// 	return errors.New("missing required field: `aggregation_temporality`")
+	// }
 	if err := d.MetricValueType.Unmarshal(parser); err != nil {
 		return err
 	}
@@ -179,4 +188,46 @@ func (d sum) HasMonotonic() bool {
 
 func (d sum) HasAggregated() bool {
 	return true
+}
+
+func (d sum) Instrument() string {
+	instrumentName := cases.Title(language.English).String(d.MetricValueType.BasicType())
+
+	if !d.Monotonic {
+		instrumentName += "UpDown"
+	}
+	instrumentName += "Counter"
+	return instrumentName
+}
+
+type histogram struct {
+	AggregationTemporality `mapstructure:"aggregation_temporality"`
+	Mono                   `mapstructure:",squash"`
+	MetricValueType        `mapstructure:"value_type"`
+	MetricInputType        `mapstructure:",squash"`
+}
+
+func (d histogram) Type() string {
+	return "Histogram"
+}
+
+func (d histogram) HasMonotonic() bool {
+	return true
+}
+
+func (d histogram) HasAggregated() bool {
+	return true
+}
+
+func (d histogram) Instrument() string {
+	instrumentName := cases.Title(language.English).String(d.MetricValueType.BasicType())
+	return instrumentName + d.Type()
+}
+
+// Unmarshal is a custom unmarshaler for histogram. Needed mostly to avoid MetricValueType.Unmarshal inheritance.
+func (d *histogram) Unmarshal(parser *confmap.Conf) error {
+	if err := d.MetricValueType.Unmarshal(parser); err != nil {
+		return err
+	}
+	return parser.Unmarshal(d, confmap.WithIgnoreUnused())
 }

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+    "go.uber.org/multierr"
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
@@ -15,3 +16,34 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("{{ .ScopeName }}")
 }
+{{- if .Telemetry.Metrics }}
+
+// TelemetryBuilder provides an interface for components to report telemetry 
+// as defined in metadata and user config.
+type TelemetryBuilder struct {
+	{{- range $name, $metric := .Telemetry.Metrics }}
+	{{ $name.Render }} metric.{{ $metric.Type }}
+	{{- end }}
+}
+
+// telemetryBuilderOption applies changes to default builder.
+type telemetryBuilderOption func(*TelemetryBuilder)
+
+// NewTelemetryBuilder provides a struct with methods to update all internal telemetry
+// for a component
+func NewTelemetryBuilder(settings component.TelemetrySettings, options ...telemetryBuilderOption) (*TelemetryBuilder, error) {
+    builder := TelemetryBuilder{}
+    var err, errors error
+    meter := Meter(settings)
+    {{- range $name, $metric := .Telemetry.Metrics }}
+    builder.{{ $name.Render }}, err = meter.{{ $metric.Type }}(
+        "{{ $name }}",
+        metric.WithDescription("{{ $metric.Description }}"),
+        metric.WithUnit("{{ $metric.Unit }}"),
+    )
+    errors = multierr.Append(errors, err)
+    {{- end }}
+    return &builder, errors
+}
+
+{{- end }}

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -6,7 +6,9 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+    {{- if .Telemetry.Metrics }}
     "go.uber.org/multierr"
+    {{- end }}
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -22,7 +22,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
 	{{- range $name, $metric := .Telemetry.Metrics }}
-	{{ $name.Render }} metric.{{ $metric.Type }}
+	{{ $name.Render }} metric.{{ $metric.Data.Instrument }}
 	{{- end }}
 }
 
@@ -36,7 +36,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
     var err, errors error
     meter := Meter(settings)
     {{- range $name, $metric := .Telemetry.Metrics }}
-    builder.{{ $name.Render }}, err = meter.{{ $metric.Type }}(
+    builder.{{ $name.Render }}, err = meter.{{ $metric.Data.Instrument }}(
         "{{ $name }}",
         metric.WithDescription("{{ $metric.Description }}"),
         metric.WithUnit("{{ $metric.Unit }}"),

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -3,12 +3,13 @@
 package {{ .Package }}
 
 import (
+    {{- if .Telemetry.Metrics }}
+    "errors"
+    {{- end }}
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-    {{- if .Telemetry.Metrics }}
-    "go.uber.org/multierr"
-    {{- end }}
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
@@ -35,7 +36,7 @@ type telemetryBuilderOption func(*TelemetryBuilder)
 // for a component
 func NewTelemetryBuilder(settings component.TelemetrySettings, options ...telemetryBuilderOption) (*TelemetryBuilder, error) {
     builder := TelemetryBuilder{}
-    var err, errors error
+    var err, errs error
     meter := Meter(settings)
     {{- range $name, $metric := .Telemetry.Metrics }}
     builder.{{ $name.Render }}, err = meter.{{ $metric.Data.Instrument }}(
@@ -43,9 +44,9 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
         metric.WithDescription("{{ $metric.Description }}"),
         metric.WithUnit("{{ $metric.Unit }}"),
     )
-    errors = multierr.Append(errors, err)
+    errs = errors.Join(errs, err)
     {{- end }}
-    return &builder, errors
+    return &builder, errs
 }
 
 {{- end }}

--- a/processor/batchprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/batchprocessor/internal/metadata/generated_telemetry.go
@@ -3,9 +3,10 @@
 package metadata
 
 import (
+	"errors"
+
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/multierr"
 
 	"go.opentelemetry.io/collector/component"
 )
@@ -34,31 +35,31 @@ type telemetryBuilderOption func(*TelemetryBuilder)
 // for a component
 func NewTelemetryBuilder(settings component.TelemetrySettings, options ...telemetryBuilderOption) (*TelemetryBuilder, error) {
 	builder := TelemetryBuilder{}
-	var err, errors error
+	var err, errs error
 	meter := Meter(settings)
 	builder.ProcessorBatchBatchSendSize, err = meter.Int64Histogram(
 		"processor_batch_batch_send_size",
 		metric.WithDescription("Number of units in the batch"),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errs = errors.Join(errs, err)
 	builder.ProcessorBatchBatchSendSizeBytes, err = meter.Int64Histogram(
 		"processor_batch_batch_send_size_bytes",
 		metric.WithDescription("Number of bytes in batch that was sent"),
 		metric.WithUnit("By"),
 	)
-	errors = multierr.Append(errors, err)
+	errs = errors.Join(errs, err)
 	builder.ProcessorBatchBatchSizeTriggerSend, err = meter.Int64Counter(
 		"processor_batch_batch_size_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a size trigger"),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errs = errors.Join(errs, err)
 	builder.ProcessorBatchTimeoutTriggerSend, err = meter.Int64Counter(
 		"processor_batch_timeout_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a timeout trigger"),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
-	return &builder, errors
+	errs = errors.Join(errs, err)
+	return &builder, errs
 }

--- a/processor/batchprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/batchprocessor/internal/metadata/generated_telemetry.go
@@ -5,6 +5,7 @@ package metadata
 import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/multierr"
 
 	"go.opentelemetry.io/collector/component"
 )
@@ -15,4 +16,49 @@ func Meter(settings component.TelemetrySettings) metric.Meter {
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
 	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/processor/batchprocessor")
+}
+
+// TelemetryBuilder provides an interface for components to report telemetry
+// as defined in metadata and user config.
+type TelemetryBuilder struct {
+	ProcessorBatchBatchSendSize        metric.Int64Histogram
+	ProcessorBatchBatchSendSizeBytes   metric.Int64Histogram
+	ProcessorBatchBatchSizeTriggerSend metric.Int64Counter
+	ProcessorBatchTimeoutTriggerSend   metric.Int64Counter
+}
+
+// telemetryBuilderOption applies changes to default builder.
+type telemetryBuilderOption func(*TelemetryBuilder)
+
+// NewTelemetryBuilder provides a struct with methods to update all internal telemetry
+// for a component
+func NewTelemetryBuilder(settings component.TelemetrySettings, options ...telemetryBuilderOption) (*TelemetryBuilder, error) {
+	builder := TelemetryBuilder{}
+	var err, errors error
+	meter := Meter(settings)
+	builder.ProcessorBatchBatchSendSize, err = meter.Int64Histogram(
+		"processor_batch_batch_send_size",
+		metric.WithDescription("Number of units in the batch"),
+		metric.WithUnit("1"),
+	)
+	errors = multierr.Append(errors, err)
+	builder.ProcessorBatchBatchSendSizeBytes, err = meter.Int64Histogram(
+		"processor_batch_batch_send_size_bytes",
+		metric.WithDescription("Number of bytes in batch that was sent"),
+		metric.WithUnit("By"),
+	)
+	errors = multierr.Append(errors, err)
+	builder.ProcessorBatchBatchSizeTriggerSend, err = meter.Int64Counter(
+		"processor_batch_batch_size_trigger_send",
+		metric.WithDescription("Number of times the batch was sent due to a size trigger"),
+		metric.WithUnit("1"),
+	)
+	errors = multierr.Append(errors, err)
+	builder.ProcessorBatchTimeoutTriggerSend, err = meter.Int64Counter(
+		"processor_batch_timeout_trigger_send",
+		metric.WithDescription("Number of times the batch was sent due to a timeout trigger"),
+		metric.WithUnit("1"),
+	)
+	errors = multierr.Append(errors, err)
+	return &builder, errors
 }

--- a/processor/batchprocessor/metadata.yaml
+++ b/processor/batchprocessor/metadata.yaml
@@ -14,14 +14,14 @@ telemetry:
       enabled: true
       description: Number of times the batch was sent due to a size trigger
       unit: 1
-      counter:
+      sum:
         value_type: int
         monotonic: true
     processor_batch_timeout_trigger_send:
       enabled: true
       description: Number of times the batch was sent due to a timeout trigger
       unit: 1
-      counter:
+      sum:
         value_type: int
         monotonic: true
     processor_batch_batch_send_size:

--- a/processor/batchprocessor/metadata.yaml
+++ b/processor/batchprocessor/metadata.yaml
@@ -7,3 +7,32 @@ status:
   distributions: [core, contrib]
 
 tests:
+
+telemetry:
+  metrics:
+    processor_batch_batch_size_trigger_send:
+      enabled: true
+      description: Number of times the batch was sent due to a size trigger
+      unit: 1
+      counter:
+        value_type: int
+        monotonic: true
+    processor_batch_timeout_trigger_send:
+      enabled: true
+      description: Number of times the batch was sent due to a timeout trigger
+      unit: 1
+      counter:
+        value_type: int
+        monotonic: true
+    processor_batch_batch_send_size:
+      enabled: true
+      description: Number of units in the batch
+      unit: 1
+      histogram:
+        value_type: int
+    processor_batch_batch_send_size_bytes:
+      enabled: true
+      description: Number of bytes in batch that was sent
+      unit: By
+      histogram:
+        value_type: int


### PR DESCRIPTION
#### Description

This updates mdatagen to generate internal telemetry for components based on metadata.yaml configuration.

#### Testing

Added tests to mdatagen and updated the batch processor to use this as well for synchronous counters and histogram
