### PR TITLE
[chore] pin version of npm package

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install markdown-link-check
-        run: npm install -g markdown-link-check
+        run: npm install -g markdown-link-check@3.11.2
 
       - name: Run markdown-link-check
         run: |


### PR DESCRIPTION
this addresses a security concern around the version of the package installed
