### PR TITLE
[otelcol] rfc for how to log during startup

### DIFF
--- a/docs/rfcs/logging-before-config-resolution.md
+++ b/docs/rfcs/logging-before-config-resolution.md
@@ -26,7 +26,7 @@ be shared with users such as:
 
 1. Once the primary logger is instantiated, it should be usable anywhere in the Collector that does logging.
 2. Log timestamps must be accurate to when the log was written, regardless of when the log is written to the user-specified location(s)
-3. If an error occurs before the primary logger is created any previously written logs MUST be written to the user-specified location(s) if they have not already been written there.
+3. If an error occurs before the primary logger is created any previously written logs MUST be written to the either stout or stderr if they have not already been written there.
 
 ## Current behavior
 

--- a/docs/rfcs/logging-before-config-resolution.md
+++ b/docs/rfcs/logging-before-config-resolution.md
@@ -62,6 +62,6 @@ Downsides:
 
 ## Accepted Solution
 
-[Buffer Logs in Memory and Write Them Once the Primary Logger Exists](#Buffer-Logs-in-Memory-and-Write-Them-Once-the-Primary-Logger-Exists)
+[Buffer Logs in Memory and Write Them Once the Primary Logger Exists](#buffer-logs-in-memory-and-write-them-once-the-primary-logger-exists)
 
 This solution, while more complex, allows the collector to write out the logs in the user-specified format whenever possible.  A fallback logger must be used in situations where the primary logger could not be created and the collector is shutting down, such as when encountering an error during configuration resolution, but otherwise the primary logger will be used to write logs that occurred before the primary logger existed.

--- a/docs/rfcs/logging-before-config-resolution.md
+++ b/docs/rfcs/logging-before-config-resolution.md
@@ -26,7 +26,8 @@ be shared with users such as:
 
 1. Once the primary logger is instantiated, it should be usable anywhere in the Collector that does logging.
 2. Log timestamps must be accurate to when the log was written, regardless of when the log is written to the user-specified location(s)
-3. If an error causes the collector to gracefully terminate before the primary logger is created any previously written logs MUST be written to the either stout or stderr if they have not already been written there.
+3. The EntryCaller (what line number the log originates from) must be accurate to where the log was written.
+4. If an error causes the collector to gracefully terminate before the primary logger is created any previously written logs MUST be written to the either stout or stderr if they have not already been written there.
 
 ## Current behavior
 
@@ -61,4 +62,6 @@ Downsides:
 
 ## Accepted Solution
 
-I'll fill this out once we decide.
+[Buffer Logs in Memory and Write Them Once the Primary Logger Exists](#Buffer-Logs-in-Memory-and-Write-Them-Once-the-Primary-Logger-Exists)
+
+This solution, while more complex, allows the collector to write out the logs in the user-specified format whenever possible.  A fallback logger must be used in situations where the primary logger could not be created and the collector is shutting down, such as when encountering an error during configuration resolution, but otherwise the primary logger will be used to write logs that occurred before the primary logger existed.

--- a/docs/rfcs/logging-before-config-resolution.md
+++ b/docs/rfcs/logging-before-config-resolution.md
@@ -26,7 +26,7 @@ be shared with users such as:
 
 1. Once the primary logger is instantiated, it should be usable anywhere in the Collector that does logging.
 2. Log timestamps must be accurate to when the log was written, regardless of when the log is written to the user-specified location(s)
-3. If an error occurs before the primary logger is created any previously written logs MUST be written to the either stout or stderr if they have not already been written there.
+3. If an error causes the collector to gracefully terminate before the primary logger is created any previously written logs MUST be written to the either stout or stderr if they have not already been written there.
 
 ## Current behavior
 

--- a/docs/rfcs/logging-before-config-resolution.md
+++ b/docs/rfcs/logging-before-config-resolution.md
@@ -25,8 +25,8 @@ be shared with users such as:
 ## Requirements for any solution
 
 1. Once the primary logger is instantiated, it should be usable anywhere in the Collector that does logging.
-2. Log timestamps must be accurate to when the log was written, regardless of when the log is written to stdout/sterr
-3. If an error occurs before the primary logger is created any previously written logs MUST be written to either stout or stderr if they have not already been written there.
+2. Log timestamps must be accurate to when the log was written, regardless of when the log is written to the user-specified location(s)
+3. If an error occurs before the primary logger is created any previously written logs MUST be written to the user-specified location(s) if they have not already been written there.
 
 ## Current behavior
 

--- a/docs/rfcs/logging-before-config-resolution.md
+++ b/docs/rfcs/logging-before-config-resolution.md
@@ -25,7 +25,7 @@ be shared with users such as:
 ## Requirements for any solution
 
 1. Once the primary logger is instantiated, it should be usable anywhere in the Collector that does logging.
-2. Log timestamps must be accurate to when the log was written, regardless of when the log is written to the user-specified location(s)
+2. Log timestamps must be accurate to when the log was written, regardless of when the log is written to the user-specified location(s).
 3. The EntryCaller (what line number the log originates from) must be accurate to where the log was written.
 4. If an error causes the collector to gracefully terminate before the primary logger is created any previously written logs MUST be written to the either stout or stderr if they have not already been written there.
 
@@ -44,8 +44,7 @@ Benefits:
 - Logs are written in the user-specified format/level
 
 Downsides:
-- If an error occurs before the primary logger is created the buffered logs will not be written out
-- If the primary logger is used to write any logs before the buffered logs are passed, logs will be out of order
+- If the primary logger is used to write any logs before the buffered logs are passed, logs may be out of order. There are no guarantees that logs will be written in order, so the log timestamps should be taken as the source of truth for ordering.
 
 ### Create a Logger Using the Primary Logger's Defaults
 

--- a/docs/rfcs/logging-before-config-resolution.md
+++ b/docs/rfcs/logging-before-config-resolution.md
@@ -52,7 +52,7 @@ logger is instantiated.
 
 Benefits:
 - Logs order is preserved
-- Logs are still writen when an error occurs before the primary logger can be instantiated
+- Logs are still written when an error occurs before the primary logger can be instantiated
 
 Downsides:
 - Logs may be written in a format/level that differs from the format/level of the primary logger

--- a/docs/rfcs/logging-before-config-resolution.md
+++ b/docs/rfcs/logging-before-config-resolution.md
@@ -25,6 +25,8 @@ be shared with users such as:
 ## Requirements for any solution
 
 1. Once the primary logger is instantiated, it should be usable anywhere in the Collector that does logging.
+2. Log timestamps must be accurate to when the log was written, regardless of when the log is written to stdout/sterr
+3. If an error occurs before the primary logger is created any previously written logs MUST be written to either stout or stderr if they have not already been written there.
 
 ## Current behavior
 


### PR DESCRIPTION
#### Description

This is an RFC to help us decide how we want `otelcol` to provide a logger before the primary logger is created. As we discuss I will update the doc.  Before this is merged we should have decided on a solution and the Accepted Solution section must be updated.

Related to https://github.com/open-telemetry/opentelemetry-collector/pull/10056

#### Link to tracking issue
This unblocks:
- https://github.com/open-telemetry/opentelemetry-collector/issues/9162
- https://github.com/open-telemetry/opentelemetry-collector/issues/5615