### PR TITLE
Documentation improvements  - Internal Architecture Doc + Package level comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,8 @@ in advance so that maintainers can decide if the proposal is a good fit for
 this repository. This will help avoid situations when you spend significant time
 on something that maintainers may decide this repo is not the right place for.
 
+If you're new to the Collector, the [internal architecture](docs/internal-architecture.md) documentation may be helpful.
+
 Follow the instructions below to create your PR.
 
 ### Fork

--- a/component/component.go
+++ b/component/component.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package component outlines the abstraction of components within OTEL collector.  It provides details on the component
-// lifecycle as well as defining the interface that components must fulfil.
+// lifecycle as well as defining the interface that components must fulfill.
 package component // import "go.opentelemetry.io/collector/component"
 
 import (

--- a/component/component.go
+++ b/component/component.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package component outlines the abstraction of components within OTEL collector.  It provides details on the component
+// Package component outlines the abstraction of components within the OpenTelemetry Collector.  It provides details on the component
 // lifecycle as well as defining the interface that components must fulfill.
 package component // import "go.opentelemetry.io/collector/component"
 

--- a/component/component.go
+++ b/component/component.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Package component outlines the abstraction of components within OTEL collector.  It provides details on the component
+// lifecycle as well as defining the interface that components must fulfil.
 package component // import "go.opentelemetry.io/collector/component"
 
 import (

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -1,0 +1,67 @@
+## Collector internal architecture
+There are a few resources available to understand how the collector works:
+### [Startup Diagram](#startup-diagram)
+### [Architecture Docs](https://opentelemetry.io/docs/collector/architecture/)
+### [Important Files](#important-files)
+### Startup Diagram
+```mermaid
+flowchart TD
+    A("`**command.NewCommand**`") -->|1| B("`**updateSettingsUsingFlags**`")
+    A --> |2| C("`**NewCollector**
+    Creates and returns a new instance of Collector`")
+    A --> |3| D("`**Collector.Run**
+    Starts the collector and blocks until it shuts down`")
+    D --> E("`**setupConfigurationComponents**`")
+    E -->  |1| F("`**getConfMap**`")
+    E ---> |2| G("`**Service.New**
+     Initializes telemetry, then initializes the pipelines`")
+    E --> |3| Q("`**Service.Start**
+    1. Start all extensions.
+    2. Notify extensions about Collector configuration
+    3. Start all pipelines.
+    4. Notify extensions that the pipeline is ready.
+    `")
+    Q --> R("`**Graph.StartAll**
+    Calls Start on each component in reverse topological order`")
+    G --> H("`**initExtensionsAndPipeline**
+     Creates extensions and then builds the pipeline graph`")
+    H --> I("`**Graph.Build**
+     Converts the settings to an internal graph representation`")
+    I --> J("`**createNodes**
+     Builds the node objects from pipeline configuration and adds to graph.  Also validates connectors`")
+    I --> K("`**createEdges**
+     Iterates through the pipelines and creates edges between components`")
+    I --> L("`**buildComponents**
+     Topological sort the graph, and create each component in reverse order`")
+    L --> M(Receiver Factory) & N(Processor Factory) & O(Exporter Factory)
+```
+### Important Files
+Here is a brief list of useful and/or important files that you may find valuable to glance through.
+#### [collector.go](../otelcol/collector.go)
+This file contains the main Collector struct and its constructor `NewCollector`.
+
+`Collector.Run` starts the collector blocks until it shuts down.
+
+`setupConfigurationComponents` is the "main" function responsible for startup - it orchestrates the loading of the 
+configuration, the creation of the graph, and the starting of all the components.
+
+#### [graph.go](../service/internal/graph/graph.go)
+This file contains the internal graph representation of the pipelines.
+
+`Build` is the constructor for a Graph object.  The method calls out to helpers that transform the graph from a config
+to a DAG of components.  The configuration undergoes additional validation here as well, and is used to instantiate
+the components of the pipeline.
+
+`Graph.StartAll` starts every component in the pipelines.
+
+`Graph.ShutdownAll` stops each component in the pipelines
+
+#### [component.go](../component/component.go)
+component.go outlines the abstraction of components within OTEL collector.  It provides details on the component 
+lifecycle as well as defining the interface that components must fulfil.
+
+#### Factories
+Each component type contains a Factory interface along with its corresponding NewFactory function.
+Implementations of new components use this NewFactory function in their implementation to register key functions with 
+the collector.  For example, the collector uses this interface to give receivers a handle to a nextConsumer - 
+representing where the receiver can send data to that it has received.

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -1,8 +1,5 @@
 ## Collector internal architecture
 There are a few resources available to understand how the collector works:
-### [Startup Diagram](#startup-diagram)
-### [Architecture Docs](https://opentelemetry.io/docs/collector/architecture/)
-### [Important Files](#important-files)
 ### Startup Diagram
 ```mermaid
 flowchart TD
@@ -65,3 +62,6 @@ Each component type contains a Factory interface along with its corresponding Ne
 Implementations of new components use this NewFactory function in their implementation to register key functions with 
 the collector.  For example, the collector uses this interface to give receivers a handle to a nextConsumer - 
 representing where the receiver can send data to that it has received.
+
+### [Architecture Docs](https://opentelemetry.io/docs/collector/architecture/)
+OpenTelemetry's Collector architecture is a great resource to understand the Collector!

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -2,7 +2,7 @@
 
 This document describes the Collector internal architecture and startup flow. It can be helpful if you are starting to contribute to the Collector codebase.
 
-For the end-user focused architecture document, please see the [opentelemetry.io's Architecture documentation](https://opentelemetry.io/docs/collector/architecture/).  While it is end user focused - its still a good place to start if you're trying to learn about the Collector codebase.
+For the end-user focused architecture document, please see the [opentelemetry.io's Architecture documentation](https://opentelemetry.io/docs/collector/architecture/).  While it is end user focused - it's still a good place to start if you're trying to learn about the Collector codebase.
 
 ### Startup Diagram
 ```mermaid

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -47,6 +47,7 @@ Most of these have package-level documentation and function/struct-level comment
 #### Factories
 Each component type contains a `Factory` interface along with its corresponding `NewFactory` function.
 Implementations of new components use this `NewFactory` function in their implementation to register key functions with 
-the Collector.  For example, the Collector uses this interface to give receivers a handle to a `nextConsumer` - 
-representing where the receiver can send data to that it has received.
-An example of this is in [exporter.go](../exporter/exporter.go).
+the Collector.  An example of this is in [exporter.go](../exporter/exporter.go).
+
+For example, the Collector uses this interface to give receivers a handle to a `nextConsumer` -
+which represents where the receiver will send its data next in its telemetry pipeline.

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -2,7 +2,7 @@
 
 This document describes the Collector internal architecture and startup flow. It can be helpful if you are starting to contribute to the Collector codebase.
 
-For the end-user focused architecture document, please see the [opentelemetry.io's Architecture documentation](https://opentelemetry.io/docs/collector/architecture/).  While it is end user focused - it's still a good place to start if you're trying to learn about the Collector codebase.
+For the end-user focused architecture document, please see the [opentelemetry.io's Architecture documentation](https://opentelemetry.io/docs/collector/architecture/).  While it is end user focused, it's still a good place to start if you're trying to learn about the Collector codebase.
 
 ### Startup Diagram
 ```mermaid
@@ -47,7 +47,7 @@ Most of these have package-level documentation and function/struct-level comment
 #### Factories
 Each component type contains a `Factory` interface along with its corresponding `NewFactory` function.
 Implementations of new components use this `NewFactory` function in their implementation to register key functions with 
-the Collector.  An example of this is in [exporter.go](../exporter/exporter.go).
+the Collector.  An example of this is in [receiver.go](../receiver/receiver.go).
 
 For example, the Collector uses this interface to give receivers a handle to a `nextConsumer` -
 which represents where the receiver will send its data next in its telemetry pipeline.

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -1,5 +1,7 @@
-## Collector internal architecture
-There are a few resources available to understand how the collector works:
+## Internal architecture
+
+There are a few resources available to understand how the Collector works:
+
 ### Startup Diagram
 ```mermaid
 flowchart TD
@@ -30,20 +32,20 @@ flowchart TD
      Iterates through the pipelines and creates edges between components`")
     I --> L("`**buildComponents**
      Topological sort the graph, and create each component in reverse order`")
-    L --> M(Receiver Factory) & N(Processor Factory) & O(Exporter Factory)
+    L --> M(Receiver Factory) & N(Processor Factory) & O(Exporter Factory) & P(Connector Factory)
 ```
 ### Important Files
 Here is a brief list of useful and/or important files and interfaces that you may find valuable to glance through.
-Most of these have package level documentation and function / struct level comments that help explain the collector!
+Most of these have package level documentation and function / struct level comments that help explain the Collector!
 
 - [collector.go](../otelcol/collector.go)
 - [graph.go](../service/internal/graph/graph.go)
 - [component.go](../component/component.go)
 
 #### Factories
-Each component type contains a Factory interface along with its corresponding NewFactory function.
-Implementations of new components use this NewFactory function in their implementation to register key functions with 
-the collector.  For example, the collector uses this interface to give receivers a handle to a nextConsumer - 
+Each component type contains a `Factory` interface along with its corresponding `NewFactory` function.
+Implementations of new components use this `NewFactory` function in their implementation to register key functions with 
+the Collector.  For example, the Collector uses this interface to give receivers a handle to a `nextConsumer` - 
 representing where the receiver can send data to that it has received.
 An example of this is in [exporter.go](../exporter/exporter.go)
 

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -33,35 +33,21 @@ flowchart TD
     L --> M(Receiver Factory) & N(Processor Factory) & O(Exporter Factory)
 ```
 ### Important Files
-Here is a brief list of useful and/or important files that you may find valuable to glance through.
+Here is a brief list of useful and/or important files and interfaces that you may find valuable to glance through.
+Most of these have package level documentation and function / struct level comments that help explain the collector!
+
 #### [collector.go](../otelcol/collector.go)
-This file contains the main Collector struct and its constructor `NewCollector`.
-
-`Collector.Run` starts the collector blocks until it shuts down.
-
-`setupConfigurationComponents` is the "main" function responsible for startup - it orchestrates the loading of the 
-configuration, the creation of the graph, and the starting of all the components.
 
 #### [graph.go](../service/internal/graph/graph.go)
-This file contains the internal graph representation of the pipelines.
-
-`Build` is the constructor for a Graph object.  The method calls out to helpers that transform the graph from a config
-to a DAG of components.  The configuration undergoes additional validation here as well, and is used to instantiate
-the components of the pipeline.
-
-`Graph.StartAll` starts every component in the pipelines.
-
-`Graph.ShutdownAll` stops each component in the pipelines
 
 #### [component.go](../component/component.go)
-component.go outlines the abstraction of components within OTEL collector.  It provides details on the component 
-lifecycle as well as defining the interface that components must fulfil.
 
 #### Factories
 Each component type contains a Factory interface along with its corresponding NewFactory function.
 Implementations of new components use this NewFactory function in their implementation to register key functions with 
 the collector.  For example, the collector uses this interface to give receivers a handle to a nextConsumer - 
 representing where the receiver can send data to that it has received.
+An example of this is in [exporter.go](../exporter/exporter.go)
 
 ### [Architecture Docs](https://opentelemetry.io/docs/collector/architecture/)
 OpenTelemetry's Collector architecture is a great resource to understand the Collector!

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -36,11 +36,9 @@ flowchart TD
 Here is a brief list of useful and/or important files and interfaces that you may find valuable to glance through.
 Most of these have package level documentation and function / struct level comments that help explain the collector!
 
-#### [collector.go](../otelcol/collector.go)
-
-#### [graph.go](../service/internal/graph/graph.go)
-
-#### [component.go](../component/component.go)
+- [collector.go](../otelcol/collector.go)
+- [graph.go](../service/internal/graph/graph.go)
+- [component.go](../component/component.go)
 
 #### Factories
 Each component type contains a Factory interface along with its corresponding NewFactory function.

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -2,7 +2,7 @@
 
 This document describes the Collector internal architecture and startup flow. It can be helpful if you are starting to contribute to the Collector codebase.
 
-For the end-user focused architecture document, please see the [opentelemetry.io's Architecture documentation](https://opentelemetry.io/docs/collector/architecture/) 
+For the end-user focused architecture document, please see the [opentelemetry.io's Architecture documentation](https://opentelemetry.io/docs/collector/architecture/).  While it is end user focused - its still a good place to start if you're trying to learn about the Collector codebase.
 
 ### Startup Diagram
 ```mermaid
@@ -36,7 +36,7 @@ flowchart TD
      Topological sort the graph, and create each component in reverse order`")
     L --> M(Receiver Factory) & N(Processor Factory) & O(Exporter Factory) & P(Connector Factory)
 ```
-### Important Files
+### Where to start to read the code
 Here is a brief list of useful and/or important files and interfaces that you may find valuable to glance through.
 Most of these have package-level documentation and function/struct-level comments that help explain the Collector!
 
@@ -50,6 +50,3 @@ Implementations of new components use this `NewFactory` function in their implem
 the Collector.  For example, the Collector uses this interface to give receivers a handle to a `nextConsumer` - 
 representing where the receiver can send data to that it has received.
 An example of this is in [exporter.go](../exporter/exporter.go).
-
-### [Architecture Docs](https://opentelemetry.io/docs/collector/architecture/)
-OpenTelemetry's Collector architecture is a great resource to understand the Collector!

--- a/docs/internal-architecture.md
+++ b/docs/internal-architecture.md
@@ -1,6 +1,8 @@
 ## Internal architecture
 
-There are a few resources available to understand how the Collector works:
+This document describes the Collector internal architecture and startup flow. It can be helpful if you are starting to contribute to the Collector codebase.
+
+For the end-user focused architecture document, please see the [opentelemetry.io's Architecture documentation](https://opentelemetry.io/docs/collector/architecture/) 
 
 ### Startup Diagram
 ```mermaid
@@ -26,17 +28,17 @@ flowchart TD
      Creates extensions and then builds the pipeline graph`")
     H --> I("`**Graph.Build**
      Converts the settings to an internal graph representation`")
-    I --> J("`**createNodes**
+    I --> |1| J("`**createNodes**
      Builds the node objects from pipeline configuration and adds to graph.  Also validates connectors`")
-    I --> K("`**createEdges**
+    I --> |2| K("`**createEdges**
      Iterates through the pipelines and creates edges between components`")
-    I --> L("`**buildComponents**
+    I --> |3| L("`**buildComponents**
      Topological sort the graph, and create each component in reverse order`")
     L --> M(Receiver Factory) & N(Processor Factory) & O(Exporter Factory) & P(Connector Factory)
 ```
 ### Important Files
 Here is a brief list of useful and/or important files and interfaces that you may find valuable to glance through.
-Most of these have package level documentation and function / struct level comments that help explain the Collector!
+Most of these have package-level documentation and function/struct-level comments that help explain the Collector!
 
 - [collector.go](../otelcol/collector.go)
 - [graph.go](../service/internal/graph/graph.go)
@@ -47,7 +49,7 @@ Each component type contains a `Factory` interface along with its corresponding 
 Implementations of new components use this `NewFactory` function in their implementation to register key functions with 
 the Collector.  For example, the Collector uses this interface to give receivers a handle to a `nextConsumer` - 
 representing where the receiver can send data to that it has received.
-An example of this is in [exporter.go](../exporter/exporter.go)
+An example of this is in [exporter.go](../exporter/exporter.go).
 
 ### [Architecture Docs](https://opentelemetry.io/docs/collector/architecture/)
 OpenTelemetry's Collector architecture is a great resource to understand the Collector!

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -3,7 +3,7 @@
 
 // Package otelcol handles the command-line, configuration, and runs the OpenTelemetry Collector.
 // It contains the main [Collector] struct and its constructor [NewCollector].
-// [Collector.Run] starts the collector blocks until it shuts down.
+// [Collector.Run] starts the collector and then blocks until it shuts down.
 // Collector.setupConfigurationComponents is the "main" function responsible for startup - it orchestrates the loading of the
 // configuration, the creation of the graph, and the starting of all the components.
 package otelcol // import "go.opentelemetry.io/collector/otelcol"

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -3,7 +3,7 @@
 
 // Package otelcol handles the command-line, configuration, and runs the OpenTelemetry Collector.
 // It contains the main [Collector] struct and its constructor [NewCollector].
-// [Collector.Run] starts the collector and then blocks until it shuts down.
+// [Collector.Run] starts the Collector and then blocks until it shuts down.
 package otelcol // import "go.opentelemetry.io/collector/otelcol"
 
 import (

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package otelcol handles the command-line, configuration, and runs the OpenTelemetry Collector.
-// otelcol/collector.go contains the main Collector struct and its constructor [NewCollector].
+// It contains the main [Collector] struct and its constructor [NewCollector].
 // [Collector.Run] starts the collector blocks until it shuts down.
-// [Collector.setupConfigurationComponents] is the "main" function responsible for startup - it orchestrates the loading of the
+// Collector.setupConfigurationComponents is the "main" function responsible for startup - it orchestrates the loading of the
 // configuration, the creation of the graph, and the starting of all the components.
 package otelcol // import "go.opentelemetry.io/collector/otelcol"
 

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -4,8 +4,6 @@
 // Package otelcol handles the command-line, configuration, and runs the OpenTelemetry Collector.
 // It contains the main [Collector] struct and its constructor [NewCollector].
 // [Collector.Run] starts the collector and then blocks until it shuts down.
-// Collector.setupConfigurationComponents is the "main" function responsible for startup - it orchestrates the loading of the
-// configuration, the creation of the graph, and the starting of all the components.
 package otelcol // import "go.opentelemetry.io/collector/otelcol"
 
 import (
@@ -160,7 +158,7 @@ func (col *Collector) Shutdown() {
 	}
 }
 
-// setupConfigurationComponents loads the config and starts the components. If all the steps succeeds it
+// setupConfigurationComponents loads the config, creates the graph, and starts the components. If all the steps succeeds it
 // sets the col.service with the service currently running.
 func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	col.setCollectorState(StateStarting)
@@ -252,6 +250,7 @@ func (col *Collector) DryRun(ctx context.Context) error {
 // Run starts the collector according to the given configuration, and waits for it to complete.
 // Consecutive calls to Run are not allowed, Run shouldn't be called once a collector is shut down.
 func (col *Collector) Run(ctx context.Context) error {
+	// setupConfigurationComponents is the "main" function responsible for startup
 	if err := col.setupConfigurationComponents(ctx); err != nil {
 		col.setCollectorState(StateClosed)
 		return err

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -1,8 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package service handles the command-line, configuration, and runs the
-// OpenTelemetry Collector.
+// Package otelcol handles the command-line, configuration, and runs the OpenTelemetry Collector.
+// otelcol/collector.go contains the main Collector struct and its constructor [NewCollector].
+// [Collector.Run] starts the collector blocks until it shuts down.
+// [Collector.setupConfigurationComponents] is the "main" function responsible for startup - it orchestrates the loading of the
+// configuration, the creation of the graph, and the starting of all the components.
 package otelcol // import "go.opentelemetry.io/collector/otelcol"
 
 import (

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -3,7 +3,7 @@
 
 // Package graph contains the internal graph representation of the pipelines.
 //
-// [Build] is the constructor for a Graph object.  The method calls out to helpers that transform the graph from a config
+// [Build] is the constructor for a [Graph] object.  The method calls out to helpers that transform the graph from a config
 // to a DAG of components.  The configuration undergoes additional validation here as well, and is used to instantiate
 // the components of the pipeline.
 //

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -1,6 +1,15 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Package graph contains the internal graph representation of the pipelines.
+//
+// [Build] is the constructor for a Graph object.  The method calls out to helpers that transform the graph from a config
+// to a DAG of components.  The configuration undergoes additional validation here as well, and is used to instantiate
+// the components of the pipeline.
+//
+// [Graph.StartAll] starts every component in the pipelines.
+//
+// [Graph.ShutdownAll] stops each component in the pipelines
 package graph // import "go.opentelemetry.io/collector/service/internal/graph"
 
 import (

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -7,9 +7,9 @@
 // to a DAG of components.  The configuration undergoes additional validation here as well, and is used to instantiate
 // the components of the pipeline.
 //
-// [Graph.StartAll] starts every component in the pipelines.
+// [Graph.StartAll] starts all components in each pipeline.
 //
-// [Graph.ShutdownAll] stops each component in the pipelines
+// [Graph.ShutdownAll] stops all components in each pipeline.
 package graph // import "go.opentelemetry.io/collector/service/internal/graph"
 
 import (


### PR DESCRIPTION
<!--Describe the documentation added.-->
#### Documentation
Creates an internal architecture file.  In it is a diagram of the startup flow of the collector as well as links to key files / packages.  I also added package level comments to some key packages.

I wrote some other documentation in https://github.com/open-telemetry/opentelemetry-collector/pull/10029 but split the PRs up.