### PR TITLE
[exporterhelper] Fix `enabled` config option for batch sender

### DIFF
--- a/.chloggen/batch-sender-fix-enabled-config.yaml
+++ b/.chloggen/batch-sender-fix-enabled-config.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix enabled config option for batch sender
+
+# One or more tracking issues or pull requests related to the change
+issues: [10076]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/batch_sender_test.go
+++ b/exporter/exporterhelper/batch_sender_test.go
@@ -208,7 +208,7 @@ func TestBatchSender_Shutdown(t *testing.T) {
 func TestBatchSender_Disabled(t *testing.T) {
 	cfg := exporterbatcher.NewDefaultConfig()
 	cfg.Enabled = false
-	cfg.MaxSizeItems = 10
+	cfg.MaxSizeItems = 5
 	be, err := newBaseExporter(defaultSettings, defaultType, newNoopObsrepSender,
 		WithBatcher(cfg, WithRequestBatchFuncs(fakeBatchMergeFunc, fakeBatchMergeSplitFunc)))
 	require.NotNil(t, be)
@@ -220,7 +220,7 @@ func TestBatchSender_Disabled(t *testing.T) {
 	})
 
 	sink := newFakeRequestSink()
-	// should be sent right away because batching is disabled.
+	// should be sent right away without splitting because batching is disabled.
 	require.NoError(t, be.send(context.Background(), &fakeRequest{items: 8, sink: sink}))
 	assert.Equal(t, uint64(1), sink.requestsCount.Load())
 	assert.Equal(t, uint64(8), sink.itemsCount.Load())

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -172,6 +172,10 @@ func WithRequestBatchFuncs(mf exporterbatcher.BatchMergeFunc[Request], msf expor
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
 func WithBatcher(cfg exporterbatcher.Config, opts ...BatcherOption) Option {
 	return func(o *baseExporter) error {
+		if !cfg.Enabled {
+			return nil
+		}
+
 		bs := newBatchSender(cfg, o.set, o.batchMergeFunc, o.batchMergeSplitfunc)
 		for _, opt := range opts {
 			if err := opt(bs); err != nil {


### PR DESCRIPTION
`enabled` config option for batch sender was ignored. This PR fixes it.
