### PR TITLE
feat(exporters): add support for bytes metrics for logs/traces/metrics

### DIFF
--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -23,12 +23,14 @@ var logsUnmarshaler = &plog.ProtoUnmarshaler{}
 
 type logsRequest struct {
 	ld     plog.Logs
+	sizer  plog.Sizer
 	pusher consumer.ConsumeLogsFunc
 }
 
 func newLogsRequest(ld plog.Logs, pusher consumer.ConsumeLogsFunc) Request {
 	return &logsRequest{
 		ld:     ld,
+		sizer:  &plog.ProtoMarshaler{},
 		pusher: pusher,
 	}
 }
@@ -64,7 +66,7 @@ func (req *logsRequest) ItemsCount() int {
 }
 
 func (req *logsRequest) BytesSize() int {
-	return req.ld.LogRecordBytes()
+	return req.sizer.LogsSize(req.ld)
 }
 
 type logsExporter struct {

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -63,6 +63,10 @@ func (req *logsRequest) ItemsCount() int {
 	return req.ld.LogRecordCount()
 }
 
+func (req *logsRequest) BytesSize() int {
+	return req.ld.LogRecordBytes()
+}
+
 type logsExporter struct {
 	*baseExporter
 	consumer.Logs
@@ -156,6 +160,6 @@ func newLogsExporterWithObservability(obsrep *ObsReport) requestSender {
 func (lewo *logsExporterWithObservability) send(ctx context.Context, req Request) error {
 	c := lewo.obsrep.StartLogsOp(ctx)
 	err := lewo.nextSender.send(c, req)
-	lewo.obsrep.EndLogsOp(c, req.ItemsCount(), err)
+	lewo.obsrep.EndLogsOp(c, req.ItemsCount(), req.BytesSize(), err)
 	return err
 }

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -63,6 +63,10 @@ func (req *metricsRequest) ItemsCount() int {
 	return req.md.DataPointCount()
 }
 
+func (req *metricsRequest) BytesSize() int {
+	return 0
+}
+
 type metricsExporter struct {
 	*baseExporter
 	consumer.Metrics

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -32,15 +32,15 @@ type ObsReport struct {
 
 	otelAttrs                   []attribute.KeyValue
 	sentSpans                   metric.Int64Counter
-	sentSpansBytes              metric.Int64Histogram
+	sentSpansBytes              metric.Int64Counter
 	failedToSendSpans           metric.Int64Counter
 	failedToEnqueueSpans        metric.Int64Counter
 	sentMetricPoints            metric.Int64Counter
-	sentMetricPointsBytes       metric.Int64Histogram
+	sentMetricPointsBytes       metric.Int64Counter
 	failedToSendMetricPoints    metric.Int64Counter
 	failedToEnqueueMetricPoints metric.Int64Counter
 	sentLogRecords              metric.Int64Counter
-	sentLogRecordsBytes         metric.Int64Histogram
+	sentLogRecordsBytes         metric.Int64Counter
 	failedToSendLogRecords      metric.Int64Counter
 	failedToEnqueueLogRecords   metric.Int64Counter
 }
@@ -86,7 +86,7 @@ func (or *ObsReport) createOtelMetrics(cfg ObsReportSettings) error {
 		metric.WithUnit("1"))
 	errors = multierr.Append(errors, err)
 
-	or.sentSpansBytes, err = meter.Int64Histogram(
+	or.sentSpansBytes, err = meter.Int64Counter(
 		obsmetrics.ExporterMetricPrefix+obsmetrics.SentSpansBytesKey,
 		metric.WithDescription("Bytes of spans succesfully sent to destination."),
 		metric.WithUnit("By"))
@@ -110,7 +110,7 @@ func (or *ObsReport) createOtelMetrics(cfg ObsReportSettings) error {
 		metric.WithUnit("1"))
 	errors = multierr.Append(errors, err)
 
-	or.sentMetricPointsBytes, err = meter.Int64Histogram(
+	or.sentMetricPointsBytes, err = meter.Int64Counter(
 		obsmetrics.ExporterMetricPrefix+obsmetrics.SentMetricPointsBytesKey,
 		metric.WithDescription("Bytes of metric point succesfully sent to destination."),
 		metric.WithUnit("By"))
@@ -134,7 +134,7 @@ func (or *ObsReport) createOtelMetrics(cfg ObsReportSettings) error {
 		metric.WithUnit("1"))
 	errors = multierr.Append(errors, err)
 
-	or.sentLogRecordsBytes, err = meter.Int64Histogram(
+	or.sentLogRecordsBytes, err = meter.Int64Counter(
 		obsmetrics.ExporterMetricPrefix+obsmetrics.SentLogRecordsBytesKey,
 		metric.WithDescription("Bytes of log records succesfully sent to destination."),
 		metric.WithUnit("By"))
@@ -211,7 +211,7 @@ func (or *ObsReport) recordMetrics(ctx context.Context, dataType component.DataT
 		return
 	}
 	var sentMeasure, failedMeasure metric.Int64Counter
-	var sentMeasureBytes metric.Int64Histogram
+	var sentMeasureBytes metric.Int64Counter
 	switch dataType {
 	case component.DataTypeTraces:
 		sentMeasure = or.sentSpans
@@ -229,7 +229,7 @@ func (or *ObsReport) recordMetrics(ctx context.Context, dataType component.DataT
 
 	sentMeasure.Add(ctx, sent, metric.WithAttributes(or.otelAttrs...))
 	failedMeasure.Add(ctx, failed, metric.WithAttributes(or.otelAttrs...))
-	sentMeasureBytes.Record(ctx, sentBytes, metric.WithAttributes(or.otelAttrs...))
+	sentMeasureBytes.Add(ctx, sentBytes, metric.WithAttributes(or.otelAttrs...))
 }
 
 func endSpan(ctx context.Context, err error, numSent, numFailedToSend int64, sentItemsKey, failedToSendItemsKey string) {

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -121,7 +121,7 @@ func (or *ObsReport) createOtelMetrics(cfg ObsReportSettings) error {
 	errors = multierr.Append(errors, err)
 
 	or.sentLogRecordsBytes, err = meter.Int64Histogram(
-		obsmetrics.ExporterMetricPrefix+obsmetrics.SentLogRecordsBytesKey,
+		obsmetrics.ExporterMetricPrefix+"sent_log_records_bytes",
 		metric.WithDescription("Bytes of log records succesfully sent to destination."),
 		metric.WithUnit("By"))
 	errors = multierr.Append(errors, err)

--- a/exporter/exporterhelper/obsexporter_test.go
+++ b/exporter/exporterhelper/obsexporter_test.go
@@ -183,7 +183,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	require.NoError(t, err)
 	ctx := obsrep.StartTracesOp(context.Background())
 	require.NotNil(t, ctx)
-	obsrep.EndTracesOp(ctx, 7, nil)
+	obsrep.EndTracesOp(ctx, 7, 0, nil)
 
 	assert.NoError(t, tt.CheckExporterTraces(7, 0))
 	assert.Error(t, tt.CheckExporterTraces(7, 7))

--- a/exporter/exporterhelper/obsexporter_test.go
+++ b/exporter/exporterhelper/obsexporter_test.go
@@ -141,7 +141,7 @@ func TestExportLogsOp(t *testing.T) {
 			ctx := obsrep.StartLogsOp(parentCtx)
 			assert.NotNil(t, ctx)
 
-			obsrep.EndLogsOp(ctx, params[i].items, params[i].err)
+			obsrep.EndLogsOp(ctx, params[i].items, 0, params[i].err)
 		}
 
 		spans := tt.SpanRecorder.Ended()
@@ -223,7 +223,7 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	require.NoError(t, err)
 	ctx := obsrep.StartLogsOp(context.Background())
 	require.NotNil(t, ctx)
-	obsrep.EndLogsOp(ctx, 7, nil)
+	obsrep.EndLogsOp(ctx, 7, 0, nil)
 
 	assert.NoError(t, tt.CheckExporterLogs(7, 0))
 	assert.Error(t, tt.CheckExporterLogs(7, 7))

--- a/exporter/exporterhelper/obsexporter_test.go
+++ b/exporter/exporterhelper/obsexporter_test.go
@@ -43,7 +43,7 @@ func TestExportTraceDataOp(t *testing.T) {
 		for i := range params {
 			ctx := obsrep.StartTracesOp(parentCtx)
 			assert.NotNil(t, ctx)
-			obsrep.EndTracesOp(ctx, params[i].items, params[i].err)
+			obsrep.EndTracesOp(ctx, params[i].items, 0, params[i].err)
 		}
 
 		spans := tt.SpanRecorder.Ended()
@@ -92,7 +92,7 @@ func TestExportMetricsOp(t *testing.T) {
 			ctx := obsrep.StartMetricsOp(parentCtx)
 			assert.NotNil(t, ctx)
 
-			obsrep.EndMetricsOp(ctx, params[i].items, params[i].err)
+			obsrep.EndMetricsOp(ctx, params[i].items, 0, params[i].err)
 		}
 
 		spans := tt.SpanRecorder.Ended()
@@ -203,7 +203,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	ctx := obsrep.StartMetricsOp(context.Background())
 	require.NotNil(t, ctx)
-	obsrep.EndMetricsOp(ctx, 7, nil)
+	obsrep.EndMetricsOp(ctx, 7, 0, nil)
 
 	assert.NoError(t, tt.CheckExporterMetrics(7, 0))
 	assert.Error(t, tt.CheckExporterMetrics(7, 7))

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -17,6 +17,8 @@ type Request interface {
 	// sent. For example, for OTLP exporter, this value represents the number of spans,
 	// metric data points or log records.
 	ItemsCount() int
+
+	BytesSize() int
 }
 
 // RequestErrorHandler is an optional interface that can be implemented by Request to provide a way handle partial

--- a/exporter/exporterhelper/request_test.go
+++ b/exporter/exporterhelper/request_test.go
@@ -54,6 +54,8 @@ func (r *fakeRequest) ItemsCount() int {
 	return r.items
 }
 
+func (r *fakeRequest) BytesSize() int { return 0 }
+
 func fakeBatchMergeFunc(_ context.Context, r1 Request, r2 Request) (Request, error) {
 	if r1 == nil {
 		return r2, nil

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -282,6 +282,10 @@ func (mer *mockErrorRequest) ItemsCount() int {
 	return 7
 }
 
+func (mer *mockErrorRequest) BytesSize() int {
+	return 0
+}
+
 func newErrorRequest() Request {
 	return &mockErrorRequest{}
 }
@@ -305,6 +309,8 @@ func (m *mockRequest) Export(ctx context.Context) error {
 	// Respond like gRPC/HTTP, if context is cancelled, return error
 	return ctx.Err()
 }
+
+func (m *mockRequest) BytesSize() int { return 0 }
 
 func (m *mockRequest) OnError(error) Request {
 	return &mockRequest{

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -63,6 +63,8 @@ func (req *tracesRequest) ItemsCount() int {
 	return req.td.SpanCount()
 }
 
+func (req *tracesRequest) BytesSize() int { return 0 }
+
 type traceExporter struct {
 	*baseExporter
 	consumer.Traces

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -83,3 +83,5 @@ replace go.opentelemetry.io/collector/config/configtelemetry => ../config/config
 replace go.opentelemetry.io/collector/pdata => ../pdata
 
 replace go.opentelemetry.io/collector/pdata/plog => ../pdata/plog
+
+replace go.opentelemetry.io/collector/internal/obsreportconfig => ../internal/obsreportconfig

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -70,8 +70,6 @@ replace go.opentelemetry.io/collector/extension => ../extension
 
 replace go.opentelemetry.io/collector/featuregate => ../featuregate
 
-replace go.opentelemetry.io/collector/pdata => ../pdata
-
 replace go.opentelemetry.io/collector/pdata/testdata => ../pdata/testdata
 
 replace go.opentelemetry.io/collector/receiver => ../receiver
@@ -81,3 +79,7 @@ retract v0.76.0 // Depends on retracted pdata v1.0.0-rc10 module
 replace go.opentelemetry.io/collector/config/configretry => ../config/configretry
 
 replace go.opentelemetry.io/collector/config/configtelemetry => ../config/configtelemetry
+
+replace go.opentelemetry.io/collector/pdata => ../pdata
+
+replace go.opentelemetry.io/collector/pdata/plog => ../pdata/plog

--- a/internal/obsreportconfig/obsmetrics/obs_exporter.go
+++ b/internal/obsreportconfig/obsmetrics/obs_exporter.go
@@ -23,6 +23,8 @@ const (
 
 	// SentLogRecordsKey used to track logs sent by exporters.
 	SentLogRecordsKey = "sent_log_records"
+	// SentLogRecordsKey used to track logs sent by exporters.
+	SentLogRecordsBytesKey = "sent_log_records_bytes"
 	// FailedToSendLogRecordsKey used to track logs that failed to be sent by exporters.
 	FailedToSendLogRecordsKey = "send_failed_log_records"
 	// FailedToEnqueueLogRecordsKey used to track logs that failed to be enqueued by exporters.

--- a/internal/obsreportconfig/obsmetrics/obs_exporter.go
+++ b/internal/obsreportconfig/obsmetrics/obs_exporter.go
@@ -9,6 +9,8 @@ const (
 
 	// SentSpansKey used to track spans sent by exporters.
 	SentSpansKey = "sent_spans"
+	// SentSpansKey used to track spans (in bytes) sent by exporters.
+	SentSpansBytesKey = "sent_spans_bytes"
 	// FailedToSendSpansKey used to track spans that failed to be sent by exporters.
 	FailedToSendSpansKey = "send_failed_spans"
 	// FailedToEnqueueSpansKey used to track spans that failed to be enqueued by exporters.
@@ -16,6 +18,8 @@ const (
 
 	// SentMetricPointsKey used to track metric points sent by exporters.
 	SentMetricPointsKey = "sent_metric_points"
+	// SentMetricPointsKey used to track metric points (in bytes) sent by exporters.
+	SentMetricPointsBytesKey = "sent_metric_points_bytes"
 	// FailedToSendMetricPointsKey used to track metric points that failed to be sent by exporters.
 	FailedToSendMetricPointsKey = "send_failed_metric_points"
 	// FailedToEnqueueMetricPointsKey used to track metric points that failed to be enqueued by exporters.
@@ -23,7 +27,7 @@ const (
 
 	// SentLogRecordsKey used to track logs sent by exporters.
 	SentLogRecordsKey = "sent_log_records"
-	// SentLogRecordsKey used to track logs sent by exporters.
+	// SentLogRecordsBytesKey used to track logs (in bytes) sent by exporters.
 	SentLogRecordsBytesKey = "sent_log_records_bytes"
 	// FailedToSendLogRecordsKey used to track logs that failed to be sent by exporters.
 	FailedToSendLogRecordsKey = "send_failed_log_records"

--- a/internal/obsreportconfig/obsmetrics/obs_receiver.go
+++ b/internal/obsreportconfig/obsmetrics/obs_receiver.go
@@ -23,7 +23,8 @@ const (
 	RefusedMetricPointsKey = "refused_metric_points"
 
 	// AcceptedLogRecordsKey used to identify log records accepted by the Collector.
-	AcceptedLogRecordsKey = "accepted_log_records"
+	AcceptedLogRecordsKey        = "accepted_log_records"
+	AcceptedLogRecordsInBytesKey = "accepted_log_recods_bytes"
 	// RefusedLogRecordsKey used to identify log records refused (ie.: not ingested) by the
 	// Collector.
 	RefusedLogRecordsKey = "refused_log_records"

--- a/internal/obsreportconfig/obsmetrics/obs_receiver.go
+++ b/internal/obsreportconfig/obsmetrics/obs_receiver.go
@@ -13,18 +13,23 @@ const (
 
 	// AcceptedSpansKey used to identify spans accepted by the Collector.
 	AcceptedSpansKey = "accepted_spans"
+	// AcceptedSpansBytesKey used to calculate spans in bytes accepted by the Collector.
+	AcceptedSpansBytesKey = "accepted_spans_bytes"
 	// RefusedSpansKey used to identify spans refused (ie.: not ingested) by the Collector.
 	RefusedSpansKey = "refused_spans"
 
 	// AcceptedMetricPointsKey used to identify metric points accepted by the Collector.
 	AcceptedMetricPointsKey = "accepted_metric_points"
+	// AcceptedMetricPointsBytesKey used to calculate metric points in bytes accepted by the Collector.
+	AcceptedMetricPointsBytesKey = "accepted_metric_points_bytes"
 	// RefusedMetricPointsKey used to identify metric points refused (ie.: not ingested) by the
 	// Collector.
 	RefusedMetricPointsKey = "refused_metric_points"
 
 	// AcceptedLogRecordsKey used to identify log records accepted by the Collector.
-	AcceptedLogRecordsKey        = "accepted_log_records"
-	AcceptedLogRecordsInBytesKey = "accepted_log_recods_bytes"
+	AcceptedLogRecordsKey = "accepted_log_records"
+	// AcceptedLogRecordsBytesKey used to calculate log records in bytes accepted by the Collector.
+	AcceptedLogRecordsBytesKey = "accepted_log_records_bytes"
 	// RefusedLogRecordsKey used to identify log records refused (ie.: not ingested) by the
 	// Collector.
 	RefusedLogRecordsKey = "refused_log_records"

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -70,3 +70,5 @@ replace go.opentelemetry.io/collector/pdata/testdata => ../pdata/testdata
 retract v0.76.0 // Depends on retracted pdata v1.0.0-rc10 module
 
 replace go.opentelemetry.io/collector/config/configtelemetry => ../config/configtelemetry
+
+replace go.opentelemetry.io/collector/internal/obsreportconfig => ../internal/obsreportconfig

--- a/receiver/receiverhelper/obsreport.go
+++ b/receiver/receiverhelper/obsreport.go
@@ -35,15 +35,15 @@ type ObsReport struct {
 
 	otelAttrs []attribute.KeyValue
 
-	acceptedSpansCounter               metric.Int64Counter
-	acceptedSpansBytesHistogram        metric.Int64Histogram
-	refusedSpansCounter                metric.Int64Counter
-	acceptedMetricPointsCounter        metric.Int64Counter
-	acceptedMetricPointsBytesHistogram metric.Int64Histogram
-	refusedMetricPointsCounter         metric.Int64Counter
-	acceptedLogRecordsCounter          metric.Int64Counter
-	acceptedLogRecodsBytesHistogram    metric.Int64Histogram
-	refusedLogRecordsCounter           metric.Int64Counter
+	acceptedSpansCounter             metric.Int64Counter
+	acceptedSpansBytesCounter        metric.Int64Counter
+	refusedSpansCounter              metric.Int64Counter
+	acceptedMetricPointsCounter      metric.Int64Counter
+	acceptedMetricPointsBytesCounter metric.Int64Counter
+	refusedMetricPointsCounter       metric.Int64Counter
+	acceptedLogRecordsCounter        metric.Int64Counter
+	acceptedLogRecordsBytesCounter   metric.Int64Counter
+	refusedLogRecordsCounter         metric.Int64Counter
 }
 
 // ObsReportSettings are settings for creating an ObsReport.
@@ -97,7 +97,7 @@ func (rec *ObsReport) createOtelMetrics() error {
 	)
 	errors = multierr.Append(errors, err)
 
-	rec.acceptedSpansBytesHistogram, err = rec.meter.Int64Histogram(
+	rec.acceptedSpansBytesCounter, err = rec.meter.Int64Counter(
 		obsmetrics.ReceiverMetricPrefix+obsmetrics.AcceptedLogRecordsBytesKey,
 		metric.WithDescription("Bytes of spans successfully pushed into the pipeline."),
 		metric.WithUnit("By"),
@@ -118,7 +118,7 @@ func (rec *ObsReport) createOtelMetrics() error {
 	)
 	errors = multierr.Append(errors, err)
 
-	rec.acceptedMetricPointsBytesHistogram, err = rec.meter.Int64Histogram(
+	rec.acceptedMetricPointsBytesCounter, err = rec.meter.Int64Counter(
 		obsmetrics.ReceiverMetricPrefix+obsmetrics.AcceptedLogRecordsBytesKey,
 		metric.WithDescription("Bytes of metric points successfully pushed into the pipeline."),
 		metric.WithUnit("By"),
@@ -139,7 +139,7 @@ func (rec *ObsReport) createOtelMetrics() error {
 	)
 	errors = multierr.Append(errors, err)
 
-	rec.acceptedLogRecodsBytesHistogram, err = rec.meter.Int64Histogram(
+	rec.acceptedLogRecordsBytesCounter, err = rec.meter.Int64Counter(
 		obsmetrics.ReceiverMetricPrefix+obsmetrics.AcceptedLogRecordsBytesKey,
 		metric.WithDescription("Bytes of log records successfully pushed into the pipeline."),
 		metric.WithUnit("By"),
@@ -290,8 +290,7 @@ func (rec *ObsReport) endOp(
 }
 
 func (rec *ObsReport) recordMetrics(receiverCtx context.Context, dataType component.DataType, numAccepted, bytesAccepted, numRefused int) {
-	var acceptedMeasure, refusedMeasure metric.Int64Counter
-	var accecptedBytesMeasure metric.Int64Histogram
+	var acceptedMeasure, accecptedBytesMeasure, refusedMeasure metric.Int64Counter
 	switch dataType {
 	case component.DataTypeTraces:
 		acceptedMeasure = rec.acceptedSpansCounter
@@ -309,5 +308,5 @@ func (rec *ObsReport) recordMetrics(receiverCtx context.Context, dataType compon
 
 	acceptedMeasure.Add(receiverCtx, int64(numAccepted), metric.WithAttributes(rec.otelAttrs...))
 	refusedMeasure.Add(receiverCtx, int64(numRefused), metric.WithAttributes(rec.otelAttrs...))
-	accecptedBytesMeasure.Record(receiverCtx, int64(bytesAccepted), metric.WithAttributes(rec.otelAttrs...))
+	accecptedBytesMeasure.Add(receiverCtx, int64(bytesAccepted), metric.WithAttributes(rec.otelAttrs...))
 }

--- a/receiver/receiverhelper/obsreport_test.go
+++ b/receiver/receiverhelper/obsreport_test.go
@@ -101,7 +101,7 @@ func TestReceiveLogsOp(t *testing.T) {
 
 			ctx := rec.StartLogsOp(parentCtx)
 			assert.NotNil(t, ctx)
-			rec.EndLogsOp(ctx, format, params[i].items, param.err)
+			rec.EndLogsOp(ctx, format, params[i].items, 0, param.err)
 		}
 
 		spans := tt.SpanRecorder.Ended()
@@ -288,7 +288,7 @@ func TestCheckReceiverLogsViews(t *testing.T) {
 	require.NoError(t, err)
 	ctx := rec.StartLogsOp(context.Background())
 	require.NotNil(t, ctx)
-	rec.EndLogsOp(ctx, format, 7, nil)
+	rec.EndLogsOp(ctx, format, 7, 0, nil)
 
 	assert.NoError(t, tt.CheckReceiverLogs(transport, 7, 0))
 	assert.Error(t, tt.CheckReceiverLogs(transport, 7, 7))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

For log records it is really useful to know how not only the number of log records but their size in bytes as well.
This PR in it's current state showcases a potential solution to this problem, please let me know your thoughts @djaglowski @ChrsMark 

I will also make sure that it is disabled by default, but wanted to gather early feedback before went with this further.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #9412

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->

TODOs:

- [ ] docs
- [ ] testing
- [ ] make sure disabled by default