### PR TITLE
[builder] Support for --skip-new-go-module

### DIFF
--- a/.chloggen/builder-skip-go-mod.yaml
+++ b/.chloggen/builder-skip-go-mod.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a --skip-new-go-module flag to skip creating a module in the output directory.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9252]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/Makefile
+++ b/cmd/builder/Makefile
@@ -1,5 +1,7 @@
 include ../../Makefile.Common
 
+GOTEST_TIMEOUT=360s
+
 .PHONY: ocb
 ocb:
 	CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/ocb_$(GOOS)_$(GOARCH) .

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -157,6 +157,26 @@ ocb --skip-generate --skip-get-modules --config=config.yaml
 ```
 to only execute the compilation step.
 
+### Avoiding the use of a new go.mod file
+
+There is an additional option that controls one aspect of the build
+process, which specifically allows skipping the use of a new `go.mod`
+file.  When the `--skip-new-go-module` command-line flag is supplied,
+the build process issues a `go get` command for each component,
+relying on the Go toolchain to update the enclosing Go module
+appropriately.
+
+This command will avoid downgrading a dependency in the enclosing
+module, according to
+[`semver.Compare()`](https://pkg.go.dev/golang.org/x/mod/semver#Compare),
+and will instead issue a log indicating that the component was not
+upgraded.
+
+This mode cannot be used in conjunction with several features that
+control the generated `go.mod` file, including `replaces`, `excludes`,
+and the component `path` override.  For each of these features, users
+are expected to modify the enclosing `go.mod` directly.
+
 ### Strict versioning checks
 
 The builder checks the relevant `go.mod`

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -159,11 +159,10 @@ to only execute the compilation step.
 
 ### Avoiding the use of a new go.mod file
 
-There is an additional option that controls one aspect of the build
-process, which specifically allows skipping the use of a new `go.mod`
-file.  When the `--skip-new-go-module` command-line flag is supplied,
-the build process issues a `go get` command for each component,
-relying on the Go toolchain to update the enclosing Go module
+You can optionally skip creating a new `go.mod` file. This is helpful when 
+using a monorepo setup with a shared go.mod file. When the `--skip-new-go-module` 
+command-line flag is supplied, the build process issues a `go get` command for 
+each component, relying on the Go toolchain to update the enclosing Go module 
 appropriately.
 
 This command will avoid downgrading a dependency in the enclosing
@@ -172,8 +171,7 @@ module, according to
 and will instead issue a log indicating that the component was not
 upgraded.
 
-This mode cannot be used in conjunction with several features that
-control the generated `go.mod` file, including `replaces`, `excludes`,
+`--skip-new-go-module` is incompatible with `replaces`, `excludes`,
 and the component `path` override.  For each of these features, users
 are expected to modify the enclosing `go.mod` directly.
 

--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.10.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/cmd/builder/go.sum
+++ b/cmd/builder/go.sum
@@ -37,8 +37,8 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
-github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -259,7 +259,7 @@ func (c *Config) validateModules(name string, mods []Module) error {
 			return fmt.Errorf("%s module at index %v: %w", name, i, ErrMissingGoMod)
 		}
 		if mod.Path != "" && c.SkipNewGoModule {
-			return fmt.Errorf("%w cannot modify mod.path \"%v\" combined with --skip-new-go-module; please modify the enclosing go.mod file directly", ErrIncompatibleConfigurationValues, mod.Path)
+			return fmt.Errorf("%w cannot modify mod.path %q combined with --skip-new-go-module; please modify the enclosing go.mod file directly", ErrIncompatibleConfigurationValues, mod.Path)
 		}
 	}
 	return nil

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -19,8 +19,12 @@ import (
 
 const defaultOtelColVersion = "0.107.0"
 
-// ErrMissingGoMod indicates an empty gomod field
-var ErrMissingGoMod = errors.New("missing gomod specification for module")
+var (
+	// ErrMissingGoMod indicates an empty gomod field
+	ErrMissingGoMod = errors.New("missing gomod specification for module")
+	// ErrIncompatibleConfigurationValues indicates that there is configuration that cannot be combined
+	ErrIncompatibleConfigurationValues = errors.New("cannot combine configuration values")
+)
 
 // Config holds the builder's configuration
 type Config struct {
@@ -29,6 +33,7 @@ type Config struct {
 	SkipGenerate         bool   `mapstructure:"-"`
 	SkipCompilation      bool   `mapstructure:"-"`
 	SkipGetModules       bool   `mapstructure:"-"`
+	SkipNewGoModule      bool   `mapstructure:"-"`
 	SkipStrictVersioning bool   `mapstructure:"-"`
 	LDFlags              string `mapstructure:"-"`
 	Verbose              bool   `mapstructure:"-"`
@@ -116,14 +121,15 @@ func NewDefaultConfig() Config {
 func (c *Config) Validate() error {
 	var providersError error
 	if c.Providers != nil {
-		providersError = validateModules("provider", *c.Providers)
+		providersError = c.validateModules("provider", *c.Providers)
 	}
 	return multierr.Combine(
-		validateModules("extension", c.Extensions),
-		validateModules("receiver", c.Receivers),
-		validateModules("exporter", c.Exporters),
-		validateModules("processor", c.Processors),
-		validateModules("connector", c.Connectors),
+		c.validateModules("extension", c.Extensions),
+		c.validateModules("receiver", c.Receivers),
+		c.validateModules("exporter", c.Exporters),
+		c.validateModules("processor", c.Processors),
+		c.validateModules("connector", c.Connectors),
+		c.validateFlags(),
 		providersError,
 	)
 }
@@ -240,10 +246,20 @@ func (c *Config) ParseModules() error {
 	return nil
 }
 
-func validateModules(name string, mods []Module) error {
+func (c *Config) validateFlags() error {
+	if c.SkipNewGoModule && (len(c.Replaces) != 0 || len(c.Excludes) != 0) {
+		return fmt.Errorf("%w excludes or replaces with --skip-new-go-module; please modify the enclosing go.mod file directly", ErrIncompatibleConfigurationValues)
+	}
+	return nil
+}
+
+func (c *Config) validateModules(name string, mods []Module) error {
 	for i, mod := range mods {
 		if mod.GoMod == "" {
 			return fmt.Errorf("%s module at index %v: %w", name, i, ErrMissingGoMod)
+		}
+		if mod.Path != "" && c.SkipNewGoModule {
+			return fmt.Errorf("%w cannot modify mod.path \"%v\" combined with --skip-new-go-module; please modify the enclosing go.mod file directly", ErrIncompatibleConfigurationValues, mod.Path)
 		}
 	}
 	return nil

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -4,7 +4,6 @@
 package builder
 
 import (
-	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -140,10 +139,37 @@ func TestMissingModule(t *testing.T) {
 			},
 			err: ErrMissingGoMod,
 		},
+		{
+			cfg: Config{
+				Logger:          zap.NewNop(),
+				SkipNewGoModule: true,
+				Extensions: []Module{{
+					GoMod: "some-module",
+					Path:  "invalid",
+				}},
+			},
+			err: ErrIncompatibleConfigurationValues,
+		},
+		{
+			cfg: Config{
+				Logger:          zap.NewNop(),
+				SkipNewGoModule: true,
+				Replaces:        []string{"", ""},
+			},
+			err: ErrIncompatibleConfigurationValues,
+		},
+		{
+			cfg: Config{
+				Logger:          zap.NewNop(),
+				SkipNewGoModule: true,
+				Excludes:        []string{"", ""},
+			},
+			err: ErrIncompatibleConfigurationValues,
+		},
 	}
 
 	for _, test := range configurations {
-		assert.True(t, errors.Is(test.cfg.Validate(), test.err))
+		assert.ErrorIs(t, test.cfg.Validate(), test.err)
 	}
 }
 

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -260,6 +260,11 @@ func (c *Config) updateModules() error {
 }
 
 func (c *Config) updateGoModule(modspec string) error {
+	mod, ver, found := strings.Cut(modspec, " ")
+	if !found {
+		return fmt.Errorf("ill-formatted modspec %q: missing space separator", modspec)
+	}
+
 	// Re-parse the go.mod file on each iteration, since it can
 	// change each time.
 	modulePath, dependencyVersions, err := c.readGoModFile()
@@ -267,7 +272,6 @@ func (c *Config) updateGoModule(modspec string) error {
 		return err
 	}
 
-	mod, ver, _ := strings.Cut(modspec, " ")
 	if mod == modulePath {
 		// this component is part of the same module, nothing to update.
 		return nil
@@ -288,9 +292,9 @@ func (c *Config) updateGoModule(modspec string) error {
 	}
 
 	// upgrading or changing version
-	updatespec := mod + "@" + ver
+	updatespec := "-require=" + mod + "@" + ver
 
-	if _, err := runGoCommand(*c, "get", updatespec); err != nil {
+	if _, err := runGoCommand(*c, "mod", "edit", updatespec); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/builder/internal/builder/modfiles_test.go
+++ b/cmd/builder/internal/builder/modfiles_test.go
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+const (
+	goModTestFile = `// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+module go.opentelemetry.io/collector/cmd/builder/unittests
+
+go 1.21.0
+
+require (
+	go.opentelemetry.io/collector/component v0.106.0
+	go.opentelemetry.io/collector/confmap v0.106.0
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.106.0
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.106.0
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.106.0
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.106.0
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.106.0
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.106.0
+	go.opentelemetry.io/collector/connector v0.106.0
+	go.opentelemetry.io/collector/exporter v0.106.0
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.106.0
+	go.opentelemetry.io/collector/extension v0.106.0
+	go.opentelemetry.io/collector/otelcol v0.106.0
+	go.opentelemetry.io/collector/processor v0.106.0
+	go.opentelemetry.io/collector/receiver v0.106.0
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.106.0
+	golang.org/x/sys v0.20.0
+)`
+
+	invalidDependencyGoMod = `// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+module go.opentelemetry.io/collector/cmd/builder/unittests
+
+go 1.21.0
+
+require (
+	go.opentelemetry.io/collector/bad/otelcol v0.94.1
+	go.opentelemetry.io/collector/component v0.102.1
+	go.opentelemetry.io/collector/confmap v0.102.1
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.102.1
+	go.opentelemetry.io/collector/connector v0.102.1
+	go.opentelemetry.io/collector/exporter v0.102.1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.102.1
+	go.opentelemetry.io/collector/extension v0.102.1
+	go.opentelemetry.io/collector/otelcol v0.102.1
+	go.opentelemetry.io/collector/processor v0.102.1
+	go.opentelemetry.io/collector/receiver v0.102.1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.102.1
+	golang.org/x/sys v0.20.0
+)`
+
+	malformedGoMod = `// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+module go.opentelemetry.io/collector/cmd/builder/unittests
+
+go 1.21.0
+
+require (
+	go.opentelemetry.io/collector/componentv0.102.1
+	go.opentelemetry.io/collector/confmap v0.102.1
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.102.1
+	go.opentelemetry.io/collector/connector v0.102.1
+	go.opentelemetry.io/collector/exporter v0.102.1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.102.1
+	go.opentelemetry.io/collector/extension v0.102.1
+	go.opentelemetry.io/collector/otelcol v0.102.1
+	go.opentelemetry.io/collector/processor v0.102.1
+	go.opentelemetry.io/collector/receiver v0.102.1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.102.1
+	golang.org/x/sys v0.20.0
+)`
+)

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -85,7 +85,7 @@ configuration is provided, ocb will generate a default Collector.
 	cmd.Flags().BoolVar(&cfg.SkipGenerate, skipGenerateFlag, false, "Whether builder should skip generating go code (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipCompilation, skipCompilationFlag, false, "Whether builder should only generate go code with no compile of the collector (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipGetModules, skipGetModulesFlag, false, "Whether builder should skip updating go.mod and retrieve Go module list (default false)")
-	cmd.Flags().BoolVar(&cfg.SkipNewGoModule, skipNewGoModuleFlag, false, "Whether builder should skip generating a new go.mod file, use enclosing Go module instead (default false)")
+	cmd.Flags().BoolVar(&cfg.SkipNewGoModule, skipNewGoModuleFlag, false, "Whether builder should skip generating a new go.mod file, using the enclosing Go module instead (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipStrictVersioning, skipStrictVersioningFlag, false, "Whether builder should skip strictly checking the calculated versions following dependency resolution")
 	cmd.Flags().BoolVar(&cfg.Verbose, verboseFlag, false, "Whether builder should print verbose output (default false)")
 	cmd.Flags().StringVar(&cfg.LDFlags, ldflagsFlag, "", `ldflags to include in the "go build" command`)

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -23,6 +23,7 @@ const (
 	skipGenerateFlag               = "skip-generate"
 	skipCompilationFlag            = "skip-compilation"
 	skipGetModulesFlag             = "skip-get-modules"
+	skipNewGoModuleFlag            = "skip-new-go-module"
 	skipStrictVersioningFlag       = "skip-strict-versioning"
 	ldflagsFlag                    = "ldflags"
 	distributionNameFlag           = "name"
@@ -84,6 +85,7 @@ configuration is provided, ocb will generate a default Collector.
 	cmd.Flags().BoolVar(&cfg.SkipGenerate, skipGenerateFlag, false, "Whether builder should skip generating go code (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipCompilation, skipCompilationFlag, false, "Whether builder should only generate go code with no compile of the collector (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipGetModules, skipGetModulesFlag, false, "Whether builder should skip updating go.mod and retrieve Go module list (default false)")
+	cmd.Flags().BoolVar(&cfg.SkipNewGoModule, skipNewGoModuleFlag, false, "Whether builder should skip generating a new go.mod file, use enclosing Go module instead (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipStrictVersioning, skipStrictVersioningFlag, false, "Whether builder should skip strictly checking the calculated versions following dependency resolution")
 	cmd.Flags().BoolVar(&cfg.Verbose, verboseFlag, false, "Whether builder should print verbose output (default false)")
 	cmd.Flags().StringVar(&cfg.LDFlags, ldflagsFlag, "", `ldflags to include in the "go build" command`)
@@ -184,6 +186,9 @@ func applyCfgFromFile(flags *flag.FlagSet, cfgFromFile builder.Config) {
 	}
 	if !flags.Changed(skipGetModulesFlag) && cfgFromFile.SkipGetModules {
 		cfg.SkipGetModules = cfgFromFile.SkipGetModules
+	}
+	if !flags.Changed(skipNewGoModuleFlag) && cfgFromFile.SkipNewGoModule {
+		cfg.SkipNewGoModule = cfgFromFile.SkipNewGoModule
 	}
 	if !flags.Changed(skipStrictVersioningFlag) && cfgFromFile.SkipStrictVersioning {
 		cfg.SkipStrictVersioning = cfgFromFile.SkipStrictVersioning

--- a/cmd/builder/internal/command_test.go
+++ b/cmd/builder/internal/command_test.go
@@ -248,6 +248,54 @@ func Test_applyCfgFromFile(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Skip new go mod false",
+			args: args{
+				flags: flag.NewFlagSet("version=1.0.0", 1),
+				cfgFromFile: builder.Config{
+					Logger:          zap.NewNop(),
+					SkipGenerate:    true,
+					SkipCompilation: true,
+					SkipGetModules:  true,
+					SkipNewGoModule: false,
+					Distribution:    testDistribution,
+				},
+			},
+			want: builder.Config{
+				Logger:               zap.NewNop(),
+				SkipGenerate:         true,
+				SkipCompilation:      true,
+				SkipGetModules:       true,
+				SkipStrictVersioning: true,
+				SkipNewGoModule:      false,
+				Distribution:         testDistribution,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Skip new go mod true",
+			args: args{
+				flags: flag.NewFlagSet("version=1.0.0", 1),
+				cfgFromFile: builder.Config{
+					Logger:          zap.NewNop(),
+					SkipGenerate:    true,
+					SkipCompilation: true,
+					SkipGetModules:  true,
+					SkipNewGoModule: true,
+					Distribution:    testDistribution,
+				},
+			},
+			want: builder.Config{
+				Logger:               zap.NewNop(),
+				SkipGenerate:         true,
+				SkipCompilation:      true,
+				SkipGetModules:       true,
+				SkipStrictVersioning: true,
+				SkipNewGoModule:      true,
+				Distribution:         testDistribution,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
A continuation of https://github.com/open-telemetry/opentelemetry-collector/pull/9253 and https://github.com/open-telemetry/opentelemetry-collector/pull/9631

Description: Adds a `--skip-new-go-module` flag to the OTC builder. This enables users working in an existing go module environment (say, a "monorepo") to update the module they have, vs forcing the use of a new module.

With the new support inside an existing Go module, a collector main package can be generated using a go:generate directive. For example, in the directory where I want my collector built, the file generate.go has this line:

//go:generate builder --skip-new-go-module --skip-compilation --strict-versioning --config=./build-config.yaml
In the same directory, the build-config.yaml describes the collector to build. The builder generates the other files in the same directory. At this point, normal Go workflows can be used to update indirect dependencies.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector/issues/9252

Testing: Will add unit tests in the next few days.

Documentation: Yes.