### PR TITLE
[mdatagen] Run tests when skipping goleak

### DIFF
--- a/.chloggen/fix_skip_goleak.yaml
+++ b/.chloggen/fix_skip_goleak.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Run package tests when goleak is skipped
+
+# One or more tracking issues or pull requests related to the change
+issues: [10125]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/templates/package_test.go.tmpl
+++ b/cmd/mdatagen/templates/package_test.go.tmpl
@@ -14,6 +14,7 @@ func TestMain(m *testing.M) {
     {{- end }}
     {{- if .Tests.GoLeak.Skip }}
     // skipping goleak test as per metadata.yml configuration
+    os.Exit(m.Run())
     {{- else }}
 	goleak.VerifyTestMain(m {{- range $val := .Tests.GoLeak.Ignore.Top}}, goleak.IgnoreTopFunction("{{$val}}"){{end}}{{- range $val := .Tests.GoLeak.Ignore.Any}}, goleak.IgnoreAnyFunction("{{$val}}"){{end}} )
     {{- end }}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Tests are currently not being run when `goleak` checks are skipped. This is because `TestMain` is called in the generated file, and needs to call `m.Run()` to properly run the package's tests. This call was missing.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10125

<!--Describe what testing was performed and which tests were added.-->
#### Testing
There aren't any `goleak` checks currently being skipped in core from the generated package tests, but there are quite a few in `contrib`. This will fix the skipped tests in `contrib`.