### PR TITLE
MemoryLimiterProcessor - switch to  MustNewID instead of zero value ID

### DIFF
--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -56,7 +56,9 @@ func TestNoDataLoss(t *testing.T) {
 	limiter, err := newMemoryLimiterProcessor(set, cfg)
 	require.NoError(t, err)
 
-	processor, err := processorhelper.NewLogsProcessor(context.Background(), processor.CreateSettings{}, cfg, exporter,
+	processor, err := processorhelper.NewLogsProcessor(context.Background(), processor.CreateSettings{
+		ID: component.MustNewID("nop"),
+	}, cfg, exporter,
 		limiter.processLogs,
 		processorhelper.WithStart(limiter.start),
 		processorhelper.WithShutdown(limiter.shutdown))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
In an upcoming PR, I change Type to be an interface.  This means the zero value of Type will be nil - which will cause this test to fail.  Initializing ID instead of relying on the zero value fixes this

<!-- Issue number if applicable -->
#### Link to tracking issue
related to https://github.com/open-telemetry/opentelemetry-collector/issues/9429


<!--Please delete paragraphs that you did not use before submitting.-->
In preparation for https://github.com/open-telemetry/opentelemetry-collector/pull/10069