### PR TITLE
[confighttp] Don't marshal CustomRoundTripper

### DIFF
--- a/.chloggen/confighttp-marshaling.yaml
+++ b/.chloggen/confighttp-marshaling.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Explicitly exclude `CustomRoundTripper` from marshaling
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/confighttp-marshaling.yaml
+++ b/.chloggen/confighttp-marshaling.yaml
@@ -10,7 +10,7 @@ component: confighttp
 note: Explicitly exclude `CustomRoundTripper` from marshaling
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [10136]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -57,7 +57,7 @@ type ClientConfig struct {
 	Headers map[string]configopaque.String `mapstructure:"headers"`
 
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
-	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
+	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error) `mapstructure:"-"`
 
 	// Auth configuration for outgoing HTTP calls.
 	Auth *configauth.Authentication `mapstructure:"auth"`

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
@@ -29,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/extension/auth"
 	"go.opentelemetry.io/collector/extension/auth/authtest"
 )
@@ -1307,7 +1309,24 @@ func TestServerWithDecoder(t *testing.T) {
 	srv.Handler.ServeHTTP(response, req)
 	// verify
 	assert.Equal(t, response.Result().StatusCode, http.StatusOK)
+}
 
+func TestClientConfigCanBeMarshaled(t *testing.T) {
+	clientCfg := ClientConfig{}
+	conf := confmap.New()
+	err := conf.Marshal(clientCfg)
+	require.NoError(t, err)
+	_, err = yaml.Marshal(conf.ToStringMap())
+	require.NoError(t, err)
+}
+
+func TestServerConfigCanBeMarshaled(t *testing.T) {
+	cfg := ServerConfig{}
+	conf := confmap.New()
+	err := conf.Marshal(cfg)
+	require.NoError(t, err)
+	_, err = yaml.Marshal(conf.ToStringMap())
+	require.NoError(t, err)
 }
 
 type mockHost struct {

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -15,12 +15,14 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.100.0
 	go.opentelemetry.io/collector/config/configtls v0.100.0
 	go.opentelemetry.io/collector/config/internal v0.100.0
+	go.opentelemetry.io/collector/confmap v0.100.0
 	go.opentelemetry.io/collector/extension/auth v0.100.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.51.0
 	go.opentelemetry.io/otel v1.26.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/net v0.25.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -44,7 +46,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.100.0 // indirect
 	go.opentelemetry.io/collector/extension v0.100.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.7.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.7.0 // indirect
@@ -59,7 +60,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace go.opentelemetry.io/collector => ../../


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

While trying to marshal a `confmap.Conf` created using `Conf.Marshal(*otelcol.Config)`, I noticed that calling `yaml.Marshal` on the `confmap.Conf` throws an error because it tries to marshal the `CustomRoundTripper` field. I'm not sure how we enforce this, but I think we should ensure all our configs can be re-marshaled.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

I added a test that shows the issue. I would have preferred to require that configs can be unmarshaled into something more generic than YAML, but I think YAML is a good default.

I can issue follow-up PRs for other `config` packages if this one looks good. I don't know how we enforce this more broadly within our components, but I would like it for our unmarshaling and marshaling to be largely lossless operations after things like `Config.Unmarshal` and `Config.Validate` are called the first time. That is, we should be able to go YAML [user] -> otelcol.Config -> YAML [0] -> otelcol.Config -> YAML [1] and have YAML 0 and YAML 1 be identical.