### PR TITLE
[confmap] Start deprecation processor for env var expand syntax ($ENV)

### DIFF
--- a/.chloggen/confmap-expandconverter-featuregate.yaml
+++ b/.chloggen/confmap-expandconverter-featuregate.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: expandconverter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds `confmap.allowEnvVarExpansion` feature gate to control use of $ENV syntax.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10144]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Deprecates expandconverter
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -24,6 +24,13 @@ func main() {
 		Version:     "{{ .Distribution.Version }}",
 	}
 
+    var converterFactories []confmap.ConverterFactory
+    if otelcol.PreventEnvVarExpansionFeatureGate.IsEnabled() {
+        converterFactories = []confmap.ConverterFactory{
+            expandconverter.NewFactory(),
+        }
+    }
+
 	set := otelcol.CollectorSettings{
 		BuildInfo: info,
 		Factories: components,
@@ -35,9 +42,7 @@ func main() {
 					{{.Name}}.NewFactory(),
 					{{- end}}
 				},
-				ConverterFactories: []confmap.ConverterFactory{
-					expandconverter.NewFactory(),
-				},
+				ConverterFactories: converterFactories,
 			},
 		},
 		{{- end}}

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -25,7 +25,7 @@ func main() {
 	}
 
 	var converterFactories []confmap.ConverterFactory
-	if otelcol.AllowEnvVarExpansionFeatureGate.IsEnabled() {
+	if otelcol.PreventEnvVarExpansionFeatureGate.IsEnabled() {
 		converterFactories = []confmap.ConverterFactory{
 			expandconverter.NewFactory(),
 		}

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -24,6 +24,13 @@ func main() {
 		Version:     "0.100.0-dev",
 	}
 
+	var converterFactories []confmap.ConverterFactory
+	if otelcol.AllowEnvVarExpansionFeatureGate.IsEnabled() {
+		converterFactories = []confmap.ConverterFactory{
+			expandconverter.NewFactory(),
+		}
+	}
+
 	set := otelcol.CollectorSettings{
 		BuildInfo: info,
 		Factories: components,
@@ -36,9 +43,7 @@ func main() {
 					httpsprovider.NewFactory(),
 					yamlprovider.NewFactory(),
 				},
-				ConverterFactories: []confmap.ConverterFactory{
-					expandconverter.NewFactory(),
-				},
+				ConverterFactories: converterFactories,
 			},
 		},
 	}

--- a/confmap/converter/expandconverter/expand.go
+++ b/confmap/converter/expandconverter/expand.go
@@ -23,6 +23,10 @@ type converter struct {
 
 // NewFactory returns a factory for a  confmap.Converter,
 // which expands all environment variables for a given confmap.Conf.
+//
+// Deprecated: [v0.101.0] The expand converter is deprecated, the collector will no longer support this style environment
+// variable substitution by default. Use ${...} or ${env:...} instead.
+// See https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/env-vars.md for more details.
 func NewFactory() confmap.ConverterFactory {
 	return confmap.NewConverterFactory(newConverter)
 }

--- a/otelcol/command_test.go
+++ b/otelcol/command_test.go
@@ -73,7 +73,7 @@ func TestAddDefaultConfmapModules(t *testing.T) {
 			ResolverSettings: confmap.ResolverSettings{},
 		},
 	}
-	flgs := flags(featuregate.NewRegistry())
+	flgs := flags(featuregate.GlobalRegistry())
 	err := flgs.Parse([]string{"--config=otelcol-nop.yaml"})
 	require.NoError(t, err)
 

--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -17,10 +17,10 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 )
 
-// AllowEnvVarExpansionFeatureGate is the feature gate that controls whether the collector
+// PreventEnvVarExpansionFeatureGate is the feature gate that controls whether the collector
 // supports configuring the OpenTelemetry SDK via configuration
-var AllowEnvVarExpansionFeatureGate = featuregate.GlobalRegistry().MustRegister(
-	"confmap.allowEnvVarExpansion",
+var PreventEnvVarExpansionFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"confmap.preventEnvVarExpansion",
 	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("controls whether the collector supports expanding $ENV in configuration"),
 	featuregate.WithRegisterFromVersion("v0.101.0"),
@@ -143,7 +143,7 @@ func (cm *configProvider) GetConfmap(ctx context.Context) (*confmap.Conf, error)
 
 func newDefaultConfigProviderSettings(uris []string) ConfigProviderSettings {
 	var converterFactories []confmap.ConverterFactory
-	if AllowEnvVarExpansionFeatureGate.IsEnabled() {
+	if !PreventEnvVarExpansionFeatureGate.IsEnabled() {
 		converterFactories = []confmap.ConverterFactory{
 			expandconverter.NewFactory(),
 		}


### PR DESCRIPTION
#### Description
Starts the deprecation for support of env var expand syntax ($ENV) by adding a feature gate and a deprecation warning

#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/8215

#### Testing
Local testing