### PR TITLE
[chore] set permissions to read explicitly

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -13,6 +13,9 @@ env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
   GOPROXY: https://goproxy1.cncf.selfactuated.dev,direct
 
+permissions:
+  contents: read
+
 # Do not cancel this workflow on main. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,9 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This is as recommended by dependabot security warnings.
