### PR TITLE
[chore] follow codeql recommendation

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -67,7 +67,7 @@ fmt: $(GOIMPORTS)
 .PHONY: tidy
 tidy:
 	rm -fr go.sum
-	$(GOCMD) mod tidy -compat=1.21
+	$(GOCMD) mod tidy -compat=1.21.0
 
 .PHONY: lint
 lint: $(LINT)

--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -3,7 +3,7 @@
 
 module go.opentelemetry.io/collector/cmd/builder
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/hashicorp/go-version v1.6.0

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/cmd/mdatagen
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -2,7 +2,7 @@
 
 module go.opentelemetry.io/collector/cmd/otelcorecol
 
-go 1.21
+go 1.21.0
 
 require (
 	go.opentelemetry.io/collector/component v0.101.0

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -4,6 +4,8 @@ module go.opentelemetry.io/collector/cmd/otelcorecol
 
 go 1.21.0
 
+toolchain go1.21.10
+
 require (
 	go.opentelemetry.io/collector/component v0.101.0
 	go.opentelemetry.io/collector/confmap v0.101.0

--- a/component/go.mod
+++ b/component/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/prometheus/client_golang v1.19.1

--- a/config/configauth/go.mod
+++ b/config/configauth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configauth
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/config/configcompression/go.mod
+++ b/config/configcompression/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configcompression
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configgrpc
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/mostynb/go-grpc-compression v1.2.2

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confighttp
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/golang/snappy v0.0.4

--- a/config/confignet/go.mod
+++ b/config/confignet/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confignet
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/config/configopaque/go.mod
+++ b/config/configopaque/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configopaque
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/config/configretry/go.mod
+++ b/config/configretry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configretry
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/config/configtelemetry/go.mod
+++ b/config/configtelemetry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtelemetry
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/config/configtls/go.mod
+++ b/config/configtls/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtls
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0

--- a/config/internal/go.mod
+++ b/config/internal/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/internal
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/confmap/converter/expandconverter/go.mod
+++ b/confmap/converter/expandconverter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/converter/expandconverter
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1

--- a/confmap/provider/envprovider/go.mod
+++ b/confmap/provider/envprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/envprovider
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/confmap/provider/fileprovider/go.mod
+++ b/confmap/provider/fileprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/fileprovider
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/confmap/provider/httpprovider/go.mod
+++ b/confmap/provider/httpprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpprovider
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/confmap/provider/httpsprovider/go.mod
+++ b/confmap/provider/httpsprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpsprovider
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/confmap/provider/yamlprovider/go.mod
+++ b/confmap/provider/yamlprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/yamlprovider
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/forwardconnector
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/debugexporter
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -1,7 +1,7 @@
 // Deprecated: loggingexporter is deprecated in favour of the debugexporter. It will be removed in September 2024.
 module go.opentelemetry.io/collector/exporter/loggingexporter
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/nopexporter
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlpexporter
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlphttpexporter
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/extension/auth/go.mod
+++ b/extension/auth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/auth
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/extension/ballastextension/go.mod
+++ b/extension/ballastextension/go.mod
@@ -1,7 +1,7 @@
 // Deprecated: Use the GOMEMLIMIT environment variable instead.
 module go.opentelemetry.io/collector/extension/ballastextension
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/memorylimiterextension
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/zpagesextension
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/featuregate/go.mod
+++ b/featuregate/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/featuregate
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/hashicorp/go-version v1.6.0

--- a/filter/go.mod
+++ b/filter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/filter
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/shirou/gopsutil/v3 v3.24.4

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/e2e
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/tools
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/a8m/envsubst v1.4.2

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/otelcol
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/spf13/cobra v1.8.0

--- a/pdata/go.mod
+++ b/pdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/testdata
 
-go 1.21
+go 1.21.0
 
 require go.opentelemetry.io/collector/pdata v1.8.0
 

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/batchprocessor
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/prometheus/client_golang v1.19.1

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/memorylimiterprocessor
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/nopreceiver
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/otlpreceiver
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/semconv/go.mod
+++ b/semconv/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/semconv
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/hashicorp/go-version v1.6.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/service
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
CodeQL is currently reporting "Invalid Go toolchain version: As of Go 1.21, toolchain versions must use the 1.N.P syntax.". This PR attempts to fix this.
