### PR TITLE
[confmap] Remove deprecated ResolverSettings fields

### DIFF
--- a/.chloggen/remove-confmap-instances.yaml
+++ b/.chloggen/remove-confmap-instances.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `Providers` and `Converters` from `confmap.ResolverSettings`
+
+# One or more tracking issues or pull requests related to the change
+issues: [10173]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use `ProviderSettings` and `ConverterSettings` instead.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/confmap/resolver_test.go
+++ b/confmap/resolver_test.go
@@ -382,44 +382,6 @@ func TestResolverShutdownClosesWatch(t *testing.T) {
 	watcherWG.Wait()
 }
 
-func TestCantConfigureTwoProviderSettings(t *testing.T) {
-	_, err := NewResolver(ResolverSettings{
-		URIs:               []string{filepath.Join("testdata", "config.yaml")},
-		ProviderFactories:  []ProviderFactory{newFileProvider(t)},
-		Providers:          map[string]Provider{"mock": &mockProvider{}},
-		ConverterFactories: nil,
-	})
-	require.Error(t, err)
-}
-
-func TestCantConfigureTwoConverterSettings(t *testing.T) {
-	_, err := NewResolver(ResolverSettings{
-		URIs:               []string{filepath.Join("testdata", "config.yaml")},
-		ProviderFactories:  []ProviderFactory{newFileProvider(t)},
-		ConverterFactories: []ConverterFactory{NewConverterFactory(func(_ ConverterSettings) Converter { return &mockConverter{} })},
-		Converters:         []Converter{&mockConverter{err: errors.New("converter_err")}},
-	})
-	require.Error(t, err)
-}
-
-func TestTakesInstantiatedProviders(t *testing.T) {
-	_, err := NewResolver(ResolverSettings{
-		URIs:               []string{filepath.Join("testdata", "config.yaml")},
-		Providers:          map[string]Provider{"mock": &mockProvider{}},
-		ConverterFactories: nil,
-	})
-	require.NoError(t, err)
-}
-
-func TestTakesInstantiatedConverters(t *testing.T) {
-	_, err := NewResolver(ResolverSettings{
-		URIs:              []string{filepath.Join("testdata", "config.yaml")},
-		ProviderFactories: []ProviderFactory{newFileProvider(t)},
-		Converters:        []Converter{&mockConverter{err: errors.New("converter_err")}},
-	})
-	require.NoError(t, err)
-}
-
 func TestProvidesDefaultLogger(t *testing.T) {
 	factory, provider := newObservableFileProvider(t)
 	_, err := NewResolver(ResolverSettings{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

These fields were deprecated in v0.99.0 and aren't used in any upstream repositories.

These appear to still be used in downstream distributions. If we want to lengthen the deprecation period for these fields, I'll open a PR to instead set a timeline for their removal.