### PR TITLE
[confighttp] Add support for cookies

### DIFF
--- a/.chloggen/cookie_support.yaml
+++ b/.chloggen/cookie_support.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: confighttp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add support for cookies in HTTP clients with `cookies_enabled`.
+note: Add support for cookies in HTTP clients with `cookies::enabled`.
 
 # One or more tracking issues or pull requests related to the change
 issues: [10175]

--- a/.chloggen/cookie_support.yaml
+++ b/.chloggen/cookie_support.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for cookies in HTTP clients with `cookies_enabled`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10175]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The method `confighttp.ToClient` will return a client with a `cookiejar.Jar` which will reuse cookies from server responses in subsequent requests.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -36,9 +36,6 @@ README](../configtls/README.md).
 - [`http2_ping_timeout`](https://pkg.go.dev/golang.org/x/net/http2#Transport)
 - [`cookies`](https://pkg.go.dev/net/http#CookieJar)
   - [`enabled`] if enabled, the client will store cookies from server responses and reuse them in subsequent requests.
-  - [`insecure`] if true, the client accepts setting cookies for any domain. This is useful for testing but is insecure:
-    it means that the HTTP server for foo.co.uk can set a cookie for bar.co.uk.
-    If false, the client will allow setting cookies based on the list provided by https://publicsuffix.org/
 
 Example:
 

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -34,6 +34,7 @@ README](../configtls/README.md).
 - [`disable_keep_alives`](https://golang.org/pkg/net/http/#Transport)
 - [`http2_read_idle_timeout`](https://pkg.go.dev/golang.org/x/net/http2#Transport)
 - [`http2_ping_timeout`](https://pkg.go.dev/golang.org/x/net/http2#Transport)
+- [`cookies_enabled`](https://pkg.go.dev/net/http#CookieJar) if enabled, the client will store cookies from server responses and reuse them in subsequent requests.
 
 Example:
 

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -36,6 +36,9 @@ README](../configtls/README.md).
 - [`http2_ping_timeout`](https://pkg.go.dev/golang.org/x/net/http2#Transport)
 - [`cookies`](https://pkg.go.dev/net/http#CookieJar)
   - [`enabled`] if enabled, the client will store cookies from server responses and reuse them in subsequent requests.
+  - [`insecure`] if true, the client accepts setting cookies for any domain. This is useful for testing but is insecure:
+    it means that the HTTP server for foo.co.uk can set a cookie for bar.co.uk.
+    If false, the client will allow setting cookies based on the list provided by https://publicsuffix.org/
 
 Example:
 

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -34,7 +34,8 @@ README](../configtls/README.md).
 - [`disable_keep_alives`](https://golang.org/pkg/net/http/#Transport)
 - [`http2_read_idle_timeout`](https://pkg.go.dev/golang.org/x/net/http2#Transport)
 - [`http2_ping_timeout`](https://pkg.go.dev/golang.org/x/net/http2#Transport)
-- [`cookies_enabled`](https://pkg.go.dev/net/http#CookieJar) if enabled, the client will store cookies from server responses and reuse them in subsequent requests.
+- [`cookies`](https://pkg.go.dev/net/http#CookieJar)
+  - [`enabled`] if enabled, the client will store cookies from server responses and reuse them in subsequent requests.
 
 Example:
 
@@ -52,6 +53,8 @@ exporter:
       test1: "value1"
       "test 2": "value 2"
     compression: zstd
+    cookies:
+      enabled: true
 ```
 
 ## Server Configuration

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -104,10 +104,14 @@ type ClientConfig struct {
 	// HTTP2PingTimeout if there's no response to the ping within the configured value, the connection will be closed.
 	// If not set or set to 0, it defaults to 15s.
 	HTTP2PingTimeout time.Duration `mapstructure:"http2_ping_timeout"`
+	// Cookies configures the cookie management of the HTTP client.
+	Cookies *CookiesConfig `mapstructure:"cookies"`
+}
 
-	// CookiesEnabled enables reusing cookies between requests.
-	// This is useful to manage sticky session cookies.
-	CookiesEnabled bool `mapstructure:"cookies_enabled"`
+// CookiesConfig defines the configuration of the HTTP client regarding cookies served by the server.
+type CookiesConfig struct {
+	// Enabled if true, cookies from HTTP responses will be reused in further HTTP requests with the same server.
+	Enabled bool `mapstructure:"enabled"`
 }
 
 // NewDefaultClientConfig returns ClientConfig type object with
@@ -237,7 +241,7 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 	}
 
 	var jar http.CookieJar
-	if hcs.CookiesEnabled {
+	if hcs.Cookies != nil && hcs.Cookies.Enabled {
 		jar, err = cookiejar.New(nil)
 		if err != nil {
 			return nil, err

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -113,10 +113,6 @@ type ClientConfig struct {
 type CookiesConfig struct {
 	// Enabled if true, cookies from HTTP responses will be reused in further HTTP requests with the same server.
 	Enabled bool `mapstructure:"enabled"`
-	// Insecure if true, the client accepts setting cookies for any domain. This is useful for testing but is insecure:
-	// it means that the HTTP server for foo.co.uk can set a cookie for bar.co.uk.
-	// If false, the client will allow setting cookies based on the list provided by https://publicsuffix.org/
-	Insecure bool `mapstructure:"insecure"`
 }
 
 // NewDefaultClientConfig returns ClientConfig type object with
@@ -247,12 +243,7 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 
 	var jar http.CookieJar
 	if hcs.Cookies != nil && hcs.Cookies.Enabled {
-		opts := &cookiejar.Options{}
-		if !hcs.Cookies.Insecure {
-			opts.PublicSuffixList = publicsuffix.List
-		}
-
-		jar, err = cookiejar.New(opts)
+		jar, err = cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 		if err != nil {
 			return nil, err
 		}

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -83,6 +83,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				IdleConnTimeout:      &idleConnTimeout,
 				Compression:          "",
 				DisableKeepAlives:    true,
+				CookiesEnabled:       true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
 			},

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -83,7 +83,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				IdleConnTimeout:      &idleConnTimeout,
 				Compression:          "",
 				DisableKeepAlives:    true,
-				CookiesEnabled:       true,
+				Cookies:              &CookiesConfig{Enabled: true},
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
 			},

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -83,7 +83,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				IdleConnTimeout:      &idleConnTimeout,
 				Compression:          "",
 				DisableKeepAlives:    true,
-				Cookies:              &CookiesConfig{Enabled: true},
+				Cookies:              &CookiesConfig{Enabled: true, Insecure: true},
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
 			},

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -83,7 +83,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				IdleConnTimeout:      &idleConnTimeout,
 				Compression:          "",
 				DisableKeepAlives:    true,
-				Cookies:              &CookiesConfig{Enabled: true, Insecure: true},
+				Cookies:              &CookiesConfig{Enabled: true},
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
 			},


### PR DESCRIPTION
#### Description
Add support for cookies in HTTP clients with `cookies::enabled`.

#### Link to tracking issue
Fixes #10175

#### Testing
Unit test

#### Documentation
Added to README