### PR TITLE
[confmap] Read YAML struct tags

### DIFF
--- a/.chloggen/confmap-yaml-tag.yaml
+++ b/.chloggen/confmap-yaml-tag.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support marshaling using the `omitempty` and `inline` flags with the `yaml` tag
+
+# One or more tracking issues or pull requests related to the change
+issues: [10200]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This is only for compatibility with third-party configuration structs, first-party structs
+  should still use the `mapstructure` tag and its preferred flags.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/confmap/internal/mapstructure/encoder_test.go
+++ b/confmap/internal/mapstructure/encoder_test.go
@@ -15,13 +15,15 @@ import (
 )
 
 type TestComplexStruct struct {
-	Skipped   TestEmptyStruct             `mapstructure:",squash"`
-	Nested    TestSimpleStruct            `mapstructure:",squash"`
-	Slice     []TestSimpleStruct          `mapstructure:"slice,omitempty"`
-	Pointer   *TestSimpleStruct           `mapstructure:"ptr"`
-	Map       map[string]TestSimpleStruct `mapstructure:"map,omitempty"`
-	Remain    map[string]any              `mapstructure:",remain"`
-	Interface encoding.TextMarshaler
+	Skipped     TestEmptyStruct             `mapstructure:",squash"`
+	Nested      TestSimpleStruct            `mapstructure:",squash"`
+	Slice       []TestSimpleStruct          `mapstructure:"slice,omitempty"`
+	Pointer     *TestSimpleStruct           `mapstructure:"ptr"`
+	Map         map[string]TestSimpleStruct `mapstructure:"map,omitempty"`
+	Remain      map[string]any              `mapstructure:",remain"`
+	YAMLInline  map[string]any              `yaml:",inline"`
+	YAMLOmitted []TestSimpleStruct          `yaml:"omitted,omitempty"`
+	Interface   encoding.TextMarshaler
 }
 
 type TestSimpleStruct struct {
@@ -116,6 +118,10 @@ func TestEncode(t *testing.T) {
 					"remain2": "value",
 				},
 				Interface: TestID("value"),
+				YAMLInline: map[string]any{
+					"inline1": 23,
+					"inline2": "value",
+				},
 			},
 			want: map[string]any{
 				"value": "nested",
@@ -127,6 +133,8 @@ func TestEncode(t *testing.T) {
 				"interface": "value_",
 				"remain1":   23,
 				"remain2":   "value",
+				"inline1":   23,
+				"inline2":   "value",
 			},
 		},
 	}
@@ -160,10 +168,10 @@ func TestGetTagInfo(t *testing.T) {
 		},
 		"WithoutMapStructureTag": {
 			field: reflect.StructField{
-				Tag:  `yaml:"hello,inline"`,
-				Name: "YAML",
+				Tag:  `unsupported:"hello,inline"`,
+				Name: "ALLCAPS",
 			},
-			wantName: "yaml",
+			wantName: "allcaps",
 		},
 		"WithRename": {
 			field: reflect.StructField{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Third party configuration structs, such as those used in the Prometheus receiver, [use YAML struct tags](https://github.com/prometheus/common/blob/main/config/http_config.go#L313) that are necessary for `confmap` to understand if we want to be able to marshal YAML. In particular, in `(*Conf).ToStringMap`, we convert structs to a Map object, where ignoring flags like `omitempty` or `squash` causes the map to have a different structure than it would if we called `yaml.Marshal` on the same struct.

This PR allows `ToStringMap` to read `omitempty` and `inline` when struct fields have been annotated with the `yaml` tag. These are 2/3 of the flags the `yaml` tag supports: https://pkg.go.dev/gopkg.in/yaml.v3#Marshal.

Caveats:
* Things like `yaml:",squash"` and `mapstructure:",inline"` will be possible now. I figure that allowing any valid flag regardless of the tag that it applies to is okay (we also support `remain` as an alias) and won't incur any issues, but if we are concerned about conflicts or stability guarantees, I can enforce a stricter schema for which tags support which flags.
* I'm leaving out support for the `json` tag for now since we don't support JSON the way we support YAML, but I can add support for it here if we'd like.

Required for https://github.com/open-telemetry/opentelemetry-collector/pull/10139.
