### PR TITLE
[cmd/builder] Generate replace directives when path is specified for provider

### DIFF
--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -34,6 +34,9 @@ require (
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 )
 
+{{- range .Providers}}
+{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{- end}}
 {{- range .Connectors}}
 {{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes a bug where replace directives were not being generated when the path was specified for a provider in the builder configuration.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Built ocb with the changes and ran it on the following configuration:

```
dist:
  name: otelcol
  output_path: ./build

receivers:
  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.99.0

exporters:
  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.99.0

providers:
  - gomod: foo.bar/dynamodbprovider v0.0.0
    path: ./confmap/dynamodbprovider
```

The generated go.mod contained the expected replace statement.