### PR TITLE
Add support for TimeEncoding for Zap logger

### DIFF
--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -92,6 +92,19 @@ type LogsConfig struct {
 	//
 	// By default, there is no initial field.
 	InitialFields map[string]any `mapstructure:"initial_fields"`
+
+	// TimeEncoding controls the zap logger's time encoding
+	// Permitted values are:
+	//  - "Epoch"
+	//  - "EpochMillis"
+	//  - "EpochNanos"
+	//  - "ISO8601"
+	//  - "RFC3339"
+	//  - "RFC3339Nano"
+	// Leaving the value blank results in the default time encoding, which
+	// depends on the message encoding (for JSON, it will be EpochNanos,
+	// and for console, it will be ISO8601
+	TimeEncoding string `mapstructure:"time_encoding"`
 }
 
 // LogsSamplingConfig sets a sampling strategy for the logger. Sampling caps the

--- a/service/telemetry/logger.go
+++ b/service/telemetry/logger.go
@@ -27,6 +27,23 @@ func newLogger(cfg LogsConfig, options []zap.Option) (*zap.Logger, error) {
 		zapCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	}
 
+	switch cfg.TimeEncoding {
+	case "Epoch":
+		zapCfg.EncoderConfig.EncodeTime = zapcore.EpochTimeEncoder
+	case "EpochMillis":
+		zapCfg.EncoderConfig.EncodeTime = zapcore.EpochMillisTimeEncoder
+	case "EpochNanos":
+		zapCfg.EncoderConfig.EncodeTime = zapcore.EpochNanosTimeEncoder
+	case "ISO8601":
+		zapCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	case "RFC3339":
+		zapCfg.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+	case "RFC3339Nano":
+		zapCfg.EncoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+	case "":
+		// no-op
+	}
+
 	logger, err := zapCfg.Build(options...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### Description
- Add `TimeEncoding` field under `LogsConfig` to control Zap logger time encoding explicitly
- Update `newLogger` to read and interpret the selected option

#### Link to tracking issue
Fixes #10204

#### Testing

None yet (wasn't able to find existing tests for `newLogger`)

#### Documentation

None yet (unsure where the docs for this live)
