### PR TITLE
[mdatagen] Add basic telemetry test

### DIFF
--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -19,15 +19,16 @@ import (
 
 func TestRunContents(t *testing.T) {
 	tests := []struct {
-		yml                  string
-		wantMetricsGenerated bool
-		wantConfigGenerated  bool
-		wantStatusGenerated  bool
-		wantGoleakIgnore     bool
-		wantGoleakSkip       bool
-		wantGoleakSetup      bool
-		wantGoleakTeardown   bool
-		wantErr              bool
+		yml                    string
+		wantMetricsGenerated   bool
+		wantConfigGenerated    bool
+		wantTelemetryGenerated bool
+		wantStatusGenerated    bool
+		wantGoleakIgnore       bool
+		wantGoleakSkip         bool
+		wantGoleakSetup        bool
+		wantGoleakTeardown     bool
+		wantErr                bool
 	}{
 		{
 			yml:     "invalid.yaml",
@@ -88,6 +89,15 @@ func TestRunContents(t *testing.T) {
 			wantStatusGenerated: true,
 			wantGoleakTeardown:  true,
 		},
+		{
+			yml:                    "with_telemetry.yaml",
+			wantStatusGenerated:    true,
+			wantTelemetryGenerated: true,
+		},
+		{
+			yml:     "invalid_telemetry_missing_value_type_for_histogram.yaml",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.yml, func(t *testing.T) {
@@ -117,7 +127,6 @@ foo
 			} else {
 				require.NoFileExists(t, filepath.Join(tmpdir, "internal/metadata/generated_metrics.go"))
 				require.NoFileExists(t, filepath.Join(tmpdir, "internal/metadata/generated_metrics_test.go"))
-				require.NoFileExists(t, filepath.Join(tmpdir, "documentation.md"))
 			}
 
 			if tt.wantConfigGenerated {
@@ -126,6 +135,19 @@ foo
 			} else {
 				require.NoFileExists(t, filepath.Join(tmpdir, "internal/metadata/generated_config.go"))
 				require.NoFileExists(t, filepath.Join(tmpdir, "internal/metadata/generated_config_test.go"))
+			}
+
+			if tt.wantTelemetryGenerated {
+				require.FileExists(t, filepath.Join(tmpdir, "internal/metadata/generated_telemetry.go"))
+				require.FileExists(t, filepath.Join(tmpdir, "internal/metadata/generated_telemetry_test.go"))
+				require.FileExists(t, filepath.Join(tmpdir, "documentation.md"))
+			} else {
+				require.NoFileExists(t, filepath.Join(tmpdir, "internal/metadata/generated_telemetry.go"))
+				require.NoFileExists(t, filepath.Join(tmpdir, "internal/metadata/generated_telemetry_test.go"))
+			}
+
+			if !tt.wantMetricsGenerated && !tt.wantTelemetryGenerated {
+				require.NoFileExists(t, filepath.Join(tmpdir, "documentation.md"))
 			}
 
 			var contents []byte

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -152,7 +152,7 @@ telemetry:
     unit:
     # Required: metric type with its settings.
     <sum|gauge|histogram>:
-      # Required for sum and gauge metrics: type of number data point values.
+      # Required: type of number data point values.
       value_type: <int|double>
       # Required for sum metric: whether the metric is monotonic (no negative delta values).
       monotonic: bool

--- a/cmd/mdatagen/testdata/invalid_telemetry_missing_value_type_for_histogram.yaml
+++ b/cmd/mdatagen/testdata/invalid_telemetry_missing_value_type_for_histogram.yaml
@@ -1,0 +1,13 @@
+type: metric
+
+status:
+  class: receiver
+  stability:
+    beta: [traces, logs, metrics]
+telemetry:
+  metrics:
+    sampling_decision_latency:
+      description: Latency (in microseconds) of a given sampling policy
+      unit: µs
+      enabled: true
+      histogram:

--- a/cmd/mdatagen/testdata/with_telemetry.yaml
+++ b/cmd/mdatagen/testdata/with_telemetry.yaml
@@ -1,0 +1,14 @@
+type: metric
+
+status:
+  class: receiver
+  stability:
+    beta: [traces, logs, metrics]
+telemetry:
+  metrics:
+    sampling_decision_latency:
+      description: Latency (in microseconds) of a given sampling policy
+      unit: µs
+      enabled: true
+      histogram:
+        value_type: int


### PR DESCRIPTION
This PR adds basic tests for the telemetry generation, and fixes the documentation about value type being required for histograms.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
