### PR TITLE
[exporterhelper] Adding shutdown & startup debug logs for retry, queue, and batch sender

### DIFF
--- a/.chloggen/exporterhelper-sender-start-shutdown-logging.yaml
+++ b/.chloggen/exporterhelper-sender-start-shutdown-logging.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: adding debug logs to retry, queue, and batch sender in exporterhelper
+
+# One or more tracking issues or pull requests related to the change
+issues: [10201]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/batch_sender.go
+++ b/exporter/exporterhelper/batch_sender.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
-	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
 // batchSender is a component that places requests into batches before passing them to the downstream senders.
@@ -39,8 +38,7 @@ type batchSender struct {
 	mu          sync.Mutex
 	activeBatch *batch
 
-	fullName string
-	logger   *zap.Logger
+	logger *zap.Logger
 
 	shutdownCh chan struct{}
 	stopped    *atomic.Bool
@@ -50,7 +48,6 @@ type batchSender struct {
 func newBatchSender(cfg exporterbatcher.Config, set exporter.CreateSettings,
 	mf exporterbatcher.BatchMergeFunc[Request], msf exporterbatcher.BatchMergeSplitFunc[Request]) *batchSender {
 	bs := &batchSender{
-		fullName:       set.ID.String(),
 		activeBatch:    newEmptyBatch(),
 		cfg:            cfg,
 		logger:         set.Logger,
@@ -94,7 +91,7 @@ func (bs *batchSender) Start(_ context.Context, _ component.Host) error {
 		}
 	}()
 
-	bs.logger.Debug("Started Batch Sender", zap.String(obsmetrics.ExporterKey, bs.fullName))
+	bs.logger.Debug("Started Batch Sender")
 	return nil
 }
 
@@ -217,7 +214,7 @@ func (bs *batchSender) updateActiveBatch(ctx context.Context, req Request) {
 }
 
 func (bs *batchSender) Shutdown(context.Context) error {
-	bs.logger.Debug("Shutting down Batch Sender", zap.String(obsmetrics.ExporterKey, bs.fullName))
+	bs.logger.Debug("Shutting down Batch Sender")
 
 	bs.stopped.Store(true)
 	close(bs.shutdownCh)
@@ -226,6 +223,6 @@ func (bs *batchSender) Shutdown(context.Context) error {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	bs.logger.Debug("Batch Sender has been shutdown", zap.String(obsmetrics.ExporterKey, bs.fullName))
+	bs.logger.Debug("Batch Sender has been shutdown")
 	return nil
 }

--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -109,7 +109,7 @@ func newQueueSender(q exporterqueue.Queue[Request], set exporter.CreateSettings,
 
 // Start is invoked during service startup.
 func (qs *queueSender) Start(ctx context.Context, host component.Host) error {
-	qs.logger.Debug("Starting Queue Sender", zap.String(obsmetrics.ExporterKey, qs.fullName))
+	qs.logger.Debug("Starting Queue Sender")
 
 	if err := qs.consumers.Start(ctx, host); err != nil {
 		return err
@@ -139,19 +139,19 @@ func (qs *queueSender) Start(ctx context.Context, host component.Host) error {
 			return nil
 		}))
 
-	qs.logger.Debug("Started Queue Sender", zap.String(obsmetrics.ExporterKey, qs.fullName), zap.Error(err))
 	errs = multierr.Append(errs, err)
+	qs.logger.Debug("Started Queue Sender", zap.Error(errs))
 	return errs
 }
 
 // Shutdown is invoked during service shutdown.
 func (qs *queueSender) Shutdown(ctx context.Context) error {
-	qs.logger.Debug("Shutting Down Queue Sender", zap.String(obsmetrics.ExporterKey, qs.fullName))
+	qs.logger.Debug("Shutting Down Queue Sender")
 
 	// Stop the queue and consumers, this will drain the queue and will call the retry (which is stopped) that will only
 	// try once every request.
 	err := qs.consumers.Shutdown(ctx)
-	qs.logger.Debug("Queue Sender has shut down", zap.String(obsmetrics.ExporterKey, qs.fullName), zap.Error(err))
+	qs.logger.Debug("Queue Sender has shut down", zap.Error(err))
 	return err
 }
 

--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -62,6 +62,7 @@ func newRetrySender(config configretry.BackOffConfig, set exporter.CreateSetting
 
 func (rs *retrySender) Shutdown(context.Context) error {
 	close(rs.stopCh)
+	rs.logger.Debug("Retry Sender has been shutdown", zap.String(obsmetrics.ExporterKey, rs.traceAttribute.Value.AsString()))
 	return nil
 }
 

--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -62,7 +62,7 @@ func newRetrySender(config configretry.BackOffConfig, set exporter.CreateSetting
 
 func (rs *retrySender) Shutdown(context.Context) error {
 	close(rs.stopCh)
-	rs.logger.Debug("Retry Sender has been shutdown", zap.String(obsmetrics.ExporterKey, rs.traceAttribute.Value.AsString()))
+	rs.logger.Debug("Retry Sender has been shutdown")
 	return nil
 }
 


### PR DESCRIPTION
#### Description

Adding debug logs to starting and shutdown of batch, retry, and queue sender in exporterhelper to understand which component is stuck shutting down or starting up. This is added in order to improve debugging when one of these components are stuck shutting down or starting up.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10201

<!--Describe what testing was performed and which tests were added.-->
#### Testing

N/A

<!--Describe the documentation added.-->
#### Documentation

N/A


