### PR TITLE
[chore] fix schema for telemetry/metrics/<metric-name>

### DIFF
--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -130,31 +130,32 @@ tests:
 # Optional: map of metric names with the key being the metric name and value
 # being described below.
 telemetry:
-  <metric.name>:
-    # Required: whether the metric is collected by default.
-    enabled: bool
-    # Required: metric description.
-    description:
-    # Optional: extended documentation of the metric.
-    extended_documentation:
-    # Optional: warnings that will be shown to user under specified conditions.
-    warnings:
-      # A warning that will be displayed if the metric is enabled in user config.
-      # Should be used for deprecated default metrics that will be removed soon.
-      if_enabled:
-      # A warning that will be displayed if `enabled` field is not set explicitly in user config.
-      # Should be used for metrics that will be turned from default to optional or vice versa.
-      if_enabled_not_set:
-      # A warning that will be displayed if the metrics is configured by user in any way.
-      # Should be used for deprecated optional metrics that will be removed soon.
-      if_configured:
-    # Required: metric unit as defined by https://ucum.org/ucum.html.
-    unit:
-    # Required: metric type with its settings.
-    <sum|gauge|histogram>:
-      # Required: type of number data point values.
-      value_type: <int|double>
-      # Required for sum metric: whether the metric is monotonic (no negative delta values).
-      monotonic: bool
-    # Optional: array of attributes that were defined in the attributes section that are emitted by this metric.
-    attributes: [string]
+  metrics:
+    <metric.name>:
+      # Required: whether the metric is collected by default.
+      enabled: bool
+      # Required: metric description.
+      description:
+      # Optional: extended documentation of the metric.
+      extended_documentation:
+      # Optional: warnings that will be shown to user under specified conditions.
+      warnings:
+        # A warning that will be displayed if the metric is enabled in user config.
+        # Should be used for deprecated default metrics that will be removed soon.
+        if_enabled:
+        # A warning that will be displayed if `enabled` field is not set explicitly in user config.
+        # Should be used for metrics that will be turned from default to optional or vice versa.
+        if_enabled_not_set:
+        # A warning that will be displayed if the metrics is configured by user in any way.
+        # Should be used for deprecated optional metrics that will be removed soon.
+        if_configured:
+      # Required: metric unit as defined by https://ucum.org/ucum.html.
+      unit:
+      # Required: metric type with its settings.
+      <sum|gauge|histogram>:
+        # Required: type of number data point values.
+        value_type: <int|double>
+        # Required for sum metric: whether the metric is monotonic (no negative delta values).
+        monotonic: bool
+      # Optional: array of attributes that were defined in the attributes section that are emitted by this metric.
+      attributes: [string]


### PR DESCRIPTION
Apparently there's an error on the schema for the telemetry node: looking at a working example, I see this:

```
telemetry:
  metrics:
    processor_tail_sampling_sampling_decision_latency:
      description: Latency (in microseconds) of a given sampling policy
      unit: µs
      enabled: true
      histogram:
        value_type: int
```

However, the current schema seems to indicate that the `metrics` node shouldn't be there. This PR brings the schema to be in-line with the code.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
