### PR TITLE
[chore]fix semconv script

### DIFF
--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -61,6 +61,7 @@ jobs:
         with:
           repository: open-telemetry/semantic-conventions
           path: tmp-semantic-conventions
+          fetch-tags: true
 
       - name: Update version
         env:

--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -61,7 +61,7 @@ jobs:
         with:
           repository: open-telemetry/semantic-conventions
           path: tmp-semantic-conventions
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Update version
         env:

--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -21,7 +21,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # version in this repo are prefixed with v
           latest_version=v$(gh release view \
                                --repo open-telemetry/semantic-conventions \
                                --json tagName \

--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -27,8 +27,8 @@ jobs:
                                --jq .tagName \
                              | sed 's/^v//')
 
-          rc=$(find semconv -name $latest_version | grep .)
-          if $rc == 0; then
+          found=$(find semconv -name $latest_version)
+          if [[ $found =~ $latest_version ]]; then
             already_added=true
           fi
 

--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout semantic-convention
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
-          repository: open-telemetry/semantic-convention
+          repository: open-telemetry/semantic-conventions
           path: tmp-semantic-conventions
 
       - name: Update version


### PR DESCRIPTION
The automation script that runs on a cron to auto-generate PRs for new semconv updates has been failing since it was created. This PR fixes a couple of issues w/ the workflow that were preventing it from working.