### PR TITLE
[chore] remove TODO from confmap code

### DIFF
--- a/confmap/provider.go
+++ b/confmap/provider.go
@@ -89,7 +89,6 @@ type Provider interface {
 type WatcherFunc func(*ChangeEvent)
 
 // ChangeEvent describes the particular change event that happened with the config.
-// TODO: see if this can be eliminated.
 type ChangeEvent struct {
 	// Error is nil if the config is changed and needs to be re-fetched.
 	// Any non-nil error indicates that there was a problem with watching the config changes.


### PR DESCRIPTION
Remove a TODO comment on confmap/provider.go related to ChangeEvent. This struct is used extensively in providers that rely on changes such as:
https://github.com/signalfx/splunk-otel-collector/blob/main/internal/configsource/etcd2configsource/source.go#L84