### PR TITLE
[otelcol] Removed deprecated `ConfigProvider` field from settings

### DIFF
--- a/.chloggen/otelcol-remove-deprecations.yaml
+++ b/.chloggen/otelcol-remove-deprecations.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otelcol
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `ConfigProvider` field from `CollectorSettings`
+
+# One or more tracking issues or pull requests related to the change
+issues: [10281]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -68,11 +68,6 @@ type CollectorSettings struct {
 	// and manually handle the signals to shutdown the collector.
 	DisableGracefulShutdown bool
 
-	// Deprecated: [v0.95.0] Use ConfigProviderSettings instead.
-	// ConfigProvider provides the service configuration.
-	// If the provider watches for configuration change, collector may reload the new configuration upon changes.
-	ConfigProvider ConfigProvider
-
 	// ConfigProviderSettings allows configuring the way the Collector retrieves its configuration
 	// The Collector will reload based on configuration changes from the ConfigProvider if any
 	// confmap.Providers watch for configuration changes.
@@ -118,9 +113,6 @@ type Collector struct {
 
 // NewCollector creates and returns a new instance of Collector.
 func NewCollector(set CollectorSettings) (*Collector, error) {
-	var err error
-	configProvider := set.ConfigProvider
-
 	bc := newBufferedCore(zapcore.DebugLevel)
 	cc := &collectorCore{core: bc}
 	options := append([]zap.Option{zap.WithCaller(true)}, set.LoggingOptions...)
@@ -128,11 +120,9 @@ func NewCollector(set CollectorSettings) (*Collector, error) {
 	set.ConfigProviderSettings.ResolverSettings.ProviderSettings = confmap.ProviderSettings{Logger: logger}
 	set.ConfigProviderSettings.ResolverSettings.ConverterSettings = confmap.ConverterSettings{Logger: logger}
 
-	if configProvider == nil {
-		configProvider, err = NewConfigProvider(set.ConfigProviderSettings)
-		if err != nil {
-			return nil, err
-		}
+	configProvider, err := NewConfigProvider(set.ConfigProviderSettings)
+	if err != nil {
+		return nil, err
 	}
 
 	state := &atomic.Int32{}

--- a/otelcol/command.go
+++ b/otelcol/command.go
@@ -43,22 +43,20 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 
 // Puts command line flags from flags into the CollectorSettings, to be used during config resolution.
 func updateSettingsUsingFlags(set *CollectorSettings, flags *flag.FlagSet) error {
-	if set.ConfigProvider == nil {
-		resolverSet := &set.ConfigProviderSettings.ResolverSettings
-		configFlags := getConfigFlag(flags)
+	resolverSet := &set.ConfigProviderSettings.ResolverSettings
+	configFlags := getConfigFlag(flags)
 
-		if len(configFlags) > 0 {
-			resolverSet.URIs = configFlags
-		}
-		if len(resolverSet.URIs) == 0 {
-			return errors.New("at least one config flag must be provided")
-		}
-		// Provide a default set of providers and converters if none have been specified.
-		// TODO: Remove this after CollectorSettings.ConfigProvider is removed and instead
-		// do it in the builder.
-		if len(resolverSet.ProviderFactories) == 0 && len(resolverSet.ConverterFactories) == 0 {
-			set.ConfigProviderSettings = newDefaultConfigProviderSettings(resolverSet.URIs)
-		}
+	if len(configFlags) > 0 {
+		resolverSet.URIs = configFlags
+	}
+	if len(resolverSet.URIs) == 0 {
+		return errors.New("at least one config flag must be provided")
+	}
+	// Provide a default set of providers and converters if none have been specified.
+	// TODO: Remove this after CollectorSettings.ConfigProvider is removed and instead
+	// do it in the builder.
+	if len(resolverSet.ProviderFactories) == 0 && len(resolverSet.ConverterFactories) == 0 {
+		set.ConfigProviderSettings = newDefaultConfigProviderSettings(resolverSet.URIs)
 	}
 	return nil
 }

--- a/otelcol/command_components_test.go
+++ b/otelcol/command_components_test.go
@@ -17,13 +17,10 @@ import (
 )
 
 func TestNewBuildSubCommand(t *testing.T) {
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
-	require.NoError(t, err)
-
 	set := CollectorSettings{
-		BuildInfo:      component.NewDefaultBuildInfo(),
-		Factories:      nopFactories,
-		ConfigProvider: cfgProvider,
+		BuildInfo:              component.NewDefaultBuildInfo(),
+		Factories:              nopFactories,
+		ConfigProviderSettings: newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}),
 	}
 	cmd := NewCommand(set)
 	cmd.SetArgs([]string{"components"})


### PR DESCRIPTION
#### Description
Removes the deprecated `ConfigProvider` field from `CollectorSettings`.