### PR TITLE
[confighttp] Apply MaxRequestBodySize to the result of a decompressed body

### DIFF
--- a/.chloggen/jpkroehling_set-maxrequestbodysize-to-compressed.yaml
+++ b/.chloggen/jpkroehling_set-maxrequestbodysize-to-compressed.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Apply MaxRequestBodySize to the result of a decompressed body
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: When using compressed payloads, the Collector would verify only the size of the compressed payload. This change applies the same restriction to the decompressed content.

--- a/.chloggen/jpkroehling_set-maxrequestbodysize-to-compressed.yaml
+++ b/.chloggen/jpkroehling_set-maxrequestbodysize-to-compressed.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: 'bug_fix'
+change_type: 'breaking'
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: confighttp
@@ -10,9 +10,13 @@ component: confighttp
 note: Apply MaxRequestBodySize to the result of a decompressed body
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [10289]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: When using compressed payloads, the Collector would verify only the size of the compressed payload. This change applies the same restriction to the decompressed content.
+subtext: |
+  When using compressed payloads, the Collector would verify only the size of the compressed payload. 
+  This change applies the same restriction to the decompressed content. As a security measure, a limit of 20 MiB was added, which makes this a breaking change. 
+  For most clients, this shouldn't be a problem, but if you often have payloads that decompress to more than 20 MiB, you might want to either configure your
+  client to send smaller batches (recommended), or increase the limit using the MaxRequestBodySize option.

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -134,7 +134,7 @@ func TestHTTPCustomDecompression(t *testing.T) {
 			return io.NopCloser(strings.NewReader("decompressed body")), nil
 		},
 	}
-	srv := httptest.NewServer(httpContentDecompressor(handler, defaultErrorHandler, decoders))
+	srv := httptest.NewServer(httpContentDecompressor(handler, defaultMaxRequestBodySize, defaultErrorHandler, decoders))
 
 	t.Cleanup(srv.Close)
 
@@ -253,7 +253,7 @@ func TestHTTPContentDecompressionHandler(t *testing.T) {
 				require.NoError(t, err, "failed to read request body: %v", err)
 				assert.EqualValues(t, testBody, string(body))
 				w.WriteHeader(http.StatusOK)
-			}), defaultErrorHandler, noDecoders))
+			}), defaultMaxRequestBodySize, defaultErrorHandler, noDecoders))
 			t.Cleanup(srv.Close)
 
 			req, err := http.NewRequest(http.MethodGet, srv.URL, tt.reqBody)

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -270,7 +270,7 @@ type ServerConfig struct {
 	// Auth for this receiver
 	Auth *configauth.Authentication `mapstructure:"auth"`
 
-	// MaxRequestBodySize sets the maximum request body size in bytes
+	// MaxRequestBodySize sets the maximum request body size in bytes. Default: 20MiB.
 	MaxRequestBodySize int64 `mapstructure:"max_request_body_size"`
 
 	// IncludeMetadata propagates the client metadata from the incoming requests to the downstream consumers

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -341,7 +341,7 @@ func (hss *ServerConfig) ToServer(_ context.Context, host component.Host, settin
 		o(serverOpts)
 	}
 
-	if hss.MaxRequestBodySize == 0 {
+	if hss.MaxRequestBodySize <= 0 {
 		hss.MaxRequestBodySize = defaultMaxRequestBodySize
 	}
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -30,6 +30,7 @@ import (
 )
 
 const headerContentEncoding = "Content-Encoding"
+const defaultMaxRequestBodySize = 20 * 1024 * 1024 // 20MiB
 
 // ClientConfig defines settings for creating an HTTP client.
 type ClientConfig struct {
@@ -340,7 +341,11 @@ func (hss *ServerConfig) ToServer(_ context.Context, host component.Host, settin
 		o(serverOpts)
 	}
 
-	handler = httpContentDecompressor(handler, serverOpts.errHandler, serverOpts.decoders)
+	if hss.MaxRequestBodySize == 0 {
+		hss.MaxRequestBodySize = defaultMaxRequestBodySize
+	}
+
+	handler = httpContentDecompressor(handler, hss.MaxRequestBodySize, serverOpts.errHandler, serverOpts.decoders)
 
 	if hss.MaxRequestBodySize > 0 {
 		handler = maxRequestBodySizeInterceptor(handler, hss.MaxRequestBodySize)

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -4,6 +4,7 @@
 package confighttp
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1301,7 +1302,7 @@ func TestServerWithDecoder(t *testing.T) {
 	// test
 	response := &httptest.ResponseRecorder{}
 
-	req, err := http.NewRequest(http.MethodGet, srv.Addr, nil)
+	req, err := http.NewRequest(http.MethodGet, srv.Addr, bytes.NewBuffer([]byte("something")))
 	require.NoError(t, err, "Error creating request: %v", err)
 	req.Header.Set("Content-Encoding", "something-else")
 


### PR DESCRIPTION
This change applies a restriction on the size of the decompressed payload. Before this change, this is the result of the test added in this PR:

```
--- FAIL: TestServerWithDecompression (0.03s)
    /home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/confighttp_test.go:1327: 
        	Error Trace:	/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/confighttp_test.go:1327
        	            				/usr/lib/golang/src/net/http/server.go:2166
        	            				/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/compression.go:163
        	            				/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/confighttp.go:455
        	            				/usr/lib/golang/src/net/http/server.go:2166
        	            				/home/jpkroehling/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.52.0/handler.go:212
        	            				/home/jpkroehling/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.52.0/handler.go:73
        	            				/usr/lib/golang/src/net/http/server.go:2166
        	            				/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/clientinfohandler.go:26
        	            				/usr/lib/golang/src/net/http/server.go:3137
        	            				/usr/lib/golang/src/net/http/server.go:2039
        	            				/usr/lib/golang/src/runtime/asm_amd64.s:1695
        	Error:      	An error is expected but got nil.
        	Test:       	TestServerWithDecompression
    /home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/confighttp_test.go:1328: 
        	Error Trace:	/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/confighttp_test.go:1328
        	            				/usr/lib/golang/src/net/http/server.go:2166
        	            				/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/compression.go:163
        	            				/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/confighttp.go:455
        	            				/usr/lib/golang/src/net/http/server.go:2166
        	            				/home/jpkroehling/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.52.0/handler.go:212
        	            				/home/jpkroehling/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.52.0/handler.go:73
        	            				/usr/lib/golang/src/net/http/server.go:2166
        	            				/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/clientinfohandler.go:26
        	            				/usr/lib/golang/src/net/http/server.go:3137
        	            				/usr/lib/golang/src/net/http/server.go:2039
        	            				/usr/lib/golang/src/runtime/asm_amd64.s:1695
        	Error:      	
        	Test:       	TestServerWithDecompression
    /home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/confighttp_test.go:1357: 
        	Error Trace:	/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/confighttp/confighttp_test.go:1357
        	Error:      	Not equal: 
        	            	expected: 200
        	            	actual  : 400
        	Test:       	TestServerWithDecompression
FAIL
FAIL	go.opentelemetry.io/collector/config/confighttp	0.036s
FAIL
```

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
