### PR TITLE
[confighttp] Deprecate `CustomRoundTripper`

### DIFF
--- a/.chloggen/confighttp-customroundtripper.yaml
+++ b/.chloggen/confighttp-customroundtripper.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `ClientConfig.CustomRoundTripper`
+
+# One or more tracking issues or pull requests related to the change
+issues: [8627]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Set the `Transport` field on the `*http.Client` object returned from `(ClientConfig).ToClient` instead.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -224,6 +224,13 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 		clientTransport = otelhttp.NewTransport(clientTransport, otelOpts...)
 	}
 
+	if hcs.CustomRoundTripper != nil {
+		clientTransport, err = hcs.CustomRoundTripper(clientTransport)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &http.Client{
 		Transport: clientTransport,
 		Timeout:   hcs.Timeout,

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -58,7 +58,10 @@ type ClientConfig struct {
 	Headers map[string]configopaque.String `mapstructure:"headers"`
 
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
-	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
+	//
+	// Deprecated: [v0.103.0] Set (*http.Client).Transport on the *http.Client returned from ToClient
+	// to configure this.
+	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error) `mapstructure:"-"`
 
 	// Auth configuration for outgoing HTTP calls.
 	Auth *configauth.Authentication `mapstructure:"auth"`
@@ -219,13 +222,6 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 	// wrapping http transport with otelhttp transport to enable otel instrumentation
 	if settings.TracerProvider != nil && settings.MeterProvider != nil {
 		clientTransport = otelhttp.NewTransport(clientTransport, otelOpts...)
-	}
-
-	if hcs.CustomRoundTripper != nil {
-		clientTransport, err = hcs.CustomRoundTripper(clientTransport)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return &http.Client{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Deprecates the `CustomRoundTripper` field on `confighttp.ClientConfig`, which is unused outside tests in Contrib and causes errors because it cannot be unmarshaled or marshaled. Additionally, having a non-configurable field on a Config struct seems non-ideal.

Soft depends on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33371 so we're not using deprecated APIs.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #8627

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Adapted tests to how the new way of doing this will look. It's slightly less ergonomic (you can't load up all the settings then just run `ToClient`), but we have no examples of this being used by any components, so I'm reluctant to add it to the API.


