### PR TITLE
[exporterhelper] Fix shutdown hang on unstarted exporter

### DIFF
--- a/.chloggen/fix_batch_sender_shutdown.yaml
+++ b/.chloggen/fix_batch_sender_shutdown.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a bug where an unstarted batch_sender exporter hangs on shutdown
+
+# One or more tracking issues or pull requests related to the change
+issues: [10306]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/batch_sender_test.go
+++ b/exporter/exporterhelper/batch_sender_test.go
@@ -436,6 +436,15 @@ func TestBatchSender_WithBatcherOption(t *testing.T) {
 	}
 }
 
+func TestBatchSender_UnstartedShutdown(t *testing.T) {
+	be, err := newBaseExporter(defaultSettings, defaultDataType, newNoopObsrepSender,
+		WithBatcher(exporterbatcher.NewDefaultConfig(), WithRequestBatchFuncs(fakeBatchMergeFunc, fakeBatchMergeSplitFunc)))
+	require.NoError(t, err)
+
+	err = be.Shutdown(context.Background())
+	require.NoError(t, err)
+}
+
 // TestBatchSender_ShutdownDeadlock tests that the exporter does not deadlock when shutting down while a batch is being
 // merged.
 func TestBatchSender_ShutdownDeadlock(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix a bug where shutdown hangs if batch_sender exporter is not started. The bug causes generated component tests to fail as well.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10306

