### PR TITLE
[mdatagen] make meter a struct member of telemetryBuilder

### DIFF
--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -26,6 +26,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
+	meter                                metric.Meter
 	BatchSizeTriggerSend                 metric.Int64Counter
 	ProcessRuntimeTotalAllocBytes        metric.Int64ObservableCounter
 	observeProcessRuntimeTotalAllocBytes func() int64
@@ -65,22 +66,19 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	for _, op := range options {
 		op(&builder)
 	}
-	var (
-		err, errs error
-		meter     metric.Meter
-	)
+	var err, errs error
 	if builder.level >= configtelemetry.LevelBasic {
-		meter = Meter(settings)
+		builder.meter = Meter(settings)
 	} else {
-		meter = noop.Meter{}
+		builder.meter = noop.Meter{}
 	}
-	builder.BatchSizeTriggerSend, err = meter.Int64Counter(
+	builder.BatchSizeTriggerSend, err = builder.meter.Int64Counter(
 		"batch_size_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a size trigger"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessRuntimeTotalAllocBytes, err = meter.Int64ObservableCounter(
+	builder.ProcessRuntimeTotalAllocBytes, err = builder.meter.Int64ObservableCounter(
 		"process_runtime_total_alloc_bytes",
 		metric.WithDescription("Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')"),
 		metric.WithUnit("By"),
@@ -90,7 +88,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		}),
 	)
 	errs = errors.Join(errs, err)
-	builder.RequestDuration, err = meter.Float64Histogram(
+	builder.RequestDuration, err = builder.meter.Float64Histogram(
 		"request_duration",
 		metric.WithDescription("Duration of request"),
 		metric.WithUnit("s"), metric.WithExplicitBucketBoundaries([]float64{1, 10, 100}...),

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -29,6 +29,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry 
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
+    meter metric.Meter
 	{{- range $name, $metric := .Telemetry.Metrics }}
 	{{ $name.Render }} metric.{{ $metric.Data.Instrument }}
     {{- if $metric.Data.Async }}
@@ -77,18 +78,15 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	for _, op := range options {
 		op(&builder)
 	}
-    var (
-        err, errs error
-        meter     metric.Meter
-    )
+    var err, errs error
     if builder.level >= configtelemetry.Level{{ casesTitle .Telemetry.Level.String }} {
-        meter = Meter(settings)
+        builder.meter = Meter(settings)
     } else {
-        meter = noop.Meter{}
+        builder.meter = noop.Meter{}
     }
     
     {{- range $name, $metric := .Telemetry.Metrics }}
-    builder.{{ $name.Render }}, err = meter.{{ $metric.Data.Instrument }}(
+    builder.{{ $name.Render }}, err = builder.meter.{{ $metric.Data.Instrument }}(
         "{{ $name }}",
         metric.WithDescription("{{ $metric.Description }}"),
         metric.WithUnit("{{ $metric.Unit }}"),

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -24,6 +24,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
+	meter                             metric.Meter
 	ExporterEnqueueFailedLogRecords   metric.Int64Counter
 	ExporterEnqueueFailedMetricPoints metric.Int64Counter
 	ExporterEnqueueFailedSpans        metric.Int64Counter
@@ -53,64 +54,61 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	for _, op := range options {
 		op(&builder)
 	}
-	var (
-		err, errs error
-		meter     metric.Meter
-	)
+	var err, errs error
 	if builder.level >= configtelemetry.LevelBasic {
-		meter = Meter(settings)
+		builder.meter = Meter(settings)
 	} else {
-		meter = noop.Meter{}
+		builder.meter = noop.Meter{}
 	}
-	builder.ExporterEnqueueFailedLogRecords, err = meter.Int64Counter(
+	builder.ExporterEnqueueFailedLogRecords, err = builder.meter.Int64Counter(
 		"exporter_enqueue_failed_log_records",
 		metric.WithDescription("Number of log records failed to be added to the sending queue."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ExporterEnqueueFailedMetricPoints, err = meter.Int64Counter(
+	builder.ExporterEnqueueFailedMetricPoints, err = builder.meter.Int64Counter(
 		"exporter_enqueue_failed_metric_points",
 		metric.WithDescription("Number of metric points failed to be added to the sending queue."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ExporterEnqueueFailedSpans, err = meter.Int64Counter(
+	builder.ExporterEnqueueFailedSpans, err = builder.meter.Int64Counter(
 		"exporter_enqueue_failed_spans",
 		metric.WithDescription("Number of spans failed to be added to the sending queue."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ExporterSendFailedLogRecords, err = meter.Int64Counter(
+	builder.ExporterSendFailedLogRecords, err = builder.meter.Int64Counter(
 		"exporter_send_failed_log_records",
 		metric.WithDescription("Number of log records in failed attempts to send to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ExporterSendFailedMetricPoints, err = meter.Int64Counter(
+	builder.ExporterSendFailedMetricPoints, err = builder.meter.Int64Counter(
 		"exporter_send_failed_metric_points",
 		metric.WithDescription("Number of metric points in failed attempts to send to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ExporterSendFailedSpans, err = meter.Int64Counter(
+	builder.ExporterSendFailedSpans, err = builder.meter.Int64Counter(
 		"exporter_send_failed_spans",
 		metric.WithDescription("Number of spans in failed attempts to send to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ExporterSentLogRecords, err = meter.Int64Counter(
+	builder.ExporterSentLogRecords, err = builder.meter.Int64Counter(
 		"exporter_sent_log_records",
 		metric.WithDescription("Number of log record successfully sent to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ExporterSentMetricPoints, err = meter.Int64Counter(
+	builder.ExporterSentMetricPoints, err = builder.meter.Int64Counter(
 		"exporter_sent_metric_points",
 		metric.WithDescription("Number of metric points successfully sent to destination."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ExporterSentSpans, err = meter.Int64Counter(
+	builder.ExporterSentSpans, err = builder.meter.Int64Counter(
 		"exporter_sent_spans",
 		metric.WithDescription("Number of spans successfully sent to destination."),
 		metric.WithUnit("1"),

--- a/processor/batchprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/batchprocessor/internal/metadata/generated_telemetry.go
@@ -26,6 +26,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
+	meter                                    metric.Meter
 	ProcessorBatchBatchSendSize              metric.Int64Histogram
 	ProcessorBatchBatchSendSizeBytes         metric.Int64Histogram
 	ProcessorBatchBatchSizeTriggerSend       metric.Int64Counter
@@ -67,34 +68,31 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	for _, op := range options {
 		op(&builder)
 	}
-	var (
-		err, errs error
-		meter     metric.Meter
-	)
+	var err, errs error
 	if builder.level >= configtelemetry.LevelNormal {
-		meter = Meter(settings)
+		builder.meter = Meter(settings)
 	} else {
-		meter = noop.Meter{}
+		builder.meter = noop.Meter{}
 	}
-	builder.ProcessorBatchBatchSendSize, err = meter.Int64Histogram(
+	builder.ProcessorBatchBatchSendSize, err = builder.meter.Int64Histogram(
 		"processor_batch_batch_send_size",
 		metric.WithDescription("Number of units in the batch"),
 		metric.WithUnit("1"), metric.WithExplicitBucketBoundaries([]float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000}...),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorBatchBatchSendSizeBytes, err = meter.Int64Histogram(
+	builder.ProcessorBatchBatchSendSizeBytes, err = builder.meter.Int64Histogram(
 		"processor_batch_batch_send_size_bytes",
 		metric.WithDescription("Number of bytes in batch that was sent"),
 		metric.WithUnit("By"), metric.WithExplicitBucketBoundaries([]float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000, 200000, 300000, 400000, 500000, 600000, 700000, 800000, 900000, 1e+06, 2e+06, 3e+06, 4e+06, 5e+06, 6e+06, 7e+06, 8e+06, 9e+06}...),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorBatchBatchSizeTriggerSend, err = meter.Int64Counter(
+	builder.ProcessorBatchBatchSizeTriggerSend, err = builder.meter.Int64Counter(
 		"processor_batch_batch_size_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a size trigger"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorBatchMetadataCardinality, err = meter.Int64ObservableUpDownCounter(
+	builder.ProcessorBatchMetadataCardinality, err = builder.meter.Int64ObservableUpDownCounter(
 		"processor_batch_metadata_cardinality",
 		metric.WithDescription("Number of distinct metadata value combinations being processed"),
 		metric.WithUnit("1"),
@@ -104,7 +102,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		}),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorBatchTimeoutTriggerSend, err = meter.Int64Counter(
+	builder.ProcessorBatchTimeoutTriggerSend, err = builder.meter.Int64Counter(
 		"processor_batch_timeout_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a timeout trigger"),
 		metric.WithUnit("1"),

--- a/processor/processorhelper/internal/metadata/generated_telemetry.go
+++ b/processor/processorhelper/internal/metadata/generated_telemetry.go
@@ -24,6 +24,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
+	meter                         metric.Meter
 	ProcessorAcceptedLogRecords   metric.Int64Counter
 	ProcessorAcceptedMetricPoints metric.Int64Counter
 	ProcessorAcceptedSpans        metric.Int64Counter
@@ -53,64 +54,61 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	for _, op := range options {
 		op(&builder)
 	}
-	var (
-		err, errs error
-		meter     metric.Meter
-	)
+	var err, errs error
 	if builder.level >= configtelemetry.LevelBasic {
-		meter = Meter(settings)
+		builder.meter = Meter(settings)
 	} else {
-		meter = noop.Meter{}
+		builder.meter = noop.Meter{}
 	}
-	builder.ProcessorAcceptedLogRecords, err = meter.Int64Counter(
+	builder.ProcessorAcceptedLogRecords, err = builder.meter.Int64Counter(
 		"processor_accepted_log_records",
 		metric.WithDescription("Number of log records successfully pushed into the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorAcceptedMetricPoints, err = meter.Int64Counter(
+	builder.ProcessorAcceptedMetricPoints, err = builder.meter.Int64Counter(
 		"processor_accepted_metric_points",
 		metric.WithDescription("Number of metric points successfully pushed into the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorAcceptedSpans, err = meter.Int64Counter(
+	builder.ProcessorAcceptedSpans, err = builder.meter.Int64Counter(
 		"processor_accepted_spans",
 		metric.WithDescription("Number of spans successfully pushed into the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorDroppedLogRecords, err = meter.Int64Counter(
+	builder.ProcessorDroppedLogRecords, err = builder.meter.Int64Counter(
 		"processor_dropped_log_records",
 		metric.WithDescription("Number of log records that were dropped."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorDroppedMetricPoints, err = meter.Int64Counter(
+	builder.ProcessorDroppedMetricPoints, err = builder.meter.Int64Counter(
 		"processor_dropped_metric_points",
 		metric.WithDescription("Number of metric points that were dropped."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorDroppedSpans, err = meter.Int64Counter(
+	builder.ProcessorDroppedSpans, err = builder.meter.Int64Counter(
 		"processor_dropped_spans",
 		metric.WithDescription("Number of spans that were dropped."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorRefusedLogRecords, err = meter.Int64Counter(
+	builder.ProcessorRefusedLogRecords, err = builder.meter.Int64Counter(
 		"processor_refused_log_records",
 		metric.WithDescription("Number of log records that were rejected by the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorRefusedMetricPoints, err = meter.Int64Counter(
+	builder.ProcessorRefusedMetricPoints, err = builder.meter.Int64Counter(
 		"processor_refused_metric_points",
 		metric.WithDescription("Number of metric points that were rejected by the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorRefusedSpans, err = meter.Int64Counter(
+	builder.ProcessorRefusedSpans, err = builder.meter.Int64Counter(
 		"processor_refused_spans",
 		metric.WithDescription("Number of spans that were rejected by the next component in the pipeline."),
 		metric.WithUnit("1"),

--- a/receiver/receiverhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/receiverhelper/internal/metadata/generated_telemetry.go
@@ -24,6 +24,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
+	meter                        metric.Meter
 	ReceiverAcceptedLogRecords   metric.Int64Counter
 	ReceiverAcceptedMetricPoints metric.Int64Counter
 	ReceiverAcceptedSpans        metric.Int64Counter
@@ -50,46 +51,43 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	for _, op := range options {
 		op(&builder)
 	}
-	var (
-		err, errs error
-		meter     metric.Meter
-	)
+	var err, errs error
 	if builder.level >= configtelemetry.LevelBasic {
-		meter = Meter(settings)
+		builder.meter = Meter(settings)
 	} else {
-		meter = noop.Meter{}
+		builder.meter = noop.Meter{}
 	}
-	builder.ReceiverAcceptedLogRecords, err = meter.Int64Counter(
+	builder.ReceiverAcceptedLogRecords, err = builder.meter.Int64Counter(
 		"receiver_accepted_log_records",
 		metric.WithDescription("Number of log records successfully pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ReceiverAcceptedMetricPoints, err = meter.Int64Counter(
+	builder.ReceiverAcceptedMetricPoints, err = builder.meter.Int64Counter(
 		"receiver_accepted_metric_points",
 		metric.WithDescription("Number of metric points successfully pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ReceiverAcceptedSpans, err = meter.Int64Counter(
+	builder.ReceiverAcceptedSpans, err = builder.meter.Int64Counter(
 		"receiver_accepted_spans",
 		metric.WithDescription("Number of spans successfully pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ReceiverRefusedLogRecords, err = meter.Int64Counter(
+	builder.ReceiverRefusedLogRecords, err = builder.meter.Int64Counter(
 		"receiver_refused_log_records",
 		metric.WithDescription("Number of log records that could not be pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ReceiverRefusedMetricPoints, err = meter.Int64Counter(
+	builder.ReceiverRefusedMetricPoints, err = builder.meter.Int64Counter(
 		"receiver_refused_metric_points",
 		metric.WithDescription("Number of metric points that could not be pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ReceiverRefusedSpans, err = meter.Int64Counter(
+	builder.ReceiverRefusedSpans, err = builder.meter.Int64Counter(
 		"receiver_refused_spans",
 		metric.WithDescription("Number of spans that could not be pushed into the pipeline."),
 		metric.WithUnit("1"),


### PR DESCRIPTION
This will be used in a follow up PR that allows initialization of optional internal metrics which address the queue metric use-case.
