### PR TITLE
[mdatagen] add support for optional internal metrics

### DIFF
--- a/.chloggen/codeboten_optional-internal-metric.yaml
+++ b/.chloggen/codeboten_optional-internal-metric.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add support for optional internal metrics
+
+# One or more tracking issues or pull requests related to the change
+issues: [10316]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/samplereceiver/documentation.md
+++ b/cmd/mdatagen/internal/samplereceiver/documentation.md
@@ -125,6 +125,16 @@ Number of times the batch was sent due to a size trigger
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
+### optional_metric
+
+This metric is optional and therefore not initialized in NewTelemetryBuilder.
+
+For example this metric only exists if feature A is enabled.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| 1 | Gauge | Int |
+
 ### process_runtime_total_alloc_bytes
 
 Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')

--- a/cmd/mdatagen/internal/samplereceiver/documentation.md
+++ b/cmd/mdatagen/internal/samplereceiver/documentation.md
@@ -125,7 +125,15 @@ Number of times the batch was sent due to a size trigger
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### optional_metric
+### process_runtime_total_alloc_bytes
+
+Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| By | Sum | Int | true |
+
+### queue_length
 
 This metric is optional and therefore not initialized in NewTelemetryBuilder.
 
@@ -134,14 +142,6 @@ For example this metric only exists if feature A is enabled.
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | 1 | Gauge | Int |
-
-### process_runtime_total_alloc_bytes
-
-Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
-
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| By | Sum | Int | true |
 
 ### request_duration
 

--- a/cmd/mdatagen/internal/samplereceiver/factory.go
+++ b/cmd/mdatagen/internal/samplereceiver/factory.go
@@ -32,7 +32,7 @@ func createMetrics(ctx context.Context, set receiver.Settings, _ component.Confi
 		return nil, err
 	}
 	telemetryBuilder.BatchSizeTriggerSend.Add(ctx, 1)
-	return nopInstance, nil
+	return nopReceiver{telemetryBuilder: telemetryBuilder}, nil
 }
 
 func createLogs(context.Context, receiver.Settings, component.Config, consumer.Logs) (receiver.Logs, error) {
@@ -44,4 +44,9 @@ var nopInstance = &nopReceiver{}
 type nopReceiver struct {
 	component.StartFunc
 	component.ShutdownFunc
+	telemetryBuilder *metadata.TelemetryBuilder
+}
+
+func (r nopReceiver) initOptionalMetric() {
+	_ = r.telemetryBuilder.InitOptionalMetric(func() int64 { return 1 })
 }

--- a/cmd/mdatagen/internal/samplereceiver/factory.go
+++ b/cmd/mdatagen/internal/samplereceiver/factory.go
@@ -48,5 +48,5 @@ type nopReceiver struct {
 }
 
 func (r nopReceiver) initOptionalMetric() {
-	_ = r.telemetryBuilder.InitOptionalMetric(func() int64 { return 1 })
+	_ = r.telemetryBuilder.InitQueueLength(func() int64 { return 1 })
 }

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -28,9 +28,9 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 type TelemetryBuilder struct {
 	meter                                metric.Meter
 	BatchSizeTriggerSend                 metric.Int64Counter
-	OptionalMetric                       metric.Int64ObservableGauge
 	ProcessRuntimeTotalAllocBytes        metric.Int64ObservableCounter
 	observeProcessRuntimeTotalAllocBytes func() int64
+	QueueLength                          metric.Int64ObservableGauge
 	RequestDuration                      metric.Float64Histogram
 	level                                configtelemetry.Level
 	attributeSet                         attribute.Set
@@ -53,11 +53,18 @@ func WithAttributeSet(set attribute.Set) telemetryBuilderOption {
 	}
 }
 
-// InitOptionalMetric configures the OptionalMetric metric.
-func (builder *TelemetryBuilder) InitOptionalMetric(cb func() int64) error {
+// WithProcessRuntimeTotalAllocBytesCallback sets callback for observable ProcessRuntimeTotalAllocBytes metric.
+func WithProcessRuntimeTotalAllocBytesCallback(cb func() int64) telemetryBuilderOption {
+	return func(builder *TelemetryBuilder) {
+		builder.observeProcessRuntimeTotalAllocBytes = cb
+	}
+}
+
+// InitQueueLength configures the QueueLength metric.
+func (builder *TelemetryBuilder) InitQueueLength(cb func() int64) error {
 	var err error
-	builder.OptionalMetric, err = builder.meter.Int64ObservableGauge(
-		"optional_metric",
+	builder.QueueLength, err = builder.meter.Int64ObservableGauge(
+		"queue_length",
 		metric.WithDescription("This metric is optional and therefore not initialized in NewTelemetryBuilder."),
 		metric.WithUnit("1"),
 		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
@@ -66,13 +73,6 @@ func (builder *TelemetryBuilder) InitOptionalMetric(cb func() int64) error {
 		}),
 	)
 	return err
-}
-
-// WithProcessRuntimeTotalAllocBytesCallback sets callback for observable ProcessRuntimeTotalAllocBytes metric.
-func WithProcessRuntimeTotalAllocBytesCallback(cb func() int64) telemetryBuilderOption {
-	return func(builder *TelemetryBuilder) {
-		builder.observeProcessRuntimeTotalAllocBytes = cb
-	}
 }
 
 // NewTelemetryBuilder provides a struct with methods to update all internal telemetry

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -174,3 +174,12 @@ telemetry:
         async: true
         value_type: int
         monotonic: true
+    optional_metric:
+      enabled: true
+      description: This metric is optional and therefore not initialized in NewTelemetryBuilder.
+      extended_documentation: For example this metric only exists if feature A is enabled.
+      unit: 1
+      optional: true
+      gauge:
+        async: true
+        value_type: int

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -174,7 +174,7 @@ telemetry:
         async: true
         value_type: int
         monotonic: true
-    optional_metric:
+    queue_length:
       enabled: true
       description: This metric is optional and therefore not initialized in NewTelemetryBuilder.
       extended_documentation: For example this metric only exists if feature A is enabled.

--- a/cmd/mdatagen/internal/samplereceiver/metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/metrics_test.go
@@ -91,7 +91,7 @@ func TestComponentTelemetry(t *testing.T) {
 			},
 		},
 		{
-			Name:        "optional_metric",
+			Name:        "queue_length",
 			Description: "This metric is optional and therefore not initialized in NewTelemetryBuilder.",
 			Unit:        "1",
 			Data: metricdata.Gauge[int64]{

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -111,6 +111,10 @@ type metric struct {
 	// be appended to the description used in generated documentation.
 	ExtendedDocumentation string `mapstructure:"extended_documentation"`
 
+	// Optional can be used to specify metrics that may
+	// or may not be present in all cases, depending on configuration.
+	Optional bool `mapstructure:"optional"`
+
 	// Unit of the metric.
 	Unit *string `mapstructure:"unit"`
 

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -263,6 +263,19 @@ func TestLoadMetadata(t *testing.T) {
 								Async: true,
 							},
 						},
+						"optional_metric": {
+							Enabled:               true,
+							Description:           "This metric is optional and therefore not initialized in NewTelemetryBuilder.",
+							ExtendedDocumentation: "For example this metric only exists if feature A is enabled.",
+							Unit:                  strPtr("1"),
+							Optional:              true,
+							Gauge: &gauge{
+								MetricValueType: MetricValueType{
+									ValueType: pmetric.NumberDataPointValueTypeInt,
+								},
+								Async: true,
+							},
+						},
 					},
 				},
 				ScopeName:       "go.opentelemetry.io/collector/internal/receiver/samplereceiver",

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -263,7 +263,7 @@ func TestLoadMetadata(t *testing.T) {
 								Async: true,
 							},
 						},
-						"optional_metric": {
+						"queue_length": {
 							Enabled:               true,
 							Description:           "This metric is optional and therefore not initialized in NewTelemetryBuilder.",
 							ExtendedDocumentation: "For example this metric only exists if feature A is enabled.",

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -140,6 +140,9 @@ telemetry:
       description:
       # Optional: extended documentation of the metric.
       extended_documentation:
+      # Optional: whether or not this metric is optional. Optional metrics may only be initialized
+      # if certain features are enabled or configured.
+      optional: bool
       # Optional: warnings that will be shown to user under specified conditions.
       warnings:
         # A warning that will be displayed if the metric is enabled in user config.

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -32,7 +32,7 @@ type TelemetryBuilder struct {
     meter metric.Meter
 	{{- range $name, $metric := .Telemetry.Metrics }}
 	{{ $name.Render }} metric.{{ $metric.Data.Instrument }}
-    {{- if $metric.Data.Async }}
+    {{- if and ($metric.Data.Async) (not $metric.Optional) }}
     observe{{ $name.Render }} func() {{ $metric.Data.BasicType }}
     {{- end }}
 	{{- end }}
@@ -60,6 +60,28 @@ func WithAttributeSet(set attribute.Set) telemetryBuilderOption {
 {{- end }}
 
 {{- range $name, $metric := .Telemetry.Metrics }}
+    {{- if $metric.Optional }}
+// Init{{ $name.Render }} configures the {{ $name.Render }} metric.
+func (builder *TelemetryBuilder) Init{{ $name.Render }}({{ if $metric.Data.Async -}}cb func() {{ $metric.Data.BasicType }}{{- end }}) error {
+    var err error
+    builder.{{ $name.Render }}, err = builder.meter.{{ $metric.Data.Instrument }}(
+        "{{ $name }}",
+        metric.WithDescription("{{ $metric.Description }}"),
+        metric.WithUnit("{{ $metric.Unit }}"),
+        {{- if eq $metric.Data.Type "Histogram" -}}
+        {{ if $metric.Data.Boundaries -}}metric.WithExplicitBucketBoundaries([]float64{ {{- range $metric.Data.Boundaries }} {{.}}, {{- end }} }...),{{- end }}
+        {{- end }}
+        {{ if $metric.Data.Async -}}
+        metric.With{{ casesTitle $metric.Data.BasicType }}Callback(func(_ context.Context, o metric.{{ casesTitle $metric.Data.BasicType }}Observer) error {
+            o.Observe(cb(), metric.WithAttributeSet(builder.attributeSet))
+            return nil
+        }),
+        {{- end }}
+    )
+    return err
+}
+
+    {{- else }}
     {{ if $metric.Data.Async -}}
 // With{{ $name.Render }}Callback sets callback for observable {{ $name.Render }} metric.
 func With{{ $name.Render }}Callback(cb func() {{ $metric.Data.BasicType }}) telemetryBuilderOption {
@@ -67,6 +89,7 @@ func With{{ $name.Render }}Callback(cb func() {{ $metric.Data.BasicType }}) tele
         builder.observe{{ $name.Render }} = cb
     }
 }
+    {{- end }}
     {{- end }}
 {{- end }}
 
@@ -86,6 +109,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
     }
     
     {{- range $name, $metric := .Telemetry.Metrics }}
+    {{- if not $metric.Optional }}
     builder.{{ $name.Render }}, err = builder.meter.{{ $metric.Data.Instrument }}(
         "{{ $name }}",
         metric.WithDescription("{{ $metric.Description }}"),
@@ -101,6 +125,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
         {{- end }}
     )
     errs = errors.Join(errs, err)
+    {{- end }}
     {{- end }}
     return &builder, errs
 }


### PR DESCRIPTION
This allows metrics to be initialized at a later time as is the case for the queue metrics in exporterhelper which are only initialized if a queue is configured.