### PR TITLE
[chore] Clarify that cmd/otelcorecol and top-level go.mod are not the source of the core distro

### DIFF
--- a/cmd/otelcorecol/README.md
+++ b/cmd/otelcorecol/README.md
@@ -1,0 +1,4 @@
+# `otelcorecol` test binary
+
+This folder contains the sources for the `otelcorecol` test binary. This binary is intended for **TEST PURPOSES ONLY**. The source files in this folder are **NOT** the ones used to build any official OpenTelemetry Collector releases.
+Check [open-telemetry/opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) for the official releases. Check the [**`otelcol` folder**](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol) on that repository for the official Collector core manifest.

--- a/cmd/otelcorecol/README.md
+++ b/cmd/otelcorecol/README.md
@@ -1,4 +1,4 @@
 # `otelcorecol` test binary
 
-This folder contains the sources for the `otelcorecol` test binary. This binary is intended for **TEST PURPOSES ONLY**. The source files in this folder are **NOT** the ones used to build any official OpenTelemetry Collector releases.
+This folder contains the sources for the `otelcorecol` test binary. This binary is intended for internal **TEST PURPOSES ONLY**. The source files in this folder are **NOT** the ones used to build any official OpenTelemetry Collector releases.
 Check [open-telemetry/opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) for the official releases. Check the [**`otelcol` folder**](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol) on that repository for the official Collector core manifest.

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -1,3 +1,11 @@
+# NOTE:
+# This builder configuration is NOT used to build any official binary.
+# To see the builder manifests used for official binaries, 
+# check https://github.com/open-telemetry/opentelemetry-collector-releases
+# 
+# For the OpenTelemetry Collector Core official distribution sources, check
+# https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
+
 dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,13 @@
 module go.opentelemetry.io/collector
 
+// NOTE:
+// This go.mod is NOT used to build any official binary.
+// To see the builder manifests used for official binaries,
+// check https://github.com/open-telemetry/opentelemetry-collector-releases
+//
+// For the OpenTelemetry Collector Core distribution specifically, see
+// https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
+
 go 1.21.0
 
 require (


### PR DESCRIPTION
#### Description

Documents the purpose of `cmd/otelcorecol` in a new README and in a comment on the builder manifest. Adds note to top-level go.mod.

This is a common point of confusion and was recently confusing for users on the aftermath of CVE-2024-36129

Counterpart to open-telemetry/opentelemetry-collector-contrib/pull/33409