### PR TITLE
[configgrpc] create zstd.Decoder's using WithDecoderConcurrency(1)

### DIFF
--- a/config/configgrpc/internal/zstd.go
+++ b/config/configgrpc/internal/zstd.go
@@ -52,7 +52,7 @@ type reader struct {
 func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
 	z, inPool := c.poolDecompressor.Get().(*reader)
 	if !inPool {
-		newZ, err := zstd.NewReader(r)
+		newZ, err := zstd.NewReader(r, zstd.WithDecoderConcurrency(1))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### Description

The zstd.Decoder documentation states:
> It is important to use the "Close" function when you no longer need
> the Reader to stop running goroutines, when running with default
> settings. Goroutines will exit once an error has been returned,
> including io.EOF at the end of a stream.
>
> Streams are decoded concurrently in 4 asynchronous stages to give
> the best possible throughput. However, if you prefer synchronous
> decompression, use WithDecoderConcurrency(1) which will decompress
> data as it is being requested only.

Since we store zstd.Decoder's in a sync.Pool, we should probably use WithDecoderConcurrency(1), so that we don't need to call Close() when they are dropped from the pool.

#### Link to tracking issue

Relates to #10323

#### Testing

TODO