### PR TITLE
[otelcol] Add featuregate to use stable expansion rules

### DIFF
--- a/.chloggen/confmap-add-expand-featuregate.yaml
+++ b/.chloggen/confmap-add-expand-featuregate.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `otelcol.useStableExpansionRules` feature gate to allow enabling stable expansion rules.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10259]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - When enabled, this feature gate will disable the ability to expand `$ENV` syntax. Use `${env:ENV}` instead.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -38,13 +38,20 @@ func main() {
 				{{- if .ConfResolver.DefaultURIScheme }}
 				DefaultScheme: "{{ .ConfResolver.DefaultURIScheme }}",
 				{{- end }}
-				ConverterFactories: []confmap.ConverterFactory{
-					expandconverter.NewFactory(),
-				},
 			},
 		},
 		{{- end}}
 	}
+
+    {{ if .Distribution.SupportsConfmapFactories }}
+    if otelcol.UseStableExpansionRules.IsEnabled() && set.ConfigProviderSettings.ResolverSettings.DefaultScheme == "" {
+        set.ConfigProviderSettings.ResolverSettings.DefaultScheme = "env"
+    } else {
+        set.ConfigProviderSettings.ResolverSettings.ConverterFactories = []confmap.ConverterFactory{
+            expandconverter.NewFactory(),
+        }
+    }
+    {{- end}}
 
 	if err := run(set); err != nil {
 		log.Fatal(err)

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -36,11 +36,16 @@ func main() {
 					httpsprovider.NewFactory(),
 					yamlprovider.NewFactory(),
 				},
-				ConverterFactories: []confmap.ConverterFactory{
-					expandconverter.NewFactory(),
-				},
 			},
 		},
+	}
+
+	if otelcol.UseStableExpansionRules.IsEnabled() && set.ConfigProviderSettings.ResolverSettings.DefaultScheme == "" {
+		set.ConfigProviderSettings.ResolverSettings.DefaultScheme = "env"
+	} else {
+		set.ConfigProviderSettings.ResolverSettings.ConverterFactories = []confmap.ConverterFactory{
+			expandconverter.NewFactory(),
+		}
 	}
 
 	if err := run(set); err != nil {

--- a/otelcol/command.go
+++ b/otelcol/command.go
@@ -12,6 +12,11 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 )
 
+var UseStableExpansionRules = featuregate.GlobalRegistry().MustRegister("otelcol.useStableExpansionRules",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterFromVersion("v0.102.0"),
+	featuregate.WithRegisterDescription("Uses the env provider to expand `${}` instead of the expandconverter and no longer expands $ENV syntax"))
+
 // NewCommand constructs a new cobra.Command using the given CollectorSettings.
 // Any URIs specified in CollectorSettings.ConfigProviderSettings.ResolverSettings.URIs
 // are considered defaults and will be overwritten by config flags passed as
@@ -52,9 +57,7 @@ func updateSettingsUsingFlags(set *CollectorSettings, flags *flag.FlagSet) error
 	if len(resolverSet.URIs) == 0 {
 		return errors.New("at least one config flag must be provided")
 	}
-	// Provide a default set of providers and converters if none have been specified.
-	// TODO: Remove this after CollectorSettings.ConfigProvider is removed and instead
-	// do it in the builder.
+
 	if len(resolverSet.ProviderFactories) == 0 && len(resolverSet.ConverterFactories) == 0 {
 		set.ConfigProviderSettings = newDefaultConfigProviderSettings(resolverSet.URIs)
 	}

--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -132,7 +132,7 @@ func (cm *configProvider) GetConfmap(ctx context.Context) (*confmap.Conf, error)
 }
 
 func newDefaultConfigProviderSettings(uris []string) ConfigProviderSettings {
-	return ConfigProviderSettings{
+	set := ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
 			URIs: uris,
 			ProviderFactories: []confmap.ProviderFactory{
@@ -142,7 +142,12 @@ func newDefaultConfigProviderSettings(uris []string) ConfigProviderSettings {
 				httpprovider.NewFactory(),
 				httpsprovider.NewFactory(),
 			},
-			ConverterFactories: []confmap.ConverterFactory{expandconverter.NewFactory()},
 		},
 	}
+	if UseStableExpansionRules.IsEnabled() {
+		set.ResolverSettings.DefaultScheme = "env"
+	} else {
+		set.ResolverSettings.ConverterFactories = []confmap.ConverterFactory{expandconverter.NewFactory()}
+	}
+	return set
 }


### PR DESCRIPTION
#### Description
This PR adds a feature gate to control all our use of the expandconverter.  When enabled, the feature gate will use `DefaultScheme="env"` instead of the expandconverter for OCB and when supplying default providers in `NewCommand`.

Alternative to https://github.com/open-telemetry/opentelemetry-collector/pull/10259

<!-- Issue number if applicable -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/10161
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/8215
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/7111

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests
