### PR TITLE
[chore] update deprecated goreleaser flag

### DIFF
--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: latest
-          args: release --rm-dist -f cmd/builder/.goreleaser.yml
+          args: release --clean -f cmd/builder/.goreleaser.yml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This flag is being removed in the latest version, see https://goreleaser.com/deprecations/#-rm-dist
