### PR TITLE
[confmap] Only log error in expandconverter if expansion actually happens

### DIFF
--- a/.chloggen/confmap-fix-log.yaml
+++ b/.chloggen/confmap-fix-log.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: expandconverter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where an warning was logged incorrectly.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10392]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/confmap/converter/expandconverter/expand.go
+++ b/confmap/converter/expandconverter/expand.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"regexp"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/internal/envvar"
-
-	"go.uber.org/zap"
 )
 
 type converter struct {

--- a/confmap/converter/expandconverter/expand.go
+++ b/confmap/converter/expandconverter/expand.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"regexp"
 
-	"go.uber.org/zap"
-
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/internal/envvar"
+
+	"go.uber.org/zap"
 )
 
 type converter struct {
@@ -80,6 +80,14 @@ func (c converter) expandStringValues(value any) (any, error) {
 func (c converter) expandEnv(s string) (string, error) {
 	var err error
 	res := os.Expand(s, func(str string) string {
+		// This allows escaping environment variable substitution via $$, e.g.
+		// - $FOO will be substituted with env var FOO
+		// - $$FOO will be replaced with $FOO
+		// - $$$FOO will be replaced with $ + substituted env var FOO
+		if str == "$" {
+			return "$"
+		}
+
 		// Matches on $VAR style environment variables
 		// in order to make sure we don't log a warning for ${VAR}
 		var regex = regexp.MustCompile(fmt.Sprintf(`\$%s`, regexp.QuoteMeta(str)))
@@ -88,13 +96,7 @@ func (c converter) expandEnv(s string) (string, error) {
 			c.logger.Warn(msg, zap.String("variable", str))
 			c.loggedDeprecations[str] = struct{}{}
 		}
-		// This allows escaping environment variable substitution via $$, e.g.
-		// - $FOO will be substituted with env var FOO
-		// - $$FOO will be replaced with $FOO
-		// - $$$FOO will be replaced with $ + substituted env var FOO
-		if str == "$" {
-			return "$"
-		}
+
 		// For $ENV style environment variables os.Expand returns once it hits a character that isn't an underscore or
 		// an alphanumeric character - so we cannot detect those malformed environment variables.
 		// For ${ENV} style variables we can detect those kinds of env var names!


### PR DESCRIPTION
#### Description
Fix a bug where we printed a warning log when we were not expanding a value

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/10356

#### Testing
Tested manually
