### PR TITLE
[chore] link release managers

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -156,15 +156,15 @@ Once a module is ready to be released under the `1.x` version scheme, file a PR 
 
 ## Release schedule
 
-| Date       | Version  | Release manager |
-|------------|----------|-----------------|
-| 2024-06-17 | v0.103.0 | @djaglowski     |
-| 2024-07-01 | v0.104.0 | @atoulme        |
-| 2024-07-15 | v0.105.0 | @TylerHelmuth   |
-| 2024-07-29 | v0.106.0 | @songy23        |
-| 2024-08-12 | v0.107.0 | @dmitryax       |
-| 2024-08-26 | v0.108.0 | @codeboten      |
-| 2024-09-09 | v0.109.0 | @bogdandrutu    |
-| 2024-09-23 | v0.110.0 | @jpkrohling     |
-| 2024-10-07 | v0.111.0 | @mx-psi         |
-| 2024-10-21 | v0.112.0 | @evan-bradley   |
+| Date       | Version  | Release manager                                  |
+|------------|----------|--------------------------------------------------|
+| 2024-06-17 | v0.103.0 | [@djaglowski](https://github.com/djaglowski)     |
+| 2024-07-01 | v0.104.0 | [@atoulme](https://github.com/atoulme)           |
+| 2024-07-15 | v0.105.0 | [@TylerHelmuth](https://github.com/TylerHelmuth) |
+| 2024-07-29 | v0.106.0 | [@songy23](https://github.com/songy23)           |
+| 2024-08-12 | v0.107.0 | [@dmitryax](https://github.com/dmitryax)         |
+| 2024-08-26 | v0.108.0 | [@codeboten](https://github.com/codeboten)       |
+| 2024-09-09 | v0.109.0 | [@bogdandrutu](https://github.com/bogdandrutu)   |
+| 2024-09-23 | v0.110.0 | [@jpkrohling](https://github.com/jpkrohling)     |
+| 2024-10-07 | v0.111.0 | [@mx-psi](https://github.com/mx-psi)             |
+| 2024-10-21 | v0.112.0 | [@evan-bradley](https://github.com/evan-bradley) |


### PR DESCRIPTION
#### Description

In normal github issues etc, if you `@user`, it makes a link for you. So, it feels weird to see `@user` without a link. Feel free to reject this if it is a cure worse than the disease.
