### PR TITLE
[confmap] remove bool logic from expandURI

### DIFF
--- a/confmap/expand.go
+++ b/confmap/expand.go
@@ -111,9 +111,13 @@ func (mr *Resolver) findAndExpandURI(ctx context.Context, input string) (any, bo
 	if uri == input {
 		// If the value is a single URI, then the return value can be anything.
 		// This is the case `foo: ${file:some_extra_config.yml}`.
-		return mr.expandURI(ctx, input)
+		expanded, err := mr.expandURI(ctx, input)
+		if err != nil {
+			return input, false, err
+		}
+		return expanded, true, err
 	}
-	expanded, changed, err := mr.expandURI(ctx, uri)
+	expanded, err := mr.expandURI(ctx, uri)
 	if err != nil {
 		return input, false, err
 	}
@@ -121,7 +125,7 @@ func (mr *Resolver) findAndExpandURI(ctx context.Context, input string) (any, bo
 	if err != nil {
 		return input, false, fmt.Errorf("expanding %v: %w", uri, err)
 	}
-	return strings.ReplaceAll(input, uri, repl), changed, err
+	return strings.ReplaceAll(input, uri, repl), true, err
 }
 
 // toString attempts to convert input to a string.
@@ -142,7 +146,7 @@ func toString(input any) (string, error) {
 	}
 }
 
-func (mr *Resolver) expandURI(ctx context.Context, input string) (any, bool, error) {
+func (mr *Resolver) expandURI(ctx context.Context, input string) (any, error) {
 	// strip ${ and }
 	uri := input[2 : len(input)-1]
 
@@ -152,19 +156,18 @@ func (mr *Resolver) expandURI(ctx context.Context, input string) (any, bool, err
 
 	lURI, err := newLocation(uri)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	if strings.Contains(lURI.opaqueValue, "$") {
-		return nil, false, fmt.Errorf("the uri %q contains unsupported characters ('$')", lURI.asString())
+		return nil, fmt.Errorf("the uri %q contains unsupported characters ('$')", lURI.asString())
 	}
 	ret, err := mr.retrieveValue(ctx, lURI)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	mr.closers = append(mr.closers, ret.Close)
-	val, err := ret.AsRaw()
-	return val, true, err
+	return ret.AsRaw()
 }
 
 type location struct {


### PR DESCRIPTION
expandURI can always be viewed as changing the value as long as no error is returned.