### PR TITLE
Update image version to latest #10407

### DIFF
--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -65,7 +65,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-agent-config.yaml"
-        image: otel/opentelemetry-collector:0.94.0
+        image: otel/opentelemetry-collector:latest
         name: otel-agent
         resources:
           limits:
@@ -183,7 +183,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-collector-config.yaml"
-        image: otel/opentelemetry-collector:0.94.0
+        image: otel/opentelemetry-collector:latest
         name: otel-collector
         resources:
           limits:


### PR DESCRIPTION
During the installation of otlp in recent days, it was found that the installed version is somewhat outdated, which is not conducive to users trying out the latest features. It's also unnecessary to modify the installation yaml file every time a new version is released. Would it be more appropriate to change it to "latest"?
