### PR TITLE
[chore][golangci-lint] Remove gosec excludes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,13 +119,6 @@ linters-settings:
           files:
             - "!**/*_test.go"
 
-  gosec:
-    excludes:
-      # https://github.com/open-telemetry/opentelemetry-collector/issues/10213
-      - G601
-      # https://github.com/open-telemetry/opentelemetry-collector/issues/10213
-      - G113
-
 linters:
   enable:
     - depguard


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The upstream issue was fixed by https://github.com/golangci/golangci-lint/pull/4748, which was included in release [`v1.59.0`](https://github.com/golangci/golangci-lint/releases/tag/v1.59.0) of `golangci-lint`. From local testing, we're pulling version `v1.59.0` of `golangci-lint`, so the issue should be resolved.

Local runtime with excludes:
```
$ .tools/golangci-lint run -v --enable-only gosec
...
INFO Execution took 1.866075148s
INFO Execution took 1.218805785s
INFO Execution took 1.09527985s
```
Local runtime without excludes:
```
$ .tools/golangci-lint run -v --enable-only gosec
...
INFO Execution took 2.244716429s
INFO Execution took 1.539717296s
INFO Execution took 1.530163777s
```

Note: I ran `.tools/golangci-lint cache clean` between each test to clean the cache and keep results as consistent as possible.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/10213