### PR TITLE
Print Span.TraceState() in debugexporter

### DIFF
--- a/.chloggen/print-tracestate.yaml
+++ b/.chloggen/print-tracestate.yaml
@@ -10,7 +10,7 @@ component: debugexporter
 note: Print Span.TraceState() when present.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [10421]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/print-tracestate.yaml
+++ b/.chloggen/print-tracestate.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component:
+component: debugexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Print Span.TraceState() when present.

--- a/.chloggen/print-tracestate.yaml
+++ b/.chloggen/print-tracestate.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Print Span.TraceState() when present.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Enables viewing sampling threshold information (as by OTEP 235 samplers).
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/internal/otlptext/testdata/traces/two_spans.out
+++ b/exporter/internal/otlptext/testdata/traces/two_spans.out
@@ -11,6 +11,7 @@ Span #0
     ID             : 1112131415161718
     Name           : operationA
     Kind           : Unspecified
+    TraceState     : ot=th:0
     Start time     : 2020-02-11 20:26:12.000000321 +0000 UTC
     End time       : 2020-02-11 20:26:13.000000789 +0000 UTC
     Status code    : Error
@@ -32,6 +33,7 @@ Span #1
     ID             : 
     Name           : operationB
     Kind           : Unspecified
+    TraceState     : ot=th:8
     Start time     : 2020-02-11 20:26:12.000000321 +0000 UTC
     End time       : 2020-02-11 20:26:13.000000789 +0000 UTC
     Status code    : Unset

--- a/exporter/internal/otlptext/testdata/traces/two_spans.out
+++ b/exporter/internal/otlptext/testdata/traces/two_spans.out
@@ -33,7 +33,6 @@ Span #1
     ID             : 
     Name           : operationB
     Kind           : Unspecified
-    TraceState     : ot=th:8
     Start time     : 2020-02-11 20:26:12.000000321 +0000 UTC
     End time       : 2020-02-11 20:26:13.000000789 +0000 UTC
     Status code    : Unset

--- a/exporter/internal/otlptext/traces.go
+++ b/exporter/internal/otlptext/traces.go
@@ -39,6 +39,7 @@ func (textTracesMarshaler) MarshalTraces(td ptrace.Traces) ([]byte, error) {
 				buf.logAttr("ID", span.SpanID())
 				buf.logAttr("Name", span.Name())
 				buf.logAttr("Kind", span.Kind().String())
+				buf.logAttr("TraceState", span.TraceState().AsRaw())
 				buf.logAttr("Start time", span.StartTimestamp().String())
 				buf.logAttr("End time", span.EndTimestamp().String())
 

--- a/exporter/internal/otlptext/traces.go
+++ b/exporter/internal/otlptext/traces.go
@@ -39,7 +39,9 @@ func (textTracesMarshaler) MarshalTraces(td ptrace.Traces) ([]byte, error) {
 				buf.logAttr("ID", span.SpanID())
 				buf.logAttr("Name", span.Name())
 				buf.logAttr("Kind", span.Kind().String())
-				buf.logAttr("TraceState", span.TraceState().AsRaw())
+				if ts := span.TraceState().AsRaw(); len(ts) != 0 {
+					buf.logAttr("TraceState", ts)
+				}
 				buf.logAttr("Start time", span.StartTimestamp().String())
 				buf.logAttr("End time", span.EndTimestamp().String())
 

--- a/pdata/testdata/trace.go
+++ b/pdata/testdata/trace.go
@@ -60,7 +60,6 @@ func fillSpanTwo(span ptrace.Span) {
 	span.SetName("operationB")
 	span.SetStartTimestamp(spanStartTimestamp)
 	span.SetEndTimestamp(spanEndTimestamp)
-	span.TraceState().FromRaw("ot=th:8") // 50% sampling
 	link0 := span.Links().AppendEmpty()
 	link0.Attributes().PutStr("span-link-attr", "span-link-attr-val")
 	link0.SetDroppedAttributesCount(4)

--- a/pdata/testdata/trace.go
+++ b/pdata/testdata/trace.go
@@ -37,6 +37,7 @@ func fillSpanOne(span ptrace.Span) {
 	span.SetStartTimestamp(spanStartTimestamp)
 	span.SetEndTimestamp(spanEndTimestamp)
 	span.SetDroppedAttributesCount(1)
+	span.TraceState().FromRaw("ot=th:0") // 100% sampling
 	span.SetTraceID([16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10})
 	span.SetSpanID([8]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18})
 	evs := span.Events()
@@ -59,6 +60,7 @@ func fillSpanTwo(span ptrace.Span) {
 	span.SetName("operationB")
 	span.SetStartTimestamp(spanStartTimestamp)
 	span.SetEndTimestamp(spanEndTimestamp)
+	span.TraceState().FromRaw("ot=th:8") // 50% sampling
 	link0 := span.Links().AppendEmpty()
 	link0.Attributes().PutStr("span-link-attr", "span-link-attr-val")
 	link0.SetDroppedAttributesCount(4)


### PR DESCRIPTION
#### Description
Span.TraceState() is not printed, but is a part of the OTel span data model.

#### Link to tracking issue
Part of 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31918

#### Testing
✅ 

#### Documentation
n/a
