### PR TITLE
Add goreleaser check and attempt update

### DIFF
--- a/.github/workflows/check-goreleaser.yaml
+++ b/.github/workflows/check-goreleaser.yaml
@@ -1,0 +1,29 @@
+name: Check GoReleaser Config
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ~1.21.5
+      - name: Check GoReleaser
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: check --verbose cmd/builder/.goreleaser.yml
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -36,4 +36,4 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
-  skip: true
+  disable: true

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -36,4 +36,4 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
-  disable: true
+  skip: true


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector/pull/10384 updated `goreleaser` to a new major version and this appears to have [broken the config](https://github.com/open-telemetry/opentelemetry-collector/actions/runs/9565775767/job/26369463094). This problem only became apparent during the release process since the config is not used otherwise.

This PR adds a github action to run `goreleaser check` on all PRs, since changes to the config may not be caught until release is attempted.

I've also included what may be the only necessary change to the config, by [renaming `changelog.skip` to `changelog.disable`](https://github.com/goreleaser/goreleaser/commit/29f30b623ef8f0a19607afab22b3f3a2f9f68172). This passes `goreleaser check` when run locally.

The `monorepo` section of the config fails locally, but the feature appears to require the Pro version so I'm unclear if it will pass with the OSS version.