### PR TITLE
Change builder release trigger to module tag

### DIFF
--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -3,7 +3,7 @@ name: Builder - Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'cmd/builder/v*'
 
 jobs:
   goreleaser:


### PR DESCRIPTION
This PR changes the trigger for releasing the builder to match the builder module tag. This allows us to release the builder separately by pushing a dedicated tag.