### PR TITLE
[chore] revert tag trigger change

### DIFF
--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -3,7 +3,7 @@ name: Builder - Release
 on:
   push:
     tags:
-      - 'cmd/builder/v*'
+      - 'v*'
 
 jobs:
   goreleaser:


### PR DESCRIPTION
This causes the goreleaser and gh release steps to conflict as the goreleaser will create a release for the builder tag, and gh release will try to create the same.

See https://github.com/open-telemetry/opentelemetry-collector/actions/runs/9568657405/job/26379389384 for more details