### PR TITLE
[confighttp] Add option to include query params in auth context

### DIFF
--- a/.chloggen/jpkroehling-add-query-params-to-authcontext-api.yaml
+++ b/.chloggen/jpkroehling-add-query-params-to-authcontext-api.yaml
@@ -1,0 +1,4 @@
+change_type: 'enhancement'
+component: confighttp
+note: Add option to include query params in auth context
+issues: [4806]

--- a/.chloggen/jpkroehling-add-query-params-to-authcontext.yaml
+++ b/.chloggen/jpkroehling-add-query-params-to-authcontext.yaml
@@ -1,0 +1,4 @@
+change_type: 'enhancement'
+component: confighttp
+note: Add option to include query params in auth context
+issues: [4806]

--- a/.chloggen/jpkroehling-add-query-params-to-authcontext.yaml
+++ b/.chloggen/jpkroehling-add-query-params-to-authcontext.yaml
@@ -1,4 +1,10 @@
-change_type: 'enhancement'
+change_type: 'breaking'
 component: confighttp
-note: Add option to include query params in auth context
+note: Auth data type signature has changed
+subtext: | 
+  As part of the linked PR, the `auth` attribute was moved from `configauth.Authentication` 
+  to a new `AuthConfig`, which contains a `configauth.Authentication`. For end-users, this
+  is a non-breaking change. For users of the API, create a new AuthConfig using the
+  `configauth.Authentication` instance that was being used before.
 issues: [4806]
+change_logs: [api]

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -82,6 +82,7 @@ will not be enabled.
 - `compression_algorithms`: configures the list of compression algorithms the server can accept. Default: ["", "gzip", "zstd", "zlib", "snappy", "deflate"]
 - [`tls`](../configtls/README.md)
 - [`auth`](../configauth/README.md)
+  - `request_params`: a list of query parameter names to add to the auth context, along with the HTTP headers
 
 You can enable [`attribute processor`][attribute-processor] to append any http header to span's attribute using custom key. You also need to enable the "include_metadata"
 
@@ -94,6 +95,8 @@ receivers:
       http:
         include_metadata: true
         auth:
+          request_params:
+          - token
           authenticator: some-authenticator-extension
         cors:
           allowed_origins:

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -291,7 +291,7 @@ type ServerConfig struct {
 	CORS *CORSConfig `mapstructure:"cors"`
 
 	// Auth for this receiver
-	Auth *configauth.Authentication `mapstructure:"auth"`
+	Auth *AuthConfig `mapstructure:"auth"`
 
 	// MaxRequestBodySize sets the maximum request body size in bytes. Default: 20MiB.
 	MaxRequestBodySize int64 `mapstructure:"max_request_body_size"`
@@ -306,6 +306,14 @@ type ServerConfig struct {
 
 	// CompressionAlgorithms configures the list of compression algorithms the server can accept. Default: ["", "gzip", "zstd", "zlib", "snappy", "deflate"]
 	CompressionAlgorithms []string `mapstructure:"compression_algorithms"`
+}
+
+type AuthConfig struct {
+	// Auth for this receiver.
+	*configauth.Authentication `mapstructure:"-"`
+
+	// RequestParameters is a list of parameters that should be extracted from the request and added to the context.
+	RequestParameters []string `mapstructure:"request_params"`
 }
 
 // ToListener creates a net.Listener.
@@ -387,7 +395,7 @@ func (hss *ServerConfig) ToServer(_ context.Context, host component.Host, settin
 			return nil, err
 		}
 
-		handler = authInterceptor(handler, server)
+		handler = authInterceptor(handler, server, hss.Auth.RequestParameters)
 	}
 
 	if hss.CORS != nil && len(hss.CORS.AllowedOrigins) > 0 {
@@ -467,9 +475,16 @@ type CORSConfig struct {
 	MaxAge int `mapstructure:"max_age"`
 }
 
-func authInterceptor(next http.Handler, server auth.Server) http.Handler {
+func authInterceptor(next http.Handler, server auth.Server, requestParams []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, err := server.Authenticate(r.Context(), r.Header)
+		sources := r.Header
+		query := r.URL.Query()
+		for _, param := range requestParams {
+			if val, ok := query[param]; ok {
+				sources[param] = val
+			}
+		}
+		ctx, err := server.Authenticate(r.Context(), sources)
 		if err != nil {
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -313,6 +313,7 @@ type AuthConfig struct {
 	*configauth.Authentication `mapstructure:"-"`
 
 	// RequestParameters is a list of parameters that should be extracted from the request and added to the context.
+	// When a parameter is found in both the query string and the header, the value from the query string will be used.
 	RequestParameters []string `mapstructure:"request_params"`
 }
 

--- a/extension/auth/server.go
+++ b/extension/auth/server.go
@@ -18,7 +18,7 @@ import (
 type Server interface {
 	extension.Extension
 
-	// Authenticate checks whether the given headers map contains valid auth data. Successfully authenticated calls will always return a nil error.
+	// Authenticate checks whether the given map contains valid auth data. Successfully authenticated calls will always return a nil error.
 	// When the authentication fails, an error must be returned and the caller must not retry. This function is typically called from interceptors,
 	// on behalf of receivers, but receivers can still call this directly if the usage of interceptors isn't suitable.
 	// The deadline and cancellation given to this function must be respected, but note that authentication data has to be part of the map, not context.
@@ -26,7 +26,7 @@ type Server interface {
 	// authentication data (if possible). This will allow other components in the pipeline to make decisions based on that data, such as routing based
 	// on tenancy as determined by the group membership, or passing through the authentication data to the next collector/backend.
 	// The context keys to be used are not defined yet.
-	Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error)
+	Authenticate(ctx context.Context, sources map[string][]string) (context.Context, error)
 }
 
 type defaultServer struct {
@@ -39,14 +39,14 @@ type defaultServer struct {
 type ServerOption func(*defaultServer)
 
 // ServerAuthenticateFunc defines the signature for the function responsible for performing the authentication based
-// on the given headers map. See Server.Authenticate.
-type ServerAuthenticateFunc func(ctx context.Context, headers map[string][]string) (context.Context, error)
+// on the given sources map. See Server.Authenticate.
+type ServerAuthenticateFunc func(ctx context.Context, sources map[string][]string) (context.Context, error)
 
-func (f ServerAuthenticateFunc) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
+func (f ServerAuthenticateFunc) Authenticate(ctx context.Context, sources map[string][]string) (context.Context, error) {
 	if f == nil {
 		return ctx, nil
 	}
-	return f(ctx, headers)
+	return f(ctx, sources)
 }
 
 // WithServerAuthenticate specifies which function to use to perform the authentication.

--- a/extension/zpagesextension/zpagesextension_test.go
+++ b/extension/zpagesextension/zpagesextension_test.go
@@ -78,8 +78,10 @@ func TestZPagesExtensionBadAuthExtension(t *testing.T) {
 	cfg := &Config{
 		confighttp.ServerConfig{
 			Endpoint: "localhost:0",
-			Auth: &configauth.Authentication{
-				AuthenticatorID: component.MustNewIDWithName("foo", "bar"),
+			Auth: &confighttp.AuthConfig{
+				Authentication: &configauth.Authentication{
+					AuthenticatorID: component.MustNewIDWithName("foo", "bar"),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds a new option to the ServerConfig's Auth option, allowing users to specify a list of query parameters to add to the sources of auth data, in addition to HTTP headers. Instead of simply adding all parameters, which might be numeruous, we require users to specify which ones to include.

Auth extensions don't need to be changed, but should document which attributes they expect to find in the context and how to configure confighttp to accomplish that.

Fixes #4806

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
