### PR TITLE
[chore] Remove telemetry from graph initialization

### DIFF
--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/service/internal/servicetelemetry"
 	"go.opentelemetry.io/collector/service/internal/status"
+	"go.opentelemetry.io/collector/service/internal/status/statustest"
 	"go.opentelemetry.io/collector/service/internal/testcomponents"
 	"go.opentelemetry.io/collector/service/pipelines"
 )
@@ -154,13 +155,13 @@ func TestGraphStartStop(t *testing.T) {
 				pg.componentGraph.SetEdge(simple.Edge{F: f, T: t})
 			}
 
-			require.NoError(t, pg.StartAll(ctx, componenttest.NewNopHost()))
+			require.NoError(t, pg.StartAll(ctx, componenttest.NewNopHost(), statustest.NewNopStatusReporter()))
 			for _, edge := range tt.edges {
 				assert.Greater(t, ctx.order[edge[0]], ctx.order[edge[1]])
 			}
 
 			ctx.order = map[component.ID]int{}
-			require.NoError(t, pg.ShutdownAll(ctx))
+			require.NoError(t, pg.ShutdownAll(ctx, statustest.NewNopStatusReporter()))
 			for _, edge := range tt.edges {
 				assert.Less(t, ctx.order[edge[0]], ctx.order[edge[1]])
 			}
@@ -188,11 +189,11 @@ func TestGraphStartStopCycle(t *testing.T) {
 	pg.componentGraph.SetEdge(simple.Edge{F: c1, T: e1})
 	pg.componentGraph.SetEdge(simple.Edge{F: c1, T: p1}) // loop back
 
-	err := pg.StartAll(context.Background(), componenttest.NewNopHost())
+	err := pg.StartAll(context.Background(), componenttest.NewNopHost(), statustest.NewNopStatusReporter())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `topo: no topological ordering: cyclic components`)
 
-	err = pg.ShutdownAll(context.Background())
+	err = pg.ShutdownAll(context.Background(), statustest.NewNopStatusReporter())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `topo: no topological ordering: cyclic components`)
 }
@@ -216,8 +217,8 @@ func TestGraphStartStopComponentError(t *testing.T) {
 		F: r1,
 		T: e1,
 	})
-	assert.EqualError(t, pg.StartAll(context.Background(), componenttest.NewNopHost()), "foo")
-	assert.EqualError(t, pg.ShutdownAll(context.Background()), "bar")
+	assert.EqualError(t, pg.StartAll(context.Background(), componenttest.NewNopHost(), statustest.NewNopStatusReporter()), "foo")
+	assert.EqualError(t, pg.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()), "bar")
 }
 
 func TestConnectorPipelinesGraph(t *testing.T) {
@@ -768,7 +769,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 
 			assert.Equal(t, len(test.pipelineConfigs), len(pg.pipelines))
 
-			assert.NoError(t, pg.StartAll(context.Background(), componenttest.NewNopHost()))
+			assert.NoError(t, pg.StartAll(context.Background(), componenttest.NewNopHost(), statustest.NewNopStatusReporter()))
 
 			mutatingPipelines := make(map[component.ID]bool, len(test.pipelineConfigs))
 
@@ -892,7 +893,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 			}
 
 			// Shut down the entire component graph
-			assert.NoError(t, pg.ShutdownAll(context.Background()))
+			assert.NoError(t, pg.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 
 			// Check each pipeline individually, ensuring that all components are stopped.
 			for pipelineID := range test.pipelineConfigs {
@@ -2148,8 +2149,8 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 			}
 			pipelines, err := Build(context.Background(), set)
 			assert.NoError(t, err)
-			assert.Error(t, pipelines.StartAll(context.Background(), componenttest.NewNopHost()))
-			assert.Error(t, pipelines.ShutdownAll(context.Background()))
+			assert.Error(t, pipelines.StartAll(context.Background(), componenttest.NewNopHost(), statustest.NewNopStatusReporter()))
+			assert.Error(t, pipelines.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 		})
 
 		t.Run(dt.String()+"/processor", func(t *testing.T) {
@@ -2162,8 +2163,8 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 			}
 			pipelines, err := Build(context.Background(), set)
 			assert.NoError(t, err)
-			assert.Error(t, pipelines.StartAll(context.Background(), componenttest.NewNopHost()))
-			assert.Error(t, pipelines.ShutdownAll(context.Background()))
+			assert.Error(t, pipelines.StartAll(context.Background(), componenttest.NewNopHost(), statustest.NewNopStatusReporter()))
+			assert.Error(t, pipelines.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 		})
 
 		t.Run(dt.String()+"/exporter", func(t *testing.T) {
@@ -2176,8 +2177,8 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 			}
 			pipelines, err := Build(context.Background(), set)
 			assert.NoError(t, err)
-			assert.Error(t, pipelines.StartAll(context.Background(), componenttest.NewNopHost()))
-			assert.Error(t, pipelines.ShutdownAll(context.Background()))
+			assert.Error(t, pipelines.StartAll(context.Background(), componenttest.NewNopHost(), statustest.NewNopStatusReporter()))
+			assert.Error(t, pipelines.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 		})
 
 		for _, dt2 := range dataTypes {
@@ -2196,8 +2197,8 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 				}
 				pipelines, err := Build(context.Background(), set)
 				assert.NoError(t, err)
-				assert.Error(t, pipelines.StartAll(context.Background(), componenttest.NewNopHost()))
-				assert.Error(t, pipelines.ShutdownAll(context.Background()))
+				assert.Error(t, pipelines.StartAll(context.Background(), componenttest.NewNopHost(), statustest.NewNopStatusReporter()))
+				assert.Error(t, pipelines.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 			})
 		}
 	}
@@ -2350,8 +2351,8 @@ func TestStatusReportedOnStartupShutdown(t *testing.T) {
 			}
 			pg.componentGraph.SetEdge(simple.Edge{F: e0, T: e1})
 
-			assert.Equal(t, tc.startupErr, pg.StartAll(context.Background(), componenttest.NewNopHost()))
-			assert.Equal(t, tc.shutdownErr, pg.ShutdownAll(context.Background()))
+			assert.Equal(t, tc.startupErr, pg.StartAll(context.Background(), componenttest.NewNopHost(), rep))
+			assert.Equal(t, tc.shutdownErr, pg.ShutdownAll(context.Background(), rep))
 			assertEqualStatuses(t, tc.expectedStatuses, actualStatuses)
 		})
 	}

--- a/service/internal/servicetelemetry/telemetry_settings.go
+++ b/service/internal/servicetelemetry/telemetry_settings.go
@@ -37,7 +37,7 @@ type TelemetrySettings struct {
 
 	// Status contains a Reporter that allows the service to report status on behalf of a
 	// component.
-	Status *status.Reporter
+	Status status.Reporter
 }
 
 // ToComponentTelemetrySettings returns a TelemetrySettings for a specific component derived from

--- a/service/internal/status/statustest/statustest.go
+++ b/service/internal/status/statustest/statustest.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package statustest // import "go.opentelemetry.io/collector/service/internal/status/statustest"
+
+import (
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/service/internal/status"
+)
+
+func NewNopStatusReporter() status.Reporter {
+	return &nopStatusReporter{}
+}
+
+type nopStatusReporter struct{}
+
+func (r *nopStatusReporter) Ready() {}
+
+func (r *nopStatusReporter) ReportStatus(*component.InstanceID, *component.StatusEvent) {}
+
+func (r *nopStatusReporter) ReportOKIfStarting(*component.InstanceID) {}

--- a/service/internal/status/statustest/statustest_test.go
+++ b/service/internal/status/statustest/statustest_test.go
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package statustest // import "go.opentelemetry.io/collector/service/internal/status/statustest"
+
+import "testing"
+
+func TestNopStatusReporter(*testing.T) {
+	nop := NewNopStatusReporter()
+	nop.Ready()
+	nop.ReportOKIfStarting(nil)
+	nop.ReportStatus(nil, nil)
+}

--- a/service/service.go
+++ b/service/service.go
@@ -141,11 +141,22 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		}),
 	}
 
-	// process the configuration and initialize the pipeline
-	if err = srv.initExtensionsAndPipeline(ctx, set, cfg); err != nil {
-		// If pipeline initialization fails then shut down telemetry
+	if err = srv.initGraph(ctx, set, cfg); err != nil {
 		err = multierr.Append(err, srv.shutdownTelemetry(ctx))
 		return nil, err
+	}
+
+	// process the configuration and initialize the pipeline
+	if err = srv.initExtensions(ctx, cfg.Extensions); err != nil {
+		err = multierr.Append(err, srv.shutdownTelemetry(ctx))
+		return nil, err
+	}
+
+	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && cfg.Telemetry.Metrics.Address != "" {
+		// The process telemetry initialization requires the ballast size, which is available after the extensions are initialized.
+		if err = proctelemetry.RegisterProcessMetrics(srv.telemetrySettings, getBallastSize(srv.host)); err != nil {
+			return nil, fmt.Errorf("failed to register process metrics: %w", err)
+		}
 	}
 
 	return srv, nil
@@ -197,7 +208,7 @@ func (srv *Service) Start(ctx context.Context) error {
 		}
 	}
 
-	if err := srv.host.pipelines.StartAll(ctx, srv.host); err != nil {
+	if err := srv.host.pipelines.StartAll(ctx, srv.host, srv.telemetrySettings.Status); err != nil {
 		return fmt.Errorf("cannot start pipelines: %w", err)
 	}
 
@@ -248,7 +259,7 @@ func (srv *Service) Shutdown(ctx context.Context) error {
 		errs = multierr.Append(errs, fmt.Errorf("failed to notify that pipeline is not ready: %w", err))
 	}
 
-	if err := srv.host.pipelines.ShutdownAll(ctx); err != nil {
+	if err := srv.host.pipelines.ShutdownAll(ctx, srv.telemetrySettings.Status); err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown pipelines: %w", err))
 	}
 
@@ -263,19 +274,24 @@ func (srv *Service) Shutdown(ctx context.Context) error {
 	return errs
 }
 
-// Creates extensions and then builds the pipeline graph.
-func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings, cfg Config) error {
+// Creates extensions.
+func (srv *Service) initExtensions(ctx context.Context, cfg extensions.Config) error {
 	var err error
 	extensionsSettings := extensions.Settings{
 		Telemetry:  srv.telemetrySettings,
 		BuildInfo:  srv.buildInfo,
 		Extensions: srv.host.extensions,
 	}
-	if srv.host.serviceExtensions, err = extensions.New(ctx, extensionsSettings, cfg.Extensions); err != nil {
+	if srv.host.serviceExtensions, err = extensions.New(ctx, extensionsSettings, cfg); err != nil {
 		return fmt.Errorf("failed to build extensions: %w", err)
 	}
+	return nil
+}
 
-	pSet := graph.Settings{
+// Creates the pipeline graph.
+func (srv *Service) initGraph(ctx context.Context, set Settings, cfg Config) error {
+	var err error
+	if srv.host.pipelines, err = graph.Build(ctx, graph.Settings{
 		Telemetry:        srv.telemetrySettings,
 		BuildInfo:        srv.buildInfo,
 		ReceiverBuilder:  set.Receivers,
@@ -283,19 +299,9 @@ func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings,
 		ExporterBuilder:  set.Exporters,
 		ConnectorBuilder: set.Connectors,
 		PipelineConfigs:  cfg.Pipelines,
-	}
-
-	if srv.host.pipelines, err = graph.Build(ctx, pSet); err != nil {
+	}); err != nil {
 		return fmt.Errorf("failed to build pipelines: %w", err)
 	}
-
-	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && cfg.Telemetry.Metrics.Address != "" {
-		// The process telemetry initialization requires the ballast size, which is available after the extensions are initialized.
-		if err = proctelemetry.RegisterProcessMetrics(srv.telemetrySettings, getBallastSize(srv.host)); err != nil {
-			return fmt.Errorf("failed to register process metrics: %w", err)
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This PR refactors the service graph initialization so that the graph can be assembled without the intention to start it.
1. Do not save telemetry on the graph. The only use of this was for reporting component status. Instead, pass in a reporter when starting or stopping. Correspondingly, add an internal `statustest` package to make it easy to pass in a status reporter in tests.
2. Decouple graph building from extension building. There isn't any direct relationship so these things should be separated.