### PR TITLE
[otlpexporter] support validation for dns:// and dns:///

### DIFF
--- a/.chloggen/codeboten_remove-additional-slash.yaml
+++ b/.chloggen/codeboten_remove-additional-slash.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: configgrpc
+component: otlpexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Update validation to support both dns:// and dns:///

--- a/.chloggen/codeboten_remove-additional-slash.yaml
+++ b/.chloggen/codeboten_remove-additional-slash.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update validation to support both dns:// and dns:///
+
+# One or more tracking issues or pull requests related to the change
+issues: [10449]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -49,8 +50,9 @@ func (c *Config) sanitizedEndpoint() string {
 		return strings.TrimPrefix(c.Endpoint, "http://")
 	case strings.HasPrefix(c.Endpoint, "https://"):
 		return strings.TrimPrefix(c.Endpoint, "https://")
-	case strings.HasPrefix(c.Endpoint, "dns:///"):
-		return strings.TrimPrefix(c.Endpoint, "dns:///")
+	case strings.HasPrefix(c.Endpoint, "dns://"):
+		r := regexp.MustCompile("^dns://[/]?")
+		return r.ReplaceAllString(c.Endpoint, "")
 	default:
 		return c.Endpoint
 	}

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -134,6 +134,17 @@ func TestUnmarshalInvalidConfig(t *testing.T) {
 func TestValidDNSEndpoint(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = "dns:///backend.example.com:4317"
+	cfg.Endpoint = "dns://backend.example.com:4317"
 	assert.NoError(t, cfg.Validate())
+}
+
+func TestSanitizeEndpoint(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Endpoint = "dns://backend.example.com:4317"
+	assert.Equal(t, "backend.example.com:4317", cfg.sanitizedEndpoint())
+	cfg.Endpoint = "dns:///backend.example.com:4317"
+	assert.Equal(t, "backend.example.com:4317", cfg.sanitizedEndpoint())
+	cfg.Endpoint = "dns:////backend.example.com:4317"
+	assert.Equal(t, "/backend.example.com:4317", cfg.sanitizedEndpoint())
 }

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -134,7 +134,7 @@ func TestUnmarshalInvalidConfig(t *testing.T) {
 func TestValidDNSEndpoint(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = "dns://backend.example.com:4317"
+	cfg.Endpoint = "dns://authority/backend.example.com:4317"
 	assert.NoError(t, cfg.Validate())
 }
 

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -141,8 +141,8 @@ func TestValidDNSEndpoint(t *testing.T) {
 func TestSanitizeEndpoint(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = "dns://backend.example.com:4317"
-	assert.Equal(t, "backend.example.com:4317", cfg.sanitizedEndpoint())
+	cfg.Endpoint = "dns://authority/backend.example.com:4317"
+	assert.Equal(t, "authority/backend.example.com:4317", cfg.sanitizedEndpoint())
 	cfg.Endpoint = "dns:///backend.example.com:4317"
 	assert.Equal(t, "backend.example.com:4317", cfg.sanitizedEndpoint())
 	cfg.Endpoint = "dns:////backend.example.com:4317"


### PR DESCRIPTION
This allows users to continue using the recommended dns://authority/host:port notation when needing to specify a custom authority.
    
Fixes #10449