### PR TITLE
[builder] more information for missing gomod error

### DIFF
--- a/.chloggen/builder-empty-gomod-field.yaml
+++ b/.chloggen/builder-empty-gomod-field.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: provide context when a module in the config is missing its gomod value
+
+# One or more tracking issues or pull requests related to the change
+issues: [10474]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -19,8 +19,8 @@ import (
 
 const defaultOtelColVersion = "0.104.0"
 
-// ErrInvalidGoMod indicates an invalid gomod
-var ErrInvalidGoMod = errors.New("invalid gomod specification for module")
+// ErrMissingGoMod indicates an empty gomod field
+var ErrMissingGoMod = errors.New("missing gomod specification for module")
 
 // Config holds the builder's configuration
 type Config struct {
@@ -115,14 +115,14 @@ func NewDefaultConfig() Config {
 func (c *Config) Validate() error {
 	var providersError error
 	if c.Providers != nil {
-		providersError = validateModules(*c.Providers)
+		providersError = validateModules("provider", *c.Providers)
 	}
 	return multierr.Combine(
-		validateModules(c.Extensions),
-		validateModules(c.Receivers),
-		validateModules(c.Exporters),
-		validateModules(c.Processors),
-		validateModules(c.Connectors),
+		validateModules("extension", c.Extensions),
+		validateModules("receiver", c.Receivers),
+		validateModules("exporter", c.Exporters),
+		validateModules("processor", c.Processors),
+		validateModules("connector", c.Connectors),
 		providersError,
 	)
 }
@@ -235,10 +235,10 @@ func (c *Config) ParseModules() error {
 	return nil
 }
 
-func validateModules(mods []Module) error {
-	for _, mod := range mods {
+func validateModules(name string, mods []Module) error {
+	for i, mod := range mods {
 		if mod.GoMod == "" {
-			return fmt.Errorf("module %q: %w", mod.GoMod, ErrInvalidGoMod)
+			return fmt.Errorf("%s module at index %v: %w", name, i, ErrMissingGoMod)
 		}
 	}
 	return nil

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -79,7 +79,7 @@ func TestModuleFromCore(t *testing.T) {
 	assert.True(t, strings.HasPrefix(cfg.Extensions[0].Name, "otlpreceiver"))
 }
 
-func TestInvalidModule(t *testing.T) {
+func TestMissingModule(t *testing.T) {
 	type invalidModuleTest struct {
 		cfg Config
 		err error
@@ -89,11 +89,20 @@ func TestInvalidModule(t *testing.T) {
 		{
 			cfg: Config{
 				Logger: zap.NewNop(),
+				Providers: &[]Module{{
+					Import: "invalid",
+				}},
+			},
+			err: ErrMissingGoMod,
+		},
+		{
+			cfg: Config{
+				Logger: zap.NewNop(),
 				Extensions: []Module{{
 					Import: "invalid",
 				}},
 			},
-			err: ErrInvalidGoMod,
+			err: ErrMissingGoMod,
 		},
 		{
 			cfg: Config{
@@ -102,7 +111,7 @@ func TestInvalidModule(t *testing.T) {
 					Import: "invalid",
 				}},
 			},
-			err: ErrInvalidGoMod,
+			err: ErrMissingGoMod,
 		},
 		{
 			cfg: Config{
@@ -111,7 +120,7 @@ func TestInvalidModule(t *testing.T) {
 					Import: "invali",
 				}},
 			},
-			err: ErrInvalidGoMod,
+			err: ErrMissingGoMod,
 		},
 		{
 			cfg: Config{
@@ -120,7 +129,16 @@ func TestInvalidModule(t *testing.T) {
 					Import: "invalid",
 				}},
 			},
-			err: ErrInvalidGoMod,
+			err: ErrMissingGoMod,
+		},
+		{
+			cfg: Config{
+				Logger: zap.NewNop(),
+				Connectors: []Module{{
+					Import: "invalid",
+				}},
+			},
+			err: ErrMissingGoMod,
 		},
 	}
 


### PR DESCRIPTION
#### Description
improving an error message - a missing gomod field would be reported but without informing where in the config the field is missing.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10474

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests pass, added some tests for missing cases, manually tested

new error looks like:
```
../../bin/ocb_darwin_amd64 --config=./default.yaml
2024-06-27T11:39:10.316-0700	INFO	internal/command.go:125	OpenTelemetry Collector Builder	{"version": "", "date": "unknown"}
2024-06-27T11:39:10.319-0700	INFO	internal/command.go:161	Using config file	{"path": "./default.yaml"}
Error: invalid configuration: receiver module at index 0: missing gomod specification for module; provider module at index 2: missing gomod specification for module
```
