### PR TITLE
fix: remove extra closing parenthesis in sub-config error

### DIFF
--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -137,7 +137,7 @@ func (l *Conf) Sub(key string) (*Conf, error) {
 		return NewFromStringMap(v), nil
 	}
 
-	return nil, fmt.Errorf("unexpected sub-config value kind for key:%s value:%v kind:%v)", key, data, reflect.TypeOf(data).Kind())
+	return nil, fmt.Errorf("unexpected sub-config value kind for key:%s value:%v kind:%v", key, data, reflect.TypeOf(data).Kind())
 }
 
 // ToStringMap creates a map[string]any from a Parser.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Removed an extra closing parenthesis. This corrects the formatting of the error message for unexpected sub-config value kinds.

Found in: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33268/files#diff-9137db5fde5eb0d6870425c0023cec1a5bdfe92f58f8a72e278b55635afc6e95R48

<!-- Issue number if applicable -->
#### Link to tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
