### PR TITLE
[chore] Fix pprofile and testdata

### DIFF
--- a/pdata/pprofile/go.mod
+++ b/pdata/pprofile/go.mod
@@ -2,8 +2,6 @@ module go.opentelemetry.io/collector/pdata/pprofile
 
 go 1.21.0
 
-toolchain go1.21.11
-
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/pdata v1.10.0

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -4,7 +4,7 @@ go 1.21.0
 
 require (
 	go.opentelemetry.io/collector/pdata v1.10.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.103.0
+	go.opentelemetry.io/collector/pdata/pprofile v0.0.0-20240628190926-ee4eb85f58e9
 )
 
 require (

--- a/versions.yaml
+++ b/versions.yaml
@@ -9,7 +9,6 @@ module-sets:
       - go.opentelemetry.io/collector/pdata
       - go.opentelemetry.io/collector/config/configopaque
       - go.opentelemetry.io/collector/config/configcompression
-      - go.opentelemetry.io/collector/config/configretry
   beta:
     version: v0.103.0
     modules:
@@ -46,7 +45,6 @@ module-sets:
       - go.opentelemetry.io/collector/extension/zpagesextension
       - go.opentelemetry.io/collector/extension/memorylimiterextension
       - go.opentelemetry.io/collector/otelcol
-      - go.opentelemetry.io/collector/otelcol/otelcoltest
       - go.opentelemetry.io/collector/pdata/pprofile
       - go.opentelemetry.io/collector/pdata/testdata
       - go.opentelemetry.io/collector/processor
@@ -58,9 +56,11 @@ module-sets:
       - go.opentelemetry.io/collector/semconv
       - go.opentelemetry.io/collector/service
       - go.opentelemetry.io/collector/filter
+      - go.opentelemetry.io/collector/config/configretry
 
 excluded-modules:
   - go.opentelemetry.io/collector/cmd/otelcorecol
   - go.opentelemetry.io/collector/internal/e2e
   - go.opentelemetry.io/collector/internal/tools
   - go.opentelemetry.io/collector/confmap/internal/e2e
+  - go.opentelemetry.io/collector/otelcol/otelcoltest


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Ran into an issue in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33813 where `pdata/testdata` [isn't correctly importing `pprofile`](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/9717762507/job/26824275117?pr=33813) and I think it is because `testdata` was using a version that `pprofile` was never tagged with.
