### PR TITLE
[mdatagen] bugfix: fix generated package test when skipping goleak, because os package import is forgotten

### DIFF
--- a/cmd/mdatagen/templates/package_test.go.tmpl
+++ b/cmd/mdatagen/templates/package_test.go.tmpl
@@ -3,6 +3,9 @@
 package {{ if isCommand -}}main{{ else }}{{ .Package }}{{- end }}
 
 import (
+    {{- if .Tests.GoLeak.Skip }}
+    "os"
+    {{- end }}
 	"testing"
 
     {{- if not .Tests.GoLeak.Skip }}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When `tests.goleak.skip` flag is set to true, the generated_package_test.go file looks like the following image.

<img width="457" alt="スクリーンショット 2024-06-30 062940" src="https://github.com/open-telemetry/opentelemetry-collector/assets/32762324/5ff948b7-331c-4444-8407-fdb3b93d8a14">

Since `import os` statement is missing, you fail to run the test. I added the missing import in this PR.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Compare the generated generated_package_test.go when tests.goleak.skip flag is toggle from false to true.

**before**

```diff
--- a/receiver/runnreceiver/generated_package_test.go
+++ b/receiver/runnreceiver/generated_package_test.go
@@ -3,10 +3,10 @@
 package runnreceiver

 import (
-       "go.uber.org/goleak"
        "testing"
 )

 func TestMain(m *testing.M) {
-       goleak.VerifyTestMain(m)
+       // skipping goleak test as per metadata.yml configuration
+       os.Exit(m.Run())
 }
```

**after**

```diff
--- a/receiver/runnreceiver/generated_package_test.go
+++ b/receiver/runnreceiver/generated_package_test.go
@@ -3,10 +3,11 @@
 package runnreceiver

 import (
-       "go.uber.org/goleak"
+       "os"
        "testing"
 )

 func TestMain(m *testing.M) {
-       goleak.VerifyTestMain(m)
+       // skipping goleak test as per metadata.yml configuration
+       os.Exit(m.Run())
 }
```
