### PR TITLE
[telemetry] Add ability to set service.name for spans emitted by the Collector

### DIFF
--- a/.chloggen/jpkroehling_fix-servicename-own-telemetry.yaml
+++ b/.chloggen/jpkroehling_fix-servicename-own-telemetry.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: service/telemetry
+note: Add ability to set service.name for spans emitted by the Collector
+issues: [10489]

--- a/service/telemetry/factory.go
+++ b/service/telemetry/factory.go
@@ -51,9 +51,9 @@ func NewFactory() Factory {
 			c := *cfg.(*Config)
 			return newLogger(c.Logs, set.ZapOptions)
 		}),
-		internal.WithTracerProvider(func(ctx context.Context, _ Settings, cfg component.Config) (trace.TracerProvider, error) {
+		internal.WithTracerProvider(func(ctx context.Context, set Settings, cfg component.Config) (trace.TracerProvider, error) {
 			c := *cfg.(*Config)
-			return newTracerProvider(ctx, c)
+			return newTracerProvider(ctx, set, c)
 		}),
 	)
 }

--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -31,7 +31,14 @@ func newTracerProvider(ctx context.Context, set Settings, cfg Config) (trace.Tra
 		string(semconv.ServiceNameKey): set.BuildInfo.Version,
 	}
 	for k, v := range cfg.Resource {
-		attrs[k] = *v
+		if v != nil {
+			attrs[k] = *v
+		}
+
+		// the new value is nil, delete the existing key
+		if _, ok := attrs[k]; ok && v == nil {
+			delete(attrs, k)
+		}
 	}
 	sch := semconv.SchemaURL
 	res := config.Resource{

--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"errors"
 
-	semconv "go.opentelemetry.io/collector/semconv/v1.25.0"
 	"go.opentelemetry.io/contrib/config"
 	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -27,17 +27,16 @@ var (
 
 // New creates a new Telemetry from Config.
 func newTracerProvider(ctx context.Context, set Settings, cfg Config) (trace.TracerProvider, error) {
-	attrs := map[string]any{}
+	attrs := map[string]interface{}{
+		string(semconv.ServiceNameKey): set.BuildInfo.Version,
+	}
 	for k, v := range cfg.Resource {
 		attrs[k] = *v
 	}
 	sch := semconv.SchemaURL
 	res := config.Resource{
-		SchemaUrl: &sch,
-		Attributes: &config.Attributes{
-			ServiceName:          &set.BuildInfo.Command,
-			AdditionalProperties: attrs,
-		},
+		SchemaUrl:  &sch,
+		Attributes: attrs,
 	}
 
 	sdk, err := config.NewSDK(


### PR DESCRIPTION
#### Description
This PR bridges the config that is exposed to Collector users to the internal format expected by the config helpers around the tracer provider.

#### Link to tracking issue
Fixes #10489

#### Testing
Manual testing performed.

Config:
```yaml
receivers:
  otlp:
    protocols:
      http:
      grpc:

exporters:
  debug:

service:
  pipelines:
    traces:
      receivers: [otlp]
      exporters: [debug]
    metrics:
      receivers: [otlp]
      exporters: [debug]
    logs:
      receivers: [otlp]
      exporters: [debug]
  telemetry:
    traces:
      processors:
        - batch:
            schedule_delay: 1000
            exporter:
              otlp:
                endpoint: https://otlp-gateway-prod-eu-west-2.grafana.net/otlp/v1/traces
                protocol: http/protobuf
                headers:
                  Authorization: "Basic ..."
    metrics:
      level: detailed
      readers:
        - periodic:
            exporter:
              otlp:
                endpoint: https://otlp-gateway-prod-eu-west-2.grafana.net/otlp/v1/metrics
                protocol: http/protobuf
                headers:
                  Authorization: "Basic ..."
    resource:
      "service.name": "otelcol-own-telemetry"
```

Sent this telemetry to the collector: 
```console
telemetrygen traces --traces 1 --otlp-insecure --otlp-attributes='cookbook="own-telemetry"'
```

Resulting in this:

![image](https://github.com/open-telemetry/opentelemetry-collector/assets/13387/b55d281b-8941-4b78-9f16-c08f495b6e89)


#### Documentation
None.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
