### PR TITLE
[chore] Add for-all make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,16 @@ gotest-with-cover:
 goporto: $(PORTO)
 	$(PORTO) -w --include-internal --skip-dirs "^cmd/mdatagen/third_party$$" ./
 
+.PHONY: for-all
+for-all:
+	@echo "running $${CMD} in root"
+	@$${CMD}
+	@set -e; for dir in $(GOMODULES); do \
+	  (cd "$${dir}" && \
+	  	echo "running $${CMD} in $${dir}" && \
+	 	$${CMD} ); \
+	done
+
 .PHONY: golint
 golint:
 	@$(MAKE) for-all-target TARGET="lint"


### PR DESCRIPTION
Same as we have in contrib. Sometimes it's helpful to run a specific command in all modules not just a make target. For example, `CMD="go mod edit -replace go.opentelemetry.io/otel/sdk/metric=../opentelemetry-go/sdk/metric" make for-all` to debug go library issues.
