### PR TITLE
[chore] Update the Collector target audiences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,12 @@ End-users are the target audience for our binary distributions, as made availabl
 [opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) repository, as
 well as distributions created using the [OpenTelemetry Collector
 Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder). To them, stability in the
-behavior is important, be it runtime or configuration. They are more numerous and harder to get in touch with, making
-our changes to the Collector more disruptive to them than to other audiences. As a general rule, whenever you are
-developing OpenTelemetry Collector components (extensions, receivers, processors, exporters, connectors), you should
-have end-users' interests in mind. Similarly, changes to code within packages like `config` will have an impact on this
-audience. Make sure to cause minimal disruption when doing changes here.
+behavior is important, be it runtime, configuration or [internal
+telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/). They are more numerous and harder to get in
+touch with, making our changes to the Collector more disruptive to them than to other audiences. As a general rule,
+whenever you are developing OpenTelemetry Collector components (extensions, receivers, processors, exporters,
+connectors), you should have end-users' interests in mind. Similarly, changes to code within packages like `config` will
+have an impact on this audience. Make sure to cause minimal disruption when doing changes here.
 
 ### Component developers
 
@@ -33,7 +34,7 @@ Component developers create new extensions, receivers, processors, exporters and
 OpenTelemetry Collector. They are the primary audience for the opentelemetry-collector repository's public Go API. A
 significant part of them will contribute to opentelemetry-collector-contrib. In addition to the end-user aspect
 mentioned above, this audience also cares about Go API compatibility of Go modules such as the ones in the `pdata`,
-`component`, `consumer`, `confmap`, `exporterhelper` and other modules, even though such changes wouldn't cause any
+`component`, `consumer`, `confmap`, `exporterhelper`, `config*` modules and others, even though such changes wouldn't cause any
 impact to end-users. See the "Breaking changes" in this document for more information on how to perform changes
 affecting this audience.
 
@@ -42,7 +43,7 @@ affecting this audience.
 A third audience uses the OpenTelemetry Collector as a library to build their own distributions or other projects based
 on the Collector. This audience is the main consumer of modules such as `service` or `otelcol`. They also share the same
 concerns as component developers regarding Go API compatibility, and are interested in behavior stability as end-users
-are.
+are. These are our most advanced users and are the most equipped to deal with disruptive changes.
 
 ## How to structure PRs to get expedient reviews?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,33 +5,44 @@ meeting](https://github.com/open-telemetry/community#special-interest-groups).
 
 ## Target audiences
 
-The OpenTelemetry Collector has two main target audiences:
+The OpenTelemetry Collector has three main target audiences:
 
-1. End-users, aiming to use an OpenTelemetry Collector binary.
-1. Collector distributions, consuming the APIs exposed by the OpenTelemetry core repository. Distributions can be an
-official OpenTelemetry community project, such as the OpenTelemetry Collector "core" and "contrib", or external
-distributions, such as other open-source projects building on top of the Collector or vendor-specific distributions.
+1. *End-users*, aiming to use an OpenTelemetry Collector binary.
+1. *Component developers*, consuming the Go APIs to create components compatible with the OpenTelemetry Collector Builder.
+1. *Collector library users*, consuming other Go APIs exposed by the opentelemetry-collector repository, for example to
+   build custom distributions or other projects building on top of the Collector Go APIs.
+
+When the needs of these audiences conflict, end-users should be prioritized, followed by component developers, and
+finally Collector library users.
 
 ### End-users
 
 End-users are the target audience for our binary distributions, as made available via the
-[opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) repository. To
-them, stability in the behavior is important, be it runtime or configuration. They are more numerous and harder to get
-in touch with, making our changes to the collector more disruptive to them than to other audiences. As a general rule,
-whenever you are developing OpenTelemetry Collector components (extensions, receivers, processors, exporters), you
-should have end-users' interests in mind. Similarly, changes to code within packages like `config` will have an impact
-on this audience. Make sure to cause minimal disruption when doing changes here.
+[opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) repository, as
+well as distributions created using the [OpenTelemetry Collector
+Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder). To them, stability in the
+behavior is important, be it runtime or configuration. They are more numerous and harder to get in touch with, making
+our changes to the Collector more disruptive to them than to other audiences. As a general rule, whenever you are
+developing OpenTelemetry Collector components (extensions, receivers, processors, exporters, connectors), you should
+have end-users' interests in mind. Similarly, changes to code within packages like `config` will have an impact on this
+audience. Make sure to cause minimal disruption when doing changes here.
 
-### Collector distributions
+### Component developers
 
-In this capacity, the opentelemetry-collector repository's public Go types, functions, and interfaces act as an API for
-other projects. In addition to the end-user aspect mentioned above, this audience also cares about API compatibility,
-making them susceptible to our refactorings, even though such changes wouldn't cause any impact to end-users. See the
-"Breaking changes" in this document for more information on how to perform changes affecting this audience.
+Component developers create new extensions, receivers, processors, exporters and connectors to be used with the
+OpenTelemetry Collector. They are the primary audience for the opentelemetry-collector repository's public Go API. A
+significant part of them will contribute to opentelemetry-collector-contrib. In addition to the end-user aspect
+mentioned above, this audience also cares about Go API compatibility of Go modules such as the ones in the `pdata`,
+`component`, `consumer`, `confmap`, `exporterhelper` and other modules, even though such changes wouldn't cause any
+impact to end-users. See the "Breaking changes" in this document for more information on how to perform changes
+affecting this audience.
 
-This audience might use tools like the
-[opentelemetry-collector-builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) as
-part of their delivery pipeline. Be mindful that changes there might cause disruption to this audience.
+### Collector library users
+
+A third audience uses the OpenTelemetry Collector as a library to build their own distributions or other projects based
+on the Collector. This audience is the main consumer of modules such as `service` or `otelcol`. They also share the same
+concerns as component developers regarding Go API compatibility, and are interested in behavior stability as end-users
+are.
 
 ## How to structure PRs to get expedient reviews?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ affecting this audience.
 
 A third audience uses the OpenTelemetry Collector as a library to build their own distributions or other projects based
 on the Collector. This audience is the main consumer of modules such as `service` or `otelcol`. They also share the same
-concerns as component developers regarding Go API compatibility, and are interested in behavior stability as end-users
-are. These are our most advanced users and are the most equipped to deal with disruptive changes.
+concerns as component developers regarding Go API compatibility, and are also interested in behavior stability. These
+are our most advanced users and are the most equipped to deal with disruptive changes.
 
 ## How to structure PRs to get expedient reviews?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ OpenTelemetry Collector. They are the primary audience for the opentelemetry-col
 significant part of them will contribute to opentelemetry-collector-contrib. In addition to the end-user aspect
 mentioned above, this audience also cares about Go API compatibility of Go modules such as the ones in the `pdata`,
 `component`, `consumer`, `confmap`, `exporterhelper`, `config*` modules and others, even though such changes wouldn't cause any
-impact to end-users. See the "Breaking changes" in this document for more information on how to perform changes
+impact to end-users. See the [Breaking changes](#breaking-changes) in this document for more information on how to perform changes
 affecting this audience.
 
 ### Collector library users


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Reworks 'Target audiences' section to:

1. Reflect the three audiences we have today, distinguishing between component developers and Collector library users
2. Reflect that we encourage end-users to use the OpenTelemetry Collector Builder and that builder compatibility should be a concern when thinking about binary end-users

#### Link to tracking issue

Relates to #10004
