### PR TITLE
[chore] Use different name for telemetry level key

### DIFF
--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	zapKeyTelemetryAddress = "address"
-	zapKeyTelemetryLevel   = "level"
+	zapKeyTelemetryLevel   = "metrics level"
 )
 
 type meterProvider struct {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Renames key to avoid conflict in JSON format.

#### Link to tracking issue

Fixes #10537
