### PR TITLE
[chore] Use string for unit type

### DIFF
--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -110,7 +110,7 @@ metrics:
   optional.metric:
     enabled: false
     description: "[DEPRECATED] Gauge double metric disabled by default."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr]
@@ -155,7 +155,7 @@ telemetry:
     batch_size_trigger_send:
       enabled: true
       description: Number of times the batch was sent due to a size trigger
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -178,7 +178,7 @@ telemetry:
       enabled: true
       description: This metric is optional and therefore not initialized in NewTelemetryBuilder.
       extended_documentation: For example this metric only exists if feature A is enabled.
-      unit: 1
+      unit: "1"
       optional: true
       gauge:
         async: true

--- a/cmd/mdatagen/testdata/invalid_type_attr.yaml
+++ b/cmd/mdatagen/testdata/invalid_type_attr.yaml
@@ -18,7 +18,7 @@ metrics:
   metric:
     enabled: true
     description: Metric.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [used_attr]

--- a/cmd/mdatagen/testdata/no_type_attr.yaml
+++ b/cmd/mdatagen/testdata/no_type_attr.yaml
@@ -17,7 +17,7 @@ metrics:
   metric:
     enabled: true
     description: Metric.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [used_attr]

--- a/cmd/mdatagen/testdata/unused_attribute.yaml
+++ b/cmd/mdatagen/testdata/unused_attribute.yaml
@@ -23,7 +23,7 @@ metrics:
   metric:
     enabled: true
     description: Metric.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [used_attr]

--- a/exporter/exporterhelper/metadata.yaml
+++ b/exporter/exporterhelper/metadata.yaml
@@ -12,7 +12,7 @@ telemetry:
     exporter_sent_spans:
       enabled: true
       description: Number of spans successfully sent to destination.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -20,7 +20,7 @@ telemetry:
     exporter_send_failed_spans:
       enabled: true
       description: Number of spans in failed attempts to send to destination.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -28,7 +28,7 @@ telemetry:
     exporter_enqueue_failed_spans:
       enabled: true
       description: Number of spans failed to be added to the sending queue.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -36,7 +36,7 @@ telemetry:
     exporter_sent_metric_points:
       enabled: true
       description: Number of metric points successfully sent to destination.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -44,7 +44,7 @@ telemetry:
     exporter_send_failed_metric_points:
       enabled: true
       description: Number of metric points in failed attempts to send to destination.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -52,7 +52,7 @@ telemetry:
     exporter_enqueue_failed_metric_points:
       enabled: true
       description: Number of metric points failed to be added to the sending queue.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -60,7 +60,7 @@ telemetry:
     exporter_sent_log_records:
       enabled: true
       description: Number of log record successfully sent to destination.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -68,7 +68,7 @@ telemetry:
     exporter_send_failed_log_records:
       enabled: true
       description: Number of log records in failed attempts to send to destination.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -76,7 +76,7 @@ telemetry:
     exporter_enqueue_failed_log_records:
       enabled: true
       description: Number of log records failed to be added to the sending queue.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -84,7 +84,7 @@ telemetry:
     exporter_queue_size:
       enabled: true
       description: Current size of the retry queue (in batches)
-      unit: 1
+      unit: "1"
       optional: true
       gauge:
         value_type: int
@@ -93,7 +93,7 @@ telemetry:
     exporter_queue_capacity:
       enabled: true
       description: Fixed capacity of the retry queue (in batches)
-      unit: 1
+      unit: "1"
       optional: true
       gauge:
         value_type: int

--- a/processor/batchprocessor/metadata.yaml
+++ b/processor/batchprocessor/metadata.yaml
@@ -14,21 +14,21 @@ telemetry:
     processor_batch_batch_size_trigger_send:
       enabled: true
       description: Number of times the batch was sent due to a size trigger
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
     processor_batch_timeout_trigger_send:
       enabled: true
       description: Number of times the batch was sent due to a timeout trigger
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
     processor_batch_batch_send_size:
       enabled: true
       description: Number of units in the batch
-      unit: 1
+      unit: "1"
       histogram:
         value_type: int
         bucket_boundaries: [10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000]
@@ -42,7 +42,7 @@ telemetry:
     processor_batch_metadata_cardinality:
       enabled: true
       description: Number of distinct metadata value combinations being processed
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         async: true

--- a/processor/processorhelper/metadata.yaml
+++ b/processor/processorhelper/metadata.yaml
@@ -12,7 +12,7 @@ telemetry:
     processor_accepted_spans:
       enabled: true
       description: Number of spans successfully pushed into the next component in the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -20,7 +20,7 @@ telemetry:
     processor_refused_spans:
       enabled: true
       description: Number of spans that were rejected by the next component in the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -28,7 +28,7 @@ telemetry:
     processor_dropped_spans:
       enabled: true
       description: Number of spans that were dropped.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -36,7 +36,7 @@ telemetry:
     processor_inserted_spans:
       enabled: true
       description: Number of spans that were inserted.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -44,7 +44,7 @@ telemetry:
     processor_accepted_metric_points:
       enabled: true
       description: Number of metric points successfully pushed into the next component in the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -52,7 +52,7 @@ telemetry:
     processor_refused_metric_points:
       enabled: true
       description: Number of metric points that were rejected by the next component in the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -60,7 +60,7 @@ telemetry:
     processor_dropped_metric_points:
       enabled: true
       description: Number of metric points that were dropped.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -68,7 +68,7 @@ telemetry:
     processor_inserted_metric_points:
       enabled: true
       description: Number of metric points that were inserted.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -76,7 +76,7 @@ telemetry:
     processor_accepted_log_records:
       enabled: true
       description: Number of log records successfully pushed into the next component in the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -84,7 +84,7 @@ telemetry:
     processor_refused_log_records:
       enabled: true
       description: Number of log records that were rejected by the next component in the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -92,7 +92,7 @@ telemetry:
     processor_dropped_log_records:
       enabled: true
       description: Number of log records that were dropped.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -100,7 +100,7 @@ telemetry:
     processor_inserted_log_records:
       enabled: true
       description: Number of log records that were inserted.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true

--- a/receiver/receiverhelper/metadata.yaml
+++ b/receiver/receiverhelper/metadata.yaml
@@ -12,7 +12,7 @@ telemetry:
     receiver_accepted_spans:
       enabled: true
       description: Number of spans successfully pushed into the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -20,7 +20,7 @@ telemetry:
     receiver_refused_spans:
       enabled: true
       description: Number of spans that could not be pushed into the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -28,7 +28,7 @@ telemetry:
     receiver_accepted_metric_points:
       enabled: true
       description: Number of metric points successfully pushed into the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -36,7 +36,7 @@ telemetry:
     receiver_refused_metric_points:
       enabled: true
       description: Number of metric points that could not be pushed into the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -44,7 +44,7 @@ telemetry:
     receiver_accepted_log_records:
       enabled: true
       description: Number of log records successfully pushed into the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -52,7 +52,7 @@ telemetry:
     receiver_refused_log_records:
       enabled: true
       description: Number of log records that could not be pushed into the pipeline.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true

--- a/receiver/scraperhelper/metadata.yaml
+++ b/receiver/scraperhelper/metadata.yaml
@@ -12,7 +12,7 @@ telemetry:
     scraper_scraped_metric_points:
       enabled: true
       description: Number of metric points successfully scraped.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true
@@ -20,7 +20,7 @@ telemetry:
     scraper_errored_metric_points:
       enabled: true
       description: Number of metric points that were unable to be scraped.
-      unit: 1
+      unit: "1"
       sum:
         value_type: int
         monotonic: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Uses string type for `unit` field in mdatagen related files.

<!-- Issue number if applicable -->
#### Link to tracking issue

Needed for #10554
