### PR TITLE
[chore][confmap] Add string representation to mocked env provider

### DIFF
--- a/confmap/expand_test.go
+++ b/confmap/expand_test.go
@@ -414,27 +414,27 @@ func newEnvProvider() ProviderFactory {
 		}
 		switch uri {
 		case "env:COMPLEX_VALUE":
-			return NewRetrieved([]any{"localhost:3042"})
+			return NewRetrievedFromYAML([]byte("[localhost:3042]"))
 		case "env:HOST":
-			return NewRetrieved("localhost")
+			return NewRetrievedFromYAML([]byte("localhost"))
 		case "env:OS":
-			return NewRetrieved("ubuntu")
+			return NewRetrievedFromYAML([]byte("ubuntu"))
 		case "env:PR":
-			return NewRetrieved("amd")
+			return NewRetrievedFromYAML([]byte("amd"))
 		case "env:PORT":
-			return NewRetrieved(3044)
+			return NewRetrievedFromYAML([]byte("3044"))
 		case "env:INT":
-			return NewRetrieved(1)
+			return NewRetrievedFromYAML([]byte("1"))
 		case "env:INT32":
-			return NewRetrieved(32)
+			return NewRetrieved(int32(32), withStringRepresentation("32"))
 		case "env:INT64":
-			return NewRetrieved(64)
+			return NewRetrieved(int64(64), withStringRepresentation("64"))
 		case "env:FLOAT32":
-			return NewRetrieved(float32(3.25))
+			return NewRetrieved(float32(3.25), withStringRepresentation("3.25"))
 		case "env:FLOAT64":
-			return NewRetrieved(float64(6.4))
+			return NewRetrieved(float64(6.4), withStringRepresentation("6.4"))
 		case "env:BOOL":
-			return NewRetrieved(true)
+			return NewRetrievedFromYAML([]byte("true"))
 		}
 		return nil, errors.New("impossible")
 	})


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Adds string representation to all inputs returned by mock env provider used in tests. 

The real `env` provider (and all other providers on this repository) do this by default since they use `NewRetrievedFromYAML`.

Note that certain types are not really obtainable with the real `env` provider (e.g. `int32` or `float64`). I have kept them and added the string representation manually.

#### Link to tracking issue

Needed for #10554
