### PR TITLE
[confmap] Fix bug where expand didn't honor escaping

### DIFF
--- a/.chloggen/confmap-fix-escape-bug.yaml
+++ b/.chloggen/confmap-fix-escape-bug.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes issue where confmap could not escape `$$` when `confmap.unifyEnvVarExpansion` is enabled.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10560]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/confmap/expand.go
+++ b/confmap/expand.go
@@ -81,7 +81,7 @@ func (mr *Resolver) expandValue(ctx context.Context, value any) (any, bool, erro
 // findURI attempts to find the first potentially expandable URI in input. It returns a potentially expandable
 // URI, or an empty string if none are found.
 // Note: findURI is only called when input contains a closing bracket.
-// We do not support escaping nested URIs, since that would result in a $ in the URI which is not supported.
+// We do not support escaping nested URIs (such as ${env:$${FOO}}, since that would result in an invalid outer URI (${env:${FOO}}).
 func (mr *Resolver) findURI(input string) string {
 	closeIndex := strings.Index(input, "}")
 	remaining := input[closeIndex+1:]
@@ -109,7 +109,7 @@ func (mr *Resolver) findURI(input string) string {
 		}
 		index--
 	}
-	// if we found an odd number of immediately $ preceding ${, then ${ is a proper escape
+	// if we found an odd number of immediately $ preceding ${, then the expansion is escaped
 	if count%2 == 1 {
 		return ""
 	}

--- a/confmap/expand.go
+++ b/confmap/expand.go
@@ -81,6 +81,7 @@ func (mr *Resolver) expandValue(ctx context.Context, value any) (any, bool, erro
 // findURI attempts to find the first potentially expandable URI in input. It returns a potentially expandable
 // URI, or an empty string if none are found.
 // Note: findURI is only called when input contains a closing bracket.
+// We do not support escaping nested URIs, since that would result in a $ in the URI which is not supported.
 func (mr *Resolver) findURI(input string) string {
 	closeIndex := strings.Index(input, "}")
 	remaining := input[closeIndex+1:]
@@ -96,6 +97,21 @@ func (mr *Resolver) findURI(input string) string {
 			return ""
 		}
 		return mr.findURI(remaining)
+	}
+
+	index := openIndex - 1
+	currentRune := '$'
+	count := 0
+	for index >= 0 && currentRune == '$' {
+		currentRune = rune(input[index])
+		if currentRune == '$' {
+			count++
+		}
+		index--
+	}
+	// if we found an odd number of immediately $ preceding ${, then ${ is a proper escape
+	if count%2 == 1 {
+		return ""
 	}
 
 	return input[openIndex : closeIndex+1]

--- a/confmap/expand_test.go
+++ b/confmap/expand_test.go
@@ -577,3 +577,45 @@ func TestResolverDefaultProviderExpand(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{"foo": "localhost"}, cfgMap.ToStringMap())
 }
+
+func Test_EscapedEnvVars(t *testing.T) {
+	const mapValue2 = "some map value"
+
+	expectedMap := map[string]any{
+		"test_map": map[string]any{
+			"recv.1":  "$MAP_VALUE_1",
+			"recv.2":  "$$MAP_VALUE_2",
+			"recv.3":  "$$MAP_VALUE_3",
+			"recv.4":  "$" + mapValue2,
+			"recv.5":  "some${MAP_VALUE_4}text",
+			"recv.6":  "${ONE}${TWO}",
+			"recv.7":  "text$",
+			"recv.8":  "$",
+			"recv.9":  "${1}${env:2}",
+			"recv.10": "some${env:MAP_VALUE_4}text",
+			"recv.11": "${env:" + mapValue2 + "}",
+			"recv.12": "${env:${MAP_VALUE_2}}",
+			"recv.13": "env:MAP_VALUE_2}${MAP_VALUE_2}{",
+			"recv.14": "${env:MAP_VALUE_2${MAP_VALUE_2}",
+		}}
+
+	fileProvider := newFakeProvider("file", func(_ context.Context, uri string, _ WatcherFunc) (*Retrieved, error) {
+		return NewRetrieved(newConfFromFile(t, uri[5:]))
+	})
+	envProvider := newFakeProvider("env", func(_ context.Context, uri string, _ WatcherFunc) (*Retrieved, error) {
+		if uri == "env:MAP_VALUE_2" {
+			return NewRetrieved(mapValue2)
+		}
+		return nil, errors.New("should not be expanding any other env vars")
+	})
+
+	resolver, err := NewResolver(ResolverSettings{URIs: []string{filepath.Join("testdata", "expand-escaped-env.yaml")}, ProviderFactories: []ProviderFactory{fileProvider, envProvider}, ConverterFactories: nil, DefaultScheme: "env"})
+	require.NoError(t, err)
+
+	// Test that expanded configs are the same with the simple config with no env vars.
+	cfgMap, err := resolver.Resolve(context.Background())
+	require.NoError(t, err)
+	m := cfgMap.ToStringMap()
+	assert.Equal(t, expectedMap, m)
+
+}

--- a/confmap/expand_test.go
+++ b/confmap/expand_test.go
@@ -597,6 +597,7 @@ func Test_EscapedEnvVars(t *testing.T) {
 			"recv.12": "${env:${MAP_VALUE_2}}",
 			"recv.13": "env:MAP_VALUE_2}${MAP_VALUE_2}{",
 			"recv.14": "${env:MAP_VALUE_2${MAP_VALUE_2}",
+			"recv.15": "$" + mapValue2,
 		}}
 
 	fileProvider := newFakeProvider("file", func(_ context.Context, uri string, _ WatcherFunc) (*Retrieved, error) {

--- a/confmap/go.sum
+++ b/confmap/go.sum
@@ -24,6 +24,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.opentelemetry.io/collector/internal/featuregates v0.0.0-20240708164628-4a11a3e09648 h1:neiAdO/BGxH06Kc9YYjzcqB+wF12m5PxKXqHtFRb2hk=
+go.opentelemetry.io/collector/internal/featuregates v0.0.0-20240708164628-4a11a3e09648/go.mod h1:lC66DIONH2+irSDc+lVazcyCvLNlW+K5IWI/TdmZtPI=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/confmap/go.sum
+++ b/confmap/go.sum
@@ -24,8 +24,6 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-go.opentelemetry.io/collector/internal/featuregates v0.0.0-20240708164628-4a11a3e09648 h1:neiAdO/BGxH06Kc9YYjzcqB+wF12m5PxKXqHtFRb2hk=
-go.opentelemetry.io/collector/internal/featuregates v0.0.0-20240708164628-4a11a3e09648/go.mod h1:lC66DIONH2+irSDc+lVazcyCvLNlW+K5IWI/TdmZtPI=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -10,9 +10,10 @@ import (
 	"regexp"
 	"strings"
 
-	"go.opentelemetry.io/collector/internal/featuregates"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/internal/featuregates"
 )
 
 // follows drive-letter specification:

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 
+	"go.opentelemetry.io/collector/internal/featuregates"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
@@ -171,7 +172,13 @@ func (mr *Resolver) Resolve(ctx context.Context) (*Conf, error) {
 		if err != nil {
 			return nil, err
 		}
-		cfgMap[k] = val
+
+		if v, ok := val.(string); ok && featuregates.UseUnifiedEnvVarExpansionRules.IsEnabled() {
+			cfgMap[k] = strings.ReplaceAll(v, "$$", "$")
+		} else {
+			cfgMap[k] = val
+		}
+
 	}
 	retMap = NewFromStringMap(cfgMap)
 

--- a/confmap/testdata/expand-escaped-env.yaml
+++ b/confmap/testdata/expand-escaped-env.yaml
@@ -1,0 +1,29 @@
+test_map:
+  # $$ -> escaped $
+  recv.1: "$$MAP_VALUE_1"
+  # $$$ -> escaped $ + $MAP_VALUE_2
+  recv.2: "$$$MAP_VALUE_2"
+  # $$$$ -> two escaped $
+  recv.3: "$$$$MAP_VALUE_3"
+  # $$$ -> escaped $ + substituted env var
+  recv.4: "$$${MAP_VALUE_2}"
+  # escaped $ in the middle
+  recv.5: "some$${MAP_VALUE_4}text"
+  # two escaped $
+  recv.6: "$${ONE}$${TWO}"
+  # trailing escaped $
+  recv.7: "text$$"
+  # escaped $ alone
+  recv.8: "$$"
+  # Escape numbers
+  recv.9: "$${1}$${env:2}"
+  # can escape provider
+  recv.10: "some$${env:MAP_VALUE_4}text"
+  # can escape outer when nested
+  recv.11: "$${env:${MAP_VALUE_2}}"
+  # can escape inner and outer when nested
+  recv.12: "$${env:$${MAP_VALUE_2}}"
+  # can escape partial
+  recv.13: "env:MAP_VALUE_2}$${MAP_VALUE_2}{"
+  # can escape partial
+  recv.14: "${env:MAP_VALUE_2$${MAP_VALUE_2}"

--- a/confmap/testdata/expand-escaped-env.yaml
+++ b/confmap/testdata/expand-escaped-env.yaml
@@ -27,3 +27,5 @@ test_map:
   recv.13: "env:MAP_VALUE_2}$${MAP_VALUE_2}{"
   # can escape partial
   recv.14: "${env:MAP_VALUE_2$${MAP_VALUE_2}"
+  # $$$ -> escaped $ + substituted env var
+  recv.15: "$$${env:MAP_VALUE_2}"


### PR DESCRIPTION
#### Description

When we promoted `confmap.unifyEnvVarExpansion` to beta, we found that the new expansion logic in `confmap` wasn't handling escaping of `$$` like it is supposed to.  This PR fixes that bug, but adding escaping logic for `$$`.

@azunna1 this fixes the bug you mentioned in https://github.com/open-telemetry/opentelemetry-collector/pull/10435 around the metricstransformprocessor:

```yaml
  metricstransform:
    transforms:
      - include: '^k8s\.(.*)\.(.*)$$'
        match_type: regexp
        action: update
        new_name: 'kubernetes.$${1}.$${2}'
      - include: '^container_([0-9A-Za-z]+)_([0-9A-Za-z]+)_.*'
        match_type: regexp
        action: update
        new_name: 'container.$${1}.$${2}'
```

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added new unit tests explicitly for escaping logic