### PR TITLE
Properly handle error code translation

### DIFF
--- a/.chloggen/fix-http-grpc-error-code-mapping.yaml
+++ b/.chloggen/fix-http-grpc-error-code-mapping.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a bug where the otlp receiver's http response was not properly translating grpc error codes to http status codes.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10574]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/otlpreceiver/internal/errors/errors.go
+++ b/receiver/otlpreceiver/internal/errors/errors.go
@@ -40,6 +40,18 @@ func GetHTTPStatusCodeFromStatus(s *status.Status) int {
 	case codes.ResourceExhausted:
 		return http.StatusTooManyRequests
 	// Not Retryable
+	case codes.InvalidArgument:
+		return http.StatusBadRequest
+	// Not Retryable
+	case codes.Unauthenticated:
+		return http.StatusUnauthorized
+	// Not Retryable
+	case codes.PermissionDenied:
+		return http.StatusForbidden
+	// Not Retryable
+	case codes.Unimplemented:
+		return http.StatusNotFound
+	// Not Retryable
 	default:
 		return http.StatusInternalServerError
 	}

--- a/receiver/otlpreceiver/internal/errors/errors_test.go
+++ b/receiver/otlpreceiver/internal/errors/errors_test.go
@@ -58,13 +58,33 @@ func Test_GetHTTPStatusCodeFromStatus(t *testing.T) {
 		},
 		{
 			name:     "Non-retryable Status",
-			input:    status.New(codes.InvalidArgument, "test"),
+			input:    status.New(codes.Internal, "test"),
 			expected: http.StatusInternalServerError,
 		},
 		{
 			name:     "Specifically 429",
 			input:    status.New(codes.ResourceExhausted, "test"),
 			expected: http.StatusTooManyRequests,
+		},
+		{
+			name:     "Specifically 400",
+			input:    status.New(codes.InvalidArgument, "test"),
+			expected: http.StatusBadRequest,
+		},
+		{
+			name:     "Specifically 401",
+			input:    status.New(codes.Unauthenticated, "test"),
+			expected: http.StatusUnauthorized,
+		},
+		{
+			name:     "Specifically 403",
+			input:    status.New(codes.PermissionDenied, "test"),
+			expected: http.StatusForbidden,
+		},
+		{
+			name:     "Specifically 404",
+			input:    status.New(codes.Unimplemented, "test"),
+			expected: http.StatusNotFound,
 		},
 	}
 	for _, tt := range tests {

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -104,8 +104,8 @@ func TestJsonHttp(t *testing.T) {
 			name:               "Permanent GRPCError",
 			encoding:           "",
 			contentType:        "application/json",
-			err:                status.New(codes.InvalidArgument, "").Err(),
-			expectedStatus:     &spb.Status{Code: int32(codes.InvalidArgument), Message: ""},
+			err:                status.New(codes.Internal, "").Err(),
+			expectedStatus:     &spb.Status{Code: int32(codes.Internal), Message: ""},
 			expectedStatusCode: http.StatusInternalServerError,
 		},
 		{
@@ -361,7 +361,7 @@ func TestProtoHttp(t *testing.T) {
 			encoding:           "",
 			err:                status.New(codes.InvalidArgument, "").Err(),
 			expectedStatus:     &spb.Status{Code: int32(codes.InvalidArgument), Message: ""},
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
 			name:               "Retryable GRPCError",


### PR DESCRIPTION
#### Description

Fixes a bug where the otlpreceiver was not translating grpc error codes to http status codes the same way that the otlp exporter was translating http status codes to grpc error codes.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/10538

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit tests