### PR TITLE
[configauth] Deprecate GetClientAuthenticatorContext and GetServerAuthenticatorContext

### DIFF
--- a/.chloggen/configauth-removed-deprecated-funcs.yaml
+++ b/.chloggen/configauth-removed-deprecated-funcs.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configauth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecated `Authentication.GetClientAuthenticatorContext` and `Authentication.GetServerAuthenticatorContext`
+
+# One or more tracking issues or pull requests related to the change
+issues: [10578]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -34,15 +34,7 @@ func NewDefaultAuthentication() *Authentication {
 
 // GetServerAuthenticator attempts to select the appropriate auth.Server from the list of extensions,
 // based on the requested extension name. If an authenticator is not found, an error is returned.
-//
-// Deprecated: [v0.103.0] Use GetServerAuthenticatorContext instead.
-func (a Authentication) GetServerAuthenticator(extensions map[component.ID]component.Component) (auth.Server, error) {
-	return a.GetServerAuthenticatorContext(context.Background(), extensions)
-}
-
-// GetServerAuthenticatorContext attempts to select the appropriate auth.Server from the list of extensions,
-// based on the requested extension name. If an authenticator is not found, an error is returned.
-func (a Authentication) GetServerAuthenticatorContext(_ context.Context, extensions map[component.ID]component.Component) (auth.Server, error) {
+func (a Authentication) GetServerAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (auth.Server, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if server, ok := ext.(auth.Server); ok {
 			return server, nil
@@ -53,15 +45,18 @@ func (a Authentication) GetServerAuthenticatorContext(_ context.Context, extensi
 	return nil, fmt.Errorf("failed to resolve authenticator %q: %w", a.AuthenticatorID, errAuthenticatorNotFound)
 }
 
-// Deprecated: [v0.103.0] Use GetClientAuthenticatorContext instead.
-func (a Authentication) GetClientAuthenticator(extensions map[component.ID]component.Component) (auth.Client, error) {
-	return a.GetClientAuthenticatorContext(context.Background(), extensions)
+// GetServerAuthenticatorContext attempts to select the appropriate auth.Server from the list of extensions,
+// based on the requested extension name. If an authenticator is not found, an error is returned.
+//
+// Deprecated: [v0.105.0] Use GetServerAuthenticator instead.
+func (a Authentication) GetServerAuthenticatorContext(ctx context.Context, extensions map[component.ID]component.Component) (auth.Server, error) {
+	return a.GetServerAuthenticator(ctx, extensions)
 }
 
-// GetClientAuthenticatorContext attempts to select the appropriate auth.Client from the list of extensions,
+// GetClientAuthenticator attempts to select the appropriate auth.Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by HTTP clients.
-func (a Authentication) GetClientAuthenticatorContext(_ context.Context, extensions map[component.ID]component.Component) (auth.Client, error) {
+func (a Authentication) GetClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (auth.Client, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if client, ok := ext.(auth.Client); ok {
 			return client, nil
@@ -69,4 +64,13 @@ func (a Authentication) GetClientAuthenticatorContext(_ context.Context, extensi
 		return nil, errNotClient
 	}
 	return nil, fmt.Errorf("failed to resolve authenticator %q: %w", a.AuthenticatorID, errAuthenticatorNotFound)
+}
+
+// GetClientAuthenticatorContext attempts to select the appropriate auth.Client from the list of extensions,
+// based on the component id of the extension. If an authenticator is not found, an error is returned.
+// This should be only used by HTTP clients.
+//
+// Deprecated: [v0.105.0] Use GetClientAuthenticatorContext instead.
+func (a Authentication) GetClientAuthenticatorContext(ctx context.Context, extensions map[component.ID]component.Component) (auth.Client, error) {
+	return a.GetClientAuthenticator(ctx, extensions)
 }

--- a/config/configauth/configauth_test.go
+++ b/config/configauth/configauth_test.go
@@ -49,7 +49,7 @@ func TestGetServer(t *testing.T) {
 				mockID: tC.authenticator,
 			}
 
-			authenticator, err := cfg.GetServerAuthenticatorContext(context.Background(), ext)
+			authenticator, err := cfg.GetServerAuthenticator(context.Background(), ext)
 
 			// verify
 			if tC.expected != nil {
@@ -68,7 +68,7 @@ func TestGetServerFails(t *testing.T) {
 		AuthenticatorID: component.MustNewID("does_not_exist"),
 	}
 
-	authenticator, err := cfg.GetServerAuthenticatorContext(context.Background(), map[component.ID]component.Component{})
+	authenticator, err := cfg.GetServerAuthenticator(context.Background(), map[component.ID]component.Component{})
 	assert.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }
@@ -100,7 +100,7 @@ func TestGetClient(t *testing.T) {
 				mockID: tC.authenticator,
 			}
 
-			authenticator, err := cfg.GetClientAuthenticatorContext(context.Background(), ext)
+			authenticator, err := cfg.GetClientAuthenticator(context.Background(), ext)
 
 			// verify
 			if tC.expected != nil {
@@ -118,7 +118,7 @@ func TestGetClientFails(t *testing.T) {
 	cfg := &Authentication{
 		AuthenticatorID: component.MustNewID("does_not_exist"),
 	}
-	authenticator, err := cfg.GetClientAuthenticatorContext(context.Background(), map[component.ID]component.Component{})
+	authenticator, err := cfg.GetClientAuthenticator(context.Background(), map[component.ID]component.Component{})
 	assert.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -277,7 +277,7 @@ func (gcs *ClientConfig) toDialOptions(ctx context.Context, host component.Host,
 			return nil, errors.New("no extensions configuration available")
 		}
 
-		grpcAuthenticator, cerr := gcs.Auth.GetClientAuthenticatorContext(ctx, host.GetExtensions())
+		grpcAuthenticator, cerr := gcs.Auth.GetClientAuthenticator(ctx, host.GetExtensions())
 		if cerr != nil {
 			return nil, cerr
 		}
@@ -393,7 +393,7 @@ func (gss *ServerConfig) toServerOption(host component.Host, settings component.
 	var sInterceptors []grpc.StreamServerInterceptor
 
 	if gss.Auth != nil {
-		authenticator, err := gss.Auth.GetServerAuthenticatorContext(context.Background(), host.GetExtensions())
+		authenticator, err := gss.Auth.GetServerAuthenticator(context.Background(), host.GetExtensions())
 		if err != nil {
 			return nil, err
 		}

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -195,7 +195,7 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 			return nil, errors.New("extensions configuration not found")
 		}
 
-		httpCustomAuthRoundTripper, aerr := hcs.Auth.GetClientAuthenticatorContext(ctx, ext)
+		httpCustomAuthRoundTripper, aerr := hcs.Auth.GetClientAuthenticator(ctx, ext)
 		if aerr != nil {
 			return nil, aerr
 		}
@@ -382,7 +382,7 @@ func (hss *ServerConfig) ToServer(_ context.Context, host component.Host, settin
 	}
 
 	if hss.Auth != nil {
-		server, err := hss.Auth.GetServerAuthenticatorContext(context.Background(), host.GetExtensions())
+		server, err := hss.Auth.GetServerAuthenticator(context.Background(), host.GetExtensions())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### Description
Deprecates GetClientAuthenticatorContext and GetServerAuthenticatorContext.

<!-- Issue number if applicable -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9808