### PR TITLE
[exporterhelper] Deprecate the obsreport API

### DIFF
--- a/.chloggen/exporterhelper-deprecate-obsreport-api.yaml
+++ b/.chloggen/exporterhelper-deprecate-obsreport-api.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'deprecation'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the obsreport API in the exporterhelper package.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10592]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -80,7 +80,7 @@ func (or *ObsReport) StartTracesOp(ctx context.Context) context.Context {
 
 // EndTracesOp completes the export operation that was started with StartTracesOp.
 //
-// Deprecated: [v0.104.0] Not expected to be used directly.
+// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) EndTracesOp(ctx context.Context, numSpans int, err error) {
 	numSent, numFailedToSend := toNumItems(numSpans, err)

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -92,7 +92,7 @@ func (or *ObsReport) EndTracesOp(ctx context.Context, numSpans int, err error) {
 // The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
 //
-// Deprecated: [v0.104.0] Not expected to be used directly.
+// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) StartMetricsOp(ctx context.Context) context.Context {
 	return or.startOp(ctx, obsmetrics.ExportMetricsOperationSuffix)

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -42,7 +42,7 @@ type ObsReportSettings struct {
 
 // NewObsReport creates a new Exporter.
 //
-// Deprecated: [v0.104.0] Not expected to be used directly.
+// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func NewObsReport(cfg ObsReportSettings) (*ObsReport, error) {
 	return newExporter(cfg)

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -72,7 +72,7 @@ func newExporter(cfg ObsReportSettings) (*ObsReport, error) {
 // The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
 //
-// Deprecated: [v0.104.0] Not expected to be used directly.
+// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) StartTracesOp(ctx context.Context) context.Context {
 	return or.startOp(ctx, obsmetrics.ExportTraceDataOperationSuffix)

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -20,7 +20,7 @@ import (
 
 // ObsReport is a helper to add observability to an exporter.
 //
-// Deprecated: [v0.104.0] Not expected to be used directly.
+// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 type ObsReport struct {
 	level          configtelemetry.Level

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -33,7 +33,7 @@ type ObsReport struct {
 
 // ObsReportSettings are settings for creating an ObsReport.
 //
-// Deprecated: [v0.104.0] Not expected to be used directly.
+// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 type ObsReportSettings struct {
 	ExporterID             component.ID

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -113,7 +113,7 @@ func (or *ObsReport) EndMetricsOp(ctx context.Context, numMetricPoints int, err 
 // The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
 //
-// Deprecated: [v0.104.0] Not expected to be used directly.
+// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) StartLogsOp(ctx context.Context) context.Context {
 	return or.startOp(ctx, obsmetrics.ExportLogsOperationSuffix)

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -19,6 +19,9 @@ import (
 )
 
 // ObsReport is a helper to add observability to an exporter.
+//
+// Deprecated: [v0.104.0] Not expected to be used directly.
+// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 type ObsReport struct {
 	level          configtelemetry.Level
 	spanNamePrefix string
@@ -29,12 +32,18 @@ type ObsReport struct {
 }
 
 // ObsReportSettings are settings for creating an ObsReport.
+//
+// Deprecated: [v0.104.0] Not expected to be used directly.
+// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 type ObsReportSettings struct {
 	ExporterID             component.ID
 	ExporterCreateSettings exporter.Settings
 }
 
 // NewObsReport creates a new Exporter.
+//
+// Deprecated: [v0.104.0] Not expected to be used directly.
+// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func NewObsReport(cfg ObsReportSettings) (*ObsReport, error) {
 	return newExporter(cfg)
 }
@@ -62,11 +71,17 @@ func newExporter(cfg ObsReportSettings) (*ObsReport, error) {
 // StartTracesOp is called at the start of an Export operation.
 // The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
+//
+// Deprecated: [v0.104.0] Not expected to be used directly.
+// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) StartTracesOp(ctx context.Context) context.Context {
 	return or.startOp(ctx, obsmetrics.ExportTraceDataOperationSuffix)
 }
 
 // EndTracesOp completes the export operation that was started with StartTracesOp.
+//
+// Deprecated: [v0.104.0] Not expected to be used directly.
+// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) EndTracesOp(ctx context.Context, numSpans int, err error) {
 	numSent, numFailedToSend := toNumItems(numSpans, err)
 	or.recordMetrics(context.WithoutCancel(ctx), component.DataTypeTraces, numSent, numFailedToSend)
@@ -76,12 +91,18 @@ func (or *ObsReport) EndTracesOp(ctx context.Context, numSpans int, err error) {
 // StartMetricsOp is called at the start of an Export operation.
 // The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
+//
+// Deprecated: [v0.104.0] Not expected to be used directly.
+// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) StartMetricsOp(ctx context.Context) context.Context {
 	return or.startOp(ctx, obsmetrics.ExportMetricsOperationSuffix)
 }
 
 // EndMetricsOp completes the export operation that was started with
 // StartMetricsOp.
+//
+// Deprecated: [v0.104.0] Not expected to be used directly.
+// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) EndMetricsOp(ctx context.Context, numMetricPoints int, err error) {
 	numSent, numFailedToSend := toNumItems(numMetricPoints, err)
 	or.recordMetrics(context.WithoutCancel(ctx), component.DataTypeMetrics, numSent, numFailedToSend)
@@ -91,11 +112,17 @@ func (or *ObsReport) EndMetricsOp(ctx context.Context, numMetricPoints int, err 
 // StartLogsOp is called at the start of an Export operation.
 // The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
+//
+// Deprecated: [v0.104.0] Not expected to be used directly.
+// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) StartLogsOp(ctx context.Context) context.Context {
 	return or.startOp(ctx, obsmetrics.ExportLogsOperationSuffix)
 }
 
 // EndLogsOp completes the export operation that was started with StartLogsOp.
+//
+// Deprecated: [v0.104.0] Not expected to be used directly.
+// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) EndLogsOp(ctx context.Context, numLogRecords int, err error) {
 	numSent, numFailedToSend := toNumItems(numLogRecords, err)
 	or.recordMetrics(context.WithoutCancel(ctx), component.DataTypeLogs, numSent, numFailedToSend)

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -121,7 +121,7 @@ func (or *ObsReport) StartLogsOp(ctx context.Context) context.Context {
 
 // EndLogsOp completes the export operation that was started with StartLogsOp.
 //
-// Deprecated: [v0.104.0] Not expected to be used directly.
+// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) EndLogsOp(ctx context.Context, numLogRecords int, err error) {
 	numSent, numFailedToSend := toNumItems(numLogRecords, err)

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -101,7 +101,7 @@ func (or *ObsReport) StartMetricsOp(ctx context.Context) context.Context {
 // EndMetricsOp completes the export operation that was started with
 // StartMetricsOp.
 //
-// Deprecated: [v0.104.0] Not expected to be used directly.
+// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
 func (or *ObsReport) EndMetricsOp(ctx context.Context, numMetricPoints int, err error) {
 	numSent, numFailedToSend := toNumItems(numMetricPoints, err)


### PR DESCRIPTION
Deprecate the obsreport API in the exporterhelper package. The top-level helpers `exporterhelper.New[Metrics|Traces|Logs]Exporter` are supposed to be used instead.

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/10592