### PR TITLE
[builder] fix the TestGenerateInvalidOutputPath

### DIFF
--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -109,7 +109,7 @@ func TestGenerateDefault(t *testing.T) {
 
 func TestGenerateInvalidOutputPath(t *testing.T) {
 	cfg := newInitializedConfig(t)
-	cfg.Distribution.OutputPath = "/:invalid"
+	cfg.Distribution.OutputPath = ":/invalid"
 	err := Generate(cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create output path")


### PR DESCRIPTION
If the test is executed with the `root` user, the `TestGenerateInvalidOutputPath` test fails.
The behaviour was noticed with a GitLab runner that was executed with root rights.

An attempt is made to create the directory `/:invalid` during the test.
A user without root rights receives the message `cannot create directory '/:invalid': Permission denied`. 
In contrast, the `root` user can create the directory without any problems because this is a valid path.

To correct the behaviour of the test, the path to `:/invalid` was adjusted.
This is not a valid path under Windows or Linux.