### PR TITLE
Add mechanism to report go module for each factory

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -180,6 +180,10 @@ type Factory interface {
 	// 'componenttest.CheckConfigStruct'. It is recommended to have these checks in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() Config
+
+	// GoModule reports the go module and version of the component.
+	// Example: "go.opentelemetry.io/collector/exporter/otlpexporter@v0.1.0"
+	GoModule() string
 }
 
 // CreateDefaultConfigFunc is the equivalent of Factory.CreateDefaultConfig().

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
+	"runtime"
 
 	"go.uber.org/zap"
 
@@ -311,6 +313,8 @@ type factory struct {
 	logsToTracesStabilityLevel  component.StabilityLevel
 	logsToMetricsStabilityLevel component.StabilityLevel
 	logsToLogsStabilityLevel    component.StabilityLevel
+
+	goModule string
 }
 
 // Type returns the type of component.
@@ -428,11 +432,21 @@ func (f factory) LogsToLogsStability() component.StabilityLevel {
 	return f.logsToLogsStabilityLevel
 }
 
+func (f factory) GoModule() string {
+	return f.goModule
+}
+
 // NewFactory returns a Factory.
 func NewFactory(cfgType component.Type, createDefaultConfig component.CreateDefaultConfigFunc, options ...FactoryOption) Factory {
+	goModule := "unknown@v0.0.0"
+	_, caller, _, ok := runtime.Caller(1)
+	if ok {
+		goModule = path.Dir(caller)
+	}
 	f := &factory{
 		cfgType:                 cfgType,
 		CreateDefaultConfigFunc: createDefaultConfig,
+		goModule:                goModule,
 	}
 	for _, opt := range options {
 		opt.apply(f)

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -6,6 +6,8 @@ package extension // import "go.opentelemetry.io/collector/extension"
 import (
 	"context"
 	"fmt"
+	"path"
+	"runtime"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
@@ -103,6 +105,7 @@ type factory struct {
 	component.CreateDefaultConfigFunc
 	CreateFunc
 	extensionStability component.StabilityLevel
+	goModule           string
 }
 
 func (f *factory) Type() component.Type {
@@ -115,17 +118,27 @@ func (f *factory) ExtensionStability() component.StabilityLevel {
 	return f.extensionStability
 }
 
+func (f *factory) GoModule() string {
+	return f.goModule
+}
+
 // NewFactory returns a new Factory  based on this configuration.
 func NewFactory(
 	cfgType component.Type,
 	createDefaultConfig component.CreateDefaultConfigFunc,
 	createServiceExtension CreateFunc,
 	sl component.StabilityLevel) Factory {
+	goModule := "unknown@v0.0.0"
+	_, caller, _, ok := runtime.Caller(1)
+	if ok {
+		goModule = path.Dir(caller)
+	}
 	return &factory{
 		cfgType:                 cfgType,
 		CreateDefaultConfigFunc: createDefaultConfig,
 		CreateFunc:              createServiceExtension,
 		extensionStability:      sl,
+		goModule:                goModule,
 	}
 }
 

--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -20,6 +20,7 @@ import (
 
 type componentWithStability struct {
 	Name      component.Type
+	Module    string
 	Stability map[string]string
 }
 
@@ -49,7 +50,8 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			components := componentsOutput{}
 			for _, con := range sortFactoriesByType[connector.Factory](factories.Connectors) {
 				components.Connectors = append(components.Connectors, componentWithStability{
-					Name: con.Type(),
+					Name:   con.Type(),
+					Module: con.GoModule(),
 					Stability: map[string]string{
 						"logs-to-logs":    con.LogsToLogsStability().String(),
 						"logs-to-metrics": con.LogsToMetricsStability().String(),
@@ -67,7 +69,8 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			}
 			for _, ext := range sortFactoriesByType[extension.Factory](factories.Extensions) {
 				components.Extensions = append(components.Extensions, componentWithStability{
-					Name: ext.Type(),
+					Name:   ext.Type(),
+					Module: ext.GoModule(),
 					Stability: map[string]string{
 						"extension": ext.ExtensionStability().String(),
 					},
@@ -75,7 +78,8 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			}
 			for _, prs := range sortFactoriesByType[processor.Factory](factories.Processors) {
 				components.Processors = append(components.Processors, componentWithStability{
-					Name: prs.Type(),
+					Name:   prs.Type(),
+					Module: prs.GoModule(),
 					Stability: map[string]string{
 						"logs":    prs.LogsProcessorStability().String(),
 						"metrics": prs.MetricsProcessorStability().String(),
@@ -85,7 +89,8 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			}
 			for _, rcv := range sortFactoriesByType[receiver.Factory](factories.Receivers) {
 				components.Receivers = append(components.Receivers, componentWithStability{
-					Name: rcv.Type(),
+					Name:   rcv.Type(),
+					Module: rcv.GoModule(),
 					Stability: map[string]string{
 						"logs":    rcv.LogsReceiverStability().String(),
 						"metrics": rcv.MetricsReceiverStability().String(),
@@ -95,7 +100,8 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			}
 			for _, exp := range sortFactoriesByType[exporter.Factory](factories.Exporters) {
 				components.Exporters = append(components.Exporters, componentWithStability{
-					Name: exp.Type(),
+					Name:   exp.Type(),
+					Module: exp.GoModule(),
 					Stability: map[string]string{
 						"logs":    exp.LogsExporterStability().String(),
 						"metrics": exp.MetricsExporterStability().String(),


### PR DESCRIPTION
#### Description

Adds each component's module to the `components` subcommand output.

```
➜  ./bin/otelcorecol_darwin_arm64 components                                                                                    ✭
...
buildinfo:
    command: otelcorecol
    description: Local OpenTelemetry Collector binary, testing only.
    version: 0.104.0-dev
receivers:
    - name: nop
      module: go.opentelemetry.io/collector/receiver/nopreceiver@v0.104.0
      stability:
        logs: Beta
        metrics: Beta
        traces: Beta
    - name: otlp
      module: go.opentelemetry.io/collector/receiver/otlpreceiver@v0.104.0
      stability:
        logs: Beta
        metrics: Stable
        traces: Stable
processors:
    - name: batch
      module: go.opentelemetry.io/collector/processor/batchprocessor@v0.104.0
      stability:
        logs: Beta
        metrics: Beta
        traces: Beta
    - name: memory_limiter
      module: go.opentelemetry.io/collector/processor/memorylimiterprocessor@v0.104.0
      stability:
        logs: Beta
        metrics: Beta
        traces: Beta
exporters:
    - name: debug
      module: go.opentelemetry.io/collector/exporter/debugexporter@v0.104.0
      stability:
        logs: Development
        metrics: Development
        traces: Development
    - name: logging
      module: go.opentelemetry.io/collector/exporter/loggingexporter@v0.104.0
      stability:
        logs: Deprecated
        metrics: Deprecated
        traces: Deprecated
    - name: nop
      module: go.opentelemetry.io/collector/exporter/nopexporter@v0.104.0
      stability:
        logs: Beta
        metrics: Beta
        traces: Beta
    - name: otlp
      module: go.opentelemetry.io/collector/exporter/otlpexporter@v0.104.0
      stability:
        logs: Beta
        metrics: Stable
        traces: Stable
    - name: otlphttp
      module: go.opentelemetry.io/collector/exporter/otlphttpexporter@v0.104.0
      stability:
        logs: Beta
        metrics: Stable
        traces: Stable
connectors:
    - name: forward
      module: go.opentelemetry.io/collector/connector/forwardconnector@v0.104.0
      stability:
        logs-to-logs: Beta
        logs-to-metrics: Undefined
        logs-to-traces: Undefined
        metrics-to-logs: Undefined
        metrics-to-metrics: Beta
        metrics-to-traces: Undefined
        traces-to-logs: Undefined
        traces-to-metrics: Undefined
        traces-to-traces: Beta
extensions:
    - name: memory_ballast
      module: go.opentelemetry.io/collector/extension/ballastextension@v0.104.0
      stability:
        extension: Deprecated
    - name: memory_limiter
      module: go.opentelemetry.io/collector/extension/memorylimiterextension@v0.104.0
      stability:
        extension: Development
    - name: zpages
      module: go.opentelemetry.io/collector/extension/zpagesextension@v0.104.0
      stability:
        extension: Beta
```

#### Issue

Resolves #10570

#### Testing

Manual only so far.

#### Documentation

None so far. 
