### PR TITLE
[confmap] Use original string value on expansion

### DIFF
--- a/.chloggen/mx-psi_as-string.yaml
+++ b/.chloggen/mx-psi_as-string.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: When passing value to a string field through the `${<provider>:URI}` or `${URI}` syntax, the original raw string value is now preserved.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - This change only applies under the `confmap.unifyEnvVarExpansion` feature gate.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/mx-psi_as-string.yaml
+++ b/.chloggen/mx-psi_as-string.yaml
@@ -10,7 +10,7 @@ component: confmap
 note: When passing value to a string field through the `${<provider>:URI}` or `${URI}` syntax, the original raw string value is now preserved.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [10603]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/confmap/internal/e2e/types_test.go
+++ b/confmap/internal/e2e/types_test.go
@@ -228,27 +228,27 @@ func TestStrictTypeCasting(t *testing.T) {
 		{
 			value:       "\"0123\"",
 			targetField: TargetFieldString,
-			expected:    "0123",
+			expected:    "\"0123\"",
 		},
 		{
 			value:        "\"0123\"",
 			targetField:  TargetFieldInt,
-			unmarshalErr: "'field' expected type 'int', got unconvertible type 'string', value: '0123'",
+			unmarshalErr: "'field' expected type 'int', got unconvertible type 'string', value: '\"0123\"'",
 		},
 		{
 			value:       "\"0123\"",
 			targetField: TargetFieldInlineString,
-			expected:    "inline field with 0123 expansion",
+			expected:    "inline field with \"0123\" expansion",
 		},
 		{
 			value:       "!!str 0123",
 			targetField: TargetFieldString,
-			expected:    "0123",
+			expected:    "!!str 0123",
 		},
 		{
 			value:       "!!str 0123",
 			targetField: TargetFieldInlineString,
-			expected:    "inline field with 0123 expansion",
+			expected:    "inline field with !!str 0123 expansion",
 		},
 		{
 			value:        "t",

--- a/confmap/internal/e2e/types_test.go
+++ b/confmap/internal/e2e/types_test.go
@@ -98,27 +98,22 @@ func TestTypeCasting(t *testing.T) {
 		{
 			value:       "\"0123\"",
 			targetField: TargetFieldString,
-			expected:    "0123",
-		},
-		{
-			value:       "\"0123\"",
-			targetField: TargetFieldInt,
-			expected:    83,
+			expected:    "\"0123\"",
 		},
 		{
 			value:       "\"0123\"",
 			targetField: TargetFieldInlineString,
-			expected:    "inline field with 0123 expansion",
+			expected:    "inline field with \"0123\" expansion",
 		},
 		{
 			value:       "!!str 0123",
 			targetField: TargetFieldString,
-			expected:    "0123",
+			expected:    "!!str 0123",
 		},
 		{
 			value:       "!!str 0123",
 			targetField: TargetFieldInlineString,
-			expected:    "inline field with 0123 expansion",
+			expected:    "inline field with !!str 0123 expansion",
 		},
 		{
 			value:       "t",

--- a/confmap/provider.go
+++ b/confmap/provider.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/collector/internal/featuregates"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
+
+	"go.opentelemetry.io/collector/internal/featuregates"
 )
 
 // ProviderSettings are the settings to initialize a Provider.

--- a/confmap/provider_test.go
+++ b/confmap/provider_test.go
@@ -85,8 +85,8 @@ func TestNewRetrievedFromYAMLString(t *testing.T) {
 		},
 		{
 			yaml:       "\"string\"",
-			value:      "string",
-			altStrRepr: "string",
+			value:      "\"string\"",
+			altStrRepr: "\"string\"",
 		},
 		{
 			yaml:  "123",

--- a/docs/rfcs/env-vars.md
+++ b/docs/rfcs/env-vars.md
@@ -216,7 +216,7 @@ loading a field with the braces syntax, `env` syntax.
 | `0123`       | integer    | 83                                       | 83                                             | 83                             | n/a                                   |
 | `0123`       | string     | 0123                                     | 83                                             | 0123                           | 0123                                  |
 | `0xdeadbeef` | string     | 0xdeadbeef                               | 3735928559                                     | 0xdeadbeef                     | 0xdeadbeef                            |
-| `"0123"`     | string     | "0123"                                   | 0123                                           | 0123                           | 0123                                  |
-| `!!str 0123` | string     | !!str 0123                               | 0123                                           | 0123                           | 0123                                  |
+| `"0123"`     | string     | "0123"                                   | 0123                                           | "0123"                         | "0123"                                |
+| `!!str 0123` | string     | !!str 0123                               | 0123                                           | !!str 0123                     | !!str 0123                            |
 | `t`          | boolean    | true                                     | true                                           | Error: mapping string to bool  | n/a                                   |
 | `23`         | boolean    | true                                     | true                                           | Error: mapping integer to bool | n/a                                   |


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Originally on the [env var RFC](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/env-vars.md) I proposed using the YAML parsed value when parsing a string, which has been the default behavior until now of `${env:ENV}` and friends.
An alternative is to use the raw string value, which is what `${ENV}` used to do. The difference (after enabling strict types) does not matter much in practice save for a few edge cases (since strings can be represented in multiple ways), namely on the YAML parsing scenario:
- Quotes get removed (`"opentelemetry"` -> `opentelemetry`)
- YAML type tags get removed (`!!str opentelemetry` -> `opentelemetry`)
- Literal newlines get removed (although this may be a bug in our parser, see go-yaml/yaml/issues/963)
- Escaping sequences are mapped to their own character

It's a matter of opinion which behavior is more intuitive to end users. In this PR I change the behavior to use the raw string value. I think the arguments in favor are:
- It's arguably less surprising (you get what you wrote)
- It solves a real issue faced by an user (see below)

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/10405#issuecomment-2225292473
