### PR TITLE
[mdatagen] Remove WithAttributes from the telemetry builder constructor

### DIFF
--- a/.chloggen/mdatagen-remove-with-attributes-helper.yaml
+++ b/.chloggen/mdatagen-remove-with-attributes-helper.yaml
@@ -1,0 +1,22 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove WithAttributes option from the telemetry builder constructor.
+
+subtext: |
+  Attribute sets for async instruments now can be set as options to callback setters and async instruments initializers.
+  This allows each async instrument to have its own attribute set.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10608]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -14,7 +14,6 @@ require (
 	go.opentelemetry.io/collector/pdata v1.12.0
 	go.opentelemetry.io/collector/receiver v0.105.0
 	go.opentelemetry.io/collector/semconv v0.105.0
-	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/metric v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0
 	go.opentelemetry.io/otel/trace v1.28.0
@@ -49,6 +48,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.12.0 // indirect
 	go.opentelemetry.io/collector/internal/globalgates v0.105.0 // indirect
+	go.opentelemetry.io/otel v1.28.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.50.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.28.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/cmd/mdatagen/main.go
+++ b/cmd/mdatagen/main.go
@@ -189,14 +189,6 @@ func templatize(tmplFile string, md metadata) *template.Template {
 					}
 					return result
 				},
-				"hasAsync": func(t telemetry) bool {
-					for _, m := range t.Metrics {
-						if m.Data().IsAsync() {
-							return true
-						}
-					}
-					return false
-				},
 				"inc": func(i int) int { return i + 1 },
 				"distroURL": func(name string) string {
 					return distros[name]

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -8,7 +8,6 @@ import (
     "errors"
     {{- end }}
 
-    {{ if hasAsync .Telemetry }}"go.opentelemetry.io/otel/attribute"{{- end }}
 	"go.opentelemetry.io/otel/metric"
     "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
@@ -33,11 +32,10 @@ type TelemetryBuilder struct {
 	{{- range $name, $metric := .Telemetry.Metrics }}
 	{{ $name.Render }} metric.{{ $metric.Data.Instrument }}
     {{- if and ($metric.Data.Async) (not $metric.Optional) }}
-    observe{{ $name.Render }} func() {{ $metric.Data.BasicType }}
+    observe{{ $name.Render }} func(context.Context, metric.Observer) error
     {{- end }}
 	{{- end }}
     level configtelemetry.Level
-    {{ if hasAsync .Telemetry }}attributeSet attribute.Set{{- end }}
 }
 
 // telemetryBuilderOption applies changes to default builder.
@@ -50,19 +48,10 @@ func WithLevel(lvl configtelemetry.Level) telemetryBuilderOption {
     }
 }
 
-{{- if hasAsync .Telemetry }}
-// WithAttributeSet applies a set of attributes for asynchronous instruments.
-func WithAttributeSet(set attribute.Set) telemetryBuilderOption {
-	return func(builder *TelemetryBuilder) {
-		builder.attributeSet = set
-	}
-}
-{{- end }}
-
 {{- range $name, $metric := .Telemetry.Metrics }}
 {{- if $metric.Optional }}
 // Init{{ $name.Render }} configures the {{ $name.Render }} metric.
-func (builder *TelemetryBuilder) Init{{ $name.Render }}({{ if $metric.Data.Async -}}cb func() {{ $metric.Data.BasicType }}{{- end }}) error {
+func (builder *TelemetryBuilder) Init{{ $name.Render }}({{ if $metric.Data.Async -}}cb func() {{ $metric.Data.BasicType }}{{- end }}, opts ...metric.ObserveOption) error {
     var err error
     builder.{{ $name.Render }}, err = builder.meter.{{ $metric.Data.Instrument }}(
         "{{ $name }}",
@@ -77,7 +66,7 @@ func (builder *TelemetryBuilder) Init{{ $name.Render }}({{ if $metric.Data.Async
         return err
     }
     _, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-        o.Observe{{ casesTitle $metric.Data.BasicType }}(builder.{{ $name.Render }}, cb(), metric.WithAttributeSet(builder.attributeSet))
+        o.Observe{{ casesTitle $metric.Data.BasicType }}(builder.{{ $name.Render }}, cb(), opts...)
         return nil
     }, builder.{{ $name.Render }})
     {{- end }}
@@ -87,9 +76,12 @@ func (builder *TelemetryBuilder) Init{{ $name.Render }}({{ if $metric.Data.Async
     {{- else }}
     {{ if $metric.Data.Async -}}
 // With{{ $name.Render }}Callback sets callback for observable {{ $name.Render }} metric.
-func With{{ $name.Render }}Callback(cb func() {{ $metric.Data.BasicType }}) telemetryBuilderOption {
+func With{{ $name.Render }}Callback(cb func() {{ $metric.Data.BasicType }}, opts ...metric.ObserveOption) telemetryBuilderOption {
     return func(builder *TelemetryBuilder) {
-        builder.observe{{ $name.Render }} = cb
+        builder.observe{{ $name.Render }} = func(_ context.Context, o metric.Observer) error {
+            o.Observe{{ casesTitle $metric.Data.BasicType }}(builder.{{ $name.Render }}, cb(), opts...)
+            return nil
+        }
     }
 }
     {{- end }}
@@ -123,10 +115,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
     )
     errs = errors.Join(errs, err)
     {{- if $metric.Data.Async }}
-    _, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-        o.Observe{{ casesTitle $metric.Data.BasicType }}(builder.{{ $name.Render }}, builder.observe{{ $name.Render }}(), metric.WithAttributeSet(builder.attributeSet))
-        return nil
-    }, builder.{{ $name.Render }})
+    _, err = builder.meter.RegisterCallback(builder.observe{{ $name.Render }}, builder.{{ $name.Render }})
     errs = errors.Join(errs, err)
     {{- end }}
     {{- end }}

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -49,9 +49,7 @@ func NewObsReport(cfg ObsReportSettings) (*ObsReport, error) {
 }
 
 func newExporter(cfg ObsReportSettings) (*ObsReport, error) {
-	telemetryBuilder, err := metadata.NewTelemetryBuilder(cfg.ExporterCreateSettings.TelemetrySettings,
-		metadata.WithAttributeSet(attribute.NewSet(attribute.String(obsmetrics.ExporterKey, cfg.ExporterID.String()))),
-	)
+	telemetryBuilder, err := metadata.NewTelemetryBuilder(cfg.ExporterCreateSettings.TelemetrySettings)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -37,8 +37,9 @@ func newBatchProcessorTelemetry(set processor.Settings, currentMetadataCardinali
 
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(set.TelemetrySettings,
 		metadata.WithLevel(set.MetricsLevel),
-		metadata.WithProcessorBatchMetadataCardinalityCallback(func() int64 { return int64(currentMetadataCardinality()) }),
-		metadata.WithAttributeSet(attrs),
+		metadata.WithProcessorBatchMetadataCardinalityCallback(func() int64 {
+			return int64(currentMetadataCardinality())
+		}, metric.WithAttributeSet(attrs)),
 	)
 
 	if err != nil {

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
@@ -28,19 +27,18 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 type TelemetryBuilder struct {
 	meter                                    metric.Meter
 	ProcessCPUSeconds                        metric.Float64ObservableCounter
-	observeProcessCPUSeconds                 func() float64
+	observeProcessCPUSeconds                 func(context.Context, metric.Observer) error
 	ProcessMemoryRss                         metric.Int64ObservableGauge
-	observeProcessMemoryRss                  func() int64
+	observeProcessMemoryRss                  func(context.Context, metric.Observer) error
 	ProcessRuntimeHeapAllocBytes             metric.Int64ObservableGauge
-	observeProcessRuntimeHeapAllocBytes      func() int64
+	observeProcessRuntimeHeapAllocBytes      func(context.Context, metric.Observer) error
 	ProcessRuntimeTotalAllocBytes            metric.Int64ObservableCounter
-	observeProcessRuntimeTotalAllocBytes     func() int64
+	observeProcessRuntimeTotalAllocBytes     func(context.Context, metric.Observer) error
 	ProcessRuntimeTotalSysMemoryBytes        metric.Int64ObservableGauge
-	observeProcessRuntimeTotalSysMemoryBytes func() int64
+	observeProcessRuntimeTotalSysMemoryBytes func(context.Context, metric.Observer) error
 	ProcessUptime                            metric.Float64ObservableCounter
-	observeProcessUptime                     func() float64
+	observeProcessUptime                     func(context.Context, metric.Observer) error
 	level                                    configtelemetry.Level
-	attributeSet                             attribute.Set
 }
 
 // telemetryBuilderOption applies changes to default builder.
@@ -53,52 +51,63 @@ func WithLevel(lvl configtelemetry.Level) telemetryBuilderOption {
 	}
 }
 
-// WithAttributeSet applies a set of attributes for asynchronous instruments.
-func WithAttributeSet(set attribute.Set) telemetryBuilderOption {
-	return func(builder *TelemetryBuilder) {
-		builder.attributeSet = set
-	}
-}
-
 // WithProcessCPUSecondsCallback sets callback for observable ProcessCPUSeconds metric.
-func WithProcessCPUSecondsCallback(cb func() float64) telemetryBuilderOption {
+func WithProcessCPUSecondsCallback(cb func() float64, opts ...metric.ObserveOption) telemetryBuilderOption {
 	return func(builder *TelemetryBuilder) {
-		builder.observeProcessCPUSeconds = cb
+		builder.observeProcessCPUSeconds = func(_ context.Context, o metric.Observer) error {
+			o.ObserveFloat64(builder.ProcessCPUSeconds, cb(), opts...)
+			return nil
+		}
 	}
 }
 
 // WithProcessMemoryRssCallback sets callback for observable ProcessMemoryRss metric.
-func WithProcessMemoryRssCallback(cb func() int64) telemetryBuilderOption {
+func WithProcessMemoryRssCallback(cb func() int64, opts ...metric.ObserveOption) telemetryBuilderOption {
 	return func(builder *TelemetryBuilder) {
-		builder.observeProcessMemoryRss = cb
+		builder.observeProcessMemoryRss = func(_ context.Context, o metric.Observer) error {
+			o.ObserveInt64(builder.ProcessMemoryRss, cb(), opts...)
+			return nil
+		}
 	}
 }
 
 // WithProcessRuntimeHeapAllocBytesCallback sets callback for observable ProcessRuntimeHeapAllocBytes metric.
-func WithProcessRuntimeHeapAllocBytesCallback(cb func() int64) telemetryBuilderOption {
+func WithProcessRuntimeHeapAllocBytesCallback(cb func() int64, opts ...metric.ObserveOption) telemetryBuilderOption {
 	return func(builder *TelemetryBuilder) {
-		builder.observeProcessRuntimeHeapAllocBytes = cb
+		builder.observeProcessRuntimeHeapAllocBytes = func(_ context.Context, o metric.Observer) error {
+			o.ObserveInt64(builder.ProcessRuntimeHeapAllocBytes, cb(), opts...)
+			return nil
+		}
 	}
 }
 
 // WithProcessRuntimeTotalAllocBytesCallback sets callback for observable ProcessRuntimeTotalAllocBytes metric.
-func WithProcessRuntimeTotalAllocBytesCallback(cb func() int64) telemetryBuilderOption {
+func WithProcessRuntimeTotalAllocBytesCallback(cb func() int64, opts ...metric.ObserveOption) telemetryBuilderOption {
 	return func(builder *TelemetryBuilder) {
-		builder.observeProcessRuntimeTotalAllocBytes = cb
+		builder.observeProcessRuntimeTotalAllocBytes = func(_ context.Context, o metric.Observer) error {
+			o.ObserveInt64(builder.ProcessRuntimeTotalAllocBytes, cb(), opts...)
+			return nil
+		}
 	}
 }
 
 // WithProcessRuntimeTotalSysMemoryBytesCallback sets callback for observable ProcessRuntimeTotalSysMemoryBytes metric.
-func WithProcessRuntimeTotalSysMemoryBytesCallback(cb func() int64) telemetryBuilderOption {
+func WithProcessRuntimeTotalSysMemoryBytesCallback(cb func() int64, opts ...metric.ObserveOption) telemetryBuilderOption {
 	return func(builder *TelemetryBuilder) {
-		builder.observeProcessRuntimeTotalSysMemoryBytes = cb
+		builder.observeProcessRuntimeTotalSysMemoryBytes = func(_ context.Context, o metric.Observer) error {
+			o.ObserveInt64(builder.ProcessRuntimeTotalSysMemoryBytes, cb(), opts...)
+			return nil
+		}
 	}
 }
 
 // WithProcessUptimeCallback sets callback for observable ProcessUptime metric.
-func WithProcessUptimeCallback(cb func() float64) telemetryBuilderOption {
+func WithProcessUptimeCallback(cb func() float64, opts ...metric.ObserveOption) telemetryBuilderOption {
 	return func(builder *TelemetryBuilder) {
-		builder.observeProcessUptime = cb
+		builder.observeProcessUptime = func(_ context.Context, o metric.Observer) error {
+			o.ObserveFloat64(builder.ProcessUptime, cb(), opts...)
+			return nil
+		}
 	}
 }
 
@@ -121,10 +130,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		metric.WithUnit("s"),
 	)
 	errs = errors.Join(errs, err)
-	_, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		o.ObserveFloat64(builder.ProcessCPUSeconds, builder.observeProcessCPUSeconds(), metric.WithAttributeSet(builder.attributeSet))
-		return nil
-	}, builder.ProcessCPUSeconds)
+	_, err = builder.meter.RegisterCallback(builder.observeProcessCPUSeconds, builder.ProcessCPUSeconds)
 	errs = errors.Join(errs, err)
 	builder.ProcessMemoryRss, err = builder.meter.Int64ObservableGauge(
 		"process_memory_rss",
@@ -132,10 +138,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	_, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		o.ObserveInt64(builder.ProcessMemoryRss, builder.observeProcessMemoryRss(), metric.WithAttributeSet(builder.attributeSet))
-		return nil
-	}, builder.ProcessMemoryRss)
+	_, err = builder.meter.RegisterCallback(builder.observeProcessMemoryRss, builder.ProcessMemoryRss)
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeHeapAllocBytes, err = builder.meter.Int64ObservableGauge(
 		"process_runtime_heap_alloc_bytes",
@@ -143,10 +146,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	_, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		o.ObserveInt64(builder.ProcessRuntimeHeapAllocBytes, builder.observeProcessRuntimeHeapAllocBytes(), metric.WithAttributeSet(builder.attributeSet))
-		return nil
-	}, builder.ProcessRuntimeHeapAllocBytes)
+	_, err = builder.meter.RegisterCallback(builder.observeProcessRuntimeHeapAllocBytes, builder.ProcessRuntimeHeapAllocBytes)
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeTotalAllocBytes, err = builder.meter.Int64ObservableCounter(
 		"process_runtime_total_alloc_bytes",
@@ -154,10 +154,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	_, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		o.ObserveInt64(builder.ProcessRuntimeTotalAllocBytes, builder.observeProcessRuntimeTotalAllocBytes(), metric.WithAttributeSet(builder.attributeSet))
-		return nil
-	}, builder.ProcessRuntimeTotalAllocBytes)
+	_, err = builder.meter.RegisterCallback(builder.observeProcessRuntimeTotalAllocBytes, builder.ProcessRuntimeTotalAllocBytes)
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeTotalSysMemoryBytes, err = builder.meter.Int64ObservableGauge(
 		"process_runtime_total_sys_memory_bytes",
@@ -165,10 +162,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	_, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		o.ObserveInt64(builder.ProcessRuntimeTotalSysMemoryBytes, builder.observeProcessRuntimeTotalSysMemoryBytes(), metric.WithAttributeSet(builder.attributeSet))
-		return nil
-	}, builder.ProcessRuntimeTotalSysMemoryBytes)
+	_, err = builder.meter.RegisterCallback(builder.observeProcessRuntimeTotalSysMemoryBytes, builder.ProcessRuntimeTotalSysMemoryBytes)
 	errs = errors.Join(errs, err)
 	builder.ProcessUptime, err = builder.meter.Float64ObservableCounter(
 		"process_uptime",
@@ -176,10 +170,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 		metric.WithUnit("s"),
 	)
 	errs = errors.Join(errs, err)
-	_, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		o.ObserveFloat64(builder.ProcessUptime, builder.observeProcessUptime(), metric.WithAttributeSet(builder.attributeSet))
-		return nil
-	}, builder.ProcessUptime)
+	_, err = builder.meter.RegisterCallback(builder.observeProcessUptime, builder.ProcessUptime)
 	errs = errors.Join(errs, err)
 	return &builder, errs
 }


### PR DESCRIPTION
Attribute sets for async instruments now can be set as options to callback setters and async instruments initializers. This allows each async instrument to have its own attribute set.

Unblocks https://github.com/open-telemetry/opentelemetry-collector/pull/10593