### PR TITLE
[exporterhelper] expose an option to organize data in batches

### DIFF
--- a/.chloggen/batch_by_resource_attrs.yaml
+++ b/.chloggen/batch_by_resource_attrs.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add to the exporterhelper options an option to batch incoming data by resource attributes.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10630]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -315,7 +315,7 @@ func (be *baseExporter) send(ctx context.Context, req Request) error {
 // connectSenders connects the senders in the predefined order.
 func (be *baseExporter) connectSenders() {
 	be.queueSender.setNextSender(be.organizeSender)
-	be.queueSender.setNextSender(be.batchSender)
+	be.organizeSender.setNextSender(be.batchSender)
 	be.batchSender.setNextSender(be.obsrepSender)
 	be.obsrepSender.setNextSender(be.retrySender)
 	be.retrySender.setNextSender(be.timeoutSender)

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -95,4 +96,17 @@ func TestBaseExporterLogging(t *testing.T) {
 	require.Error(t, sendErr)
 
 	require.Len(t, observed.FilterLevelExact(zap.ErrorLevel).All(), 1)
+}
+
+func TestBaseExporterWithBatchPerResourceAttributeInvalid(t *testing.T) {
+	set := exportertest.NewNopSettings()
+	_, err := newBaseExporter(set, defaultDataType, newNoopObsrepSender, WithBatchPerResourceAttribute())
+	assert.EqualError(t, err, "WithBatchPerResourceAttribute must be provided with at least one attribute key")
+}
+
+func TestBaseExporterWithBatchPerResourceAttribute(t *testing.T) {
+	set := exportertest.NewNopSettings()
+	be, err := newBaseExporter(set, defaultDataType, newNoopObsrepSender, WithBatchPerResourceAttribute("foo"))
+	assert.NoError(t, err)
+	require.NotNil(t, be)
 }

--- a/exporter/exporterhelper/organize_sender.go
+++ b/exporter/exporterhelper/organize_sender.go
@@ -1,0 +1,172 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporterhelper"
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/multierr"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+var separator = string([]byte{0x0, 0x1})
+
+func newOrganizeSender(attrKeys []string) *organizeSender {
+	return &organizeSender{
+		attrKeys: attrKeys,
+	}
+}
+
+type organizeSender struct {
+	baseRequestSender
+	attrKeys []string
+}
+
+func (o *organizeSender) send(ctx context.Context, req Request) error {
+	var err error
+	switch r := req.(type) {
+	case *metricsRequest:
+		mds := organizeMetrics(o.attrKeys, r.md)
+		for _, md := range mds {
+			mr := &metricsRequest{
+				md:     md,
+				pusher: r.pusher,
+			}
+			err = multierr.Combine(err, o.nextSender.send(ctx, mr))
+		}
+	case *logsRequest:
+		lds := organizeLogs(o.attrKeys, r.ld)
+		for _, ld := range lds {
+			lr := &logsRequest{
+				ld:     ld,
+				pusher: r.pusher,
+			}
+			err = multierr.Combine(err, o.nextSender.send(ctx, lr))
+		}
+	case *tracesRequest:
+		tds := organizeTraces(o.attrKeys, r.td)
+		for _, td := range tds {
+			tr := &tracesRequest{
+				td:     td,
+				pusher: r.pusher,
+			}
+			err = multierr.Combine(err, o.nextSender.send(ctx, tr))
+		}
+	default:
+		return fmt.Errorf("unsupported type %v", req)
+	}
+	return err
+}
+
+func organizeLogs(attrKeys []string, ld plog.Logs) []plog.Logs {
+	rls := ld.ResourceLogs()
+	lenRls := rls.Len()
+	// If zero or one resource logs, return early
+	if lenRls <= 1 {
+		return []plog.Logs{ld}
+	}
+
+	indicesByAttr := make(map[string][]int)
+	for i := 0; i < lenRls; i++ {
+		rl := rls.At(i)
+		var attrVal string
+		for _, k := range attrKeys {
+			if attributeValue, ok := rl.Resource().Attributes().Get(k); ok {
+				attrVal = fmt.Sprintf("%s%s%s", attrVal, separator, attributeValue.Str())
+			}
+		}
+		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
+	}
+	// If there is a single attribute value, return early
+	if len(indicesByAttr) <= 1 {
+		return []plog.Logs{ld}
+	}
+
+	var result []plog.Logs
+	for _, indices := range indicesByAttr {
+		logsForAttr := plog.NewLogs()
+		result = append(result, logsForAttr)
+		for _, i := range indices {
+			rs := rls.At(i)
+			rs.CopyTo(logsForAttr.ResourceLogs().AppendEmpty())
+		}
+	}
+	return result
+}
+
+func organizeMetrics(attrKeys []string, md pmetric.Metrics) []pmetric.Metrics {
+	rms := md.ResourceMetrics()
+	lenRls := rms.Len()
+	// If zero or one resource metrics, return early
+	if lenRls <= 1 {
+		return []pmetric.Metrics{md}
+	}
+
+	indicesByAttr := make(map[string][]int)
+	for i := 0; i < lenRls; i++ {
+		rm := rms.At(i)
+		var attrVal string
+		for _, k := range attrKeys {
+			if attributeValue, ok := rm.Resource().Attributes().Get(k); ok {
+				attrVal = fmt.Sprintf("%s%s%s", attrVal, separator, attributeValue.Str())
+			}
+		}
+		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
+	}
+	// If there is a single attribute value, return early
+	if len(indicesByAttr) <= 1 {
+		return []pmetric.Metrics{md}
+	}
+
+	var result []pmetric.Metrics
+	for _, indices := range indicesByAttr {
+		metricsForAttr := pmetric.NewMetrics()
+		result = append(result, metricsForAttr)
+		for _, i := range indices {
+			rs := rms.At(i)
+			rs.CopyTo(metricsForAttr.ResourceMetrics().AppendEmpty())
+		}
+	}
+	return result
+}
+
+func organizeTraces(attrKeys []string, td ptrace.Traces) []ptrace.Traces {
+	rss := td.ResourceSpans()
+	lenRls := rss.Len()
+	// If zero or one resource traces, return early
+	if lenRls <= 1 {
+		return []ptrace.Traces{td}
+	}
+
+	indicesByAttr := make(map[string][]int)
+	for i := 0; i < lenRls; i++ {
+		rs := rss.At(i)
+		var attrVal string
+		for _, k := range attrKeys {
+			if attributeValue, ok := rs.Resource().Attributes().Get(k); ok {
+				attrVal = fmt.Sprintf("%s%s%s", attrVal, separator, attributeValue.Str())
+			}
+		}
+		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
+	}
+	// If there is a single attribute value, return early
+	if len(indicesByAttr) <= 1 {
+		return []ptrace.Traces{td}
+	}
+
+	var result []ptrace.Traces
+	for _, indices := range indicesByAttr {
+		tracesForAttr := ptrace.NewTraces()
+		result = append(result, tracesForAttr)
+		for _, i := range indices {
+			rs := rss.At(i)
+			rs.CopyTo(tracesForAttr.ResourceSpans().AppendEmpty())
+		}
+	}
+	return result
+}

--- a/exporter/exporterhelper/organize_sender.go
+++ b/exporter/exporterhelper/organize_sender.go
@@ -16,22 +16,25 @@ import (
 
 var separator = string([]byte{0x0, 0x1})
 
-func newOrganizeSender(attrKeys []string) *organizeSender {
-	return &organizeSender{
-		attrKeys: attrKeys,
-	}
+func newOrganizeSender() *organizeSender {
+	return &organizeSender{}
 }
 
 type organizeSender struct {
 	baseRequestSender
-	attrKeys []string
+	organizeLogs    func(plog.Logs) []plog.Logs
+	organizeMetrics func(pmetric.Metrics) []pmetric.Metrics
+	organizeTraces  func(traces ptrace.Traces) []ptrace.Traces
 }
 
 func (o *organizeSender) send(ctx context.Context, req Request) error {
 	var err error
 	switch r := req.(type) {
 	case *metricsRequest:
-		mds := organizeMetrics(o.attrKeys, r.md)
+		if o.organizeMetrics == nil {
+			return o.nextSender.send(ctx, req)
+		}
+		mds := (o.organizeMetrics)(r.md)
 		for _, md := range mds {
 			mr := &metricsRequest{
 				md:     md,
@@ -40,7 +43,10 @@ func (o *organizeSender) send(ctx context.Context, req Request) error {
 			err = multierr.Combine(err, o.nextSender.send(ctx, mr))
 		}
 	case *logsRequest:
-		lds := organizeLogs(o.attrKeys, r.ld)
+		if o.organizeLogs == nil {
+			return o.nextSender.send(ctx, req)
+		}
+		lds := (o.organizeLogs)(r.ld)
 		for _, ld := range lds {
 			lr := &logsRequest{
 				ld:     ld,
@@ -49,7 +55,10 @@ func (o *organizeSender) send(ctx context.Context, req Request) error {
 			err = multierr.Combine(err, o.nextSender.send(ctx, lr))
 		}
 	case *tracesRequest:
-		tds := organizeTraces(o.attrKeys, r.td)
+		if o.organizeTraces == nil {
+			return o.nextSender.send(ctx, req)
+		}
+		tds := (o.organizeTraces)(r.td)
 		for _, td := range tds {
 			tr := &tracesRequest{
 				td:     td,
@@ -61,112 +70,4 @@ func (o *organizeSender) send(ctx context.Context, req Request) error {
 		return fmt.Errorf("unsupported type %v", req)
 	}
 	return err
-}
-
-func organizeLogs(attrKeys []string, ld plog.Logs) []plog.Logs {
-	rls := ld.ResourceLogs()
-	lenRls := rls.Len()
-	// If zero or one resource logs, return early
-	if lenRls <= 1 {
-		return []plog.Logs{ld}
-	}
-
-	indicesByAttr := make(map[string][]int)
-	for i := 0; i < lenRls; i++ {
-		rl := rls.At(i)
-		var attrVal string
-		for _, k := range attrKeys {
-			if attributeValue, ok := rl.Resource().Attributes().Get(k); ok {
-				attrVal = fmt.Sprintf("%s%s%s", attrVal, separator, attributeValue.Str())
-			}
-		}
-		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
-	}
-	// If there is a single attribute value, return early
-	if len(indicesByAttr) <= 1 {
-		return []plog.Logs{ld}
-	}
-
-	var result []plog.Logs
-	for _, indices := range indicesByAttr {
-		logsForAttr := plog.NewLogs()
-		result = append(result, logsForAttr)
-		for _, i := range indices {
-			rs := rls.At(i)
-			rs.CopyTo(logsForAttr.ResourceLogs().AppendEmpty())
-		}
-	}
-	return result
-}
-
-func organizeMetrics(attrKeys []string, md pmetric.Metrics) []pmetric.Metrics {
-	rms := md.ResourceMetrics()
-	lenRls := rms.Len()
-	// If zero or one resource metrics, return early
-	if lenRls <= 1 {
-		return []pmetric.Metrics{md}
-	}
-
-	indicesByAttr := make(map[string][]int)
-	for i := 0; i < lenRls; i++ {
-		rm := rms.At(i)
-		var attrVal string
-		for _, k := range attrKeys {
-			if attributeValue, ok := rm.Resource().Attributes().Get(k); ok {
-				attrVal = fmt.Sprintf("%s%s%s", attrVal, separator, attributeValue.Str())
-			}
-		}
-		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
-	}
-	// If there is a single attribute value, return early
-	if len(indicesByAttr) <= 1 {
-		return []pmetric.Metrics{md}
-	}
-
-	var result []pmetric.Metrics
-	for _, indices := range indicesByAttr {
-		metricsForAttr := pmetric.NewMetrics()
-		result = append(result, metricsForAttr)
-		for _, i := range indices {
-			rs := rms.At(i)
-			rs.CopyTo(metricsForAttr.ResourceMetrics().AppendEmpty())
-		}
-	}
-	return result
-}
-
-func organizeTraces(attrKeys []string, td ptrace.Traces) []ptrace.Traces {
-	rss := td.ResourceSpans()
-	lenRls := rss.Len()
-	// If zero or one resource traces, return early
-	if lenRls <= 1 {
-		return []ptrace.Traces{td}
-	}
-
-	indicesByAttr := make(map[string][]int)
-	for i := 0; i < lenRls; i++ {
-		rs := rss.At(i)
-		var attrVal string
-		for _, k := range attrKeys {
-			if attributeValue, ok := rs.Resource().Attributes().Get(k); ok {
-				attrVal = fmt.Sprintf("%s%s%s", attrVal, separator, attributeValue.Str())
-			}
-		}
-		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
-	}
-	// If there is a single attribute value, return early
-	if len(indicesByAttr) <= 1 {
-		return []ptrace.Traces{td}
-	}
-
-	var result []ptrace.Traces
-	for _, indices := range indicesByAttr {
-		tracesForAttr := ptrace.NewTraces()
-		result = append(result, tracesForAttr)
-		for _, i := range indices {
-			rs := rss.At(i)
-			rs.CopyTo(tracesForAttr.ResourceSpans().AppendEmpty())
-		}
-	}
-	return result
 }

--- a/exporter/exporterhelper/organize_sender_test.go
+++ b/exporter/exporterhelper/organize_sender_test.go
@@ -1,0 +1,463 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exporterhelper
+
+import (
+	"context"
+	"math/rand"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestSplitTracesOneResourceSpans(t *testing.T) {
+	inBatch := ptrace.NewTraces()
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+
+	outBatches := organizeTraces([]string{"attr_key"}, inBatch)
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, inBatch, outBatches[0])
+}
+
+func TestOriginalResourceSpansUnchanged(t *testing.T) {
+	inBatch := ptrace.NewTraces()
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+
+	outBatches := organizeTraces([]string{"attr_key"}, inBatch)
+	require.Len(t, outBatches, 1)
+}
+
+func TestSplitTracesSameResource(t *testing.T) {
+	inBatch := ptrace.NewTraces()
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "same_attr_val", "1")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "same_attr_val", "1")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "same_attr_val", "1")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "same_attr_val", "1")
+	expected := ptrace.NewTraces()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeTraces([]string{"same_attr_val"}, inBatch)
+	require.Len(t, outBatches, 1)
+}
+
+func TestSplitTracesIntoDifferentBatches(t *testing.T) {
+	inBatch := ptrace.NewTraces()
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "2")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "3")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "4")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "2")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "3")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "4")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "diff_attr_key", "1")
+	expected := ptrace.NewTraces()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeTraces([]string{"attr_key"}, inBatch)
+	require.Len(t, outBatches, 5)
+	sortTraces(outBatches, "attr_key")
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(8)), outBatches[0])
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(0), expected.ResourceSpans().At(4)), outBatches[1])
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(1), expected.ResourceSpans().At(5)), outBatches[2])
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(2), expected.ResourceSpans().At(6)), outBatches[3])
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(3), expected.ResourceSpans().At(7)), outBatches[4])
+}
+
+func TestSplitTracesIntoDifferentBatchesWithMultipleKeys(t *testing.T) {
+	inBatch := ptrace.NewTraces()
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "5", "attr_key2", "6")
+	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "diff_attr_key", "1")
+	expected := ptrace.NewTraces()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeTraces([]string{"attr_key", "attr_key2"}, inBatch)
+	sortTraces(outBatches, "attr_key")
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(9)), outBatches[0])
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(0), expected.ResourceSpans().At(4)), outBatches[1])
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(1), expected.ResourceSpans().At(5)), outBatches[2])
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(2), expected.ResourceSpans().At(6)), outBatches[3])
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(3), expected.ResourceSpans().At(7)), outBatches[4])
+	assert.Equal(t, newTraces(expected.ResourceSpans().At(8)), outBatches[5])
+}
+
+func TestSplitMetricsOneResourceMetrics(t *testing.T) {
+	inBatch := pmetric.NewMetrics()
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
+	expected := pmetric.NewMetrics()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeMetrics([]string{"attr_key"}, inBatch)
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, expected, outBatches[0])
+}
+
+func TestOriginalResourceMetricsUnchanged(t *testing.T) {
+	inBatch := pmetric.NewMetrics()
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
+
+	outBatches := organizeMetrics([]string{"attr_key"}, inBatch)
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, inBatch, outBatches[0])
+}
+
+func TestSplitMetricsSameResource(t *testing.T) {
+	inBatch := pmetric.NewMetrics()
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "same_attr_val", "1")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "same_attr_val", "1")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "same_attr_val", "1")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "same_attr_val", "1")
+	expected := pmetric.NewMetrics()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeMetrics([]string{"same_attr_val"}, inBatch)
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, expected, outBatches[0])
+}
+
+func TestSplitMetricsIntoDifferentBatches(t *testing.T) {
+	inBatch := pmetric.NewMetrics()
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "2")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "3")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "4")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "2")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "3")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "4")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "diff_attr_key", "1")
+	expected := pmetric.NewMetrics()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeMetrics([]string{"attr_key"}, inBatch)
+	require.Len(t, outBatches, 5)
+	sortMetrics(outBatches, "attr_key")
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(8)), outBatches[0])
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(0), expected.ResourceMetrics().At(4)), outBatches[1])
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(1), expected.ResourceMetrics().At(5)), outBatches[2])
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(2), expected.ResourceMetrics().At(6)), outBatches[3])
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(3), expected.ResourceMetrics().At(7)), outBatches[4])
+}
+
+func TestSplitMetricsIntoDifferentBatchesWithMultipleKeys(t *testing.T) {
+	inBatch := pmetric.NewMetrics()
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "5", "attr_key2", "6")
+	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "diff_attr_key", "1")
+	expected := pmetric.NewMetrics()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeMetrics([]string{"attr_key", "attr_key2"}, inBatch)
+	require.Len(t, outBatches, 6)
+	sortMetrics(outBatches, "attr_key")
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(9)), outBatches[0])
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(0), expected.ResourceMetrics().At(4)), outBatches[1])
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(1), expected.ResourceMetrics().At(5)), outBatches[2])
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(2), expected.ResourceMetrics().At(6)), outBatches[3])
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(3), expected.ResourceMetrics().At(7)), outBatches[4])
+	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(8)), outBatches[5])
+}
+
+func TestSplitLogsOneResourceLogs(t *testing.T) {
+	inBatch := plog.NewLogs()
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
+	expected := plog.NewLogs()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeLogs([]string{"attr_key"}, inBatch)
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, expected, outBatches[0])
+}
+
+func TestOriginalResourceLogsUnchanged(t *testing.T) {
+	inBatch := plog.NewLogs()
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
+
+	outBatches := organizeLogs([]string{"attr_key"}, inBatch)
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, inBatch, outBatches[0])
+}
+
+func TestSplitLogsSameResource(t *testing.T) {
+	inBatch := plog.NewLogs()
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "same_attr_val", "1")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "same_attr_val", "1")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "same_attr_val", "1")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "same_attr_val", "1")
+	expected := plog.NewLogs()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeLogs([]string{"same_attr_val"}, inBatch)
+	require.Len(t, outBatches, 1)
+	assert.Equal(t, expected, outBatches[0])
+}
+
+func TestSplitLogsIntoDifferentBatches(t *testing.T) {
+	inBatch := plog.NewLogs()
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "2")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "3")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "4")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "2")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "3")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "4")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "diff_attr_key", "1")
+	expected := plog.NewLogs()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeLogs([]string{"attr_key"}, inBatch)
+	require.Len(t, outBatches, 5)
+	sortLogs(outBatches, "attr_key")
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(8)), outBatches[0])
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(0), expected.ResourceLogs().At(4)), outBatches[1])
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(1), expected.ResourceLogs().At(5)), outBatches[2])
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(2), expected.ResourceLogs().At(6)), outBatches[3])
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(3), expected.ResourceLogs().At(7)), outBatches[4])
+}
+
+func TestSplitLogsIntoDifferentBatchesWithMultipleKeys(t *testing.T) {
+	inBatch := plog.NewLogs()
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "5", "attr_key2", "6")
+	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "diff_attr_key", "1")
+	expected := plog.NewLogs()
+	inBatch.CopyTo(expected)
+
+	outBatches := organizeLogs([]string{"attr_key", "attr_key2"}, inBatch)
+	require.Len(t, outBatches, 6)
+	sortLogs(outBatches, "attr_key")
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(9)), outBatches[0])
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(0), expected.ResourceLogs().At(4)), outBatches[1])
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(1), expected.ResourceLogs().At(5)), outBatches[2])
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(2), expected.ResourceLogs().At(6)), outBatches[3])
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(3), expected.ResourceLogs().At(7)), outBatches[4])
+	assert.Equal(t, newLogs(expected.ResourceLogs().At(8)), outBatches[5])
+}
+func newTraces(rss ...ptrace.ResourceSpans) ptrace.Traces {
+	td := ptrace.NewTraces()
+	for _, rs := range rss {
+		rs.CopyTo(td.ResourceSpans().AppendEmpty())
+	}
+	return td
+}
+
+func sortTraces(tds []ptrace.Traces, attrKey string) {
+	sort.Slice(tds, func(i, j int) bool {
+		valI := ""
+		if av, ok := tds[i].ResourceSpans().At(0).Resource().Attributes().Get(attrKey); ok {
+			valI = av.Str()
+		}
+		valJ := ""
+		if av, ok := tds[j].ResourceSpans().At(0).Resource().Attributes().Get(attrKey); ok {
+			valJ = av.Str()
+		}
+		return valI < valJ
+	})
+}
+func fillResourceSpans(rs ptrace.ResourceSpans, kv ...string) {
+	for i := 0; i < len(kv); i += 2 {
+		rs.Resource().Attributes().PutStr(kv[i], kv[i+1])
+	}
+
+	rs.Resource().Attributes().PutInt("__other_key__", 123)
+	ils := rs.ScopeSpans().AppendEmpty()
+	firstSpan := ils.Spans().AppendEmpty()
+	firstSpan.SetName("first-span")
+	firstSpan.SetTraceID(pcommon.TraceID([16]byte{byte(rand.Int())}))
+	secondSpan := ils.Spans().AppendEmpty()
+	secondSpan.SetName("second-span")
+	secondSpan.SetTraceID(pcommon.TraceID([16]byte{byte(rand.Int())}))
+}
+
+func newMetrics(rms ...pmetric.ResourceMetrics) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	for _, rm := range rms {
+		rm.CopyTo(md.ResourceMetrics().AppendEmpty())
+	}
+	return md
+}
+
+func sortMetrics(tds []pmetric.Metrics, attrKey string) {
+	sort.Slice(tds, func(i, j int) bool {
+		valI := ""
+		if av, ok := tds[i].ResourceMetrics().At(0).Resource().Attributes().Get(attrKey); ok {
+			valI = av.Str()
+		}
+		valJ := ""
+		if av, ok := tds[j].ResourceMetrics().At(0).Resource().Attributes().Get(attrKey); ok {
+			valJ = av.Str()
+		}
+		return valI < valJ
+	})
+}
+
+func fillResourceMetrics(rs pmetric.ResourceMetrics, kv ...string) {
+	for i := 0; i < len(kv); i += 2 {
+		rs.Resource().Attributes().PutStr(kv[i], kv[i+1])
+	}
+	rs.Resource().Attributes().PutInt("__other_key__", 123)
+	ils := rs.ScopeMetrics().AppendEmpty()
+	firstMetric := ils.Metrics().AppendEmpty()
+	firstMetric.SetName("first-metric")
+	firstMetric.SetEmptyGauge()
+	secondMetric := ils.Metrics().AppendEmpty()
+	secondMetric.SetName("second-metric")
+	secondMetric.SetEmptySum()
+}
+
+func newLogs(rls ...plog.ResourceLogs) plog.Logs {
+	ld := plog.NewLogs()
+	for _, rl := range rls {
+		rl.CopyTo(ld.ResourceLogs().AppendEmpty())
+	}
+	return ld
+}
+
+func sortLogs(tds []plog.Logs, attrKey string) {
+	sort.Slice(tds, func(i, j int) bool {
+		valI := ""
+		if av, ok := tds[i].ResourceLogs().At(0).Resource().Attributes().Get(attrKey); ok {
+			valI = av.Str()
+		}
+		valJ := ""
+		if av, ok := tds[j].ResourceLogs().At(0).Resource().Attributes().Get(attrKey); ok {
+			valJ = av.Str()
+		}
+		return valI < valJ
+	})
+}
+
+func fillResourceLogs(rs plog.ResourceLogs, kv ...string) {
+	for i := 0; i < len(kv); i += 2 {
+		rs.Resource().Attributes().PutStr(kv[i], kv[i+1])
+	}
+	rs.Resource().Attributes().PutInt("__other_key__", 123)
+	ils := rs.ScopeLogs().AppendEmpty()
+	firstLogRecord := ils.LogRecords().AppendEmpty()
+	firstLogRecord.SetFlags(plog.LogRecordFlags(rand.Int31()))
+	secondLogRecord := ils.LogRecords().AppendEmpty()
+	secondLogRecord.SetFlags(plog.LogRecordFlags(rand.Int31()))
+}
+
+func BenchmarkBatchPerResourceTraces(b *testing.B) {
+	inBatch := ptrace.NewTraces()
+	rss := inBatch.ResourceSpans()
+	rss.EnsureCapacity(64)
+	for i := 0; i < 64; i++ {
+		fillResourceSpans(rss.AppendEmpty(), "attr_key", strconv.Itoa(i%8))
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		organizeTraces([]string{"attr_key"}, inBatch)
+	}
+}
+
+func BenchmarkBatchPerResourceMetrics(b *testing.B) {
+	inBatch := pmetric.NewMetrics()
+	inBatch.ResourceMetrics().EnsureCapacity(64)
+	for i := 0; i < 64; i++ {
+		fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", strconv.Itoa(i%8))
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_ = organizeMetrics([]string{"attr_key"}, inBatch)
+	}
+}
+
+func BenchmarkBatchPerResourceLogs(b *testing.B) {
+	inBatch := plog.NewLogs()
+	inBatch.ResourceLogs().EnsureCapacity(64)
+	for i := 0; i < 64; i++ {
+		fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", strconv.Itoa(i%8))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_ = organizeLogs([]string{"attr_key"}, inBatch)
+	}
+}
+
+type nopSender struct {
+	baseRequestSender
+}
+
+func (n nopSender) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (n nopSender) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func (n nopSender) send(_ context.Context, _ Request) error {
+	return nil
+}
+
+func (n nopSender) setNextSender(_ requestSender) {
+	panic("unsupported")
+}
+
+func TestSend(t *testing.T) {
+
+	sender := &organizeSender{
+		attrKeys: []string{"attr_key"},
+	}
+	sender.setNextSender(nopSender{})
+
+	logBatch := plog.NewLogs()
+	fillResourceLogs(logBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
+	err := sender.send(context.Background(), &logsRequest{ld: logBatch})
+	require.NoError(t, err)
+
+	tracesBatch := ptrace.NewTraces()
+	fillResourceSpans(tracesBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+	err = sender.send(context.Background(), &tracesRequest{td: tracesBatch})
+	require.NoError(t, err)
+
+	metricsBatch := pmetric.NewMetrics()
+	fillResourceSpans(tracesBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+	err = sender.send(context.Background(), &metricsRequest{md: metricsBatch})
+	require.NoError(t, err)
+
+	err = sender.send(context.Background(), nil)
+	require.EqualError(t, err, "unsupported type <nil>")
+}

--- a/exporter/exporterhelper/organize_sender_test.go
+++ b/exporter/exporterhelper/organize_sender_test.go
@@ -5,12 +5,10 @@ package exporterhelper
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
-	"sort"
-	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
@@ -20,276 +18,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-func TestSplitTracesOneResourceSpans(t *testing.T) {
-	inBatch := ptrace.NewTraces()
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
-
-	outBatches := organizeTraces([]string{"attr_key"}, inBatch)
-	require.Len(t, outBatches, 1)
-	assert.Equal(t, inBatch, outBatches[0])
-}
-
-func TestOriginalResourceSpansUnchanged(t *testing.T) {
-	inBatch := ptrace.NewTraces()
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
-
-	outBatches := organizeTraces([]string{"attr_key"}, inBatch)
-	require.Len(t, outBatches, 1)
-}
-
-func TestSplitTracesSameResource(t *testing.T) {
-	inBatch := ptrace.NewTraces()
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "same_attr_val", "1")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "same_attr_val", "1")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "same_attr_val", "1")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "same_attr_val", "1")
-	expected := ptrace.NewTraces()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeTraces([]string{"same_attr_val"}, inBatch)
-	require.Len(t, outBatches, 1)
-}
-
-func TestSplitTracesIntoDifferentBatches(t *testing.T) {
-	inBatch := ptrace.NewTraces()
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "2")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "3")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "4")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "2")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "3")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "4")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "diff_attr_key", "1")
-	expected := ptrace.NewTraces()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeTraces([]string{"attr_key"}, inBatch)
-	require.Len(t, outBatches, 5)
-	sortTraces(outBatches, "attr_key")
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(8)), outBatches[0])
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(0), expected.ResourceSpans().At(4)), outBatches[1])
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(1), expected.ResourceSpans().At(5)), outBatches[2])
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(2), expected.ResourceSpans().At(6)), outBatches[3])
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(3), expected.ResourceSpans().At(7)), outBatches[4])
-}
-
-func TestSplitTracesIntoDifferentBatchesWithMultipleKeys(t *testing.T) {
-	inBatch := ptrace.NewTraces()
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "5", "attr_key2", "6")
-	fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "diff_attr_key", "1")
-	expected := ptrace.NewTraces()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeTraces([]string{"attr_key", "attr_key2"}, inBatch)
-	sortTraces(outBatches, "attr_key")
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(9)), outBatches[0])
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(0), expected.ResourceSpans().At(4)), outBatches[1])
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(1), expected.ResourceSpans().At(5)), outBatches[2])
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(2), expected.ResourceSpans().At(6)), outBatches[3])
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(3), expected.ResourceSpans().At(7)), outBatches[4])
-	assert.Equal(t, newTraces(expected.ResourceSpans().At(8)), outBatches[5])
-}
-
-func TestSplitMetricsOneResourceMetrics(t *testing.T) {
-	inBatch := pmetric.NewMetrics()
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
-	expected := pmetric.NewMetrics()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeMetrics([]string{"attr_key"}, inBatch)
-	require.Len(t, outBatches, 1)
-	assert.Equal(t, expected, outBatches[0])
-}
-
-func TestOriginalResourceMetricsUnchanged(t *testing.T) {
-	inBatch := pmetric.NewMetrics()
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
-
-	outBatches := organizeMetrics([]string{"attr_key"}, inBatch)
-	require.Len(t, outBatches, 1)
-	assert.Equal(t, inBatch, outBatches[0])
-}
-
-func TestSplitMetricsSameResource(t *testing.T) {
-	inBatch := pmetric.NewMetrics()
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "same_attr_val", "1")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "same_attr_val", "1")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "same_attr_val", "1")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "same_attr_val", "1")
-	expected := pmetric.NewMetrics()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeMetrics([]string{"same_attr_val"}, inBatch)
-	require.Len(t, outBatches, 1)
-	assert.Equal(t, expected, outBatches[0])
-}
-
-func TestSplitMetricsIntoDifferentBatches(t *testing.T) {
-	inBatch := pmetric.NewMetrics()
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "2")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "3")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "4")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "2")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "3")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "4")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "diff_attr_key", "1")
-	expected := pmetric.NewMetrics()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeMetrics([]string{"attr_key"}, inBatch)
-	require.Len(t, outBatches, 5)
-	sortMetrics(outBatches, "attr_key")
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(8)), outBatches[0])
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(0), expected.ResourceMetrics().At(4)), outBatches[1])
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(1), expected.ResourceMetrics().At(5)), outBatches[2])
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(2), expected.ResourceMetrics().At(6)), outBatches[3])
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(3), expected.ResourceMetrics().At(7)), outBatches[4])
-}
-
-func TestSplitMetricsIntoDifferentBatchesWithMultipleKeys(t *testing.T) {
-	inBatch := pmetric.NewMetrics()
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "5", "attr_key2", "6")
-	fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "diff_attr_key", "1")
-	expected := pmetric.NewMetrics()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeMetrics([]string{"attr_key", "attr_key2"}, inBatch)
-	require.Len(t, outBatches, 6)
-	sortMetrics(outBatches, "attr_key")
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(9)), outBatches[0])
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(0), expected.ResourceMetrics().At(4)), outBatches[1])
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(1), expected.ResourceMetrics().At(5)), outBatches[2])
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(2), expected.ResourceMetrics().At(6)), outBatches[3])
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(3), expected.ResourceMetrics().At(7)), outBatches[4])
-	assert.Equal(t, newMetrics(expected.ResourceMetrics().At(8)), outBatches[5])
-}
-
-func TestSplitLogsOneResourceLogs(t *testing.T) {
-	inBatch := plog.NewLogs()
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
-	expected := plog.NewLogs()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeLogs([]string{"attr_key"}, inBatch)
-	require.Len(t, outBatches, 1)
-	assert.Equal(t, expected, outBatches[0])
-}
-
-func TestOriginalResourceLogsUnchanged(t *testing.T) {
-	inBatch := plog.NewLogs()
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
-
-	outBatches := organizeLogs([]string{"attr_key"}, inBatch)
-	require.Len(t, outBatches, 1)
-	assert.Equal(t, inBatch, outBatches[0])
-}
-
-func TestSplitLogsSameResource(t *testing.T) {
-	inBatch := plog.NewLogs()
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "same_attr_val", "1")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "same_attr_val", "1")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "same_attr_val", "1")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "same_attr_val", "1")
-	expected := plog.NewLogs()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeLogs([]string{"same_attr_val"}, inBatch)
-	require.Len(t, outBatches, 1)
-	assert.Equal(t, expected, outBatches[0])
-}
-
-func TestSplitLogsIntoDifferentBatches(t *testing.T) {
-	inBatch := plog.NewLogs()
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "2")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "3")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "4")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "2")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "3")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "4")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "diff_attr_key", "1")
-	expected := plog.NewLogs()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeLogs([]string{"attr_key"}, inBatch)
-	require.Len(t, outBatches, 5)
-	sortLogs(outBatches, "attr_key")
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(8)), outBatches[0])
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(0), expected.ResourceLogs().At(4)), outBatches[1])
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(1), expected.ResourceLogs().At(5)), outBatches[2])
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(2), expected.ResourceLogs().At(6)), outBatches[3])
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(3), expected.ResourceLogs().At(7)), outBatches[4])
-}
-
-func TestSplitLogsIntoDifferentBatchesWithMultipleKeys(t *testing.T) {
-	inBatch := plog.NewLogs()
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "1", "attr_key2", "1")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "2", "attr_key2", "2")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "3", "attr_key2", "3")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "4", "attr_key2", "4")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "5", "attr_key2", "6")
-	fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "diff_attr_key", "1")
-	expected := plog.NewLogs()
-	inBatch.CopyTo(expected)
-
-	outBatches := organizeLogs([]string{"attr_key", "attr_key2"}, inBatch)
-	require.Len(t, outBatches, 6)
-	sortLogs(outBatches, "attr_key")
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(9)), outBatches[0])
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(0), expected.ResourceLogs().At(4)), outBatches[1])
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(1), expected.ResourceLogs().At(5)), outBatches[2])
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(2), expected.ResourceLogs().At(6)), outBatches[3])
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(3), expected.ResourceLogs().At(7)), outBatches[4])
-	assert.Equal(t, newLogs(expected.ResourceLogs().At(8)), outBatches[5])
-}
-func newTraces(rss ...ptrace.ResourceSpans) ptrace.Traces {
-	td := ptrace.NewTraces()
-	for _, rs := range rss {
-		rs.CopyTo(td.ResourceSpans().AppendEmpty())
-	}
-	return td
-}
-
-func sortTraces(tds []ptrace.Traces, attrKey string) {
-	sort.Slice(tds, func(i, j int) bool {
-		valI := ""
-		if av, ok := tds[i].ResourceSpans().At(0).Resource().Attributes().Get(attrKey); ok {
-			valI = av.Str()
-		}
-		valJ := ""
-		if av, ok := tds[j].ResourceSpans().At(0).Resource().Attributes().Get(attrKey); ok {
-			valJ = av.Str()
-		}
-		return valI < valJ
-	})
-}
 func fillResourceSpans(rs ptrace.ResourceSpans, kv ...string) {
 	for i := 0; i < len(kv); i += 2 {
 		rs.Resource().Attributes().PutStr(kv[i], kv[i+1])
@@ -303,28 +31,6 @@ func fillResourceSpans(rs ptrace.ResourceSpans, kv ...string) {
 	secondSpan := ils.Spans().AppendEmpty()
 	secondSpan.SetName("second-span")
 	secondSpan.SetTraceID(pcommon.TraceID([16]byte{byte(rand.Int())}))
-}
-
-func newMetrics(rms ...pmetric.ResourceMetrics) pmetric.Metrics {
-	md := pmetric.NewMetrics()
-	for _, rm := range rms {
-		rm.CopyTo(md.ResourceMetrics().AppendEmpty())
-	}
-	return md
-}
-
-func sortMetrics(tds []pmetric.Metrics, attrKey string) {
-	sort.Slice(tds, func(i, j int) bool {
-		valI := ""
-		if av, ok := tds[i].ResourceMetrics().At(0).Resource().Attributes().Get(attrKey); ok {
-			valI = av.Str()
-		}
-		valJ := ""
-		if av, ok := tds[j].ResourceMetrics().At(0).Resource().Attributes().Get(attrKey); ok {
-			valJ = av.Str()
-		}
-		return valI < valJ
-	})
 }
 
 func fillResourceMetrics(rs pmetric.ResourceMetrics, kv ...string) {
@@ -341,28 +47,6 @@ func fillResourceMetrics(rs pmetric.ResourceMetrics, kv ...string) {
 	secondMetric.SetEmptySum()
 }
 
-func newLogs(rls ...plog.ResourceLogs) plog.Logs {
-	ld := plog.NewLogs()
-	for _, rl := range rls {
-		rl.CopyTo(ld.ResourceLogs().AppendEmpty())
-	}
-	return ld
-}
-
-func sortLogs(tds []plog.Logs, attrKey string) {
-	sort.Slice(tds, func(i, j int) bool {
-		valI := ""
-		if av, ok := tds[i].ResourceLogs().At(0).Resource().Attributes().Get(attrKey); ok {
-			valI = av.Str()
-		}
-		valJ := ""
-		if av, ok := tds[j].ResourceLogs().At(0).Resource().Attributes().Get(attrKey); ok {
-			valJ = av.Str()
-		}
-		return valI < valJ
-	})
-}
-
 func fillResourceLogs(rs plog.ResourceLogs, kv ...string) {
 	for i := 0; i < len(kv); i += 2 {
 		rs.Resource().Attributes().PutStr(kv[i], kv[i+1])
@@ -373,47 +57,6 @@ func fillResourceLogs(rs plog.ResourceLogs, kv ...string) {
 	firstLogRecord.SetFlags(plog.LogRecordFlags(rand.Int31()))
 	secondLogRecord := ils.LogRecords().AppendEmpty()
 	secondLogRecord.SetFlags(plog.LogRecordFlags(rand.Int31()))
-}
-
-func BenchmarkBatchPerResourceTraces(b *testing.B) {
-	inBatch := ptrace.NewTraces()
-	rss := inBatch.ResourceSpans()
-	rss.EnsureCapacity(64)
-	for i := 0; i < 64; i++ {
-		fillResourceSpans(rss.AppendEmpty(), "attr_key", strconv.Itoa(i%8))
-	}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		organizeTraces([]string{"attr_key"}, inBatch)
-	}
-}
-
-func BenchmarkBatchPerResourceMetrics(b *testing.B) {
-	inBatch := pmetric.NewMetrics()
-	inBatch.ResourceMetrics().EnsureCapacity(64)
-	for i := 0; i < 64; i++ {
-		fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", strconv.Itoa(i%8))
-	}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		_ = organizeMetrics([]string{"attr_key"}, inBatch)
-	}
-}
-
-func BenchmarkBatchPerResourceLogs(b *testing.B) {
-	inBatch := plog.NewLogs()
-	inBatch.ResourceLogs().EnsureCapacity(64)
-	for i := 0; i < 64; i++ {
-		fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", strconv.Itoa(i%8))
-	}
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		_ = organizeLogs([]string{"attr_key"}, inBatch)
-	}
 }
 
 type nopSender struct {
@@ -438,8 +81,12 @@ func (n nopSender) setNextSender(_ requestSender) {
 
 func TestSend(t *testing.T) {
 
+	ako := attrKeyOrganizer{attrKeys: []string{"attr_key"}}
+
 	sender := &organizeSender{
-		attrKeys: []string{"attr_key"},
+		organizeMetrics: ako.organizeMetrics,
+		organizeLogs:    ako.organizeLogs,
+		organizeTraces:  ako.organizeTraces,
 	}
 	sender.setNextSender(nopSender{})
 
@@ -454,10 +101,145 @@ func TestSend(t *testing.T) {
 	require.NoError(t, err)
 
 	metricsBatch := pmetric.NewMetrics()
-	fillResourceSpans(tracesBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+	fillResourceMetrics(metricsBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
 	err = sender.send(context.Background(), &metricsRequest{md: metricsBatch})
 	require.NoError(t, err)
 
 	err = sender.send(context.Background(), nil)
 	require.EqualError(t, err, "unsupported type <nil>")
+}
+
+func TestSendNoFuncs(t *testing.T) {
+
+	sender := &organizeSender{}
+	sender.setNextSender(nopSender{})
+
+	logBatch := plog.NewLogs()
+	fillResourceLogs(logBatch.ResourceLogs().AppendEmpty(), "attr_key", "1")
+	err := sender.send(context.Background(), &logsRequest{ld: logBatch})
+	require.NoError(t, err)
+
+	tracesBatch := ptrace.NewTraces()
+	fillResourceSpans(tracesBatch.ResourceSpans().AppendEmpty(), "attr_key", "1")
+	err = sender.send(context.Background(), &tracesRequest{td: tracesBatch})
+	require.NoError(t, err)
+
+	metricsBatch := pmetric.NewMetrics()
+	fillResourceMetrics(metricsBatch.ResourceMetrics().AppendEmpty(), "attr_key", "1")
+	err = sender.send(context.Background(), &metricsRequest{md: metricsBatch})
+	require.NoError(t, err)
+
+	err = sender.send(context.Background(), nil)
+	require.EqualError(t, err, "unsupported type <nil>")
+}
+
+type attrKeyOrganizer struct {
+	attrKeys []string
+}
+
+func (ako attrKeyOrganizer) organizeMetrics(md pmetric.Metrics) []pmetric.Metrics {
+	rms := md.ResourceMetrics()
+	lenRls := rms.Len()
+	// If zero or one resource metrics, return early
+	if lenRls <= 1 {
+		return []pmetric.Metrics{md}
+	}
+
+	indicesByAttr := make(map[string][]int)
+	for i := 0; i < lenRls; i++ {
+		rm := rms.At(i)
+		var attrVal string
+		for _, k := range ako.attrKeys {
+			if attributeValue, ok := rm.Resource().Attributes().Get(k); ok {
+				attrVal = fmt.Sprintf("%s%s%s", attrVal, separator, attributeValue.Str())
+			}
+		}
+		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
+	}
+	// If there is a single attribute value, return early
+	if len(indicesByAttr) <= 1 {
+		return []pmetric.Metrics{md}
+	}
+
+	var result []pmetric.Metrics
+	for _, indices := range indicesByAttr {
+		metricsForAttr := pmetric.NewMetrics()
+		result = append(result, metricsForAttr)
+		for _, i := range indices {
+			rs := rms.At(i)
+			rs.CopyTo(metricsForAttr.ResourceMetrics().AppendEmpty())
+		}
+	}
+	return result
+}
+func (ako attrKeyOrganizer) organizeLogs(ld plog.Logs) []plog.Logs {
+	rls := ld.ResourceLogs()
+	lenRls := rls.Len()
+	// If zero or one resource logs, return early
+	if lenRls <= 1 {
+		return []plog.Logs{ld}
+	}
+
+	indicesByAttr := make(map[string][]int)
+	for i := 0; i < lenRls; i++ {
+		rl := rls.At(i)
+		var attrVal string
+		for _, k := range ako.attrKeys {
+			if attributeValue, ok := rl.Resource().Attributes().Get(k); ok {
+				attrVal = fmt.Sprintf("%s%s%s", attrVal, separator, attributeValue.Str())
+			}
+		}
+		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
+	}
+	// If there is a single attribute value, return early
+	if len(indicesByAttr) <= 1 {
+		return []plog.Logs{ld}
+	}
+
+	var result []plog.Logs
+	for _, indices := range indicesByAttr {
+		logsForAttr := plog.NewLogs()
+		result = append(result, logsForAttr)
+		for _, i := range indices {
+			rs := rls.At(i)
+			rs.CopyTo(logsForAttr.ResourceLogs().AppendEmpty())
+		}
+	}
+	return result
+}
+
+func (ako attrKeyOrganizer) organizeTraces(td ptrace.Traces) []ptrace.Traces {
+	rss := td.ResourceSpans()
+	lenRls := rss.Len()
+	// If zero or one resource traces, return early
+	if lenRls <= 1 {
+		return []ptrace.Traces{td}
+	}
+
+	indicesByAttr := make(map[string][]int)
+	for i := 0; i < lenRls; i++ {
+		rs := rss.At(i)
+		var attrVal string
+		for _, k := range ako.attrKeys {
+			if attributeValue, ok := rs.Resource().Attributes().Get(k); ok {
+				attrVal = fmt.Sprintf("%s%s%s", attrVal, separator, attributeValue.Str())
+			}
+		}
+		indicesByAttr[attrVal] = append(indicesByAttr[attrVal], i)
+	}
+	// If there is a single attribute value, return early
+	if len(indicesByAttr) <= 1 {
+		return []ptrace.Traces{td}
+	}
+
+	var result []ptrace.Traces
+	for _, indices := range indicesByAttr {
+		tracesForAttr := ptrace.NewTraces()
+		result = append(result, tracesForAttr)
+		for _, i := range indices {
+			rs := rss.At(i)
+			rs.CopyTo(tracesForAttr.ResourceSpans().AppendEmpty())
+		}
+	}
+	return result
 }


### PR DESCRIPTION
#### Description
add to the exporterhelper options an option to organize data into batches. The tests show a practical use where we organize data based on resource attributes.

#### Testing
Unit testing.

#### Documentation
Just godocs.