### PR TITLE
[configauth] remove deprecated methods

### DIFF
--- a/.chloggen/codeboten_configauth-deprecated.yaml
+++ b/.chloggen/codeboten_configauth-deprecated.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configauth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: removing deprecated methods GetServerAuthenticatorContext and GetClientAuthenticatorContext
+
+# One or more tracking issues or pull requests related to the change
+issues: [9808]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -45,14 +45,6 @@ func (a Authentication) GetServerAuthenticator(_ context.Context, extensions map
 	return nil, fmt.Errorf("failed to resolve authenticator %q: %w", a.AuthenticatorID, errAuthenticatorNotFound)
 }
 
-// GetServerAuthenticatorContext attempts to select the appropriate auth.Server from the list of extensions,
-// based on the requested extension name. If an authenticator is not found, an error is returned.
-//
-// Deprecated: [v0.105.0] Use GetServerAuthenticator instead.
-func (a Authentication) GetServerAuthenticatorContext(ctx context.Context, extensions map[component.ID]component.Component) (auth.Server, error) {
-	return a.GetServerAuthenticator(ctx, extensions)
-}
-
 // GetClientAuthenticator attempts to select the appropriate auth.Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by HTTP clients.
@@ -64,13 +56,4 @@ func (a Authentication) GetClientAuthenticator(_ context.Context, extensions map
 		return nil, errNotClient
 	}
 	return nil, fmt.Errorf("failed to resolve authenticator %q: %w", a.AuthenticatorID, errAuthenticatorNotFound)
-}
-
-// GetClientAuthenticatorContext attempts to select the appropriate auth.Client from the list of extensions,
-// based on the component id of the extension. If an authenticator is not found, an error is returned.
-// This should be only used by HTTP clients.
-//
-// Deprecated: [v0.105.0] Use GetClientAuthenticatorContext instead.
-func (a Authentication) GetClientAuthenticatorContext(ctx context.Context, extensions map[component.ID]component.Component) (auth.Client, error) {
-	return a.GetClientAuthenticator(ctx, extensions)
 }


### PR DESCRIPTION
Removes GetServerAuthenticatorContext and GetClientAuthenticatorContext
