### PR TITLE
[chore] Explicitly note that service and otelcol are not part of 1.0

### DIFF
--- a/docs/ga-roadmap.md
+++ b/docs/ga-roadmap.md
@@ -21,6 +21,7 @@ All stabilized modules will conform to the API expectations outlined in the [VER
 Explicitly, the following are not in the scope of v1 for the purposes of this document:
 
 * stabilization of additional components/APIs needed by distribution maintainers. Vendors are not the audience
+  * This explicitly excludes the `service` and `otelcol` modules.
 * Collector Builder
 * telemetrygen
 * mdatagen

--- a/docs/ga-roadmap.md
+++ b/docs/ga-roadmap.md
@@ -21,7 +21,7 @@ All stabilized modules will conform to the API expectations outlined in the [VER
 Explicitly, the following are not in the scope of v1 for the purposes of this document:
 
 * stabilization of additional components/APIs needed by distribution maintainers. Vendors are not the audience
-  * This explicitly excludes the `service` and `otelcol` modules, for which we only aim to guarantee behavior stability.
+  * This explicitly excludes the `service` and `otelcol` modules, for which we will only guarantee that there are no breaking changes impacting end-users of the binary after 1.0, while Go API only changes will continue to be admissible until these modules are tagged as 1.0.
 * Collector Builder
 * telemetrygen
 * mdatagen

--- a/docs/ga-roadmap.md
+++ b/docs/ga-roadmap.md
@@ -21,7 +21,7 @@ All stabilized modules will conform to the API expectations outlined in the [VER
 Explicitly, the following are not in the scope of v1 for the purposes of this document:
 
 * stabilization of additional components/APIs needed by distribution maintainers. Vendors are not the audience
-  * This explicitly excludes the `service` and `otelcol` modules.
+  * This explicitly excludes the `service` and `otelcol` modules, for which we only aim to guarantee behavior stability.
 * Collector Builder
 * telemetrygen
 * mdatagen


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Explicitly excludes service and otelcol from 1.0 efforts.

These modules are useful for distribution maintainers but not end-users, for which the 1.0 effort is targeted.
