### PR TITLE
[processorhelper] update units for metrics

### DIFF
--- a/processor/processorhelper/documentation.md
+++ b/processor/processorhelper/documentation.md
@@ -12,7 +12,7 @@ Number of log records successfully pushed into the next component in the pipelin
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {records} | Sum | Int | true |
 
 ### otelcol_processor_accepted_metric_points
 
@@ -20,7 +20,7 @@ Number of metric points successfully pushed into the next component in the pipel
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {datapoints} | Sum | Int | true |
 
 ### otelcol_processor_accepted_spans
 
@@ -28,7 +28,7 @@ Number of spans successfully pushed into the next component in the pipeline.
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {spans} | Sum | Int | true |
 
 ### otelcol_processor_dropped_log_records
 
@@ -36,7 +36,7 @@ Number of log records that were dropped.
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {records} | Sum | Int | true |
 
 ### otelcol_processor_dropped_metric_points
 
@@ -44,7 +44,7 @@ Number of metric points that were dropped.
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {datapoints} | Sum | Int | true |
 
 ### otelcol_processor_dropped_spans
 
@@ -52,7 +52,7 @@ Number of spans that were dropped.
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {spans} | Sum | Int | true |
 
 ### otelcol_processor_inserted_log_records
 
@@ -60,7 +60,7 @@ Number of log records that were inserted.
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {records} | Sum | Int | true |
 
 ### otelcol_processor_inserted_metric_points
 
@@ -68,7 +68,7 @@ Number of metric points that were inserted.
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {datapoints} | Sum | Int | true |
 
 ### otelcol_processor_inserted_spans
 
@@ -76,7 +76,7 @@ Number of spans that were inserted.
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {spans} | Sum | Int | true |
 
 ### otelcol_processor_refused_log_records
 
@@ -84,7 +84,7 @@ Number of log records that were rejected by the next component in the pipeline.
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {records} | Sum | Int | true |
 
 ### otelcol_processor_refused_metric_points
 
@@ -92,7 +92,7 @@ Number of metric points that were rejected by the next component in the pipeline
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {datapoints} | Sum | Int | true |
 
 ### otelcol_processor_refused_spans
 
@@ -100,4 +100,4 @@ Number of spans that were rejected by the next component in the pipeline.
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| {spans} | Sum | Int | true |

--- a/processor/processorhelper/internal/metadata/generated_telemetry.go
+++ b/processor/processorhelper/internal/metadata/generated_telemetry.go
@@ -66,73 +66,73 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	builder.ProcessorAcceptedLogRecords, err = builder.meter.Int64Counter(
 		"otelcol_processor_accepted_log_records",
 		metric.WithDescription("Number of log records successfully pushed into the next component in the pipeline."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorAcceptedMetricPoints, err = builder.meter.Int64Counter(
 		"otelcol_processor_accepted_metric_points",
 		metric.WithDescription("Number of metric points successfully pushed into the next component in the pipeline."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorAcceptedSpans, err = builder.meter.Int64Counter(
 		"otelcol_processor_accepted_spans",
 		metric.WithDescription("Number of spans successfully pushed into the next component in the pipeline."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorDroppedLogRecords, err = builder.meter.Int64Counter(
 		"otelcol_processor_dropped_log_records",
 		metric.WithDescription("Number of log records that were dropped."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorDroppedMetricPoints, err = builder.meter.Int64Counter(
 		"otelcol_processor_dropped_metric_points",
 		metric.WithDescription("Number of metric points that were dropped."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorDroppedSpans, err = builder.meter.Int64Counter(
 		"otelcol_processor_dropped_spans",
 		metric.WithDescription("Number of spans that were dropped."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorInsertedLogRecords, err = builder.meter.Int64Counter(
 		"otelcol_processor_inserted_log_records",
 		metric.WithDescription("Number of log records that were inserted."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorInsertedMetricPoints, err = builder.meter.Int64Counter(
 		"otelcol_processor_inserted_metric_points",
 		metric.WithDescription("Number of metric points that were inserted."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorInsertedSpans, err = builder.meter.Int64Counter(
 		"otelcol_processor_inserted_spans",
 		metric.WithDescription("Number of spans that were inserted."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedLogRecords, err = builder.meter.Int64Counter(
 		"otelcol_processor_refused_log_records",
 		metric.WithDescription("Number of log records that were rejected by the next component in the pipeline."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedMetricPoints, err = builder.meter.Int64Counter(
 		"otelcol_processor_refused_metric_points",
 		metric.WithDescription("Number of metric points that were rejected by the next component in the pipeline."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedSpans, err = builder.meter.Int64Counter(
 		"otelcol_processor_refused_spans",
 		metric.WithDescription("Number of spans that were rejected by the next component in the pipeline."),
-		metric.WithUnit("1"),
+		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	return &builder, errs

--- a/processor/processorhelper/metadata.yaml
+++ b/processor/processorhelper/metadata.yaml
@@ -12,7 +12,7 @@ telemetry:
     processor_accepted_spans:
       enabled: true
       description: Number of spans successfully pushed into the next component in the pipeline.
-      unit: "1"
+      unit: "{spans}"
       sum:
         value_type: int
         monotonic: true
@@ -20,7 +20,7 @@ telemetry:
     processor_refused_spans:
       enabled: true
       description: Number of spans that were rejected by the next component in the pipeline.
-      unit: "1"
+      unit: "{spans}"
       sum:
         value_type: int
         monotonic: true
@@ -28,7 +28,7 @@ telemetry:
     processor_dropped_spans:
       enabled: true
       description: Number of spans that were dropped.
-      unit: "1"
+      unit: "{spans}"
       sum:
         value_type: int
         monotonic: true
@@ -36,7 +36,7 @@ telemetry:
     processor_inserted_spans:
       enabled: true
       description: Number of spans that were inserted.
-      unit: "1"
+      unit: "{spans}"
       sum:
         value_type: int
         monotonic: true
@@ -44,7 +44,7 @@ telemetry:
     processor_accepted_metric_points:
       enabled: true
       description: Number of metric points successfully pushed into the next component in the pipeline.
-      unit: "1"
+      unit: "{datapoints}"
       sum:
         value_type: int
         monotonic: true
@@ -52,7 +52,7 @@ telemetry:
     processor_refused_metric_points:
       enabled: true
       description: Number of metric points that were rejected by the next component in the pipeline.
-      unit: "1"
+      unit: "{datapoints}"
       sum:
         value_type: int
         monotonic: true
@@ -60,7 +60,7 @@ telemetry:
     processor_dropped_metric_points:
       enabled: true
       description: Number of metric points that were dropped.
-      unit: "1"
+      unit: "{datapoints}"
       sum:
         value_type: int
         monotonic: true
@@ -68,7 +68,7 @@ telemetry:
     processor_inserted_metric_points:
       enabled: true
       description: Number of metric points that were inserted.
-      unit: "1"
+      unit: "{datapoints}"
       sum:
         value_type: int
         monotonic: true
@@ -76,7 +76,7 @@ telemetry:
     processor_accepted_log_records:
       enabled: true
       description: Number of log records successfully pushed into the next component in the pipeline.
-      unit: "1"
+      unit: "{records}"
       sum:
         value_type: int
         monotonic: true
@@ -84,7 +84,7 @@ telemetry:
     processor_refused_log_records:
       enabled: true
       description: Number of log records that were rejected by the next component in the pipeline.
-      unit: "1"
+      unit: "{records}"
       sum:
         value_type: int
         monotonic: true
@@ -92,7 +92,7 @@ telemetry:
     processor_dropped_log_records:
       enabled: true
       description: Number of log records that were dropped.
-      unit: "1"
+      unit: "{records}"
       sum:
         value_type: int
         monotonic: true
@@ -100,7 +100,7 @@ telemetry:
     processor_inserted_log_records:
       enabled: true
       description: Number of log records that were inserted.
-      unit: "1"
+      unit: "{records}"
       sum:
         value_type: int
         monotonic: true


### PR DESCRIPTION
This updates units for processhelper's internal telemetry.

For this PR i updated `metadata.yaml` and ran `make gogenerate`, then `make -C processor test`