### PR TITLE
[chore] adding minimal test for attributes

### DIFF
--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -25,8 +25,7 @@ var (
 	errUnsupportedPropagator = errors.New("unsupported trace propagator")
 )
 
-// New creates a new Telemetry from Config.
-func newTracerProvider(ctx context.Context, set Settings, cfg Config) (trace.TracerProvider, error) {
+func attributes(set Settings, cfg Config) map[string]interface{} {
 	attrs := map[string]interface{}{
 		string(semconv.ServiceNameKey):    set.BuildInfo.Command,
 		string(semconv.ServiceVersionKey): set.BuildInfo.Version,
@@ -41,10 +40,15 @@ func newTracerProvider(ctx context.Context, set Settings, cfg Config) (trace.Tra
 			delete(attrs, k)
 		}
 	}
+	return attrs
+}
+
+// New creates a new Telemetry from Config.
+func newTracerProvider(ctx context.Context, set Settings, cfg Config) (trace.TracerProvider, error) {
 	sch := semconv.SchemaURL
 	res := config.Resource{
 		SchemaUrl:  &sch,
-		Attributes: attrs,
+		Attributes: attributes(set, cfg),
 	}
 
 	sdk, err := config.NewSDK(

--- a/service/telemetry/tracer_test.go
+++ b/service/telemetry/tracer_test.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry // import "go.opentelemetry.io/collector/service/telemetry"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/service/telemetry/internal"
+)
+
+func TestAttributes(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            Config
+		buildInfo      component.BuildInfo
+		wantAttributes map[string]interface{}
+	}{
+		{
+			name:           "no build info and no resource config",
+			cfg:            Config{},
+			wantAttributes: map[string]interface{}{"service.name": "", "service.version": ""},
+		},
+		{
+			name:           "build info and no resource config",
+			cfg:            Config{},
+			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
+			wantAttributes: map[string]interface{}{"service.name": "otelcoltest", "service.version": "0.0.0-test"},
+		},
+		{
+			name:           "no build info and resource config",
+			cfg:            Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "test": ptr("test")}},
+			wantAttributes: map[string]interface{}{"service.name": "resource.name", "service.version": "resource.version", "test": "test"},
+		},
+		{
+			name:           "build info and resource config",
+			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
+			cfg:            Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "test": ptr("test")}},
+			wantAttributes: map[string]interface{}{"service.name": "resource.name", "service.version": "resource.version", "test": "test"},
+		},
+		{
+			name:           "deleting a nil value",
+			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
+			cfg:            Config{Resource: map[string]*string{"service.name": nil, "service.version": ptr("resource.version"), "test": ptr("test")}},
+			wantAttributes: map[string]interface{}{"service.version": "resource.version", "test": "test"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := attributes(internal.Settings{BuildInfo: tt.buildInfo}, tt.cfg)
+			require.Equal(t, tt.wantAttributes, attrs)
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
This isn't as good as emitting telemetry w/ the service but at least it ensures resource attributes are set.

Follow up to https://github.com/open-telemetry/opentelemetry-collector/pull/10490 and https://github.com/open-telemetry/opentelemetry-collector/pull/10645