### PR TITLE
[chore] avoid mixing pointer and non-pointer receiver on struct functions

### DIFF
--- a/connector/internal/factory.go
+++ b/connector/internal/factory.go
@@ -243,11 +243,11 @@ func (f CreateLogsToLogsFunc) CreateLogsToLogs(
 }
 
 // Type returns the type of component.
-func (f *factory) Type() component.Type {
+func (f factory) Type() component.Type {
 	return f.cfgType
 }
 
-func (f *factory) unexportedFactoryFunc() {}
+func (f factory) unexportedFactoryFunc() {}
 
 func (f factory) TracesToTracesStability() component.StabilityLevel {
 	return f.tracesToTracesStabilityLevel


### PR DESCRIPTION
Fix an IDE warning about mixing receiver types.