### PR TITLE
[configtelemetry] Add a read header timeout of 10s on the configtelemetry Prometheus HTTP server

### DIFF
--- a/.chloggen/add_default_timeout.yaml
+++ b/.chloggen/add_default_timeout.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configtelemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add 10s read header timeout on the configtelemetry Prometheus HTTP server.
+
+# One or more tracking issues or pull requests related to the change
+issues: [5699]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -147,10 +147,6 @@ issues:
     - text: "G402:"
       linters:
         - gosec
-    # https://github.com/open-telemetry/opentelemetry-collector/issues/5699
-    - text: "G112:"
-      linters:
-        - gosec
 
   # The list of ids of default excludes to include or disable. By default it's empty.
   # See the list of default excludes here https://golangci-lint.run/usage/configuration.

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -469,12 +469,12 @@ func (hss *ServerConfig) ToServer(_ context.Context, host component.Host, settin
 	}
 
 	server := &http.Server{
-		Handler: handler,
+		Handler:           handler,
+		ReadTimeout:       hss.ReadTimeout,
+		ReadHeaderTimeout: hss.ReadHeaderTimeout,
+		WriteTimeout:      hss.WriteTimeout,
+		IdleTimeout:       hss.IdleTimeout,
 	}
-	server.ReadTimeout = hss.ReadTimeout
-	server.ReadHeaderTimeout = hss.ReadHeaderTimeout
-	server.WriteTimeout = hss.WriteTimeout
-	server.IdleTimeout = hss.IdleTimeout
 
 	return server, nil
 }

--- a/service/internal/proctelemetry/config.go
+++ b/service/internal/proctelemetry/config.go
@@ -41,8 +41,9 @@ const (
 	HTTPInstrumentation = "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	// supported protocols
-	protocolProtobufHTTP = "http/protobuf"
-	protocolProtobufGRPC = "grpc/protobuf"
+	protocolProtobufHTTP     = "http/protobuf"
+	protocolProtobufGRPC     = "grpc/protobuf"
+	defaultReadHeaderTimeout = 10 * time.Second
 )
 
 var (
@@ -96,8 +97,9 @@ func InitPrometheusServer(registry *prometheus.Registry, address string, asyncEr
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	server := &http.Server{
-		Addr:    address,
-		Handler: mux,
+		Addr:              address,
+		Handler:           mux,
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
 	}
 	go func() {
 		if serveErr := server.ListenAndServe(); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add 10s read header timeout on the configtelemetry Prometheus HTTP server.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #5699
