### PR TITLE
[confighttp, configgrpc] Remove experimental note on IncludeMetadata

### DIFF
--- a/.chloggen/experimental_include_metadata.yaml
+++ b/.chloggen/experimental_include_metadata.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp, configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the experimental comment on `IncludeMetadata` in confighttp and configgrpc
+
+# One or more tracking issues or pull requests related to the change
+issues: [9381]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -188,7 +188,6 @@ type ServerConfig struct {
 	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// Include propagates the incoming connection's metadata to downstream consumers.
-	// Experimental: *NOTE* this option is subject to change or removal in the future.
 	IncludeMetadata bool `mapstructure:"include_metadata"`
 }
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -297,7 +297,6 @@ type ServerConfig struct {
 	MaxRequestBodySize int64 `mapstructure:"max_request_body_size"`
 
 	// IncludeMetadata propagates the client metadata from the incoming requests to the downstream consumers
-	// Experimental: *NOTE* this option is subject to change or removal in the future.
 	IncludeMetadata bool `mapstructure:"include_metadata"`
 
 	// Additional headers attached to each HTTP response sent to the client.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Remove the experimental comment on `IncludeMetadata` in confighttp and configgrpc

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #9381, Fixes #9642
