### PR TITLE
[cmd/builder] ldflags should be customizable even if `debug_comppilat…

### DIFF
--- a/.chloggen/bugfix_builder_ldflags.yaml
+++ b/.chloggen/bugfix_builder_ldflags.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Use the complete value of `--ldflags` arg instead of appending it to the exisitng `-s -w` ldflags. Debug symbols also should not be stripped by default if debug compilation is enabled"
+
+# One or more tracking issues or pull requests related to the change
+issues: [10689]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -86,7 +86,7 @@ configuration is provided, ocb will generate a default Collector.
 	cmd.Flags().BoolVar(&cfg.SkipGetModules, skipGetModulesFlag, false, "Whether builder should skip updating go.mod and retrieve Go module list (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipStrictVersioning, skipStrictVersioningFlag, false, "Whether builder should skip strictly checking the calculated versions following dependency resolution")
 	cmd.Flags().BoolVar(&cfg.Verbose, verboseFlag, false, "Whether builder should print verbose output (default false)")
-	cmd.Flags().StringVar(&cfg.LDFlags, ldflagsFlag, "", `ldflags to include in the "go build" command`)
+	cmd.Flags().StringVar(&cfg.LDFlags, ldflagsFlag, builder.DefaultLDFlags, `ldflags to include in the "go build" command`)
 	cmd.Flags().StringVar(&cfg.Distribution.Name, distributionNameFlag, "otelcol-custom", "The executable name for the OpenTelemetry Collector distribution")
 	if err := cmd.Flags().MarkDeprecated(distributionNameFlag, "use config distribution::name"); err != nil {
 		return nil, err


### PR DESCRIPTION
#### Description
This change enables ldflags to be customizable regardless if `debug_compilation` is enabled or disabled

#### Testing
1. debug compilation disabled without `--ldflags` argument
```
$ grep debug_compilation ocb/ocb.yaml
  debug_compilation: false
$ ./builder --verbose --config ocb/ocb.yaml
...
2024-07-22T04:36:49.083Z	INFO	builder/main.go:35	Running go subcommand.	{"arguments": ["build", "-trimpath", "-o", "cf-otel-collector", "-ldflags=-s -w"]}
...
```
2. debug compilation disabled **with** `--ldflags` argument
```
$ grep debug_compilation ocb/ocb.yaml
  debug_compilation: false
$ ./builder --verbose --ldflags '-w' --config ocb/ocb.yaml
...
2024-07-22T04:39:19.500Z	INFO	builder/main.go:35	Running go subcommand.	{"arguments": ["build", "-trimpath", "-o", "cf-otel-collector", "-ldflags=-w"]}
...
```
3. debug compilation enabled without `--ldflags` argument which does not strip the native debug and DWARF symbols
```
$ grep debug_compilation ocb/ocb.yaml      
  debug_compilation: true
$ ./builder --verbose --config ocb/ocb.yaml
...
2024-07-22T04:42:26.217Z	INFO	builder/main.go:35	Running go subcommand.	{"arguments": ["build", "-trimpath", "-o", "cf-otel-collector", "-gcflags=all=-N -l", "-ldflags="]}
...
```
4. debug compilation enabled **with** `--ldflags` argument
```
$ grep debug_compilation ocb/ocb.yaml
  debug_compilation: true
$ ./builder --verbose --ldflags '-w' --config ocb/ocb.yaml
...
2024-07-22T04:43:30.140Z	INFO	builder/main.go:35	Running go subcommand.	{"arguments": ["build", "-trimpath", "-o", "cf-otel-collector", "-gcflags=all=-N -l", "-ldflags=-w"]}
...
```