### PR TITLE
Add fuzz tests for unmarshaling routines

### DIFF
--- a/pdata/plog/fuzz_test.go
+++ b/pdata/plog/fuzz_test.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package plog // import "go.opentelemetry.io/collector/pdata/plog"
+
+import (
+	"testing"
+)
+
+func FuzzUnmarshalJsonLogs(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		u := &JSONUnmarshaler{}
+		//nolint: errcheck
+		_, _ = u.UnmarshalLogs(data)
+	})
+}
+
+func FuzzUnmarshalPBLogs(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		u := &ProtoUnmarshaler{}
+		//nolint: errcheck
+		_, _ = u.UnmarshalLogs(data)
+	})
+}

--- a/pdata/plog/plogotlp/fuzz_test.go
+++ b/pdata/plog/plogotlp/fuzz_test.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package plogotlp // import "go.opentelemetry.io/collector/pdata/plog/plogotlp"
+
+import (
+	"testing"
+)
+
+func FuzzRequestUnmarshalJSON(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportRequest()
+		//nolint: errcheck
+		er.UnmarshalJSON(data)
+	})
+}
+
+func FuzzResponseUnmarshalJSON(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportResponse()
+		//nolint: errcheck
+		er.UnmarshalJSON(data)
+	})
+}
+
+func FuzzRequestUnmarshalProto(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportRequest()
+		//nolint: errcheck
+		er.UnmarshalProto(data)
+	})
+}
+
+func FuzzResponseUnmarshalProto(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportResponse()
+		//nolint: errcheck
+		er.UnmarshalProto(data)
+	})
+}

--- a/pdata/pmetric/fuzz_test.go
+++ b/pdata/pmetric/fuzz_test.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pmetric // import "go.opentelemetry.io/collector/pdata/pmetric"
+
+import (
+	"testing"
+)
+
+func FuzzUnmarshalMetrics(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		u := &JSONUnmarshaler{}
+		//nolint: errcheck
+		_, _ = u.UnmarshalMetrics(data)
+	})
+}

--- a/pdata/pmetric/pmetricotlp/fuzz_test.go
+++ b/pdata/pmetric/pmetricotlp/fuzz_test.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pmetricotlp // import "go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+
+import (
+	"testing"
+)
+
+func FuzzRequestUnmarshalJSON(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportRequest()
+		//nolint: errcheck
+		er.UnmarshalJSON(data)
+	})
+}
+
+func FuzzResponseUnmarshalJSON(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportResponse()
+		//nolint: errcheck
+		er.UnmarshalJSON(data)
+	})
+}
+
+func FuzzRequestUnmarshalProto(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportRequest()
+		//nolint: errcheck
+		er.UnmarshalProto(data)
+	})
+}
+
+func FuzzResponseUnmarshalProto(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportResponse()
+		//nolint: errcheck
+		er.UnmarshalProto(data)
+	})
+}

--- a/pdata/ptrace/fuzz_test.go
+++ b/pdata/ptrace/fuzz_test.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ptrace // import "go.opentelemetry.io/collector/pdata/ptrace"
+
+import (
+	"testing"
+)
+
+func FuzzUnmarshalTraces(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		u := &JSONUnmarshaler{}
+		//nolint: errcheck
+		_, _ = u.UnmarshalTraces(data)
+	})
+}

--- a/pdata/ptrace/ptraceotlp/fuzz_test.go
+++ b/pdata/ptrace/ptraceotlp/fuzz_test.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ptraceotlp // import "go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+
+import (
+	"testing"
+)
+
+func FuzzRequestUnmarshalJSON(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportRequest()
+		//nolint: errcheck
+		er.UnmarshalJSON(data)
+	})
+}
+
+func FuzzResponseUnmarshalJSON(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportResponse()
+		//nolint: errcheck
+		er.UnmarshalJSON(data)
+	})
+}
+
+func FuzzRequestUnmarshalProto(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportRequest()
+		//nolint: errcheck
+		er.UnmarshalProto(data)
+	})
+}
+
+func FuzzResponseUnmarshalProto(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		er := NewExportResponse()
+		//nolint: errcheck
+		er.UnmarshalProto(data)
+	})
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds fuzz tests for various unmarshaling routines.

This can be tested with `go test -fuzz=`

This is ongoing work for https://github.com/open-telemetry/sig-security/issues/55

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
