### PR TITLE
Deprecate component.Host.GetFactory

### DIFF
--- a/.chloggen/component-deprecate-GetFactory.yaml
+++ b/.chloggen/component-deprecate-GetFactory.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecates Host.GetFactory.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10709]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/component/componenttest/nop_host_test.go
+++ b/component/componenttest/nop_host_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"go.opentelemetry.io/collector/component"
 )
 
 func TestNewNopHost(t *testing.T) {
@@ -18,5 +16,4 @@ func TestNewNopHost(t *testing.T) {
 	require.IsType(t, &nopHost{}, nh)
 
 	assert.Nil(t, nh.GetExtensions())
-	assert.Nil(t, nh.GetFactory(component.KindReceiver, component.MustNewType("test")))
 }

--- a/component/host.go
+++ b/component/host.go
@@ -17,6 +17,8 @@ type Host interface {
 	// GetFactory can be called by the component anytime after Component.Start() begins and
 	// until Component.Shutdown() ends. Note that the component is responsible for destroying
 	// other components that it creates.
+	//
+	// Deprecated: [v0.106.0] component.Host no longer requires implementors to expose a GetFactory function.
 	GetFactory(kind Kind, componentType Type) Factory
 
 	// GetExtensions returns the map of extensions. Only enabled and created extensions will be returned.


### PR DESCRIPTION
#### Description
This PR deprecates the `component.Host.GetFactory` interface. This has the benefit of keeping the `component.Host` interface as simple as possible.  Components that were relying on this method can instead check if the underlying `component.Host` implementation supports the interface.  An example of this pattern can be found here: https://github.com/open-telemetry/opentelemetry-collector/blob/91f13c309d00eef5b997a2e810effb2a4ccd95d4/extension/zpagesextension/zpagesextension.go#L58-L66

<!-- Issue number if applicable -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9511
