### PR TITLE
[confmap] Allow more recursion and URI expansions

### DIFF
--- a/confmap/expand.go
+++ b/confmap/expand.go
@@ -28,7 +28,7 @@ var (
 )
 
 func (mr *Resolver) expandValueRecursively(ctx context.Context, value any) (any, error) {
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1000; i++ {
 		val, changed, err := mr.expandValue(ctx, value)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
#### Description
Bumps the limit of how much recursion we allow.  This check is also gating non-recursive expansions.  We probably could separate these concerns, but thats work that isn't really worthwhile, a simple constant bump is simple and will cover most users.  For the rest, there are workarounds.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/10617