### PR TITLE
[chore][component] Document component.Host expectations

### DIFF
--- a/component/host.go
+++ b/component/host.go
@@ -5,6 +5,10 @@ package component // import "go.opentelemetry.io/collector/component"
 
 // Host represents the entity that is hosting a Component. It is used to allow communication
 // between the Component and its host (normally the service.Collector is the host).
+//
+// Components may require `component.Host` to implement additional interfaces to properly function.
+// The component is expected to cast the `component.Host` to the interface it needs and return
+// an error if the type assertion fails.
 type Host interface {
 	// GetFactory of the specified kind. Returns the factory for a component type.
 	// This allows components to create other components. For example:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Adds a note to the `component.Host` interface documenting that components may require additional interfaces.
I think this is the only sustainable pattern post 1.0, since we won't be able to add any new methods to the `component.Host` interface.

This pattern is also used today by:
- The zpages extension (https://github.com/open-telemetry/opentelemetry-collector/blob/91f13c309d00eef5b997a2e810effb2a4ccd95d4/extension/zpagesextension/zpagesextension.go#L58-L66)
- The receiver creator (after open-telemetry/opentelemetry-collector-contrib/pull/34234)
- Some contrib components (open-telemetry/opentelemetry-collector-contrib/pull/32498)

#### Link to tracking issue

Fixes #10181
