### PR TITLE
Add a timeout alignment property to batch config

### DIFF
--- a/exporter/exporterbatcher/config.go
+++ b/exporter/exporterbatcher/config.go
@@ -19,6 +19,9 @@ type Config struct {
 	// FlushTimeout sets the time after which a batch will be sent regardless of its size.
 	FlushTimeout time.Duration `mapstructure:"flush_timeout"`
 
+	// UseFlushTimeoutAlignment indicates if the flush timeout should be aligned at the timeout boundary.
+	UseFlushTimeoutAlignment bool `mapstructure:"use_flush_timeout_alignment"`
+
 	MinSizeConfig `mapstructure:",squash"`
 	MaxSizeConfig `mapstructure:",squash"`
 }

--- a/exporter/exporterhelper/batch_sender_test.go
+++ b/exporter/exporterhelper/batch_sender_test.go
@@ -694,6 +694,46 @@ func TestBatchSenderTimerFlush(t *testing.T) {
 	require.NoError(t, be.Shutdown(context.Background()))
 }
 
+func TestBatchSenderTimerFlushWithUseTimerFlushAlignment(t *testing.T) {
+	bCfg := exporterbatcher.NewDefaultConfig()
+	bCfg.MinSizeItems = 8
+	bCfg.FlushTimeout = 100 * time.Millisecond
+	bCfg.UseFlushTimeoutAlignment = true // Use flush timeout alignment
+	be, err := newBaseExporter(defaultSettings, defaultDataType, newNoopObsrepSender,
+		WithBatcher(bCfg, WithRequestBatchFuncs(fakeBatchMergeFunc, fakeBatchMergeSplitFunc)))
+	require.NoError(t, err)
+	now := time.Now()
+	wait := now.Truncate(bCfg.FlushTimeout).Add(bCfg.FlushTimeout + 10*time.Millisecond).Sub(now)
+	time.Sleep(wait)
+	// Start the exporter at 10ms mark.
+	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+	sink := newFakeRequestSink()
+	time.Sleep(50 * time.Millisecond)
+
+	// Send 2 concurrent requests that should be merged in one batch and sent immediately
+	go func() {
+		require.NoError(t, be.send(context.Background(), &fakeRequest{items: 4, sink: sink}))
+	}()
+	go func() {
+		require.NoError(t, be.send(context.Background(), &fakeRequest{items: 4, sink: sink}))
+	}()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.LessOrEqual(c, uint64(1), sink.requestsCount.Load())
+		assert.EqualValues(c, 8, sink.itemsCount.Load())
+	}, 30*time.Millisecond, 5*time.Millisecond)
+
+	// Send another request that should be flushed at the 100ms mark instead of waiting for 100ms since last flush
+	go func() {
+		require.NoError(t, be.send(context.Background(), &fakeRequest{items: 4, sink: sink}))
+	}()
+
+	// Confirm that it is flushed in 50ms
+	time.Sleep(50 * time.Millisecond)
+	assert.LessOrEqual(t, uint64(2), sink.requestsCount.Load())
+	assert.EqualValues(t, 12, sink.itemsCount.Load())
+	require.NoError(t, be.Shutdown(context.Background()))
+}
+
 func queueBatchExporter(t *testing.T, batchOption Option) *baseExporter {
 	be, err := newBaseExporter(defaultSettings, defaultDataType, newNoopObsrepSender, batchOption,
 		WithRequestQueue(exporterqueue.NewDefaultConfig(), exporterqueue.NewMemoryQueueFactory[Request]()))

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -745,7 +745,7 @@ func TestBatchMetricsProcessor_Timeout(t *testing.T) {
 func TestBatchMetricsProcessor_Timeout_UseTimeoutAlignment(t *testing.T) {
 	cfg := Config{
 		Timeout:             100 * time.Millisecond,
-		SendBatchSize:       101,
+		SendBatchSize:       100000000, // very large number to not trigger size-based batching
 		UseTimeoutAlignment: true,
 	}
 	requestCount := 5
@@ -755,10 +755,12 @@ func TestBatchMetricsProcessor_Timeout_UseTimeoutAlignment(t *testing.T) {
 	creationSet := processortest.NewNopSettings()
 	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 
-	now := time.Now()
-	time.Sleep(now.Truncate(cfg.Timeout).Add(cfg.Timeout).Sub(now) + cfg.Timeout/2)
+	timePoint := time.Now()
+	// sleep until the time is over the half line [timePoint.Truncate(cfg.Timeout), timePoint.Truncate(cfg.Timeout).Add(cfg.Timeout)]
+	durationUntilNextTimeoutBoundary := timePoint.Truncate(cfg.Timeout).Add(cfg.Timeout).Sub(timePoint) - cfg.Timeout/2
+	time.Sleep(durationUntilNextTimeoutBoundary)
 
-	// create the batcher at cfg.Timeout / 2 mark
+	// create the batcher at [cfg.Timeout / 2, cfg.Timeout] mark
 	start := time.Now()
 	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg)
 	require.NoError(t, err)
@@ -768,9 +770,9 @@ func TestBatchMetricsProcessor_Timeout_UseTimeoutAlignment(t *testing.T) {
 		assert.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
 	}
 
-	// One batch must be sent within cfg.Timeout / 2 since the batcher creation instead of cfg.Timeout when UseTimeoutAlignment is true.
-	<-time.After(cfg.Timeout / 2)
-	require.Greater(t, sink.DataPointCount(), 0)
+	// One batch must be sent within [cfg.Timeout / 2, cfg.Timeout) since the batcher creation instead of cfg.Timeout when UseTimeoutAlignment is true.
+	<-time.After(cfg.Timeout * 3 / 5)
+	require.Greaterf(t, sink.DataPointCount(), 0, "timePoint=%v start=%v check=%v", timePoint, start, time.Now())
 
 	elapsed := time.Since(start)
 	require.Less(t, elapsed.Nanoseconds(), cfg.Timeout.Nanoseconds())

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -742,6 +742,56 @@ func TestBatchMetricsProcessor_Timeout(t *testing.T) {
 	}
 }
 
+func TestBatchMetricsProcessor_Timeout_UseTimeoutAlignment(t *testing.T) {
+	cfg := Config{
+		Timeout:             100 * time.Millisecond,
+		SendBatchSize:       101,
+		UseTimeoutAlignment: true,
+	}
+	requestCount := 5
+	metricsPerRequest := 10
+	sink := new(consumertest.MetricsSink)
+
+	creationSet := processortest.NewNopSettings()
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+
+	now := time.Now()
+	time.Sleep(now.Truncate(cfg.Timeout).Add(cfg.Timeout).Sub(now) + cfg.Timeout/2)
+
+	// create the batcher at cfg.Timeout / 2 mark
+	start := time.Now()
+	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg)
+	require.NoError(t, err)
+	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
+	for requestNum := 0; requestNum < requestCount; requestNum++ {
+		md := testdata.GenerateMetrics(metricsPerRequest)
+		assert.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
+	}
+
+	// One batch must be sent within cfg.Timeout / 2 since the batcher creation instead of cfg.Timeout when UseTimeoutAlignment is true.
+	<-time.After(cfg.Timeout / 2)
+	require.Greater(t, sink.DataPointCount(), 0)
+
+	elapsed := time.Since(start)
+	require.Less(t, elapsed.Nanoseconds(), cfg.Timeout.Nanoseconds())
+
+	// This should not change the results in the sink, verified by the expectedBatchesNum
+	require.NoError(t, batcher.Shutdown(context.Background()))
+
+	expectedBatchesNum := 1
+	expectedBatchingFactor := 5
+
+	require.Equal(t, requestCount*2*metricsPerRequest, sink.DataPointCount())
+	receivedMds := sink.AllMetrics()
+	require.Equal(t, expectedBatchesNum, len(receivedMds))
+	for _, md := range receivedMds {
+		require.Equal(t, expectedBatchingFactor, md.ResourceMetrics().Len())
+		for i := 0; i < expectedBatchingFactor; i++ {
+			require.Equal(t, metricsPerRequest, md.ResourceMetrics().At(i).ScopeMetrics().At(0).Metrics().Len())
+		}
+	}
+}
+
 func TestBatchMetricProcessor_Shutdown(t *testing.T) {
 	cfg := Config{
 		Timeout:       3 * time.Second,

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -18,6 +18,9 @@ type Config struct {
 	// When this is set to zero, batched data will be sent immediately.
 	Timeout time.Duration `mapstructure:"timeout"`
 
+	// UseTimeoutAlignment indicates if a batch should be sent at the timeout boundary.
+	UseTimeoutAlignment bool `mapstructure:"use_timeout_alignment"`
+
 	// SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
 	// When this is set to zero, the batch size is ignored and data will be sent immediately
 	// subject to only send_batch_max_size.

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -37,6 +37,22 @@ func TestUnmarshalConfig(t *testing.T) {
 		}, cfg)
 }
 
+func TestUnmarshalConfig_UseTimeoutAlignment(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config2.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	assert.NoError(t, cm.Unmarshal(&cfg))
+	assert.Equal(t,
+		&Config{
+			SendBatchSize:            uint32(10000),
+			SendBatchMaxSize:         uint32(11000),
+			Timeout:                  time.Second * 10,
+			MetadataCardinalityLimit: 1000,
+			UseTimeoutAlignment:      true,
+		}, cfg)
+}
+
 func TestValidateConfig_DefaultBatchMaxSize(t *testing.T) {
 	cfg := &Config{
 		SendBatchSize:    100,

--- a/processor/batchprocessor/testdata/config2.yaml
+++ b/processor/batchprocessor/testdata/config2.yaml
@@ -1,0 +1,4 @@
+timeout: 10s
+send_batch_size: 10000
+send_batch_max_size: 11000
+use_timeout_alignment: true


### PR DESCRIPTION
#### Description
Add a boolean timeout alignment property to batch processor config and batch sender config. This is to indicate if a batch submission should be aligned at the timeout boundary.

Dropbox is adopting Open Telemetry for their internal metrics system. The system uses 10s sampling rate and expects data submission to be more or less at the sampling rate boundary. This is to ensure metric data is ingested and streamed in time to various backend processes.

Without the timeout alignment feature, metric data can be submitted quite late. Consider the case when timeout is 10s and the batch processor happens to start at 00:00:07 mark. A request{ts=00:00:09} is sent to the batch processor. This request is associated with ts.truncateUp(samplingRate)=00:00:10 system timestamp. However, it is not until 00:00:07 + 10s = 00:00:17 that a batch is submitted. This data submission is quite late.

#### Link to tracking issue
No tracking issue #

#### Testing
Unit tests added to verify the batch processor and batch sender behavior when timeout alignment is used.

#### Documentation
Inline comment to indicate the usage.
