### PR TITLE
[chore] skip stable module check if unset

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,9 +35,6 @@ jobs:
           }
 
           validate_stable_version() {
-            if [[ -z "$1" ]]; then
-              exit 0
-            fi
             local regex_pattern_stable='^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
             if [[ ! "$1" =~ $regex_pattern_stable ]]; then
               echo "Invalid stable version format for $2. Major version must be greater than 1."
@@ -47,7 +44,9 @@ jobs:
 
           validate_beta_version "${{ inputs.candidate-beta }}" "candidate-beta"
           validate_beta_version "${{ inputs.current-beta }}" "current-beta"
-          validate_stable_version "${{ inputs.candidate-stable }}" "candidate-stable"
+          if [[ ! -z "${{ inputs.candidate-stable }}" ]]; then
+            validate_stable_version "${{ inputs.candidate-stable }}" "candidate-stable"
+          fi
           validate_stable_version "${{ inputs.current-stable }}" "current-stable"
         shell: bash
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,6 +35,9 @@ jobs:
           }
 
           validate_stable_version() {
+            if [[ -z "$1" ]]; then
+              exit 0
+            fi
             local regex_pattern_stable='^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
             if [[ ! "$1" =~ $regex_pattern_stable ]]; then
               echo "Invalid stable version format for $2. Major version must be greater than 1."


### PR DESCRIPTION
From https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/release.md#releasing-opentelemetry-collector:

> If not intending to release stable modules, do not specify a version for Release candidate version stable.

`validate-versions` workflow fails on empty version right now, it should instead skip if stable module candidate version is empty.