### PR TITLE
[configauth] Fix unmarshaling of confighttp.AuthConfig

### DIFF
--- a/.chloggen/mx-psi_fix-106-issue.yaml
+++ b/.chloggen/mx-psi_fix-106-issue.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configauth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix unmarshaling of authentication in HTTP servers.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10750]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -341,7 +341,7 @@ func NewDefaultServerConfig() ServerConfig {
 
 type AuthConfig struct {
 	// Auth for this receiver.
-	*configauth.Authentication `mapstructure:"-"`
+	configauth.Authentication `mapstructure:",squash"`
 
 	// RequestParameters is a list of parameters that should be extracted from the request and added to the context.
 	// When a parameter is found in both the query string and the header, the value from the query string will be used.

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -866,7 +866,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 			AllowedOrigins: []string{"*"},
 		},
 		Auth: &AuthConfig{
-			Authentication: &configauth.Authentication{
+			Authentication: configauth.Authentication{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1171,7 +1171,7 @@ func TestServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: &configauth.Authentication{
+			Authentication: configauth.Authentication{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1207,7 +1207,7 @@ func TestServerAuth(t *testing.T) {
 func TestInvalidServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Auth: &AuthConfig{
-			Authentication: &configauth.Authentication{
+			Authentication: configauth.Authentication{
 				AuthenticatorID: nonExistingID,
 			},
 		},
@@ -1223,7 +1223,7 @@ func TestFailedServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: &configauth.Authentication{
+			Authentication: configauth.Authentication{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1404,7 +1404,7 @@ func TestAuthWithQueryParams(t *testing.T) {
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
 			RequestParameters: []string{"auth"},
-			Authentication: &configauth.Authentication{
+			Authentication: configauth.Authentication{
 				AuthenticatorID: mockID,
 			},
 		},

--- a/extension/zpagesextension/zpagesextension_test.go
+++ b/extension/zpagesextension/zpagesextension_test.go
@@ -79,7 +79,7 @@ func TestZPagesExtensionBadAuthExtension(t *testing.T) {
 		confighttp.ServerConfig{
 			Endpoint: "localhost:0",
 			Auth: &confighttp.AuthConfig{
-				Authentication: &configauth.Authentication{
+				Authentication: configauth.Authentication{
 					AuthenticatorID: component.MustNewIDWithName("foo", "bar"),
 				},
 			},

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
@@ -117,6 +118,11 @@ func TestUnmarshalConfig(t *testing.T) {
 				},
 				HTTP: &HTTPConfig{
 					ServerConfig: &confighttp.ServerConfig{
+						Auth: &confighttp.AuthConfig{
+							Authentication: configauth.Authentication{
+								AuthenticatorID: component.MustNewID("test"),
+							},
+						},
 						Endpoint: "localhost:4318",
 						TLSSetting: &configtls.ServerConfig{
 							Config: configtls.Config{

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector v0.106.0
 	go.opentelemetry.io/collector/component v0.106.0
+	go.opentelemetry.io/collector/config/configauth v0.106.0
 	go.opentelemetry.io/collector/config/configgrpc v0.106.0
 	go.opentelemetry.io/collector/config/confighttp v0.106.0
 	go.opentelemetry.io/collector/config/confignet v0.106.0
@@ -56,7 +57,6 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rs/cors v1.11.0 // indirect
 	go.opentelemetry.io/collector/client v0.106.0 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.106.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.12.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.106.0 // indirect

--- a/receiver/otlpreceiver/testdata/config.yaml
+++ b/receiver/otlpreceiver/testdata/config.yaml
@@ -26,6 +26,8 @@ protocols:
         min_time: 10s
         permit_without_stream: true
   http:
+    auth:
+      authenticator: test
     # The following entry demonstrates how to specify TLS credentials for the server.
     # Note: These files do not exist. If the receiver is started with this configuration, it will fail.
     tls:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Uses `mapstructure:",squash"` instead of `mapstructure:"-"` for the Authenticator field
- Removes pointer (since pointers can't be squashed)
- Adds test in OTLP receiver for this reproducing the user's issue

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10750
