### PR TITLE
[mdatagen] expose host in generated test code by mdatagen

### DIFF
--- a/.chloggen/expose_host_tests.yaml
+++ b/.chloggen/expose_host_tests.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Expose a setting on tests::host to set up your own host initialization code
+
+# One or more tracking issues or pull requests related to the change
+issues: [10765]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Some receivers require a host that has additional capabilities such as exposing exporters.
+  For those, we can expose a setting that allows them to place a different host in the generated code.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -229,6 +229,7 @@ type tests struct {
 	SkipShutdown        bool   `mapstructure:"skip_shutdown"`
 	GoLeak              goLeak `mapstructure:"goleak"`
 	ExpectConsumerError bool   `mapstructure:"expect_consumer_error"`
+	Host                string `mapstructure:"host"`
 }
 
 type telemetry struct {
@@ -257,7 +258,7 @@ type metadata struct {
 	ScopeName string `mapstructure:"scope_name"`
 	// ShortFolderName is the shortened folder name of the component, removing class if present
 	ShortFolderName string `mapstructure:"-"`
-
+	// Tests is the set of tests generated with the component
 	Tests tests `mapstructure:"tests"`
 }
 
@@ -285,7 +286,7 @@ func loadMetadata(filePath string) (metadata, error) {
 		return metadata{}, err
 	}
 
-	md := metadata{ShortFolderName: shortFolderName(filePath)}
+	md := metadata{ShortFolderName: shortFolderName(filePath), Tests: tests{Host: "componenttest.NewNopHost()"}}
 	if err = conf.Unmarshal(&md); err != nil {
 		return md, err
 	}

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -280,6 +280,7 @@ func TestLoadMetadata(t *testing.T) {
 				},
 				ScopeName:       "go.opentelemetry.io/collector/internal/receiver/samplereceiver",
 				ShortFolderName: "sample",
+				Tests:           tests{Host: "componenttest.NewNopHost()"},
 			},
 		},
 		{
@@ -289,6 +290,7 @@ func TestLoadMetadata(t *testing.T) {
 				Parent:          "parentComponent",
 				ScopeName:       "go.opentelemetry.io/collector/cmd/mdatagen",
 				ShortFolderName: "testdata",
+				Tests:           tests{Host: "componenttest.NewNopHost()"},
 			},
 		},
 		{

--- a/cmd/mdatagen/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/templates/component_test.go.tmpl
@@ -118,7 +118,7 @@ func TestComponentLifecycle(t *testing.T) {
 		t.Run(test.name + "-lifecycle", func(t *testing.T) {
 			c, err := test.createFn(context.Background(), exportertest.NewNopSettings(), cfg)
 			require.NoError(t, err)
-			host := componenttest.NewNopHost()
+			host := {{ .Tests.Host }}
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
@@ -215,7 +215,7 @@ func TestComponentLifecycle(t *testing.T) {
 		t.Run(test.name + "-lifecycle", func(t *testing.T) {
 			c, err := test.createFn(context.Background(), processortest.NewNopSettings(), cfg)
 			require.NoError(t, err)
-			host := componenttest.NewNopHost()
+			host := {{ .Tests.Host }}
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
@@ -310,7 +310,7 @@ func TestComponentLifecycle(t *testing.T) {
 		t.Run(test.name + "-lifecycle", func(t *testing.T) {
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopSettings(), cfg)
 			require.NoError(t, err)
-			host := componenttest.NewNopHost()
+			host := {{ .Tests.Host }}
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))
@@ -348,12 +348,12 @@ func TestComponentLifecycle(t *testing.T) {
 	t.Run("lifecycle", func(t *testing.T) {
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
+		require.NoError(t, firstExt.Start(context.Background(), {{ .Tests.Host }}))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
+		require.NoError(t, secondExt.Start(context.Background(), {{ .Tests.Host }}))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 	{{- end }}
@@ -472,7 +472,7 @@ func TestComponentLifecycle(t *testing.T) {
 		t.Run(test.name + "-lifecycle", func(t *testing.T) {
 			firstConnector, err := test.createFn(context.Background(), connectortest.NewNopSettings(), cfg)
 			require.NoError(t, err)
-			host := componenttest.NewNopHost()
+			host := {{ .Tests.Host }}
 			require.NoError(t, err)
 			require.NoError(t, firstConnector.Start(context.Background(), host))
 			require.NoError(t, firstConnector.Shutdown(context.Background()))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Expose a setting on tests::host to set up your own host initialization code

Some receivers require a host that has additional capabilities such as exposing exporters.
For those, we can expose a setting that allows them to place a different host in the generated code.
