### PR TITLE
[cmd/builder] clarify mismatched versions in the warning message

### DIFF
--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -74,7 +74,7 @@ func Generate(cfg Config) error {
 	}
 	// create a warning message for non-aligned builder and collector base
 	if cfg.Distribution.OtelColVersion != defaultOtelColVersion {
-		cfg.Logger.Info("You're building a distribution with non-aligned version of the builder. The version mismatch may cause the compilation failure. It's recommended to use the same version.", zap.String("collector-version", cfg.Distribution.OtelColVersion), zap.String("builder-version", defaultOtelColVersion))
+		cfg.Logger.Info("You're building a distribution with non-aligned version of the builder. The version mismatch may cause a compilation failure. It's recommended to use the same version.", zap.String("collector-version", cfg.Distribution.OtelColVersion), zap.String("builder-version", defaultOtelColVersion))
 	}
 	// if the file does not exist, try to create it
 	if _, err := os.Stat(cfg.Distribution.OutputPath); os.IsNotExist(err) {

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -74,7 +74,7 @@ func Generate(cfg Config) error {
 	}
 	// create a warning message for non-aligned builder and collector base
 	if cfg.Distribution.OtelColVersion != defaultOtelColVersion {
-		cfg.Logger.Info("You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API", zap.String("builder-version", defaultOtelColVersion))
+		cfg.Logger.Info("You're building a distribution with non-aligned version of the builder. The version mismatch may cause the compilation failure. It's recommended to use the same version.", zap.String("collector-version", cfg.Distribution.OtelColVersion), zap.String("builder-version", defaultOtelColVersion))
 	}
 	// if the file does not exist, try to create it
 	if _, err := os.Stat(cfg.Distribution.OutputPath); os.IsNotExist(err) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Refine the warning message to make it useful for the end user.

<!-- Issue number if applicable -->
#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/10514

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Locally tested.
```sh
2024-07-31T22:03:05.984+0900    INFO    internal/command.go:125 OpenTelemetry Collector Builder {"version": "(devel)"}
2024-07-31T22:03:05.984+0900    INFO    internal/command.go:136 Using default build configuration
2024-07-31T22:03:05.985+0900    INFO    builder/config.go:142   Using go        {"go-executable": "/usr/local/bin/go"}
2024-07-31T22:03:05.985+0900    INFO    builder/main.go:77      You're building a distribution with non-aligned version of the builder. The version mismatch may cause the compilation failure. It's recommended to use the same version.       {"collector-version": "0.104.0", "builder-version": "0.106.1"}
2024-07-31T22:03:05.985+0900    INFO    builder/main.go:100     Sources created {"path": "/tmp/otelcol-distribution3869530617"}
2024-07-31T22:03:06.510+0900    INFO    builder/main.go:191     Getting go modules
2024-07-31T22:03:06.552+0900    INFO    builder/main.go:111     Compiling
2024-07-31T22:03:07.080+0900    INFO    builder/main.go:130     Compiled        {"binary": "/tmp/otelcol-distribution3869530617/otelcorecol"}
```

<!--Describe the documentation added.-->
#### Documentation

N/A

<!--Please delete paragraphs that you did not use before submitting.-->
#### Note

I did not add a changelog entry because other PRs that only changed logging messages and behavior did not add it too.
If this is an incorrect understanding, please point it out.