### PR TITLE
[component] Remove deprecated `Host.GetFactory` method

### DIFF
--- a/.chloggen/component-remove-deprecated-method.yaml
+++ b/.chloggen/component-remove-deprecated-method.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removes the deprecated `Host.GetFactory` method.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10771]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/component/host.go
+++ b/component/host.go
@@ -10,21 +10,6 @@ package component // import "go.opentelemetry.io/collector/component"
 // The component is expected to cast the `component.Host` to the interface it needs and return
 // an error if the type assertion fails.
 type Host interface {
-	// GetFactory of the specified kind. Returns the factory for a component type.
-	// This allows components to create other components. For example:
-	//   func (r MyReceiver) Start(host component.Host) error {
-	//     apacheFactory := host.GetFactory(KindReceiver,"apache").(receiver.Factory)
-	//     receiver, err := apacheFactory.CreateMetrics(...)
-	//     ...
-	//   }
-	//
-	// GetFactory can be called by the component anytime after Component.Start() begins and
-	// until Component.Shutdown() ends. Note that the component is responsible for destroying
-	// other components that it creates.
-	//
-	// Deprecated: [v0.106.0] component.Host no longer requires implementors to expose a GetFactory function.
-	GetFactory(kind Kind, componentType Type) Factory
-
 	// GetExtensions returns the map of extensions. Only enabled and created extensions will be returned.
 	// Typically, it is used to find an extension by type or by full config name. Both cases
 	// can be done by iterating the returned map. There are typically very few extensions,


### PR DESCRIPTION
#### Description
Removes the deprecated `GetFactory` method from the `component.Host` interface

<!-- Issue number if applicable -->
#### Link to tracking issue
Closes https://github.com/open-telemetry/opentelemetry-collector/issues/9511