### PR TITLE
[exporterhelper] delete deprecated `exporterhelper.ObsReport`

### DIFF
--- a/.chloggen/obsexporter.yaml
+++ b/.chloggen/obsexporter.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Delete deprecated `exporterhelper.ObsReport` and `exporterhelper.NewObsReport`
+
+# One or more tracking issues or pull requests related to the change
+issues: [10779, 10592]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -41,7 +41,7 @@ func (b *baseRequestSender) setNextSender(nextSender requestSender) {
 	b.nextSender = nextSender
 }
 
-type obsrepSenderFactory func(obsrep *ObsReport) requestSender
+type obsrepSenderFactory func(obsrep *obsReport) requestSender
 
 // Option apply changes to baseExporter.
 type Option func(*baseExporter) error
@@ -232,7 +232,7 @@ type baseExporter struct {
 	unmarshaler exporterqueue.Unmarshaler[Request]
 
 	set    exporter.Settings
-	obsrep *ObsReport
+	obsrep *obsReport
 
 	// Message for the user to be added with an export failure message.
 	exportFailureMessage string
@@ -250,7 +250,7 @@ type baseExporter struct {
 }
 
 func newBaseExporter(set exporter.Settings, signal component.DataType, osf obsrepSenderFactory, options ...Option) (*baseExporter, error) {
-	obsReport, err := NewObsReport(ObsReportSettings{ExporterID: set.ID, ExporterCreateSettings: set, DataType: signal})
+	obsReport, err := newObsReport(obsReportSettings{exporterID: set.ID, exporterCreateSettings: set, dataType: signal})
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -33,7 +33,7 @@ var (
 	}()
 )
 
-func newNoopObsrepSender(*ObsReport) requestSender {
+func newNoopObsrepSender(*obsReport) requestSender {
 	return &baseRequestSender{}
 }
 

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -146,17 +146,17 @@ func NewLogsRequestExporter(
 
 type logsExporterWithObservability struct {
 	baseRequestSender
-	obsrep *ObsReport
+	obsrep *obsReport
 }
 
-func newLogsExporterWithObservability(obsrep *ObsReport) requestSender {
+func newLogsExporterWithObservability(obsrep *obsReport) requestSender {
 	return &logsExporterWithObservability{obsrep: obsrep}
 }
 
 func (lewo *logsExporterWithObservability) send(ctx context.Context, req Request) error {
-	c := lewo.obsrep.StartLogsOp(ctx)
+	c := lewo.obsrep.startLogsOp(ctx)
 	numLogRecords := req.ItemsCount()
 	err := lewo.nextSender.send(c, req)
-	lewo.obsrep.EndLogsOp(c, numLogRecords, err)
+	lewo.obsrep.endLogsOp(c, numLogRecords, err)
 	return err
 }

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -146,17 +146,17 @@ func NewMetricsRequestExporter(
 
 type metricsSenderWithObservability struct {
 	baseRequestSender
-	obsrep *ObsReport
+	obsrep *obsReport
 }
 
-func newMetricsSenderWithObservability(obsrep *ObsReport) requestSender {
+func newMetricsSenderWithObservability(obsrep *obsReport) requestSender {
 	return &metricsSenderWithObservability{obsrep: obsrep}
 }
 
 func (mewo *metricsSenderWithObservability) send(ctx context.Context, req Request) error {
-	c := mewo.obsrep.StartMetricsOp(ctx)
+	c := mewo.obsrep.startMetricsOp(ctx)
 	numMetricDataPoints := req.ItemsCount()
 	err := mewo.nextSender.send(c, req)
-	mewo.obsrep.EndMetricsOp(c, numMetricDataPoints, err)
+	mewo.obsrep.endMetricsOp(c, numMetricDataPoints, err)
 	return err
 }

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -18,11 +18,8 @@ import (
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
-// ObsReport is a helper to add observability to an exporter.
-//
-// Deprecated: [v0.105.0] Not expected to be used directly.
-// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
-type ObsReport struct {
+// obsReport is a helper to add observability to an exporter.
+type obsReport struct {
 	level          configtelemetry.Level
 	spanNamePrefix string
 	tracer         trace.Tracer
@@ -32,98 +29,76 @@ type ObsReport struct {
 	telemetryBuilder *metadata.TelemetryBuilder
 }
 
-// ObsReportSettings are settings for creating an ObsReport.
-//
-// Deprecated: [v0.105.0] Not expected to be used directly.
-// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
-type ObsReportSettings struct {
-	ExporterID             component.ID
-	ExporterCreateSettings exporter.Settings
-	DataType               component.DataType
+// obsReportSettings are settings for creating an obsReport.
+type obsReportSettings struct {
+	exporterID             component.ID
+	exporterCreateSettings exporter.Settings
+	dataType               component.DataType
 }
 
-// NewObsReport creates a new Exporter.
-//
-// Deprecated: [v0.105.0] Not expected to be used directly.
-// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
-func NewObsReport(cfg ObsReportSettings) (*ObsReport, error) {
+// newObsReport creates a new Exporter.
+func newObsReport(cfg obsReportSettings) (*obsReport, error) {
 	return newExporter(cfg)
 }
 
-func newExporter(cfg ObsReportSettings) (*ObsReport, error) {
-	telemetryBuilder, err := metadata.NewTelemetryBuilder(cfg.ExporterCreateSettings.TelemetrySettings)
+func newExporter(cfg obsReportSettings) (*obsReport, error) {
+	telemetryBuilder, err := metadata.NewTelemetryBuilder(cfg.exporterCreateSettings.TelemetrySettings)
 	if err != nil {
 		return nil, err
 	}
 
-	return &ObsReport{
-		level:          cfg.ExporterCreateSettings.TelemetrySettings.MetricsLevel,
-		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.ExporterID.String(),
-		tracer:         cfg.ExporterCreateSettings.TracerProvider.Tracer(cfg.ExporterID.String()),
-		dataType:       cfg.DataType,
+	return &obsReport{
+		level:          cfg.exporterCreateSettings.TelemetrySettings.MetricsLevel,
+		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.exporterID.String(),
+		tracer:         cfg.exporterCreateSettings.TracerProvider.Tracer(cfg.exporterID.String()),
+		dataType:       cfg.dataType,
 		otelAttrs: []attribute.KeyValue{
-			attribute.String(obsmetrics.ExporterKey, cfg.ExporterID.String()),
+			attribute.String(obsmetrics.ExporterKey, cfg.exporterID.String()),
 		},
 		telemetryBuilder: telemetryBuilder,
 	}, nil
 }
 
-// StartTracesOp is called at the start of an Export operation.
+// startTracesOp is called at the start of an Export operation.
 // The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
-//
-// Deprecated: [v0.105.0] Not expected to be used directly.
-// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
-func (or *ObsReport) StartTracesOp(ctx context.Context) context.Context {
+func (or *obsReport) startTracesOp(ctx context.Context) context.Context {
 	return or.startOp(ctx, obsmetrics.ExportTraceDataOperationSuffix)
 }
 
-// EndTracesOp completes the export operation that was started with StartTracesOp.
-//
-// Deprecated: [v0.105.0] Not expected to be used directly.
-// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
-func (or *ObsReport) EndTracesOp(ctx context.Context, numSpans int, err error) {
+// endTracesOp completes the export operation that was started with startTracesOp.
+func (or *obsReport) endTracesOp(ctx context.Context, numSpans int, err error) {
 	numSent, numFailedToSend := toNumItems(numSpans, err)
 	or.recordMetrics(context.WithoutCancel(ctx), component.DataTypeTraces, numSent, numFailedToSend)
 	endSpan(ctx, err, numSent, numFailedToSend, obsmetrics.SentSpansKey, obsmetrics.FailedToSendSpansKey)
 }
 
-// StartMetricsOp is called at the start of an Export operation.
+// startMetricsOp is called at the start of an Export operation.
 // The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
-//
-// Deprecated: [v0.105.0] Not expected to be used directly.
-// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
-func (or *ObsReport) StartMetricsOp(ctx context.Context) context.Context {
+func (or *obsReport) startMetricsOp(ctx context.Context) context.Context {
 	return or.startOp(ctx, obsmetrics.ExportMetricsOperationSuffix)
 }
 
-// EndMetricsOp completes the export operation that was started with
-// StartMetricsOp.
+// endMetricsOp completes the export operation that was started with
+// startMetricsOp.
 //
-// Deprecated: [v0.105.0] Not expected to be used directly.
 // If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
-func (or *ObsReport) EndMetricsOp(ctx context.Context, numMetricPoints int, err error) {
+func (or *obsReport) endMetricsOp(ctx context.Context, numMetricPoints int, err error) {
 	numSent, numFailedToSend := toNumItems(numMetricPoints, err)
 	or.recordMetrics(context.WithoutCancel(ctx), component.DataTypeMetrics, numSent, numFailedToSend)
 	endSpan(ctx, err, numSent, numFailedToSend, obsmetrics.SentMetricPointsKey, obsmetrics.FailedToSendMetricPointsKey)
 }
 
-// StartLogsOp is called at the start of an Export operation.
+// startLogsOp is called at the start of an Export operation.
 // The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
-//
-// Deprecated: [v0.105.0] Not expected to be used directly.
-// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
-func (or *ObsReport) StartLogsOp(ctx context.Context) context.Context {
+func (or *obsReport) startLogsOp(ctx context.Context) context.Context {
 	return or.startOp(ctx, obsmetrics.ExportLogsOperationSuffix)
 }
 
-// EndLogsOp completes the export operation that was started with StartLogsOp.
-//
-// Deprecated: [v0.105.0] Not expected to be used directly.
-// If needed, report your use case in https://github.com/open-telemetry/opentelemetry-collector/issues/10592.
-func (or *ObsReport) EndLogsOp(ctx context.Context, numLogRecords int, err error) {
+// endLogsOp completes the export operation that was started with startLogsOp.
+func (or *obsReport) endLogsOp(ctx context.Context, numLogRecords int, err error) {
 	numSent, numFailedToSend := toNumItems(numLogRecords, err)
 	or.recordMetrics(context.WithoutCancel(ctx), component.DataTypeLogs, numSent, numFailedToSend)
 	endSpan(ctx, err, numSent, numFailedToSend, obsmetrics.SentLogRecordsKey, obsmetrics.FailedToSendLogRecordsKey)
@@ -131,13 +106,13 @@ func (or *ObsReport) EndLogsOp(ctx context.Context, numLogRecords int, err error
 
 // startOp creates the span used to trace the operation. Returning
 // the updated context and the created span.
-func (or *ObsReport) startOp(ctx context.Context, operationSuffix string) context.Context {
+func (or *obsReport) startOp(ctx context.Context, operationSuffix string) context.Context {
 	spanName := or.spanNamePrefix + operationSuffix
 	ctx, _ = or.tracer.Start(ctx, spanName)
 	return ctx
 }
 
-func (or *ObsReport) recordMetrics(ctx context.Context, dataType component.DataType, sent, failed int64) {
+func (or *obsReport) recordMetrics(ctx context.Context, dataType component.DataType, sent, failed int64) {
 	if or.level == configtelemetry.LevelNone {
 		return
 	}
@@ -180,7 +155,7 @@ func toNumItems(numExportedItems int, err error) (int64, int64) {
 	return int64(numExportedItems), 0
 }
 
-func (or *ObsReport) recordEnqueueFailure(ctx context.Context, dataType component.DataType, failed int64) {
+func (or *obsReport) recordEnqueueFailure(ctx context.Context, dataType component.DataType, failed int64) {
 	var enqueueFailedMeasure metric.Int64Counter
 	switch dataType {
 	case component.DataTypeTraces:

--- a/exporter/exporterhelper/obsexporter_test.go
+++ b/exporter/exporterhelper/obsexporter_test.go
@@ -30,9 +30,9 @@ func TestExportTraceDataOp(t *testing.T) {
 		parentCtx, parentSpan := tt.TelemetrySettings().TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
-		obsrep, err := newExporter(ObsReportSettings{
-			ExporterID:             exporterID,
-			ExporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+		obsrep, err := newExporter(obsReportSettings{
+			exporterID:             exporterID,
+			exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 		})
 		require.NoError(t, err)
 
@@ -41,9 +41,9 @@ func TestExportTraceDataOp(t *testing.T) {
 			{items: 14, err: errFake},
 		}
 		for i := range params {
-			ctx := obsrep.StartTracesOp(parentCtx)
+			ctx := obsrep.startTracesOp(parentCtx)
 			assert.NotNil(t, ctx)
-			obsrep.EndTracesOp(ctx, params[i].items, params[i].err)
+			obsrep.endTracesOp(ctx, params[i].items, params[i].err)
 		}
 
 		spans := tt.SpanRecorder.Ended()
@@ -78,9 +78,9 @@ func TestExportMetricsOp(t *testing.T) {
 		parentCtx, parentSpan := tt.TelemetrySettings().TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
-		obsrep, err := newExporter(ObsReportSettings{
-			ExporterID:             exporterID,
-			ExporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+		obsrep, err := newExporter(obsReportSettings{
+			exporterID:             exporterID,
+			exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 		})
 		require.NoError(t, err)
 
@@ -89,10 +89,10 @@ func TestExportMetricsOp(t *testing.T) {
 			{items: 23, err: errFake},
 		}
 		for i := range params {
-			ctx := obsrep.StartMetricsOp(parentCtx)
+			ctx := obsrep.startMetricsOp(parentCtx)
 			assert.NotNil(t, ctx)
 
-			obsrep.EndMetricsOp(ctx, params[i].items, params[i].err)
+			obsrep.endMetricsOp(ctx, params[i].items, params[i].err)
 		}
 
 		spans := tt.SpanRecorder.Ended()
@@ -127,9 +127,9 @@ func TestExportLogsOp(t *testing.T) {
 		parentCtx, parentSpan := tt.TelemetrySettings().TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
-		obsrep, err := newExporter(ObsReportSettings{
-			ExporterID:             exporterID,
-			ExporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+		obsrep, err := newExporter(obsReportSettings{
+			exporterID:             exporterID,
+			exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 		})
 		require.NoError(t, err)
 
@@ -138,10 +138,10 @@ func TestExportLogsOp(t *testing.T) {
 			{items: 23, err: errFake},
 		}
 		for i := range params {
-			ctx := obsrep.StartLogsOp(parentCtx)
+			ctx := obsrep.startLogsOp(parentCtx)
 			assert.NotNil(t, ctx)
 
-			obsrep.EndLogsOp(ctx, params[i].items, params[i].err)
+			obsrep.endLogsOp(ctx, params[i].items, params[i].err)
 		}
 
 		spans := tt.SpanRecorder.Ended()
@@ -176,14 +176,14 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := NewObsReport(ObsReportSettings{
-		ExporterID:             exporterID,
-		ExporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+	obsrep, err := newObsReport(obsReportSettings{
+		exporterID:             exporterID,
+		exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})
 	require.NoError(t, err)
-	ctx := obsrep.StartTracesOp(context.Background())
+	ctx := obsrep.startTracesOp(context.Background())
 	require.NotNil(t, ctx)
-	obsrep.EndTracesOp(ctx, 7, nil)
+	obsrep.endTracesOp(ctx, 7, nil)
 
 	assert.NoError(t, tt.CheckExporterTraces(7, 0))
 	assert.Error(t, tt.CheckExporterTraces(7, 7))
@@ -196,14 +196,14 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := NewObsReport(ObsReportSettings{
-		ExporterID:             exporterID,
-		ExporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+	obsrep, err := newObsReport(obsReportSettings{
+		exporterID:             exporterID,
+		exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})
 	require.NoError(t, err)
-	ctx := obsrep.StartMetricsOp(context.Background())
+	ctx := obsrep.startMetricsOp(context.Background())
 	require.NotNil(t, ctx)
-	obsrep.EndMetricsOp(ctx, 7, nil)
+	obsrep.endMetricsOp(ctx, 7, nil)
 
 	assert.NoError(t, tt.CheckExporterMetrics(7, 0))
 	assert.Error(t, tt.CheckExporterMetrics(7, 7))
@@ -216,14 +216,14 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := NewObsReport(ObsReportSettings{
-		ExporterID:             exporterID,
-		ExporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+	obsrep, err := newObsReport(obsReportSettings{
+		exporterID:             exporterID,
+		exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})
 	require.NoError(t, err)
-	ctx := obsrep.StartLogsOp(context.Background())
+	ctx := obsrep.startLogsOp(context.Background())
 	require.NotNil(t, ctx)
-	obsrep.EndLogsOp(ctx, 7, nil)
+	obsrep.endLogsOp(ctx, 7, nil)
 
 	assert.NoError(t, tt.CheckExporterLogs(7, 0))
 	assert.Error(t, tt.CheckExporterLogs(7, 7))

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -19,9 +19,9 @@ func TestExportEnqueueFailure(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := NewObsReport(ObsReportSettings{
-		ExporterID:             exporterID,
-		ExporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+	obsrep, err := newObsReport(obsReportSettings{
+		exporterID:             exporterID,
+		exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})
 	require.NoError(t, err)
 

--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -73,12 +73,12 @@ type queueSender struct {
 	traceAttribute attribute.KeyValue
 	consumers      *queue.Consumers[Request]
 
-	obsrep     *ObsReport
+	obsrep     *obsReport
 	exporterID component.ID
 }
 
 func newQueueSender(q exporterqueue.Queue[Request], set exporter.Settings, numConsumers int,
-	exportFailureMessage string, obsrep *ObsReport) *queueSender {
+	exportFailureMessage string, obsrep *obsReport) *queueSender {
 	qs := &queueSender{
 		queue:          q,
 		numConsumers:   numConsumers,

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -432,9 +432,9 @@ func TestQueuedRetryPersistentEnabled_NoDataLossOnShutdown(t *testing.T) {
 func TestQueueSenderNoStartShutdown(t *testing.T) {
 	queue := queue.NewBoundedMemoryQueue[Request](queue.MemoryQueueSettings[Request]{})
 	set := exportertest.NewNopSettings()
-	obsrep, err := NewObsReport(ObsReportSettings{
-		ExporterID:             exporterID,
-		ExporterCreateSettings: exportertest.NewNopSettings(),
+	obsrep, err := newObsReport(obsReportSettings{
+		exporterID:             exporterID,
+		exporterCreateSettings: exportertest.NewNopSettings(),
 	})
 	assert.NoError(t, err)
 	qs := newQueueSender(queue, set, 1, "", obsrep)

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -339,7 +339,7 @@ type observabilityConsumerSender struct {
 	droppedItemsCount *atomic.Int64
 }
 
-func newObservabilityConsumerSender(*ObsReport) requestSender {
+func newObservabilityConsumerSender(*obsReport) requestSender {
 	return &observabilityConsumerSender{
 		waitGroup:         new(sync.WaitGroup),
 		droppedItemsCount: &atomic.Int64{},

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -146,18 +146,18 @@ func NewTracesRequestExporter(
 
 type tracesExporterWithObservability struct {
 	baseRequestSender
-	obsrep *ObsReport
+	obsrep *obsReport
 }
 
-func newTracesExporterWithObservability(obsrep *ObsReport) requestSender {
+func newTracesExporterWithObservability(obsrep *obsReport) requestSender {
 	return &tracesExporterWithObservability{obsrep: obsrep}
 }
 
 func (tewo *tracesExporterWithObservability) send(ctx context.Context, req Request) error {
-	c := tewo.obsrep.StartTracesOp(ctx)
+	c := tewo.obsrep.startTracesOp(ctx)
 	numTraceSpans := req.ItemsCount()
 	// Forward the data to the next consumer (this pusher is the next).
 	err := tewo.nextSender.send(c, req)
-	tewo.obsrep.EndTracesOp(c, numTraceSpans, err)
+	tewo.obsrep.endTracesOp(c, numTraceSpans, err)
 	return err
 }


### PR DESCRIPTION
#### Description
Delete deprecated `exporterhelper.ObsReport` and `exporterhelper.NewObsReport`

#### Link to tracking issue
Relates to https://github.com/open-telemetry/opentelemetry-collector/issues/10592
