### PR TITLE
[confmap] Validate providers scheme when building a Resolver

### DIFF
--- a/.chloggen/mx-psi_restrict-providers-scheme.yaml
+++ b/.chloggen/mx-psi_restrict-providers-scheme.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Check that providers have a correct scheme when building a confmap.Resolver.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10786]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/confmap/expand_test.go
+++ b/confmap/expand_test.go
@@ -61,11 +61,8 @@ func TestResolverDoneNotExpandOldEnvVars(t *testing.T) {
 	envProvider := newFakeProvider("env", func(context.Context, string, WatcherFunc) (*Retrieved, error) {
 		return NewRetrieved("some string")
 	})
-	emptySchemeProvider := newFakeProvider("", func(context.Context, string, WatcherFunc) (*Retrieved, error) {
-		return NewRetrieved("some string")
-	})
 
-	resolver, err := NewResolver(ResolverSettings{URIs: []string{"test:"}, ProviderFactories: []ProviderFactory{fileProvider, envProvider, emptySchemeProvider}, ConverterFactories: nil})
+	resolver, err := NewResolver(ResolverSettings{URIs: []string{"test:"}, ProviderFactories: []ProviderFactory{fileProvider, envProvider}, ConverterFactories: nil})
 	require.NoError(t, err)
 
 	// Test that expanded configs are the same with the simple config with no env vars.
@@ -509,12 +506,8 @@ func TestResolverExpandInvalidScheme(t *testing.T) {
 		panic("must not be called")
 	})
 
-	resolver, err := NewResolver(ResolverSettings{URIs: []string{"input:"}, ProviderFactories: []ProviderFactory{provider, testProvider}, ConverterFactories: nil})
-	require.NoError(t, err)
-
-	_, err = resolver.Resolve(context.Background())
-
-	assert.EqualError(t, err, `invalid uri: "g_c_s:VALUE"`)
+	_, err := NewResolver(ResolverSettings{URIs: []string{"input:"}, ProviderFactories: []ProviderFactory{provider, testProvider}, ConverterFactories: nil})
+	assert.ErrorContains(t, err, "invalid 'confmap.Provider' scheme")
 }
 
 func TestResolverExpandInvalidOpaqueValue(t *testing.T) {

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -96,7 +96,17 @@ func NewResolver(set ResolverSettings) (*Resolver, error) {
 	providers := make(map[string]Provider, len(set.ProviderFactories))
 	for _, factory := range set.ProviderFactories {
 		provider := factory.Create(set.ProviderSettings)
-		providers[provider.Scheme()] = provider
+		scheme := provider.Scheme()
+		// Check that the scheme follows the pattern.
+		if !regexp.MustCompile(schemePattern).MatchString(scheme) {
+			return nil, fmt.Errorf("invalid 'confmap.Provider' scheme %q", scheme)
+		}
+		// Check that the scheme is unique.
+		if _, ok := providers[scheme]; ok {
+			return nil, fmt.Errorf("duplicate 'confmap.Provider' scheme %q", scheme)
+		}
+
+		providers[scheme] = provider
 	}
 
 	if set.DefaultScheme != "" {

--- a/confmap/resolver_test.go
+++ b/confmap/resolver_test.go
@@ -118,6 +118,11 @@ func TestNewResolverInvalidSchemeInURI(t *testing.T) {
 	assert.EqualError(t, err, `invalid uri: "s_3:has invalid char"`)
 }
 
+func TestNewResolverDuplicateScheme(t *testing.T) {
+	_, err := NewResolver(ResolverSettings{URIs: []string{"mock:something"}, ProviderFactories: []ProviderFactory{newMockProvider(&mockProvider{scheme: "mock"}), newMockProvider(&mockProvider{scheme: "mock"})}})
+	assert.EqualError(t, err, `duplicate 'confmap.Provider' scheme "mock"`)
+}
+
 func TestResolverErrors(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/confmap/resolver_test.go
+++ b/confmap/resolver_test.go
@@ -113,8 +113,8 @@ func (m *mockConverter) Convert(context.Context, *Conf) error {
 	return errors.New("converter_err")
 }
 
-func TestNewResolverInvalidScheme(t *testing.T) {
-	_, err := NewResolver(ResolverSettings{URIs: []string{"s_3:has invalid char"}, ProviderFactories: []ProviderFactory{newMockProvider(&mockProvider{scheme: "s_3"})}})
+func TestNewResolverInvalidSchemeInURI(t *testing.T) {
+	_, err := NewResolver(ResolverSettings{URIs: []string{"s_3:has invalid char"}, ProviderFactories: []ProviderFactory{newMockProvider(&mockProvider{scheme: "s3"})}})
 	assert.EqualError(t, err, `invalid uri: "s_3:has invalid char"`)
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Validate providers schemes when building a Resolver.

I don't consider this a breaking change since the providers would be useless if they don't follow this pattern.
