### PR TITLE
Make @pjanotti owner of windows/amd64

### DIFF
--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -47,27 +47,24 @@ Tier 1 platforms are currently:
 Tier 2 platforms are _guaranteed to work with specified limitations_. Precompiled binaries are built and tested on the platform as part of the release cycle. Build and test infrastructure is provided by the platform maintainers. All tests are executed on the platform as far as they are applicable, and all prerequisites are fulfilled. Not executed tests and not tested collector add-ons (receivers, processors, exporters, etc.) are published on release of the collector distribution. Any build or test failure delays the release of the binaries for the respective platform but not the collector distribution for all other platforms. Defects are addressed but not with the priority as for Tier 1 and, if specific to the platform, require the support of the platform maintainers.
 
 Tier 2 platforms are currently:
-| Platform      | Owner(s)                                                                                                    |
-|---------------|-------------------------------------------------------------------------------------------------------------|
-| darwin/arm64  | [@MovieStoreGuy](https://github.com/MovieStoreGuy)                                                          |
-| linux/arm64   | [@atoulme](https://github.com/atoulme)                                                                      |
-| windows/amd64 | [OpenTelemetry Collector approvers](https://github.com/open-telemetry/opentelemetry-collector#contributing) |
-
+| Platform      | Owner(s)                                           |
+|---------------|----------------------------------------------------|
+| darwin/arm64  | [@MovieStoreGuy](https://github.com/MovieStoreGuy) |
+| linux/arm64   | [@atoulme](https://github.com/atoulme)             |
+| windows/amd64 | [@pjanotti](https://github.com/pjanotti)           |
 
 ### Tier 3 - Community Support
 
 Tier 3 platforms are _guaranteed to build_. Precompiled binaries are made available as part of the release process and as result of a cross compile build on Linux amd64 but the binaries are not tested at all. Any build failure delays the release of the binaries for the respective platform but not the collector distribution for all other platforms. Defects are addressed based on community contributions. Core developers might provide guidance or code reviews, but direct fixes may be limited.
 
 Tier 3 platforms are currently:
-| Platform      | Owner(s)                                                                                                                                                        |
-|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| darwin/amd64  | [@h0cheung](https://github.com/h0cheung)                                                                                                                        |
-| linux/386     | [@andrzej-stencel](https://github.com/andrzej-stencel)                                                                                                          |
-| linux/arm     | [@Wal8800](https://github.com/Wal8800), [@atoulme](https://github.com/atoulme)                                                                                  |
-| linux/ppc64le | [@IBM-Currency-Helper](https://github.com/IBM-Currency-Helper), [@adilhusain-s](https://github.com/adilhusain-s), [@seth-priya](https://github.com/seth-priya)  |
-| linux/s390x   | [@bwalk-at-ibm](https://github.com/bwalk-at-ibm), [@rrschulze](https://github.com/rrschulze)                                                                    |
-| windows/386   | [@pjanotti](https://github.com/pjanotti)                                                                                                                        |
+| Platform      | Owner(s)                                                                                                                                                       |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| darwin/amd64  | [@h0cheung](https://github.com/h0cheung)                                                                                                                       |
+| linux/386     | [@andrzej-stencel](https://github.com/andrzej-stencel)                                                                                                         |
+| linux/arm     | [@Wal8800](https://github.com/Wal8800), [@atoulme](https://github.com/atoulme)                                                                                 |
+| linux/ppc64le | [@IBM-Currency-Helper](https://github.com/IBM-Currency-Helper), [@adilhusain-s](https://github.com/adilhusain-s), [@seth-priya](https://github.com/seth-priya) |
+| linux/s390x   | [@bwalk-at-ibm](https://github.com/bwalk-at-ibm), [@rrschulze](https://github.com/rrschulze)                                                                   |
+| windows/386   | [@pjanotti](https://github.com/pjanotti)                                                                                                                       |
 
 The proposed additional platform aix/ppc64 ([#19195](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19195)) will be included into Tier 3 once it's added to the OpenTelemetry Collector as platform. 
-
-


### PR DESCRIPTION
I'm volunteering myself to own the tier 2 support for windows/amd64. This will put the windows/amd64 on par with the other tier 2 platforms by having a specific person owning it.

Some of Windows related things that I contribute(d):

* Codeowner of various Windows related components in contrib (pkg/winperfcounters, activedirectorydsreceiver, iisreceiver, windowseventlogreceiver, and windowsperfcountersreceiver)
* Fixing Windows related issues (e.g.: #9042, #9689, #9726, https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30743)
* MSI on the collector releases repo (https://github.com/open-telemetry/opentelemetry-collector-releases/pull/560)

