### PR TITLE
[chore] set fail-fast to false for contrib tests

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Skip Contrib Tests') }}
     strategy:
+      fail-fast: false
       matrix:
         group:
           - receiver-0


### PR DESCRIPTION
Continuation of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32333. This should help us identify more components that break with Core changes.