### PR TITLE
[config] Implement temporality preference option

### DIFF
--- a/.chloggen/int-telemetry-otlp-options.yaml
+++ b/.chloggen/int-telemetry-otlp-options.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Implement the `temporality_preference` setting for internal telemetry exported via OTLP"
+
+# One or more tracking issues or pull requests related to the change
+issues: [ 10745 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [ user ]

--- a/service/internal/proctelemetry/config.go
+++ b/service/internal/proctelemetry/config.go
@@ -255,12 +255,14 @@ func initOTLPgRPCExporter(ctx context.Context, otlpConfig *config.OTLPMetric) (s
 	}
 	if otlpConfig.TemporalityPreference != nil {
 		switch *otlpConfig.TemporalityPreference {
+		case "delta":
+			opts = append(opts, otlpmetricgrpc.WithTemporalitySelector(temporalityPreferenceDelta))
 		case "cumulative":
 			opts = append(opts, otlpmetricgrpc.WithTemporalitySelector(temporalityPreferenceCumulative))
-		case "delta":
-			opts = append(opts, otlpmetricgrpc.WithTemporalitySelector(temporalityPreferenceDeltaPreferred))
 		case "lowmemory":
 			opts = append(opts, otlpmetricgrpc.WithTemporalitySelector(temporalityPreferenceLowMemory))
+		default:
+			return nil, fmt.Errorf("unsupported temporality preference %q", *otlpConfig.TemporalityPreference)
 		}
 	}
 	if otlpConfig.DefaultHistogramAggregation != nil {
@@ -310,12 +312,14 @@ func initOTLPHTTPExporter(ctx context.Context, otlpConfig *config.OTLPMetric) (s
 	}
 	if otlpConfig.TemporalityPreference != nil {
 		switch *otlpConfig.TemporalityPreference {
+		case "delta":
+			opts = append(opts, otlpmetrichttp.WithTemporalitySelector(temporalityPreferenceDelta))
 		case "cumulative":
 			opts = append(opts, otlpmetrichttp.WithTemporalitySelector(temporalityPreferenceCumulative))
-		case "delta":
-			opts = append(opts, otlpmetrichttp.WithTemporalitySelector(temporalityPreferenceDeltaPreferred))
 		case "lowmemory":
 			opts = append(opts, otlpmetrichttp.WithTemporalitySelector(temporalityPreferenceLowMemory))
+		default:
+			return nil, fmt.Errorf("unsupported temporality preference %q", *otlpConfig.TemporalityPreference)
 		}
 	}
 	if otlpConfig.DefaultHistogramAggregation != nil {
@@ -351,7 +355,7 @@ func temporalityPreferenceCumulative(ik sdkmetric.InstrumentKind) metricdata.Tem
 	return metricdata.CumulativeTemporality
 }
 
-func temporalityPreferenceDeltaPreferred(ik sdkmetric.InstrumentKind) metricdata.Temporality {
+func temporalityPreferenceDelta(ik sdkmetric.InstrumentKind) metricdata.Temporality {
 	switch ik {
 	case sdkmetric.InstrumentKindCounter, sdkmetric.InstrumentKindObservableCounter, sdkmetric.InstrumentKindHistogram:
 		return metricdata.DeltaTemporality

--- a/service/internal/proctelemetry/config.go
+++ b/service/internal/proctelemetry/config.go
@@ -318,7 +318,7 @@ func initOTLPHTTPExporter(ctx context.Context, otlpConfig *config.OTLPMetric) (s
 	return otlpmetrichttp.New(ctx, opts...)
 }
 
-func temporalityPreferenceCumulative(ik sdkmetric.InstrumentKind) metricdata.Temporality {
+func temporalityPreferenceCumulative(_ sdkmetric.InstrumentKind) metricdata.Temporality {
 	return metricdata.CumulativeTemporality
 }
 

--- a/service/internal/proctelemetry/config.go
+++ b/service/internal/proctelemetry/config.go
@@ -265,14 +265,6 @@ func initOTLPgRPCExporter(ctx context.Context, otlpConfig *config.OTLPMetric) (s
 			return nil, fmt.Errorf("unsupported temporality preference %q", *otlpConfig.TemporalityPreference)
 		}
 	}
-	if otlpConfig.DefaultHistogramAggregation != nil {
-		switch *otlpConfig.DefaultHistogramAggregation {
-		case "explicit_bucket_histogram":
-			opts = append(opts, otlpmetricgrpc.WithAggregationSelector(aggregationPreferenceExplicitBucketHistogram))
-		case "base2_exponential_bucket_histogram":
-			opts = append(opts, otlpmetricgrpc.WithAggregationSelector(aggregationPreferenceExponentialHistogram))
-		}
-	}
 
 	return otlpmetricgrpc.New(ctx, opts...)
 }
@@ -322,33 +314,8 @@ func initOTLPHTTPExporter(ctx context.Context, otlpConfig *config.OTLPMetric) (s
 			return nil, fmt.Errorf("unsupported temporality preference %q", *otlpConfig.TemporalityPreference)
 		}
 	}
-	if otlpConfig.DefaultHistogramAggregation != nil {
-		switch *otlpConfig.DefaultHistogramAggregation {
-		case "explicit_bucket_histogram":
-			opts = append(opts, otlpmetrichttp.WithAggregationSelector(aggregationPreferenceExplicitBucketHistogram))
-		case "base2_exponential_bucket_histogram":
-			opts = append(opts, otlpmetrichttp.WithAggregationSelector(aggregationPreferenceExponentialHistogram))
-		}
-	}
 
 	return otlpmetrichttp.New(ctx, opts...)
-}
-
-func aggregationPreferenceExplicitBucketHistogram(ik sdkmetric.InstrumentKind) sdkmetric.Aggregation {
-	if ik == sdkmetric.InstrumentKindHistogram {
-		return sdkmetric.AggregationExplicitBucketHistogram{
-			Boundaries: []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
-			NoMinMax:   false,
-		}
-	}
-	return sdkmetric.DefaultAggregationSelector(ik)
-}
-
-func aggregationPreferenceExponentialHistogram(ik sdkmetric.InstrumentKind) sdkmetric.Aggregation {
-	if ik == sdkmetric.InstrumentKindHistogram {
-		return sdkmetric.AggregationBase2ExponentialHistogram{}
-	}
-	return sdkmetric.DefaultAggregationSelector(ik)
 }
 
 func temporalityPreferenceCumulative(ik sdkmetric.InstrumentKind) metricdata.Temporality {

--- a/service/internal/proctelemetry/config_test.go
+++ b/service/internal/proctelemetry/config_test.go
@@ -7,10 +7,17 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/contrib/config"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
 func strPtr(s string) *string {
@@ -22,15 +29,28 @@ func intPtr(i int) *int {
 }
 
 func TestMetricReader(t *testing.T) {
+	consoleExporter, err := stdoutmetric.New(
+		stdoutmetric.WithPrettyPrint(),
+	)
+	require.NoError(t, err)
+	ctx := context.Background()
+	otlpGRPCExporter, err := otlpmetricgrpc.New(ctx)
+	require.NoError(t, err)
+	otlpHTTPExporter, err := otlpmetrichttp.New(ctx)
+	require.NoError(t, err)
+	promExporter, err := otelprom.New()
+	require.NoError(t, err)
+
 	testCases := []struct {
-		name   string
-		reader config.MetricReader
-		args   any
-		err    error
+		name       string
+		reader     config.MetricReader
+		args       any
+		wantErr    error
+		wantReader sdkmetric.Reader
 	}{
 		{
-			name: "noreader",
-			err:  errors.New("unsupported metric reader type {<nil> <nil>}"),
+			name:    "noreader",
+			wantErr: errors.New("unsupported metric reader type {<nil> <nil>}"),
 		},
 		{
 			name: "pull prometheus invalid exporter",
@@ -41,7 +61,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
-			err: errNoValidMetricExporter,
+			wantErr: errNoValidMetricExporter,
 		},
 		{
 			name: "pull/prometheus-invalid-config-no-host",
@@ -52,7 +72,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("host must be specified"),
+			wantErr: errors.New("host must be specified"),
 		},
 		{
 			name: "pull/prometheus-invalid-config-no-port",
@@ -65,10 +85,10 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("port must be specified"),
+			wantErr: errors.New("port must be specified"),
 		},
 		{
-			name: "pull/prometheus-invalid-config-no-port",
+			name: "pull/prometheus-valid",
 			reader: config.MetricReader{
 				Pull: &config.PullMetricReader{
 					Exporter: config.MetricExporter{
@@ -79,6 +99,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: promExporter,
 		},
 		{
 			name: "periodic/invalid-exporter",
@@ -92,14 +113,14 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
-			err: errNoValidMetricExporter,
+			wantErr: errNoValidMetricExporter,
 		},
 		{
 			name: "periodic/no-exporter",
 			reader: config.MetricReader{
 				Periodic: &config.PeriodicMetricReader{},
 			},
-			err: errNoValidMetricExporter,
+			wantErr: errNoValidMetricExporter,
 		},
 		{
 			name: "periodic/console-exporter",
@@ -110,6 +131,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: sdkmetric.NewPeriodicReader(consoleExporter),
 		},
 		{
 			name: "periodic/console-exporter-with-timeout-interval",
@@ -122,6 +144,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: sdkmetric.NewPeriodicReader(consoleExporter),
 		},
 		{
 			name: "periodic/otlp-exporter-invalid-protocol",
@@ -134,7 +157,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("unsupported protocol http/invalid"),
+			wantErr: errors.New("unsupported protocol http/invalid"),
 		},
 		{
 			name: "periodic/otlp-grpc-exporter-no-endpoint",
@@ -152,6 +175,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpGRPCExporter),
 		},
 		{
 			name: "periodic/otlp-grpc-exporter",
@@ -170,6 +194,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpGRPCExporter),
 		},
 		{
 			name: "periodic/otlp-grpc-exporter-no-scheme",
@@ -188,6 +213,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpGRPCExporter),
 		},
 		{
 			name: "periodic/otlp-grpc-invalid-endpoint",
@@ -206,7 +232,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
-			err: &url.Error{Op: "parse", URL: "http:// ", Err: url.InvalidHostError(" ")},
+			wantErr: &url.Error{Op: "parse", URL: "http:// ", Err: url.InvalidHostError(" ")},
 		},
 		{
 			name: "periodic/otlp-grpc-invalid-compression",
@@ -225,7 +251,87 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("unsupported compression \"invalid\""),
+			wantErr: errors.New("unsupported compression \"invalid\""),
+		},
+		{
+			name: "periodic/otlp-grpc-delta-temporality",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "grpc/protobuf",
+							Endpoint:    "localhost:4318",
+							Compression: strPtr("none"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+							TemporalityPreference: strPtr("delta"),
+						},
+					},
+				},
+			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpGRPCExporter),
+		},
+		{
+			name: "periodic/otlp-grpc-cumulative-temporality",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "grpc/protobuf",
+							Endpoint:    "localhost:4318",
+							Compression: strPtr("none"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+							TemporalityPreference: strPtr("cumulative"),
+						},
+					},
+				},
+			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpGRPCExporter),
+		},
+		{
+			name: "periodic/otlp-grpc-lowmemory-temporality",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "grpc/protobuf",
+							Endpoint:    "localhost:4318",
+							Compression: strPtr("none"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+							TemporalityPreference: strPtr("lowmemory"),
+						},
+					},
+				},
+			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpGRPCExporter),
+		},
+		{
+			name: "periodic/otlp-grpc-invalid-temporality",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "grpc/protobuf",
+							Endpoint:    "localhost:4318",
+							Compression: strPtr("none"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+							TemporalityPreference: strPtr("invalid"),
+						},
+					},
+				},
+			},
+			wantErr: errors.New("unsupported temporality preference \"invalid\""),
 		},
 		{
 			name: "periodic/otlp-http-exporter",
@@ -244,6 +350,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpHTTPExporter),
 		},
 		{
 			name: "periodic/otlp-http-exporter-with-path",
@@ -262,6 +369,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpHTTPExporter),
 		},
 		{
 			name: "periodic/otlp-http-exporter-no-endpoint",
@@ -279,6 +387,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpHTTPExporter),
 		},
 		{
 			name: "periodic/otlp-http-exporter-no-scheme",
@@ -297,6 +406,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpHTTPExporter),
 		},
 		{
 			name: "periodic/otlp-http-invalid-endpoint",
@@ -315,7 +425,7 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
-			err: &url.Error{Op: "parse", URL: "http:// ", Err: url.InvalidHostError(" ")},
+			wantErr: &url.Error{Op: "parse", URL: "http:// ", Err: url.InvalidHostError(" ")},
 		},
 		{
 			name: "periodic/otlp-http-invalid-compression",
@@ -334,21 +444,115 @@ func TestMetricReader(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("unsupported compression \"invalid\""),
+			wantErr: errors.New("unsupported compression \"invalid\""),
+		},
+		{
+			name: "periodic/otlp-http-cumulative-temporality",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "http/protobuf",
+							Endpoint:    "localhost:4318",
+							Compression: strPtr("none"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+							TemporalityPreference: strPtr("cumulative"),
+						},
+					},
+				},
+			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpHTTPExporter),
+		},
+		{
+			name: "periodic/otlp-http-lowmemory-temporality",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "http/protobuf",
+							Endpoint:    "localhost:4318",
+							Compression: strPtr("none"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+							TemporalityPreference: strPtr("lowmemory"),
+						},
+					},
+				},
+			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpHTTPExporter),
+		},
+		{
+			name: "periodic/otlp-http-delta-temporality",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "http/protobuf",
+							Endpoint:    "localhost:4318",
+							Compression: strPtr("none"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+							TemporalityPreference: strPtr("delta"),
+						},
+					},
+				},
+			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpHTTPExporter),
+		},
+		{
+			name: "periodic/otlp-http-invalid-temporality",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "http/protobuf",
+							Endpoint:    "localhost:4318",
+							Compression: strPtr("none"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+							TemporalityPreference: strPtr("invalid"),
+						},
+					},
+				},
+			},
+			wantErr: errors.New("unsupported temporality preference \"invalid\""),
 		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			reader, server, err := InitMetricReader(context.Background(), tt.reader, make(chan error))
+			gotReader, server, err := InitMetricReader(context.Background(), tt.reader, make(chan error))
+
 			defer func() {
-				if reader != nil {
-					assert.NoError(t, reader.Shutdown(context.Background()))
+				if gotReader != nil {
+					assert.NoError(t, gotReader.Shutdown(context.Background()))
 				}
 				if server != nil {
 					assert.NoError(t, server.Shutdown(context.Background()))
 				}
 			}()
-			assert.Equal(t, tt.err, err)
+
+			assert.Equal(t, tt.wantErr, err)
+
+			if tt.wantReader == nil {
+				assert.Nil(t, gotReader)
+			} else {
+				assert.Equal(t, reflect.TypeOf(tt.wantReader), reflect.TypeOf(gotReader))
+
+				if reflect.TypeOf(tt.wantReader).String() == "*metric.PeriodicReader" {
+					wantExporterType := reflect.Indirect(reflect.ValueOf(tt.wantReader)).FieldByName("exporter").Elem().Type()
+					gotExporterType := reflect.Indirect(reflect.ValueOf(gotReader)).FieldByName("exporter").Elem().Type()
+					assert.Equal(t, wantExporterType, gotExporterType)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### Description
adds temporality preference option for internal telemetry exported via OTLP

#### Link to tracking issue
(partly) fixes #10745

#### Testing
unit tests

#### Documentation
Feature is already documented, but not implemented yet.
