### PR TITLE
Add `TrustedKeys` to TLS Config

### DIFF
--- a/.chloggen/sinkingpoint_trusted-keys.yaml
+++ b/.chloggen/sinkingpoint_trusted-keys.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: config/configtls
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a `trusted_keys` field to configtls that allows narrowing the accepted client certificates down to a distinct set
+
+# One or more tracking issues or pull requests related to the change
+issues: [10523]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -72,6 +72,14 @@ Additionally certificates may be reloaded by setting the below configuration.
    Accepts a [duration string](https://pkg.go.dev/time#ParseDuration),
    valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
+- `trusted_keys` (optional) : TrustedKeys allows specifying a list of SHA256 hashes to trust when verifying client certificates. This allows only trusting a specific set of keys, rather than all the keys signed by a given CA. Note: The client certificate still has to pass standard TLS verification, so you must still set the required CA values.
+
+Example:
+```
+  trusted_keys:
+    - "29:9D:39:8E:26:E7:72:88:D7:5D:2D:34:FE:8C:41:FA:9F:F1:C3:D7"
+```
+
 How TLS/mTLS is configured depends on whether configuring the client or server.
 See below for examples.
 

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -5,12 +5,14 @@ package configtls // import "go.opentelemetry.io/collector/config/configtls"
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -37,6 +39,9 @@ type Config struct {
 
 	// In memory PEM encoded cert. (optional)
 	CAPem configopaque.String `mapstructure:"ca_pem"`
+
+	// A set of SHA256 fingerprints that represent the client certificates we should trust.
+	TrustedKeys []string `mapstructure:"trusted_keys"`
 
 	// If true, load system CA certificates pool in addition to the certificates
 	// configured in this struct.
@@ -177,6 +182,19 @@ func (r *certReloader) GetCertificate() (*tls.Certificate, error) {
 	return r.cert, nil
 }
 
+func (c Config) verifyPeerCertificate(_ [][]byte, verifiedChains [][]*x509.Certificate) error {
+	for _, chain := range verifiedChains {
+		hash := fingerprintCertificate(chain[0])
+		for _, trusted := range c.TrustedKeys {
+			if hash == trusted {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("key not in trusted_keys")
+}
+
 func (c Config) Validate() error {
 	if c.hasCAFile() && c.hasCAPem() {
 		return fmt.Errorf("provide either a CA file or the PEM-encoded string, but not both")
@@ -232,13 +250,19 @@ func (c Config) loadTLSConfig() (*tls.Config, error) {
 		return nil, err
 	}
 
+	var verifyPeerCertificate func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
+	if len(c.TrustedKeys) > 0 {
+		verifyPeerCertificate = c.verifyPeerCertificate
+	}
+
 	return &tls.Config{
-		RootCAs:              certPool,
-		GetCertificate:       getCertificate,
-		GetClientCertificate: getClientCertificate,
-		MinVersion:           minTLS,
-		MaxVersion:           maxTLS,
-		CipherSuites:         cipherSuites,
+		RootCAs:               certPool,
+		GetCertificate:        getCertificate,
+		GetClientCertificate:  getClientCertificate,
+		MinVersion:            minTLS,
+		MaxVersion:            maxTLS,
+		CipherSuites:          cipherSuites,
+		VerifyPeerCertificate: verifyPeerCertificate,
 	}, nil
 }
 
@@ -447,4 +471,21 @@ var tlsVersions = map[string]uint16{
 	"1.1": tls.VersionTLS11,
 	"1.2": tls.VersionTLS12,
 	"1.3": tls.VersionTLS13,
+}
+
+// Returns a SHA256 hash of the given certificate.
+func fingerprintCertificate(cert *x509.Certificate) string {
+	sha := sha256.New()
+	sha.Write(cert.Raw)
+	fingerprint := sha.Sum(nil)
+
+	var buf strings.Builder
+	for i, f := range fingerprint {
+		if i > 0 {
+			fmt.Fprintf(&buf, ":")
+		}
+		fmt.Fprintf(&buf, "%02X", f)
+	}
+
+	return buf.String()
 }


### PR DESCRIPTION
#### Description

When using client certificates, it's sometimes useful to use publicly signed certificates to avoid
having to run your own CA infrastructure. This leaves you open though, because if you trust a public cert then _any_ public cert will work.

This alleviates this by allowing specifying a list of "Trusted Keys". This is an array of SHA256
fingerprints of certs that are trusted, allowing
us to reject any certs that are not the exact one we expect.

#### Link to tracking issue
Fixes #10523

#### Testing

Added two tests where we create a server that trusts a specific key, and then asserts that that key passes verification whereas the other cert doesn't.

#### Documentation

Added new option to README, along with an example
