### PR TITLE
[chore] update workflow to add changelog before pushing

### DIFF
--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -90,13 +90,6 @@ jobs:
 
           git checkout -b $branch
           git add semconv/
-          git commit -m "$message"
-          git push --set-upstream origin $branch
-          url=$(gh pr create --title "$message" \
-                             --body "$body" \
-                             --base main)
-
-          pull_request_number=${url//*\//}
 
           # see the template for change log entry file at blob/main/.chloggen/TEMPLATE.yaml
           cat > .chloggen/semconv-$VERSION.yaml << EOF
@@ -108,5 +101,10 @@ jobs:
 
           git add .chloggen/semconv-$VERSION.yaml
 
-          git commit -m "Add change log entry"
-          git push
+          git commit -m "$message"
+          git push --set-upstream origin $branch
+          url=$(gh pr create --title "$message" \
+                             --body "$body" \
+                             --base main)
+
+          pull_request_number=${url//*\//}


### PR DESCRIPTION
This prevents the workflow from trying to push to an existing branch which it doesn't have permissions to do.

An example of the failure can be found here: https://github.com/open-telemetry/opentelemetry-collector/actions/runs/10291429328/job/28483659786