### PR TITLE
[chore] Release ports on the dynamic range on Windows runners

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -33,6 +33,9 @@ jobs:
             ~\go\pkg\mod
             ~\AppData\Local\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Ensure required ports in the dynamic range are available
+        run: |
+          & ${{ github.workspace }}\.github\workflows\scripts\win-required-ports.ps1
       - name: Run Unit Tests
         run: make gotest
 
@@ -55,6 +58,9 @@ jobs:
             ~\go\pkg\mod
             ~\AppData\Local\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Ensure required ports in the dynamic range are available
+        run: |
+          & ${{ github.workspace }}\.github\workflows\scripts\win-required-ports.ps1
 
       - name: Make otelcorecol
         run: make otelcorecol

--- a/.github/workflows/scripts/win-required-ports.ps1
+++ b/.github/workflows/scripts/win-required-ports.ps1
@@ -1,0 +1,20 @@
+<#
+.SYNOPSIS
+    This script ensures that the ports required by the default configuration of the collector are available.
+.DESCRIPTION
+    Certain runs on GitHub Actions sometimes have ports required by the default configuration reserved by other
+    applications via the WinNAT service.
+#>
+
+#Requires -RunAsAdministrator
+
+netsh interface ip show excludedportrange protocol=tcp
+
+Stop-Service winnat
+
+# Only port in the dynamic range that is being, from time to time, reserved by other applications.
+netsh interface ip add excludedportrange protocol=tcp startport=55679 numberofports=1
+
+Start-Service winnat
+
+netsh interface ip show excludedportrange protocol=tcp


### PR DESCRIPTION
#### Description
The default port used by `zpagesextension` is in a range that Windows machines can exclude by default. This change adds a PowerShell script to release the default `zpagesextension` port (55679) on the Windows GH workflows.

#### Link to tracking issue
Fixes #10811
