### PR TITLE
[mdatagen] export ScopeName in internal/metadata package

### DIFF
--- a/.chloggen/codeboten_mdatagen-expose-scope-name.yaml
+++ b/.chloggen/codeboten_mdatagen-expose-scope-name.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: export ScopeName in internal/metadata package
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This can be used by components that need to set their scope name manually. Will save component owners from having to store a variable, which may diverge from the scope name used by the component for emitting its own telemetry.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_mdatagen-expose-scope-name.yaml
+++ b/.chloggen/codeboten_mdatagen-expose-scope-name.yaml
@@ -10,7 +10,7 @@ component: mdatagen
 note: export ScopeName in internal/metadata package
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [10845]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -14,12 +14,14 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = "go.opentelemetry.io/collector/internal/receiver/samplereceiver"
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/internal/receiver/samplereceiver")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/internal/receiver/samplereceiver")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -546,12 +546,14 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = ""
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 `,
 		},
@@ -580,12 +582,14 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = ""
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 `,
 		},

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -16,12 +16,14 @@ import (
     "go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = "{{ .ScopeName }}"
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("{{ .ScopeName }}")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("{{ .ScopeName }}")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 {{- if .Telemetry.Metrics }}
 

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -14,12 +14,14 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = "go.opentelemetry.io/collector/exporter/exporterhelper"
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/exporter/exporterhelper")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/exporter/exporterhelper")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/batchprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/batchprocessor/internal/metadata/generated_telemetry.go
@@ -14,12 +14,14 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = "go.opentelemetry.io/collector/processor/batchprocessor"
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/processor/batchprocessor")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/processor/batchprocessor")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/processorhelper/internal/metadata/generated_telemetry.go
+++ b/processor/processorhelper/internal/metadata/generated_telemetry.go
@@ -13,12 +13,14 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = "go.opentelemetry.io/collector/processor/processorhelper"
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/processor/processorhelper")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/processor/processorhelper")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/receiver/receiverhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/receiverhelper/internal/metadata/generated_telemetry.go
@@ -13,12 +13,14 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = "go.opentelemetry.io/collector/receiver/receiverhelper"
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/receiver/receiverhelper")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/receiver/receiverhelper")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/receiver/scraperhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/scraperhelper/internal/metadata/generated_telemetry.go
@@ -13,12 +13,14 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = "go.opentelemetry.io/collector/receiver/scraperhelper"
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/receiver/scraperhelper")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/receiver/scraperhelper")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -14,12 +14,14 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
+const ScopeName = "go.opentelemetry.io/collector/service"
+
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/service")
+	return settings.MeterProvider.Meter(ScopeName)
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/service")
+	return settings.TracerProvider.Tracer(ScopeName)
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry


### PR DESCRIPTION
This can be used by components that need to set their scope name manually. Will save component owners from having to store a variable, which may diverge from the scope name used by the component for emitting its own telemetry. There are about a dozen components in contrib that could use this today.

Alternatively, I could just update the scope name strings in the components manually.
