### PR TITLE
[mdatagen] move ScopeName to generated_status

### DIFF
--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_status.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("sample")
+	Type      = component.MustNewType("sample")
+	ScopeName = "go.opentelemetry.io/collector/internal/receiver/samplereceiver"
 )
 
 const (

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -14,14 +14,12 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = "go.opentelemetry.io/collector/internal/receiver/samplereceiver"
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/internal/receiver/samplereceiver")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/internal/receiver/samplereceiver")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -462,7 +462,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("foo")
+	Type      = component.MustNewType("foo")
+	ScopeName = ""
 )
 
 const (
@@ -491,7 +492,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("foo")
+	Type      = component.MustNewType("foo")
+	ScopeName = ""
 )
 
 const (
@@ -546,14 +548,12 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = ""
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("")
 }
 `,
 		},
@@ -582,14 +582,12 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = ""
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("")
 }
 `,
 		},

--- a/cmd/mdatagen/templates/status.go.tmpl
+++ b/cmd/mdatagen/templates/status.go.tmpl
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("{{ .Type }}")
+	Type      = component.MustNewType("{{ .Type }}")
+	ScopeName = "{{ .ScopeName }}"
 )
 
 const (

--- a/cmd/mdatagen/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/templates/telemetry.go.tmpl
@@ -16,14 +16,12 @@ import (
     "go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = "{{ .ScopeName }}"
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("{{ .ScopeName }}")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("{{ .ScopeName }}")
 }
 {{- if .Telemetry.Metrics }}
 

--- a/connector/forwardconnector/internal/metadata/generated_status.go
+++ b/connector/forwardconnector/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("forward")
+	Type      = component.MustNewType("forward")
+	ScopeName = "go.opentelemetry.io/collector/connector/forwardconnector"
 )
 
 const (

--- a/exporter/debugexporter/internal/metadata/generated_status.go
+++ b/exporter/debugexporter/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("debug")
+	Type      = component.MustNewType("debug")
+	ScopeName = "go.opentelemetry.io/collector/exporter/debugexporter"
 )
 
 const (

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -14,14 +14,12 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = "go.opentelemetry.io/collector/exporter/exporterhelper"
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/exporter/exporterhelper")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/exporter/exporterhelper")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/exporter/loggingexporter/internal/metadata/generated_status.go
+++ b/exporter/loggingexporter/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("logging")
+	Type      = component.MustNewType("logging")
+	ScopeName = "go.opentelemetry.io/collector/exporter/loggingexporter"
 )
 
 const (

--- a/exporter/nopexporter/internal/metadata/generated_status.go
+++ b/exporter/nopexporter/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("nop")
+	Type      = component.MustNewType("nop")
+	ScopeName = "go.opentelemetry.io/collector/exporter/nopexporter"
 )
 
 const (

--- a/exporter/otlpexporter/internal/metadata/generated_status.go
+++ b/exporter/otlpexporter/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("otlp")
+	Type      = component.MustNewType("otlp")
+	ScopeName = "go.opentelemetry.io/collector/exporter/otlpexporter"
 )
 
 const (

--- a/exporter/otlphttpexporter/internal/metadata/generated_status.go
+++ b/exporter/otlphttpexporter/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("otlphttp")
+	Type      = component.MustNewType("otlphttp")
+	ScopeName = "go.opentelemetry.io/collector/exporter/otlphttpexporter"
 )
 
 const (

--- a/extension/ballastextension/internal/metadata/generated_status.go
+++ b/extension/ballastextension/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("memory_ballast")
+	Type      = component.MustNewType("memory_ballast")
+	ScopeName = "go.opentelemetry.io/collector/extension/ballastextension"
 )
 
 const (

--- a/extension/memorylimiterextension/internal/metadata/generated_status.go
+++ b/extension/memorylimiterextension/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("memory_limiter")
+	Type      = component.MustNewType("memory_limiter")
+	ScopeName = "go.opentelemetry.io/collector/extension/memorylimiterextension"
 )
 
 const (

--- a/extension/zpagesextension/internal/metadata/generated_status.go
+++ b/extension/zpagesextension/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("zpages")
+	Type      = component.MustNewType("zpages")
+	ScopeName = "go.opentelemetry.io/collector/extension/zpagesextension"
 )
 
 const (

--- a/processor/batchprocessor/internal/metadata/generated_status.go
+++ b/processor/batchprocessor/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("batch")
+	Type      = component.MustNewType("batch")
+	ScopeName = "go.opentelemetry.io/collector/processor/batchprocessor"
 )
 
 const (

--- a/processor/batchprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/batchprocessor/internal/metadata/generated_telemetry.go
@@ -14,14 +14,12 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = "go.opentelemetry.io/collector/processor/batchprocessor"
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/processor/batchprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/processor/batchprocessor")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/memorylimiterprocessor/internal/metadata/generated_status.go
+++ b/processor/memorylimiterprocessor/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("memory_limiter")
+	Type      = component.MustNewType("memory_limiter")
+	ScopeName = "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 )
 
 const (

--- a/processor/processorhelper/internal/metadata/generated_telemetry.go
+++ b/processor/processorhelper/internal/metadata/generated_telemetry.go
@@ -13,14 +13,12 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = "go.opentelemetry.io/collector/processor/processorhelper"
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/processor/processorhelper")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/processor/processorhelper")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/receiver/nopreceiver/internal/metadata/generated_status.go
+++ b/receiver/nopreceiver/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("nop")
+	Type      = component.MustNewType("nop")
+	ScopeName = "go.opentelemetry.io/collector/receiver/nopreceiver"
 )
 
 const (

--- a/receiver/otlpreceiver/internal/metadata/generated_status.go
+++ b/receiver/otlpreceiver/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("otlp")
+	Type      = component.MustNewType("otlp")
+	ScopeName = "go.opentelemetry.io/collector/receiver/otlpreceiver"
 )
 
 const (

--- a/receiver/receiverhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/receiverhelper/internal/metadata/generated_telemetry.go
@@ -13,14 +13,12 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = "go.opentelemetry.io/collector/receiver/receiverhelper"
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/receiver/receiverhelper")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/receiver/receiverhelper")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/receiver/scraperhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/scraperhelper/internal/metadata/generated_telemetry.go
@@ -13,14 +13,12 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = "go.opentelemetry.io/collector/receiver/scraperhelper"
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/receiver/scraperhelper")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/receiver/scraperhelper")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -14,14 +14,12 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-const ScopeName = "go.opentelemetry.io/collector/service"
-
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter(ScopeName)
+	return settings.MeterProvider.Meter("go.opentelemetry.io/collector/service")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer(ScopeName)
+	return settings.TracerProvider.Tracer("go.opentelemetry.io/collector/service")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry


### PR DESCRIPTION
This will make it available to most components, as the generated_telemetry is only generated for components that have internal telemetry configured. Arguably the scope name should be moved to its own file, but i'd rather not add yet another file if possible.
