### PR TITLE
[service] Allow users to disable the tracer provider via the feature gate `service.noopTracerProvider`

### DIFF
--- a/.chloggen/codeboten_disable-tracer-without-config.yaml
+++ b/.chloggen/codeboten_disable-tracer-without-config.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure a noop tracer provider is returned if no processors are configured
+
+# One or more tracking issues or pull requests related to the change
+issues: [10858]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Previously the service was returning an instance of a SDK tracer provider regardless of whether there were any processors configured causing resources to be consumed unnecessarily.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_disable-tracer-without-config.yaml
+++ b/.chloggen/codeboten_disable-tracer-without-config.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: service
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Allow users to set a level for the `service::telemetry::trace` configuration to disable all trace providers"
+note: "Allow users to disable the tracer provider via the feature gate `service.noopTracerProvider`"
 
 # One or more tracking issues or pull requests related to the change
 issues: [10858]
@@ -15,7 +15,7 @@ issues: [10858]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Previously the service was returning an instance of a SDK tracer provider regardless of whether there were any processors configured causing resources to be consumed unnecessarily.
+subtext: The service is returning an instance of a SDK tracer provider regardless of whether there were any processors configured causing resources to be consumed unnecessarily.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/.chloggen/codeboten_disable-tracer-without-config.yaml
+++ b/.chloggen/codeboten_disable-tracer-without-config.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: service
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Ensure a noop tracer provider is returned if no processors are configured
+note: "Allow users to set a level for the `service::telemetry::trace` configuration to disable all trace providers"
 
 # One or more tracking issues or pull requests related to the change
 issues: [10858]

--- a/internal/globalgates/globalgates.go
+++ b/internal/globalgates/globalgates.go
@@ -24,3 +24,8 @@ var DisableOpenCensusBridge = featuregate.GlobalRegistry().MustRegister("service
 	featuregate.WithRegisterFromVersion("v0.105.0"),
 	featuregate.WithRegisterToVersion("v0.109.0"),
 	featuregate.WithRegisterDescription("`Disables the OpenCensus bridge meaning any component still using the OpenCensus SDK will no longer be able to produce telemetry."))
+
+var NoopTracerProvider = featuregate.GlobalRegistry().MustRegister("service.noopTracerProvider",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterFromVersion("v0.107.0"),
+	featuregate.WithRegisterDescription("Sets a Noop OpenTelemetry TracerProvider to reduce memory allocations. This featuregate is incompatible with the zPages extension."))

--- a/service/go.mod
+++ b/service/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/collector/extension v0.106.1
 	go.opentelemetry.io/collector/extension/zpagesextension v0.106.1
 	go.opentelemetry.io/collector/featuregate v1.12.0
+	go.opentelemetry.io/collector/internal/globalgates v0.106.1
 	go.opentelemetry.io/collector/pdata v1.12.0
 	go.opentelemetry.io/collector/pdata/testdata v0.106.1
 	go.opentelemetry.io/collector/processor v0.106.1
@@ -86,7 +87,6 @@ require (
 	go.opentelemetry.io/collector/config/internal v0.106.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.106.1 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.106.1 // indirect
-	go.opentelemetry.io/collector/internal/globalgates v0.106.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.106.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
 	go.opentelemetry.io/contrib/zpages v0.53.0 // indirect

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -130,6 +130,13 @@ type MetricsConfig struct {
 // TracesConfig exposes the common Telemetry configuration for collector's internal spans.
 // Experimental: *NOTE* this structure is subject to change or removal in the future.
 type TracesConfig struct {
+	// Level determines what level of tracing is enabled across the collector, the
+	// possible values are:
+	//  - "none" indicates that no trace data should be collected;
+	//  - "basic" is the recommended and covers the basics of the service telemetry.
+	//  - "normal" adds some additional spans top of basic.
+	//  - "detailed" adds all available spans to the previous levels.
+	Level configtelemetry.Level `mapstructure:"level"`
 	// Propagators is a list of TextMapPropagators from the supported propagators list. Currently,
 	// tracecontext and  b3 are supported. By default, the value is set to empty list and
 	// context propagation is disabled.

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -130,13 +130,6 @@ type MetricsConfig struct {
 // TracesConfig exposes the common Telemetry configuration for collector's internal spans.
 // Experimental: *NOTE* this structure is subject to change or removal in the future.
 type TracesConfig struct {
-	// Level determines what level of tracing is enabled across the collector, the
-	// possible values are:
-	//  - "none" indicates that no trace data should be collected;
-	//  - "basic" is the recommended and covers the basics of the service telemetry.
-	//  - "normal" adds some additional spans top of basic.
-	//  - "detailed" adds all available spans to the previous levels.
-	Level configtelemetry.Level `mapstructure:"level"`
 	// Propagators is a list of TextMapPropagators from the supported propagators list. Currently,
 	// tracecontext and  b3 are supported. By default, the value is set to empty list and
 	// context propagation is disabled.

--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 
-	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/internal/globalgates"
 )
 
 const (
@@ -48,7 +48,7 @@ func attributes(set Settings, cfg Config) map[string]interface{} {
 
 // New creates a new Telemetry from Config.
 func newTracerProvider(ctx context.Context, set Settings, cfg Config) (trace.TracerProvider, error) {
-	if cfg.Traces.Level == configtelemetry.LevelNone {
+	if globalgates.NoopTracerProvider.IsEnabled() {
 		return noop.NewTracerProvider(), nil
 	}
 	sch := semconv.SchemaURL

--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -51,33 +51,38 @@ func newTracerProvider(ctx context.Context, set Settings, cfg Config) (trace.Tra
 		Attributes: attributes(set, cfg),
 	}
 
+	var tracerProviderCfg *config.TracerProvider
+	if len(cfg.Traces.Processors) > 0 {
+		tracerProviderCfg = &config.TracerProvider{
+			Processors: cfg.Traces.Processors,
+			// TODO: once https://github.com/open-telemetry/opentelemetry-configuration/issues/83 is resolved,
+			// configuration for sampler should be done here via something like the following:
+			//
+			// Sampler: &config.Sampler{
+			// 	ParentBased: &config.SamplerParentBased{
+			// 		LocalParentSampled: &config.Sampler{
+			// 			AlwaysOn: config.SamplerAlwaysOn{},
+			// 		},
+			// 		LocalParentNotSampled: &config.Sampler{
+			//	        RecordOnly: config.SamplerRecordOnly{},
+			//      },
+			// 		RemoteParentSampled: &config.Sampler{
+			// 			AlwaysOn: config.SamplerAlwaysOn{},
+			// 		},
+			// 		RemoteParentNotSampled: &config.Sampler{
+			//	        RecordOnly: config.SamplerRecordOnly{},
+			//      },
+			// 	},
+			// },
+		}
+	}
+
 	sdk, err := config.NewSDK(
 		config.WithContext(ctx),
 		config.WithOpenTelemetryConfiguration(
 			config.OpenTelemetryConfiguration{
-				Resource: &res,
-				TracerProvider: &config.TracerProvider{
-					Processors: cfg.Traces.Processors,
-					// TODO: once https://github.com/open-telemetry/opentelemetry-configuration/issues/83 is resolved,
-					// configuration for sampler should be done here via something like the following:
-					//
-					// Sampler: &config.Sampler{
-					// 	ParentBased: &config.SamplerParentBased{
-					// 		LocalParentSampled: &config.Sampler{
-					// 			AlwaysOn: config.SamplerAlwaysOn{},
-					// 		},
-					// 		LocalParentNotSampled: &config.Sampler{
-					//	        RecordOnly: config.SamplerRecordOnly{},
-					//      },
-					// 		RemoteParentSampled: &config.Sampler{
-					// 			AlwaysOn: config.SamplerAlwaysOn{},
-					// 		},
-					// 		RemoteParentNotSampled: &config.Sampler{
-					//	        RecordOnly: config.SamplerRecordOnly{},
-					//      },
-					// 	},
-					// },
-				},
+				Resource:       &res,
+				TracerProvider: tracerProviderCfg,
 			},
 		),
 	)

--- a/service/telemetry/tracer_test.go
+++ b/service/telemetry/tracer_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/contrib/config"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/service/telemetry/internal"
 )
 
@@ -67,7 +67,12 @@ func TestNewTracerProvider(t *testing.T) {
 		wantTracerProvider any
 	}{
 		{
-			name:               "no processors",
+			name: "no processors",
+			cfg: Config{
+				Traces: TracesConfig{
+					Level: configtelemetry.LevelNone,
+				},
+			},
 			wantTracerProvider: noop.TracerProvider{},
 		},
 		{
@@ -75,15 +80,7 @@ func TestNewTracerProvider(t *testing.T) {
 			cfg: Config{
 				Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "test": ptr("test")},
 				Traces: TracesConfig{
-					Processors: []config.SpanProcessor{
-						{
-							Simple: &config.SimpleSpanProcessor{
-								Exporter: config.SpanExporter{
-									Console: config.Console{},
-								},
-							},
-						},
-					},
+					Level: configtelemetry.LevelBasic,
 				},
 			},
 			wantTracerProvider: &sdktrace.TracerProvider{},


### PR DESCRIPTION
Previously the service was returning an instance of a SDK tracer provider regardless of whether there were any processors configured causing resources to be consumed unnecessarily.

Fixes #10858
