### PR TITLE
[mdatagen] Update usage output

### DIFF
--- a/.chloggen/mdatagen-usage.yaml
+++ b/.chloggen/mdatagen-usage.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: mdatagen

--- a/.chloggen/mdatagen-usage.yaml
+++ b/.chloggen/mdatagen-usage.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updates mdatagen's usage to output a complete command line example, including the metadata.yaml file.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10886]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/main.go
+++ b/cmd/mdatagen/main.go
@@ -28,6 +28,10 @@ const (
 )
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s metadata.yaml\n", os.Args[0])
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 	yml := flag.Arg(0)
 	if err := run(yml); err != nil {


### PR DESCRIPTION
#### Description
Updates mdatagen's output to show a complete example including the required metadata.yaml file.

#### Link to tracking issue
- Closes #10886

#### Testing
Running `mdatagen -h` now shows `Usage: ./mdatagen metadata.yaml`

#### Documentation
N/A