### PR TITLE
chore (deps): migrate rand to rand/v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,6 +110,8 @@ linters-settings:
             desc: "Use 'errors' or 'fmt' instead of github.com/pkg/errors"
           - pkg: github.com/hashicorp/go-multierror
             desc: "Use go.uber.org/multierr instead of github.com/hashicorp/go-multierror"
+          - pkg: "math/rand$"
+            desc: "Use the newer 'math/rand/v2' instead of math/rand"
         # Add a different guard rule so that we can ignore tests.
       ignore-in-test:
           deny:

--- a/exporter/exportertest/mock_consumer.go
+++ b/exporter/exportertest/mock_consumer.go
@@ -5,7 +5,7 @@ package exportertest // import "go.opentelemetry.io/collector/exporter/exportert
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 
 	"google.golang.org/grpc/codes"

--- a/receiver/receivertest/contract_checker.go
+++ b/receiver/receivertest/contract_checker.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"testing"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Migrated rand dependency to rand/v2. We only use rand in tests and mocks and the only two functions we use are float32 and float64 which still exist in the new v2 API so nothing very exciting going on here.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10885

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Ran `make test` successfully

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
