### PR TITLE
[chore] pin version for npm tooling

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -80,7 +80,7 @@ jobs:
         run: npm install
       - name: Run markdown-link-check
         run: |
-          markdown-link-check \
+          npx --no -- markdown-link-check \
             --verbose \
             --config .github/workflows/check_links_config.json \
             changelog_preview.md \

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Render .chloggen changelog entries
         run: make chlog-preview > changelog_preview.md
       - name: Install markdown-link-check
-        run: npm install -g markdown-link-check
+        run: npm install
       - name: Run markdown-link-check
         run: |
           markdown-link-check \

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,7 +1,7 @@
 name: check-links
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 concurrency:
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install markdown-link-check
-        run: npm install -g markdown-link-check@3.11.2
+        run: npm install
 
       - name: Run markdown-link-check
         run: |

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run markdown-link-check
         run: |
-          markdown-link-check \
+          npx --no -- markdown-link-check \
             --verbose \
             --config .github/workflows/check_links_config.json \
             ${{needs.changedfiles.outputs.md}} \

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ benchmarks.txt
 
 # golang
 go.work*
+
+# npm (used for markdown-link-check)
+node_modules/*
+package-lock.json
+

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -10,7 +10,7 @@ traces, metrics and logs pipelines (sorted alphabetically):
 - [OTLP HTTP](otlphttpexporter/README.md)
 
 The [contrib
-repository](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+repository](https://github.com/open-telemetry/opentelemetry-collector-contrib) 
 has more exporters available in its builds.
 
 ## Configuring Exporters

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -10,7 +10,7 @@ traces, metrics and logs pipelines (sorted alphabetically):
 - [OTLP HTTP](otlphttpexporter/README.md)
 
 The [contrib
-repository](https://github.com/open-telemetry/opentelemetry-collector-contrib) 
+repository](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 has more exporters available in its builds.
 
 ## Configuring Exporters

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "markdown-link-check": "^3.11.2"
+  }
+}


### PR DESCRIPTION
The repo uses markdown-link-check and not having a package.json file to pin the version causes dependabot security checks sadness. Following the same pattern as the specification repo for storing package.json in the root of the repo.
