### PR TITLE
[otelcol] Preserve internal representation for components' configurations

### DIFF
--- a/.chloggen/mx-psi_preserve-internal-repr.yaml
+++ b/.chloggen/mx-psi_preserve-internal-repr.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otelcol
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve internal representation when unmarshaling component configs
+
+# One or more tracking issues or pull requests related to the change
+issues: [10552]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/otelcol/internal/configunmarshaler/configs.go
+++ b/otelcol/internal/configunmarshaler/configs.go
@@ -31,11 +31,17 @@ func (c *Configs[F]) Unmarshal(conf *confmap.Conf) error {
 	// Prepare resulting map.
 	c.cfgs = make(map[component.ID]component.Config)
 	// Iterate over raw configs and create a config for each.
-	for id, value := range rawCfgs {
+	for id := range rawCfgs {
 		// Find factory based on component kind and type that we read from config source.
 		factory, ok := c.factories[id.Type()]
 		if !ok {
 			return errorUnknownType(id, maps.Keys(c.factories))
+		}
+
+		// Get the configuration from the confmap.Conf to preserve internal representation.
+		sub, err := conf.Sub(id.String())
+		if err != nil {
+			return errorUnmarshalError(id, err)
 		}
 
 		// Create the default config for this component.
@@ -43,7 +49,7 @@ func (c *Configs[F]) Unmarshal(conf *confmap.Conf) error {
 
 		// Now that the default config struct is created we can Unmarshal into it,
 		// and it will apply user-defined config on top of the default.
-		if err := confmap.NewFromStringMap(value).Unmarshal(&cfg); err != nil {
+		if err := sub.Unmarshal(&cfg); err != nil {
 			return errorUnmarshalError(id, err)
 		}
 

--- a/otelcol/unmarshal_dry_run_test.go
+++ b/otelcol/unmarshal_dry_run_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/receiver"
@@ -20,7 +21,7 @@ type ValidateTestConfig struct {
 	String string `mapstructure:"string"`
 }
 
-var genericType component.Type = component.MustNewType("generic")
+var genericType = component.MustNewType("generic")
 
 func NewFactories(_ *testing.T) func() (Factories, error) {
 	return func() (Factories, error) {
@@ -93,7 +94,7 @@ func TestDryRunWithExpandedValues(t *testing.T) {
 							newFakeProvider("mock", func(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
 								return confmap.NewRetrievedFromYAML([]byte(tt.mockMap[uri[len("mock:"):]]))
 							}),
-							newFakeProvider("file", func(_ context.Context, _ string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
+							newFakeProvider("file", func(context.Context, string, confmap.WatcherFunc) (*confmap.Retrieved, error) {
 								return confmap.NewRetrievedFromYAML([]byte(tt.yamlConfig))
 							}),
 						},

--- a/otelcol/unmarshal_dry_run_test.go
+++ b/otelcol/unmarshal_dry_run_test.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/receiver"
+)
+
+var _ component.Config = (*Config)(nil)
+
+type ValidateTestConfig struct {
+	Number int    `mapstructure:"number"`
+	String string `mapstructure:"string"`
+}
+
+var genericType component.Type = component.MustNewType("generic")
+
+func NewFactories(t *testing.T) func() (Factories, error) {
+	return func() (Factories, error) {
+		factories, err := nopFactories()
+		if err != nil {
+			return Factories{}, err
+		}
+		factories.Receivers[genericType] = receiver.NewFactory(
+			genericType,
+			func() component.Config {
+				return &ValidateTestConfig{
+					Number: 1,
+					String: "default",
+				}
+			})
+
+		return factories, nil
+	}
+}
+
+var sampleYAMLConfig = `
+receivers:
+  generic:
+    number: ${mock:number}
+    string: ${mock:number}
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    traces:
+      receivers: [generic]
+      exporters: [nop]
+`
+
+func TestDryRunWithExpandedValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		yamlConfig string
+		mockMap    map[string]string
+		expectErr  bool
+	}{
+		{
+			name:       "string that looks like an integer",
+			yamlConfig: sampleYAMLConfig,
+			mockMap: map[string]string{
+				"number": "123",
+			},
+		},
+		{
+			name:       "string that looks like a bool",
+			yamlConfig: sampleYAMLConfig,
+			mockMap: map[string]string{
+				"number": "true",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector, err := NewCollector(CollectorSettings{
+				Factories: NewFactories(t),
+				ConfigProviderSettings: ConfigProviderSettings{
+					ResolverSettings: confmap.ResolverSettings{
+						URIs:          []string{"file:file"},
+						DefaultScheme: "mock",
+						ProviderFactories: []confmap.ProviderFactory{
+							newFakeProvider("mock", func(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
+								return confmap.NewRetrievedFromYAML([]byte(tt.mockMap[uri[len("mock:"):]]))
+							}),
+							newFakeProvider("file", func(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
+								return confmap.NewRetrievedFromYAML([]byte(tt.yamlConfig))
+							}),
+						},
+					},
+				},
+				SkipSettingGRPCLogger: true,
+			})
+			require.NoError(t, err)
+
+			err = collector.DryRun(context.Background())
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/otelcol/unmarshal_dry_run_test.go
+++ b/otelcol/unmarshal_dry_run_test.go
@@ -93,7 +93,7 @@ func TestDryRunWithExpandedValues(t *testing.T) {
 							newFakeProvider("mock", func(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
 								return confmap.NewRetrievedFromYAML([]byte(tt.mockMap[uri[len("mock:"):]]))
 							}),
-							newFakeProvider("file", func(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
+							newFakeProvider("file", func(_ context.Context, _ string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
 								return confmap.NewRetrievedFromYAML([]byte(tt.yamlConfig))
 							}),
 						},

--- a/otelcol/unmarshal_dry_run_test.go
+++ b/otelcol/unmarshal_dry_run_test.go
@@ -22,7 +22,7 @@ type ValidateTestConfig struct {
 
 var genericType component.Type = component.MustNewType("generic")
 
-func NewFactories(t *testing.T) func() (Factories, error) {
+func NewFactories(_ *testing.T) func() (Factories, error) {
 	return func() (Factories, error) {
 		factories, err := nopFactories()
 		if err != nil {


### PR DESCRIPTION
Fork of https://github.com/open-telemetry/opentelemetry-collector/pull/10897 with fixed linter. Cannot push or make a PR against Pablo's  branch for some reason