### PR TITLE
[configgrpc] fix integer overflow in configuration

### DIFF
--- a/.chloggen/codeboten_int64-int.yaml
+++ b/.chloggen/codeboten_int64-int.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the value of max_recv_msg_size_mib from uint64 to int to avoid a case where misconfiguration caused an integer overflow.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -169,7 +169,7 @@ type ServerConfig struct {
 	TLSSetting *configtls.ServerConfig `mapstructure:"tls"`
 
 	// MaxRecvMsgSizeMiB sets the maximum size (in MiB) of messages accepted by the server.
-	MaxRecvMsgSizeMiB uint64 `mapstructure:"max_recv_msg_size_mib"`
+	MaxRecvMsgSizeMiB int `mapstructure:"max_recv_msg_size_mib"`
 
 	// MaxConcurrentStreams sets the limit on the number of concurrent streams to each ServerTransport.
 	// It has effect only for streaming RPCs.
@@ -320,6 +320,22 @@ func validateBalancerName(balancerName string) bool {
 	return balancer.Get(balancerName) != nil
 }
 
+func (gss *ServerConfig) Validate() error {
+	if gss.MaxRecvMsgSizeMiB*1024*1024 < 0 {
+		return fmt.Errorf("invalid max_recv_msg_size_mib value: %d", gss.MaxRecvMsgSizeMiB)
+	}
+
+	if gss.ReadBufferSize < 0 {
+		return fmt.Errorf("invalid read_buffer_size value: %d", gss.ReadBufferSize)
+	}
+
+	if gss.WriteBufferSize < 0 {
+		return fmt.Errorf("invalid write_buffer_size value: %d", gss.WriteBufferSize)
+	}
+
+	return nil
+}
+
 // ToServer returns a grpc.Server for the configuration
 func (gss *ServerConfig) ToServer(_ context.Context, host component.Host, settings component.TelemetrySettings, extraOpts ...grpc.ServerOption) (*grpc.Server, error) {
 	opts, err := gss.toServerOption(host, settings)
@@ -346,8 +362,8 @@ func (gss *ServerConfig) toServerOption(host component.Host, settings component.
 		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsCfg)))
 	}
 
-	if gss.MaxRecvMsgSizeMiB > 0 {
-		opts = append(opts, grpc.MaxRecvMsgSize(int(gss.MaxRecvMsgSizeMiB*1024*1024)))
+	if gss.MaxRecvMsgSizeMiB > 0 && gss.MaxRecvMsgSizeMiB*1024*1024 > 0 {
+		opts = append(opts, grpc.MaxRecvMsgSize(gss.MaxRecvMsgSizeMiB*1024*1024))
 	}
 
 	if gss.MaxConcurrentStreams > 0 {

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -249,6 +249,58 @@ func TestDefaultGrpcServerSettings(t *testing.T) {
 	assert.Len(t, opts, 3)
 }
 
+func TestGrpcServerValidate(t *testing.T) {
+	tests := []struct {
+		gss *ServerConfig
+		err string
+	}{
+		{
+			gss: &ServerConfig{
+				MaxRecvMsgSizeMiB: -1,
+				NetAddr: confignet.AddrConfig{
+					Endpoint: "0.0.0.0:1234",
+				},
+			},
+			err: "invalid max_recv_msg_size_mib value: -1",
+		},
+		{
+			gss: &ServerConfig{
+				MaxRecvMsgSizeMiB: 9223372036854775807,
+				NetAddr: confignet.AddrConfig{
+					Endpoint: "0.0.0.0:1234",
+				},
+			},
+			err: "invalid max_recv_msg_size_mib value",
+		},
+		{
+			gss: &ServerConfig{
+				ReadBufferSize: -1,
+				NetAddr: confignet.AddrConfig{
+					Endpoint: "0.0.0.0:1234",
+				},
+			},
+			err: "invalid read_buffer_size value",
+		},
+		{
+			gss: &ServerConfig{
+				WriteBufferSize: -1,
+				NetAddr: confignet.AddrConfig{
+					Endpoint: "0.0.0.0:1234",
+				},
+			},
+			err: "invalid write_buffer_size value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.err, func(t *testing.T) {
+			err := tt.gss.Validate()
+			assert.Error(t, err)
+			assert.Regexp(t, tt.err, err)
+		})
+	}
+}
+
 func TestAllGrpcServerSettingsExceptAuth(t *testing.T) {
 	gss := &ServerConfig{
 		NetAddr: confignet.AddrConfig{


### PR DESCRIPTION
Change the value of max_recv_msg_size_mib from uint64 to int to avoid a case where misconfiguration caused an integer overflow. Added a Validate function to configgrpc as part of this to validate that users didn't set the value to something that would overflow when converted from megabytes to bytes.
