### PR TITLE
remove unnecessary level

### DIFF
--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/metadata"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
@@ -20,7 +19,6 @@ import (
 
 // obsReport is a helper to add observability to an exporter.
 type obsReport struct {
-	level          configtelemetry.Level
 	spanNamePrefix string
 	tracer         trace.Tracer
 	dataType       component.DataType
@@ -48,7 +46,6 @@ func newExporter(cfg obsReportSettings) (*obsReport, error) {
 	}
 
 	return &obsReport{
-		level:          cfg.exporterCreateSettings.TelemetrySettings.MetricsLevel,
 		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.exporterID.String(),
 		tracer:         cfg.exporterCreateSettings.TracerProvider.Tracer(cfg.exporterID.String()),
 		dataType:       cfg.dataType,
@@ -113,9 +110,6 @@ func (or *obsReport) startOp(ctx context.Context, operationSuffix string) contex
 }
 
 func (or *obsReport) recordMetrics(ctx context.Context, dataType component.DataType, sent, failed int64) {
-	if or.level == configtelemetry.LevelNone {
-		return
-	}
 	var sentMeasure, failedMeasure metric.Int64Counter
 	switch dataType {
 	case component.DataTypeTraces:

--- a/receiver/receiverhelper/obsreport.go
+++ b/receiver/receiverhelper/obsreport.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper/internal/metadata"
@@ -22,7 +21,6 @@ import (
 
 // ObsReport is a helper to add observability to a receiver.
 type ObsReport struct {
-	level          configtelemetry.Level
 	spanNamePrefix string
 	transport      string
 	longLivedCtx   bool
@@ -56,7 +54,6 @@ func newReceiver(cfg ObsReportSettings) (*ObsReport, error) {
 		return nil, err
 	}
 	return &ObsReport{
-		level:          cfg.ReceiverCreateSettings.TelemetrySettings.MetricsLevel,
 		spanNamePrefix: obsmetrics.ReceiverPrefix + cfg.ReceiverID.String(),
 		transport:      cfg.Transport,
 		longLivedCtx:   cfg.LongLivedCtx,
@@ -166,9 +163,7 @@ func (rec *ObsReport) endOp(
 
 	span := trace.SpanFromContext(receiverCtx)
 
-	if rec.level != configtelemetry.LevelNone {
-		rec.recordMetrics(receiverCtx, dataType, numAccepted, numRefused)
-	}
+	rec.recordMetrics(receiverCtx, dataType, numAccepted, numRefused)
 
 	// end span according to errors
 	if span.IsRecording() {

--- a/receiver/scraperhelper/obsreport.go
+++ b/receiver/scraperhelper/obsreport.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
@@ -22,7 +21,6 @@ import (
 
 // ObsReport is a helper to add observability to a scraper.
 type ObsReport struct {
-	level      configtelemetry.Level
 	receiverID component.ID
 	scraper    component.ID
 	tracer     trace.Tracer
@@ -49,7 +47,6 @@ func newScraper(cfg ObsReportSettings) (*ObsReport, error) {
 		return nil, err
 	}
 	return &ObsReport{
-		level:      cfg.ReceiverCreateSettings.TelemetrySettings.MetricsLevel,
 		receiverID: cfg.ReceiverID,
 		scraper:    cfg.Scraper,
 		tracer:     cfg.ReceiverCreateSettings.TracerProvider.Tracer(cfg.Scraper.String()),
@@ -91,9 +88,7 @@ func (s *ObsReport) EndMetricsOp(
 
 	span := trace.SpanFromContext(scraperCtx)
 
-	if s.level != configtelemetry.LevelNone {
-		s.recordMetrics(scraperCtx, numScrapedMetrics, numErroredMetrics)
-	}
+	s.recordMetrics(scraperCtx, numScrapedMetrics, numErroredMetrics)
 
 	// end span according to errors
 	if span.IsRecording() {


### PR DESCRIPTION
The MeterProvider used to generate the matric will make calls to recording the metric Noops. Removing the level check.
