### PR TITLE
[chore] newObsReport is no longer needed

### DIFF
--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -250,7 +250,7 @@ type baseExporter struct {
 }
 
 func newBaseExporter(set exporter.Settings, signal component.DataType, osf obsrepSenderFactory, options ...Option) (*baseExporter, error) {
-	obsReport, err := newObsReport(obsReportSettings{exporterID: set.ID, exporterCreateSettings: set, dataType: signal})
+	obsReport, err := newExporter(obsReportSettings{exporterID: set.ID, exporterCreateSettings: set, dataType: signal})
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/exporterhelper/obsexporter.go
+++ b/exporter/exporterhelper/obsexporter.go
@@ -34,11 +34,6 @@ type obsReportSettings struct {
 	dataType               component.DataType
 }
 
-// newObsReport creates a new Exporter.
-func newObsReport(cfg obsReportSettings) (*obsReport, error) {
-	return newExporter(cfg)
-}
-
 func newExporter(cfg obsReportSettings) (*obsReport, error) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(cfg.exporterCreateSettings.TelemetrySettings)
 	if err != nil {

--- a/exporter/exporterhelper/obsexporter_test.go
+++ b/exporter/exporterhelper/obsexporter_test.go
@@ -176,7 +176,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := newObsReport(obsReportSettings{
+	obsrep, err := newExporter(obsReportSettings{
 		exporterID:             exporterID,
 		exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})
@@ -196,7 +196,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := newObsReport(obsReportSettings{
+	obsrep, err := newExporter(obsReportSettings{
 		exporterID:             exporterID,
 		exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})
@@ -216,7 +216,7 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := newObsReport(obsReportSettings{
+	obsrep, err := newExporter(obsReportSettings{
 		exporterID:             exporterID,
 		exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -19,7 +19,7 @@ func TestExportEnqueueFailure(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := newObsReport(obsReportSettings{
+	obsrep, err := newExporter(obsReportSettings{
 		exporterID:             exporterID,
 		exporterCreateSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -432,7 +432,7 @@ func TestQueuedRetryPersistentEnabled_NoDataLossOnShutdown(t *testing.T) {
 func TestQueueSenderNoStartShutdown(t *testing.T) {
 	queue := queue.NewBoundedMemoryQueue[Request](queue.MemoryQueueSettings[Request]{})
 	set := exportertest.NewNopSettings()
-	obsrep, err := newObsReport(obsReportSettings{
+	obsrep, err := newExporter(obsReportSettings{
 		exporterID:             exporterID,
 		exporterCreateSettings: exportertest.NewNopSettings(),
 	})


### PR DESCRIPTION
This is leftover from the refactor to make that func private to the package. Removing it as all the callers can use newExporter directly.
