### PR TITLE
[scraperhelper] deprecate NewObsReport, ObsReport, ObsReportSettings

### DIFF
--- a/.chloggen/codeboten_cleanup-unnecessary-func-2.yaml
+++ b/.chloggen/codeboten_cleanup-unnecessary-func-2.yaml
@@ -22,4 +22,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [api]

--- a/.chloggen/codeboten_cleanup-unnecessary-func-2.yaml
+++ b/.chloggen/codeboten_cleanup-unnecessary-func-2.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: scraperhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: deprecate NewObsReport, scrapers should use NewScraperControllerReceiver instead
+
+# One or more tracking issues or pull requests related to the change
+issues: [10959]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_cleanup-unnecessary-func-2.yaml
+++ b/.chloggen/codeboten_cleanup-unnecessary-func-2.yaml
@@ -7,7 +7,7 @@ change_type: deprecation
 component: scraperhelper
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: deprecate NewObsReport, scrapers should use NewScraperControllerReceiver instead
+note: deprecate NewObsReport, ObsReport, ObsReportSettings, scrapers should use NewScraperControllerReceiver
 
 # One or more tracking issues or pull requests related to the change
 issues: [10959]

--- a/receiver/scraperhelper/obsreport.go
+++ b/receiver/scraperhelper/obsreport.go
@@ -37,6 +37,8 @@ type ObsReportSettings struct {
 }
 
 // NewObsReport creates a new ObsReport.
+//
+// Deprecated: [v0.108.0] will be removed, scrapers should use NewScraperControllerReceiver instead.
 func NewObsReport(cfg ObsReportSettings) (*ObsReport, error) {
 	return newScraper(cfg)
 }

--- a/receiver/scraperhelper/obsreport.go
+++ b/receiver/scraperhelper/obsreport.go
@@ -20,6 +20,8 @@ import (
 )
 
 // ObsReport is a helper to add observability to a scraper.
+//
+// Deprecated: [v0.108.0] will be removed.
 type ObsReport struct {
 	receiverID component.ID
 	scraper    component.ID
@@ -30,6 +32,8 @@ type ObsReport struct {
 }
 
 // ObsReportSettings are settings for creating an ObsReport.
+//
+// Deprecated: [v0.108.0] will be removed.
 type ObsReportSettings struct {
 	ReceiverID             component.ID
 	Scraper                component.ID

--- a/receiver/scraperhelper/obsreport_test.go
+++ b/receiver/scraperhelper/obsreport_test.go
@@ -95,7 +95,7 @@ func TestCheckScraperMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	s, err := NewObsReport(ObsReportSettings{
+	s, err := newScraper(ObsReportSettings{
 		ReceiverID:             receiverID,
 		Scraper:                scraperID,
 		ReceiverCreateSettings: receiver.Settings{ID: receiverID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -103,7 +103,7 @@ func NewScraperControllerReceiver(
 
 	sc.obsScrapers = make([]*ObsReport, len(sc.scrapers))
 	for i, scraper := range sc.scrapers {
-		scrp, err := NewObsReport(ObsReportSettings{
+		scrp, err := newScraper(ObsReportSettings{
 			ReceiverID:             sc.id,
 			Scraper:                scraper.ID(),
 			ReceiverCreateSettings: sc.recvSettings,


### PR DESCRIPTION
These functions and structs doesn't appear used in any of the components in either core or contrib. Deprecating to remove the surface area of the package.
