### PR TITLE
fix(renovate): add package rule for disabling toolchain updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,11 @@
         "matchManagers": ["gomod"],
         "matchPackagePrefixes": ["go.opentelemetry.io/build-tools"],
         "groupName": "All go.opentelemetry.io/build-tools packages"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepTypes": ["toolchain"],
+        "enabled": false
       }
     ],
     "ignoreDeps": [


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
- Added a rule to ignore updates to the go toolchain. According to [this](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/gomod/update.ts#L51-L55), the toolchain update is a `depType` in the `gomod` manager. 

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10932

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- Is there a way to test this aside from just waiting for the next renovate update? 
