### PR TITLE
[confmaptest] Add a test on empty slice to nil

### DIFF
--- a/confmap/confmaptest/configtest_test.go
+++ b/confmap/confmaptest/configtest_test.go
@@ -30,6 +30,13 @@ func TestLoadConf(t *testing.T) {
 	assert.Equal(t, map[string]any{"floating": 3.14}, cfg.ToStringMap())
 }
 
+func TestToStringMapSanitizeEmptySlice(t *testing.T) {
+	cfg, err := LoadConf(filepath.Join("testdata", "empty-slice.yaml"))
+	require.NoError(t, err)
+	var nilSlice []interface{}
+	assert.Equal(t, map[string]any{"slice": nilSlice}, cfg.ToStringMap())
+}
+
 func TestValidateProviderScheme(t *testing.T) {
 	assert.NoError(t, ValidateProviderScheme(&schemeProvider{scheme: "file"}))
 	assert.NoError(t, ValidateProviderScheme(&schemeProvider{scheme: "s3"}))

--- a/confmap/confmaptest/testdata/empty-slice.yaml
+++ b/confmap/confmaptest/testdata/empty-slice.yaml
@@ -1,0 +1,1 @@
+slice: [] # empty slices are sanitized to nil in ToStringMap


### PR DESCRIPTION
#### Description

Add a test on empty slices being sanitized to `nil` in `ToStringMap`