### PR TITLE
[otlphttpreceiver] Allow H2C connections to otlp http receiver

### DIFF
--- a/.chloggen/10952-allow-h2c-connections-otlphttp.yaml
+++ b/.chloggen/10952-allow-h2c-connections-otlphttp.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow H2C connections to otlp http receiver"
+
+# One or more tracking issues or pull requests related to the change
+issues: [10952]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -6,6 +6,7 @@ package confighttp
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
 
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
@@ -522,6 +524,7 @@ func TestHttpReception(t *testing.T) {
 		tlsClientCreds *configtls.ClientConfig
 		hasError       bool
 		forceHTTP1     bool
+		allowh2c       bool
 	}{
 		{
 			name:           "noTLS",
@@ -529,6 +532,14 @@ func TestHttpReception(t *testing.T) {
 			tlsClientCreds: &configtls.ClientConfig{
 				Insecure: true,
 			},
+		},
+		{
+			name:           "noTLS and AllowH2CUpgrade",
+			tlsServerCreds: nil,
+			tlsClientCreds: &configtls.ClientConfig{
+				Insecure: true,
+			},
+			allowh2c: true,
 		},
 		{
 			name: "TLS",
@@ -641,8 +652,9 @@ func TestHttpReception(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hss := &ServerConfig{
-				Endpoint:   "localhost:0",
-				TLSSetting: tt.tlsServerCreds,
+				Endpoint:        "localhost:0",
+				TLSSetting:      tt.tlsServerCreds,
+				AllowH2CUpgrade: tt.allowh2c,
 			}
 			ln, err := hss.ToListener(context.Background())
 			require.NoError(t, err)
@@ -661,11 +673,13 @@ func TestHttpReception(t *testing.T) {
 				_ = s.Serve(ln)
 			}()
 
-			prefix := "https://"
 			expectedProto := "HTTP/2.0"
+			prefix := "https://"
 			if tt.tlsClientCreds.Insecure {
 				prefix = "http://"
-				expectedProto = "HTTP/1.1"
+				if !tt.allowh2c {
+					expectedProto = "HTTP/1.1"
+				}
 			}
 
 			hcs := &ClientConfig{
@@ -675,6 +689,17 @@ func TestHttpReception(t *testing.T) {
 
 			client, errClient := hcs.ToClient(context.Background(), componenttest.NewNopHost(), nilProvidersSettings)
 			require.NoError(t, errClient)
+
+			if tt.allowh2c {
+				client.Transport = &http2.Transport{
+					AllowHTTP: true,
+					// Pretend we are dialing a TLS endpoint. (Note, we ignore the passed tls.Config)
+					DialTLS: func(netw, addr string, _ *tls.Config) (net.Conn, error) {
+						return net.Dial(netw, addr)
+					},
+				}
+				defer client.Transport.(*http2.Transport).CloseIdleConnections()
+			}
 
 			if tt.forceHTTP1 {
 				expectedProto = "HTTP/1.1"


### PR DESCRIPTION
#### Description
Allow H2C connections to otlp http receiver

Fixes #10952
