### PR TITLE
[chore][mdatagen] Add note about the supported types of telemetry metric attributes

### DIFF
--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -165,4 +165,5 @@ telemetry:
         # Bucket boundaries are only available to set for histogram metrics.
         bucket_boundaries: [double]
       # Optional: array of attributes that were defined in the attributes section that are emitted by this metric.
+      # Note: Only the following attribute types are supported: <string|int|double|bool>
       attributes: [string]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The context can be found [here.](https://github.com/open-telemetry/opentelemetry-collector/issues/10801#issuecomment-2313541198) Only a subset of attribute types are supported for `telemetry` metrics vs. regular `metrics`. There's no instrumentation equivalent for attributes of the type `bytes`, `slice`, and `map`.