### PR TITLE
[chore] remove mentions of the `memory_ballast` extension

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -10,7 +10,6 @@ performance profile.
 
 Supported service extensions (sorted alphabetically):
 
-- [Memory Ballast](ballastextension/README.md)
 - [zPages](zpagesextension/README.md)
 
 The [contributors
@@ -28,5 +27,5 @@ will be shutdown. The ordering is determined in the `extensions` tag under the
 service:
   # Extensions specified below are going to be loaded by the service in the
   # order given below, and shutdown on reverse order.
-  extensions: [memory_ballast, zpages]
+  extensions: [extension1, extension2]
 ```


### PR DESCRIPTION
Removing references to the memory ballast extension
