### PR TITLE
[chore] cleaning up references to logging exporter

### DIFF
--- a/confmap/internal/e2e/testdata/issue-10787-main.yaml
+++ b/confmap/internal/e2e/testdata/issue-10787-main.yaml
@@ -19,4 +19,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]

--- a/confmap/internal/e2e/testdata/issue-10787-snippet.yaml
+++ b/confmap/internal/e2e/testdata/issue-10787-snippet.yaml
@@ -1,3 +1,3 @@
 # ${hello.world}
-logging:
+debug:
   verbosity: detailed

--- a/confmap/internal/e2e/types_test.go
+++ b/confmap/internal/e2e/types_test.go
@@ -422,7 +422,7 @@ func TestIssue10787(t *testing.T) {
 	assert.Equal(t, conf.ToStringMap(),
 		map[string]any{
 			"exporters": map[string]any{
-				"logging": map[string]any{
+				"debug": map[string]any{
 					"verbosity": "detailed",
 				},
 			},
@@ -444,7 +444,7 @@ func TestIssue10787(t *testing.T) {
 			"service": map[string]any{
 				"pipelines": map[string]any{
 					"traces": map[string]any{
-						"exporters":  []any{"logging"},
+						"exporters":  []any{"debug"},
 						"processors": []any{"batch"},
 						"receivers":  []any{"otlp"},
 					},
@@ -462,16 +462,16 @@ func TestIssue10787(t *testing.T) {
 func TestStructMappingIssue10787(t *testing.T) {
 	resolver := NewResolver(t, "types_expand.yaml")
 	t.Setenv("ENV", `# this is a comment
-logging:
+debug:
   verbosity: detailed`)
 	conf, err := resolver.Resolve(context.Background())
 	require.NoError(t, err)
 
-	type Logging struct {
+	type Debug struct {
 		Verbosity string `mapstructure:"verbosity"`
 	}
 	type Exporters struct {
-		Logging Logging `mapstructure:"logging"`
+		Debug Debug `mapstructure:"debug"`
 	}
 	type Target struct {
 		Field Exporters `mapstructure:"field"`
@@ -482,7 +482,7 @@ logging:
 	require.NoError(t, err)
 	require.Equal(t,
 		Target{Field: Exporters{
-			Logging: Logging{
+			Debug: Debug{
 				Verbosity: "detailed",
 			},
 		}},
@@ -495,7 +495,7 @@ logging:
 	err = confStr.Unmarshal(&cfgStr)
 	require.NoError(t, err)
 	require.Equal(t, `# this is a comment
-logging:
+debug:
   verbosity: detailed`,
 		cfgStr.Field,
 	)
@@ -505,16 +505,16 @@ func TestStructMappingIssue10787_ExpandComment(t *testing.T) {
 	resolver := NewResolver(t, "types_expand.yaml")
 	t.Setenv("EXPAND_ME", "an expanded env var")
 	t.Setenv("ENV", `# this is a comment with ${EXPAND_ME}
-logging:
+debug:
   verbosity: detailed`)
 	conf, err := resolver.Resolve(context.Background())
 	require.NoError(t, err)
 
-	type Logging struct {
+	type Debug struct {
 		Verbosity string `mapstructure:"verbosity"`
 	}
 	type Exporters struct {
-		Logging Logging `mapstructure:"logging"`
+		Debug Debug `mapstructure:"debug"`
 	}
 	type Target struct {
 		Field Exporters `mapstructure:"field"`
@@ -525,7 +525,7 @@ logging:
 	require.NoError(t, err)
 	require.Equal(t,
 		Target{Field: Exporters{
-			Logging: Logging{
+			Debug: Debug{
 				Verbosity: "detailed",
 			},
 		}},
@@ -538,7 +538,7 @@ logging:
 	err = confStr.Unmarshal(&cfgStr)
 	require.NoError(t, err)
 	require.Equal(t, `# this is a comment with an expanded env var
-logging:
+debug:
   verbosity: detailed`,
 		cfgStr.Field,
 	)


### PR DESCRIPTION
These should have been updated to debug some time ago, but they're low priority as they're just tests
