### PR TITLE
[chore] add fuzzing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
   </a>
   <a href="https://www.bestpractices.dev/projects/8404"><img src="https://www.bestpractices.dev/projects/8404/badge">
   </a>
+  <a href="https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:opentelemetry">
+    <img alt="Fuzzing Status" src="https://oss-fuzz-build-logs.storage.googleapis.com/badges/opentelemetry.svg">
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
This adds a badge to the oss-fuzz project that's running fuzzing tests against a build of the collector
