### PR TITLE
[component] Remove incorrect comment on Factory interface

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -165,9 +165,6 @@ func (sl StabilityLevel) LogMessage() string {
 }
 
 // Factory is implemented by all Component factories.
-//
-// This interface cannot be directly implemented. Implementations must
-// use the factory helpers for the appropriate component type.
 type Factory interface {
 	// Type gets the type of the component created by this factory.
 	Type() Type


### PR DESCRIPTION
#### Description
Removes an incorrect comment from the `component.Factory interface`.

This comment was added via https://github.com/open-telemetry/opentelemetry-collector/pull/4338 when the extension/receiver/processor/exporter factory types all still [lived in](https://github.com/mx-psi/opentelemetry-collector/blob/b4be13e74923ebefb521f69a97288ce8d6f51ea9/component/exporter.go#L61) `component`. Since the factories have been moved to other modules, `component.Factory` needs to be implementable.

The specific extension/receiver/processor/exporter factory types are unimplementable since they are defined in internal packages. 

<!-- Issue number if applicable -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/6506
