### PR TITLE
[chore]: enable len and empty rules from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,14 +125,12 @@ linters-settings:
     # TODO: enable all rules
     disable:
       - compares
-      - empty
       - error-is-as
       - error-nil
       - expected-actual
       - float-compare
       - formatter
       - go-require
-      - len
       - negative-positive
       - nil-compare
       - require-error

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ gotest-with-cover:
 	@$(MAKE) for-all-target TARGET="test-with-cover"
 	$(GOCMD) tool covdata textfmt -i=./coverage/unit -o ./coverage.txt
 
+.PHONY: gotestifylint-fix
+gotestifylint-fix:
+	$(MAKE) for-all-target TARGET="testifylint-fix"
+
 .PHONY: goporto
 goporto: $(PORTO)
 	$(PORTO) -w --include-internal --skip-dirs "^cmd/mdatagen/third_party$$" ./

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -36,6 +36,9 @@ MULTIMOD     := $(TOOLS_BIN_DIR)/multimod
 PORTO        := $(TOOLS_BIN_DIR)/porto
 SEMCONVGEN   := $(TOOLS_BIN_DIR)/semconvgen
 SEMCONVKIT   := $(TOOLS_BIN_DIR)/semconvkit
+TESTIFYLINT  := $(TOOLS_BIN_DIR)/testifylint
+
+TESTIFYLINT_OPT?= --enable-all --disable=compares,error-is-as,error-nil,expected-actual,float-compare,formatter,go-require,negative-positive,nil-compare,require-error
 
 .PHONY: install-tools
 install-tools: $(TOOLS_BIN_NAMES)
@@ -88,3 +91,9 @@ impi: $(IMPI)
 .PHONY: moddownload
 moddownload:
 	$(GOCMD) mod download
+
+.PHONY: testifylint-fix
+testifylint-fix:$(TESTIFYLINT)
+	@echo "running $(TESTIFYLINT)"
+	@$(TESTIFYLINT) $(TESTIFYLINT_OPT) -fix ./...
+

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -171,10 +171,10 @@ func TestNewBuiltinConfig(t *testing.T) {
 	// Unlike the config initialized in NewDefaultConfig(), we expect
 	// the builtin default to be practically useful, so there must be
 	// a set of modules present.
-	assert.NotZero(t, len(cfg.Receivers))
-	assert.NotZero(t, len(cfg.Exporters))
-	assert.NotZero(t, len(cfg.Extensions))
-	assert.NotZero(t, len(cfg.Processors))
+	assert.NotEmpty(t, cfg.Receivers)
+	assert.NotEmpty(t, cfg.Exporters)
+	assert.NotEmpty(t, cfg.Extensions)
+	assert.NotEmpty(t, cfg.Processors)
 }
 
 func TestSkipGoValidation(t *testing.T) {

--- a/connector/connectorprofiles/profiles_router_test.go
+++ b/connector/connectorprofiles/profiles_router_test.go
@@ -120,8 +120,8 @@ func TestProfilessRouterConsumer(t *testing.T) {
 	assert.Len(t, rcs, 2)
 	assert.ElementsMatch(t, []component.ID{fooID, barID}, rcs)
 
-	assert.Len(t, foo.AllProfiles(), 0)
-	assert.Len(t, bar.AllProfiles(), 0)
+	assert.Empty(t, foo.AllProfiles())
+	assert.Empty(t, bar.AllProfiles())
 
 	both, err := r.Consumer(fooID, barID)
 	assert.NotNil(t, both)

--- a/connector/forwardconnector/forward_test.go
+++ b/connector/forwardconnector/forward_test.go
@@ -57,7 +57,7 @@ func TestForward(t *testing.T) {
 	assert.NoError(t, metricsToMetrics.Shutdown(ctx))
 	assert.NoError(t, logsToLogs.Shutdown(ctx))
 
-	assert.Equal(t, 1, len(tracesSink.AllTraces()))
-	assert.Equal(t, 2, len(metricsSink.AllMetrics()))
-	assert.Equal(t, 3, len(logsSink.AllLogs()))
+	assert.Len(t, tracesSink.AllTraces(), 1)
+	assert.Len(t, metricsSink.AllMetrics(), 2)
+	assert.Len(t, logsSink.AllLogs(), 3)
 }

--- a/connector/logs_router_test.go
+++ b/connector/logs_router_test.go
@@ -119,8 +119,8 @@ func TestLogsRouterConsumers(t *testing.T) {
 	assert.Len(t, rcs, 2)
 	assert.ElementsMatch(t, []component.ID{fooID, barID}, rcs)
 
-	assert.Len(t, foo.AllLogs(), 0)
-	assert.Len(t, bar.AllLogs(), 0)
+	assert.Empty(t, foo.AllLogs())
+	assert.Empty(t, bar.AllLogs())
 
 	both, err := r.Consumer(fooID, barID)
 	assert.NotNil(t, both)

--- a/connector/metrics_router_test.go
+++ b/connector/metrics_router_test.go
@@ -119,8 +119,8 @@ func TestMetricsRouterConsumers(t *testing.T) {
 	assert.Len(t, rcs, 2)
 	assert.ElementsMatch(t, []component.ID{fooID, barID}, rcs)
 
-	assert.Len(t, foo.AllMetrics(), 0)
-	assert.Len(t, bar.AllMetrics(), 0)
+	assert.Empty(t, foo.AllMetrics())
+	assert.Empty(t, bar.AllMetrics())
 
 	both, err := r.Consumer(fooID, barID)
 	assert.NotNil(t, both)

--- a/connector/traces_router_test.go
+++ b/connector/traces_router_test.go
@@ -119,8 +119,8 @@ func TestTracesRouterConsumer(t *testing.T) {
 	assert.Len(t, rcs, 2)
 	assert.ElementsMatch(t, []component.ID{fooID, barID}, rcs)
 
-	assert.Len(t, foo.AllTraces(), 0)
-	assert.Len(t, bar.AllTraces(), 0)
+	assert.Empty(t, foo.AllTraces())
+	assert.Empty(t, bar.AllTraces())
 
 	both, err := r.Consumer(fooID, barID)
 	assert.NotNil(t, both)

--- a/consumer/consumertest/sink_test.go
+++ b/consumer/consumertest/sink_test.go
@@ -28,7 +28,7 @@ func TestTracesSink(t *testing.T) {
 	assert.Equal(t, want, sink.AllTraces())
 	assert.Equal(t, len(want), sink.SpanCount())
 	sink.Reset()
-	assert.Equal(t, 0, len(sink.AllTraces()))
+	assert.Empty(t, sink.AllTraces())
 	assert.Equal(t, 0, sink.SpanCount())
 }
 
@@ -43,7 +43,7 @@ func TestMetricsSink(t *testing.T) {
 	assert.Equal(t, want, sink.AllMetrics())
 	assert.Equal(t, 2*len(want), sink.DataPointCount())
 	sink.Reset()
-	assert.Equal(t, 0, len(sink.AllMetrics()))
+	assert.Empty(t, sink.AllMetrics())
 	assert.Equal(t, 0, sink.DataPointCount())
 }
 
@@ -58,7 +58,7 @@ func TestLogsSink(t *testing.T) {
 	assert.Equal(t, want, sink.AllLogs())
 	assert.Equal(t, len(want), sink.LogRecordCount())
 	sink.Reset()
-	assert.Equal(t, 0, len(sink.AllLogs()))
+	assert.Empty(t, sink.AllLogs())
 	assert.Equal(t, 0, sink.LogRecordCount())
 }
 
@@ -72,5 +72,5 @@ func TestProfilesSink(t *testing.T) {
 	}
 	assert.Equal(t, want, sink.AllProfiles())
 	sink.Reset()
-	assert.Equal(t, 0, len(sink.AllProfiles()))
+	assert.Empty(t, sink.AllProfiles())
 }

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -418,7 +418,7 @@ func checkWrapSpanForLogsExporter(t *testing.T, sr *tracetest.SpanRecorder, trac
 
 	// Inspection time!
 	gotSpanData := sr.Ended()
-	require.Equal(t, numRequests+1, len(gotSpanData))
+	require.Len(t, gotSpanData, numRequests+1)
 
 	parentSpan := gotSpanData[numRequests]
 	require.Equalf(t, fakeLogsParentSpanName, parentSpan.Name(), "SpanData %v", parentSpan)

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -424,7 +424,7 @@ func checkWrapSpanForMetricsExporter(t *testing.T, sr *tracetest.SpanRecorder, t
 
 	// Inspection time!
 	gotSpanData := sr.Ended()
-	require.Equal(t, numRequests+1, len(gotSpanData))
+	require.Len(t, gotSpanData, numRequests+1)
 
 	parentSpan := gotSpanData[numRequests]
 	require.Equalf(t, fakeMetricsParentSpanName, parentSpan.Name(), "SpanData %v", parentSpan)

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -426,7 +426,7 @@ func checkWrapSpanForTracesExporter(t *testing.T, sr *tracetest.SpanRecorder, tr
 
 	// Inspection time!
 	gotSpanData := sr.Ended()
-	require.Equal(t, numRequests+1, len(gotSpanData))
+	require.Len(t, gotSpanData, numRequests+1)
 
 	parentSpan := gotSpanData[numRequests]
 	require.Equalf(t, fakeTraceParentSpanName, parentSpan.Name(), "SpanData %v", parentSpan)

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -300,7 +300,7 @@ func TestSendTraces(t *testing.T) {
 
 	md := rcv.getMetadata()
 	require.EqualValues(t, md.Get("header"), expectedHeader)
-	require.Equal(t, len(md.Get("User-Agent")), 1)
+	require.Len(t, md.Get("User-Agent"), 1)
 	require.Contains(t, md.Get("User-Agent")[0], "Collector/1.2.3test")
 
 	// Return partial success
@@ -472,7 +472,7 @@ func TestSendMetrics(t *testing.T) {
 
 	mdata := rcv.getMetadata()
 	require.EqualValues(t, mdata.Get("header"), expectedHeader)
-	require.Equal(t, len(mdata.Get("User-Agent")), 1)
+	require.Len(t, mdata.Get("User-Agent"), 1)
 	require.Contains(t, mdata.Get("User-Agent")[0], "Collector/1.2.3test")
 
 	st := status.New(codes.InvalidArgument, "Invalid argument")
@@ -763,7 +763,7 @@ func TestSendLogData(t *testing.T) {
 	assert.EqualValues(t, ld, rcv.getLastRequest())
 
 	md := rcv.getMetadata()
-	require.Equal(t, len(md.Get("User-Agent")), 1)
+	require.Len(t, md.Get("User-Agent"), 1)
 	require.Contains(t, md.Get("User-Agent")[0], "Collector/1.2.3test")
 
 	st := status.New(codes.InvalidArgument, "Invalid argument")

--- a/internal/e2e/status_test.go
+++ b/internal/e2e/status_test.go
@@ -121,7 +121,7 @@ func Test_ComponentStatusReporting_SharedInstance(t *testing.T) {
 	err = s.Shutdown(context.Background())
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(eventsReceived))
+	require.Len(t, eventsReceived, 2)
 
 	for instanceID, events := range eventsReceived {
 		pipelineIDs := ""

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -26,12 +26,12 @@ type baseComponent struct {
 
 func TestNewMap(t *testing.T) {
 	comps := NewMap[component.ID, *baseComponent]()
-	assert.Len(t, comps.components, 0)
+	assert.Empty(t, comps.components)
 }
 
 func TestNewSharedComponentsCreateError(t *testing.T) {
 	comps := NewMap[component.ID, *baseComponent]()
-	assert.Len(t, comps.components, 0)
+	assert.Empty(t, comps.components)
 	myErr := errors.New("my error")
 	_, err := comps.LoadOrStore(
 		id,
@@ -39,7 +39,7 @@ func TestNewSharedComponentsCreateError(t *testing.T) {
 		newNopTelemetrySettings(),
 	)
 	assert.ErrorIs(t, err, myErr)
-	assert.Len(t, comps.components, 0)
+	assert.Empty(t, comps.components)
 }
 
 func TestSharedComponentsLoadOrStore(t *testing.T) {
@@ -65,7 +65,7 @@ func TestSharedComponentsLoadOrStore(t *testing.T) {
 
 	// Shutdown nop will remove
 	assert.NoError(t, got.Shutdown(context.Background()))
-	assert.Len(t, comps.components, 0)
+	assert.Empty(t, comps.components)
 	gotThird, err := comps.LoadOrStore(
 		id,
 		func() (*baseComponent, error) { return nop, nil },
@@ -200,7 +200,7 @@ func TestReportStatusOnStartShutdown(t *testing.T) {
 				require.Equal(t, tc.shutdownErr, err)
 			}
 
-			require.Equal(t, tc.expectedNumReporterInstances, len(reportedStatuses))
+			require.Len(t, reportedStatuses, tc.expectedNumReporterInstances)
 
 			for _, actualStatuses := range reportedStatuses {
 				require.Equal(t, tc.expectedStatuses, actualStatuses)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -149,14 +149,14 @@ func createExclusionsList(exclusionsText string, t testing.TB) []portpair {
 	var exclusions []portpair
 
 	parts := strings.Split(exclusionsText, "--------")
-	require.Equal(t, len(parts), 3)
+	require.Len(t, parts, 3)
 	portsText := strings.Split(parts[2], "*")
 	require.Greater(t, len(portsText), 1) // original text may have a suffix like " - Administered port exclusions."
 	lines := strings.Split(portsText[0], "\n")
 	for _, line := range lines {
 		if strings.TrimSpace(line) != "" {
 			entries := strings.Fields(strings.TrimSpace(line))
-			require.Equal(t, len(entries), 2)
+			require.Len(t, entries, 2)
 			pair := portpair{entries[0], entries[1]}
 			exclusions = append(exclusions, pair)
 		}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -68,8 +68,8 @@ Start Port    End Port
 * - Administered port exclusions.
 `
 	exclusions := createExclusionsList(exclusionsText, t)
-	require.Equal(t, len(exclusions), 2)
+	require.Len(t, exclusions, 2)
 
 	emptyExclusions := createExclusionsList(emptyExclusionsText, t)
-	require.Equal(t, len(emptyExclusions), 0)
+	require.Empty(t, emptyExclusions)
 }

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -5,6 +5,7 @@ go 1.22.1
 toolchain go1.22.6
 
 require (
+	github.com/Antonboom/testifylint v1.4.3
 	github.com/a8m/envsubst v1.4.2
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.60.1
@@ -29,7 +30,6 @@ require (
 	github.com/Abirdcfly/dupword v0.0.14 // indirect
 	github.com/Antonboom/errname v0.1.13 // indirect
 	github.com/Antonboom/nilnil v0.1.9 // indirect
-	github.com/Antonboom/testifylint v1.4.3 // indirect
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/Crocmagnon/fatcontext v0.4.0 // indirect
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 // indirect

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -11,6 +11,7 @@ package tools // import "go.opentelemetry.io/collector/internal/tools"
 // This ensures that all systems use the same version of tools in addition to regular dependencies.
 
 import (
+	_ "github.com/Antonboom/testifylint"
 	_ "github.com/a8m/envsubst/cmd/envsubst"
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"

--- a/otelcol/buffered_core_test.go
+++ b/otelcol/buffered_core_test.go
@@ -72,7 +72,7 @@ func Test_bufferedCore_Write(t *testing.T) {
 		e,
 		fields,
 	}
-	require.Equal(t, 1, len(bc.logs))
+	require.Len(t, bc.logs, 1)
 	require.Equal(t, expected, bc.logs[0])
 }
 

--- a/otelcol/collector_core_test.go
+++ b/otelcol/collector_core_test.go
@@ -72,7 +72,7 @@ func Test_collectorCore_Write(t *testing.T) {
 		e,
 		fields,
 	}
-	require.Equal(t, 1, len(cc.core.(*bufferedCore).logs))
+	require.Len(t, cc.core.(*bufferedCore).logs, 1)
 	require.Equal(t, expected, cc.core.(*bufferedCore).logs[0])
 }
 

--- a/otelcol/otelcoltest/nop_factories_test.go
+++ b/otelcol/otelcoltest/nop_factories_test.go
@@ -17,27 +17,27 @@ func TestNopFactories(t *testing.T) {
 	nopFactories, err := NopFactories()
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(nopFactories.Receivers))
+	require.Len(t, nopFactories.Receivers, 1)
 	nopReceiverFactory, ok := nopFactories.Receivers[nopType]
 	require.True(t, ok)
 	require.Equal(t, nopType, nopReceiverFactory.Type())
 
-	require.Equal(t, 1, len(nopFactories.Processors))
+	require.Len(t, nopFactories.Processors, 1)
 	nopProcessorFactory, ok := nopFactories.Processors[nopType]
 	require.True(t, ok)
 	require.Equal(t, nopType, nopProcessorFactory.Type())
 
-	require.Equal(t, 1, len(nopFactories.Exporters))
+	require.Len(t, nopFactories.Exporters, 1)
 	nopExporterFactory, ok := nopFactories.Exporters[nopType]
 	require.True(t, ok)
 	require.Equal(t, nopType, nopExporterFactory.Type())
 
-	require.Equal(t, 1, len(nopFactories.Extensions))
+	require.Len(t, nopFactories.Extensions, 1)
 	nopExtensionFactory, ok := nopFactories.Extensions[nopType]
 	require.True(t, ok)
 	require.Equal(t, nopType, nopExtensionFactory.Type())
 
-	require.Equal(t, 1, len(nopFactories.Connectors))
+	require.Len(t, nopFactories.Connectors, 1)
 	nopConnectorFactory, ok := nopFactories.Connectors[nopType]
 	require.True(t, ok)
 	require.Equal(t, nopType, nopConnectorFactory.Type())

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -320,7 +320,7 @@ func TestMap_Range(t *testing.T) {
 		delete(rawMap, k)
 		return true
 	})
-	assert.EqualValues(t, 0, len(rawMap))
+	assert.Empty(t, rawMap)
 }
 
 func TestMap_FromRaw(t *testing.T) {

--- a/pdata/pcommon/slice_test.go
+++ b/pdata/pcommon/slice_test.go
@@ -77,7 +77,7 @@ func TestSlice_EnsureCapacity(t *testing.T) {
 	for i := 0; i < es.Len(); i++ {
 		expectedEs[es.At(i).getOrig()] = true
 	}
-	assert.Equal(t, es.Len(), len(expectedEs))
+	assert.Len(t, expectedEs, es.Len())
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
 	foundEs := make(map[*otlpcommon.AnyValue]bool, es.Len())
@@ -89,7 +89,7 @@ func TestSlice_EnsureCapacity(t *testing.T) {
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
 	oldLen := es.Len()
-	assert.Equal(t, oldLen, len(expectedEs))
+	assert.Len(t, expectedEs, oldLen)
 	es.EnsureCapacity(ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.getOrig()))
 }

--- a/pdata/plog/pb_test.go
+++ b/pdata/plog/pb_test.go
@@ -44,7 +44,7 @@ func BenchmarkLogsToProto(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		buf, err := marshaler.MarshalLogs(logs)
 		require.NoError(b, err)
-		assert.NotEqual(b, 0, len(buf))
+		assert.NotEmpty(b, buf)
 	}
 }
 
@@ -54,7 +54,7 @@ func BenchmarkLogsFromProto(b *testing.B) {
 	baseLogs := generateBenchmarkLogs(128)
 	buf, err := marshaler.MarshalLogs(baseLogs)
 	require.NoError(b, err)
-	assert.NotEqual(b, 0, len(buf))
+	assert.NotEmpty(b, buf)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {

--- a/pdata/pmetric/pb_test.go
+++ b/pdata/pmetric/pb_test.go
@@ -43,7 +43,7 @@ func BenchmarkMetricsToProto(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		buf, err := marshaler.MarshalMetrics(metrics)
 		require.NoError(b, err)
-		assert.NotEqual(b, 0, len(buf))
+		assert.NotEmpty(b, buf)
 	}
 }
 
@@ -53,7 +53,7 @@ func BenchmarkMetricsFromProto(b *testing.B) {
 	baseMetrics := generateBenchmarkMetrics(128)
 	buf, err := marshaler.MarshalMetrics(baseMetrics)
 	require.NoError(b, err)
-	assert.NotEqual(b, 0, len(buf))
+	assert.NotEmpty(b, buf)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {

--- a/pdata/ptrace/pb_test.go
+++ b/pdata/ptrace/pb_test.go
@@ -44,7 +44,7 @@ func BenchmarkTracesToProto(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		buf, err := marshaler.MarshalTraces(traces)
 		require.NoError(b, err)
-		assert.NotEqual(b, 0, len(buf))
+		assert.NotEmpty(b, buf)
 	}
 }
 
@@ -54,7 +54,7 @@ func BenchmarkTracesFromProto(b *testing.B) {
 	baseTraces := generateBenchmarkTraces(128)
 	buf, err := marshaler.MarshalTraces(baseTraces)
 	require.NoError(b, err)
-	assert.NotEqual(b, 0, len(buf))
+	assert.NotEmpty(b, buf)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -201,7 +201,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 
 	require.Equal(t, requestCount*spansPerRequest, sink.SpanCount())
 	receivedTraces := sink.AllTraces()
-	require.EqualValues(t, expectedBatchesNum, len(receivedTraces))
+	require.Len(t, receivedTraces, expectedBatchesNum)
 	for _, td := range receivedTraces {
 		sizeSum += sizer.TracesSize(td)
 		rss := td.ResourceSpans()
@@ -323,7 +323,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 
 	require.Equal(t, totalSpans, sink.SpanCount())
 	receivedTraces := sink.AllTraces()
-	require.EqualValues(t, expectedBatchesNum, len(receivedTraces))
+	require.Len(t, receivedTraces, expectedBatchesNum)
 	// we have to count the size after it was processed since splitTraces will cause some
 	// repeated ResourceSpan data to be sent through the processor
 	var min, max int
@@ -467,7 +467,7 @@ func TestBatchProcessorSentByTimeout(t *testing.T) {
 
 	require.Equal(t, requestCount*spansPerRequest, sink.SpanCount())
 	receivedTraces := sink.AllTraces()
-	require.EqualValues(t, expectedBatchesNum, len(receivedTraces))
+	require.Len(t, receivedTraces, expectedBatchesNum)
 	for _, td := range receivedTraces {
 		rss := td.ResourceSpans()
 		require.Equal(t, expectedBatchingFactor, rss.Len())
@@ -500,7 +500,7 @@ func TestBatchProcessorTraceSendWhenClosing(t *testing.T) {
 	require.NoError(t, batcher.Shutdown(context.Background()))
 
 	require.Equal(t, requestCount*spansPerRequest, sink.SpanCount())
-	require.Equal(t, 1, len(sink.AllTraces()))
+	require.Len(t, sink.AllTraces(), 1)
 }
 
 func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
@@ -592,7 +592,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 
 	require.Equal(t, requestCount*2*metricsPerRequest, sink.DataPointCount())
 	receivedMds := sink.AllMetrics()
-	require.Equal(t, expectedBatchesNum, len(receivedMds))
+	require.Len(t, receivedMds, expectedBatchesNum)
 	for _, md := range receivedMds {
 		require.Equal(t, expectedBatchingFactor, md.ResourceMetrics().Len())
 		for i := 0; i < expectedBatchingFactor; i++ {
@@ -733,7 +733,7 @@ func TestBatchMetricsProcessor_Timeout(t *testing.T) {
 
 	require.Equal(t, requestCount*2*metricsPerRequest, sink.DataPointCount())
 	receivedMds := sink.AllMetrics()
-	require.Equal(t, expectedBatchesNum, len(receivedMds))
+	require.Len(t, receivedMds, expectedBatchesNum)
 	for _, md := range receivedMds {
 		require.Equal(t, expectedBatchingFactor, md.ResourceMetrics().Len())
 		for i := 0; i < expectedBatchingFactor; i++ {
@@ -765,7 +765,7 @@ func TestBatchMetricProcessor_Shutdown(t *testing.T) {
 	require.NoError(t, batcher.Shutdown(context.Background()))
 
 	require.Equal(t, requestCount*2*metricsPerRequest, sink.DataPointCount())
-	require.Equal(t, 1, len(sink.AllMetrics()))
+	require.Len(t, sink.AllMetrics(), 1)
 }
 
 func getTestSpanName(requestNum, index int) string {
@@ -972,7 +972,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 
 	require.Equal(t, requestCount*logsPerRequest, sink.LogRecordCount())
 	receivedMds := sink.AllLogs()
-	require.Equal(t, expectedBatchesNum, len(receivedMds))
+	require.Len(t, receivedMds, expectedBatchesNum)
 	for _, ld := range receivedMds {
 		require.Equal(t, expectedBatchingFactor, ld.ResourceLogs().Len())
 		for i := 0; i < expectedBatchingFactor; i++ {
@@ -1094,7 +1094,7 @@ func TestBatchLogsProcessor_Timeout(t *testing.T) {
 
 	require.Equal(t, requestCount*logsPerRequest, sink.LogRecordCount())
 	receivedMds := sink.AllLogs()
-	require.Equal(t, expectedBatchesNum, len(receivedMds))
+	require.Len(t, receivedMds, expectedBatchesNum)
 	for _, ld := range receivedMds {
 		require.Equal(t, expectedBatchingFactor, ld.ResourceLogs().Len())
 		for i := 0; i < expectedBatchingFactor; i++ {
@@ -1126,7 +1126,7 @@ func TestBatchLogProcessor_Shutdown(t *testing.T) {
 	require.NoError(t, batcher.Shutdown(context.Background()))
 
 	require.Equal(t, requestCount*logsPerRequest, sink.LogRecordCount())
-	require.Equal(t, 1, len(sink.AllLogs()))
+	require.Len(t, sink.AllLogs(), 1)
 }
 
 func getTestLogSeverityText(requestNum, index int) string {
@@ -1349,7 +1349,7 @@ func TestBatchZeroConfig(t *testing.T) {
 
 	// Expect them to be the original sizes.
 	receivedMds := sink.AllLogs()
-	require.Equal(t, requestCount, len(receivedMds))
+	require.Len(t, receivedMds, requestCount)
 	for i, ld := range receivedMds {
 		require.Equal(t, 1, ld.ResourceLogs().Len())
 		require.Equal(t, logsPerRequest+i, ld.LogRecordCount())
@@ -1387,7 +1387,7 @@ func TestBatchSplitOnly(t *testing.T) {
 
 	// Expect them to be the limited by maxBatch.
 	receivedMds := sink.AllLogs()
-	require.Equal(t, requestCount*logsPerRequest/maxBatch, len(receivedMds))
+	require.Len(t, receivedMds, requestCount*logsPerRequest/maxBatch)
 	for _, ld := range receivedMds {
 		require.Equal(t, maxBatch, ld.LogRecordCount())
 	}

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -589,7 +589,7 @@ func TestOTLPReceiverGRPCTracesIngestTest(t *testing.T) {
 		assert.Equal(t, ingestionState.expectedCode, errStatus.Code())
 	}
 
-	require.Equal(t, expectedReceivedBatches, len(sink.AllTraces()))
+	require.Len(t, sink.AllTraces(), expectedReceivedBatches)
 
 	require.NoError(t, tt.CheckReceiverTraces("grpc", int64(expectedReceivedBatches), int64(expectedIngestionBlockedRPCs)))
 }
@@ -677,7 +677,7 @@ func TestOTLPReceiverHTTPTracesIngestTest(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, expectedReceivedBatches, len(sink.AllTraces()))
+	require.Len(t, sink.AllTraces(), expectedReceivedBatches)
 
 	require.NoError(t, tt.CheckReceiverTraces("http", int64(expectedReceivedBatches), int64(expectedIngestionBlockedRPCs)))
 }

--- a/receiver/receiverhelper/obsreport_test.go
+++ b/receiver/receiverhelper/obsreport_test.go
@@ -211,7 +211,7 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 
 	for i, span := range spans {
 		assert.False(t, span.Parent().IsValid())
-		require.Equal(t, 1, len(span.Links()))
+		require.Len(t, span.Links(), 1)
 		link := span.Links()[0]
 		assert.Equal(t, parentSpan.SpanContext().TraceID(), link.SpanContext.TraceID())
 		assert.Equal(t, parentSpan.SpanContext().SpanID(), link.SpanContext.SpanID())

--- a/receiver/receivertest/contract_checker.go
+++ b/receiver/receivertest/contract_checker.go
@@ -148,7 +148,7 @@ func checkConsumeContractScenario(params CheckConsumeContractParams, decisionFun
 			defer wg.Done()
 			for atomic.AddInt64(&generatedIndex, 1) <= int64(params.GenerateCount) {
 				ids := params.Generator.Generate()
-				require.Greater(params.T, len(ids), 0)
+				require.NotEmpty(params.T, ids)
 
 				mux.Lock()
 				duplicates := generatedIDs.mergeSlice(ids)

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -1012,19 +1012,19 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 				mutatingPipelines[pipelineID] = expectMutatesData
 
 				expectedReceivers, expectedExporters := expectedInstances(test.pipelineConfigs, pipelineID)
-				require.Equal(t, expectedReceivers, len(pipeline.receivers))
+				require.Len(t, pipeline.receivers, expectedReceivers)
 				require.Equal(t, len(pipelineCfg.Processors), len(pipeline.processors))
-				require.Equal(t, expectedExporters, len(pipeline.exporters))
+				require.Len(t, pipeline.exporters, expectedExporters)
 
 				for _, n := range pipeline.exporters {
 					switch c := n.(type) {
 					case *exporterNode:
 						e := c.Component.(*testcomponents.ExampleExporter)
 						require.True(t, e.Started())
-						require.Equal(t, 0, len(e.Traces))
-						require.Equal(t, 0, len(e.Metrics))
-						require.Equal(t, 0, len(e.Logs))
-						require.Equal(t, 0, len(e.Profiles))
+						require.Empty(t, e.Traces)
+						require.Empty(t, e.Metrics)
+						require.Empty(t, e.Logs)
+						require.Empty(t, e.Profiles)
 					case *connectorNode:
 						// connector needs to be unwrapped to access component as ExampleConnector
 						switch ct := c.Component.(type) {
@@ -1179,7 +1179,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 			allExporters := pg.GetExporters()
 			for _, e := range allExporters[component.DataTypeTraces] {
 				tracesExporter := e.(*testcomponents.ExampleExporter)
-				assert.Equal(t, test.expectedPerExporter, len(tracesExporter.Traces))
+				assert.Len(t, tracesExporter.Traces, test.expectedPerExporter)
 				expectedMutable := testdata.GenerateTraces(1)
 				expectedReadOnly := testdata.GenerateTraces(1)
 				expectedReadOnly.MarkReadOnly()
@@ -1193,7 +1193,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 			}
 			for _, e := range allExporters[component.DataTypeMetrics] {
 				metricsExporter := e.(*testcomponents.ExampleExporter)
-				assert.Equal(t, test.expectedPerExporter, len(metricsExporter.Metrics))
+				assert.Len(t, metricsExporter.Metrics, test.expectedPerExporter)
 				expectedMutable := testdata.GenerateMetrics(1)
 				expectedReadOnly := testdata.GenerateMetrics(1)
 				expectedReadOnly.MarkReadOnly()
@@ -1207,7 +1207,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 			}
 			for _, e := range allExporters[component.DataTypeLogs] {
 				logsExporter := e.(*testcomponents.ExampleExporter)
-				assert.Equal(t, test.expectedPerExporter, len(logsExporter.Logs))
+				assert.Len(t, logsExporter.Logs, test.expectedPerExporter)
 				expectedMutable := testdata.GenerateLogs(1)
 				expectedReadOnly := testdata.GenerateLogs(1)
 				expectedReadOnly.MarkReadOnly()
@@ -1221,7 +1221,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 			}
 			for _, e := range allExporters[componentprofiles.DataTypeProfiles] {
 				profilesExporter := e.(*testcomponents.ExampleExporter)
-				assert.Equal(t, test.expectedPerExporter, len(profilesExporter.Profiles))
+				assert.Len(t, profilesExporter.Profiles, test.expectedPerExporter)
 				expectedMutable := testdata.GenerateProfiles(1)
 				expectedReadOnly := testdata.GenerateProfiles(1)
 				expectedReadOnly.MarkReadOnly()
@@ -1381,20 +1381,20 @@ func TestConnectorRouter(t *testing.T) {
 
 	// Consume 1, validate it went right
 	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
-	assert.Equal(t, 1, len(tracesRight.Traces))
-	assert.Equal(t, 0, len(tracesLeft.Traces))
+	assert.Len(t, tracesRight.Traces, 1)
+	assert.Empty(t, tracesLeft.Traces)
 
 	// Consume 1, validate it went left
 	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
-	assert.Equal(t, 1, len(tracesRight.Traces))
-	assert.Equal(t, 1, len(tracesLeft.Traces))
+	assert.Len(t, tracesRight.Traces, 1)
+	assert.Len(t, tracesLeft.Traces, 1)
 
 	// Consume 3, validate 2 went right, 1 went left
 	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
 	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
 	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
-	assert.Equal(t, 3, len(tracesRight.Traces))
-	assert.Equal(t, 2, len(tracesLeft.Traces))
+	assert.Len(t, tracesRight.Traces, 3)
+	assert.Len(t, tracesLeft.Traces, 2)
 
 	// Get a handle for the metrics receiver and both Exporters
 	metricsReceiver := allReceivers[component.DataTypeMetrics][rcvrID].(*testcomponents.ExampleReceiver)
@@ -1403,20 +1403,20 @@ func TestConnectorRouter(t *testing.T) {
 
 	// Consume 1, validate it went right
 	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
-	assert.Equal(t, 1, len(metricsRight.Metrics))
-	assert.Equal(t, 0, len(metricsLeft.Metrics))
+	assert.Len(t, metricsRight.Metrics, 1)
+	assert.Empty(t, metricsLeft.Metrics)
 
 	// Consume 1, validate it went left
 	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
-	assert.Equal(t, 1, len(metricsRight.Metrics))
-	assert.Equal(t, 1, len(metricsLeft.Metrics))
+	assert.Len(t, metricsRight.Metrics, 1)
+	assert.Len(t, metricsLeft.Metrics, 1)
 
 	// Consume 3, validate 2 went right, 1 went left
 	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
 	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
 	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
-	assert.Equal(t, 3, len(metricsRight.Metrics))
-	assert.Equal(t, 2, len(metricsLeft.Metrics))
+	assert.Len(t, metricsRight.Metrics, 3)
+	assert.Len(t, metricsLeft.Metrics, 2)
 
 	// Get a handle for the logs receiver and both Exporters
 	logsReceiver := allReceivers[component.DataTypeLogs][rcvrID].(*testcomponents.ExampleReceiver)
@@ -1425,20 +1425,20 @@ func TestConnectorRouter(t *testing.T) {
 
 	// Consume 1, validate it went right
 	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
-	assert.Equal(t, 1, len(logsRight.Logs))
-	assert.Equal(t, 0, len(logsLeft.Logs))
+	assert.Len(t, logsRight.Logs, 1)
+	assert.Empty(t, logsLeft.Logs)
 
 	// Consume 1, validate it went left
 	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
-	assert.Equal(t, 1, len(logsRight.Logs))
-	assert.Equal(t, 1, len(logsLeft.Logs))
+	assert.Len(t, logsRight.Logs, 1)
+	assert.Len(t, logsLeft.Logs, 1)
 
 	// Consume 3, validate 2 went right, 1 went left
 	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
 	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
 	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
-	assert.Equal(t, 3, len(logsRight.Logs))
-	assert.Equal(t, 2, len(logsLeft.Logs))
+	assert.Len(t, logsRight.Logs, 3)
+	assert.Len(t, logsLeft.Logs, 2)
 
 	// Get a handle for the profiles receiver and both Exporters
 	profilesReceiver := allReceivers[componentprofiles.DataTypeProfiles][rcvrID].(*testcomponents.ExampleReceiver)
@@ -1447,20 +1447,20 @@ func TestConnectorRouter(t *testing.T) {
 
 	// Consume 1, validate it went right
 	assert.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
-	assert.Equal(t, 1, len(profilesRight.Profiles))
-	assert.Equal(t, 0, len(profilesLeft.Profiles))
+	assert.Len(t, profilesRight.Profiles, 1)
+	assert.Empty(t, profilesLeft.Profiles)
 
 	// Consume 1, validate it went left
 	assert.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
-	assert.Equal(t, 1, len(profilesRight.Profiles))
-	assert.Equal(t, 1, len(profilesLeft.Profiles))
+	assert.Len(t, profilesRight.Profiles, 1)
+	assert.Len(t, profilesLeft.Profiles, 1)
 
 	// Consume 3, validate 2 went right, 1 went left
 	assert.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
 	assert.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
 	assert.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
-	assert.Equal(t, 3, len(profilesRight.Profiles))
-	assert.Equal(t, 2, len(profilesLeft.Profiles))
+	assert.Len(t, profilesRight.Profiles, 3)
+	assert.Len(t, profilesLeft.Profiles, 2)
 
 }
 

--- a/service/internal/proctelemetry/process_telemetry_linux_test.go
+++ b/service/internal/proctelemetry/process_telemetry_linux_test.go
@@ -32,7 +32,7 @@ func TestProcessTelemetryWithHostProc(t *testing.T) {
 	for _, metricName := range expectedMetrics {
 		metric, ok := mp[metricName]
 		require.True(t, ok)
-		require.True(t, len(metric.Metric) == 1)
+		require.Len(t, metric.Metric, 1)
 		var metricValue float64
 		if metric.GetType() == io_prometheus_client.MetricType_COUNTER {
 			metricValue = metric.Metric[0].GetCounter().GetValue()

--- a/service/internal/proctelemetry/process_telemetry_test.go
+++ b/service/internal/proctelemetry/process_telemetry_test.go
@@ -93,7 +93,7 @@ func TestProcessTelemetry(t *testing.T) {
 	for _, metricName := range expectedMetrics {
 		metric, ok := mp[metricName]
 		require.True(t, ok)
-		require.True(t, len(metric.Metric) == 1)
+		require.Len(t, metric.Metric, 1)
 		var metricValue float64
 		if metric.GetType() == io_prometheus_client.MetricType_COUNTER {
 			metricValue = metric.Metric[0].GetCounter().GetValue()

--- a/service/internal/testcomponents/example_exporter_test.go
+++ b/service/internal/testcomponents/example_exporter_test.go
@@ -23,21 +23,21 @@ func TestExampleExporter(t *testing.T) {
 	assert.NoError(t, exp.Start(context.Background(), host))
 	assert.True(t, exp.Started())
 
-	assert.Equal(t, 0, len(exp.Traces))
+	assert.Empty(t, exp.Traces)
 	assert.NoError(t, exp.ConsumeTraces(context.Background(), ptrace.Traces{}))
-	assert.Equal(t, 1, len(exp.Traces))
+	assert.Len(t, exp.Traces, 1)
 
-	assert.Equal(t, 0, len(exp.Metrics))
+	assert.Empty(t, exp.Metrics)
 	assert.NoError(t, exp.ConsumeMetrics(context.Background(), pmetric.Metrics{}))
-	assert.Equal(t, 1, len(exp.Metrics))
+	assert.Len(t, exp.Metrics, 1)
 
-	assert.Equal(t, 0, len(exp.Logs))
+	assert.Empty(t, exp.Logs)
 	assert.NoError(t, exp.ConsumeLogs(context.Background(), plog.Logs{}))
-	assert.Equal(t, 1, len(exp.Logs))
+	assert.Len(t, exp.Logs, 1)
 
-	assert.Equal(t, 0, len(exp.Profiles))
+	assert.Empty(t, exp.Profiles)
 	assert.NoError(t, exp.ConsumeProfiles(context.Background(), pprofile.Profiles{}))
-	assert.Equal(t, 1, len(exp.Profiles))
+	assert.Len(t, exp.Profiles, 1)
 
 	assert.False(t, exp.Stopped())
 	assert.NoError(t, exp.Shutdown(context.Background()))

--- a/service/internal/testcomponents/example_router_test.go
+++ b/service/internal/testcomponents/example_router_test.go
@@ -58,7 +58,7 @@ func TestTracesRouter(t *testing.T) {
 
 	assert.NoError(t, tr.ConsumeTraces(context.Background(), td))
 	assert.Len(t, sinkRight.AllTraces(), 1)
-	assert.Len(t, sinkLeft.AllTraces(), 0)
+	assert.Empty(t, sinkLeft.AllTraces())
 
 	assert.NoError(t, tr.ConsumeTraces(context.Background(), td))
 	assert.Len(t, sinkRight.AllTraces(), 1)
@@ -97,7 +97,7 @@ func TestMetricsRouter(t *testing.T) {
 
 	assert.NoError(t, mr.ConsumeMetrics(context.Background(), md))
 	assert.Len(t, sinkRight.AllMetrics(), 1)
-	assert.Len(t, sinkLeft.AllMetrics(), 0)
+	assert.Empty(t, sinkLeft.AllMetrics())
 
 	assert.NoError(t, mr.ConsumeMetrics(context.Background(), md))
 	assert.Len(t, sinkRight.AllMetrics(), 1)
@@ -136,7 +136,7 @@ func TestLogsRouter(t *testing.T) {
 
 	assert.NoError(t, lr.ConsumeLogs(context.Background(), ld))
 	assert.Len(t, sinkRight.AllLogs(), 1)
-	assert.Len(t, sinkLeft.AllLogs(), 0)
+	assert.Empty(t, sinkLeft.AllLogs())
 
 	assert.NoError(t, lr.ConsumeLogs(context.Background(), ld))
 	assert.Len(t, sinkRight.AllLogs(), 1)
@@ -175,7 +175,7 @@ func TestProfilesRouter(t *testing.T) {
 
 	assert.NoError(t, tr.ConsumeProfiles(context.Background(), td))
 	assert.Len(t, sinkRight.AllProfiles(), 1)
-	assert.Len(t, sinkLeft.AllProfiles(), 0)
+	assert.Empty(t, sinkLeft.AllProfiles())
 
 	assert.NoError(t, tr.ConsumeProfiles(context.Background(), td))
 	assert.Len(t, sinkRight.AllProfiles(), 1)


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [len](https://github.com/Antonboom/testifylint?tab=readme-ov-file#len) and [empty](https://github.com/Antonboom/testifylint?tab=readme-ov-file#empty) rules from [testifylint](https://github.com/Antonboom/testifylint)

It also adds testifylint as tool to use with a make command