### PR TITLE
[service] implement a noop tracer provider

### DIFF
--- a/.chloggen/codeboten_noop-providers.yaml
+++ b/.chloggen/codeboten_noop-providers.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: implement a no-op tracer provider that doesn't propagate the context
+
+# One or more tracking issues or pull requests related to the change
+issues: [11026]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The no-op tracer provider supported by the SDK incurs a memory cost of propagating the context no matter
+  what. This is not needed if tracing is not enabled in the Collector. This implementation of the no-op tracer
+  provider removes the need to allocate memory when tracing is disabled.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -54,7 +54,7 @@ type noopNoContextTracer struct {
 
 var noopSpan = noop.Span{}
 
-func (n *noopNoContextTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+func (n *noopNoContextTracer) Start(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return ctx, noopSpan
 }
 
@@ -62,7 +62,7 @@ type noopNoContextTracerProvider struct {
 	embedded.TracerProvider
 }
 
-func (n *noopNoContextTracerProvider) Tracer(name string, options ...trace.TracerOption) trace.Tracer {
+func (n *noopNoContextTracerProvider) Tracer(_ string, _ ...trace.TracerOption) trace.Tracer {
 	return &noopNoContextTracer{}
 }
 

--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
@@ -47,10 +48,28 @@ func attributes(set Settings, cfg Config) map[string]interface{} {
 	return attrs
 }
 
+type noopNoContextTracer struct {
+	embedded.Tracer
+}
+
+var noopSpan = noop.Span{}
+
+func (n *noopNoContextTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return ctx, noopSpan
+}
+
+type noopNoContextTracerProvider struct {
+	embedded.TracerProvider
+}
+
+func (n *noopNoContextTracerProvider) Tracer(name string, options ...trace.TracerOption) trace.Tracer {
+	return &noopNoContextTracer{}
+}
+
 // New creates a new Telemetry from Config.
 func newTracerProvider(ctx context.Context, set Settings, cfg Config) (trace.TracerProvider, error) {
 	if globalgates.NoopTracerProvider.IsEnabled() || cfg.Traces.Level == configtelemetry.LevelNone {
-		return noop.NewTracerProvider(), nil
+		return &noopNoContextTracerProvider{}, nil
 	}
 
 	sch := semconv.SchemaURL

--- a/service/telemetry/tracer_test.go
+++ b/service/telemetry/tracer_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace/noop"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
@@ -76,13 +75,13 @@ func TestNewTracerProvider(t *testing.T) {
 					Level: configtelemetry.LevelNone,
 				},
 			},
-			wantTracerProvider: noop.TracerProvider{},
+			wantTracerProvider: &noopNoContextTracerProvider{},
 		},
 		{
 			name:               "noop tracer feature gate",
 			cfg:                Config{},
 			noopTracerGate:     true,
-			wantTracerProvider: noop.TracerProvider{},
+			wantTracerProvider: &noopNoContextTracerProvider{},
 		},
 		{
 			name:               "tracer provider",


### PR DESCRIPTION
This is to address some of the memory concerns around the SDK's noop tracer provider. Instead of using the published noop tracer provider, we implement our own to avoid the cost of context propagation, which has been proven to be high enough to cause issues for end users.

Part of #10858
