### PR TITLE
[exporter/logging] Add warning to logging exporter

### DIFF
--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -44,6 +44,7 @@ func createDefaultConfig() component.Config {
 }
 
 func createTracesExporter(ctx context.Context, set exporter.Settings, config component.Config) (exporter.Traces, error) {
+	set.TelemetrySettings.Logger.Warn("The logging exporter is DEPRECATED and will be REMOVED in v0.111.0. Use the debug exporter instead: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter")
 	cfg := config.(*Config)
 	return common.CreateTracesExporter(ctx, set, config, &common.Common{
 		Verbosity:          cfg.Verbosity,
@@ -55,6 +56,7 @@ func createTracesExporter(ctx context.Context, set exporter.Settings, config com
 }
 
 func createMetricsExporter(ctx context.Context, set exporter.Settings, config component.Config) (exporter.Metrics, error) {
+	set.TelemetrySettings.Logger.Warn("The logging exporter is DEPRECATED and will be REMOVED in v0.111.0. Use the debug exporter instead: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter")
 	cfg := config.(*Config)
 	return common.CreateMetricsExporter(ctx, set, config, &common.Common{
 		Verbosity:          cfg.Verbosity,
@@ -66,6 +68,7 @@ func createMetricsExporter(ctx context.Context, set exporter.Settings, config co
 }
 
 func createLogsExporter(ctx context.Context, set exporter.Settings, config component.Config) (exporter.Logs, error) {
+	set.TelemetrySettings.Logger.Warn("The logging exporter is DEPRECATED and will be REMOVED in v0.111.0. Use the debug exporter instead: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter")
 	cfg := config.(*Config)
 	return common.CreateLogsExporter(ctx, set, config, &common.Common{
 		Verbosity:          cfg.Verbosity,


### PR DESCRIPTION
#### Description

Add warning to logging exporter on startup to remind users to switch to the debug exporter.

<!-- Issue number if applicable -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037

<!--Describe what testing was performed and which tests were added.-->
#### Testing
![image](https://github.com/user-attachments/assets/7d9cd908-6fdf-45c4-82f0-56cce35dbcee)