### PR TITLE
PAUSED - [exporter] Split an API of exporter/queue: from pop(updateSizeCallback) to pop() and updateSize(deltaSize)

### DIFF
--- a/exporter/internal/queue/bounded_memory_queue.go
+++ b/exporter/internal/queue/bounded_memory_queue.go
@@ -44,10 +44,11 @@ func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
 // The call blocks until there is an item available or the queue is stopped.
 // The function returns true when an item is consumed or false if the queue is stopped and emptied.
 func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T) error) bool {
-	item, ok := q.sizedChannel.pop(func(el memQueueEl[T]) int64 { return q.sizer.Sizeof(el.req) })
+	item, ok := q.sizedChannel.pop()
 	if !ok {
 		return false
 	}
+	q.updateSize(-q.sizer.Sizeof(item.req))
 	// the memory queue doesn't handle consume errors
 	_ = consumeFunc(item.ctx, item.req)
 	return true

--- a/exporter/internal/queue/sized_channel.go
+++ b/exporter/internal/queue/sized_channel.go
@@ -62,22 +62,19 @@ func (vcq *sizedChannel[T]) push(el T, size int64, callback func() error) error 
 // pop removes the element from the queue and returns it.
 // The call blocks until there is an item available or the queue is stopped.
 // The function returns true when an item is consumed or false if the queue is stopped and emptied.
-// The callback is called before the element is removed from the queue. It must return the size of the element.
-func (vcq *sizedChannel[T]) pop(callback func(T) (size int64)) (T, bool) {
+func (vcq *sizedChannel[T]) pop() (T, bool) {
 	el, ok := <-vcq.ch
-	if !ok {
-		return el, false
-	}
+	return el, ok
+}
 
-	size := callback(el)
-
+// updateSize updates size. It should be called when an item is removed from the queue.
+func (vcq *sizedChannel[T]) updateSize(deltaSize int64) {
 	// The used size and the channel size might be not in sync with the queue in case it's restored from the disk
 	// because we don't flush the current queue size on the disk on every read/write.
 	// In that case we need to make sure it doesn't go below 0.
-	if vcq.used.Add(-size) < 0 {
+	if vcq.used.Add(deltaSize) < 0 {
 		vcq.used.Store(0)
 	}
-	return el, true
 }
 
 // syncSize updates the used size to 0 if the queue is empty.

--- a/exporter/internal/queue/sized_channel_test.go
+++ b/exporter/internal/queue/sized_channel_test.go
@@ -27,18 +27,21 @@ func TestSizedCapacityChannel(t *testing.T) {
 	assert.Error(t, q.push(4, 4, nil))
 	assert.Equal(t, 4, q.Size())
 
-	el, ok := q.pop(func(el int) int64 { return int64(el) })
+	el, ok := q.pop()
+	q.updateSize(-int64(el))
 	assert.Equal(t, 1, el)
 	assert.True(t, ok)
 	assert.Equal(t, 3, q.Size())
 
-	el, ok = q.pop(func(el int) int64 { return int64(el) })
+	el, ok = q.pop()
+	q.updateSize(-int64(el))
 	assert.Equal(t, 3, el)
 	assert.True(t, ok)
 	assert.Equal(t, 0, q.Size())
 
 	q.shutdown()
-	el, ok = q.pop(func(el int) int64 { return int64(el) })
+	el, ok = q.pop()
+	q.updateSize(-int64(el))
 	assert.False(t, ok)
 	assert.Equal(t, 0, el)
 }


### PR DESCRIPTION
#### Description

This PR splits an API of `exporter/internal/sized_channel`:
`pop(updateSizeCallback func(int))` => `pop()` and `updateSize(deltaSize)`

Why?
As part of the effort to move from a queue->batch pushing model to a pulling model, we would like to parallelize reading especially for persistent queues. "popping an item from the sized channel" in this context, is more of a signal that the queue is non-empty and ready to be read. We would like to enable the caller to complete the following READ process asynchronously and then report back.

POC: https://github.com/sfc-gh-sili/opentelemetry-collector/pull/2


This change does not affect any user because queue is an internal package. Nor does this PR change any behavior.

#### Link to tracking issue

https://github.com/open-telemetry/opentelemetry-collector/issues/10368

#### Testing
Ran `opentelemetry-collector$ make` to make sure all tests still pass.

