### PR TITLE
[chore] unset var used in test

### DIFF
--- a/confmap/internal/e2e/types_test.go
+++ b/confmap/internal/e2e/types_test.go
@@ -647,6 +647,7 @@ func TestIssue10937_ComplexType(t *testing.T) {
 }
 
 func TestIssue10949_UnsetVar(t *testing.T) {
+	t.Setenv("ENV", "")
 	resolver := NewResolver(t, "types_expand.yaml")
 	conf, err := resolver.Resolve(context.Background())
 	require.NoError(t, err)


### PR DESCRIPTION
This prevents the test from failing for users who set the variable locally
