### PR TITLE
return queue is full error if sized_channel is full

### DIFF
--- a/.chloggen/fix-persistent-queue-deadlock.yaml
+++ b/.chloggen/fix-persistent-queue-deadlock.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: 'exporterqueue'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a bug in persistent queue that Offer can becomes deadlocked when queue is almost full
+
+# One or more tracking issues or pull requests related to the change
+issues: [11015]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -593,7 +593,6 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 	case <-doneCtx.Done():
 		assert.Fail(t, "timed out waiting for producers to complete")
 	}
-	
 	assert.Zero(t, pq.sizedChannel.Size())
 }
 

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -539,12 +539,12 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 	pq := createTestPersistentQueueWithItemsCapacity(t, ext, 250)
 
 	proWg := sync.WaitGroup{}
-	for j := 0; j < 50; j++ {
+	for j := 0; j < 2; j++ {
 		proWg.Add(1)
 		go func() {
 			defer proWg.Done()
 			// Put in items up to capacity
-			for i := 0; i < 10; i++ {
+			for i := 0; i < 250; i++ {
 				for {
 					// retry infinitely so the exact amount of items are added to the queue eventually
 					if err := pq.Offer(context.Background(), req); err == nil {
@@ -557,11 +557,11 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 	}
 
 	conWg := sync.WaitGroup{}
-	for j := 0; j < 50; j++ {
+	for j := 0; j < 2; j++ {
 		conWg.Add(1)
 		go func() {
 			defer conWg.Done()
-			for i := 0; i < 10; i++ {
+			for i := 0; i < 250; i++ {
 				require.True(t, pq.Consume(func(context.Context, tracesRequest) error { return nil }))
 			}
 		}()

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -536,7 +536,7 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 	req := newTracesRequest(1, 1)
 
 	ext := NewMockStorageExtensionWithDelay(nil, 20*time.Nanosecond)
-	pq := createTestPersistentQueueWithItemsCapacity(t, ext, 2500)
+	pq := createTestPersistentQueueWithItemsCapacity(t, ext, 250)
 
 	proWg := sync.WaitGroup{}
 	for j := 0; j < 50; j++ {
@@ -544,7 +544,7 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 		go func() {
 			defer proWg.Done()
 			// Put in items up to capacity
-			for i := 0; i < 100; i++ {
+			for i := 0; i < 10; i++ {
 				for {
 					// retry infinitely so the exact amount of items are added to the queue eventually
 					if err := pq.Offer(context.Background(), req); err == nil {
@@ -561,7 +561,7 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 		conWg.Add(1)
 		go func() {
 			defer conWg.Done()
-			for i := 0; i < 100; i++ {
+			for i := 0; i < 10; i++ {
 				require.True(t, pq.Consume(func(context.Context, tracesRequest) error { return nil }))
 			}
 		}()

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -529,6 +530,68 @@ func TestPersistentQueueStartWithNonDispatched(t *testing.T) {
 	// Reload with extra capacity to make sure we re-enqueue in-progress items.
 	newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 6)
 	require.Equal(t, 6, newPs.Size())
+}
+
+func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
+	req := newTracesRequest(1, 1)
+
+	ext := NewMockStorageExtensionWithDelay(nil, 50*time.Nanosecond)
+	pq := createTestPersistentQueueWithItemsCapacity(t, ext, 2500)
+
+	proWg := sync.WaitGroup{}
+	for j := 0; j < 50; j++ {
+		proWg.Add(1)
+		go func() {
+			defer proWg.Done()
+			// Put in items up to capacity
+			for i := 0; i < 100; i++ {
+				for {
+					// retry infinitely so the exact amount of items are added to the queue eventually
+					if err := pq.Offer(context.Background(), req); err == nil {
+						break
+					}
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}()
+	}
+
+	conWg := sync.WaitGroup{}
+	for j := 0; j < 50; j++ {
+		conWg.Add(1)
+		go func() {
+			defer conWg.Done()
+			for i := 0; i < 100; i++ {
+				require.True(t, pq.Consume(func(context.Context, tracesRequest) error { return nil }))
+			}
+		}()
+	}
+
+	conDone := make(chan struct{})
+	go func() {
+		defer close(conDone)
+		conWg.Wait()
+	}()
+
+	proDone := make(chan struct{})
+	go func() {
+		defer close(proDone)
+		proWg.Wait()
+	}()
+
+	doneCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	select {
+	case <-conDone:
+	case <-doneCtx.Done():
+		assert.Fail(t, "timed out waiting for consumers to complete")
+	}
+
+	select {
+	case <-proDone:
+	case <-doneCtx.Done():
+		assert.Fail(t, "timed out waiting for producers to complete")
+	}
 }
 
 func TestPersistentQueue_PutCloseReadClose(t *testing.T) {

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -542,40 +542,29 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 	// Sending small amount of data as windows test can't handle the test fast enough
 	for j := 0; j < 5; j++ {
 		proWg.Add(1)
-		t.Log("spawning a producer goroutine")
 		go func() {
-			t.Log("spawned a producer goroutine")
 			defer proWg.Done()
 			// Put in items up to capacity
 			for i := 0; i < 10; i++ {
 				for {
 					// retry infinitely so the exact amount of items are added to the queue eventually
 					if err := pq.Offer(context.Background(), req); err == nil {
-						t.Log("offer was successful")
 						break
-					} else {
-						t.Log(err.Error())
 					}
-					t.Log("sleeping and trying again")
 					time.Sleep(50 * time.Nanosecond)
 				}
 			}
-			t.Log("exiting producer loop")
 		}()
 	}
 
 	conWg := sync.WaitGroup{}
 	for j := 0; j < 5; j++ {
 		conWg.Add(1)
-		t.Log("spawning a consumer goroutine")
 		go func() {
-			t.Log("spanwed a consumer goroutine")
 			defer conWg.Done()
 			for i := 0; i < 10; i++ {
 				require.True(t, pq.Consume(func(context.Context, tracesRequest) error { return nil }))
-				t.Log("consume was successful")
 			}
-			t.Log("exiting consumer loop")
 		}()
 	}
 

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -593,6 +593,8 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 	case <-doneCtx.Done():
 		assert.Fail(t, "timed out waiting for producers to complete")
 	}
+	
+	assert.Zero(t, pq.sizedChannel.Size())
 }
 
 func TestPersistentQueue_PutCloseReadClose(t *testing.T) {

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -536,34 +536,45 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 	req := newTracesRequest(1, 1)
 
 	ext := NewMockStorageExtensionWithDelay(nil, 20*time.Nanosecond)
-	pq := createTestPersistentQueueWithItemsCapacity(t, ext, 250)
+	pq := createTestPersistentQueueWithItemsCapacity(t, ext, 300)
 
 	proWg := sync.WaitGroup{}
 	for j := 0; j < 2; j++ {
 		proWg.Add(1)
+		t.Log("spawning a producer goroutine")
 		go func() {
+			t.Log("spawned a producer goroutine")
 			defer proWg.Done()
 			// Put in items up to capacity
-			for i := 0; i < 250; i++ {
+			for i := 0; i < 150; i++ {
 				for {
 					// retry infinitely so the exact amount of items are added to the queue eventually
 					if err := pq.Offer(context.Background(), req); err == nil {
+						t.Log("offer was successful")
 						break
+					} else {
+						t.Log(err.Error())
 					}
+					t.Log("sleeping and trying again")
 					time.Sleep(50 * time.Nanosecond)
 				}
 			}
+			t.Log("exiting producer loop")
 		}()
 	}
 
 	conWg := sync.WaitGroup{}
 	for j := 0; j < 2; j++ {
 		conWg.Add(1)
+		t.Log("spawning a consumer goroutine")
 		go func() {
+			t.Log("spanwed a consumer goroutine")
 			defer conWg.Done()
-			for i := 0; i < 250; i++ {
+			for i := 0; i < 150; i++ {
 				require.True(t, pq.Consume(func(context.Context, tracesRequest) error { return nil }))
+				t.Log("consume was successful")
 			}
+			t.Log("exiting consumer loop")
 		}()
 	}
 

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -535,7 +535,7 @@ func TestPersistentQueueStartWithNonDispatched(t *testing.T) {
 func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 	req := newTracesRequest(1, 1)
 
-	ext := NewMockStorageExtensionWithDelay(nil, 50*time.Nanosecond)
+	ext := NewMockStorageExtensionWithDelay(nil, 20*time.Nanosecond)
 	pq := createTestPersistentQueueWithItemsCapacity(t, ext, 2500)
 
 	proWg := sync.WaitGroup{}
@@ -550,7 +550,7 @@ func TestPersistentQueueStartWithNonDispatchedConcurrent(t *testing.T) {
 					if err := pq.Offer(context.Background(), req); err == nil {
 						break
 					}
-					time.Sleep(time.Millisecond)
+					time.Sleep(50 * time.Nanosecond)
 				}
 			}
 		}()

--- a/exporter/internal/queue/sized_channel_test.go
+++ b/exporter/internal/queue/sized_channel_test.go
@@ -42,3 +42,13 @@ func TestSizedCapacityChannel(t *testing.T) {
 	assert.False(t, ok)
 	assert.Equal(t, 0, el)
 }
+
+func TestSizedCapacityChannel_Offer_sizedNotFullButChannelFull(t *testing.T) {
+	q := newSizedChannel[int](1, nil, 0)
+	assert.NoError(t, q.push(1, 1, nil))
+
+	q.used.Store(0)
+	err := q.push(1, 1, nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrQueueIsFull, err)
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This change fixes a potential deadlock bug for persistent queue.

There is a race condition in persistent queue that caused `used` in `sizedChannel` to become out of sync with `ch` len. This causes `Offer` to be deadlocked in specific race condition. For example:
1. Multiple consumers are calling Consume
2. Multiple producers are calling Offer to insert into the queue
  a. All elements are taken from consumers. ch is empty
3. One consumer completes consume, calls onProcessingFinished
  a. Inside sizedChannel, syncSize is invoked, used is reset to 0 when other consumers are still waiting for lock to consume
4. More Offer is called inserting elements -> used and ch len should equal
5. As step 3a consumers completes, used is decreased  -> used is lower than ch len
  a. More Offer is called inserting since used is below capacity. however, ch is full.
  b. goroutine calling offer is holding the mutex but can’t release it as ch is full.
  c. no consumer can acquire mutex to complete previous onProcessingFinished

This change returns an error if channel is full instead of waiting for it to unblock.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes # https://github.com/open-telemetry/opentelemetry-collector/issues/11015

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added concurrent test in persistent queue that can reproduce the problem(note: need to re-run it 100 times as the race condition is not consistent).
- Added unit test for sizedChannel

<!--Describe the documentation added.-->
#### Documentation
Added comment in the block explaining it

<!--Please delete paragraphs that you did not use before submitting.-->
