### PR TITLE
[chore] move attributes func into separate file

### DIFF
--- a/service/telemetry/attributes.go
+++ b/service/telemetry/attributes.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry // import "go.opentelemetry.io/collector/service/telemetry"
+
+import semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+
+func attributes(set Settings, cfg Config) map[string]interface{} {
+	attrs := map[string]interface{}{
+		string(semconv.ServiceNameKey):    set.BuildInfo.Command,
+		string(semconv.ServiceVersionKey): set.BuildInfo.Version,
+	}
+	for k, v := range cfg.Resource {
+		if v != nil {
+			attrs[k] = *v
+		}
+
+		// the new value is nil, delete the existing key
+		if _, ok := attrs[k]; ok && v == nil {
+			delete(attrs, k)
+		}
+	}
+	return attrs
+}

--- a/service/telemetry/attributes_test.go
+++ b/service/telemetry/attributes_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/service/telemetry/internal"
 )

--- a/service/telemetry/attributes_test.go
+++ b/service/telemetry/attributes_test.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry // import "go.opentelemetry.io/collector/service/telemetry"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/service/telemetry/internal"
+)
+
+func TestAttributes(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            Config
+		buildInfo      component.BuildInfo
+		wantAttributes map[string]interface{}
+	}{
+		{
+			name:           "no build info and no resource config",
+			cfg:            Config{},
+			wantAttributes: map[string]interface{}{"service.name": "", "service.version": ""},
+		},
+		{
+			name:           "build info and no resource config",
+			cfg:            Config{},
+			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
+			wantAttributes: map[string]interface{}{"service.name": "otelcoltest", "service.version": "0.0.0-test"},
+		},
+		{
+			name:           "no build info and resource config",
+			cfg:            Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "test": ptr("test")}},
+			wantAttributes: map[string]interface{}{"service.name": "resource.name", "service.version": "resource.version", "test": "test"},
+		},
+		{
+			name:           "build info and resource config",
+			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
+			cfg:            Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "test": ptr("test")}},
+			wantAttributes: map[string]interface{}{"service.name": "resource.name", "service.version": "resource.version", "test": "test"},
+		},
+		{
+			name:           "deleting a nil value",
+			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
+			cfg:            Config{Resource: map[string]*string{"service.name": nil, "service.version": ptr("resource.version"), "test": ptr("test")}},
+			wantAttributes: map[string]interface{}{"service.version": "resource.version", "test": "test"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := attributes(internal.Settings{BuildInfo: tt.buildInfo}, tt.cfg)
+			require.Equal(t, tt.wantAttributes, attrs)
+		})
+	}
+}

--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -30,24 +30,6 @@ var (
 	errUnsupportedPropagator = errors.New("unsupported trace propagator")
 )
 
-func attributes(set Settings, cfg Config) map[string]interface{} {
-	attrs := map[string]interface{}{
-		string(semconv.ServiceNameKey):    set.BuildInfo.Command,
-		string(semconv.ServiceVersionKey): set.BuildInfo.Version,
-	}
-	for k, v := range cfg.Resource {
-		if v != nil {
-			attrs[k] = *v
-		}
-
-		// the new value is nil, delete the existing key
-		if _, ok := attrs[k]; ok && v == nil {
-			delete(attrs, k)
-		}
-	}
-	return attrs
-}
-
 type noopNoContextTracer struct {
 	embedded.Tracer
 }

--- a/service/telemetry/tracer_test.go
+++ b/service/telemetry/tracer_test.go
@@ -10,56 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/internal/globalgates"
 	"go.opentelemetry.io/collector/service/telemetry/internal"
 )
-
-func TestAttributes(t *testing.T) {
-	tests := []struct {
-		name           string
-		cfg            Config
-		buildInfo      component.BuildInfo
-		wantAttributes map[string]interface{}
-	}{
-		{
-			name:           "no build info and no resource config",
-			cfg:            Config{},
-			wantAttributes: map[string]interface{}{"service.name": "", "service.version": ""},
-		},
-		{
-			name:           "build info and no resource config",
-			cfg:            Config{},
-			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
-			wantAttributes: map[string]interface{}{"service.name": "otelcoltest", "service.version": "0.0.0-test"},
-		},
-		{
-			name:           "no build info and resource config",
-			cfg:            Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "test": ptr("test")}},
-			wantAttributes: map[string]interface{}{"service.name": "resource.name", "service.version": "resource.version", "test": "test"},
-		},
-		{
-			name:           "build info and resource config",
-			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
-			cfg:            Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "test": ptr("test")}},
-			wantAttributes: map[string]interface{}{"service.name": "resource.name", "service.version": "resource.version", "test": "test"},
-		},
-		{
-			name:           "deleting a nil value",
-			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
-			cfg:            Config{Resource: map[string]*string{"service.name": nil, "service.version": ptr("resource.version"), "test": ptr("test")}},
-			wantAttributes: map[string]interface{}{"service.version": "resource.version", "test": "test"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			attrs := attributes(internal.Settings{BuildInfo: tt.buildInfo}, tt.cfg)
-			require.Equal(t, tt.wantAttributes, attrs)
-		})
-	}
-}
 
 func TestNewTracerProvider(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
No functional change, just moving it into its own file to clean up the tracer config since the meter provider will also use attributes.
