### PR TITLE
[chore][confighttp] Update docs for max_request_body_size default value

### DIFF
--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -78,7 +78,7 @@ will not be enabled.
   header, allowing clients to cache the response to CORS preflight requests. If
   not set, browsers use a default of 5 seconds.
 - `endpoint`: Valid value syntax available [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
-- `max_request_body_size`: configures the maximum allowed body size in bytes for a single request. Default: `0` (no restriction)
+- `max_request_body_size`: configures the maximum allowed body size in bytes for a single request. Default: 20MiB.
 - `compression_algorithms`: configures the list of compression algorithms the server can accept. Default: ["", "gzip", "zstd", "zlib", "snappy", "deflate"]
 - [`tls`](../configtls/README.md)
 - [`auth`](../configauth/README.md)

--- a/receiver/otlpreceiver/config.md
+++ b/receiver/otlpreceiver/config.md
@@ -71,12 +71,12 @@ Config defines configuration for OTLP receiver.
 
 ### confighttp-HTTPServerSettings
 
-| Name                  | Type                                                      | Default      | Docs                                                                                                                                    |
-|-----------------------|-----------------------------------------------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| endpoint              | string                                                    | localhost:4318 | Endpoint configures the listening address for the server.                                                                               |
-| tls                   | [configtls-TLSServerSetting](#configtls-tlsserversetting) | <no value>   | TLSSetting struct exposes TLS client configuration.                                                                                     |
-| cors                  | [confighttp-CORSConfig](#confighttp-corsconfig)           | <no value>   | CORSConfig configures a receiver for HTTP cross-origin resource sharing (CORS).                                                       |
-| max_request_body_size | int                                                       | 0            | MaxRequestBodySize configures the maximum allowed body size in bytes for a single request. The default `0` means there's no restriction |
+| Name                  | Type                                                      | Default       | Docs                                                                                                                   |
+|-----------------------|-----------------------------------------------------------|---------------|------------------------------------------------------------------------------------------------------------------------|
+| endpoint              | string                                                    | localhost:4318 | Endpoint configures the listening address for the server.                                                              |
+| tls                   | [configtls-TLSServerSetting](#configtls-tlsserversetting) | <no value>    | TLSSetting struct exposes TLS client configuration.                                                                    |
+| cors                  | [confighttp-CORSConfig](#confighttp-corsconfig)           | <no value>    | CORSConfig configures a receiver for HTTP cross-origin resource sharing (CORS).                                        |
+| max_request_body_size | int                                                       | 20MiB         | MaxRequestBodySize configures the maximum allowed body size in bytes for a single request. The default value is 20MiB. |
 
 ### confighttp-CORSConfig
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
As a result of [CVE-2024-36129](https://nvd.nist.gov/vuln/detail/CVE-2024-36129), we had to update the default value for the `max_request_body_size` in the `confighttp` server settings to be 20MiB. It looks like some places in documentation were not updated along with the code change, so this resolves the outdated documentation

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/11066
Related to https://github.com/open-telemetry/opentelemetry-collector/pull/10289