### PR TITLE
[chore] Fix flaky Test_ComponentStatusReporting_SharedInstance test

### DIFF
--- a/internal/e2e/status_test.go
+++ b/internal/e2e/status_test.go
@@ -35,6 +35,8 @@ import (
 
 var nopType = component.MustNewType("nop")
 
+var wg = sync.WaitGroup{}
+
 func Test_ComponentStatusReporting_SharedInstance(t *testing.T) {
 	eventsReceived := make(map[*componentstatus.InstanceID][]*componentstatus.Event)
 	exporterFactory := exportertest.NewNopFactory()
@@ -112,9 +114,10 @@ func Test_ComponentStatusReporting_SharedInstance(t *testing.T) {
 	s, err := service.New(context.Background(), set, cfg)
 	require.NoError(t, err)
 
+	wg.Add(1)
 	err = s.Start(context.Background())
 	require.NoError(t, err)
-	time.Sleep(15 * time.Second)
+	wg.Wait()
 	err = s.Shutdown(context.Background())
 	require.NoError(t, err)
 
@@ -170,6 +173,7 @@ func (t *testReceiver) Start(_ context.Context, host component.Host) error {
 	componentstatus.ReportStatus(host, componentstatus.NewRecoverableErrorEvent(errors.New("test recoverable error")))
 	go func() {
 		componentstatus.ReportStatus(host, componentstatus.NewEvent(componentstatus.StatusOK))
+		wg.Done()
 	}()
 	return nil
 }
@@ -246,7 +250,6 @@ func createExtension(_ context.Context, _ extension.Settings, cfg component.Conf
 
 type testExtension struct {
 	eventsReceived map[*componentstatus.InstanceID][]*componentstatus.Event
-	lock           sync.Mutex
 }
 
 type extensionConfig struct {
@@ -272,8 +275,6 @@ func (t *testExtension) ComponentStatusChanged(
 	source *componentstatus.InstanceID,
 	event *componentstatus.Event,
 ) {
-	t.lock.Lock()
-	defer t.lock.Unlock()
 	if source.ComponentID() == component.NewID(component.MustNewType("test")) {
 		t.eventsReceived[source] = append(t.eventsReceived[source], event)
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Try adding wait group to ensure `StatusOk` is reported before the call to `Shutdown`.

Passed with `go test status_test.go --count 2000` 

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/10927