### PR TITLE
Refine scraperhelper.NewScraper to take component.Type directly

### DIFF
--- a/.chloggen/refine-new-scraper.yaml
+++ b/.chloggen/refine-new-scraper.yaml
@@ -10,7 +10,7 @@ component: scraperhelper
 note: deprecate NewScraper, should use NewScraperWithComponentType
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [11082]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/refine-new-scraper.yaml
+++ b/.chloggen/refine-new-scraper.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: scraperhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: deprecate NewScraper, should use NewScraperWithComponentType
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/scraperhelper/scraper.go
+++ b/receiver/scraperhelper/scraper.go
@@ -61,13 +61,21 @@ func (b *baseScraper) ID() component.ID {
 
 // NewScraper creates a Scraper that calls Scrape at the specified collection interval,
 // reports observability information, and passes the scraped metrics to the next consumer.
+//
+// Deprecated: [v0.109.0] use NewScraperWithComponentType instead.
 func NewScraper(name string, scrape ScrapeFunc, options ...ScraperOption) (Scraper, error) {
+	return NewScraperWithComponentType(component.MustNewType(name), scrape, options...)
+}
+
+// NewScraperWithComponentType creates a Scraper that calls Scrape at the specified collection interval,
+// reports observability information, and passes the scraped metrics to the next consumer.
+func NewScraperWithComponentType(t component.Type, scrape ScrapeFunc, options ...ScraperOption) (Scraper, error) {
 	if scrape == nil {
 		return nil, errNilFunc
 	}
 	bs := &baseScraper{
 		ScrapeFunc: scrape,
-		id:         component.NewID(component.MustNewType(name)),
+		id:         component.NewID(t),
 	}
 	for _, op := range options {
 		op(bs)

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -223,7 +223,7 @@ func configureMetricOptions(t *testing.T, test metricsTestCase, initializeChs []
 
 		scrapeMetricsChs[i] = make(chan int)
 		tsm := &testScrapeMetrics{ch: scrapeMetricsChs[i], err: test.scrapeErr}
-		scp, err := NewScraper("scraper", tsm.scrape, scraperOptions...)
+		scp, err := NewScraperWithComponentType(component.MustNewType("scraper"), tsm.scrape, scraperOptions...)
 		assert.NoError(t, err)
 
 		metricOptions = append(metricOptions, AddScraper(scp))
@@ -325,7 +325,7 @@ func TestSingleScrapePerInterval(t *testing.T) {
 
 	tickerCh := make(chan time.Time)
 
-	scp, err := NewScraper("scaper", tsm.scrape)
+	scp, err := NewScraperWithComponentType(component.MustNewType("scaper"), tsm.scrape)
 	assert.NoError(t, err)
 
 	receiver, err := NewScraperControllerReceiver(
@@ -367,7 +367,7 @@ func TestScrapeControllerStartsOnInit(t *testing.T) {
 		ch: make(chan int, 1),
 	}
 
-	scp, err := NewScraper("scraper", tsm.scrape)
+	scp, err := NewScraperWithComponentType(component.MustNewType("scraper"), tsm.scrape)
 	require.NoError(t, err, "Must not error when creating scraper")
 
 	r, err := NewScraperControllerReceiver(
@@ -403,7 +403,7 @@ func TestScrapeControllerInitialDelay(t *testing.T) {
 		}
 	)
 
-	scp, err := NewScraper("timed", func(context.Context) (pmetric.Metrics, error) {
+	scp, err := NewScraperWithComponentType(component.MustNewType("timed"), func(context.Context) (pmetric.Metrics, error) {
 		elapsed <- time.Now()
 		return pmetric.NewMetrics(), nil
 	})


### PR DESCRIPTION
#### Description

Create new function to  enable to pass `component.Type` to `scraperhelper.NewScraper`

Because many contrib scrapers name the scraper with the same name as the component itself, create a function to take `component.Type`.
For example, https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/0e2bea5ac2763421e1a3943093f67184e109265f/receiver/activedirectorydsreceiver/factory_windows.go#L35 passes `metadata.Type.String()` as a name of scraper. With this change, you can pass `metadata.Type` instead 

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #9473
