### PR TITLE
feat(compression): Add the option of configuring compression levels

### DIFF
--- a/.chloggen/configure-compression-levels.yaml
+++ b/.chloggen/configure-compression-levels.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added support for configuring compression levels.
+
+# One or more tracking issues or pull requests related to the change
+issues: [10467]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/configure-compression-levels.yaml
+++ b/.chloggen/configure-compression-levels.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: confighttp
@@ -22,4 +22,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user, api]

--- a/.chloggen/configure-compression-levels.yaml
+++ b/.chloggen/configure-compression-levels.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: breaking
+change_type: 'enhancement'
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: confighttp

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -68,7 +68,7 @@ func (ct *TypeWithLevel) UnmarshalText(in []byte) error {
 		return nil
 	}
 
-	return fmt.Errorf("unsupported compression type/level %s/%d", compressionTyp, ct.Level)
+	return fmt.Errorf("unsupported compression type and level(default if not specified) %s - %d", compressionTyp, ct.Level)
 
 }
 

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -44,7 +44,7 @@ func (ct *TypeWithLevel) UnmarshalText(in []byte) error {
 	parts := strings.Split(string(in), "/")
 	compressionTyp = Type(parts[0])
 	level = zlib.DefaultCompression
-	if len(parts) > 1 {
+	if len(parts) == 2 {
 		level, err = strconv.Atoi(parts[1])
 		if err != nil {
 			return fmt.Errorf("invalid compression level: %q", parts[1])

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -38,12 +38,10 @@ func (ct *Type) IsCompressed() bool {
 }
 
 func (ct *TypeWithLevel) UnmarshalText(in []byte) error {
-	var compressionTyp Type
-	var level int
 	var err error
 	parts := strings.Split(string(in), "/")
-	compressionTyp = Type(parts[0])
-	level = zlib.DefaultCompression
+	compressionTyp := Type(parts[0])
+	level := zlib.DefaultCompression
 	if len(parts) == 2 {
 		level, err = strconv.Atoi(parts[1])
 		if err != nil {

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -16,8 +16,8 @@ type Type string
 type Level int
 
 type TypeWithLevel struct {
-	Type  Type
-	Level Level
+	Type  Type  `mapstructure:"type"`
+	Level Level `mapstructure:"level"`
 }
 
 const (

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -48,6 +48,7 @@ func (ct *TypeWithLevel) UnmarshalText(in []byte) error {
 			return fmt.Errorf("invalid compression level: %q", parts[1])
 		}
 		if compressionTyp == TypeSnappy ||
+			compressionTyp == TypeLz4 ||
 			compressionTyp == typeNone ||
 			compressionTyp == typeEmpty {
 			return fmt.Errorf("compression level is not supported for %q", compressionTyp)
@@ -58,6 +59,7 @@ func (ct *TypeWithLevel) UnmarshalText(in []byte) error {
 		(compressionTyp == TypeZlib && isValidLevel(level)) ||
 		(compressionTyp == TypeDeflate && isValidLevel(level)) ||
 		compressionTyp == TypeSnappy ||
+		compressionTyp == TypeLz4 ||
 		compressionTyp == TypeZstd ||
 		compressionTyp == typeNone ||
 		compressionTyp == typeEmpty {

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -3,7 +3,13 @@
 
 package configcompression // import "go.opentelemetry.io/collector/config/configcompression"
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/klauspost/compress/zlib"
+)
 
 // Type represents a compression method
 type Type string
@@ -39,4 +45,54 @@ func (ct *Type) UnmarshalText(in []byte) error {
 		return nil
 	}
 	return fmt.Errorf("unsupported compression type %q", typ)
+}
+
+// IsZstd returns true if the compression type is zstd.
+func (ct *Type) IsZstd() bool {
+	parts := strings.Split(string(*ct), "/")
+	return parts[0] == string(TypeZstd)
+}
+
+// IsGzip returns true if the compression type is gzip and the specified compression level is valid.
+func (ct *Type) IsGzip() bool {
+	parts := strings.Split(string(*ct), "/")
+	if parts[0] == string(TypeGzip) {
+		if len(parts) > 1 {
+			levelStr, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return false
+			}
+			if levelStr == zlib.BestSpeed ||
+				levelStr == zlib.BestCompression ||
+				levelStr == zlib.DefaultCompression ||
+				levelStr == zlib.HuffmanOnly ||
+				levelStr == zlib.NoCompression {
+				return true
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// IsZlib returns true if the compression type is zlib and the specified compression level is valid.
+func (ct *Type) IsZlib() bool {
+	parts := strings.Split(string(*ct), "/")
+	if parts[0] == string(TypeZlib) || parts[0] == string(TypeDeflate) {
+		if len(parts) > 1 {
+			levelStr, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return false
+			}
+			if levelStr == zlib.BestSpeed ||
+				levelStr == zlib.BestCompression ||
+				levelStr == zlib.DefaultCompression ||
+				levelStr == zlib.HuffmanOnly ||
+				levelStr == zlib.NoCompression {
+				return true
+			}
+		}
+		return true
+	}
+	return false
 }

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -5,14 +5,18 @@ package configcompression // import "go.opentelemetry.io/collector/config/config
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/klauspost/compress/zlib"
 )
 
 // Type represents a compression method
 type Type string
+type Level int
+
+type TypeWithLevel struct {
+	Type  Type  `mapstructure:"type"`
+	Level Level `mapstructure:"level"`
+}
 
 const (
 	TypeGzip    Type = "gzip"
@@ -31,82 +35,26 @@ func (ct *Type) IsCompressed() bool {
 	return *ct != typeEmpty && *ct != typeNone
 }
 
-func (ct *Type) UnmarshalText(in []byte) error {
-	typ := Type(in)
-	if typ == TypeGzip ||
-		typ == TypeZlib ||
-		typ == TypeDeflate ||
+func (ct *TypeWithLevel) UnmarshalText() (TypeWithLevel, error) {
+	typ := ct.Type
+	if (typ == TypeGzip && isValidLevel(int(ct.Level))) ||
+		(typ == TypeZlib && isValidLevel(int(ct.Level))) ||
+		(typ == TypeDeflate && isValidLevel(int(ct.Level))) ||
 		typ == TypeSnappy ||
 		typ == TypeZstd ||
 		typ == TypeLz4 ||
 		typ == typeNone ||
 		typ == typeEmpty {
-		*ct = typ
-		return nil
+		return TypeWithLevel{Type: typ, Level: ct.Level}, nil
 	}
-	return fmt.Errorf("unsupported compression type %q", typ)
+
+	return TypeWithLevel{Type: typ, Level: ct.Level}, fmt.Errorf("unsupported compression type/level %q/%q", typ, ct.Level)
 }
 
-// IsZstd returns true if the compression type is zstd.
-// The specified compression level is not validated.
-// Because zstd supports returning an encoder level that closest matches the compression ratio of a specific zstd compression level.
-// Many input values will provide the same compression level.
-func (ct *Type) IsZstd() bool {
-	parts := strings.Split(string(*ct), "/")
-	return parts[0] == string(TypeZstd)
-}
-
-// Compression level isn't supported for snappy.
-func (ct *Type) IsSnappy() bool {
-	parts := strings.Split(string(*ct), "/")
-	if len(parts) > 1 {
-		return false
-	}
-	return parts[0] == string(TypeSnappy)
-}
-
-// IsGzip returns true if the compression type is gzip and the specified compression level is valid.
-func (ct *Type) IsGzip() bool {
-	parts := strings.Split(string(*ct), "/")
-	if parts[0] == string(TypeGzip) {
-		if len(parts) > 1 {
-			levelStr, err := strconv.Atoi(parts[1])
-			if err != nil {
-				return false
-			}
-			if levelStr == zlib.BestSpeed ||
-				levelStr == zlib.BestCompression ||
-				levelStr == zlib.DefaultCompression ||
-				levelStr == zlib.HuffmanOnly ||
-				levelStr == zlib.NoCompression {
-				return true
-			}
-			return false
-		}
-		return true
-	}
-	return false
-}
-
-// IsZlib returns true if the compression type is zlib and the specified compression level is valid.
-func (ct *Type) IsZlib() bool {
-	parts := strings.Split(string(*ct), "/")
-	if parts[0] == string(TypeZlib) || parts[0] == string(TypeDeflate) {
-		if len(parts) > 1 {
-			levelStr, err := strconv.Atoi(parts[1])
-			if err != nil {
-				return false
-			}
-			if levelStr == zlib.BestSpeed ||
-				levelStr == zlib.BestCompression ||
-				levelStr == zlib.DefaultCompression ||
-				levelStr == zlib.HuffmanOnly ||
-				levelStr == zlib.NoCompression {
-				return true
-			}
-			return false
-		}
-		return true
-	}
-	return false
+func isValidLevel(level int) bool {
+	return level == zlib.BestSpeed ||
+		level == zlib.BestCompression ||
+		level == zlib.DefaultCompression ||
+		level == zlib.HuffmanOnly ||
+		level == zlib.NoCompression
 }

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -74,9 +74,9 @@ func (ct *TypeWithLevel) UnmarshalText(in []byte) error {
 
 // Checks the validity of zlib/gzip/flate compression levels
 func isValidLevel(level int) bool {
-	return level == zlib.BestSpeed ||
-		level == zlib.BestCompression ||
-		level == zlib.DefaultCompression ||
+	return level == zlib.DefaultCompression ||
 		level == zlib.HuffmanOnly ||
-		level == zlib.NoCompression
+		level == zlib.NoCompression ||
+		level == zlib.BestSpeed ||
+		(level >= zlib.BestSpeed && level <= zlib.BestCompression)
 }

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -69,7 +69,6 @@ func (ct *TypeWithLevel) UnmarshalText(in []byte) error {
 	}
 
 	return fmt.Errorf("unsupported compression type and level(default if not specified) %s - %d", compressionTyp, ct.Level)
-
 }
 
 // Checks the validity of zlib/gzip/flate compression levels

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -48,9 +48,21 @@ func (ct *Type) UnmarshalText(in []byte) error {
 }
 
 // IsZstd returns true if the compression type is zstd.
+// The specified compression level is not validated.
+// Because zstd supports returning an encoder level that closest matches the compression ratio of a specific zstd compression level.
+// Many input values will provide the same compression level.
 func (ct *Type) IsZstd() bool {
 	parts := strings.Split(string(*ct), "/")
 	return parts[0] == string(TypeZstd)
+}
+
+// Compression level isn't supported for snappy.
+func (ct *Type) IsSnappy() bool {
+	parts := strings.Split(string(*ct), "/")
+	if len(parts) > 1 {
+		return false
+	}
+	return parts[0] == string(TypeSnappy)
 }
 
 // IsGzip returns true if the compression type is gzip and the specified compression level is valid.
@@ -69,6 +81,7 @@ func (ct *Type) IsGzip() bool {
 				levelStr == zlib.NoCompression {
 				return true
 			}
+			return false
 		}
 		return true
 	}
@@ -91,6 +104,7 @@ func (ct *Type) IsZlib() bool {
 				levelStr == zlib.NoCompression {
 				return true
 			}
+			return false
 		}
 		return true
 	}

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -72,6 +72,7 @@ func (ct *TypeWithLevel) UnmarshalText(in []byte) error {
 
 }
 
+// Checks the validity of zlib/gzip/flate compression levels
 func isValidLevel(level int) bool {
 	return level == zlib.BestSpeed ||
 		level == zlib.BestCompression ||

--- a/config/configcompression/compressiontype_test.go
+++ b/config/configcompression/compressiontype_test.go
@@ -84,3 +84,141 @@ func TestUnmarshalText(t *testing.T) {
 		})
 	}
 }
+
+func TestIsZstd(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Type
+		expected bool
+	}{
+		{
+			name:     "ValidZstd",
+			input:    TypeZstd,
+			expected: true,
+		},
+		{
+			name:     "InvalidZstd",
+			input:    TypeGzip,
+			expected: false,
+		},
+		{
+			name:     "ValidZstdLevel",
+			input:    "zstd/11",
+			expected: true,
+		},
+		{
+			name:     "ValidZstdLevel",
+			input:    "zstd/One",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.input.IsZstd())
+		})
+	}
+}
+
+func TestIsGzip(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Type
+		expected bool
+	}{
+		{
+			name:     "ValidGzip",
+			input:    TypeGzip,
+			expected: true,
+		},
+		{
+			name:     "InvalidGzip",
+			input:    TypeZlib,
+			expected: false,
+		},
+		{
+			name:     "ValidZlibCompressionLevel",
+			input:    "gzip/1",
+			expected: true,
+		},
+		{
+			name:     "InvalidZlibCompressionLevel",
+			input:    "gzip/10",
+			expected: false,
+		},
+		{
+			name:     "InvalidZlibCompressionLevel",
+			input:    "gzip/one", // Uses the default compression level
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.input.IsGzip())
+		})
+	}
+}
+
+func TestIsZlib(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Type
+		expected bool
+		err      bool
+	}{
+		{
+			name:     "ValidZlib",
+			input:    TypeZlib,
+			expected: true,
+		},
+		{
+			name:     "InvalidZlib",
+			input:    TypeGzip,
+			expected: false,
+		},
+		{
+			name:     "ValidZlibCompressionLevel",
+			input:    "zlib/1",
+			expected: true,
+		},
+		{
+			name:     "InvalidZlibCompressionLevel",
+			input:    "zlib/10",
+			expected: false,
+		},
+		{
+			name:     "InvalidZlibCompressionLevel",
+			input:    "zlib/one", // Uses the default compression level
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.input.IsZlib())
+		})
+	}
+}
+
+func TestIsSnappy(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Type
+		expected bool
+		err      bool
+	}{
+		{
+			name:     "ValidSnappy",
+			input:    "snappy",
+			expected: true,
+		},
+		{
+			name:     "InvliaSnappy",
+			input:    "snappy/1", // Uses the default compression level
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.input.IsSnappy())
+		})
+	}
+}

--- a/config/configcompression/compressiontype_test.go
+++ b/config/configcompression/compressiontype_test.go
@@ -4,6 +4,7 @@
 package configcompression
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,12 @@ func TestUnmarshalText(t *testing.T) {
 			isCompressed:    true,
 		},
 		{
+			name:            "ValidZstdLevel",
+			compressionName: []byte("zstd/11"),
+			shouldError:     false,
+			isCompressed:    true,
+		},
+		{
 			name:            "ValidEmpty",
 			compressionName: []byte(""),
 			shouldError:     false,
@@ -68,19 +75,47 @@ func TestUnmarshalText(t *testing.T) {
 			compressionName: []byte("ggip"),
 			shouldError:     true,
 		},
+		{
+			name:            "InvalidSnappy",
+			compressionName: []byte("snappy/1"),
+			shouldError:     true,
+		},
+		{
+			name:            "InvalidNone",
+			compressionName: []byte("none/1"),
+			shouldError:     true,
+		},
+		{
+			name:            "InvalidGzip",
+			compressionName: []byte("gzip/10"),
+			shouldError:     true,
+			isCompressed:    true,
+		},
+		{
+			name:            "InvalidZlib",
+			compressionName: []byte("zlib/10"),
+			shouldError:     true,
+			isCompressed:    true,
+		},
+		{
+			name:            "InvalidZstdLevel",
+			compressionName: []byte("zstd/ten"),
+			shouldError:     true,
+			isCompressed:    true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			temp := TypeWithLevel{Type(tt.compressionName), 0}
-			ct, err := temp.UnmarshalText()
+			var temp TypeWithLevel
+			err := temp.UnmarshalText(tt.compressionName)
 			if tt.shouldError {
 				assert.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			// ct := Type(tt.compressionName)
-			assert.Equal(t, temp, ct)
-			assert.Equal(t, tt.isCompressed, ct.Type.IsCompressed())
+			ct := Type(strings.Split(string(tt.compressionName), "/")[0])
+			assert.Equal(t, temp.Type, ct)
+			assert.Equal(t, tt.isCompressed, ct.IsCompressed())
 		})
 	}
 }

--- a/config/configcompression/compressiontype_test.go
+++ b/config/configcompression/compressiontype_test.go
@@ -71,154 +71,16 @@ func TestUnmarshalText(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			temp := typeNone
-			err := temp.UnmarshalText(tt.compressionName)
+			temp := TypeWithLevel{Type(tt.compressionName), 0}
+			ct, err := temp.UnmarshalText()
 			if tt.shouldError {
 				assert.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			ct := Type(tt.compressionName)
+			// ct := Type(tt.compressionName)
 			assert.Equal(t, temp, ct)
-			assert.Equal(t, tt.isCompressed, ct.IsCompressed())
-		})
-	}
-}
-
-func TestIsZstd(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    Type
-		expected bool
-	}{
-		{
-			name:     "ValidZstd",
-			input:    TypeZstd,
-			expected: true,
-		},
-		{
-			name:     "InvalidZstd",
-			input:    TypeGzip,
-			expected: false,
-		},
-		{
-			name:     "ValidZstdLevel",
-			input:    "zstd/11",
-			expected: true,
-		},
-		{
-			name:     "ValidZstdLevel",
-			input:    "zstd/One",
-			expected: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.IsZstd())
-		})
-	}
-}
-
-func TestIsGzip(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    Type
-		expected bool
-	}{
-		{
-			name:     "ValidGzip",
-			input:    TypeGzip,
-			expected: true,
-		},
-		{
-			name:     "InvalidGzip",
-			input:    TypeZlib,
-			expected: false,
-		},
-		{
-			name:     "ValidZlibCompressionLevel",
-			input:    "gzip/1",
-			expected: true,
-		},
-		{
-			name:     "InvalidZlibCompressionLevel",
-			input:    "gzip/10",
-			expected: false,
-		},
-		{
-			name:     "InvalidZlibCompressionLevel",
-			input:    "gzip/one", // Uses the default compression level
-			expected: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.IsGzip())
-		})
-	}
-}
-
-func TestIsZlib(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    Type
-		expected bool
-		err      bool
-	}{
-		{
-			name:     "ValidZlib",
-			input:    TypeZlib,
-			expected: true,
-		},
-		{
-			name:     "InvalidZlib",
-			input:    TypeGzip,
-			expected: false,
-		},
-		{
-			name:     "ValidZlibCompressionLevel",
-			input:    "zlib/1",
-			expected: true,
-		},
-		{
-			name:     "InvalidZlibCompressionLevel",
-			input:    "zlib/10",
-			expected: false,
-		},
-		{
-			name:     "InvalidZlibCompressionLevel",
-			input:    "zlib/one", // Uses the default compression level
-			expected: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.IsZlib())
-		})
-	}
-}
-
-func TestIsSnappy(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    Type
-		expected bool
-		err      bool
-	}{
-		{
-			name:     "ValidSnappy",
-			input:    "snappy",
-			expected: true,
-		},
-		{
-			name:     "InvliaSnappy",
-			input:    "snappy/1", // Uses the default compression level
-			expected: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.IsSnappy())
+			assert.Equal(t, tt.isCompressed, ct.Type.IsCompressed())
 		})
 	}
 }

--- a/config/configcompression/compressiontype_test.go
+++ b/config/configcompression/compressiontype_test.go
@@ -4,7 +4,6 @@
 package configcompression
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,12 +48,6 @@ func TestUnmarshalText(t *testing.T) {
 			isCompressed:    true,
 		},
 		{
-			name:            "ValidZstdLevel",
-			compressionName: []byte("zstd/11"),
-			shouldError:     false,
-			isCompressed:    true,
-		},
-		{
 			name:            "ValidEmpty",
 			compressionName: []byte(""),
 			shouldError:     false,
@@ -75,34 +68,6 @@ func TestUnmarshalText(t *testing.T) {
 			compressionName: []byte("ggip"),
 			shouldError:     true,
 		},
-		{
-			name:            "InvalidSnappy",
-			compressionName: []byte("snappy/1"),
-			shouldError:     true,
-		},
-		{
-			name:            "InvalidNone",
-			compressionName: []byte("none/1"),
-			shouldError:     true,
-		},
-		{
-			name:            "InvalidGzip",
-			compressionName: []byte("gzip/10"),
-			shouldError:     true,
-			isCompressed:    true,
-		},
-		{
-			name:            "InvalidZlib",
-			compressionName: []byte("zlib/10"),
-			shouldError:     true,
-			isCompressed:    true,
-		},
-		{
-			name:            "InvalidZstdLevel",
-			compressionName: []byte("zstd/ten"),
-			shouldError:     true,
-			isCompressed:    true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -113,7 +78,7 @@ func TestUnmarshalText(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			ct := Type(strings.Split(string(tt.compressionName), "/")[0])
+			ct := Type(tt.compressionName)
 			assert.Equal(t, temp.Type, ct)
 			assert.Equal(t, tt.isCompressed, ct.IsCompressed())
 		})

--- a/config/configcompression/go.mod
+++ b/config/configcompression/go.mod
@@ -3,6 +3,7 @@ module go.opentelemetry.io/collector/config/configcompression
 go 1.22.0
 
 require (
+	github.com/klauspost/compress v1.17.9
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
 )

--- a/config/configcompression/go.sum
+++ b/config/configcompression/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -28,27 +28,27 @@ README](../configtls/README.md).
   - `none` will be treated as uncompressed, and any other inputs will cause an error.
   - Compression levels can now be configured as part of the compression type like below. Not specifying any compression level will result in the default.
     - `gzip`
-      - NoCompression: `0`
-      - BestSpeed: `1`
-      - BestCompression: `9`
-      - DefaultCompression: `-1`
+      - NoCompression: `gzip/0`
+      - BestSpeed: `gzip/1`
+      - BestCompression: `gzip/9`
+      - DefaultCompression: `gzip/-1`
     - `zlib`
-      - NoCompression: `0`
-      - BestSpeed: `1`
-      - BestCompression: `9`
-      - DefaultCompression: `-1`
+      - NoCompression: `zlib/0`
+      - BestSpeed: `zlib/1`
+      - BestCompression: `zlib/9`
+      - DefaultCompression: `zlib/-1`
     - `deflate`
-      - NoCompression: `0`
-      - BestSpeed: `1`
-      - BestCompression: `9`
-      - DefaultCompression: `-1`
+      - NoCompression: `deflate/0`
+      - BestSpeed: `deflate/1`
+      - BestCompression: `deflate/9`
+      - DefaultCompression: `deflate/-1`
     - `zstd`
-      - SpeedFastest: `1`
-      - SpeedDefault: `3`
-      - SpeedBetterCompression: `6`
-      - SpeedBestCompression: `11`
+      - SpeedFastest: `zstd/1`
+      - SpeedDefault: `zstd/3`
+      - SpeedBetterCompression: `zstd/6`
+      - SpeedBestCompression: `zstd/11`
     - `snappy`
-      No compression levels supported
+      No compression levels supported yet
 - [`max_idle_conns`](https://golang.org/pkg/net/http/#Transport)
 - [`max_idle_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
 - [`max_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
@@ -75,9 +75,7 @@ exporter:
     headers:
       test1: "value1"
       "test 2": "value 2"
-    compression: 
-      type: zstd
-      level: 11
+    compression: zstd
     cookies:
       enabled: true
 ```

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -28,25 +28,27 @@ README](../configtls/README.md).
   - `none` will be treated as uncompressed, and any other inputs will cause an error.
   - Compression levels can now be configured as part of the compression type like below. Not specifying any compression level will result in the default.
     - `gzip`
-      - NoCompression: `gzip/0`
-      - BestSpeed: `gzip/1`
-      - BestCompression: `gzip/9`
-      - DefaultCompression: `gzip/-1`
+      - NoCompression: `0`
+      - BestSpeed: `1`
+      - BestCompression: `9`
+      - DefaultCompression: `-1`
     - `zlib`
-      - NoCompression: `zlib/0`
-      - BestSpeed: `zlib/1`
-      - BestCompression: `zlib/9`
-      - DefaultCompression: `zlib/-1`
+      - NoCompression: `0`
+      - BestSpeed: `1`
+      - BestCompression: `9`
+      - DefaultCompression: `-1`
     - `deflate`
-      - NoCompression: `deflate/0`
-      - BestSpeed: `deflate/1`
-      - BestCompression: `deflate/9`
-      - DefaultCompression: `deflate/-1`
+      - NoCompression: `0`
+      - BestSpeed: `1`
+      - BestCompression: `9`
+      - DefaultCompression: `-1`
     - `zstd`
-      - SpeedFastest: `zstd/1`
-      - SpeedDefault: `zstd/3`
-      - SpeedBetterCompression: `zstd/6`
-      - SpeedBestCompression: `zstd/11`
+      - SpeedFastest: `1`
+      - SpeedDefault: `3`
+      - SpeedBetterCompression: `6`
+      - SpeedBestCompression: `11`
+    - `snappy`
+      No compression levels supported
 - [`max_idle_conns`](https://golang.org/pkg/net/http/#Transport)
 - [`max_idle_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
 - [`max_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
@@ -73,7 +75,9 @@ exporter:
     headers:
       test1: "value1"
       "test 2": "value 2"
-    compression: zstd
+    compression: 
+      type: zstd
+      level: 11
     cookies:
       enabled: true
 ```

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -26,6 +26,27 @@ README](../configtls/README.md).
 - `compression`: Compression type to use among `gzip`, `zstd`, `snappy`, `zlib`, `deflate`, and `lz4`.
   - look at the documentation for the server-side of the communication.
   - `none` will be treated as uncompressed, and any other inputs will cause an error.
+  - Compression levels can now be configured as part of the compression type like below. Not specifying any compression level will result in the default.
+    - `gzip`
+      - NoCompression: `gzip/0`
+      - BestSpeed: `gzip/1`
+      - BestCompression: `gzip/9`
+      - DefaultCompression: `gzip/-1`
+    - `zlib`
+      - NoCompression: `zlib/0`
+      - BestSpeed: `zlib/1`
+      - BestCompression: `zlib/9`
+      - DefaultCompression: `zlib/-1`
+    - `deflate`
+      - NoCompression: `deflate/0`
+      - BestSpeed: `deflate/1`
+      - BestCompression: `deflate/9`
+      - DefaultCompression: `deflate/-1`
+    - `zstd`
+      - SpeedFastest: `zstd/1`
+      - SpeedDefault: `zstd/3`
+      - SpeedBetterCompression: `zstd/6`
+      - SpeedBestCompression: `zstd/11`
 - [`max_idle_conns`](https://golang.org/pkg/net/http/#Transport)
 - [`max_idle_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
 - [`max_conns_per_host`](https://golang.org/pkg/net/http/#Transport)

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -31,17 +31,17 @@ README](../configtls/README.md).
       - NoCompression: `gzip/0`
       - BestSpeed: `gzip/1`
       - BestCompression: `gzip/9`
-      - DefaultCompression: `gzip/-1`
+      - DefaultCompression: `gzip`
     - `zlib`
       - NoCompression: `zlib/0`
       - BestSpeed: `zlib/1`
       - BestCompression: `zlib/9`
-      - DefaultCompression: `zlib/-1`
+      - DefaultCompression: `zlib`
     - `deflate`
       - NoCompression: `deflate/0`
       - BestSpeed: `deflate/1`
       - BestCompression: `deflate/9`
-      - DefaultCompression: `deflate/-1`
+      - DefaultCompression: `deflate`
     - `zstd`
       - SpeedFastest: `zstd/1`
       - SpeedDefault: `zstd/3`

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -26,11 +26,6 @@ type compressRoundTripper struct {
 	compressor      *compressor
 }
 
-type CompressionOptions struct {
-	compressionType  configcompression.Type
-	compressionLevel int
-}
-
 var availableDecoders = map[string]func(body io.ReadCloser) (io.ReadCloser, error){
 	"": func(io.ReadCloser) (io.ReadCloser, error) {
 		// Not a compressed payload. Nothing to do.
@@ -81,14 +76,14 @@ var availableDecoders = map[string]func(body io.ReadCloser) (io.ReadCloser, erro
 	},
 }
 
-func newCompressRoundTripper(rt http.RoundTripper, compressionopts CompressionOptions) (*compressRoundTripper, error) {
-	encoder, err := newCompressor(compressionopts)
+func newCompressRoundTripper(rt http.RoundTripper, compressionType configcompression.Type) (*compressRoundTripper, error) {
+	encoder, err := newCompressor(compressionType)
 	if err != nil {
 		return nil, err
 	}
 	return &compressRoundTripper{
 		rt:              rt,
-		compressionType: compressionopts.compressionType,
+		compressionType: compressionType,
 		compressor:      encoder,
 	}, nil
 }

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -22,7 +22,7 @@ import (
 
 type compressRoundTripper struct {
 	rt              http.RoundTripper
-	compressionType configcompression.Type
+	compressionType configcompression.TypeWithLevel
 	compressor      *compressor
 }
 
@@ -76,7 +76,7 @@ var availableDecoders = map[string]func(body io.ReadCloser) (io.ReadCloser, erro
 	},
 }
 
-func newCompressRoundTripper(rt http.RoundTripper, compressionType configcompression.Type) (*compressRoundTripper, error) {
+func newCompressRoundTripper(rt http.RoundTripper, compressionType configcompression.TypeWithLevel) (*compressRoundTripper, error) {
 	encoder, err := newCompressor(compressionType)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func (r *compressRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 
 	// Clone the headers and add the encoding header.
 	cReq.Header = req.Header.Clone()
-	cReq.Header.Add(headerContentEncoding, string(r.compressionType))
+	cReq.Header.Add(headerContentEncoding, string(r.compressionType.Type))
 
 	return r.rt.RoundTrip(cReq)
 }

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -26,6 +26,11 @@ type compressRoundTripper struct {
 	compressor      *compressor
 }
 
+type CompressionOptions struct {
+	compressionType  configcompression.Type
+	compressionLevel int
+}
+
 var availableDecoders = map[string]func(body io.ReadCloser) (io.ReadCloser, error){
 	"": func(io.ReadCloser) (io.ReadCloser, error) {
 		// Not a compressed payload. Nothing to do.
@@ -76,14 +81,14 @@ var availableDecoders = map[string]func(body io.ReadCloser) (io.ReadCloser, erro
 	},
 }
 
-func newCompressRoundTripper(rt http.RoundTripper, compressionType configcompression.Type) (*compressRoundTripper, error) {
-	encoder, err := newCompressor(compressionType)
+func newCompressRoundTripper(rt http.RoundTripper, compressionopts CompressionOptions) (*compressRoundTripper, error) {
+	encoder, err := newCompressor(compressionopts)
 	if err != nil {
 		return nil, err
 	}
 	return &compressRoundTripper{
 		rt:              rt,
-		compressionType: compressionType,
+		compressionType: compressionopts.compressionType,
 		compressor:      encoder,
 	}, nil
 }

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -117,12 +117,12 @@ func TestHTTPClientCompression(t *testing.T) {
 				Compression: tt.encoding,
 			}
 			client, err := clientSettings.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
-			require.NoError(t, err)
-			res, err := client.Do(req)
 			if tt.shouldError {
 				assert.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
+			res, err := client.Do(req)
 			require.NoError(t, err)
 
 			_, err = io.ReadAll(res.Body)
@@ -309,8 +309,9 @@ func TestHTTPContentCompressionRequestWithNilBody(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
 	require.NoError(t, err, "failed to create request to test handler")
 
-	client := srv.Client()
-	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, configcompression.TypeGzip)
+	client := http.Client{}
+	// compression := CompressionOptions{configcompression.TypeGzip, gzip.BestSpeed}
+	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, "gzip/1")
 	require.NoError(t, err)
 	res, err := client.Do(req)
 	require.NoError(t, err)

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -111,10 +111,10 @@ func TestHTTPClientCompression(t *testing.T) {
 
 			req, err := http.NewRequest(http.MethodGet, srv.URL, reqBody)
 			require.NoError(t, err, "failed to create request to test handler")
-
+			compression := configcompression.TypeWithLevel{Type: tt.encoding, Level: gzip.BestSpeed}
 			clientSettings := ClientConfig{
 				Endpoint:    srv.URL,
-				Compression: tt.encoding,
+				Compression: compression,
 			}
 			client, err := clientSettings.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			if tt.shouldError {

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -35,51 +35,58 @@ func TestHTTPClientCompression(t *testing.T) {
 	compressedZstdBody := compressZstd(t, testBody)
 	compressedLz4Body := compressLz4(t, testBody)
 
+	const (
+		GzipLevel    configcompression.Type = "gzip/1"
+		ZlibLevel    configcompression.Type = "zlib/1"
+		DeflateLevel configcompression.Type = "deflate/1"
+		ZstdLevel    configcompression.Type = "zstd/11"
+	)
+
 	tests := []struct {
 		name        string
-		encoding    configcompression.TypeWithLevel
+		encoding    configcompression.Type
 		reqBody     []byte
 		shouldError bool
 	}{
 		{
 			name:        "ValidEmpty",
-			encoding:    configcompression.TypeWithLevel{Type: configcompression.Type(""), Level: 0},
+			encoding:    "",
 			reqBody:     testBody,
 			shouldError: false,
 		},
 		{
 			name:        "ValidNone",
-			encoding:    configcompression.TypeWithLevel{Type: configcompression.Type("none"), Level: 0},
+			encoding:    "none",
 			reqBody:     testBody,
 			shouldError: false,
 		},
 		{
 			name:        "ValidGzip",
-			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeGzip, Level: gzip.BestSpeed},
+			encoding:    GzipLevel,
 			reqBody:     compressedGzipBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidZlib",
-			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeZlib, Level: zlib.BestSpeed},
+			encoding:    ZlibLevel,
 			reqBody:     compressedZlibBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidDeflate",
-			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeDeflate, Level: zlib.BestSpeed},
+			encoding:    DeflateLevel,
 			reqBody:     compressedDeflateBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidSnappy",
-			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeSnappy, Level: 0},
+			encoding:    configcompression.TypeSnappy,
 			reqBody:     compressedSnappyBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidZstd",
-			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeZstd, Level: 11},
+			encoding:    ZstdLevel,
 			reqBody:     compressedZstdBody.Bytes(),
 			shouldError: false,
 		},
@@ -303,7 +310,7 @@ func TestHTTPContentCompressionRequestWithNilBody(t *testing.T) {
 	require.NoError(t, err, "failed to create request to test handler")
 
 	client := http.Client{}
-	compression := configcompression.TypeWithLevel{configcompression.TypeGzip, gzip.BestSpeed}
+	compression := configcompression.TypeWithLevel{Type: configcompression.TypeGzip, Level: gzip.BestSpeed}
 	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, compression)
 	require.NoError(t, err)
 	res, err := client.Do(req)
@@ -324,7 +331,7 @@ func TestHTTPContentCompressionCopyError(t *testing.T) {
 	require.NoError(t, err)
 
 	client := srv.Client()
-	compression := configcompression.TypeWithLevel{configcompression.TypeGzip, zlib.DefaultCompression}
+	compression := configcompression.TypeWithLevel{Type: configcompression.TypeGzip, Level: zlib.DefaultCompression}
 	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, compression)
 	require.NoError(t, err)
 	_, err = client.Do(req)
@@ -349,7 +356,7 @@ func TestHTTPContentCompressionRequestBodyCloseError(t *testing.T) {
 	require.NoError(t, err)
 
 	client := srv.Client()
-	compression := configcompression.TypeWithLevel{configcompression.TypeGzip, zlib.DefaultCompression}
+	compression := configcompression.TypeWithLevel{Type: configcompression.TypeGzip, Level: zlib.DefaultCompression}
 	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, compression)
 	require.NoError(t, err)
 	_, err = client.Do(req)

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -35,6 +35,13 @@ func TestHTTPClientCompression(t *testing.T) {
 	compressedZstdBody := compressZstd(t, testBody)
 	compressedLz4Body := compressLz4(t, testBody)
 
+	const (
+		GzipLevel    configcompression.Type = "gzip/1"
+		ZlibLevel    configcompression.Type = "zlib/1"
+		DeflateLevel configcompression.Type = "deflate/1"
+		ZstdLevel    configcompression.Type = "zstd/11"
+	)
+
 	tests := []struct {
 		name        string
 		encoding    configcompression.Type
@@ -55,19 +62,19 @@ func TestHTTPClientCompression(t *testing.T) {
 		},
 		{
 			name:        "ValidGzip",
-			encoding:    configcompression.TypeGzip,
+			encoding:    GzipLevel,
 			reqBody:     compressedGzipBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidZlib",
-			encoding:    configcompression.TypeZlib,
+			encoding:    ZlibLevel,
 			reqBody:     compressedZlibBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidDeflate",
-			encoding:    configcompression.TypeDeflate,
+			encoding:    DeflateLevel,
 			reqBody:     compressedDeflateBody.Bytes(),
 			shouldError: false,
 		},
@@ -79,7 +86,7 @@ func TestHTTPClientCompression(t *testing.T) {
 		},
 		{
 			name:        "ValidZstd",
-			encoding:    configcompression.TypeZstd,
+			encoding:    ZstdLevel,
 			reqBody:     compressedZstdBody.Bytes(),
 			shouldError: false,
 		},
@@ -448,7 +455,7 @@ func TestDecompressorAvoidDecompressionBomb(t *testing.T) {
 
 func compressGzip(t testing.TB, body []byte) *bytes.Buffer {
 	var buf bytes.Buffer
-	gw := gzip.NewWriter(&buf)
+	gw, _ := gzip.NewWriterLevel(&buf, gzip.BestSpeed)
 	_, err := gw.Write(body)
 	require.NoError(t, err)
 	require.NoError(t, gw.Close())
@@ -457,7 +464,7 @@ func compressGzip(t testing.TB, body []byte) *bytes.Buffer {
 
 func compressZlib(t testing.TB, body []byte) *bytes.Buffer {
 	var buf bytes.Buffer
-	zw := zlib.NewWriter(&buf)
+	zw, _ := zlib.NewWriterLevel(&buf, zlib.BestSpeed)
 	_, err := zw.Write(body)
 	require.NoError(t, err)
 	require.NoError(t, zw.Close())
@@ -475,7 +482,9 @@ func compressSnappy(t testing.TB, body []byte) *bytes.Buffer {
 
 func compressZstd(t testing.TB, body []byte) *bytes.Buffer {
 	var buf bytes.Buffer
-	zw, _ := zstd.NewWriter(&buf)
+	compression := zstd.SpeedFastest
+	encoderLevel := zstd.WithEncoderLevel(compression)
+	zw, _ := zstd.NewWriter(&buf, encoderLevel)
 	_, err := zw.Write(body)
 	require.NoError(t, err)
 	require.NoError(t, zw.Close())

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -42,6 +42,7 @@ func TestHTTPClientCompression(t *testing.T) {
 		DeflateLevel configcompression.Type = "deflate/1"
 		ZstdLevel    configcompression.Type = "zstd/11"
 	)
+	var level int
 
 	tests := []struct {
 		name        string
@@ -116,7 +117,7 @@ func TestHTTPClientCompression(t *testing.T) {
 			compressionLevel := configcompression.Level(gzip.BestSpeed)
 			compressionType := configcompression.Type(parts[0])
 			if len(parts) == 2 {
-				level, err := strconv.Atoi(parts[1])
+				level, err = strconv.Atoi(parts[1])
 				require.NoError(t, err)
 				compressionLevel = configcompression.Level(level)
 			}

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -111,7 +112,15 @@ func TestHTTPClientCompression(t *testing.T) {
 
 			req, err := http.NewRequest(http.MethodGet, srv.URL, reqBody)
 			require.NoError(t, err, "failed to create request to test handler")
-			compression := configcompression.TypeWithLevel{Type: tt.encoding, Level: gzip.BestSpeed}
+			parts := strings.Split(string(tt.encoding), "/")
+			compressionLevel := configcompression.Level(gzip.BestSpeed)
+			compressionType := configcompression.Type(parts[0])
+			if len(parts) == 2 {
+				level, err := strconv.Atoi(parts[1])
+				require.NoError(t, err)
+				compressionLevel = configcompression.Level(level)
+			}
+			compression := configcompression.TypeWithLevel{Type: compressionType, Level: compressionLevel}
 			clientSettings := ClientConfig{
 				Endpoint:    srv.URL,
 				Compression: compression,

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -35,58 +35,51 @@ func TestHTTPClientCompression(t *testing.T) {
 	compressedZstdBody := compressZstd(t, testBody)
 	compressedLz4Body := compressLz4(t, testBody)
 
-	const (
-		GzipLevel    configcompression.Type = "gzip/1"
-		ZlibLevel    configcompression.Type = "zlib/1"
-		DeflateLevel configcompression.Type = "deflate/1"
-		ZstdLevel    configcompression.Type = "zstd/11"
-	)
-
 	tests := []struct {
 		name        string
-		encoding    configcompression.Type
+		encoding    configcompression.TypeWithLevel
 		reqBody     []byte
 		shouldError bool
 	}{
 		{
 			name:        "ValidEmpty",
-			encoding:    "",
+			encoding:    configcompression.TypeWithLevel{Type: configcompression.Type(""), Level: 0},
 			reqBody:     testBody,
 			shouldError: false,
 		},
 		{
 			name:        "ValidNone",
-			encoding:    "none",
+			encoding:    configcompression.TypeWithLevel{Type: configcompression.Type("none"), Level: 0},
 			reqBody:     testBody,
 			shouldError: false,
 		},
 		{
 			name:        "ValidGzip",
-			encoding:    GzipLevel,
+			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeGzip, Level: gzip.BestSpeed},
 			reqBody:     compressedGzipBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidZlib",
-			encoding:    ZlibLevel,
+			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeZlib, Level: zlib.BestSpeed},
 			reqBody:     compressedZlibBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidDeflate",
-			encoding:    DeflateLevel,
+			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeDeflate, Level: zlib.BestSpeed},
 			reqBody:     compressedDeflateBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidSnappy",
-			encoding:    configcompression.TypeSnappy,
+			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeSnappy, Level: 0},
 			reqBody:     compressedSnappyBody.Bytes(),
 			shouldError: false,
 		},
 		{
 			name:        "ValidZstd",
-			encoding:    ZstdLevel,
+			encoding:    configcompression.TypeWithLevel{Type: configcompression.TypeZstd, Level: 11},
 			reqBody:     compressedZstdBody.Bytes(),
 			shouldError: false,
 		},
@@ -310,8 +303,8 @@ func TestHTTPContentCompressionRequestWithNilBody(t *testing.T) {
 	require.NoError(t, err, "failed to create request to test handler")
 
 	client := http.Client{}
-	// compression := CompressionOptions{configcompression.TypeGzip, gzip.BestSpeed}
-	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, "gzip/1")
+	compression := configcompression.TypeWithLevel{configcompression.TypeGzip, gzip.BestSpeed}
+	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, compression)
 	require.NoError(t, err)
 	res, err := client.Do(req)
 	require.NoError(t, err)
@@ -331,7 +324,8 @@ func TestHTTPContentCompressionCopyError(t *testing.T) {
 	require.NoError(t, err)
 
 	client := srv.Client()
-	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, configcompression.TypeGzip)
+	compression := configcompression.TypeWithLevel{configcompression.TypeGzip, zlib.DefaultCompression}
+	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, compression)
 	require.NoError(t, err)
 	_, err = client.Do(req)
 	require.Error(t, err)
@@ -355,7 +349,8 @@ func TestHTTPContentCompressionRequestBodyCloseError(t *testing.T) {
 	require.NoError(t, err)
 
 	client := srv.Client()
-	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, configcompression.TypeGzip)
+	compression := configcompression.TypeWithLevel{configcompression.TypeGzip, zlib.DefaultCompression}
+	client.Transport, err = newCompressRoundTripper(http.DefaultTransport, compression)
 	require.NoError(t, err)
 	_, err = client.Do(req)
 	require.Error(t, err)

--- a/config/confighttp/compressor.go
+++ b/config/confighttp/compressor.go
@@ -9,6 +9,8 @@ import (
 	"compress/zlib"
 	"errors"
 	"io"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/golang/snappy"
@@ -26,24 +28,41 @@ type compressor struct {
 	pool sync.Pool
 }
 
+// Gets the compression type and level from the configuration.
+func getCompression(compressionField configcompression.Type) (compressionType configcompression.Type, compressionLevel int) {
+	parts := strings.Split(string(compressionField), "/")
+
+	compressionLevel = zlib.DefaultCompression
+	compressionType = configcompression.Type(parts[0])
+	if len(parts) > 1 {
+		levelStr := parts[1]
+		if level, err := strconv.Atoi(levelStr); err == nil {
+			compressionLevel = level
+		}
+	}
+	return compressionType, compressionLevel
+}
+
 // writerFactory defines writer field in CompressRoundTripper.
 // The validity of input is already checked when NewCompressRoundTripper was called in confighttp,
-func newCompressor(compressionopts CompressionOptions) (*compressor, error) {
-	switch compressionopts.compressionType {
+func newCompressor(compressionType configcompression.Type) (*compressor, error) {
+	compressionType, compressionLevel := getCompression(compressionType)
+
+	switch compressionType {
 	case configcompression.TypeGzip:
 		var _ writeCloserReset = (*gzip.Writer)(nil)
-		return &compressor{pool: sync.Pool{New: func() any { w, _ := gzip.NewWriterLevel(nil, compressionopts.compressionLevel); return w }}}, nil
+		return &compressor{pool: sync.Pool{New: func() any { w, _ := gzip.NewWriterLevel(nil, compressionLevel); return w }}}, nil
 	case configcompression.TypeSnappy:
 		var _ writeCloserReset = (*snappy.Writer)(nil)
 		return &compressor{pool: sync.Pool{New: func() any { return snappy.NewBufferedWriter(nil) }}}, nil
 	case configcompression.TypeZstd:
 		var _ writeCloserReset = (*zstd.Encoder)(nil)
-		compression := zstd.EncoderLevelFromZstd(compressionopts.compressionLevel)
+		compression := zstd.EncoderLevelFromZstd(compressionLevel)
 		encoderLevel := zstd.WithEncoderLevel(compression)
 		return &compressor{pool: sync.Pool{New: func() any { zw, _ := zstd.NewWriter(nil, zstd.WithEncoderConcurrency(1), encoderLevel); return zw }}}, nil
 	case configcompression.TypeZlib, configcompression.TypeDeflate:
 		var _ writeCloserReset = (*zlib.Writer)(nil)
-		return &compressor{pool: sync.Pool{New: func() any { w, _ := zlib.NewWriterLevel(nil, compressionopts.compressionLevel); return w }}}, nil
+		return &compressor{pool: sync.Pool{New: func() any { w, _ := zlib.NewWriterLevel(nil, compressionLevel); return w }}}, nil
 	}
 	return nil, errors.New("unsupported compression type")
 }

--- a/config/confighttp/compressor.go
+++ b/config/confighttp/compressor.go
@@ -55,11 +55,6 @@ func newCompressor(compressionType configcompression.TypeWithLevel) (*compressor
 	case configcompression.TypeGzip:
 		gZipCompressor, exists = compressorPools.pools[mapKey]
 		if exists {
-			if gZipCompressor.pool.Get() == nil {
-				gZipCompressor.pool = sync.Pool{New: func() any { w, _ := gzip.NewWriterLevel(nil, int(compressionType.Level)); return w }}
-				compressorPools.pools[mapKey] = gZipCompressor
-				return gZipCompressor, nil
-			}
 			return gZipCompressor, nil
 		}
 		gZipCompressor = &compressor{}
@@ -77,11 +72,6 @@ func newCompressor(compressionType configcompression.TypeWithLevel) (*compressor
 		compression := zstd.EncoderLevelFromZstd(int(compressionType.Level))
 		encoderLevel := zstd.WithEncoderLevel(compression)
 		if exists {
-			if zstdCompressor.pool.Get() == nil {
-
-				zstdCompressor.pool = sync.Pool{New: func() any { zw, _ := zstd.NewWriter(nil, zstd.WithEncoderConcurrency(1), encoderLevel); return zw }}
-				return zstdCompressor, nil
-			}
 			return zstdCompressor, nil
 		}
 		zstdCompressor = &compressor{}
@@ -90,10 +80,6 @@ func newCompressor(compressionType configcompression.TypeWithLevel) (*compressor
 	case configcompression.TypeZlib, configcompression.TypeDeflate:
 		zlibCompressor, exists = compressorPools.pools[mapKey]
 		if exists {
-			if zlibCompressor.pool.Get() == nil {
-				zlibCompressor.pool = sync.Pool{New: func() any { w, _ := zlib.NewWriterLevel(nil, int(compressionType.Level)); return w }}
-				return zlibCompressor, nil
-			}
 			return zlibCompressor, nil
 		}
 		zlibCompressor = &compressor{}

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -4,7 +4,6 @@
 package confighttp // import "go.opentelemetry.io/collector/config/confighttp"
 
 import (
-	"compress/zlib"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -14,8 +13,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/rs/cors"
@@ -72,7 +69,7 @@ type ClientConfig struct {
 	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// The compression key for supported compression types within collector.
-	Compression configcompression.TypeWithLevel `mapstructure:"compression"`
+	Compression configcompression.Type `mapstructure:"compression"`
 
 	// MaxIdleConns is used to set a limit to the maximum idle HTTP connections the client can keep open.
 	// By default, it is set to 100.
@@ -135,21 +132,6 @@ func NewDefaultClientConfig() ClientConfig {
 		MaxConnsPerHost:     &defaultTransport.MaxConnsPerHost,
 		IdleConnTimeout:     &defaultTransport.IdleConnTimeout,
 	}
-}
-
-// Gets the compression type and level from the configuration.
-func getCompression(compressionField configcompression.Type) (compressionType configcompression.Type, compressionLevel configcompression.Level) {
-	parts := strings.Split(string(compressionField), "/")
-
-	compressionLevel = zlib.DefaultCompression
-	compressionType = configcompression.Type(parts[0])
-	if len(parts) > 1 {
-		levelStr := parts[1]
-		if level, err := strconv.Atoi(levelStr); err == nil {
-			compressionLevel = configcompression.Level(level)
-		}
-	}
-	return compressionType, compressionLevel
 }
 
 // ToClient creates an HTTP client.
@@ -236,13 +218,12 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 
 	// Compress the body using specified compression methods if non-empty string is provided.
 	// Supporting gzip, zlib, deflate, snappy, and zstd; none is treated as uncompressed.
-	// compressionType, compressionLevel := getCompression(hcs.Compression.Type)
-	// compressionTypeWithLevel := configcompression.TypeWithLevel{compressionType, compressionLevel}
-	compressionTypeWithLevel, err := hcs.Compression.UnmarshalText()
+	var compressionTypeWithLevel configcompression.TypeWithLevel
+	err = compressionTypeWithLevel.UnmarshalText([]byte(hcs.Compression))
 	if err != nil {
 		return nil, err
 	}
-	if hcs.Compression.Type.IsCompressed() {
+	if hcs.Compression.IsCompressed() {
 		clientTransport, err = newCompressRoundTripper(clientTransport, compressionTypeWithLevel)
 		if err != nil {
 			return nil, err

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rs/cors"
@@ -134,6 +136,21 @@ func NewDefaultClientConfig() ClientConfig {
 	}
 }
 
+func setCompression(compressionField configcompression.Type) (compressionType configcompression.Type, compressionLevel int) {
+	parts := strings.Split(string(compressionField), "/")
+
+	// Set compression type
+	compressionLevel = 1
+	compressionType = configcompression.Type(parts[0])
+	if len(parts) > 1 {
+		levelStr := parts[1]
+		if level, err := strconv.Atoi(levelStr); err == nil {
+			compressionLevel = level
+		}
+	}
+	return compressionType, compressionLevel
+}
+
 // ToClient creates an HTTP client.
 func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
 	tlsCfg, err := hcs.TLSSetting.LoadTLSConfig(ctx)
@@ -219,9 +236,20 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 	// Compress the body using specified compression methods if non-empty string is provided.
 	// Supporting gzip, zlib, deflate, snappy, and zstd; none is treated as uncompressed.
 	if hcs.Compression.IsCompressed() {
-		clientTransport, err = newCompressRoundTripper(clientTransport, hcs.Compression)
-		if err != nil {
-			return nil, err
+		if hcs.Compression.IsZstd() || hcs.Compression.IsGzip() || hcs.Compression.IsZlib() {
+			compressionType, compressionLevel := setCompression(hcs.Compression)
+			compression := CompressionOptions{compressionType, compressionLevel}
+			clientTransport, err = newCompressRoundTripper(clientTransport, compression)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			// Use the default if the compression level is not specified.
+			compressionopts := CompressionOptions{hcs.Compression, -1}
+			clientTransport, err = newCompressRoundTripper(clientTransport, compressionopts)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -13,8 +13,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/rs/cors"
@@ -136,21 +134,6 @@ func NewDefaultClientConfig() ClientConfig {
 	}
 }
 
-func setCompression(compressionField configcompression.Type) (compressionType configcompression.Type, compressionLevel int) {
-	parts := strings.Split(string(compressionField), "/")
-
-	// Set compression type
-	compressionLevel = 1
-	compressionType = configcompression.Type(parts[0])
-	if len(parts) > 1 {
-		levelStr := parts[1]
-		if level, err := strconv.Atoi(levelStr); err == nil {
-			compressionLevel = level
-		}
-	}
-	return compressionType, compressionLevel
-}
-
 // ToClient creates an HTTP client.
 func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
 	tlsCfg, err := hcs.TLSSetting.LoadTLSConfig(ctx)
@@ -236,17 +219,8 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 	// Compress the body using specified compression methods if non-empty string is provided.
 	// Supporting gzip, zlib, deflate, snappy, and zstd; none is treated as uncompressed.
 	if hcs.Compression.IsCompressed() {
-		if hcs.Compression.IsZstd() || hcs.Compression.IsGzip() || hcs.Compression.IsZlib() {
-			compressionType, compressionLevel := setCompression(hcs.Compression)
-			compression := CompressionOptions{compressionType, compressionLevel}
-			clientTransport, err = newCompressRoundTripper(clientTransport, compression)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			// Use the default if the compression level is not specified.
-			compressionopts := CompressionOptions{hcs.Compression, -1}
-			clientTransport, err = newCompressRoundTripper(clientTransport, compressionopts)
+		if hcs.Compression.IsZstd() || hcs.Compression.IsGzip() || hcs.Compression.IsZlib() || hcs.Compression.IsSnappy() {
+			clientTransport, err = newCompressRoundTripper(clientTransport, hcs.Compression)
 			if err != nil {
 				return nil, err
 			}

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -69,7 +69,7 @@ type ClientConfig struct {
 	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// The compression key for supported compression types within collector.
-	Compression configcompression.Type `mapstructure:"compression"`
+	Compression configcompression.TypeWithLevel `mapstructure:"compression"`
 
 	// MaxIdleConns is used to set a limit to the maximum idle HTTP connections the client can keep open.
 	// By default, it is set to 100.
@@ -218,13 +218,8 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 
 	// Compress the body using specified compression methods if non-empty string is provided.
 	// Supporting gzip, zlib, deflate, snappy, and zstd; none is treated as uncompressed.
-	var compressionTypeWithLevel configcompression.TypeWithLevel
-	err = compressionTypeWithLevel.UnmarshalText([]byte(hcs.Compression))
-	if err != nil {
-		return nil, err
-	}
-	if hcs.Compression.IsCompressed() {
-		clientTransport, err = newCompressRoundTripper(clientTransport, compressionTypeWithLevel)
+	if hcs.Compression.Type.IsCompressed() {
+		clientTransport, err = newCompressRoundTripper(clientTransport, hcs.Compression)
 		if err != nil {
 			return nil, err
 		}

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -4,6 +4,7 @@
 package confighttp // import "go.opentelemetry.io/collector/config/confighttp"
 
 import (
+	"compress/zlib"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -13,6 +14,8 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rs/cors"
@@ -69,7 +72,7 @@ type ClientConfig struct {
 	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// The compression key for supported compression types within collector.
-	Compression configcompression.Type `mapstructure:"compression"`
+	Compression configcompression.TypeWithLevel `mapstructure:"compression"`
 
 	// MaxIdleConns is used to set a limit to the maximum idle HTTP connections the client can keep open.
 	// By default, it is set to 100.
@@ -132,6 +135,21 @@ func NewDefaultClientConfig() ClientConfig {
 		MaxConnsPerHost:     &defaultTransport.MaxConnsPerHost,
 		IdleConnTimeout:     &defaultTransport.IdleConnTimeout,
 	}
+}
+
+// Gets the compression type and level from the configuration.
+func getCompression(compressionField configcompression.Type) (compressionType configcompression.Type, compressionLevel configcompression.Level) {
+	parts := strings.Split(string(compressionField), "/")
+
+	compressionLevel = zlib.DefaultCompression
+	compressionType = configcompression.Type(parts[0])
+	if len(parts) > 1 {
+		levelStr := parts[1]
+		if level, err := strconv.Atoi(levelStr); err == nil {
+			compressionLevel = configcompression.Level(level)
+		}
+	}
+	return compressionType, compressionLevel
 }
 
 // ToClient creates an HTTP client.
@@ -218,12 +236,16 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 
 	// Compress the body using specified compression methods if non-empty string is provided.
 	// Supporting gzip, zlib, deflate, snappy, and zstd; none is treated as uncompressed.
-	if hcs.Compression.IsCompressed() {
-		if hcs.Compression.IsZstd() || hcs.Compression.IsGzip() || hcs.Compression.IsZlib() || hcs.Compression.IsSnappy() {
-			clientTransport, err = newCompressRoundTripper(clientTransport, hcs.Compression)
-			if err != nil {
-				return nil, err
-			}
+	// compressionType, compressionLevel := getCompression(hcs.Compression.Type)
+	// compressionTypeWithLevel := configcompression.TypeWithLevel{compressionType, compressionLevel}
+	compressionTypeWithLevel, err := hcs.Compression.UnmarshalText()
+	if err != nil {
+		return nil, err
+	}
+	if hcs.Compression.Type.IsCompressed() {
+		clientTransport, err = newCompressRoundTripper(clientTransport, compressionTypeWithLevel)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -5,6 +5,7 @@ package confighttp
 
 import (
 	"bytes"
+	"compress/zlib"
 	"context"
 	"errors"
 	"fmt"
@@ -84,7 +85,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          "",
+				Compression:          configcompression.TypeWithLevel{"", zlib.DefaultCompression},
 				DisableKeepAlives:    true,
 				Cookies:              &CookiesConfig{Enabled: true},
 				HTTP2ReadIdleTimeout: idleConnTimeout,
@@ -105,7 +106,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          "none",
+				Compression:          configcompression.TypeWithLevel{"none", zlib.DefaultCompression},
 				DisableKeepAlives:    true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
@@ -125,7 +126,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          "gzip",
+				Compression:          configcompression.TypeWithLevel{"gzip", zlib.DefaultCompression},
 				DisableKeepAlives:    true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
@@ -145,7 +146,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          "gzip",
+				Compression:          configcompression.TypeWithLevel{"gzip", zlib.DefaultCompression},
 				DisableKeepAlives:    true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
@@ -174,7 +175,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				assert.EqualValues(t, 30*time.Second, transport.IdleConnTimeout)
 				assert.True(t, transport.DisableKeepAlives)
 			case *compressRoundTripper:
-				assert.EqualValues(t, "gzip", transport.compressionType)
+				assert.EqualValues(t, "gzip", transport.compressionType.Type)
 			}
 		})
 	}
@@ -411,7 +412,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			settings: ClientConfig{
 				Endpoint:    "localhost:1234",
 				Auth:        &configauth.Authentication{AuthenticatorID: component.MustNewID("mock")},
-				Compression: configcompression.TypeGzip,
+				Compression: configcompression.TypeWithLevel{configcompression.TypeGzip, zlib.DefaultCompression},
 			},
 			shouldErr: false,
 			host: &mockHost{
@@ -448,7 +449,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			transport := client.Transport
 
 			// Compression should wrap Auth, unwrap it
-			if tt.settings.Compression.IsCompressed() {
+			if tt.settings.Compression.Type.IsCompressed() {
 				ct, ok := transport.(*compressRoundTripper)
 				assert.True(t, ok)
 				assert.Equal(t, tt.settings.Compression, ct.compressionType)

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -5,7 +5,6 @@ package confighttp
 
 import (
 	"bytes"
-	"compress/zlib"
 	"context"
 	"errors"
 	"fmt"
@@ -85,7 +84,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          configcompression.TypeWithLevel{"", zlib.DefaultCompression},
+				Compression:          "",
 				DisableKeepAlives:    true,
 				Cookies:              &CookiesConfig{Enabled: true},
 				HTTP2ReadIdleTimeout: idleConnTimeout,
@@ -106,7 +105,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          configcompression.TypeWithLevel{"none", zlib.DefaultCompression},
+				Compression:          "none",
 				DisableKeepAlives:    true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
@@ -126,7 +125,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          configcompression.TypeWithLevel{"gzip", zlib.DefaultCompression},
+				Compression:          "gzip",
 				DisableKeepAlives:    true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
@@ -146,12 +145,32 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          configcompression.TypeWithLevel{"gzip", zlib.DefaultCompression},
+				Compression:          "gzip",
 				DisableKeepAlives:    true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
 			},
 			shouldError: false,
+		},
+		{
+			name: "invalid_settings_http2_health_check",
+			settings: ClientConfig{
+				Endpoint: "localhost:1234",
+				TLSSetting: configtls.ClientConfig{
+					Insecure: false,
+				},
+				ReadBufferSize:       1024,
+				WriteBufferSize:      512,
+				MaxIdleConns:         &maxIdleConns,
+				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
+				MaxConnsPerHost:      &maxConnsPerHost,
+				IdleConnTimeout:      &idleConnTimeout,
+				Compression:          "gzip/ten",
+				DisableKeepAlives:    true,
+				HTTP2ReadIdleTimeout: idleConnTimeout,
+				HTTP2PingTimeout:     http2PingTimeout,
+			},
+			shouldError: true,
 		},
 	}
 
@@ -412,7 +431,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			settings: ClientConfig{
 				Endpoint:    "localhost:1234",
 				Auth:        &configauth.Authentication{AuthenticatorID: component.MustNewID("mock")},
-				Compression: configcompression.TypeWithLevel{configcompression.TypeGzip, zlib.DefaultCompression},
+				Compression: configcompression.TypeGzip,
 			},
 			shouldErr: false,
 			host: &mockHost{
@@ -449,10 +468,10 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			transport := client.Transport
 
 			// Compression should wrap Auth, unwrap it
-			if tt.settings.Compression.Type.IsCompressed() {
+			if tt.settings.Compression.IsCompressed() {
 				ct, ok := transport.(*compressRoundTripper)
 				assert.True(t, ok)
-				assert.Equal(t, tt.settings.Compression, ct.compressionType)
+				assert.Equal(t, tt.settings.Compression, ct.compressionType.Type)
 				transport = ct.rt
 			}
 

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -84,7 +84,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          "",
+				Compression:          configcompression.TypeWithLevel{Type: "", Level: 1},
 				DisableKeepAlives:    true,
 				Cookies:              &CookiesConfig{Enabled: true},
 				HTTP2ReadIdleTimeout: idleConnTimeout,
@@ -105,7 +105,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          "none",
+				Compression:          configcompression.TypeWithLevel{Type: "none", Level: 1},
 				DisableKeepAlives:    true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
@@ -125,7 +125,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          "gzip",
+				Compression:          configcompression.TypeWithLevel{Type: "gzip", Level: 1},
 				DisableKeepAlives:    true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
@@ -145,32 +145,12 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
 				MaxConnsPerHost:      &maxConnsPerHost,
 				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          "gzip",
+				Compression:          configcompression.TypeWithLevel{Type: "gzip", Level: 1},
 				DisableKeepAlives:    true,
 				HTTP2ReadIdleTimeout: idleConnTimeout,
 				HTTP2PingTimeout:     http2PingTimeout,
 			},
 			shouldError: false,
-		},
-		{
-			name: "invalid_settings_http2_health_check",
-			settings: ClientConfig{
-				Endpoint: "localhost:1234",
-				TLSSetting: configtls.ClientConfig{
-					Insecure: false,
-				},
-				ReadBufferSize:       1024,
-				WriteBufferSize:      512,
-				MaxIdleConns:         &maxIdleConns,
-				MaxIdleConnsPerHost:  &maxIdleConnsPerHost,
-				MaxConnsPerHost:      &maxConnsPerHost,
-				IdleConnTimeout:      &idleConnTimeout,
-				Compression:          "gzip/ten",
-				DisableKeepAlives:    true,
-				HTTP2ReadIdleTimeout: idleConnTimeout,
-				HTTP2PingTimeout:     http2PingTimeout,
-			},
-			shouldError: true,
 		},
 	}
 
@@ -431,7 +411,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			settings: ClientConfig{
 				Endpoint:    "localhost:1234",
 				Auth:        &configauth.Authentication{AuthenticatorID: component.MustNewID("mock")},
-				Compression: configcompression.TypeGzip,
+				Compression: configcompression.TypeWithLevel{Type: configcompression.TypeGzip, Level: -1},
 			},
 			shouldErr: false,
 			host: &mockHost{
@@ -468,10 +448,10 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			transport := client.Transport
 
 			// Compression should wrap Auth, unwrap it
-			if tt.settings.Compression.IsCompressed() {
+			if tt.settings.Compression.Type.IsCompressed() {
 				ct, ok := transport.(*compressRoundTripper)
 				assert.True(t, ok)
-				assert.Equal(t, tt.settings.Compression, ct.compressionType.Type)
+				assert.Equal(t, tt.settings.Compression.Type, ct.compressionType.Type)
 				transport = ct.rt
 			}
 

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
@@ -76,7 +77,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				ReadBufferSize:      123,
 				WriteBufferSize:     345,
 				Timeout:             time.Second * 10,
-				Compression:         "gzip",
+				Compression:         configcompression.TypeWithLevel{Type: "gzip", Level: -1},
 				MaxIdleConns:        &defaultMaxIdleConns,
 				MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
 				MaxConnsPerHost:     &defaultMaxConnsPerHost,

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -77,7 +77,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				ReadBufferSize:      123,
 				WriteBufferSize:     345,
 				Timeout:             time.Second * 10,
-				Compression:         configcompression.TypeWithLevel{Type: "gzip", Level: -1},
+				Compression:         configcompression.TypeWithLevel{Type: "gzip", Level: 0},
 				MaxIdleConns:        &defaultMaxIdleConns,
 				MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
 				MaxConnsPerHost:     &defaultMaxConnsPerHost,

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -4,6 +4,7 @@
 package otlphttpexporter // import "go.opentelemetry.io/collector/exporter/otlphttpexporter"
 
 import (
+	"compress/gzip"
 	"context"
 	"fmt"
 	"net/url"
@@ -38,7 +39,7 @@ func createDefaultConfig() component.Config {
 	clientConfig := confighttp.NewDefaultClientConfig()
 	clientConfig.Timeout = 30 * time.Second
 	// Default to gzip compression
-	clientConfig.Compression = configcompression.TypeGzip
+	clientConfig.Compression = configcompression.TypeWithLevel{Type: configcompression.TypeGzip, Level: gzip.DefaultCompression}
 	// We almost read 0 bytes, so no need to tune ReadBufferSize.
 	clientConfig.WriteBufferSize = 512 * 1024
 

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -37,7 +37,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, ocfg.RetryConfig.MaxInterval, "default retry MaxInterval")
 	assert.True(t, ocfg.QueueConfig.Enabled, "default sending queue is enabled")
 	assert.Equal(t, EncodingProto, ocfg.Encoding)
-	assert.Equal(t, configcompression.TypeGzip, ocfg.Compression)
+	assert.Equal(t, configcompression.TypeGzip, ocfg.Compression.Type)
 }
 
 func TestCreateMetrics(t *testing.T) {
@@ -51,7 +51,7 @@ func TestCreateMetrics(t *testing.T) {
 	require.NotNil(t, oexp)
 }
 
-func clientConfig(endpoint string, headers map[string]configopaque.String, tlsSetting configtls.ClientConfig, compression configcompression.Type) confighttp.ClientConfig {
+func clientConfig(endpoint string, headers map[string]configopaque.String, tlsSetting configtls.ClientConfig, compression configcompression.TypeWithLevel) confighttp.ClientConfig {
 	clientConfig := confighttp.NewDefaultClientConfig()
 	clientConfig.TLSSetting = tlsSetting
 	clientConfig.Compression = compression
@@ -65,7 +65,7 @@ func clientConfig(endpoint string, headers map[string]configopaque.String, tlsSe
 }
 
 func TestCreateTraces(t *testing.T) {
-	var configCompression configcompression.Type
+	var configCompression configcompression.TypeWithLevel
 	endpoint := "http://" + testutil.GetAvailableLocalAddress(t)
 
 	tests := []struct {
@@ -124,25 +124,25 @@ func TestCreateTraces(t *testing.T) {
 		{
 			name: "NoneCompression",
 			config: &Config{
-				ClientConfig: clientConfig(endpoint, nil, configtls.ClientConfig{}, "none"),
+				ClientConfig: clientConfig(endpoint, nil, configtls.ClientConfig{}, configcompression.TypeWithLevel{Type: "none", Level: 0}),
 			},
 		},
 		{
 			name: "GzipCompression",
 			config: &Config{
-				ClientConfig: clientConfig(endpoint, nil, configtls.ClientConfig{}, configcompression.TypeGzip),
+				ClientConfig: clientConfig(endpoint, nil, configtls.ClientConfig{}, configcompression.TypeWithLevel{Type: configcompression.TypeGzip, Level: 1}),
 			},
 		},
 		{
 			name: "SnappyCompression",
 			config: &Config{
-				ClientConfig: clientConfig(endpoint, nil, configtls.ClientConfig{}, configcompression.TypeSnappy),
+				ClientConfig: clientConfig(endpoint, nil, configtls.ClientConfig{}, configcompression.TypeWithLevel{Type: configcompression.TypeSnappy, Level: 0}),
 			},
 		},
 		{
 			name: "ZstdCompression",
 			config: &Config{
-				ClientConfig: clientConfig(endpoint, nil, configtls.ClientConfig{}, configcompression.TypeZstd),
+				ClientConfig: clientConfig(endpoint, nil, configtls.ClientConfig{}, configcompression.TypeWithLevel{Type: configcompression.TypeZstd, Level: 11}),
 			},
 		},
 		{


### PR DESCRIPTION
#### Description
Add the option of configuring compression levels. This is not intended to be a breaking change for the user.

#### Link to tracking issue
Issue - https://github.com/open-telemetry/opentelemetry-collector/issues/10467

#### Testing
Unit tests were added/changed

#### Documentation
https://github.com/rnishtala-sumo/opentelemetry-collector/blob/configure-compression-levels/config/confighttp/README.md#client-configuration
