### PR TITLE
[scraperhelper] remove deprecated obsreport funcs/structs

### DIFF
--- a/receiver/scraperhelper/obsreport.go
+++ b/receiver/scraperhelper/obsreport.go
@@ -19,10 +19,8 @@ import (
 	"go.opentelemetry.io/collector/receiver/scraperhelper/internal/metadata"
 )
 
-// ObsReport is a helper to add observability to a scraper.
-//
-// Deprecated: [v0.108.0] will be removed.
-type ObsReport struct {
+// obsReport is a helper to add observability to a scraper.
+type obsReport struct {
 	receiverID component.ID
 	scraper    component.ID
 	tracer     trace.Tracer
@@ -31,28 +29,19 @@ type ObsReport struct {
 	telemetryBuilder *metadata.TelemetryBuilder
 }
 
-// ObsReportSettings are settings for creating an ObsReport.
-//
-// Deprecated: [v0.108.0] will be removed.
-type ObsReportSettings struct {
+// obsReportSettings are settings for creating an ObsReport.
+type obsReportSettings struct {
 	ReceiverID             component.ID
 	Scraper                component.ID
 	ReceiverCreateSettings receiver.Settings
 }
 
-// NewObsReport creates a new ObsReport.
-//
-// Deprecated: [v0.108.0] will be removed, scrapers should use NewScraperControllerReceiver instead.
-func NewObsReport(cfg ObsReportSettings) (*ObsReport, error) {
-	return newScraper(cfg)
-}
-
-func newScraper(cfg ObsReportSettings) (*ObsReport, error) {
+func newScraper(cfg obsReportSettings) (*obsReport, error) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(cfg.ReceiverCreateSettings.TelemetrySettings)
 	if err != nil {
 		return nil, err
 	}
-	return &ObsReport{
+	return &obsReport{
 		receiverID: cfg.ReceiverID,
 		scraper:    cfg.Scraper,
 		tracer:     cfg.ReceiverCreateSettings.TracerProvider.Tracer(cfg.Scraper.String()),
@@ -68,7 +57,7 @@ func newScraper(cfg ObsReportSettings) (*ObsReport, error) {
 // StartMetricsOp is called when a scrape operation is started. The
 // returned context should be used in other calls to the obsreport functions
 // dealing with the same scrape operation.
-func (s *ObsReport) StartMetricsOp(ctx context.Context) context.Context {
+func (s *obsReport) StartMetricsOp(ctx context.Context) context.Context {
 	spanName := obsmetrics.ScraperPrefix + s.receiverID.String() + obsmetrics.SpanNameSep + s.scraper.String() + obsmetrics.ScraperMetricsOperationSuffix
 	ctx, _ = s.tracer.Start(ctx, spanName)
 	return ctx
@@ -76,7 +65,7 @@ func (s *ObsReport) StartMetricsOp(ctx context.Context) context.Context {
 
 // EndMetricsOp completes the scrape operation that was started with
 // StartMetricsOp.
-func (s *ObsReport) EndMetricsOp(
+func (s *obsReport) EndMetricsOp(
 	scraperCtx context.Context,
 	numScrapedMetrics int,
 	err error,
@@ -112,7 +101,7 @@ func (s *ObsReport) EndMetricsOp(
 	span.End()
 }
 
-func (s *ObsReport) recordMetrics(scraperCtx context.Context, numScrapedMetrics, numErroredMetrics int) {
+func (s *obsReport) recordMetrics(scraperCtx context.Context, numScrapedMetrics, numErroredMetrics int) {
 	s.telemetryBuilder.ScraperScrapedMetricPoints.Add(scraperCtx, int64(numScrapedMetrics), metric.WithAttributes(s.otelAttrs...))
 	s.telemetryBuilder.ScraperErroredMetricPoints.Add(scraperCtx, int64(numErroredMetrics), metric.WithAttributes(s.otelAttrs...))
 }

--- a/receiver/scraperhelper/obsreport_test.go
+++ b/receiver/scraperhelper/obsreport_test.go
@@ -44,7 +44,7 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 			{items: 15, err: nil},
 		}
 		for i := range params {
-			scrp, err := newScraper(ObsReportSettings{
+			scrp, err := newScraper(obsReportSettings{
 				ReceiverID:             receiverID,
 				Scraper:                scraperID,
 				ReceiverCreateSettings: receiver.Settings{ID: receiverID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
@@ -95,7 +95,7 @@ func TestCheckScraperMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	s, err := newScraper(ObsReportSettings{
+	s, err := newScraper(obsReportSettings{
 		ReceiverID:             receiverID,
 		Scraper:                scraperID,
 		ReceiverCreateSettings: receiver.Settings{ID: receiverID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -51,7 +51,7 @@ type controller struct {
 	nextConsumer       consumer.Metrics
 
 	scrapers    []Scraper
-	obsScrapers []*ObsReport
+	obsScrapers []*obsReport
 
 	tickerCh <-chan time.Time
 
@@ -101,9 +101,9 @@ func NewScraperControllerReceiver(
 		op(sc)
 	}
 
-	sc.obsScrapers = make([]*ObsReport, len(sc.scrapers))
+	sc.obsScrapers = make([]*obsReport, len(sc.scrapers))
 	for i, scraper := range sc.scrapers {
-		scrp, err := newScraper(ObsReportSettings{
+		scrp, err := newScraper(obsReportSettings{
 			ReceiverID:             sc.id,
 			Scraper:                scraper.ID(),
 			ReceiverCreateSettings: sc.recvSettings,


### PR DESCRIPTION
These were only used inside scraperhelper, should have no impact.
