### PR TITLE
[service] move useOtelWithSDKConfigurationForInternalTelemetry gate to beta

### DIFF
--- a/.chloggen/codeboten_beta-internal-telemetry-gate.yaml
+++ b/.chloggen/codeboten_beta-internal-telemetry-gate.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "move `useOtelWithSDKConfigurationForInternalTelemetry` gate to beta"
+
+# One or more tracking issues or pull requests related to the change
+issues: [11091]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -19,6 +19,6 @@ var DisableHighCardinalityMetricsfeatureGate = featuregate.GlobalRegistry().Must
 // supports configuring the OpenTelemetry SDK via configuration
 var UseOtelWithSDKConfigurationForInternalTelemetryFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"telemetry.useOtelWithSDKConfigurationForInternalTelemetry",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("controls whether the collector supports extended OpenTelemetry"+
 		"configuration for internal telemetry"))

--- a/service/service.go
+++ b/service/service.go
@@ -89,7 +89,6 @@ type Service struct {
 // New creates a new Service, its telemetry, and Components.
 func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 	disableHighCard := obsreportconfig.DisableHighCardinalityMetricsfeatureGate.IsEnabled()
-	extendedConfig := obsreportconfig.UseOtelWithSDKConfigurationForInternalTelemetryFeatureGate.IsEnabled()
 
 	srv := &Service{
 		buildInfo: set.BuildInfo,
@@ -141,7 +140,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		return nil, fmt.Errorf("failed to create metric provider: %w", err)
 	}
 
-	logsAboutMeterProvider(logger, cfg.Telemetry.Metrics, mp, extendedConfig)
+	logsAboutMeterProvider(logger, cfg.Telemetry.Metrics, mp)
 	srv.telemetrySettings = component.TelemetrySettings{
 		LeveledMeterProvider: func(level configtelemetry.Level) metric.MeterProvider {
 			if level <= cfg.Telemetry.Metrics.Level {
@@ -183,7 +182,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 	return srv, nil
 }
 
-func logsAboutMeterProvider(logger *zap.Logger, cfg telemetry.MetricsConfig, mp metric.MeterProvider, extendedConfig bool) {
+func logsAboutMeterProvider(logger *zap.Logger, cfg telemetry.MetricsConfig, mp metric.MeterProvider) {
 	if cfg.Level == configtelemetry.LevelNone || (cfg.Address == "" && len(cfg.Readers) == 0) {
 		logger.Info(
 			"Skipped telemetry setup.",
@@ -193,7 +192,7 @@ func logsAboutMeterProvider(logger *zap.Logger, cfg telemetry.MetricsConfig, mp 
 		return
 	}
 
-	if len(cfg.Address) != 0 && extendedConfig {
+	if len(cfg.Address) != 0 && obsreportconfig.UseOtelWithSDKConfigurationForInternalTelemetryFeatureGate.IsEnabled() {
 		logger.Warn("service::telemetry::metrics::address is being deprecated in favor of service::telemetry::metrics::readers")
 	}
 


### PR DESCRIPTION
#### Description

This configuration of the internal collector telemetry has been using the SDK configuration for some time. Moving this gate from alpha to beta.

#### Link to tracking issue
Related to #6629
