### PR TITLE
Revert "Revert "[confignet] Mark as stable""

### DIFF
--- a/.chloggen/confignet-mark-stable.yaml
+++ b/.chloggen/confignet-mark-stable.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confignet
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark module as Stable.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9801]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/versions.yaml
+++ b/versions.yaml
@@ -15,6 +15,7 @@ module-sets:
       - go.opentelemetry.io/collector/config/configcompression
       - go.opentelemetry.io/collector/config/configretry
       - go.opentelemetry.io/collector/config/configtls
+      - go.opentelemetry.io/collector/config/confignet
   beta:
     version: v0.109.0
     modules:
@@ -32,7 +33,6 @@ module-sets:
       - go.opentelemetry.io/collector/config/configauth
       - go.opentelemetry.io/collector/config/configgrpc
       - go.opentelemetry.io/collector/config/confighttp
-      - go.opentelemetry.io/collector/config/confignet
       - go.opentelemetry.io/collector/config/configtelemetry
       - go.opentelemetry.io/collector/config/internal
       - go.opentelemetry.io/collector/connector


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector#11115

To be merged after the contrib release v0.109 is done.