### PR TITLE
[builder] Remove builder default confmap providers

### DIFF
--- a/.chloggen/fixbuilderproviders.yaml
+++ b/.chloggen/fixbuilderproviders.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: 'builder'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove default config providers. This will require users to always specify the providers.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11126]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -88,7 +88,7 @@ func TestMissingModule(t *testing.T) {
 		{
 			cfg: Config{
 				Logger: zap.NewNop(),
-				Providers: &[]Module{{
+				Providers: []Module{{
 					Import: "invalid",
 				}},
 			},
@@ -324,11 +324,10 @@ func TestConfmapFactoryVersions(t *testing.T) {
 	}
 }
 
-func TestAddsDefaultProviders(t *testing.T) {
+func TestNoProviders(t *testing.T) {
 	cfg := NewDefaultConfig()
 	cfg.Providers = nil
-	require.NoError(t, cfg.ParseModules())
-	assert.Len(t, *cfg.Providers, 5)
+	require.EqualError(t, cfg.Validate(), "at least one provider is required")
 }
 
 func TestSkipsNilFieldValidation(t *testing.T) {

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -223,7 +223,7 @@ func (c *Config) coreModuleAndVersion() (string, string) {
 
 func (c *Config) allComponents() []Module {
 	return slices.Concat[[]Module](c.Exporters, c.Receivers, c.Processors,
-		c.Extensions, c.Connectors, *c.Providers)
+		c.Extensions, c.Connectors, c.Providers)
 }
 
 func (c *Config) readGoModFile() (string, map[string]string, error) {

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -195,7 +195,7 @@ func TestVersioning(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
-				cfg.Providers = &providers
+				cfg.Providers = providers
 				return cfg
 			},
 			expectedErr: nil,
@@ -210,7 +210,7 @@ func TestVersioning(t *testing.T) {
 						GoMod: "go.opentelemetry.io/collector/exporter/otlpexporter v0.97.0",
 					},
 				}
-				cfg.Providers = &[]Module{}
+				cfg.Providers = []Module{}
 				cfg.Replaces = append(cfg.Replaces, replaces...)
 				return cfg
 			},
@@ -227,7 +227,7 @@ func TestVersioning(t *testing.T) {
 						GoMod: "go.opentelemetry.io/collector/exporter/otlpexporter v0.97.0",
 					},
 				}
-				cfg.Providers = &[]Module{}
+				cfg.Providers = []Module{}
 				cfg.Replaces = append(cfg.Replaces, replaces...)
 				return cfg
 			},
@@ -323,7 +323,7 @@ func TestGenerateAndCompile(t *testing.T) {
 				require.NoError(t, err)
 				cfg.Distribution.OutputPath = t.TempDir()
 				cfg.Replaces = append(cfg.Replaces, replaces...)
-				cfg.Providers = &[]Module{}
+				cfg.Providers = []Module{}
 				return cfg
 			},
 		},
@@ -453,6 +453,24 @@ func TestReplaceStatementsAreComplete(t *testing.T) {
 		},
 		{
 			GoMod: "go.opentelemetry.io/collector/processor/memorylimiterprocessor v1.9999.9999",
+		},
+	})
+	require.NoError(t, err)
+	cfg.Providers, err = parseModules([]Module{
+		{
+			GoMod: "go.opentelemetry.io/collector/confmap/provider/envprovider v1.9999.9999",
+		},
+		{
+			GoMod: "go.opentelemetry.io/collector/confmap/provider/fileprovider v1.9999.9999",
+		},
+		{
+			GoMod: "go.opentelemetry.io/collector/confmap/provider/httpprovider v1.9999.9999",
+		},
+		{
+			GoMod: "go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.9999.9999",
+		},
+		{
+			GoMod: "go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.9999.9999",
 		},
 	})
 	require.NoError(t, err)

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -11,6 +11,13 @@ receivers:
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.111.0
 
+providers:
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.15.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.15.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.109.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.109.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.109.0
+
 replaces:
   - go.opentelemetry.io/collector => ${WORKSPACE_DIR}
   - go.opentelemetry.io/collector/client => ${WORKSPACE_DIR}/client


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The main problem with this, is that the providers will start to have a different version than the builder and they will be independently mark as stable which will make it very hard to track all combination of builder versions with the "associated default" providers for that version.

This also fixes an issue, that for builder 0.109.0 the default providers will not work since the env and file are no longer using 0.109.0 version.

