### PR TITLE
[chore]: enable compares and negative-positive rules from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,13 +124,11 @@ linters-settings:
   testifylint:
     # TODO: enable all rules
     disable:
-      - compares
       - error-is-as
       - expected-actual
       - float-compare
       - formatter
       - go-require
-      - negative-positive
       - require-error
     enable-all: true   
 

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -38,7 +38,7 @@ SEMCONVGEN   := $(TOOLS_BIN_DIR)/semconvgen
 SEMCONVKIT   := $(TOOLS_BIN_DIR)/semconvkit
 TESTIFYLINT  := $(TOOLS_BIN_DIR)/testifylint
 
-TESTIFYLINT_OPT?= --enable-all --disable=compares,error-is-as,expected-actual,float-compare,formatter,go-require,negative-positive,require-error
+TESTIFYLINT_OPT?= --enable-all --disable=error-is-as,expected-actual,float-compare,formatter,go-require,require-error
 
 .PHONY: install-tools
 install-tools: $(TOOLS_BIN_NAMES)

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -188,7 +188,7 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 	ocs.awaitAsyncProcessing()
 
 	// The initial backoff is 10ms, but because of the throttle this should wait at least 100ms.
-	assert.True(t, 100*time.Millisecond < time.Since(start))
+	assert.Less(t, 100*time.Millisecond, time.Since(start))
 
 	mockR.checkNumRequests(t, 2)
 	ocs.checkSendItemsCount(t, 2)

--- a/internal/fanoutconsumer/logs_test.go
+++ b/internal/fanoutconsumer/logs_test.go
@@ -44,18 +44,18 @@ func TestLogsMultiplexingNonMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, ld == p1.AllLogs()[0])
-	assert.True(t, ld == p1.AllLogs()[1])
+	assert.Equal(t, ld, p1.AllLogs()[0])
+	assert.Equal(t, ld, p1.AllLogs()[1])
 	assert.EqualValues(t, ld, p1.AllLogs()[0])
 	assert.EqualValues(t, ld, p1.AllLogs()[1])
 
-	assert.True(t, ld == p2.AllLogs()[0])
-	assert.True(t, ld == p2.AllLogs()[1])
+	assert.Equal(t, ld, p2.AllLogs()[0])
+	assert.Equal(t, ld, p2.AllLogs()[1])
 	assert.EqualValues(t, ld, p2.AllLogs()[0])
 	assert.EqualValues(t, ld, p2.AllLogs()[1])
 
-	assert.True(t, ld == p3.AllLogs()[0])
-	assert.True(t, ld == p3.AllLogs()[1])
+	assert.Equal(t, ld, p3.AllLogs()[0])
+	assert.Equal(t, ld, p3.AllLogs()[1])
 	assert.EqualValues(t, ld, p3.AllLogs()[0])
 	assert.EqualValues(t, ld, p3.AllLogs()[1])
 
@@ -80,19 +80,19 @@ func TestLogsMultiplexingMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, ld != p1.AllLogs()[0])
-	assert.True(t, ld != p1.AllLogs()[1])
+	assert.NotSame(t, ld, p1.AllLogs()[0])
+	assert.NotSame(t, ld, p1.AllLogs()[1])
 	assert.EqualValues(t, ld, p1.AllLogs()[0])
 	assert.EqualValues(t, ld, p1.AllLogs()[1])
 
-	assert.True(t, ld != p2.AllLogs()[0])
-	assert.True(t, ld != p2.AllLogs()[1])
+	assert.NotSame(t, ld, p2.AllLogs()[0])
+	assert.NotSame(t, ld, p2.AllLogs()[1])
 	assert.EqualValues(t, ld, p2.AllLogs()[0])
 	assert.EqualValues(t, ld, p2.AllLogs()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, ld == p3.AllLogs()[0])
-	assert.True(t, ld == p3.AllLogs()[1])
+	assert.Equal(t, ld, p3.AllLogs()[0])
+	assert.Equal(t, ld, p3.AllLogs()[1])
 	assert.EqualValues(t, ld, p3.AllLogs()[0])
 	assert.EqualValues(t, ld, p3.AllLogs()[1])
 
@@ -121,18 +121,18 @@ func TestReadOnlyLogsMultiplexingMutating(t *testing.T) {
 
 	// All consumers should receive the cloned data.
 
-	assert.True(t, ld != p1.AllLogs()[0])
-	assert.True(t, ld != p1.AllLogs()[1])
+	assert.NotEqual(t, ld, p1.AllLogs()[0])
+	assert.NotEqual(t, ld, p1.AllLogs()[1])
 	assert.EqualValues(t, ldOrig, p1.AllLogs()[0])
 	assert.EqualValues(t, ldOrig, p1.AllLogs()[1])
 
-	assert.True(t, ld != p2.AllLogs()[0])
-	assert.True(t, ld != p2.AllLogs()[1])
+	assert.NotEqual(t, ld, p2.AllLogs()[0])
+	assert.NotEqual(t, ld, p2.AllLogs()[1])
 	assert.EqualValues(t, ldOrig, p2.AllLogs()[0])
 	assert.EqualValues(t, ldOrig, p2.AllLogs()[1])
 
-	assert.True(t, ld != p3.AllLogs()[0])
-	assert.True(t, ld != p3.AllLogs()[1])
+	assert.NotEqual(t, ld, p3.AllLogs()[0])
+	assert.NotEqual(t, ld, p3.AllLogs()[1])
 	assert.EqualValues(t, ldOrig, p3.AllLogs()[0])
 	assert.EqualValues(t, ldOrig, p3.AllLogs()[1])
 }
@@ -154,20 +154,20 @@ func TestLogsMultiplexingMixLastMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, ld != p1.AllLogs()[0])
-	assert.True(t, ld != p1.AllLogs()[1])
+	assert.NotSame(t, ld, p1.AllLogs()[0])
+	assert.NotSame(t, ld, p1.AllLogs()[1])
 	assert.EqualValues(t, ld, p1.AllLogs()[0])
 	assert.EqualValues(t, ld, p1.AllLogs()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, ld == p2.AllLogs()[0])
-	assert.True(t, ld == p2.AllLogs()[1])
+	assert.Equal(t, ld, p2.AllLogs()[0])
+	assert.Equal(t, ld, p2.AllLogs()[1])
 	assert.EqualValues(t, ld, p2.AllLogs()[0])
 	assert.EqualValues(t, ld, p2.AllLogs()[1])
 
 	// For this consumer, will clone the initial data.
-	assert.True(t, ld != p3.AllLogs()[0])
-	assert.True(t, ld != p3.AllLogs()[1])
+	assert.NotSame(t, ld, p3.AllLogs()[0])
+	assert.NotSame(t, ld, p3.AllLogs()[1])
 	assert.EqualValues(t, ld, p3.AllLogs()[0])
 	assert.EqualValues(t, ld, p3.AllLogs()[1])
 
@@ -192,19 +192,19 @@ func TestLogsMultiplexingMixLastNonMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, ld != p1.AllLogs()[0])
-	assert.True(t, ld != p1.AllLogs()[1])
+	assert.NotSame(t, ld, p1.AllLogs()[0])
+	assert.NotSame(t, ld, p1.AllLogs()[1])
 	assert.EqualValues(t, ld, p1.AllLogs()[0])
 	assert.EqualValues(t, ld, p1.AllLogs()[1])
 
-	assert.True(t, ld != p2.AllLogs()[0])
-	assert.True(t, ld != p2.AllLogs()[1])
+	assert.NotSame(t, ld, p2.AllLogs()[0])
+	assert.NotSame(t, ld, p2.AllLogs()[1])
 	assert.EqualValues(t, ld, p2.AllLogs()[0])
 	assert.EqualValues(t, ld, p2.AllLogs()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, ld == p3.AllLogs()[0])
-	assert.True(t, ld == p3.AllLogs()[1])
+	assert.Equal(t, ld, p3.AllLogs()[0])
+	assert.Equal(t, ld, p3.AllLogs()[1])
 	assert.EqualValues(t, ld, p3.AllLogs()[0])
 	assert.EqualValues(t, ld, p3.AllLogs()[1])
 
@@ -224,8 +224,8 @@ func TestLogsWhenErrors(t *testing.T) {
 		assert.Error(t, lfc.ConsumeLogs(context.Background(), ld))
 	}
 
-	assert.True(t, ld == p3.AllLogs()[0])
-	assert.True(t, ld == p3.AllLogs()[1])
+	assert.Equal(t, ld, p3.AllLogs()[0])
+	assert.Equal(t, ld, p3.AllLogs()[1])
 	assert.EqualValues(t, ld, p3.AllLogs()[0])
 	assert.EqualValues(t, ld, p3.AllLogs()[1])
 }

--- a/internal/fanoutconsumer/metrics_test.go
+++ b/internal/fanoutconsumer/metrics_test.go
@@ -44,18 +44,18 @@ func TestMetricsMultiplexingNonMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, md == p1.AllMetrics()[0])
-	assert.True(t, md == p1.AllMetrics()[1])
+	assert.Equal(t, md, p1.AllMetrics()[0])
+	assert.Equal(t, md, p1.AllMetrics()[1])
 	assert.EqualValues(t, md, p1.AllMetrics()[0])
 	assert.EqualValues(t, md, p1.AllMetrics()[1])
 
-	assert.True(t, md == p2.AllMetrics()[0])
-	assert.True(t, md == p2.AllMetrics()[1])
+	assert.Equal(t, md, p2.AllMetrics()[0])
+	assert.Equal(t, md, p2.AllMetrics()[1])
 	assert.EqualValues(t, md, p2.AllMetrics()[0])
 	assert.EqualValues(t, md, p2.AllMetrics()[1])
 
-	assert.True(t, md == p3.AllMetrics()[0])
-	assert.True(t, md == p3.AllMetrics()[1])
+	assert.Equal(t, md, p3.AllMetrics()[0])
+	assert.Equal(t, md, p3.AllMetrics()[1])
 	assert.EqualValues(t, md, p3.AllMetrics()[0])
 	assert.EqualValues(t, md, p3.AllMetrics()[1])
 
@@ -80,19 +80,19 @@ func TestMetricsMultiplexingMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, md != p1.AllMetrics()[0])
-	assert.True(t, md != p1.AllMetrics()[1])
+	assert.NotSame(t, md, p1.AllMetrics()[0])
+	assert.NotSame(t, md, p1.AllMetrics()[1])
 	assert.EqualValues(t, md, p1.AllMetrics()[0])
 	assert.EqualValues(t, md, p1.AllMetrics()[1])
 
-	assert.True(t, md != p2.AllMetrics()[0])
-	assert.True(t, md != p2.AllMetrics()[1])
+	assert.NotSame(t, md, p2.AllMetrics()[0])
+	assert.NotSame(t, md, p2.AllMetrics()[1])
 	assert.EqualValues(t, md, p2.AllMetrics()[0])
 	assert.EqualValues(t, md, p2.AllMetrics()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, md == p3.AllMetrics()[0])
-	assert.True(t, md == p3.AllMetrics()[1])
+	assert.Equal(t, md, p3.AllMetrics()[0])
+	assert.Equal(t, md, p3.AllMetrics()[1])
 	assert.EqualValues(t, md, p3.AllMetrics()[0])
 	assert.EqualValues(t, md, p3.AllMetrics()[1])
 
@@ -121,18 +121,18 @@ func TestReadOnlyMetricsMultiplexingMixFirstMutating(t *testing.T) {
 
 	// All consumers should receive the cloned data.
 
-	assert.True(t, md != p1.AllMetrics()[0])
-	assert.True(t, md != p1.AllMetrics()[1])
+	assert.NotEqual(t, md, p1.AllMetrics()[0])
+	assert.NotEqual(t, md, p1.AllMetrics()[1])
 	assert.EqualValues(t, mdOrig, p1.AllMetrics()[0])
 	assert.EqualValues(t, mdOrig, p1.AllMetrics()[1])
 
-	assert.True(t, md != p2.AllMetrics()[0])
-	assert.True(t, md != p2.AllMetrics()[1])
+	assert.NotEqual(t, md, p2.AllMetrics()[0])
+	assert.NotEqual(t, md, p2.AllMetrics()[1])
 	assert.EqualValues(t, mdOrig, p2.AllMetrics()[0])
 	assert.EqualValues(t, mdOrig, p2.AllMetrics()[1])
 
-	assert.True(t, md != p3.AllMetrics()[0])
-	assert.True(t, md != p3.AllMetrics()[1])
+	assert.NotEqual(t, md, p3.AllMetrics()[0])
+	assert.NotEqual(t, md, p3.AllMetrics()[1])
 	assert.EqualValues(t, mdOrig, p3.AllMetrics()[0])
 	assert.EqualValues(t, mdOrig, p3.AllMetrics()[1])
 }
@@ -154,20 +154,20 @@ func TestMetricsMultiplexingMixLastMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, md != p1.AllMetrics()[0])
-	assert.True(t, md != p1.AllMetrics()[1])
+	assert.NotSame(t, md, p1.AllMetrics()[0])
+	assert.NotSame(t, md, p1.AllMetrics()[1])
 	assert.EqualValues(t, md, p1.AllMetrics()[0])
 	assert.EqualValues(t, md, p1.AllMetrics()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, md == p2.AllMetrics()[0])
-	assert.True(t, md == p2.AllMetrics()[1])
+	assert.Equal(t, md, p2.AllMetrics()[0])
+	assert.Equal(t, md, p2.AllMetrics()[1])
 	assert.EqualValues(t, md, p2.AllMetrics()[0])
 	assert.EqualValues(t, md, p2.AllMetrics()[1])
 
 	// For this consumer, will clone the initial data.
-	assert.True(t, md != p3.AllMetrics()[0])
-	assert.True(t, md != p3.AllMetrics()[1])
+	assert.NotSame(t, md, p3.AllMetrics()[0])
+	assert.NotSame(t, md, p3.AllMetrics()[1])
 	assert.EqualValues(t, md, p3.AllMetrics()[0])
 	assert.EqualValues(t, md, p3.AllMetrics()[1])
 
@@ -192,19 +192,19 @@ func TestMetricsMultiplexingMixLastNonMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, md != p1.AllMetrics()[0])
-	assert.True(t, md != p1.AllMetrics()[1])
+	assert.NotSame(t, md, p1.AllMetrics()[0])
+	assert.NotSame(t, md, p1.AllMetrics()[1])
 	assert.EqualValues(t, md, p1.AllMetrics()[0])
 	assert.EqualValues(t, md, p1.AllMetrics()[1])
 
-	assert.True(t, md != p2.AllMetrics()[0])
-	assert.True(t, md != p2.AllMetrics()[1])
+	assert.NotSame(t, md, p2.AllMetrics()[0])
+	assert.NotSame(t, md, p2.AllMetrics()[1])
 	assert.EqualValues(t, md, p2.AllMetrics()[0])
 	assert.EqualValues(t, md, p2.AllMetrics()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, md == p3.AllMetrics()[0])
-	assert.True(t, md == p3.AllMetrics()[1])
+	assert.Equal(t, md, p3.AllMetrics()[0])
+	assert.Equal(t, md, p3.AllMetrics()[1])
 	assert.EqualValues(t, md, p3.AllMetrics()[0])
 	assert.EqualValues(t, md, p3.AllMetrics()[1])
 
@@ -224,8 +224,8 @@ func TestMetricsWhenErrors(t *testing.T) {
 		assert.Error(t, mfc.ConsumeMetrics(context.Background(), md))
 	}
 
-	assert.True(t, md == p3.AllMetrics()[0])
-	assert.True(t, md == p3.AllMetrics()[1])
+	assert.Equal(t, md, p3.AllMetrics()[0])
+	assert.Equal(t, md, p3.AllMetrics()[1])
 	assert.EqualValues(t, md, p3.AllMetrics()[0])
 	assert.EqualValues(t, md, p3.AllMetrics()[1])
 }

--- a/internal/fanoutconsumer/profiles_test.go
+++ b/internal/fanoutconsumer/profiles_test.go
@@ -45,18 +45,18 @@ func TestProfilesMultiplexingNonMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, td == p1.AllProfiles()[0])
-	assert.True(t, td == p1.AllProfiles()[1])
+	assert.Equal(t, td, p1.AllProfiles()[0])
+	assert.Equal(t, td, p1.AllProfiles()[1])
 	assert.EqualValues(t, td, p1.AllProfiles()[0])
 	assert.EqualValues(t, td, p1.AllProfiles()[1])
 
-	assert.True(t, td == p2.AllProfiles()[0])
-	assert.True(t, td == p2.AllProfiles()[1])
+	assert.Equal(t, td, p2.AllProfiles()[0])
+	assert.Equal(t, td, p2.AllProfiles()[1])
 	assert.EqualValues(t, td, p2.AllProfiles()[0])
 	assert.EqualValues(t, td, p2.AllProfiles()[1])
 
-	assert.True(t, td == p3.AllProfiles()[0])
-	assert.True(t, td == p3.AllProfiles()[1])
+	assert.Equal(t, td, p3.AllProfiles()[0])
+	assert.Equal(t, td, p3.AllProfiles()[1])
 	assert.EqualValues(t, td, p3.AllProfiles()[0])
 	assert.EqualValues(t, td, p3.AllProfiles()[1])
 
@@ -81,19 +81,19 @@ func TestProfilesMultiplexingMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, td != p1.AllProfiles()[0])
-	assert.True(t, td != p1.AllProfiles()[1])
+	assert.NotSame(t, td, p1.AllProfiles()[0])
+	assert.NotSame(t, td, p1.AllProfiles()[1])
 	assert.EqualValues(t, td, p1.AllProfiles()[0])
 	assert.EqualValues(t, td, p1.AllProfiles()[1])
 
-	assert.True(t, td != p2.AllProfiles()[0])
-	assert.True(t, td != p2.AllProfiles()[1])
+	assert.NotSame(t, td, p2.AllProfiles()[0])
+	assert.NotSame(t, td, p2.AllProfiles()[1])
 	assert.EqualValues(t, td, p2.AllProfiles()[0])
 	assert.EqualValues(t, td, p2.AllProfiles()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, td == p3.AllProfiles()[0])
-	assert.True(t, td == p3.AllProfiles()[1])
+	assert.Equal(t, td, p3.AllProfiles()[0])
+	assert.Equal(t, td, p3.AllProfiles()[1])
 	assert.EqualValues(t, td, p3.AllProfiles()[0])
 	assert.EqualValues(t, td, p3.AllProfiles()[1])
 
@@ -123,18 +123,18 @@ func TestReadOnlyProfilesMultiplexingMutating(t *testing.T) {
 
 	// All consumers should receive the cloned data.
 
-	assert.True(t, td != p1.AllProfiles()[0])
-	assert.True(t, td != p1.AllProfiles()[1])
+	assert.NotEqual(t, td, p1.AllProfiles()[0])
+	assert.NotEqual(t, td, p1.AllProfiles()[1])
 	assert.EqualValues(t, tdOrig, p1.AllProfiles()[0])
 	assert.EqualValues(t, tdOrig, p1.AllProfiles()[1])
 
-	assert.True(t, td != p2.AllProfiles()[0])
-	assert.True(t, td != p2.AllProfiles()[1])
+	assert.NotEqual(t, td, p2.AllProfiles()[0])
+	assert.NotEqual(t, td, p2.AllProfiles()[1])
 	assert.EqualValues(t, tdOrig, p2.AllProfiles()[0])
 	assert.EqualValues(t, tdOrig, p2.AllProfiles()[1])
 
-	assert.True(t, td != p3.AllProfiles()[0])
-	assert.True(t, td != p3.AllProfiles()[1])
+	assert.NotEqual(t, td, p3.AllProfiles()[0])
+	assert.NotEqual(t, td, p3.AllProfiles()[1])
 	assert.EqualValues(t, tdOrig, p3.AllProfiles()[0])
 	assert.EqualValues(t, tdOrig, p3.AllProfiles()[1])
 }
@@ -156,20 +156,20 @@ func TestProfilesMultiplexingMixLastMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, td != p1.AllProfiles()[0])
-	assert.True(t, td != p1.AllProfiles()[1])
+	assert.NotSame(t, td, p1.AllProfiles()[0])
+	assert.NotSame(t, td, p1.AllProfiles()[1])
 	assert.EqualValues(t, td, p1.AllProfiles()[0])
 	assert.EqualValues(t, td, p1.AllProfiles()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, td == p2.AllProfiles()[0])
-	assert.True(t, td == p2.AllProfiles()[1])
+	assert.Equal(t, td, p2.AllProfiles()[0])
+	assert.Equal(t, td, p2.AllProfiles()[1])
 	assert.EqualValues(t, td, p2.AllProfiles()[0])
 	assert.EqualValues(t, td, p2.AllProfiles()[1])
 
 	// For this consumer, will clone the initial data.
-	assert.True(t, td != p3.AllProfiles()[0])
-	assert.True(t, td != p3.AllProfiles()[1])
+	assert.NotSame(t, td, p3.AllProfiles()[0])
+	assert.NotSame(t, td, p3.AllProfiles()[1])
 	assert.EqualValues(t, td, p3.AllProfiles()[0])
 	assert.EqualValues(t, td, p3.AllProfiles()[1])
 
@@ -194,19 +194,19 @@ func TestProfilesMultiplexingMixLastNonMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, td != p1.AllProfiles()[0])
-	assert.True(t, td != p1.AllProfiles()[1])
+	assert.NotSame(t, td, p1.AllProfiles()[0])
+	assert.NotSame(t, td, p1.AllProfiles()[1])
 	assert.EqualValues(t, td, p1.AllProfiles()[0])
 	assert.EqualValues(t, td, p1.AllProfiles()[1])
 
-	assert.True(t, td != p2.AllProfiles()[0])
-	assert.True(t, td != p2.AllProfiles()[1])
+	assert.NotSame(t, td, p2.AllProfiles()[0])
+	assert.NotSame(t, td, p2.AllProfiles()[1])
 	assert.EqualValues(t, td, p2.AllProfiles()[0])
 	assert.EqualValues(t, td, p2.AllProfiles()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, td == p3.AllProfiles()[0])
-	assert.True(t, td == p3.AllProfiles()[1])
+	assert.Equal(t, td, p3.AllProfiles()[0])
+	assert.Equal(t, td, p3.AllProfiles()[1])
 	assert.EqualValues(t, td, p3.AllProfiles()[0])
 	assert.EqualValues(t, td, p3.AllProfiles()[1])
 
@@ -226,8 +226,8 @@ func TestProfilesWhenErrors(t *testing.T) {
 		assert.Error(t, tfc.ConsumeProfiles(context.Background(), td))
 	}
 
-	assert.True(t, td == p3.AllProfiles()[0])
-	assert.True(t, td == p3.AllProfiles()[1])
+	assert.Equal(t, td, p3.AllProfiles()[0])
+	assert.Equal(t, td, p3.AllProfiles()[1])
 	assert.EqualValues(t, td, p3.AllProfiles()[0])
 	assert.EqualValues(t, td, p3.AllProfiles()[1])
 }

--- a/internal/fanoutconsumer/traces_test.go
+++ b/internal/fanoutconsumer/traces_test.go
@@ -44,18 +44,18 @@ func TestTracesMultiplexingNonMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, td == p1.AllTraces()[0])
-	assert.True(t, td == p1.AllTraces()[1])
+	assert.Equal(t, td, p1.AllTraces()[0])
+	assert.Equal(t, td, p1.AllTraces()[1])
 	assert.EqualValues(t, td, p1.AllTraces()[0])
 	assert.EqualValues(t, td, p1.AllTraces()[1])
 
-	assert.True(t, td == p2.AllTraces()[0])
-	assert.True(t, td == p2.AllTraces()[1])
+	assert.Equal(t, td, p2.AllTraces()[0])
+	assert.Equal(t, td, p2.AllTraces()[1])
 	assert.EqualValues(t, td, p2.AllTraces()[0])
 	assert.EqualValues(t, td, p2.AllTraces()[1])
 
-	assert.True(t, td == p3.AllTraces()[0])
-	assert.True(t, td == p3.AllTraces()[1])
+	assert.Equal(t, td, p3.AllTraces()[0])
+	assert.Equal(t, td, p3.AllTraces()[1])
 	assert.EqualValues(t, td, p3.AllTraces()[0])
 	assert.EqualValues(t, td, p3.AllTraces()[1])
 
@@ -80,19 +80,19 @@ func TestTracesMultiplexingMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, td != p1.AllTraces()[0])
-	assert.True(t, td != p1.AllTraces()[1])
+	assert.NotSame(t, td, p1.AllTraces()[0])
+	assert.NotSame(t, td, p1.AllTraces()[1])
 	assert.EqualValues(t, td, p1.AllTraces()[0])
 	assert.EqualValues(t, td, p1.AllTraces()[1])
 
-	assert.True(t, td != p2.AllTraces()[0])
-	assert.True(t, td != p2.AllTraces()[1])
+	assert.NotSame(t, td, p2.AllTraces()[0])
+	assert.NotSame(t, td, p2.AllTraces()[1])
 	assert.EqualValues(t, td, p2.AllTraces()[0])
 	assert.EqualValues(t, td, p2.AllTraces()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, td == p3.AllTraces()[0])
-	assert.True(t, td == p3.AllTraces()[1])
+	assert.Equal(t, td, p3.AllTraces()[0])
+	assert.Equal(t, td, p3.AllTraces()[1])
 	assert.EqualValues(t, td, p3.AllTraces()[0])
 	assert.EqualValues(t, td, p3.AllTraces()[1])
 
@@ -122,18 +122,18 @@ func TestReadOnlyTracesMultiplexingMutating(t *testing.T) {
 
 	// All consumers should receive the cloned data.
 
-	assert.True(t, td != p1.AllTraces()[0])
-	assert.True(t, td != p1.AllTraces()[1])
+	assert.NotEqual(t, td, p1.AllTraces()[0])
+	assert.NotEqual(t, td, p1.AllTraces()[1])
 	assert.EqualValues(t, tdOrig, p1.AllTraces()[0])
 	assert.EqualValues(t, tdOrig, p1.AllTraces()[1])
 
-	assert.True(t, td != p2.AllTraces()[0])
-	assert.True(t, td != p2.AllTraces()[1])
+	assert.NotEqual(t, td, p2.AllTraces()[0])
+	assert.NotEqual(t, td, p2.AllTraces()[1])
 	assert.EqualValues(t, tdOrig, p2.AllTraces()[0])
 	assert.EqualValues(t, tdOrig, p2.AllTraces()[1])
 
-	assert.True(t, td != p3.AllTraces()[0])
-	assert.True(t, td != p3.AllTraces()[1])
+	assert.NotEqual(t, td, p3.AllTraces()[0])
+	assert.NotEqual(t, td, p3.AllTraces()[1])
 	assert.EqualValues(t, tdOrig, p3.AllTraces()[0])
 	assert.EqualValues(t, tdOrig, p3.AllTraces()[1])
 }
@@ -155,20 +155,20 @@ func TestTracesMultiplexingMixLastMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, td != p1.AllTraces()[0])
-	assert.True(t, td != p1.AllTraces()[1])
+	assert.NotSame(t, td, p1.AllTraces()[0])
+	assert.NotSame(t, td, p1.AllTraces()[1])
 	assert.EqualValues(t, td, p1.AllTraces()[0])
 	assert.EqualValues(t, td, p1.AllTraces()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, td == p2.AllTraces()[0])
-	assert.True(t, td == p2.AllTraces()[1])
+	assert.Equal(t, td, p2.AllTraces()[0])
+	assert.Equal(t, td, p2.AllTraces()[1])
 	assert.EqualValues(t, td, p2.AllTraces()[0])
 	assert.EqualValues(t, td, p2.AllTraces()[1])
 
 	// For this consumer, will clone the initial data.
-	assert.True(t, td != p3.AllTraces()[0])
-	assert.True(t, td != p3.AllTraces()[1])
+	assert.NotSame(t, td, p3.AllTraces()[0])
+	assert.NotSame(t, td, p3.AllTraces()[1])
 	assert.EqualValues(t, td, p3.AllTraces()[0])
 	assert.EqualValues(t, td, p3.AllTraces()[1])
 
@@ -193,19 +193,19 @@ func TestTracesMultiplexingMixLastNonMutating(t *testing.T) {
 		}
 	}
 
-	assert.True(t, td != p1.AllTraces()[0])
-	assert.True(t, td != p1.AllTraces()[1])
+	assert.NotSame(t, td, p1.AllTraces()[0])
+	assert.NotSame(t, td, p1.AllTraces()[1])
 	assert.EqualValues(t, td, p1.AllTraces()[0])
 	assert.EqualValues(t, td, p1.AllTraces()[1])
 
-	assert.True(t, td != p2.AllTraces()[0])
-	assert.True(t, td != p2.AllTraces()[1])
+	assert.NotSame(t, td, p2.AllTraces()[0])
+	assert.NotSame(t, td, p2.AllTraces()[1])
 	assert.EqualValues(t, td, p2.AllTraces()[0])
 	assert.EqualValues(t, td, p2.AllTraces()[1])
 
 	// For this consumer, will receive the initial data.
-	assert.True(t, td == p3.AllTraces()[0])
-	assert.True(t, td == p3.AllTraces()[1])
+	assert.Equal(t, td, p3.AllTraces()[0])
+	assert.Equal(t, td, p3.AllTraces()[1])
 	assert.EqualValues(t, td, p3.AllTraces()[0])
 	assert.EqualValues(t, td, p3.AllTraces()[1])
 
@@ -225,8 +225,8 @@ func TestTracesWhenErrors(t *testing.T) {
 		assert.Error(t, tfc.ConsumeTraces(context.Background(), td))
 	}
 
-	assert.True(t, td == p3.AllTraces()[0])
-	assert.True(t, td == p3.AllTraces()[1])
+	assert.Equal(t, td, p3.AllTraces()[0])
+	assert.Equal(t, td, p3.AllTraces()[1])
 	assert.EqualValues(t, td, p3.AllTraces()[0])
 	assert.EqualValues(t, td, p3.AllTraces()[1])
 }

--- a/internal/iruntime/mem_info_test.go
+++ b/internal/iruntime/mem_info_test.go
@@ -12,5 +12,5 @@ import (
 func TestReadMemInfo(t *testing.T) {
 	vmStat, err := readMemInfo()
 	assert.NoError(t, err)
-	assert.True(t, vmStat > 0)
+	assert.Positive(t, vmStat)
 }

--- a/internal/iruntime/total_memory_linux_test.go
+++ b/internal/iruntime/total_memory_linux_test.go
@@ -15,5 +15,5 @@ import (
 func TestTotalMemory(t *testing.T) {
 	totalMemory, err := TotalMemory()
 	require.NoError(t, err)
-	assert.True(t, totalMemory > 0)
+	assert.Positive(t, totalMemory)
 }


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [compares](https://github.com/Antonboom/testifylint?tab=readme-ov-file#compares) and  [negative-positive](https://github.com/Antonboom/testifylint?tab=readme-ov-file#negative-positive) rules from [testifylint](https://github.com/Antonboom/testifylint)