### PR TITLE
[exporterhelper] Rename Timeout/QueueSettings to Config

### DIFF
--- a/.chloggen/6767-exporterhelper-rename-config.yaml
+++ b/.chloggen/6767-exporterhelper-rename-config.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'deprecation'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Deprecate TimeoutSettings/QueueSettings in favor of TimeoutConfig/QueueConfig."
+
+# One or more tracking issues or pull requests related to the change
+issues: [6767]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/debugexporter/factory.go
+++ b/exporter/debugexporter/factory.go
@@ -54,7 +54,7 @@ func createTracesExporter(ctx context.Context, set exporter.Settings, config com
 	return exporterhelper.NewTracesExporter(ctx, set, config,
 		debugExporter.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithShutdown(otlptext.LoggerSync(exporterLogger)),
 	)
 }
@@ -66,7 +66,7 @@ func createMetricsExporter(ctx context.Context, set exporter.Settings, config co
 	return exporterhelper.NewMetricsExporter(ctx, set, config,
 		debugExporter.pushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithShutdown(otlptext.LoggerSync(exporterLogger)),
 	)
 }
@@ -78,7 +78,7 @@ func createLogsExporter(ctx context.Context, set exporter.Settings, config compo
 	return exporterhelper.NewLogsExporter(ctx, set, config,
 		debugExporter.pushLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithShutdown(otlptext.LoggerSync(exporterLogger)),
 	)
 }

--- a/exporter/exporterhelper/batch_sender_test.go
+++ b/exporter/exporterhelper/batch_sender_test.go
@@ -575,7 +575,7 @@ func TestBatchSender_ShutdownDeadlock(t *testing.T) {
 func TestBatchSenderWithTimeout(t *testing.T) {
 	bCfg := exporterbatcher.NewDefaultConfig()
 	bCfg.MinSizeItems = 10
-	tCfg := NewDefaultTimeoutSettings()
+	tCfg := NewDefaultTimeoutConfig()
 	tCfg.Timeout = 50 * time.Millisecond
 	be, err := newBaseExporter(defaultSettings, defaultDataType, newNoopObsrepSender,
 		WithBatcher(bCfg, WithRequestBatchFuncs(fakeBatchMergeFunc, fakeBatchMergeSplitFunc)),

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -64,11 +64,11 @@ func WithShutdown(shutdown component.ShutdownFunc) Option {
 	}
 }
 
-// WithTimeout overrides the default TimeoutSettings for an exporter.
-// The default TimeoutSettings is 5 seconds.
-func WithTimeout(timeoutSettings TimeoutSettings) Option {
+// WithTimeout overrides the default TimeoutConfig for an exporter.
+// The default TimeoutConfig is 5 seconds.
+func WithTimeout(timeoutConfig TimeoutConfig) Option {
 	return func(o *baseExporter) error {
-		o.timeoutSender.cfg = timeoutSettings
+		o.timeoutSender.cfg = timeoutConfig
 		return nil
 	}
 }
@@ -86,10 +86,10 @@ func WithRetry(config configretry.BackOffConfig) Option {
 	}
 }
 
-// WithQueue overrides the default QueueSettings for an exporter.
-// The default QueueSettings is to disable queueing.
+// WithQueue overrides the default QueueConfig for an exporter.
+// The default QueueConfig is to disable queueing.
 // This option cannot be used with the new exporter helpers New[Traces|Metrics|Logs]RequestExporter.
-func WithQueue(config QueueSettings) Option {
+func WithQueue(config QueueConfig) Option {
 	return func(o *baseExporter) error {
 		if o.marshaler == nil || o.unmarshaler == nil {
 			return fmt.Errorf("WithQueue option is not available for the new request exporters, use WithRequestQueue instead")
@@ -252,7 +252,7 @@ func newBaseExporter(set exporter.Settings, signal component.DataType, osf obsre
 		queueSender:   &baseRequestSender{},
 		obsrepSender:  osf(obsReport),
 		retrySender:   &baseRequestSender{},
-		timeoutSender: &timeoutSender{cfg: NewDefaultTimeoutSettings()},
+		timeoutSender: &timeoutSender{cfg: NewDefaultTimeoutConfig()},
 
 		set:    set,
 		obsrep: obsReport,

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -50,7 +50,7 @@ func TestBaseExporterWithOptions(t *testing.T) {
 		defaultSettings, defaultDataType, newNoopObsrepSender,
 		WithStart(func(context.Context, component.Host) error { return want }),
 		WithShutdown(func(context.Context) error { return want }),
-		WithTimeout(NewDefaultTimeoutSettings()),
+		WithTimeout(NewDefaultTimeoutConfig()),
 	)
 	require.NoError(t, err)
 	require.Equal(t, want, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -73,7 +73,7 @@ func TestQueueOptionsWithRequestExporter(t *testing.T) {
 	require.Nil(t, bs.marshaler)
 	require.Nil(t, bs.unmarshaler)
 	_, err = newBaseExporter(exportertest.NewNopSettings(), defaultDataType, newNoopObsrepSender,
-		WithRetry(configretry.NewDefaultBackOffConfig()), WithQueue(NewDefaultQueueSettings()))
+		WithRetry(configretry.NewDefaultBackOffConfig()), WithQueue(NewDefaultQueueConfig()))
 	require.Error(t, err)
 
 	_, err = newBaseExporter(exportertest.NewNopSettings(), defaultDataType, newNoopObsrepSender,

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -156,7 +156,7 @@ func TestLogsRequestExporter_Default_ExportError(t *testing.T) {
 }
 
 func TestLogsExporter_WithPersistentQueue(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID
 	rCfg := configretry.NewDefaultBackOffConfig()
@@ -253,7 +253,7 @@ func TestLogsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	rCfg := configretry.NewDefaultBackOffConfig()
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 2
 	wantErr := errors.New("some-error")

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -157,7 +157,7 @@ func TestMetricsRequestExporter_Default_ExportError(t *testing.T) {
 }
 
 func TestMetricsExporter_WithPersistentQueue(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID
 	rCfg := configretry.NewDefaultBackOffConfig()
@@ -255,7 +255,7 @@ func TestMetricsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	rCfg := configretry.NewDefaultBackOffConfig()
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 2
 	wantErr := errors.New("some-error")

--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -23,7 +23,12 @@ import (
 const defaultQueueSize = 1000
 
 // QueueSettings defines configuration for queueing batches before sending to the consumerSender.
-type QueueSettings struct {
+//
+// Deprecated: [v0.110.0] Use QueueConfig instead.
+type QueueSettings = QueueConfig
+
+// QueueConfig defines configuration for queueing batches before sending to the consumerSender.
+type QueueConfig struct {
 	// Enabled indicates whether to not enqueue batches before sending to the consumerSender.
 	Enabled bool `mapstructure:"enabled"`
 	// NumConsumers is the number of consumers from the queue. Defaults to 10.
@@ -38,8 +43,15 @@ type QueueSettings struct {
 }
 
 // NewDefaultQueueSettings returns the default settings for QueueSettings.
+//
+// Deprecated: [v0.110.0] Use NewDefaultQueueConfig instead.
 func NewDefaultQueueSettings() QueueSettings {
-	return QueueSettings{
+	return NewDefaultQueueConfig()
+}
+
+// NewDefaultQueueConfig returns the default config for QueueConfig.
+func NewDefaultQueueConfig() QueueConfig {
+	return QueueConfig{
 		Enabled:      true,
 		NumConsumers: 10,
 		// By default, batches are 8192 spans, for a total of up to 8 million spans in the queue
@@ -49,8 +61,8 @@ func NewDefaultQueueSettings() QueueSettings {
 	}
 }
 
-// Validate checks if the QueueSettings configuration is valid
-func (qCfg *QueueSettings) Validate() error {
+// Validate checks if the QueueConfig configuration is valid
+func (qCfg *QueueConfig) Validate() error {
 	if !qCfg.Enabled {
 		return nil
 	}

--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -22,8 +22,6 @@ import (
 
 const defaultQueueSize = 1000
 
-// QueueSettings defines configuration for queueing batches before sending to the consumerSender.
-//
 // Deprecated: [v0.110.0] Use QueueConfig instead.
 type QueueSettings = QueueConfig
 
@@ -42,8 +40,6 @@ type QueueConfig struct {
 	StorageID *component.ID `mapstructure:"storage"`
 }
 
-// NewDefaultQueueSettings returns the default settings for QueueSettings.
-//
 // Deprecated: [v0.110.0] Use NewDefaultQueueConfig instead.
 func NewDefaultQueueSettings() QueueSettings {
 	return NewDefaultQueueConfig()

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	rCfg := configretry.NewDefaultBackOffConfig()
 	be, err := newBaseExporter(defaultSettings, defaultDataType, newObservabilityConsumerSender,
@@ -60,7 +60,7 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 }
 
 func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	rCfg := configretry.NewDefaultBackOffConfig()
 	be, err := newBaseExporter(defaultSettings, defaultDataType, newObservabilityConsumerSender,
@@ -89,7 +89,7 @@ func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 }
 
 func TestQueuedRetry_RejectOnFull(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.QueueSize = 0
 	qCfg.NumConsumers = 0
 	set := exportertest.NewNopSettings()
@@ -119,7 +119,7 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 			queueOptions: []Option{
 				withMarshaler(mockRequestMarshaler),
 				withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
-				WithQueue(QueueSettings{
+				WithQueue(QueueConfig{
 					Enabled:      true,
 					QueueSize:    10,
 					NumConsumers: 1,
@@ -210,7 +210,7 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 		tt, err := componenttest.SetupTelemetry(defaultID)
 		require.NoError(t, err)
 
-		qCfg := NewDefaultQueueSettings()
+		qCfg := NewDefaultQueueConfig()
 		qCfg.NumConsumers = 0 // to make every request go straight to the queue
 		rCfg := configretry.NewDefaultBackOffConfig()
 		set := exporter.Settings{ID: defaultID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}
@@ -248,14 +248,14 @@ func TestNoCancellationContext(t *testing.T) {
 	assert.True(t, d.IsZero())
 }
 
-func TestQueueSettings_Validate(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+func TestQueueConfig_Validate(t *testing.T) {
+	qCfg := NewDefaultQueueConfig()
 	assert.NoError(t, qCfg.Validate())
 
 	qCfg.QueueSize = 0
 	assert.EqualError(t, qCfg.Validate(), "queue size must be positive")
 
-	qCfg = NewDefaultQueueSettings()
+	qCfg = NewDefaultQueueConfig()
 	qCfg.NumConsumers = 0
 
 	assert.EqualError(t, qCfg.Validate(), "number of queue consumers must be positive")
@@ -276,7 +276,7 @@ func TestQueueRetryWithDisabledQueue(t *testing.T) {
 				withMarshaler(mockRequestMarshaler),
 				withUnmarshaler(mockRequestUnmarshaler(&mockRequest{})),
 				func() Option {
-					qs := NewDefaultQueueSettings()
+					qs := NewDefaultQueueConfig()
 					qs.Enabled = false
 					return WithQueue(qs)
 				}(),
@@ -340,7 +340,7 @@ func TestQueuedRetryPersistenceEnabled(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID // enable persistence
 	rCfg := configretry.NewDefaultBackOffConfig()
@@ -366,7 +366,7 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID // enable persistence
 	rCfg := configretry.NewDefaultBackOffConfig()
@@ -385,7 +385,7 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 }
 
 func TestQueuedRetryPersistentEnabled_NoDataLossOnShutdown(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID // enable persistence to ensure data is re-queued on shutdown

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -36,7 +36,7 @@ func mockRequestMarshaler(Request) ([]byte, error) {
 }
 
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	rCfg := configretry.NewDefaultBackOffConfig()
 	mockR := newMockRequest(2, consumererror.NewPermanent(errors.New("bad data")))
 	be, err := newBaseExporter(defaultSettings, defaultDataType, newObservabilityConsumerSender,
@@ -60,7 +60,7 @@ func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 }
 
 func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.Enabled = false
 	be, err := newBaseExporter(defaultSettings, defaultDataType, newObservabilityConsumerSender, withMarshaler(mockRequestMarshaler),
@@ -86,7 +86,7 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 }
 
 func TestQueuedRetry_OnError(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = 0
@@ -115,7 +115,7 @@ func TestQueuedRetry_OnError(t *testing.T) {
 }
 
 func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = time.Millisecond
@@ -164,7 +164,7 @@ func (e wrappedError) Unwrap() error {
 }
 
 func TestQueuedRetry_ThrottleError(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = 10 * time.Millisecond
@@ -197,7 +197,7 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 }
 
 func TestQueuedRetry_RetryOnError(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 1
 	rCfg := configretry.NewDefaultBackOffConfig()

--- a/exporter/exporterhelper/timeout_sender.go
+++ b/exporter/exporterhelper/timeout_sender.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-// TimeoutSettings for timeout. The timeout applies to individual attempts to send data to the backend.
-//
 // Deprecated: [v0.110.0] Use TimeoutConfig instead.
 type TimeoutSettings = TimeoutConfig
 
@@ -29,8 +27,6 @@ func (ts *TimeoutConfig) Validate() error {
 	return nil
 }
 
-// NewDefaultTimeoutSettings returns the default settings for TimeoutSettings.
-//
 // Deprecated: [v0.110.0] Use NewDefaultTimeoutConfig instead.
 func NewDefaultTimeoutSettings() TimeoutSettings {
 	return NewDefaultTimeoutConfig()

--- a/exporter/exporterhelper/timeout_sender.go
+++ b/exporter/exporterhelper/timeout_sender.go
@@ -10,13 +10,18 @@ import (
 )
 
 // TimeoutSettings for timeout. The timeout applies to individual attempts to send data to the backend.
-type TimeoutSettings struct {
+//
+// Deprecated: [v0.110.0] Use TimeoutConfig instead.
+type TimeoutSettings = TimeoutConfig
+
+// TimeoutConfig for timeout. The timeout applies to individual attempts to send data to the backend.
+type TimeoutConfig struct {
 	// Timeout is the timeout for every attempt to send data to the backend.
 	// A zero timeout means no timeout.
 	Timeout time.Duration `mapstructure:"timeout"`
 }
 
-func (ts *TimeoutSettings) Validate() error {
+func (ts *TimeoutConfig) Validate() error {
 	// Negative timeouts are not acceptable, since all sends will fail.
 	if ts.Timeout < 0 {
 		return errors.New("'timeout' must be non-negative")
@@ -25,8 +30,15 @@ func (ts *TimeoutSettings) Validate() error {
 }
 
 // NewDefaultTimeoutSettings returns the default settings for TimeoutSettings.
+//
+// Deprecated: [v0.110.0] Use NewDefaultTimeoutConfig instead.
 func NewDefaultTimeoutSettings() TimeoutSettings {
-	return TimeoutSettings{
+	return NewDefaultTimeoutConfig()
+}
+
+// NewDefaultTimeoutConfig returns the default config for TimeoutConfig.
+func NewDefaultTimeoutConfig() TimeoutConfig {
+	return TimeoutConfig{
 		Timeout: 5 * time.Second,
 	}
 }
@@ -34,7 +46,7 @@ func NewDefaultTimeoutSettings() TimeoutSettings {
 // timeoutSender is a requestSender that adds a `timeout` to every request that passes this sender.
 type timeoutSender struct {
 	baseRequestSender
-	cfg TimeoutSettings
+	cfg TimeoutConfig
 }
 
 func (ts *timeoutSender) send(ctx context.Context, req Request) error {

--- a/exporter/exporterhelper/timeout_sender_test.go
+++ b/exporter/exporterhelper/timeout_sender_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewDefaultTimeoutSettings(t *testing.T) {
-	cfg := NewDefaultTimeoutSettings()
+func TestNewDefaultTimeoutConfig(t *testing.T) {
+	cfg := NewDefaultTimeoutConfig()
 	assert.NoError(t, cfg.Validate())
-	assert.Equal(t, TimeoutSettings{Timeout: 5 * time.Second}, cfg)
+	assert.Equal(t, TimeoutConfig{Timeout: 5 * time.Second}, cfg)
 }
 
 func TestInvalidTimeout(t *testing.T) {
-	cfg := NewDefaultTimeoutSettings()
+	cfg := NewDefaultTimeoutConfig()
 	assert.NoError(t, cfg.Validate())
 	cfg.Timeout = -1
 	assert.Error(t, cfg.Validate())

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -154,7 +154,7 @@ func TestTracesRequestExporter_Default_ExportError(t *testing.T) {
 }
 
 func TestTracesExporter_WithPersistentQueue(t *testing.T) {
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	storageID := component.MustNewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID
 	rCfg := configretry.NewDefaultBackOffConfig()
@@ -252,7 +252,7 @@ func TestTracesExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	rCfg := configretry.NewDefaultBackOffConfig()
-	qCfg := NewDefaultQueueSettings()
+	qCfg := NewDefaultQueueConfig()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 2
 	wantErr := errors.New("some-error")

--- a/exporter/exporterqueue/config.go
+++ b/exporter/exporterqueue/config.go
@@ -33,7 +33,7 @@ func NewDefaultConfig() Config {
 	}
 }
 
-// Validate checks if the QueueSettings configuration is valid
+// Validate checks if the Config is valid
 func (qCfg *Config) Validate() error {
 	if !qCfg.Enabled {
 		return nil

--- a/exporter/internal/common/factory.go
+++ b/exporter/internal/common/factory.go
@@ -35,7 +35,7 @@ func CreateTracesExporter(ctx context.Context, set exporter.Settings, config com
 	return exporterhelper.NewTracesExporter(ctx, set, config,
 		s.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithShutdown(otlptext.LoggerSync(exporterLogger)),
 	)
 }
@@ -46,7 +46,7 @@ func CreateMetricsExporter(ctx context.Context, set exporter.Settings, config co
 	return exporterhelper.NewMetricsExporter(ctx, set, config,
 		s.pushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithShutdown(otlptext.LoggerSync(exporterLogger)),
 	)
 }
@@ -57,7 +57,7 @@ func CreateLogsExporter(ctx context.Context, set exporter.Settings, config compo
 	return exporterhelper.NewLogsExporter(ctx, set, config,
 		s.pushLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithShutdown(otlptext.LoggerSync(exporterLogger)),
 	)
 }

--- a/exporter/otlpexporter/cfg-schema.yaml
+++ b/exporter/otlpexporter/cfg-schema.yaml
@@ -7,7 +7,7 @@ fields:
   doc: |
     Timeout is the timeout for every attempt to send data to the backend.
 - name: sending_queue
-  type: exporterhelper.QueueSettings
+  type: exporterhelper.QueueConfig
   kind: struct
   fields:
   - name: enabled

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -20,9 +20,9 @@ import (
 
 // Config defines configuration for OTLP exporter.
 type Config struct {
-	exporterhelper.TimeoutSettings `mapstructure:",squash"`     // squash ensures fields are correctly decoded in embedded struct.
-	QueueConfig                    exporterhelper.QueueSettings `mapstructure:"sending_queue"`
-	RetryConfig                    configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	exporterhelper.TimeoutConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	exporterhelper.QueueConfig   `mapstructure:"sending_queue"`
+	RetryConfig                  configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 
 	// Experimental: This configuration is at the early stage of development and may change without backward compatibility
 	// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -38,7 +38,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	assert.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
-			TimeoutSettings: exporterhelper.TimeoutSettings{
+			TimeoutConfig: exporterhelper.TimeoutConfig{
 				Timeout: 10 * time.Second,
 			},
 			RetryConfig: configretry.BackOffConfig{
@@ -49,7 +49,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				MaxInterval:         1 * time.Minute,
 				MaxElapsedTime:      10 * time.Minute,
 			},
-			QueueConfig: exporterhelper.QueueSettings{
+			QueueConfig: exporterhelper.QueueConfig{
 				Enabled:      true,
 				NumConsumers: 2,
 				QueueSize:    10,

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -34,10 +34,10 @@ func createDefaultConfig() component.Config {
 	batcherCfg.Enabled = false
 
 	return &Config{
-		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
-		RetryConfig:     configretry.NewDefaultBackOffConfig(),
-		QueueConfig:     exporterhelper.NewDefaultQueueSettings(),
-		BatcherConfig:   batcherCfg,
+		TimeoutConfig: exporterhelper.NewDefaultTimeoutConfig(),
+		RetryConfig:   configretry.NewDefaultBackOffConfig(),
+		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),
+		BatcherConfig: batcherCfg,
 		ClientConfig: configgrpc.ClientConfig{
 			Headers: map[string]configopaque.String{},
 			// Default to gzip compression
@@ -58,7 +58,7 @@ func createTracesExporter(
 	return exporterhelper.NewTracesExporter(ctx, set, cfg,
 		oce.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
+		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.RetryConfig),
 		exporterhelper.WithQueue(oCfg.QueueConfig),
 		exporterhelper.WithBatcher(oCfg.BatcherConfig),
@@ -77,7 +77,7 @@ func createMetricsExporter(
 	return exporterhelper.NewMetricsExporter(ctx, set, cfg,
 		oce.pushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
+		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.RetryConfig),
 		exporterhelper.WithQueue(oCfg.QueueConfig),
 		exporterhelper.WithBatcher(oCfg.BatcherConfig),
@@ -96,7 +96,7 @@ func createLogsExporter(
 	return exporterhelper.NewLogsExporter(ctx, set, cfg,
 		oce.pushLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
+		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.RetryConfig),
 		exporterhelper.WithQueue(oCfg.QueueConfig),
 		exporterhelper.WithBatcher(oCfg.BatcherConfig),

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -31,8 +31,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
 	assert.Equal(t, ocfg.RetryConfig, configretry.NewDefaultBackOffConfig())
-	assert.Equal(t, ocfg.QueueConfig, exporterhelper.NewDefaultQueueSettings())
-	assert.Equal(t, ocfg.TimeoutSettings, exporterhelper.NewDefaultTimeoutSettings())
+	assert.Equal(t, ocfg.QueueConfig, exporterhelper.NewDefaultQueueConfig())
+	assert.Equal(t, ocfg.TimeoutConfig, exporterhelper.NewDefaultTimeoutConfig())
 	assert.Equal(t, ocfg.Compression, configcompression.TypeGzip)
 }
 

--- a/exporter/otlphttpexporter/config.go
+++ b/exporter/otlphttpexporter/config.go
@@ -45,9 +45,9 @@ func (e *EncodingType) UnmarshalText(text []byte) error {
 
 // Config defines configuration for OTLP/HTTP exporter.
 type Config struct {
-	confighttp.ClientConfig `mapstructure:",squash"`     // squash ensures fields are correctly decoded in embedded struct.
-	QueueConfig             exporterhelper.QueueSettings `mapstructure:"sending_queue"`
-	RetryConfig             configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	confighttp.ClientConfig    `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	exporterhelper.QueueConfig `mapstructure:"sending_queue"`
+	RetryConfig                configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 
 	// The URL to send traces to. If omitted the Endpoint + "/v1/traces" will be used.
 	TracesEndpoint string `mapstructure:"traces_endpoint"`

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -46,7 +46,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				MaxInterval:         1 * time.Minute,
 				MaxElapsedTime:      10 * time.Minute,
 			},
-			QueueConfig: exporterhelper.QueueSettings{
+			QueueConfig: exporterhelper.QueueConfig{
 				Enabled:      true,
 				NumConsumers: 2,
 				QueueSize:    10,

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -35,7 +35,7 @@ func NewFactory() exporter.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		RetryConfig: configretry.NewDefaultBackOffConfig(),
-		QueueConfig: exporterhelper.NewDefaultQueueSettings(),
+		QueueConfig: exporterhelper.NewDefaultQueueConfig(),
 		Encoding:    EncodingProto,
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: "",
@@ -88,7 +88,7 @@ func createTracesExporter(
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// explicitly disable since we rely on http.Client timeout logic.
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetryConfig),
 		exporterhelper.WithQueue(oCfg.QueueConfig))
 }
@@ -114,7 +114,7 @@ func createMetricsExporter(
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// explicitly disable since we rely on http.Client timeout logic.
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetryConfig),
 		exporterhelper.WithQueue(oCfg.QueueConfig))
 }
@@ -140,7 +140,7 @@ func createLogsExporter(
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// explicitly disable since we rely on http.Client timeout logic.
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetryConfig),
 		exporterhelper.WithQueue(oCfg.QueueConfig))
 }

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -215,7 +215,7 @@ func TestErrorResponses(t *testing.T) {
 			cfg := &Config{
 				Encoding:       EncodingProto,
 				TracesEndpoint: fmt.Sprintf("%s/v1/traces", srv.URL),
-				// Create without QueueSettings and RetryConfig so that ConsumeTraces
+				// Create without QueueConfig and RetryConfig so that ConsumeTraces
 				// returns the errors that we want to check immediately.
 			}
 			exp, err := createTracesExporter(context.Background(), exportertest.NewNopSettings(), cfg)

--- a/internal/e2e/consume_contract_test.go
+++ b/internal/e2e/consume_contract_test.go
@@ -22,7 +22,7 @@ func testExporterConfig(endpoint string) component.Config {
 	retryConfig := configretry.NewDefaultBackOffConfig()
 	retryConfig.InitialInterval = time.Millisecond // interval is short for the test purposes
 	return &otlpexporter.Config{
-		QueueConfig: exporterhelper.QueueSettings{Enabled: false},
+		QueueConfig: exporterhelper.QueueConfig{Enabled: false},
 		RetryConfig: retryConfig,
 		ClientConfig: configgrpc.ClientConfig{
 			Endpoint: endpoint,


### PR DESCRIPTION
#### Description

This PR renames `TimeoutSettings` and `QueueSettings` (as well as the corresponding `NewDefault` functions) to `TimeoutConfig` and `QueueConfig`, for naming consistency reasons.

The previous struct/function names are kept as deprecated aliases of the new ones for now.

#### Link to tracking issue

Updates #6767  (edit: reworded by @mx-psi)

#### Testing

No behavior changes were made, so no additional testing should be necessary.

The references to the aforementioned structs/functions in existing tests have been renamed as well. This means the deprecated function aliases are not tested, lowering the coverage a bit.

#### Documentation

The new functions are documented identically to the previous ones.
