### PR TITLE
[chore]: enable expected-actual rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,7 +125,6 @@ linters-settings:
     # TODO: enable all rules
     disable:
       - error-is-as
-      - expected-actual
       - float-compare
       - formatter
       - go-require

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -38,7 +38,7 @@ SEMCONVGEN   := $(TOOLS_BIN_DIR)/semconvgen
 SEMCONVKIT   := $(TOOLS_BIN_DIR)/semconvkit
 TESTIFYLINT  := $(TOOLS_BIN_DIR)/testifylint
 
-TESTIFYLINT_OPT?= --enable-all --disable=error-is-as,expected-actual,float-compare,formatter,go-require,require-error
+TESTIFYLINT_OPT?= --enable-all --disable=error-is-as,float-compare,formatter,go-require,require-error
 
 .PHONY: install-tools
 install-tools: $(TOOLS_BIN_NAMES)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -71,7 +71,7 @@ func TestFromContext(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			assert.Equal(t, FromContext(tC.input), tC.expected)
+			assert.Equal(t, tC.expected, FromContext(tC.input))
 		})
 	}
 }

--- a/component/componenttest/nop_telemetry_test.go
+++ b/component/componenttest/nop_telemetry_test.go
@@ -23,5 +23,5 @@ func TestNewNopTelemetrySettings(t *testing.T) {
 		nts.MeterProvider.Meter("test")
 	})
 	assert.Equal(t, configtelemetry.LevelNone, nts.MetricsLevel)
-	assert.Equal(t, nts.Resource.Attributes().Len(), 0)
+	assert.Equal(t, 0, nts.Resource.Attributes().Len())
 }

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -1249,8 +1249,8 @@ func TestFailedServerAuth(t *testing.T) {
 	srv.Handler.ServeHTTP(response, httptest.NewRequest("GET", "/", nil))
 
 	// verify
-	assert.Equal(t, response.Result().StatusCode, http.StatusUnauthorized)
-	assert.Equal(t, response.Result().Status, fmt.Sprintf("%v %s", http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized)))
+	assert.Equal(t, http.StatusUnauthorized, response.Result().StatusCode)
+	assert.Equal(t, fmt.Sprintf("%v %s", http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized)), response.Result().Status)
 }
 
 func TestServerWithErrorHandler(t *testing.T) {
@@ -1259,7 +1259,7 @@ func TestServerWithErrorHandler(t *testing.T) {
 		Endpoint: "localhost:0",
 	}
 	eh := func(w http.ResponseWriter, _ *http.Request, _ string, statusCode int) {
-		assert.Equal(t, statusCode, http.StatusBadRequest)
+		assert.Equal(t, http.StatusBadRequest, statusCode)
 		// custom error handler changes returned status code
 		http.Error(w, "invalid request", http.StatusInternalServerError)
 	}
@@ -1281,7 +1281,7 @@ func TestServerWithErrorHandler(t *testing.T) {
 
 	srv.Handler.ServeHTTP(response, req)
 	// verify
-	assert.Equal(t, response.Result().StatusCode, http.StatusInternalServerError)
+	assert.Equal(t, http.StatusInternalServerError, response.Result().StatusCode)
 }
 
 func TestServerWithDecoder(t *testing.T) {
@@ -1309,7 +1309,7 @@ func TestServerWithDecoder(t *testing.T) {
 
 	srv.Handler.ServeHTTP(response, req)
 	// verify
-	assert.Equal(t, response.Result().StatusCode, http.StatusOK)
+	assert.Equal(t, http.StatusOK, response.Result().StatusCode)
 
 }
 
@@ -1356,7 +1356,7 @@ func TestServerWithDecompression(t *testing.T) {
 
 	// verifications is done mostly within the test, but this is only a sanity check
 	// that we got into the test handler
-	assert.Equal(t, resp.StatusCode, http.StatusBadRequest)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestDefaultMaxRequestBodySize(t *testing.T) {

--- a/confmap/internal/e2e/types_test.go
+++ b/confmap/internal/e2e/types_test.go
@@ -419,43 +419,42 @@ func TestIssue10787(t *testing.T) {
 	resolver := NewResolver(t, "issue-10787-main.yaml")
 	conf, err := resolver.Resolve(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, conf.ToStringMap(),
-		map[string]any{
-			"exporters": map[string]any{
-				"debug": map[string]any{
-					"verbosity": "detailed",
-				},
+	assert.Equal(t, map[string]any{
+		"exporters": map[string]any{
+			"debug": map[string]any{
+				"verbosity": "detailed",
 			},
-			"processors": map[string]any{
-				"batch": nil,
-			},
-			"receivers": map[string]any{
-				"otlp": map[string]any{
-					"protocols": map[string]any{
-						"grpc": map[string]any{
-							"endpoint": "0.0.0.0:4317",
-						},
-						"http": map[string]any{
-							"endpoint": "0.0.0.0:4318",
-						},
+		},
+		"processors": map[string]any{
+			"batch": nil,
+		},
+		"receivers": map[string]any{
+			"otlp": map[string]any{
+				"protocols": map[string]any{
+					"grpc": map[string]any{
+						"endpoint": "0.0.0.0:4317",
 					},
-				},
-			},
-			"service": map[string]any{
-				"pipelines": map[string]any{
-					"traces": map[string]any{
-						"exporters":  []any{"debug"},
-						"processors": []any{"batch"},
-						"receivers":  []any{"otlp"},
-					},
-				},
-				"telemetry": map[string]any{
-					"metrics": map[string]any{
-						"level": "detailed",
+					"http": map[string]any{
+						"endpoint": "0.0.0.0:4318",
 					},
 				},
 			},
 		},
+		"service": map[string]any{
+			"pipelines": map[string]any{
+				"traces": map[string]any{
+					"exporters":  []any{"debug"},
+					"processors": []any{"batch"},
+					"receivers":  []any{"otlp"},
+				},
+			},
+			"telemetry": map[string]any{
+				"metrics": map[string]any{
+					"level": "detailed",
+				},
+			},
+		},
+	}, conf.ToStringMap(),
 	)
 }
 
@@ -582,9 +581,9 @@ func TestIndirectSliceEnvVar(t *testing.T) {
 	var collectorConf CollectorConf
 	err = conf.Unmarshal(&collectorConf)
 	require.NoError(t, err)
-	assert.Equal(t, collectorConf.Exporters.OTLP.Endpoint, "localhost:4317")
-	assert.Equal(t, collectorConf.Service.Pipelines.Logs.Receivers, []string{"nop", "otlp"})
-	assert.Equal(t, collectorConf.Service.Pipelines.Logs.Exporters, []string{"otlp", "nop"})
+	assert.Equal(t, "localhost:4317", collectorConf.Exporters.OTLP.Endpoint)
+	assert.Equal(t, []string{"nop", "otlp"}, collectorConf.Service.Pipelines.Logs.Receivers)
+	assert.Equal(t, []string{"otlp", "nop"}, collectorConf.Service.Pipelines.Logs.Exporters)
 }
 
 func TestIssue10937_MapType(t *testing.T) {

--- a/exporter/debugexporter/config_test.go
+++ b/exporter/debugexporter/config_test.go
@@ -94,7 +94,7 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 
 			if tc.expectedErr == "" {
 				assert.NoError(t, err)
-				assert.Equal(t, outCfg, tc.expectedConfig)
+				assert.Equal(t, tc.expectedConfig, outCfg)
 				return
 			}
 			assert.Error(t, err)

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -359,7 +359,7 @@ func TestLogsExporter_WithShutdown_ReturnError(t *testing.T) {
 	assert.NotNil(t, le)
 	assert.NoError(t, err)
 
-	assert.Equal(t, le.Shutdown(context.Background()), want)
+	assert.Equal(t, want, le.Shutdown(context.Background()))
 }
 
 func TestLogsRequestExporter_WithShutdown_ReturnError(t *testing.T) {
@@ -371,7 +371,7 @@ func TestLogsRequestExporter_WithShutdown_ReturnError(t *testing.T) {
 	assert.NotNil(t, le)
 	assert.NoError(t, err)
 
-	assert.Equal(t, le.Shutdown(context.Background()), want)
+	assert.Equal(t, want, le.Shutdown(context.Background()))
 }
 
 func newPushLogsDataModifiedDownstream(retError error) consumer.ConsumeLogsFunc {

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -365,7 +365,7 @@ func TestTracesExporter_WithShutdown_ReturnError(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, te.Start(context.Background(), componenttest.NewNopHost()))
-	assert.Equal(t, te.Shutdown(context.Background()), want)
+	assert.Equal(t, want, te.Shutdown(context.Background()))
 }
 
 func TestTracesRequestExporter_WithShutdown_ReturnError(t *testing.T) {
@@ -378,7 +378,7 @@ func TestTracesRequestExporter_WithShutdown_ReturnError(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, te.Start(context.Background(), componenttest.NewNopHost()))
-	assert.Equal(t, te.Shutdown(context.Background()), want)
+	assert.Equal(t, want, te.Shutdown(context.Background()))
 }
 
 func newTraceDataPusher(retError error) consumer.ConsumeTracesFunc {

--- a/exporter/exportertest/contract_checker.go
+++ b/exporter/exportertest/contract_checker.go
@@ -228,9 +228,9 @@ func checkLogs(t *testing.T, params CheckConsumeContractParams, mockReceiver com
 // Test is successful if all the elements were received successfully and no error was returned
 func alwaysSucceedsPassed(t *testing.T, allRecordsNumber int, reqCounter requestCounter) {
 	require.Equal(t, allRecordsNumber, reqCounter.success)
-	require.Equal(t, reqCounter.total, allRecordsNumber)
-	require.Equal(t, reqCounter.error.nonpermanent, 0)
-	require.Equal(t, reqCounter.error.permanent, 0)
+	require.Equal(t, allRecordsNumber, reqCounter.total)
+	require.Equal(t, 0, reqCounter.error.nonpermanent)
+	require.Equal(t, 0, reqCounter.error.permanent)
 }
 
 // Test is successful if all the elements were retried on non-permanent errors

--- a/exporter/exportertest/mock_consumer_test.go
+++ b/exporter/exportertest/mock_consumer_test.go
@@ -130,10 +130,10 @@ func TestConsumeLogsNonPermanent(t *testing.T) {
 	if err != nil {
 		return
 	}
-	assert.Equal(t, mc.reqCounter.error.nonpermanent, 1)
-	assert.Equal(t, mc.reqCounter.error.permanent, 0)
-	assert.Equal(t, mc.reqCounter.success, 0)
-	assert.Equal(t, mc.reqCounter.total, 1)
+	assert.Equal(t, 1, mc.reqCounter.error.nonpermanent)
+	assert.Equal(t, 0, mc.reqCounter.error.permanent)
+	assert.Equal(t, 0, mc.reqCounter.success)
+	assert.Equal(t, 1, mc.reqCounter.total)
 
 }
 
@@ -145,10 +145,10 @@ func TestConsumeLogsPermanent(t *testing.T) {
 	if err != nil {
 		return
 	}
-	assert.Equal(t, mc.reqCounter.error.nonpermanent, 0)
-	assert.Equal(t, mc.reqCounter.error.permanent, 1)
-	assert.Equal(t, mc.reqCounter.success, 0)
-	assert.Equal(t, mc.reqCounter.total, 1)
+	assert.Equal(t, 0, mc.reqCounter.error.nonpermanent)
+	assert.Equal(t, 1, mc.reqCounter.error.permanent)
+	assert.Equal(t, 0, mc.reqCounter.success)
+	assert.Equal(t, 1, mc.reqCounter.total)
 
 }
 
@@ -159,10 +159,10 @@ func TestConsumeLogsSuccess(t *testing.T) {
 	if err != nil {
 		return
 	}
-	assert.Equal(t, mc.reqCounter.error.nonpermanent, 0)
-	assert.Equal(t, mc.reqCounter.error.permanent, 0)
-	assert.Equal(t, mc.reqCounter.success, 1)
-	assert.Equal(t, mc.reqCounter.total, 1)
+	assert.Equal(t, 0, mc.reqCounter.error.nonpermanent)
+	assert.Equal(t, 0, mc.reqCounter.error.permanent)
+	assert.Equal(t, 1, mc.reqCounter.success)
+	assert.Equal(t, 1, mc.reqCounter.total)
 
 }
 
@@ -173,10 +173,10 @@ func TestConsumeTracesNonPermanent(t *testing.T) {
 	if err != nil {
 		return
 	}
-	assert.Equal(t, mc.reqCounter.error.nonpermanent, 1)
-	assert.Equal(t, mc.reqCounter.error.permanent, 0)
-	assert.Equal(t, mc.reqCounter.success, 0)
-	assert.Equal(t, mc.reqCounter.total, 1)
+	assert.Equal(t, 1, mc.reqCounter.error.nonpermanent)
+	assert.Equal(t, 0, mc.reqCounter.error.permanent)
+	assert.Equal(t, 0, mc.reqCounter.success)
+	assert.Equal(t, 1, mc.reqCounter.total)
 
 }
 
@@ -188,10 +188,10 @@ func TestConsumeTracesPermanent(t *testing.T) {
 	if err != nil {
 		return
 	}
-	assert.Equal(t, mc.reqCounter.error.nonpermanent, 0)
-	assert.Equal(t, mc.reqCounter.error.permanent, 1)
-	assert.Equal(t, mc.reqCounter.success, 0)
-	assert.Equal(t, mc.reqCounter.total, 1)
+	assert.Equal(t, 0, mc.reqCounter.error.nonpermanent)
+	assert.Equal(t, 1, mc.reqCounter.error.permanent)
+	assert.Equal(t, 0, mc.reqCounter.success)
+	assert.Equal(t, 1, mc.reqCounter.total)
 
 }
 
@@ -202,10 +202,10 @@ func TestConsumeTracesSuccess(t *testing.T) {
 	if err != nil {
 		return
 	}
-	assert.Equal(t, mc.reqCounter.error.nonpermanent, 0)
-	assert.Equal(t, mc.reqCounter.error.permanent, 0)
-	assert.Equal(t, mc.reqCounter.success, 1)
-	assert.Equal(t, mc.reqCounter.total, 1)
+	assert.Equal(t, 0, mc.reqCounter.error.nonpermanent)
+	assert.Equal(t, 0, mc.reqCounter.error.permanent)
+	assert.Equal(t, 1, mc.reqCounter.success)
+	assert.Equal(t, 1, mc.reqCounter.total)
 
 }
 func TestConsumeMetricsNonPermanent(t *testing.T) {
@@ -215,10 +215,10 @@ func TestConsumeMetricsNonPermanent(t *testing.T) {
 	if err != nil {
 		return
 	}
-	assert.Equal(t, mc.reqCounter.error.nonpermanent, 1)
-	assert.Equal(t, mc.reqCounter.error.permanent, 0)
-	assert.Equal(t, mc.reqCounter.success, 0)
-	assert.Equal(t, mc.reqCounter.total, 1)
+	assert.Equal(t, 1, mc.reqCounter.error.nonpermanent)
+	assert.Equal(t, 0, mc.reqCounter.error.permanent)
+	assert.Equal(t, 0, mc.reqCounter.success)
+	assert.Equal(t, 1, mc.reqCounter.total)
 
 }
 
@@ -229,10 +229,10 @@ func TestConsumeMetricsPermanent(t *testing.T) {
 	if err != nil {
 		return
 	}
-	assert.Equal(t, mc.reqCounter.error.nonpermanent, 0)
-	assert.Equal(t, mc.reqCounter.error.permanent, 1)
-	assert.Equal(t, mc.reqCounter.success, 0)
-	assert.Equal(t, mc.reqCounter.total, 1)
+	assert.Equal(t, 0, mc.reqCounter.error.nonpermanent)
+	assert.Equal(t, 1, mc.reqCounter.error.permanent)
+	assert.Equal(t, 0, mc.reqCounter.success)
+	assert.Equal(t, 1, mc.reqCounter.total)
 
 }
 
@@ -243,14 +243,14 @@ func TestConsumeMetricsSuccess(t *testing.T) {
 	if err != nil {
 		return
 	}
-	assert.Equal(t, mc.reqCounter.error.nonpermanent, 0)
-	assert.Equal(t, mc.reqCounter.error.permanent, 0)
-	assert.Equal(t, mc.reqCounter.success, 1)
-	assert.Equal(t, mc.reqCounter.total, 1)
+	assert.Equal(t, 0, mc.reqCounter.error.nonpermanent)
+	assert.Equal(t, 0, mc.reqCounter.error.permanent)
+	assert.Equal(t, 1, mc.reqCounter.success)
+	assert.Equal(t, 1, mc.reqCounter.total)
 
 }
 
 func TestCapabilites(t *testing.T) {
 	mc := newMockConsumer(func() error { return nil })
-	assert.Equal(t, mc.Capabilities(), consumer.Capabilities{})
+	assert.Equal(t, consumer.Capabilities{}, mc.Capabilities())
 }

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -138,7 +138,7 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 
 			if tc.expectedErr == "" {
 				assert.NoError(t, err)
-				assert.Equal(t, outCfg, tc.expectedConfig)
+				assert.Equal(t, tc.expectedConfig, outCfg)
 				return
 			}
 			assert.Error(t, err)

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -30,10 +30,10 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
-	assert.Equal(t, ocfg.RetryConfig, configretry.NewDefaultBackOffConfig())
-	assert.Equal(t, ocfg.QueueConfig, exporterhelper.NewDefaultQueueConfig())
-	assert.Equal(t, ocfg.TimeoutConfig, exporterhelper.NewDefaultTimeoutConfig())
-	assert.Equal(t, ocfg.Compression, configcompression.TypeGzip)
+	assert.Equal(t, configretry.NewDefaultBackOffConfig(), ocfg.RetryConfig)
+	assert.Equal(t, exporterhelper.NewDefaultQueueConfig(), ocfg.QueueConfig)
+	assert.Equal(t, exporterhelper.NewDefaultTimeoutConfig(), ocfg.TimeoutConfig)
+	assert.Equal(t, configcompression.TypeGzip, ocfg.Compression)
 }
 
 func TestCreateMetricsExporter(t *testing.T) {
@@ -181,7 +181,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			if err != nil {
 				// Since the endpoint of OTLP exporter doesn't actually exist,
 				// exporter may already stop because it cannot connect.
-				assert.Equal(t, err.Error(), "rpc error: code = Canceled desc = grpc: the client connection is closing")
+				assert.Equal(t, "rpc error: code = Canceled desc = grpc: the client connection is closing", err.Error())
 			}
 		})
 	}

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -299,7 +299,7 @@ func TestSendTraces(t *testing.T) {
 	assert.EqualValues(t, td, rcv.getLastRequest())
 
 	md := rcv.getMetadata()
-	require.EqualValues(t, md.Get("header"), expectedHeader)
+	require.EqualValues(t, expectedHeader, md.Get("header"))
 	require.Len(t, md.Get("User-Agent"), 1)
 	require.Contains(t, md.Get("User-Agent")[0], "Collector/1.2.3test")
 
@@ -471,7 +471,7 @@ func TestSendMetrics(t *testing.T) {
 	assert.EqualValues(t, md, rcv.getLastRequest())
 
 	mdata := rcv.getMetadata()
-	require.EqualValues(t, mdata.Get("header"), expectedHeader)
+	require.EqualValues(t, expectedHeader, mdata.Get("header"))
 	require.Len(t, mdata.Get("User-Agent"), 1)
 	require.Contains(t, mdata.Get("User-Agent")[0], "Collector/1.2.3test")
 

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -28,15 +28,15 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
-	assert.Equal(t, ocfg.ClientConfig.Endpoint, "")
-	assert.Equal(t, ocfg.ClientConfig.Timeout, 30*time.Second, "default timeout is 30 second")
+	assert.Equal(t, "", ocfg.ClientConfig.Endpoint)
+	assert.Equal(t, 30*time.Second, ocfg.ClientConfig.Timeout, "default timeout is 30 second")
 	assert.True(t, ocfg.RetryConfig.Enabled, "default retry is enabled")
-	assert.Equal(t, ocfg.RetryConfig.MaxElapsedTime, 300*time.Second, "default retry MaxElapsedTime")
-	assert.Equal(t, ocfg.RetryConfig.InitialInterval, 5*time.Second, "default retry InitialInterval")
-	assert.Equal(t, ocfg.RetryConfig.MaxInterval, 30*time.Second, "default retry MaxInterval")
+	assert.Equal(t, 300*time.Second, ocfg.RetryConfig.MaxElapsedTime, "default retry MaxElapsedTime")
+	assert.Equal(t, 5*time.Second, ocfg.RetryConfig.InitialInterval, "default retry InitialInterval")
+	assert.Equal(t, 30*time.Second, ocfg.RetryConfig.MaxInterval, "default retry MaxInterval")
 	assert.True(t, ocfg.QueueConfig.Enabled, "default sending queue is enabled")
-	assert.Equal(t, ocfg.Encoding, EncodingProto)
-	assert.Equal(t, ocfg.Compression, configcompression.TypeGzip)
+	assert.Equal(t, EncodingProto, ocfg.Encoding)
+	assert.Equal(t, configcompression.TypeGzip, ocfg.Compression)
 }
 
 func TestCreateMetricsExporter(t *testing.T) {
@@ -192,7 +192,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			if err != nil {
 				// Since the endpoint of OTLP exporter doesn't actually exist,
 				// exporter may already stop because it cannot connect.
-				assert.Equal(t, err.Error(), "rpc error: code = Canceled desc = grpc: the client connection is closing")
+				assert.Equal(t, "rpc error: code = Canceled desc = grpc: the client connection is closing", err.Error())
 			}
 		})
 	}

--- a/internal/cgroups/mountpoint_test.go
+++ b/internal/cgroups/mountpoint_test.go
@@ -106,7 +106,7 @@ func TestNewMountPointFromLineErr(t *testing.T) {
 		errExpected := mountPointFormatInvalidError{line}
 
 		assert.Nil(t, mountPoint, "[%d] %q", i, line)
-		assert.Equal(t, err, errExpected, "[%d] %q", i, line)
+		assert.Equal(t, errExpected, err, "[%d] %q", i, line)
 	}
 }
 

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -427,7 +427,7 @@ func TestMap_EnsureCapacity_Existing(t *testing.T) {
 	// Ensure previously existing element is still there.
 	assert.Equal(t, 1, am.Len())
 	v, ok := am.Get("foo")
-	assert.Equal(t, v.Str(), "bar")
+	assert.Equal(t, "bar", v.Str())
 	assert.True(t, ok)
 
 	assert.Equal(t, 5, cap(*am.getOrig()))
@@ -439,11 +439,11 @@ func TestMap_EnsureCapacity_Existing(t *testing.T) {
 	assert.Equal(t, 2, am.Len())
 
 	v, ok = am.Get("foo")
-	assert.Equal(t, v.Str(), "bar")
+	assert.Equal(t, "bar", v.Str())
 	assert.True(t, ok)
 
 	v, ok = am.Get("abc")
-	assert.Equal(t, v.Str(), "xyz")
+	assert.Equal(t, "xyz", v.Str())
 	assert.True(t, ok)
 }
 

--- a/pdata/plog/plogotlp/request_test.go
+++ b/pdata/plog/plogotlp/request_test.go
@@ -39,9 +39,9 @@ var logsRequestJSON = []byte(`
 
 func TestRequestToPData(t *testing.T) {
 	tr := NewExportRequest()
-	assert.Equal(t, tr.Logs().LogRecordCount(), 0)
+	assert.Equal(t, 0, tr.Logs().LogRecordCount())
 	tr.Logs().ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-	assert.Equal(t, tr.Logs().LogRecordCount(), 1)
+	assert.Equal(t, 1, tr.Logs().LogRecordCount())
 }
 
 func TestRequestJSON(t *testing.T) {

--- a/pdata/pmetric/pmetricotlp/request_test.go
+++ b/pdata/pmetric/pmetricotlp/request_test.go
@@ -35,9 +35,9 @@ var metricsRequestJSON = []byte(`
 
 func TestRequestToPData(t *testing.T) {
 	tr := NewExportRequest()
-	assert.Equal(t, tr.Metrics().MetricCount(), 0)
+	assert.Equal(t, 0, tr.Metrics().MetricCount())
 	tr.Metrics().ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	assert.Equal(t, tr.Metrics().MetricCount(), 1)
+	assert.Equal(t, 1, tr.Metrics().MetricCount())
 }
 
 func TestRequestJSON(t *testing.T) {

--- a/pdata/pprofile/pprofileotlp/request_test.go
+++ b/pdata/pprofile/pprofileotlp/request_test.go
@@ -43,9 +43,9 @@ var profilesRequestJSON = []byte(`
 
 func TestRequestToPData(t *testing.T) {
 	tr := NewExportRequest()
-	assert.Equal(t, tr.Profiles().SampleCount(), 0)
+	assert.Equal(t, 0, tr.Profiles().SampleCount())
 	tr.Profiles().ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty().Profile().Sample().AppendEmpty()
-	assert.Equal(t, tr.Profiles().SampleCount(), 1)
+	assert.Equal(t, 1, tr.Profiles().SampleCount())
 }
 
 func TestRequestJSON(t *testing.T) {

--- a/pdata/ptrace/ptraceotlp/request_test.go
+++ b/pdata/ptrace/ptraceotlp/request_test.go
@@ -39,9 +39,9 @@ var tracesRequestJSON = []byte(`
 
 func TestRequestToPData(t *testing.T) {
 	tr := NewExportRequest()
-	assert.Equal(t, tr.Traces().SpanCount(), 0)
+	assert.Equal(t, 0, tr.Traces().SpanCount())
 	tr.Traces().ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
-	assert.Equal(t, tr.Traces().SpanCount(), 1)
+	assert.Equal(t, 1, tr.Traces().SpanCount())
 }
 
 func TestRequestJSON(t *testing.T) {

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -384,7 +384,7 @@ func TestScrapeControllerStartsOnInit(t *testing.T) {
 	assert.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()), "Must not error on start")
 	<-time.After(500 * time.Nanosecond)
 	assert.NoError(t, r.Shutdown(context.Background()), "Must not have errored on shutdown")
-	assert.Equal(t, tsm.timesScrapeCalled, 1, "Must have been called as soon as the controller started")
+	assert.Equal(t, 1, tsm.timesScrapeCalled, "Must have been called as soon as the controller started")
 }
 
 func TestScrapeControllerInitialDelay(t *testing.T) {

--- a/service/internal/builders/extension_test.go
+++ b/service/internal/builders/extension_test.go
@@ -43,7 +43,7 @@ func TestExtensionBuilder(t *testing.T) {
 	// Check that the extension has access to the resource attributes.
 	nop, ok := e.(nopExtension)
 	assert.True(t, ok)
-	assert.Equal(t, nop.Settings.Resource.Attributes().Len(), 0)
+	assert.Equal(t, 0, nop.Settings.Resource.Attributes().Len())
 
 	missingType, err := b.Create(context.Background(), createExtensionSettings(unknownID))
 	assert.EqualError(t, err, "extension factory not available for: \"unknown\"")

--- a/service/internal/resource/config_test.go
+++ b/service/internal/resource/config_test.go
@@ -124,7 +124,7 @@ func TestBuildResource(t *testing.T) {
 	otelRes := New(buildInfo, resMap)
 	res := pdataFromSdk(otelRes)
 
-	assert.Equal(t, res.Attributes().Len(), 3)
+	assert.Equal(t, 3, res.Attributes().Len())
 	value, ok := res.Attributes().Get(semconv.AttributeServiceName)
 	assert.True(t, ok)
 	assert.Equal(t, buildInfo.Command, value.AsString())
@@ -145,7 +145,7 @@ func TestBuildResource(t *testing.T) {
 	res = pdataFromSdk(otelRes)
 
 	// Attributes should not exist since we nil-ified all.
-	assert.Equal(t, res.Attributes().Len(), 0)
+	assert.Equal(t, 0, res.Attributes().Len())
 
 	// Check override values
 	strPtr := func(v string) *string { return &v }
@@ -157,7 +157,7 @@ func TestBuildResource(t *testing.T) {
 	otelRes = New(buildInfo, resMap)
 	res = pdataFromSdk(otelRes)
 
-	assert.Equal(t, res.Attributes().Len(), 3)
+	assert.Equal(t, 3, res.Attributes().Len())
 	value, ok = res.Attributes().Get(semconv.AttributeServiceName)
 	assert.True(t, ok)
 	assert.Equal(t, "a", value.AsString())


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [expected-actual](https://github.com/Antonboom/testifylint?tab=readme-ov-file#expected-actual) rule from [testifylint](https://github.com/Antonboom/testifylint)