### PR TITLE
[chore]: enable error-is-as rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,7 +124,6 @@ linters-settings:
   testifylint:
     # TODO: enable all rules
     disable:
-      - error-is-as
       - float-compare
       - formatter
       - go-require

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -38,7 +38,7 @@ SEMCONVGEN   := $(TOOLS_BIN_DIR)/semconvgen
 SEMCONVKIT   := $(TOOLS_BIN_DIR)/semconvkit
 TESTIFYLINT  := $(TOOLS_BIN_DIR)/testifylint
 
-TESTIFYLINT_OPT?= --enable-all --disable=error-is-as,float-compare,formatter,go-require,require-error
+TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,go-require,require-error
 
 .PHONY: install-tools
 install-tools: $(TOOLS_BIN_NAMES)

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -4,7 +4,6 @@
 package builder
 
 import (
-	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -143,7 +142,7 @@ func TestMissingModule(t *testing.T) {
 	}
 
 	for _, test := range configurations {
-		assert.True(t, errors.Is(test.cfg.Validate(), test.err))
+		assert.ErrorIs(t, test.cfg.Validate(), test.err)
 	}
 }
 

--- a/confmap/internal/mapstructure/encoder_test.go
+++ b/confmap/internal/mapstructure/encoder_test.go
@@ -306,7 +306,7 @@ func TestEncodeNonStringEncodedKey(t *testing.T) {
 	}
 	got, err := enc.Encode(testCase)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, errNonStringEncodedKey))
+	require.ErrorIs(t, err, errNonStringEncodedKey)
 	require.Nil(t, got)
 }
 
@@ -358,7 +358,7 @@ func TestEncodeStructError(t *testing.T) {
 	}
 	got, err := enc.Encode(testCase)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, wantErr))
+	require.ErrorIs(t, err, wantErr)
 	require.Nil(t, got)
 }
 

--- a/consumer/consumererror/signalerrors_test.go
+++ b/consumer/consumererror/signalerrors_test.go
@@ -21,7 +21,7 @@ func TestTraces(t *testing.T) {
 	var target Traces
 	assert.False(t, errors.As(nil, &target))
 	assert.False(t, errors.As(err, &target))
-	assert.True(t, errors.As(traceErr, &target))
+	assert.ErrorAs(t, traceErr, &target)
 	assert.Equal(t, td, target.Data())
 }
 
@@ -33,7 +33,7 @@ func TestTraces_Unwrap(t *testing.T) {
 	target := testErrorType{}
 	require.NotEqual(t, err, target)
 	// Unwrapping traceErr for err and assigning to target.
-	require.True(t, errors.As(traceErr, &target))
+	require.ErrorAs(t, traceErr, &target)
 	require.Equal(t, err, target)
 }
 
@@ -45,7 +45,7 @@ func TestLogs(t *testing.T) {
 	var target Logs
 	assert.False(t, errors.As(nil, &target))
 	assert.False(t, errors.As(err, &target))
-	assert.True(t, errors.As(logsErr, &target))
+	assert.ErrorAs(t, logsErr, &target)
 	assert.Equal(t, td, target.Data())
 }
 
@@ -57,7 +57,7 @@ func TestLogs_Unwrap(t *testing.T) {
 	target := testErrorType{}
 	require.NotEqual(t, err, target)
 	// Unwrapping logsErr for err and assigning to target.
-	require.True(t, errors.As(logsErr, &target))
+	require.ErrorAs(t, logsErr, &target)
 	require.Equal(t, err, target)
 }
 
@@ -69,7 +69,7 @@ func TestMetrics(t *testing.T) {
 	var target Metrics
 	assert.False(t, errors.As(nil, &target))
 	assert.False(t, errors.As(err, &target))
-	assert.True(t, errors.As(metricErr, &target))
+	assert.ErrorAs(t, metricErr, &target)
 	assert.Equal(t, td, target.Data())
 }
 
@@ -81,6 +81,6 @@ func TestMetrics_Unwrap(t *testing.T) {
 	target := testErrorType{}
 	require.NotEqual(t, err, target)
 	// Unwrapping metricErr for err and assigning to target.
-	require.True(t, errors.As(metricErr, &target))
+	require.ErrorAs(t, metricErr, &target)
 	require.Equal(t, err, target)
 }


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [error-is-as](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-is-as) rule from [testifylint](https://github.com/Antonboom/testifylint)