### PR TITLE
[chore]: enable float-compare rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,7 +124,6 @@ linters-settings:
   testifylint:
     # TODO: enable all rules
     disable:
-      - float-compare
       - require-error
     enable-all: true   
 

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -38,7 +38,7 @@ SEMCONVGEN   := $(TOOLS_BIN_DIR)/semconvgen
 SEMCONVKIT   := $(TOOLS_BIN_DIR)/semconvkit
 TESTIFYLINT  := $(TOOLS_BIN_DIR)/testifylint
 
-TESTIFYLINT_OPT?= --enable-all --disable=float-compare,require-error
+TESTIFYLINT_OPT?= --enable-all --disable=require-error
 
 .PHONY: install-tools
 install-tools: $(TOOLS_BIN_NAMES)

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics_test.go
@@ -188,7 +188,7 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.Equal(t, float64(1), dp.DoubleValue())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "metric.input_type":
 					assert.False(t, validatedMetrics["metric.input_type"], "Found a duplicate in the metrics slice: metric.input_type")
 					validatedMetrics["metric.input_type"] = true
@@ -229,7 +229,7 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.Equal(t, float64(1), dp.DoubleValue())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 					attrVal, ok := dp.Attributes().Get("string_attr")
 					assert.True(t, ok)
 					assert.EqualValues(t, "string_attr-val", attrVal.Str())
@@ -250,7 +250,7 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.Equal(t, float64(1), dp.DoubleValue())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 					attrVal, ok := dp.Attributes().Get("string_attr")
 					assert.True(t, ok)
 					assert.EqualValues(t, "string_attr-val", attrVal.Str())

--- a/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
@@ -173,7 +173,11 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueType{{ $metric.Data.MetricValueType }}, dp.ValueType())
+					{{- if eq $metric.Data.MetricValueType.BasicType "float64" }}
+					assert.InDelta(t, {{ $metric.Data.MetricValueType.BasicType }}(1), dp.{{ $metric.Data.MetricValueType }}Value(), 0.01)
+					{{- else }}
 					assert.Equal(t, {{ $metric.Data.MetricValueType.BasicType }}(1), dp.{{ $metric.Data.MetricValueType }}Value())
+					{{- end }}
 
 					{{- range $i, $attr := $metric.Attributes }}
 					attrVal, ok {{ if eq $i 0 }}:{{ end }}= dp.Attributes().Get("{{ (attributeInfo $attr).Name }}")

--- a/pdata/internal/cmd/pdatagen/internal/base_fields.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_fields.go
@@ -167,9 +167,17 @@ func (ms {{ .structName }}) Set{{ .accessorFieldName }}(v {{ .returnType }}) {
 
 const accessorsOneOfPrimitiveTestTemplate = `func Test{{ .structName }}_{{ .accessorFieldName }}(t *testing.T) {
 	ms := New{{ .structName }}()
+	{{- if eq .returnType "float64"}}
+	assert.InDelta(t, {{ .defaultVal }}, ms.{{ .accessorFieldName }}(), 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .defaultVal }}, ms.{{ .accessorFieldName }}())
+	{{- end }}
 	ms.Set{{ .accessorFieldName }}({{ .testValue }})
+	{{- if eq .returnType "float64" }}
+	assert.InDelta(t, {{ .testValue }}, ms.{{ .accessorFieldName }}(), 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .testValue }}, ms.{{ .accessorFieldName }}())
+	{{- end }}
 	assert.Equal(t, {{ .typeName }}, ms.{{ .originOneOfTypeFuncName }}())
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { new{{ .structName }}(&{{ .originStructName }}{}, &sharedState).Set{{ .accessorFieldName }}({{ .testValue }}) })
@@ -179,13 +187,17 @@ const accessorsPrimitiveTestTemplate = `func Test{{ .structName }}_{{ .fieldName
 	ms := New{{ .structName }}()
 	{{- if eq .returnType "bool" }}
 	assert.{{- if eq .defaultVal "true" }}True{{- else }}False{{- end }}(t, ms.{{ .fieldName }}())
-	{{- else }}	
+	{{- else if eq .returnType "float64" }}
+	assert.InDelta(t, {{ .defaultVal }}, ms.{{ .fieldName }}(), 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .defaultVal }}, ms.{{ .fieldName }}())
 	{{- end }}
 	ms.Set{{ .fieldName }}({{ .testValue }})
 	{{- if eq .returnType "bool" }}
 	assert.{{- if eq .testValue "true" }}True{{- else }}False{{- end }}(t, ms.{{ .fieldName }}())
-	{{- else }}	
+	{{- else if eq .returnType "float64"}}
+	assert.InDelta(t, {{ .testValue }}, ms.{{ .fieldName }}(), 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .testValue }}, ms.{{ .fieldName }}())
 	{{- end }}
 	sharedState := internal.StateReadOnly
@@ -243,10 +255,18 @@ func (ms {{ .structName }}) Remove{{ .fieldName }}() {
 
 const accessorsOptionalPrimitiveTestTemplate = `func Test{{ .structName }}_{{ .fieldName }}(t *testing.T) {
 	ms := New{{ .structName }}()
+	{{- if eq .returnType "float64" }}
+	assert.InDelta(t, {{ .defaultVal }}, ms.{{ .fieldName }}() , 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .defaultVal }}, ms.{{ .fieldName }}())
+	{{- end }}
 	ms.Set{{ .fieldName }}({{ .testValue }})
 	assert.True(t, ms.Has{{ .fieldName }}())
+	{{- if eq .returnType "float64" }}
+	assert.InDelta(t, {{.testValue }}, ms.{{ .fieldName }}(), 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .testValue }}, ms.{{ .fieldName }}())
+	{{- end }}
 	ms.Remove{{ .fieldName }}()
 	assert.False(t, ms.Has{{ .fieldName }}())
 }`

--- a/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
@@ -116,25 +116,49 @@ const immutableSliceTestTemplate = `func TestNew{{ .structName }}(t *testing.T) 
 	assert.Equal(t, []{{ .itemType }}{ {{ .testNewVal }} }, ms.AsRaw())
 	ms.FromRaw([]{{ .itemType }}{ {{ index .testInterfaceOrigVal 2 }} })
 	assert.Equal(t, 1, ms.Len())
-	assert.Equal(t, {{ .itemType }}( {{ index .testInterfaceOrigVal 2 }} ), ms.At(0))
+	{{- if eq .itemType "float64" }}
+	assert.InDelta(t, {{ .itemType }}({{ index .testInterfaceOrigVal 2 }}), ms.At(0), 0.01)
+	{{- else }}
+	assert.Equal(t, {{ .itemType }}({{ index .testInterfaceOrigVal 2 }}), ms.At(0))
+	{{- end }}
 
 	cp := New{{ .structName }}()
 	ms.CopyTo(cp)
 	ms.SetAt(0, {{ .itemType }}( {{ index .testInterfaceOrigVal 1 }} ))
-	assert.Equal(t, {{ .itemType }}( {{ index .testInterfaceOrigVal 1 }} ), ms.At(0))
+	{{- if eq .itemType "float64" }}
+	assert.InDelta(t, {{ .itemType }}({{ index .testInterfaceOrigVal 1 }}), ms.At(0), 0.01)
+	{{- else }}
+	assert.Equal(t, {{ .itemType }}({{ index .testInterfaceOrigVal 1 }}), ms.At(0))
+	{{- end }}
+	{{- if eq .itemType "float64" }}
+	assert.InDelta(t, {{ .itemType }}({{ index .testInterfaceOrigVal 2 }}), cp.At(0), 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .itemType }}({{ index .testInterfaceOrigVal 2 }}), cp.At(0))
+	{{- end }}
 	ms.CopyTo(cp)
+	{{- if eq .itemType "float64" }}
+	assert.InDelta(t, {{ .itemType }}({{ index .testInterfaceOrigVal 1 }}), cp.At(0), 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .itemType }}({{ index .testInterfaceOrigVal 1 }}), cp.At(0))
+	{{- end }}
 
 	mv := New{{ .structName }}()
 	ms.MoveTo(mv)
 	assert.Equal(t, 0, ms.Len())
 	assert.Equal(t, 1, mv.Len())
-	assert.Equal(t, {{ .itemType }}({{ index .testInterfaceOrigVal 1 }}), mv.At(0))
+	{{- if eq .itemType "float64" }}
+	assert.InDelta(t, {{ .itemType }}({{index .testInterfaceOrigVal 1 }}), mv.At(0), 0.01)
+	{{- else }}
+	assert.Equal(t, {{ .itemType }}({{index .testInterfaceOrigVal 1 }}), mv.At(0))
+	{{- end }}
 	ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
-	assert.Equal(t, {{ .itemType }}({{ index .testInterfaceOrigVal 0 }}), mv.At(0))
+	{{- if eq .itemType "float64" }}
+	assert.InDelta(t, {{ .itemType }}({{index .testInterfaceOrigVal 0 }}), mv.At(0), 0.01)
+	{{- else }}
+	assert.Equal(t, {{ .itemType }}({{index .testInterfaceOrigVal 0 }}), mv.At(0))
+	{{- end }}
 }
 
 func Test{{ .structName }}ReadOnly(t *testing.T) {
@@ -143,7 +167,11 @@ func Test{{ .structName }}ReadOnly(t *testing.T) {
 	ms := {{ .structName }}(internal.New{{ .structName }}(&raw, &state))
 
 	assert.Equal(t, 3, ms.Len())
+	{{- if eq .itemType "float64" }}
+	assert.InDelta(t, {{ .itemType }}( {{index .testInterfaceOrigVal 0 }} ), ms.At(0), 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .itemType }}({{ index .testInterfaceOrigVal 0 }}), ms.At(0))
+	{{- end }}
 	assert.Panics(t, func() { ms.Append({{ index .testInterfaceOrigVal 0 }}) })
 	assert.Panics(t, func() { ms.EnsureCapacity(2) })
 	assert.Equal(t, raw, ms.AsRaw())
@@ -163,7 +191,11 @@ func Test{{ .structName }}Append(t *testing.T) {
 	ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
 	ms.Append({{ .testSetVal }}, {{ .testSetVal }})
 	assert.Equal(t, 5, ms.Len())
+	{{- if eq .itemType "float64" }}
+	assert.InDelta(t, {{ .itemType }}({{ .testSetVal }} ), ms.At(4), 0.01)
+	{{- else }}
 	assert.Equal(t, {{ .itemType }}({{ .testSetVal }}), ms.At(4))
+	{{- end }}
 }
 
 func Test{{ .structName }}EnsureCapacity(t *testing.T) {

--- a/pdata/internal/json/number_test.go
+++ b/pdata/internal/json/number_test.go
@@ -270,7 +270,7 @@ func TestReadFloat64(t *testing.T) {
 				return
 			}
 			assert.NoError(t, iter.Error)
-			assert.Equal(t, tt.want, val)
+			assert.InDelta(t, tt.want, val, 0.01)
 		})
 	}
 }

--- a/pdata/pcommon/generated_float64slice_test.go
+++ b/pdata/pcommon/generated_float64slice_test.go
@@ -24,25 +24,25 @@ func TestNewFloat64Slice(t *testing.T) {
 	assert.Equal(t, []float64{1, 5, 3}, ms.AsRaw())
 	ms.FromRaw([]float64{3})
 	assert.Equal(t, 1, ms.Len())
-	assert.Equal(t, float64(3), ms.At(0))
+	assert.InDelta(t, float64(3), ms.At(0), 0.01)
 
 	cp := NewFloat64Slice()
 	ms.CopyTo(cp)
 	ms.SetAt(0, float64(2))
-	assert.Equal(t, float64(2), ms.At(0))
-	assert.Equal(t, float64(3), cp.At(0))
+	assert.InDelta(t, float64(2), ms.At(0), 0.01)
+	assert.InDelta(t, float64(3), cp.At(0), 0.01)
 	ms.CopyTo(cp)
-	assert.Equal(t, float64(2), cp.At(0))
+	assert.InDelta(t, float64(2), cp.At(0), 0.01)
 
 	mv := NewFloat64Slice()
 	ms.MoveTo(mv)
 	assert.Equal(t, 0, ms.Len())
 	assert.Equal(t, 1, mv.Len())
-	assert.Equal(t, float64(2), mv.At(0))
+	assert.InDelta(t, float64(2), mv.At(0), 0.01)
 	ms.FromRaw([]float64{1, 2, 3})
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
-	assert.Equal(t, float64(1), mv.At(0))
+	assert.InDelta(t, float64(1), mv.At(0), 0.01)
 }
 
 func TestFloat64SliceReadOnly(t *testing.T) {
@@ -51,7 +51,7 @@ func TestFloat64SliceReadOnly(t *testing.T) {
 	ms := Float64Slice(internal.NewFloat64Slice(&raw, &state))
 
 	assert.Equal(t, 3, ms.Len())
-	assert.Equal(t, float64(1), ms.At(0))
+	assert.InDelta(t, float64(1), ms.At(0), 0.01)
 	assert.Panics(t, func() { ms.Append(1) })
 	assert.Panics(t, func() { ms.EnsureCapacity(2) })
 	assert.Equal(t, raw, ms.AsRaw())
@@ -71,7 +71,7 @@ func TestFloat64SliceAppend(t *testing.T) {
 	ms.FromRaw([]float64{1, 2, 3})
 	ms.Append(5, 5)
 	assert.Equal(t, 5, ms.Len())
-	assert.Equal(t, float64(5), ms.At(4))
+	assert.InDelta(t, float64(5), ms.At(4), 0.01)
 }
 
 func TestFloat64SliceEnsureCapacity(t *testing.T) {

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -215,7 +215,7 @@ func TestMapWithEmpty(t *testing.T) {
 	val, exist = sm.Get("other_key_double")
 	assert.True(t, exist)
 	assert.EqualValues(t, ValueTypeDouble, val.Type())
-	assert.EqualValues(t, 1.23, val.Double())
+	assert.InDelta(t, 1.23, val.Double(), 0.01)
 
 	sm.PutBool("other_key_bool", true)
 	val, exist = sm.Get("other_key_bool")
@@ -245,7 +245,7 @@ func TestMapWithEmpty(t *testing.T) {
 	val, exist = sm.Get("another_key_double")
 	assert.True(t, exist)
 	assert.EqualValues(t, ValueTypeDouble, val.Type())
-	assert.EqualValues(t, 4.56, val.Double())
+	assert.InDelta(t, 4.56, val.Double(), 0.01)
 
 	sm.PutBool("another_key_bool", false)
 	val, exist = sm.Get("another_key_bool")
@@ -357,7 +357,7 @@ func TestMap_FromRaw(t *testing.T) {
 	assert.Equal(t, int64(123), v.Int())
 	v, ok = am.Get("k_double")
 	assert.True(t, ok)
-	assert.Equal(t, 1.23, v.Double())
+	assert.InDelta(t, 1.23, v.Double(), 0.01)
 	v, ok = am.Get("k_null")
 	assert.True(t, ok)
 	assert.Equal(t, ValueTypeEmpty, v.Type())

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -26,7 +26,7 @@ func TestValue(t *testing.T) {
 
 	v = NewValueDouble(3.4)
 	assert.EqualValues(t, ValueTypeDouble, v.Type())
-	assert.EqualValues(t, 3.4, v.Double())
+	assert.InDelta(t, 3.4, v.Double(), 0.01)
 
 	v = NewValueBool(true)
 	assert.EqualValues(t, ValueTypeBool, v.Type())
@@ -52,7 +52,7 @@ func TestValueReadOnly(t *testing.T) {
 	assert.EqualValues(t, ValueTypeStr, v.Type())
 	assert.EqualValues(t, "v", v.Str())
 	assert.EqualValues(t, 0, v.Int())
-	assert.EqualValues(t, 0, v.Double())
+	assert.InDelta(t, 0, v.Double(), 0.01)
 	assert.False(t, v.Bool())
 	assert.EqualValues(t, ByteSlice{}, v.Bytes())
 	assert.EqualValues(t, Map{}, v.Map())
@@ -217,7 +217,7 @@ func TestNilOrigSetValue(t *testing.T) {
 
 	av = NewValueEmpty()
 	av.SetDouble(1.23)
-	assert.EqualValues(t, 1.23, av.Double())
+	assert.InDelta(t, 1.23, av.Double(), 0.01)
 
 	av = NewValueEmpty()
 	av.SetEmptyBytes().FromRaw([]byte{1, 2, 3})
@@ -560,7 +560,7 @@ func TestInvalidValue(t *testing.T) {
 	v := Value{}
 	assert.False(t, v.Bool())
 	assert.Equal(t, int64(0), v.Int())
-	assert.Equal(t, float64(0), v.Double())
+	assert.InDelta(t, float64(0), v.Double(), 0.01)
 	assert.Equal(t, "", v.Str())
 	assert.Equal(t, ByteSlice{}, v.Bytes())
 	assert.Equal(t, Map{}, v.Map())

--- a/pdata/pmetric/generated_exemplar_test.go
+++ b/pdata/pmetric/generated_exemplar_test.go
@@ -55,9 +55,9 @@ func TestExemplar_ValueType(t *testing.T) {
 
 func TestExemplar_DoubleValue(t *testing.T) {
 	ms := NewExemplar()
-	assert.Equal(t, float64(0.0), ms.DoubleValue())
+	assert.InDelta(t, float64(0.0), ms.DoubleValue(), 0.01)
 	ms.SetDoubleValue(float64(17.13))
-	assert.Equal(t, float64(17.13), ms.DoubleValue())
+	assert.InDelta(t, float64(17.13), ms.DoubleValue(), 0.01)
 	assert.Equal(t, ExemplarValueTypeDouble, ms.ValueType())
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { newExemplar(&otlpmetrics.Exemplar{}, &sharedState).SetDoubleValue(float64(17.13)) })

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
@@ -130,39 +130,39 @@ func TestExponentialHistogramDataPoint_Flags(t *testing.T) {
 
 func TestExponentialHistogramDataPoint_Sum(t *testing.T) {
 	ms := NewExponentialHistogramDataPoint()
-	assert.Equal(t, float64(0.0), ms.Sum())
+	assert.InDelta(t, float64(0.0), ms.Sum(), 0.01)
 	ms.SetSum(float64(17.13))
 	assert.True(t, ms.HasSum())
-	assert.Equal(t, float64(17.13), ms.Sum())
+	assert.InDelta(t, float64(17.13), ms.Sum(), 0.01)
 	ms.RemoveSum()
 	assert.False(t, ms.HasSum())
 }
 
 func TestExponentialHistogramDataPoint_Min(t *testing.T) {
 	ms := NewExponentialHistogramDataPoint()
-	assert.Equal(t, float64(0.0), ms.Min())
+	assert.InDelta(t, float64(0.0), ms.Min(), 0.01)
 	ms.SetMin(float64(9.23))
 	assert.True(t, ms.HasMin())
-	assert.Equal(t, float64(9.23), ms.Min())
+	assert.InDelta(t, float64(9.23), ms.Min(), 0.01)
 	ms.RemoveMin()
 	assert.False(t, ms.HasMin())
 }
 
 func TestExponentialHistogramDataPoint_Max(t *testing.T) {
 	ms := NewExponentialHistogramDataPoint()
-	assert.Equal(t, float64(0.0), ms.Max())
+	assert.InDelta(t, float64(0.0), ms.Max(), 0.01)
 	ms.SetMax(float64(182.55))
 	assert.True(t, ms.HasMax())
-	assert.Equal(t, float64(182.55), ms.Max())
+	assert.InDelta(t, float64(182.55), ms.Max(), 0.01)
 	ms.RemoveMax()
 	assert.False(t, ms.HasMax())
 }
 
 func TestExponentialHistogramDataPoint_ZeroThreshold(t *testing.T) {
 	ms := NewExponentialHistogramDataPoint()
-	assert.Equal(t, float64(0.0), ms.ZeroThreshold())
+	assert.InDelta(t, float64(0.0), ms.ZeroThreshold(), 0.01)
 	ms.SetZeroThreshold(float64(0.5))
-	assert.Equal(t, float64(0.5), ms.ZeroThreshold())
+	assert.InDelta(t, float64(0.5), ms.ZeroThreshold(), 0.01)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {
 		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState).SetZeroThreshold(float64(0.5))

--- a/pdata/pmetric/generated_histogramdatapoint_test.go
+++ b/pdata/pmetric/generated_histogramdatapoint_test.go
@@ -102,30 +102,30 @@ func TestHistogramDataPoint_Flags(t *testing.T) {
 
 func TestHistogramDataPoint_Sum(t *testing.T) {
 	ms := NewHistogramDataPoint()
-	assert.Equal(t, float64(0.0), ms.Sum())
+	assert.InDelta(t, float64(0.0), ms.Sum(), 0.01)
 	ms.SetSum(float64(17.13))
 	assert.True(t, ms.HasSum())
-	assert.Equal(t, float64(17.13), ms.Sum())
+	assert.InDelta(t, float64(17.13), ms.Sum(), 0.01)
 	ms.RemoveSum()
 	assert.False(t, ms.HasSum())
 }
 
 func TestHistogramDataPoint_Min(t *testing.T) {
 	ms := NewHistogramDataPoint()
-	assert.Equal(t, float64(0.0), ms.Min())
+	assert.InDelta(t, float64(0.0), ms.Min(), 0.01)
 	ms.SetMin(float64(9.23))
 	assert.True(t, ms.HasMin())
-	assert.Equal(t, float64(9.23), ms.Min())
+	assert.InDelta(t, float64(9.23), ms.Min(), 0.01)
 	ms.RemoveMin()
 	assert.False(t, ms.HasMin())
 }
 
 func TestHistogramDataPoint_Max(t *testing.T) {
 	ms := NewHistogramDataPoint()
-	assert.Equal(t, float64(0.0), ms.Max())
+	assert.InDelta(t, float64(0.0), ms.Max(), 0.01)
 	ms.SetMax(float64(182.55))
 	assert.True(t, ms.HasMax())
-	assert.Equal(t, float64(182.55), ms.Max())
+	assert.InDelta(t, float64(182.55), ms.Max(), 0.01)
 	ms.RemoveMax()
 	assert.False(t, ms.HasMax())
 }

--- a/pdata/pmetric/generated_numberdatapoint_test.go
+++ b/pdata/pmetric/generated_numberdatapoint_test.go
@@ -69,9 +69,9 @@ func TestNumberDataPoint_ValueType(t *testing.T) {
 
 func TestNumberDataPoint_DoubleValue(t *testing.T) {
 	ms := NewNumberDataPoint()
-	assert.Equal(t, float64(0.0), ms.DoubleValue())
+	assert.InDelta(t, float64(0.0), ms.DoubleValue(), 0.01)
 	ms.SetDoubleValue(float64(17.13))
-	assert.Equal(t, float64(17.13), ms.DoubleValue())
+	assert.InDelta(t, float64(17.13), ms.DoubleValue(), 0.01)
 	assert.Equal(t, NumberDataPointValueTypeDouble, ms.ValueType())
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {

--- a/pdata/pmetric/generated_summarydatapoint_test.go
+++ b/pdata/pmetric/generated_summarydatapoint_test.go
@@ -73,9 +73,9 @@ func TestSummaryDataPoint_Count(t *testing.T) {
 
 func TestSummaryDataPoint_Sum(t *testing.T) {
 	ms := NewSummaryDataPoint()
-	assert.Equal(t, float64(0.0), ms.Sum())
+	assert.InDelta(t, float64(0.0), ms.Sum(), 0.01)
 	ms.SetSum(float64(17.13))
-	assert.Equal(t, float64(17.13), ms.Sum())
+	assert.InDelta(t, float64(17.13), ms.Sum(), 0.01)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, &sharedState).SetSum(float64(17.13)) })
 }

--- a/pdata/pmetric/generated_summarydatapointvalueatquantile_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantile_test.go
@@ -46,9 +46,9 @@ func TestSummaryDataPointValueAtQuantile_CopyTo(t *testing.T) {
 
 func TestSummaryDataPointValueAtQuantile_Quantile(t *testing.T) {
 	ms := NewSummaryDataPointValueAtQuantile()
-	assert.Equal(t, float64(0.0), ms.Quantile())
+	assert.InDelta(t, float64(0.0), ms.Quantile(), 0.01)
 	ms.SetQuantile(float64(17.13))
-	assert.Equal(t, float64(17.13), ms.Quantile())
+	assert.InDelta(t, float64(17.13), ms.Quantile(), 0.01)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {
 		newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &sharedState).SetQuantile(float64(17.13))
@@ -57,9 +57,9 @@ func TestSummaryDataPointValueAtQuantile_Quantile(t *testing.T) {
 
 func TestSummaryDataPointValueAtQuantile_Value(t *testing.T) {
 	ms := NewSummaryDataPointValueAtQuantile()
-	assert.Equal(t, float64(0.0), ms.Value())
+	assert.InDelta(t, float64(0.0), ms.Value(), 0.01)
 	ms.SetValue(float64(17.13))
-	assert.Equal(t, float64(17.13), ms.Value())
+	assert.InDelta(t, float64(17.13), ms.Value(), 0.01)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {
 		newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &sharedState).SetValue(float64(17.13))

--- a/pdata/pmetric/metrics_test.go
+++ b/pdata/pmetric/metrics_test.go
@@ -218,12 +218,12 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	// First point
 	assert.EqualValues(t, startTime, gaugeDataPoints.At(0).StartTimestamp())
 	assert.EqualValues(t, endTime, gaugeDataPoints.At(0).Timestamp())
-	assert.EqualValues(t, 123.1, gaugeDataPoints.At(0).DoubleValue())
+	assert.InDelta(t, 123.1, gaugeDataPoints.At(0).DoubleValue(), 0.01)
 	assert.EqualValues(t, map[string]any{"key0": "value0"}, gaugeDataPoints.At(0).Attributes().AsRaw())
 	// Second point
 	assert.EqualValues(t, startTime, gaugeDataPoints.At(1).StartTimestamp())
 	assert.EqualValues(t, endTime, gaugeDataPoints.At(1).Timestamp())
-	assert.EqualValues(t, 456.1, gaugeDataPoints.At(1).DoubleValue())
+	assert.InDelta(t, 456.1, gaugeDataPoints.At(1).DoubleValue(), 0.01)
 	assert.EqualValues(t, map[string]any{"key1": "value1"}, gaugeDataPoints.At(1).Attributes().AsRaw())
 
 	// Check double metric
@@ -239,12 +239,12 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	// First point
 	assert.EqualValues(t, startTime, sumDataPoints.At(0).StartTimestamp())
 	assert.EqualValues(t, endTime, sumDataPoints.At(0).Timestamp())
-	assert.EqualValues(t, 123.1, sumDataPoints.At(0).DoubleValue())
+	assert.InDelta(t, 123.1, sumDataPoints.At(0).DoubleValue(), 0.01)
 	assert.EqualValues(t, map[string]any{"key0": "value0"}, sumDataPoints.At(0).Attributes().AsRaw())
 	// Second point
 	assert.EqualValues(t, startTime, sumDataPoints.At(1).StartTimestamp())
 	assert.EqualValues(t, endTime, sumDataPoints.At(1).Timestamp())
-	assert.EqualValues(t, 456.1, sumDataPoints.At(1).DoubleValue())
+	assert.InDelta(t, 456.1, sumDataPoints.At(1).DoubleValue(), 0.01)
 	assert.EqualValues(t, map[string]any{"key1": "value1"}, sumDataPoints.At(1).Attributes().AsRaw())
 
 	// Check histogram metric
@@ -337,7 +337,7 @@ func TestOtlpToFromInternalGaugeMutating(t *testing.T) {
 	gaugeDataPoints.At(0).SetTimestamp(pcommon.Timestamp(endTime + 1))
 	assert.EqualValues(t, endTime+1, gaugeDataPoints.At(0).Timestamp())
 	gaugeDataPoints.At(0).SetDoubleValue(124.1)
-	assert.EqualValues(t, 124.1, gaugeDataPoints.At(0).DoubleValue())
+	assert.InDelta(t, 124.1, gaugeDataPoints.At(0).DoubleValue(), 0.01)
 	gaugeDataPoints.At(0).Attributes().Remove("key0")
 	gaugeDataPoints.At(0).Attributes().PutStr("k", "v")
 	assert.EqualValues(t, newAttributes, gaugeDataPoints.At(0).Attributes().AsRaw())
@@ -420,7 +420,7 @@ func TestOtlpToFromInternalSumMutating(t *testing.T) {
 	doubleDataPoints.At(0).SetTimestamp(pcommon.Timestamp(endTime + 1))
 	assert.EqualValues(t, endTime+1, doubleDataPoints.At(0).Timestamp())
 	doubleDataPoints.At(0).SetDoubleValue(124.1)
-	assert.EqualValues(t, 124.1, doubleDataPoints.At(0).DoubleValue())
+	assert.InDelta(t, 124.1, doubleDataPoints.At(0).DoubleValue(), 0.01)
 	doubleDataPoints.At(0).Attributes().Remove("key0")
 	doubleDataPoints.At(0).Attributes().PutStr("k", "v")
 	assert.EqualValues(t, newAttributes, doubleDataPoints.At(0).Attributes().AsRaw())

--- a/service/telemetry/metrics_test.go
+++ b/service/telemetry/metrics_test.go
@@ -242,7 +242,7 @@ func TestTelemetryInit(t *testing.T) {
 				}
 
 				require.Equal(t, metricValue.labels, labels, "labels for metric %q was different than expected", metricName)
-				require.Equal(t, metricValue.value, mf.Metric[0].Counter.GetValue(), "value for metric %q was different than expected", metricName)
+				require.InDelta(t, metricValue.value, mf.Metric[0].Counter.GetValue(), 0.01, "value for metric %q was different than expected", metricName)
 			}
 		})
 


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [float-compare](https://github.com/Antonboom/testifylint?tab=readme-ov-file#float-compare)  rule from [testifylint](https://github.com/Antonboom/testifylint)