### PR TITLE
[confmap] Do not leak expanded values on Sub

### DIFF
--- a/.chloggen/mx-psi_fix-sub-config.yaml
+++ b/.chloggen/mx-psi_fix-sub-config.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix loading config of a component from a different source.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11154]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This issue only affected loading the whole component config, loading parts of a component config from a different source was working correctly.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -172,8 +172,13 @@ func (l *Conf) Sub(key string) (*Conf, error) {
 		return New(), nil
 	}
 
-	if v, ok := data.(map[string]any); ok {
+	switch v := data.(type) {
+	case map[string]any:
 		return NewFromStringMap(v), nil
+	case expandedValue:
+		if m, ok := v.Value.(map[string]any); ok {
+			return NewFromStringMap(m), nil
+		}
 	}
 
 	return nil, fmt.Errorf("unexpected sub-config value kind for key:%s value:%v kind:%v", key, data, reflect.TypeOf(data).Kind())

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -876,6 +876,28 @@ func TestExpandedValue(t *testing.T) {
 	assert.Error(t, cm.Unmarshal(&cfgBool))
 }
 
+func TestSubExpandedValue(t *testing.T) {
+	cm := NewFromStringMap(map[string]any{
+		"key": map[string]any{
+			"subkey": expandedValue{
+				Value:    map[string]any{"subsubkey": "value"},
+				Original: "subsubkey: value",
+			},
+		},
+	})
+
+	assert.Equal(t, map[string]any{"subkey": map[string]any{"subsubkey": "value"}}, cm.Get("key"))
+	assert.Equal(t, map[string]any{"key": map[string]any{"subkey": map[string]any{"subsubkey": "value"}}}, cm.ToStringMap())
+	assert.Equal(t, map[string]any{"subsubkey": "value"}, cm.Get("key::subkey"))
+
+	sub, err := cm.Sub("key::subkey")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{"subsubkey": "value"}, sub.ToStringMap())
+
+	// This should return value, but currently `Get` does not support keys within expanded values.
+	assert.Equal(t, nil, cm.Get("key::subkey::subsubkey"))
+}
+
 func TestStringyTypes(t *testing.T) {
 	tests := []struct {
 		valueOfType any

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -895,7 +895,7 @@ func TestSubExpandedValue(t *testing.T) {
 	assert.Equal(t, map[string]any{"subsubkey": "value"}, sub.ToStringMap())
 
 	// This should return value, but currently `Get` does not support keys within expanded values.
-	assert.Equal(t, nil, cm.Get("key::subkey::subsubkey"))
+	assert.Nil(t, cm.Get("key::subkey::subsubkey"))
 }
 
 func TestStringyTypes(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Fixes `Sub` method to drop string representation if the requested sub-conf has it.

#### Link to tracking issue
Fixes #11154

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->

Added unit tests.
