### PR TITLE
Make the first argument of NewScraper `component.Type`

### DIFF
--- a/.chloggen/replace-new-scraper.yaml
+++ b/.chloggen/replace-new-scraper.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: scraperhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate NewScraperWithComponentType, should use NewScraper
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/replace-new-scraper.yaml
+++ b/.chloggen/replace-new-scraper.yaml
@@ -10,7 +10,7 @@ component: scraperhelper
 note: Deprecate NewScraperWithComponentType, should use NewScraper
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [11159]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/scraperhelper/scraper.go
+++ b/receiver/scraperhelper/scraper.go
@@ -61,15 +61,7 @@ func (b *baseScraper) ID() component.ID {
 
 // NewScraper creates a Scraper that calls Scrape at the specified collection interval,
 // reports observability information, and passes the scraped metrics to the next consumer.
-//
-// Deprecated: [v0.109.0] use NewScraperWithComponentType instead.
-func NewScraper(name string, scrape ScrapeFunc, options ...ScraperOption) (Scraper, error) {
-	return NewScraperWithComponentType(component.MustNewType(name), scrape, options...)
-}
-
-// NewScraperWithComponentType creates a Scraper that calls Scrape at the specified collection interval,
-// reports observability information, and passes the scraped metrics to the next consumer.
-func NewScraperWithComponentType(t component.Type, scrape ScrapeFunc, options ...ScraperOption) (Scraper, error) {
+func NewScraper(t component.Type, scrape ScrapeFunc, options ...ScraperOption) (Scraper, error) {
 	if scrape == nil {
 		return nil, errNilFunc
 	}
@@ -82,4 +74,12 @@ func NewScraperWithComponentType(t component.Type, scrape ScrapeFunc, options ..
 	}
 
 	return bs, nil
+}
+
+// NewScraperWithComponentType creates a Scraper that calls Scrape at the specified collection interval,
+// reports observability information, and passes the scraped metrics to the next consumer.
+//
+// Deprecated: [v0.110.0] use NewScraper instead.
+func NewScraperWithComponentType(t component.Type, scrape ScrapeFunc, options ...ScraperOption) (Scraper, error) {
+	return NewScraper(t, scrape, options...)
 }

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -223,7 +223,7 @@ func configureMetricOptions(t *testing.T, test metricsTestCase, initializeChs []
 
 		scrapeMetricsChs[i] = make(chan int)
 		tsm := &testScrapeMetrics{ch: scrapeMetricsChs[i], err: test.scrapeErr}
-		scp, err := NewScraperWithComponentType(component.MustNewType("scraper"), tsm.scrape, scraperOptions...)
+		scp, err := NewScraper(component.MustNewType("scraper"), tsm.scrape, scraperOptions...)
 		assert.NoError(t, err)
 
 		metricOptions = append(metricOptions, AddScraper(scp))
@@ -325,7 +325,7 @@ func TestSingleScrapePerInterval(t *testing.T) {
 
 	tickerCh := make(chan time.Time)
 
-	scp, err := NewScraperWithComponentType(component.MustNewType("scaper"), tsm.scrape)
+	scp, err := NewScraper(component.MustNewType("scaper"), tsm.scrape)
 	assert.NoError(t, err)
 
 	receiver, err := NewScraperControllerReceiver(
@@ -367,7 +367,7 @@ func TestScrapeControllerStartsOnInit(t *testing.T) {
 		ch: make(chan int, 1),
 	}
 
-	scp, err := NewScraperWithComponentType(component.MustNewType("scraper"), tsm.scrape)
+	scp, err := NewScraper(component.MustNewType("scraper"), tsm.scrape)
 	require.NoError(t, err, "Must not error when creating scraper")
 
 	r, err := NewScraperControllerReceiver(
@@ -403,7 +403,7 @@ func TestScrapeControllerInitialDelay(t *testing.T) {
 		}
 	)
 
-	scp, err := NewScraperWithComponentType(component.MustNewType("timed"), func(context.Context) (pmetric.Metrics, error) {
+	scp, err := NewScraper(component.MustNewType("timed"), func(context.Context) (pmetric.Metrics, error) {
 		elapsed <- time.Now()
 		return pmetric.NewMetrics(), nil
 	})


### PR DESCRIPTION
#### Description

As a step of https://github.com/open-telemetry/opentelemetry-collector/issues/9473, make the first argument of `scraperhelper.NewScraper` to take `component.Type`.

This PR deprecates `NewScraperWithComponentType` as the method is temporary and was created to change an argument of `NewScraper`
