### PR TITLE
Add 'pipeline' attribute to processor metrics

### DIFF
--- a/.chloggen/processor-pipeline-id-attribute-2.yaml
+++ b/.chloggen/processor-pipeline-id-attribute-2.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: processorhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Processor metrics now include the `pipeline` attribute.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11171]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/processor-pipeline-id-attribute-3.yaml
+++ b/.chloggen/processor-pipeline-id-attribute-3.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: componenttest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: SetupTelemetry now accepts optional `extraAttrs ...attribute.KeyValue` parameter.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11171]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/processor-pipeline-id-attribute.yaml
+++ b/.chloggen/processor-pipeline-id-attribute.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: processortest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: NewNopSettings now requires a component.DataType parameter.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11171]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/templates/component_telemetry_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/component_telemetry_test.go.tmpl
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-    
+
 	"go.opentelemetry.io/collector/component"
 	{{- if or isConnector isExporter isExtension isProcessor isReceiver }}
 	"go.opentelemetry.io/collector/config/configtelemetry"
@@ -28,8 +28,8 @@ type componentTestTelemetry struct {
 }
 
 {{- if or isConnector isExporter isExtension isProcessor isReceiver }}
-func (tt *componentTestTelemetry) NewSettings() {{ .Status.Class }}.Settings {
-	settings := {{ .Status.Class }}test.NewNopSettings()
+func (tt *componentTestTelemetry) NewSettings({{- if isProcessor -}}dt pipeline.Signal{{- end -}}) {{ .Status.Class }}.Settings {
+	settings := {{ .Status.Class }}test.NewNopSettings({{- if isProcessor -}}dt{{- end -}})
 	settings.MeterProvider = tt.meterProvider
 	settings.LeveledMeterProvider = func(_ configtelemetry.Level) metric.MeterProvider {
 		return tt.meterProvider

--- a/cmd/mdatagen/internal/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/component_test.go.tmpl
@@ -126,7 +126,7 @@ func TestComponentLifecycle(t *testing.T) {
 				switch tt.name {
 				case "logs":
 					e, ok := c.(exporter.Logs)
-					require.True(t, ok)				
+					require.True(t, ok)
 					logs := generateLifecycleTestLogs()
 					if !e.Capabilities().MutatesData {
 						logs.MarkReadOnly()
@@ -203,9 +203,19 @@ func TestComponentLifecycle(t *testing.T) {
 	require.NoError(t, sub.Unmarshal(&cfg))
 
 	for _, tt := range tests {
+		var signal pipeline.Signal
+		switch tt.name {
+		case "logs":
+			signal = pipeline.SignalLogs
+		case "metrics":
+			signal = pipeline.SignalMetrics
+		case "traces":
+			signal = pipeline.SignalTraces
+		}
+
 		{{- if not .Tests.SkipShutdown }}
 		t.Run(tt.name + "-shutdown", func(t *testing.T) {
-			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(), cfg)
+			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(signal), cfg)
 			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
@@ -214,7 +224,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 		{{- if not .Tests.SkipLifecycle }}
 		t.Run(tt.name + "-lifecycle", func(t *testing.T) {
-			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(), cfg)
+			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(signal), cfg)
 			require.NoError(t, err)
 			host := {{ .Tests.Host }}
 			err = c.Start(context.Background(), host)

--- a/component/componenttest/obsreporttest.go
+++ b/component/componenttest/obsreporttest.go
@@ -29,11 +29,14 @@ const (
 	scraperTag   = "scraper"
 	transportTag = "transport"
 	exporterTag  = "exporter"
+	processorTag = "processor"
+	pipelineTag  = "pipeline"
 )
 
 type TestTelemetry struct {
 	ts           component.TelemetrySettings
 	id           component.ID
+	extraAttrs   []attribute.KeyValue
 	SpanRecorder *tracetest.SpanRecorder
 
 	reader        *sdkmetric.ManualReader
@@ -129,16 +132,17 @@ func (tts *TestTelemetry) TelemetrySettings() component.TelemetrySettings {
 	return tts.ts
 }
 
-// SetupTelemetry sets up the testing environment to check the metrics recorded by receivers, producers, or exporters.
+// SetupTelemetry sets up the testing environment to check the metrics recorded by receivers, or exporters.
 // The caller must pass the ID of the component being tested. The ID will be used by the CreateSettings and Check methods.
 // The caller must defer a call to `Shutdown` on the returned TestTelemetry.
-func SetupTelemetry(id component.ID) (TestTelemetry, error) {
+func SetupTelemetry(id component.ID, extraAttrs ...attribute.KeyValue) (TestTelemetry, error) {
 	sr := new(tracetest.SpanRecorder)
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 
 	settings := TestTelemetry{
 		ts:           NewNopTelemetrySettings(),
 		id:           id,
+		extraAttrs:   extraAttrs,
 		SpanRecorder: sr,
 	}
 	settings.ts.TracerProvider = tp

--- a/processor/batchprocessor/factory_test.go
+++ b/processor/batchprocessor/factory_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor/processortest"
 )
 
@@ -23,20 +24,18 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 func TestCreateProcessor(t *testing.T) {
 	factory := NewFactory()
-
 	cfg := factory.CreateDefaultConfig()
-	creationSet := processortest.NewNopSettings()
-	tp, err := factory.CreateTracesProcessor(context.Background(), creationSet, cfg, nil)
+	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopSettings(pipeline.SignalTraces), cfg, nil)
 	assert.NotNil(t, tp)
 	assert.NoError(t, err, "cannot create trace processor")
 	assert.NoError(t, tp.Shutdown(context.Background()))
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), creationSet, cfg, nil)
+	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopSettings(pipeline.SignalMetrics), cfg, nil)
 	assert.NotNil(t, mp)
 	assert.NoError(t, err, "cannot create metric processor")
 	assert.NoError(t, mp.Shutdown(context.Background()))
 
-	lp, err := factory.CreateLogsProcessor(context.Background(), creationSet, cfg, nil)
+	lp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopSettings(pipeline.SignalLogs), cfg, nil)
 	assert.NotNil(t, lp)
 	assert.NoError(t, err, "cannot create logs processor")
 	assert.NoError(t, lp.Shutdown(context.Background()))

--- a/processor/batchprocessor/generated_component_telemetry_test.go
+++ b/processor/batchprocessor/generated_component_telemetry_test.go
@@ -14,6 +14,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
 )
@@ -23,8 +24,8 @@ type componentTestTelemetry struct {
 	meterProvider *sdkmetric.MeterProvider
 }
 
-func (tt *componentTestTelemetry) NewSettings() processor.Settings {
-	settings := processortest.NewNopSettings()
+func (tt *componentTestTelemetry) NewSettings(dt pipeline.Signal) processor.Settings {
+	settings := processortest.NewNopSettings(dt)
 	settings.MeterProvider = tt.meterProvider
 	settings.LeveledMeterProvider = func(_ configtelemetry.Level) metric.MeterProvider {
 		return tt.meterProvider

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/collector/consumer/consumertest v0.110.0
 	go.opentelemetry.io/collector/pdata v1.16.0
 	go.opentelemetry.io/collector/pdata/testdata v0.110.0
+	go.opentelemetry.io/collector/pipeline v0.110.0
 	go.opentelemetry.io/collector/processor v0.110.0
 	go.opentelemetry.io/otel v1.30.0
 	go.opentelemetry.io/otel/metric v1.30.0
@@ -41,7 +42,6 @@ require (
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/internal/globalsignal v0.110.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.110.0 // indirect
-	go.opentelemetry.io/collector/pipeline v0.110.0 // indirect
 	go.opentelemetry.io/collector/processor/processorprofiles v0.110.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.30.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -88,3 +88,5 @@ replace go.opentelemetry.io/collector/processor/processorprofiles => ../processo
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
+
+replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -32,7 +32,7 @@ type batchProcessorTelemetry struct {
 }
 
 func newBatchProcessorTelemetry(set processor.Settings, currentMetadataCardinality func() int) (*batchProcessorTelemetry, error) {
-	attrs := attribute.NewSet(attribute.String(internal.ProcessorKey, set.ID.String()))
+	attrs := attribute.NewSet(attribute.String(internal.ProcessorKey, set.ID.String()), attribute.String("pipeline", set.PipelineID.String()))
 
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(set.TelemetrySettings,
 		metadata.WithProcessorBatchMetadataCardinalityCallback(func() int64 {

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.110.0
+	go.opentelemetry.io/collector/component/componentprofiles v0.110.0
 	go.opentelemetry.io/collector/component/componentstatus v0.110.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.110.0
 	go.opentelemetry.io/collector/consumer v0.110.0
@@ -68,3 +69,5 @@ replace go.opentelemetry.io/collector/processor/processorprofiles => ./processor
 replace go.opentelemetry.io/collector/pipeline => ../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../internal/globalsignal
+
+replace go.opentelemetry.io/collector/component/componentprofiles => ../component/componentprofiles

--- a/processor/internal/obsmetrics.go
+++ b/processor/internal/obsmetrics.go
@@ -6,8 +6,9 @@ package internal // import "go.opentelemetry.io/collector/processor/internal"
 const (
 	MetricNameSep = "_"
 
-	// ProcessorKey is the key used to identify processors in metrics and traces.
 	ProcessorKey = "processor"
+	SignalKey    = "otel.signal"
+	PipelineKey  = "pipeline"
 
 	ProcessorMetricPrefix = ProcessorKey + MetricNameSep
 )

--- a/processor/memorylimiterprocessor/factory_test.go
+++ b/processor/memorylimiterprocessor/factory_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/internal/memorylimiter"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor/processortest"
 )
 
@@ -38,19 +39,19 @@ func TestCreateProcessor(t *testing.T) {
 	pCfg.MemorySpikeLimitMiB = 1907
 	pCfg.CheckInterval = 100 * time.Millisecond
 
-	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
+	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopSettings(pipeline.SignalTraces), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.NotNil(t, tp)
 	// test if we can shutdown a monitoring routine that has not started
 	require.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
 	require.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
+	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopSettings(pipeline.SignalMetrics), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.NotNil(t, mp)
 	require.NoError(t, mp.Start(context.Background(), componenttest.NewNopHost()))
 
-	lp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
+	lp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopSettings(pipeline.SignalLogs), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.NotNil(t, lp)
 	assert.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))

--- a/processor/memorylimiterprocessor/generated_component_telemetry_test.go
+++ b/processor/memorylimiterprocessor/generated_component_telemetry_test.go
@@ -14,6 +14,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
 )
@@ -23,8 +24,8 @@ type componentTestTelemetry struct {
 	meterProvider *sdkmetric.MeterProvider
 }
 
-func (tt *componentTestTelemetry) NewSettings() processor.Settings {
-	settings := processortest.NewNopSettings()
+func (tt *componentTestTelemetry) NewSettings(dt pipeline.Signal) processor.Settings {
+	settings := processortest.NewNopSettings(dt)
 	settings.MeterProvider = tt.meterProvider
 	settings.LeveledMeterProvider = func(_ configtelemetry.Level) metric.MeterProvider {
 		return tt.meterProvider

--- a/processor/memorylimiterprocessor/generated_component_test.go
+++ b/processor/memorylimiterprocessor/generated_component_test.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
 )
@@ -67,8 +68,17 @@ func TestComponentLifecycle(t *testing.T) {
 	require.NoError(t, sub.Unmarshal(&cfg))
 
 	for _, tt := range tests {
+		var signal pipeline.Signal
+		switch tt.name {
+		case "logs":
+			signal = pipeline.SignalLogs
+		case "metrics":
+			signal = pipeline.SignalMetrics
+		case "traces":
+			signal = pipeline.SignalTraces
+		}
 		t.Run(tt.name+"-lifecycle", func(t *testing.T) {
-			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(), cfg)
+			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(signal), cfg)
 			require.NoError(t, err)
 			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -95,3 +95,5 @@ replace go.opentelemetry.io/collector/processor/processorprofiles => ../processo
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
+
+replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal"
 	"go.opentelemetry.io/collector/processor/processorhelper"
@@ -51,7 +52,7 @@ func TestNoDataLoss(t *testing.T) {
 	cfg.MemoryLimitMiB = uint32(ms.Alloc/(1024*1024) + expectedMemoryIncreaseMiB)
 	cfg.MemorySpikeLimitMiB = 1
 
-	set := processortest.NewNopSettings()
+	set := processortest.NewNopSettings(pipeline.SignalLogs)
 
 	limiter, err := newMemoryLimiterProcessor(set, cfg)
 	require.NoError(t, err)
@@ -174,11 +175,11 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 				ms.Alloc = tt.memAlloc
 			}
 
-			ml, err := newMemoryLimiterProcessor(processortest.NewNopSettings(), tt.mlCfg)
+			ml, err := newMemoryLimiterProcessor(processortest.NewNopSettings(pipeline.SignalMetrics), tt.mlCfg)
 			require.NoError(t, err)
 			mp, err := processorhelper.NewMetricsProcessor(
 				context.Background(),
-				processortest.NewNopSettings(),
+				processortest.NewNopSettings(pipeline.SignalMetrics),
 				tt.mlCfg,
 				consumertest.NewNop(),
 				ml.processMetrics,
@@ -264,11 +265,11 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 				ms.Alloc = tt.memAlloc
 			}
 
-			ml, err := newMemoryLimiterProcessor(processortest.NewNopSettings(), tt.mlCfg)
+			ml, err := newMemoryLimiterProcessor(processortest.NewNopSettings(pipeline.SignalTraces), tt.mlCfg)
 			require.NoError(t, err)
 			tp, err := processorhelper.NewTracesProcessor(
 				context.Background(),
-				processortest.NewNopSettings(),
+				processortest.NewNopSettings(pipeline.SignalTraces),
 				tt.mlCfg,
 				consumertest.NewNop(),
 				ml.processTraces,
@@ -354,11 +355,11 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 				ms.Alloc = tt.memAlloc
 			}
 
-			ml, err := newMemoryLimiterProcessor(processortest.NewNopSettings(), tt.mlCfg)
+			ml, err := newMemoryLimiterProcessor(processortest.NewNopSettings(pipeline.SignalLogs), tt.mlCfg)
 			require.NoError(t, err)
 			tp, err := processorhelper.NewLogsProcessor(
 				context.Background(),
-				processortest.NewNopSettings(),
+				processortest.NewNopSettings(pipeline.SignalLogs),
 				tt.mlCfg,
 				consumertest.NewNop(),
 				ml.processLogs,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -39,6 +39,9 @@ type Settings struct {
 
 	// BuildInfo can be used by components for informational purposes
 	BuildInfo component.BuildInfo
+
+	// PipelineID indicates which pipeline contains this processor.
+	PipelineID pipeline.ID
 }
 
 // Factory is Factory interface for processors.

--- a/processor/processorhelper/generated_component_telemetry_test.go
+++ b/processor/processorhelper/generated_component_telemetry_test.go
@@ -14,6 +14,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
 )
@@ -23,8 +24,8 @@ type componentTestTelemetry struct {
 	meterProvider *sdkmetric.MeterProvider
 }
 
-func (tt *componentTestTelemetry) NewSettings() processor.Settings {
-	settings := processortest.NewNopSettings()
+func (tt *componentTestTelemetry) NewSettings(dt pipeline.Signal) processor.Settings {
+	settings := processortest.NewNopSettings(dt)
 	settings.MeterProvider = tt.meterProvider
 	settings.LeveledMeterProvider = func(_ configtelemetry.Level) metric.MeterProvider {
 		return tt.meterProvider

--- a/processor/processorhelper/obsreport.go
+++ b/processor/processorhelper/obsreport.go
@@ -58,7 +58,8 @@ func newObsReport(set processor.Settings, signal pipeline.Signal) (*obsReport, e
 	return &obsReport{
 		otelAttrs: []attribute.KeyValue{
 			attribute.String(internal.ProcessorKey, set.ID.String()),
-			attribute.String("otel.signal", signal.String()),
+			attribute.String(internal.SignalKey, signal.String()),
+			attribute.String(internal.PipelineKey, set.PipelineID.String()),
 		},
 		telemetryBuilder: telemetryBuilder,
 	}, nil

--- a/processor/processorprofiles/go.mod
+++ b/processor/processorprofiles/go.mod
@@ -60,3 +60,5 @@ replace go.opentelemetry.io/collector/component/componentstatus => ../../compone
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
+
+replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/processor/processortest/nop_processor.go
+++ b/processor/processortest/nop_processor.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerprofiles"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorprofiles"
 )
@@ -20,11 +21,12 @@ import (
 var nopType = component.MustNewType("nop")
 
 // NewNopSettings returns a new nop settings for Create*Processor functions.
-func NewNopSettings() processor.Settings {
+func NewNopSettings(dt pipeline.Signal) processor.Settings {
 	return processor.Settings{
 		ID:                component.NewIDWithName(nopType, uuid.NewString()),
 		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 		BuildInfo:         component.NewDefaultBuildInfo(),
+		PipelineID:        pipeline.NewID(dt),
 	}
 }
 

--- a/processor/processortest/nop_processor_test.go
+++ b/processor/processortest/nop_processor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componentprofiles"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -18,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor/processorprofiles"
 )
 
@@ -28,28 +30,28 @@ func TestNewNopFactory(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	assert.Equal(t, &nopConfig{}, cfg)
 
-	traces, err := factory.CreateTracesProcessor(context.Background(), NewNopSettings(), cfg, consumertest.NewNop())
+	traces, err := factory.CreateTracesProcessor(context.Background(), NewNopSettings(pipeline.SignalTraces), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, traces.Capabilities())
 	assert.NoError(t, traces.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, traces.ConsumeTraces(context.Background(), ptrace.NewTraces()))
 	assert.NoError(t, traces.Shutdown(context.Background()))
 
-	metrics, err := factory.CreateMetricsProcessor(context.Background(), NewNopSettings(), cfg, consumertest.NewNop())
+	metrics, err := factory.CreateMetricsProcessor(context.Background(), NewNopSettings(pipeline.SignalMetrics), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, metrics.Capabilities())
 	assert.NoError(t, metrics.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, metrics.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
 	assert.NoError(t, metrics.Shutdown(context.Background()))
 
-	logs, err := factory.CreateLogsProcessor(context.Background(), NewNopSettings(), cfg, consumertest.NewNop())
+	logs, err := factory.CreateLogsProcessor(context.Background(), NewNopSettings(pipeline.SignalLogs), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, logs.Capabilities())
 	assert.NoError(t, logs.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, logs.ConsumeLogs(context.Background(), plog.NewLogs()))
 	assert.NoError(t, logs.Shutdown(context.Background()))
 
-	profiles, err := factory.(processorprofiles.Factory).CreateProfilesProcessor(context.Background(), NewNopSettings(), cfg, consumertest.NewNop())
+	profiles, err := factory.(processorprofiles.Factory).CreateProfilesProcessor(context.Background(), NewNopSettings(componentprofiles.SignalProfiles), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, profiles.Capabilities())
 	assert.NoError(t, profiles.Start(context.Background(), componenttest.NewNopHost()))

--- a/processor/processortest/shutdown_verifier.go
+++ b/processor/processortest/shutdown_verifier.go
@@ -22,7 +22,7 @@ import (
 func verifyTracesDoesNotProduceAfterShutdown(t *testing.T, factory processor.Factory, cfg component.Config) {
 	// Create a proc and output its produce to a sink.
 	nextSink := new(consumertest.TracesSink)
-	proc, err := factory.CreateTracesProcessor(context.Background(), NewNopSettings(), cfg, nextSink)
+	proc, err := factory.CreateTracesProcessor(context.Background(), NewNopSettings(pipeline.SignalTraces), cfg, nextSink)
 	if errors.Is(err, pipeline.ErrSignalNotSupported) {
 		return
 	}
@@ -46,7 +46,7 @@ func verifyTracesDoesNotProduceAfterShutdown(t *testing.T, factory processor.Fac
 func verifyLogsDoesNotProduceAfterShutdown(t *testing.T, factory processor.Factory, cfg component.Config) {
 	// Create a proc and output its produce to a sink.
 	nextSink := new(consumertest.LogsSink)
-	proc, err := factory.CreateLogsProcessor(context.Background(), NewNopSettings(), cfg, nextSink)
+	proc, err := factory.CreateLogsProcessor(context.Background(), NewNopSettings(pipeline.SignalLogs), cfg, nextSink)
 	if errors.Is(err, pipeline.ErrSignalNotSupported) {
 		return
 	}
@@ -70,7 +70,7 @@ func verifyLogsDoesNotProduceAfterShutdown(t *testing.T, factory processor.Facto
 func verifyMetricsDoesNotProduceAfterShutdown(t *testing.T, factory processor.Factory, cfg component.Config) {
 	// Create a proc and output its produce to a sink.
 	nextSink := new(consumertest.MetricsSink)
-	proc, err := factory.CreateMetricsProcessor(context.Background(), NewNopSettings(), cfg, nextSink)
+	proc, err := factory.CreateMetricsProcessor(context.Background(), NewNopSettings(pipeline.SignalMetrics), cfg, nextSink)
 	if errors.Is(err, pipeline.ErrSignalNotSupported) {
 		return
 	}

--- a/service/internal/builders/processor_test.go
+++ b/service/internal/builders/processor_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componentprofiles"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerprofiles"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorprofiles"
 	"go.opentelemetry.io/collector/processor/processortest"
@@ -186,30 +188,36 @@ func TestNewNopProcessorBuilder(t *testing.T) {
 
 	factory := processortest.NewNopFactory()
 	cfg := factory.CreateDefaultConfig()
-	set := processortest.NewNopSettings()
-	set.ID = component.NewID(nopType)
 
-	traces, err := factory.CreateTracesProcessor(context.Background(), set, cfg, consumertest.NewNop())
+	tracesSet := processortest.NewNopSettings(pipeline.SignalTraces)
+	tracesSet.ID = component.NewID(nopType)
+	traces, err := factory.CreateTracesProcessor(context.Background(), tracesSet, cfg, consumertest.NewNop())
 	require.NoError(t, err)
-	bTraces, err := builder.CreateTraces(context.Background(), set, consumertest.NewNop())
+	bTraces, err := builder.CreateTraces(context.Background(), tracesSet, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.IsType(t, traces, bTraces)
 
-	metrics, err := factory.CreateMetricsProcessor(context.Background(), set, cfg, consumertest.NewNop())
+	metricsSet := processortest.NewNopSettings(pipeline.SignalMetrics)
+	metricsSet.ID = component.NewID(nopType)
+	metrics, err := factory.CreateMetricsProcessor(context.Background(), metricsSet, cfg, consumertest.NewNop())
 	require.NoError(t, err)
-	bMetrics, err := builder.CreateMetrics(context.Background(), set, consumertest.NewNop())
+	bMetrics, err := builder.CreateMetrics(context.Background(), metricsSet, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.IsType(t, metrics, bMetrics)
 
-	logs, err := factory.CreateLogsProcessor(context.Background(), set, cfg, consumertest.NewNop())
+	logsSet := processortest.NewNopSettings(pipeline.SignalLogs)
+	logsSet.ID = component.NewID(nopType)
+	logs, err := factory.CreateLogsProcessor(context.Background(), logsSet, cfg, consumertest.NewNop())
 	require.NoError(t, err)
-	bLogs, err := builder.CreateLogs(context.Background(), set, consumertest.NewNop())
+	bLogs, err := builder.CreateLogs(context.Background(), logsSet, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.IsType(t, logs, bLogs)
 
-	profiles, err := factory.(processorprofiles.Factory).CreateProfilesProcessor(context.Background(), set, cfg, consumertest.NewNop())
+	profilesSet := processortest.NewNopSettings(componentprofiles.SignalProfiles)
+	profilesSet.ID = component.NewID(nopType)
+	profiles, err := factory.(processorprofiles.Factory).CreateProfilesProcessor(context.Background(), profilesSet, cfg, consumertest.NewNop())
 	require.NoError(t, err)
-	bProfiles, err := builder.CreateProfiles(context.Background(), set, consumertest.NewNop())
+	bProfiles, err := builder.CreateProfiles(context.Background(), profilesSet, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.IsType(t, profiles, bProfiles)
 }

--- a/service/internal/graph/nodes.go
+++ b/service/internal/graph/nodes.go
@@ -145,7 +145,7 @@ func (n *processorNode) buildComponent(ctx context.Context,
 	next baseConsumer,
 ) error {
 	tel.Logger = components.ProcessorLogger(tel.Logger, n.componentID, n.pipelineID)
-	set := processor.Settings{ID: n.componentID, TelemetrySettings: tel, BuildInfo: info}
+	set := processor.Settings{ID: n.componentID, TelemetrySettings: tel, BuildInfo: info, PipelineID: n.pipelineID}
 	var err error
 	switch n.pipelineID.Signal() {
 	case pipeline.SignalTraces:

--- a/service/pipelines/config.go
+++ b/service/pipelines/config.go
@@ -21,7 +21,7 @@ var (
 // Config defines the configurable settings for service telemetry.
 //
 // Deprecated: [v0.110.0] Use ConfigWithPipelineID instead
-type Config map[component.ID]*PipelineConfig
+type Config map[pipeline.ID]*PipelineConfig
 
 func (cfg Config) Validate() error {
 	// Must have at least one pipeline.
@@ -32,12 +32,12 @@ func (cfg Config) Validate() error {
 	// Check that all pipelines have at least one receiver and one exporter, and they reference
 	// only configured components.
 	for pipelineID, p := range cfg {
-		switch pipelineID.Type() {
+		switch pipelineID.Signal() {
 		// nolint
-		case component.DataTypeTraces, component.DataTypeMetrics, component.DataTypeLogs, componentprofiles.DataTypeProfiles:
+		case pipeline.SignalTraces, pipeline.SignalMetrics, pipeline.SignalLogs, componentprofiles.SignalProfiles:
 			// Continue
 		default:
-			return fmt.Errorf("pipeline %q: unknown datatype %q", pipelineID, pipelineID.Type())
+			return fmt.Errorf("pipeline %q: unknown datatype %q", pipelineID, pipelineID.Signal())
 		}
 
 		// Validate pipeline has at least one receiver.

--- a/service/service.go
+++ b/service/service.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/service/extensions"
@@ -304,16 +303,12 @@ func (srv *Service) initExtensions(ctx context.Context, cfg extensions.Config) e
 	return nil
 }
 
-func convertFromComponentIDToPipelineID(id component.ID) pipeline.ID {
-	return pipeline.MustNewIDWithName(id.Type().String(), id.Name())
-}
-
 // Creates the pipeline graph.
 func (srv *Service) initGraph(ctx context.Context, cfg Config) error {
 	if len(cfg.Pipelines) > 0 {
 		cfg.PipelinesWithPipelineID = make(pipelines.ConfigWithPipelineID, len(cfg.Pipelines))
 		for k, v := range cfg.Pipelines {
-			cfg.PipelinesWithPipelineID[convertFromComponentIDToPipelineID(k)] = v
+			cfg.PipelinesWithPipelineID[k] = v
 		}
 	}
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -229,21 +229,21 @@ func TestServiceGetExporters(t *testing.T) {
 		assert.NoError(t, srv.Shutdown(context.Background()))
 	})
 
-	expMap := srv.host.GetExporters()
+	expMap := srv.host.GetExportersWithSignal()
 
-	v, ok := expMap[component.DataTypeTraces]
+	v, ok := expMap[pipeline.SignalTraces]
 	assert.True(t, ok)
 	assert.NotNil(t, v)
 
 	assert.Len(t, expMap, 4)
-	assert.Len(t, expMap[component.DataTypeTraces], 1)
-	assert.Contains(t, expMap[component.DataTypeTraces], component.NewID(nopType))
-	assert.Len(t, expMap[component.DataTypeMetrics], 1)
-	assert.Contains(t, expMap[component.DataTypeMetrics], component.NewID(nopType))
-	assert.Len(t, expMap[component.DataTypeLogs], 1)
-	assert.Contains(t, expMap[component.DataTypeLogs], component.NewID(nopType))
-	assert.Len(t, expMap[componentprofiles.DataTypeProfiles], 1)
-	assert.Contains(t, expMap[componentprofiles.DataTypeProfiles], component.NewID(nopType))
+	assert.Len(t, expMap[pipeline.SignalTraces], 1)
+	assert.Contains(t, expMap[pipeline.SignalTraces], component.NewID(nopType))
+	assert.Len(t, expMap[pipeline.SignalMetrics], 1)
+	assert.Contains(t, expMap[pipeline.SignalMetrics], component.NewID(nopType))
+	assert.Len(t, expMap[pipeline.SignalLogs], 1)
+	assert.Contains(t, expMap[pipeline.SignalLogs], component.NewID(nopType))
+	assert.Len(t, expMap[componentprofiles.SignalProfiles], 1)
+	assert.Contains(t, expMap[componentprofiles.SignalProfiles], component.NewID(nopType))
 }
 
 // nolint


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/10908

This ends up being a pretty straightforward change in actual code, but a tedious change in tests. It's also obviously a breaking change for anyone depending on these metrics.