### PR TITLE
[chore]: enable formatter rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,7 +125,6 @@ linters-settings:
     # TODO: enable all rules
     disable:
       - float-compare
-      - formatter
       - go-require
       - require-error
     enable-all: true   

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -38,7 +38,7 @@ SEMCONVGEN   := $(TOOLS_BIN_DIR)/semconvgen
 SEMCONVKIT   := $(TOOLS_BIN_DIR)/semconvkit
 TESTIFYLINT  := $(TOOLS_BIN_DIR)/testifylint
 
-TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,go-require,require-error
+TESTIFYLINT_OPT?= --enable-all --disable=float-compare,go-require,require-error
 
 .PHONY: install-tools
 install-tools: $(TOOLS_BIN_NAMES)

--- a/cmd/mdatagen/internal/validate_test.go
+++ b/cmd/mdatagen/internal/validate_test.go
@@ -4,7 +4,6 @@
 package internal
 
 import (
-	"fmt"
 	"io/fs"
 	"path/filepath"
 	"testing"
@@ -132,10 +131,10 @@ func TestValidateMetricDuplicates(t *testing.T) {
 		for _, metricName := range metrics {
 			if val, exists := seen[metricName]; exists {
 				receivers, allowed := allowedMetrics[metricName]
-				assert.True(
+				assert.Truef(
 					t,
 					allowed && contains(receiver, receivers) && contains(val, receivers),
-					fmt.Sprintf("Duplicate metric %v in receivers %v and %v. Please validate that this is intentional by adding the metric name and receiver types in the allowedMetrics map in this test\n", metricName, receiver, val),
+					"Duplicate metric %v in receivers %v and %v. Please validate that this is intentional by adding the metric name and receiver types in the allowedMetrics map in this test\n", metricName, receiver, val,
 				)
 			}
 			seen[metricName] = receiver


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [formatter](https://github.com/Antonboom/testifylint?tab=readme-ov-file#formatter) rule from [testifylint](https://github.com/Antonboom/testifylint)