### PR TITLE
[pdata]: Add support to MoveTo for Map, allow avoiding copies

### DIFF
--- a/.chloggen/add-map-moveto.yaml
+++ b/.chloggen/add-map-moveto.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support to MoveTo for Map, allow avoiding copies
+
+# One or more tracking issues or pull requests related to the change
+issues: [11175]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api, user]

--- a/pdata/pcommon/map.go
+++ b/pdata/pcommon/map.go
@@ -225,6 +225,15 @@ func (m Map) Range(f func(k string, v Value) bool) {
 	}
 }
 
+// MoveTo moves all key/values from the current map overriding the destination and
+// resetting the current instance to its zero value
+func (m Map) MoveTo(dest Map) {
+	m.getState().AssertMutable()
+	dest.getState().AssertMutable()
+	*dest.getOrig() = *m.getOrig()
+	*m.getOrig() = nil
+}
+
 // CopyTo copies all elements from the current map overriding the destination.
 func (m Map) CopyTo(dest Map) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -375,11 +375,28 @@ func TestMap_FromRaw(t *testing.T) {
 	}, v.Map().AsRaw())
 }
 
+func TestMap_MoveTo(t *testing.T) {
+	dest := NewMap()
+	// Test MoveTo to empty
+	NewMap().MoveTo(dest)
+	assert.Equal(t, 0, dest.Len())
+
+	// Test MoveTo larger slice
+	src := Map(internal.GenerateTestMap())
+	src.MoveTo(dest)
+	assert.EqualValues(t, Map(internal.GenerateTestMap()), dest)
+	assert.Equal(t, 0, src.Len())
+
+	// Test MoveTo from empty to non-empty
+	NewMap().MoveTo(dest)
+	assert.Equal(t, 0, dest.Len())
+}
+
 func TestMap_CopyTo(t *testing.T) {
 	dest := NewMap()
 	// Test CopyTo to empty
 	NewMap().CopyTo(dest)
-	assert.EqualValues(t, 0, dest.Len())
+	assert.Equal(t, 0, dest.Len())
 
 	// Test CopyTo larger slice
 	Map(internal.GenerateTestMap()).CopyTo(dest)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Can be used to remove unnecessary copies from places like https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c52a9a7ae1563127254530d416a8c569c54750bd/pkg/ottl/ottlfuncs/func_replace_all_patterns.go#L100
