### PR TITLE
[chore] cleanup confighttp tests

### DIFF
--- a/config/confighttp/confighttp_example_test.go
+++ b/config/confighttp/confighttp_example_test.go
@@ -1,0 +1,30 @@
+package confighttp
+
+import (
+	"context"
+	"net/http"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+)
+
+func ExampleServerConfig() {
+	settings := NewDefaultServerConfig()
+	settings.Endpoint = "localhost:443"
+
+	s, err := settings.ToServer(
+		context.Background(),
+		componenttest.NewNopHost(),
+		componenttest.NewNopTelemetrySettings(),
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	if err != nil {
+		panic(err)
+	}
+
+	l, err := settings.ToListener(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	if err = s.Serve(l); err != nil {
+		panic(err)
+	}
+}

--- a/config/confighttp/confighttp_example_test.go
+++ b/config/confighttp/confighttp_example_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package confighttp
 
 import (

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -1011,28 +1011,6 @@ func verifyHeadersResp(t *testing.T, url string, expected map[string]configopaqu
 	}
 }
 
-func ExampleServerConfig() {
-	settings := NewDefaultServerConfig()
-	settings.Endpoint = "localhost:443"
-
-	s, err := settings.ToServer(
-		context.Background(),
-		componenttest.NewNopHost(),
-		componenttest.NewNopTelemetrySettings(),
-		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	if err != nil {
-		panic(err)
-	}
-
-	l, err := settings.ToListener(context.Background())
-	if err != nil {
-		panic(err)
-	}
-	if err = s.Serve(l); err != nil {
-		panic(err)
-	}
-}
-
 func TestHttpClientHeaders(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
#### Description

Minor life improvements when reviewing the tests,

- Using stdlib for error reading
- Using the config client from test server
- Moving examples into their own file for easy discovery/maintainability 

#### Link to tracking issue
N/A

