### PR TITLE
[otlpexporter] Document incidental breaking change on Config struct

### DIFF
--- a/.chloggen/6767-embedded-field-rename.yaml
+++ b/.chloggen/6767-embedded-field-rename.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `TimeoutSettings` field in `otlpexporter.Config` was renamed to `TimeoutConfig`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11132]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]


### PR DESCRIPTION
#### Description

My PR #11132 introduced a small breaking change in the API of `otlpexporter`, which I failed to notice at the time. This PR adds a release note about this.

Specifically, the `TimeoutSettings` field in `otlpexporter.Config` was renamed to `TimeoutConfig` ([link to the new code](https://github.com/jade-guiton-dd/opentelemetry-collector/blob/543c4f510d3bbcd50e914f4e5d7f22c5fcbda92d/exporter/otlpexporter/config.go#L23)). As this is an embedded field, renaming the type of the field renamed the field itself.

(Another option would have been to de-embed the field, and keep the old name. This has less potential for breakage, but would also be a breaking change.)

#### Link to tracking issue
Indirectly related to #6767
