### PR TITLE
Exporterhelper: address timeout misalignment w/ context deadline

### DIFF
--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -111,7 +111,7 @@ func (rs *retrySender) send(ctx context.Context, req Request) error {
 		if deadline, has := ctx.Deadline(); has && time.Until(deadline) < backoffDelay {
 			// The delay is longer than the deadline.  There is no point in
 			// waiting for cancelation.
-			return fmt.Errorf("Exporting aborted. Deadline is shorter than retry interval.")
+			return fmt.Errorf("request will be cancelled before next retry: %w", err)
 		}
 
 		backoffDelayStr := backoffDelay.String()

--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -108,6 +108,12 @@ func (rs *retrySender) send(ctx context.Context, req Request) error {
 			backoffDelay = max(backoffDelay, throttleErr.delay)
 		}
 
+		if deadline, has := ctx.Deadline(); has && time.Until(deadline) < backoffDelay {
+			// The delay is longer than the deadline.  There is no point in
+			// waiting for cancelation.
+			return fmt.Errorf("Exporting aborted. Deadline is shorter than retry interval.")
+		}
+
 		backoffDelayStr := backoffDelay.String()
 		span.AddEvent(
 			"Exporting failed. Will retry the request after interval.",

--- a/exporter/exporterhelper/timeout_sender.go
+++ b/exporter/exporterhelper/timeout_sender.go
@@ -6,6 +6,7 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -81,6 +82,7 @@ func (ts *timeoutSender) send(ctx context.Context, req Request) error {
 				// timeout, means do nothing.
 			default:
 				// Default is sustain, the legacy behavior.
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Description

Retry sender: if the context deadline will expire before a configured attempt to retry, abort the request.  Otherwise, the retry sender will delay until the context timeout happens, which is a predictable waste of resources. Better to return immediately. As for the aborted status code, I could be convinced instead to stop retrying and return the final-retry-attempt's error. 

Timeout sender: if the context deadline will expire before the full configured timeout, present two optional new behaviors in addition to the current behavior. The three are:

- sustain: existing behavior, let a short timeout pass through to the exporter
- abort: new behavior, do not send a request if the timeout expires after the context deadline
- ignore: new behavior, send a request with the configured timeout, ignore the context deadline. 

#### Link to tracking issue
Fixes #11183.

#### Testing

TODO: This is draft for discussion purposes. I have not added or modified existing tests, and I'm aware of stylistic requirements that are not met (e.g., the use of bare string values, vs. use of a constrained value such as `configcompression.Type`).

#### Documentation

WIP: DRAFT.