### PR TITLE
[chore]: enable require-error rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,9 +122,6 @@ linters-settings:
             - "!**/*_test.go"
 
   testifylint:
-    # TODO: enable all rules
-    disable:
-      - require-error
     enable-all: true   
 
 linters:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -38,7 +38,7 @@ SEMCONVGEN   := $(TOOLS_BIN_DIR)/semconvgen
 SEMCONVKIT   := $(TOOLS_BIN_DIR)/semconvkit
 TESTIFYLINT  := $(TOOLS_BIN_DIR)/testifylint
 
-TESTIFYLINT_OPT?= --enable-all --disable=require-error
+TESTIFYLINT_OPT?= --enable-all
 
 .PHONY: install-tools
 install-tools: $(TOOLS_BIN_NAMES)

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -28,7 +28,7 @@ func TestParseModules(t *testing.T) {
 
 	// test
 	err := cfg.ParseModules()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	assert.Equal(t, "github.com/org/repo v0.1.2", cfg.Extensions[0].GoMod)
@@ -47,7 +47,7 @@ func TestRelativePath(t *testing.T) {
 
 	// test
 	err := cfg.ParseModules()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	cwd, err := os.Getwd()
@@ -72,7 +72,7 @@ func TestModuleFromCore(t *testing.T) {
 
 	// test
 	err := cfg.ParseModules()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	assert.True(t, strings.HasPrefix(cfg.Extensions[0].Name, "otlpreceiver"))
@@ -206,7 +206,7 @@ func TestDebugOptionSetConfig(t *testing.T) {
 		SkipCompilation: true,
 		SkipGetModules:  true,
 	}
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	assert.True(t, cfg.Distribution.DebugCompilation)
 }
 
@@ -314,7 +314,7 @@ func TestConfmapFactoryVersions(t *testing.T) {
 func TestAddsDefaultProviders(t *testing.T) {
 	cfg := NewDefaultConfig()
 	cfg.Providers = nil
-	assert.NoError(t, cfg.ParseModules())
+	require.NoError(t, cfg.ParseModules())
 	assert.Len(t, *cfg.Providers, 5)
 }
 

--- a/cmd/mdatagen/internal/embeded_templates_test.go
+++ b/cmd/mdatagen/internal/embeded_templates_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnsureTemplatesLoaded(t *testing.T) {
@@ -38,7 +39,7 @@ func TestEnsureTemplatesLoaded(t *testing.T) {
 		}
 		count = 0
 	)
-	assert.NoError(t, fs.WalkDir(TemplateFS, ".", func(path string, d fs.DirEntry, _ error) error {
+	require.NoError(t, fs.WalkDir(TemplateFS, ".", func(path string, d fs.DirEntry, _ error) error {
 		if d != nil && d.IsDir() {
 			return nil
 		}

--- a/component/identifiable_test.go
+++ b/component/identifiable_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalText(t *testing.T) {
 	id := NewIDWithName(MustNewType("test"), "name")
 	got, err := id.MarshalText()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, id.String(), string(got))
 }
 
@@ -92,7 +93,7 @@ func TestUnmarshalText(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expectedID, id)
 			assert.Equal(t, tt.expectedID.Type(), id.Type())
 			assert.Equal(t, tt.expectedID.Name(), id.Name())

--- a/config/configauth/configauth_test.go
+++ b/config/configauth/configauth_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
@@ -53,10 +54,10 @@ func TestGetServer(t *testing.T) {
 
 			// verify
 			if tt.expected != nil {
-				assert.ErrorIs(t, err, tt.expected)
+				require.ErrorIs(t, err, tt.expected)
 				assert.Nil(t, authenticator)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, authenticator)
 			}
 		})
@@ -69,7 +70,7 @@ func TestGetServerFails(t *testing.T) {
 	}
 
 	authenticator, err := cfg.GetServerAuthenticator(context.Background(), map[component.ID]component.Component{})
-	assert.ErrorIs(t, err, errAuthenticatorNotFound)
+	require.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }
 
@@ -104,10 +105,10 @@ func TestGetClient(t *testing.T) {
 
 			// verify
 			if tt.expected != nil {
-				assert.ErrorIs(t, err, tt.expected)
+				require.ErrorIs(t, err, tt.expected)
 				assert.Nil(t, authenticator)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, authenticator)
 			}
 		})
@@ -119,6 +120,6 @@ func TestGetClientFails(t *testing.T) {
 		AuthenticatorID: component.MustNewID("does_not_exist"),
 	}
 	authenticator, err := cfg.GetClientAuthenticator(context.Background(), map[component.ID]component.Component{})
-	assert.ErrorIs(t, err, errAuthenticatorNotFound)
+	require.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -127,7 +127,7 @@ func TestDefaultGrpcClientSettings(t *testing.T) {
 		},
 	}
 	opts, err := gcs.toDialOptions(context.Background(), componenttest.NewNopHost(), tt.TelemetrySettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, opts, 2)
 }
 
@@ -232,7 +232,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			opts, err := test.settings.toDialOptions(context.Background(), test.host, tt.TelemetrySettings())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, opts, 9)
 		})
 	}
@@ -245,7 +245,7 @@ func TestDefaultGrpcServerSettings(t *testing.T) {
 		},
 	}
 	opts, err := gss.toServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, opts, 3)
 }
 
@@ -295,7 +295,7 @@ func TestGrpcServerValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.err, func(t *testing.T) {
 			err := tt.gss.Validate()
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Regexp(t, tt.err, err)
 		})
 	}
@@ -330,7 +330,7 @@ func TestAllGrpcServerSettingsExceptAuth(t *testing.T) {
 		},
 	}
 	opts, err := gss.toServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, opts, 10)
 }
 
@@ -349,7 +349,7 @@ func TestGrpcServerAuthSettings(t *testing.T) {
 		},
 	}
 	srv, err := gss.ToServer(context.Background(), host, componenttest.NewNopTelemetrySettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, srv)
 }
 
@@ -470,7 +470,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.err, func(t *testing.T) {
 			_, err := test.settings.ToClientConn(context.Background(), test.host, tt.TelemetrySettings())
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Regexp(t, test.err, err)
 		})
 	}
@@ -489,7 +489,7 @@ func TestUseSecure(t *testing.T) {
 		Keepalive:   nil,
 	}
 	dialOpts, err := gcs.toDialOptions(context.Background(), componenttest.NewNopHost(), tt.TelemetrySettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, dialOpts, 2)
 }
 
@@ -735,9 +735,9 @@ func TestHttpReception(t *testing.T) {
 				TLSSetting: test.tlsServerCreds,
 			}
 			ln, err := gss.NetAddr.Listen(context.Background())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			s, err := gss.ToServer(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			ptraceotlp.RegisterGRPCServer(s, &grpcTraceServer{})
 
 			go func() {
@@ -749,15 +749,15 @@ func TestHttpReception(t *testing.T) {
 				TLSSetting: *test.tlsClientCreds,
 			}
 			grpcClientConn, errClient := gcs.ToClientConn(context.Background(), componenttest.NewNopHost(), tt.TelemetrySettings())
-			assert.NoError(t, errClient)
+			require.NoError(t, errClient)
 			defer func() { assert.NoError(t, grpcClientConn.Close()) }()
 			c := ptraceotlp.NewGRPCClient(grpcClientConn)
 			ctx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Second)
 			resp, errResp := c.Export(ctx, ptraceotlp.NewExportRequest(), grpc.WaitForReady(true))
 			if test.hasError {
-				assert.Error(t, errResp)
+				require.Error(t, errResp)
 			} else {
-				assert.NoError(t, errResp)
+				require.NoError(t, errResp)
 				assert.NotNil(t, resp)
 			}
 			cancelFunc()
@@ -782,9 +782,9 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 		},
 	}
 	ln, err := gss.NetAddr.Listen(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	srv, err := gss.ToServer(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ptraceotlp.RegisterGRPCServer(srv, &grpcTraceServer{})
 
 	go func() {
@@ -798,12 +798,12 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 		},
 	}
 	grpcClientConn, errClient := gcs.ToClientConn(context.Background(), componenttest.NewNopHost(), tt.TelemetrySettings())
-	assert.NoError(t, errClient)
+	require.NoError(t, errClient)
 	defer func() { assert.NoError(t, grpcClientConn.Close()) }()
 	c := ptraceotlp.NewGRPCClient(grpcClientConn)
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Second)
 	resp, errResp := c.Export(ctx, ptraceotlp.NewExportRequest(), grpc.WaitForReady(true))
-	assert.NoError(t, errResp)
+	require.NoError(t, errResp)
 	assert.NotNil(t, resp)
 	cancelFunc()
 	srv.Stop()
@@ -933,7 +933,7 @@ func TestStreamInterceptorEnhancesClient(t *testing.T) {
 	err := enhanceStreamWithClientInformation(false)(nil, stream, nil, handler)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cl := client.FromContext(outContext)
 	assert.Equal(t, "1.1.1.1", cl.Addr.String())
@@ -1052,7 +1052,7 @@ func TestDefaultUnaryInterceptorAuthSucceeded(t *testing.T) {
 
 	// verify
 	assert.Nil(t, res)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, authCalled)
 	assert.True(t, handlerCalled)
 }
@@ -1076,7 +1076,7 @@ func TestDefaultUnaryInterceptorAuthFailure(t *testing.T) {
 
 	// verify
 	assert.Nil(t, res)
-	assert.ErrorContains(t, err, expectedErr.Error())
+	require.ErrorContains(t, err, expectedErr.Error())
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 	assert.True(t, authCalled)
 }
@@ -1127,7 +1127,7 @@ func TestDefaultStreamInterceptorAuthSucceeded(t *testing.T) {
 	err := authStreamServerInterceptor(nil, streamServer, &grpc.StreamServerInfo{}, handler, auth.NewServer(auth.WithServerAuthenticate(authFunc)))
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, authCalled)
 	assert.True(t, handlerCalled)
 }
@@ -1153,7 +1153,7 @@ func TestDefaultStreamInterceptorAuthFailure(t *testing.T) {
 	err := authStreamServerInterceptor(nil, streamServer, &grpc.StreamServerInfo{}, handler, auth.NewServer(auth.WithServerAuthenticate(authFunc)))
 
 	// verify
-	assert.ErrorContains(t, err, expectedErr.Error()) // unfortunately, grpc errors don't wrap the original ones
+	require.ErrorContains(t, err, expectedErr.Error()) // unfortunately, grpc errors don't wrap the original ones
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 	assert.True(t, authCalled)
 }

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -165,7 +165,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			switch transport := client.Transport.(type) {
 			case *http.Transport:
 				assert.EqualValues(t, 1024, transport.ReadBufferSize)
@@ -213,7 +213,7 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 			tel := componenttest.NewNopTelemetrySettings()
 			tel.TracerProvider = nil
 			client, err := tt.settings.ToClient(context.Background(), host, tel)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			transport := client.Transport.(*http.Transport)
 			assert.EqualValues(t, 1024, transport.ReadBufferSize)
 			assert.EqualValues(t, 512, transport.WriteBufferSize)
@@ -446,7 +446,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, client)
 			transport := client.Transport
 
@@ -734,11 +734,11 @@ func TestHttpReception(t *testing.T) {
 
 			resp, errResp := client.Get(hcs.Endpoint)
 			if tt.hasError {
-				assert.Error(t, errResp)
+				require.Error(t, errResp)
 			} else {
-				assert.NoError(t, errResp)
+				require.NoError(t, errResp)
 				body, errRead := io.ReadAll(resp.Body)
-				assert.NoError(t, errRead)
+				require.NoError(t, errRead)
 				assert.Equal(t, "tt", string(body))
 				assert.Equal(t, expectedProto, resp.Proto)
 			}
@@ -1065,7 +1065,7 @@ func TestHttpClientHeaders(t *testing.T) {
 			}
 			client, _ := setting.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			req, err := http.NewRequest(http.MethodGet, setting.Endpoint, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = client.Do(req)
 			assert.NoError(t, err)
 		})
@@ -1101,7 +1101,7 @@ func TestHttpClientHostHeader(t *testing.T) {
 		}
 		client, _ := setting.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 		req, err := http.NewRequest(http.MethodGet, setting.Endpoint, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, err = client.Do(req)
 		assert.NoError(t, err)
 	})

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -41,7 +41,7 @@ func TestAddrConfigTimeout(t *testing.T) {
 		},
 	}
 	_, err := nac.Dial(context.Background())
-	assert.Error(t, err)
+	require.Error(t, err)
 	var netErr net.Error
 	if errors.As(err, &netErr) {
 		assert.True(t, netErr.Timeout())
@@ -58,7 +58,7 @@ func TestTCPAddrConfigTimeout(t *testing.T) {
 		},
 	}
 	_, err := nac.Dial(context.Background())
-	assert.Error(t, err)
+	require.Error(t, err)
 	var netErr net.Error
 	if errors.As(err, &netErr) {
 		assert.True(t, netErr.Timeout())
@@ -73,7 +73,7 @@ func TestAddrConfig(t *testing.T) {
 		Transport: TransportTypeTCP,
 	}
 	ln, err := nas.Listen(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	done := make(chan bool, 1)
 
 	go func() {
@@ -94,7 +94,7 @@ func TestAddrConfig(t *testing.T) {
 	}
 	var conn net.Conn
 	conn, err = nac.Dial(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = conn.Write([]byte("test"))
 	assert.NoError(t, err)
 	assert.NoError(t, conn.Close())
@@ -106,12 +106,12 @@ func Test_NetAddr_Validate(t *testing.T) {
 	na := &AddrConfig{
 		Transport: TransportTypeTCP,
 	}
-	assert.NoError(t, na.Validate())
+	require.NoError(t, na.Validate())
 
 	na = &AddrConfig{
 		Transport: transportTypeEmpty,
 	}
-	assert.Error(t, na.Validate())
+	require.Error(t, na.Validate())
 
 	na = &AddrConfig{
 		Transport: "random string",
@@ -124,7 +124,7 @@ func TestTCPAddrConfig(t *testing.T) {
 		Endpoint: "localhost:0",
 	}
 	ln, err := nas.Listen(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	done := make(chan bool, 1)
 
 	go func() {
@@ -144,7 +144,7 @@ func TestTCPAddrConfig(t *testing.T) {
 	}
 	var conn net.Conn
 	conn, err = nac.Dial(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = conn.Write([]byte("test"))
 	assert.NoError(t, err)
 	assert.NoError(t, conn.Close())

--- a/config/configretry/backoff_test.go
+++ b/config/configretry/backoff_test.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDefaultBackOffSettings(t *testing.T) {
 	cfg := NewDefaultBackOffConfig()
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	assert.Equal(t,
 		BackOffConfig{
 			Enabled:             true,
@@ -26,23 +27,23 @@ func TestNewDefaultBackOffSettings(t *testing.T) {
 
 func TestInvalidInitialInterval(t *testing.T) {
 	cfg := NewDefaultBackOffConfig()
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	cfg.InitialInterval = -1
 	assert.Error(t, cfg.Validate())
 }
 
 func TestInvalidRandomizationFactor(t *testing.T) {
 	cfg := NewDefaultBackOffConfig()
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	cfg.RandomizationFactor = -1
-	assert.Error(t, cfg.Validate())
+	require.Error(t, cfg.Validate())
 	cfg.RandomizationFactor = 2
 	assert.Error(t, cfg.Validate())
 }
 
 func TestInvalidMultiplier(t *testing.T) {
 	cfg := NewDefaultBackOffConfig()
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	cfg.Multiplier = -1
 	assert.Error(t, cfg.Validate())
 }
@@ -56,22 +57,22 @@ func TestZeroMultiplierIsValid(t *testing.T) {
 
 func TestInvalidMaxInterval(t *testing.T) {
 	cfg := NewDefaultBackOffConfig()
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	cfg.MaxInterval = -1
 	assert.Error(t, cfg.Validate())
 }
 
 func TestInvalidMaxElapsedTime(t *testing.T) {
 	cfg := NewDefaultBackOffConfig()
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	cfg.MaxElapsedTime = -1
-	assert.Error(t, cfg.Validate())
+	require.Error(t, cfg.Validate())
 	cfg.MaxElapsedTime = 60
 	// MaxElapsedTime is 60, InitialInterval is 5s, so it should be invalid
-	assert.Error(t, cfg.Validate())
+	require.Error(t, cfg.Validate())
 	cfg.InitialInterval = 0
 	// MaxElapsedTime is 60, MaxInterval is 30s, so it should be invalid
-	assert.Error(t, cfg.Validate())
+	require.Error(t, cfg.Validate())
 	cfg.MaxInterval = 0
 	assert.NoError(t, cfg.Validate())
 	cfg.InitialInterval = 50

--- a/config/configtelemetry/configtelemetry_test.go
+++ b/config/configtelemetry/configtelemetry_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _ encoding.TextMarshaler = (*Level)(nil)
@@ -50,7 +51,7 @@ func TestUnmarshalText(t *testing.T) {
 				if test.err {
 					assert.Error(t, err)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.Equal(t, test.level, lvl)
 				}
 			})
@@ -94,7 +95,7 @@ func TestLevelStringMarshal(t *testing.T) {
 		t.Run(tt.str, func(t *testing.T) {
 			assert.Equal(t, tt.str, tt.level.String())
 			got, err := tt.level.MarshalText()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.str, string(got))
 		})
 	}

--- a/config/configtls/clientcasfilereloader_test.go
+++ b/config/configtls/clientcasfilereloader_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCannotShutdownIfNotWatching(t *testing.T) {
@@ -25,10 +26,10 @@ func TestCannotStartIfAlreadyWatching(t *testing.T) {
 	reloader, _, _ := createReloader(t)
 
 	err := reloader.startWatching()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = reloader.startWatching()
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = reloader.shutdown()
 	assert.NoError(t, err)
@@ -38,12 +39,12 @@ func TestClosingWatcherDoesntBreakReloader(t *testing.T) {
 	reloader, loader, _ := createReloader(t)
 
 	err := reloader.startWatching()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 1, loader.reloadNumber())
 
 	err = reloader.watcher.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = reloader.shutdown()
 	assert.NoError(t, err)
@@ -53,14 +54,14 @@ func TestErrorRecordedIfFileDeleted(t *testing.T) {
 	reloader, loader, filePath := createReloader(t)
 
 	err := reloader.startWatching()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 1, loader.reloadNumber())
 
 	loader.returnErrorOnSubsequentCalls("test error on reload")
 
 	err = os.WriteFile(filePath, []byte("some_data"), 0600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
 		return loader.reloadNumber() > 1 && reloader.getLastError() != nil
@@ -82,7 +83,7 @@ func createReloader(t *testing.T) (*clientCAsFileReloader, *testLoader, string) 
 
 func createTempFile(t *testing.T) string {
 	tmpCa, err := os.CreateTemp("", "clientCAs.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tmpCaPath, err := filepath.Abs(tmpCa.Name())
 	assert.NoError(t, err)
 	assert.NoError(t, tmpCa.Close())

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -286,19 +286,19 @@ func TestLoadTLSClientConfig(t *testing.T) {
 		Insecure: true,
 	}
 	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, tlsCfg)
 
 	tlsSetting = ClientConfig{}
 	tlsCfg, err = tlsSetting.LoadTLSConfig(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 
 	tlsSetting = ClientConfig{
 		InsecureSkipVerify: true,
 	}
 	tlsCfg, err = tlsSetting.LoadTLSConfig(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 	assert.True(t, tlsCfg.InsecureSkipVerify)
 }
@@ -311,7 +311,7 @@ func TestLoadTLSServerConfigError(t *testing.T) {
 		},
 	}
 	_, err := tlsSetting.LoadTLSConfig(context.Background())
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	tlsSetting = ServerConfig{
 		ClientCAFile: "doesnt/exist",
@@ -323,7 +323,7 @@ func TestLoadTLSServerConfigError(t *testing.T) {
 func TestLoadTLSServerConfig(t *testing.T) {
 	tlsSetting := ServerConfig{}
 	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 }
 
@@ -339,11 +339,11 @@ func TestLoadTLSServerConfigReload(t *testing.T) {
 	}
 
 	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 
 	firstClient, err := tlsCfg.GetConfigForClient(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	overwriteClientCA(t, tmpCaPath, "ca-2.crt")
 
@@ -353,7 +353,7 @@ func TestLoadTLSServerConfigReload(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 
 	secondClient, err := tlsCfg.GetConfigForClient(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.NotEqual(t, firstClient.ClientCAs, secondClient.ClientCAs)
 }
@@ -370,11 +370,11 @@ func TestLoadTLSServerConfigFailingReload(t *testing.T) {
 	}
 
 	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 
 	firstClient, err := tlsCfg.GetConfigForClient(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	overwriteClientCA(t, tmpCaPath, "testCA-bad.txt")
 
@@ -384,7 +384,7 @@ func TestLoadTLSServerConfigFailingReload(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 
 	secondClient, err := tlsCfg.GetConfigForClient(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, firstClient.ClientCAs, secondClient.ClientCAs)
 }
@@ -401,7 +401,7 @@ func TestLoadTLSServerConfigFailingInitialLoad(t *testing.T) {
 	}
 
 	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, tlsCfg)
 }
 
@@ -415,7 +415,7 @@ func TestLoadTLSServerConfigWrongPath(t *testing.T) {
 	}
 
 	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, tlsCfg)
 }
 
@@ -431,28 +431,28 @@ func TestLoadTLSServerConfigFailing(t *testing.T) {
 	}
 
 	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 
 	firstClient, err := tlsCfg.GetConfigForClient(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, firstClient)
 
 	err = os.Remove(tmpCaPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	firstClient, err = tlsCfg.GetConfigForClient(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, firstClient)
 }
 
 func overwriteClientCA(t *testing.T, targetFilePath string, testdataFileName string) {
 	targetFile, err := os.OpenFile(filepath.Clean(targetFilePath), os.O_RDWR, 0600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testdataFilePath := filepath.Join("testdata", testdataFileName)
 	testdataFile, err := os.OpenFile(filepath.Clean(testdataFilePath), os.O_RDONLY, 0200)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = io.Copy(targetFile, testdataFile)
 	assert.NoError(t, err)
@@ -463,7 +463,7 @@ func overwriteClientCA(t *testing.T, targetFilePath string, testdataFileName str
 
 func createTempClientCaFile(t *testing.T) string {
 	tmpCa, err := os.CreateTemp("", "ca-tmp.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tmpCaPath, err := filepath.Abs(tmpCa.Name())
 	assert.NoError(t, err)
 	assert.NoError(t, tmpCa.Close())
@@ -476,13 +476,13 @@ func TestEagerlyLoadCertificate(t *testing.T) {
 		KeyFile:  filepath.Join("testdata", "client-1.key"),
 	}
 	cfg, err := options.loadTLSConfig()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cfg)
 	cert, err := cfg.GetCertificate(&tls.ClientHelloInfo{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cert)
 	pCert, err := x509.ParseCertificate(cert.Certificate[0])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, pCert)
 	assert.ElementsMatch(t, []string{"example1"}, pCert.DNSNames)
 }
@@ -540,20 +540,20 @@ func TestCertificateReload(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Copy certs into a temp dir so we can safely modify them
 			certFile, err := os.CreateTemp("", "cert")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer os.Remove(certFile.Name())
 
 			keyFile, err := os.CreateTemp("", "key")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer os.Remove(keyFile.Name())
 
 			fdc, err := os.Open(filepath.Join("testdata", "client-1.crt"))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = io.Copy(certFile, fdc)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			fdk, err := os.Open(filepath.Join("testdata", "client-1.key"))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = io.Copy(keyFile, fdk)
 			assert.NoError(t, err)
 			assert.NoError(t, fdk.Close())
@@ -564,15 +564,15 @@ func TestCertificateReload(t *testing.T) {
 				ReloadInterval: test.reloadInterval,
 			}
 			cfg, err := options.loadTLSConfig()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, cfg)
 
 			// Asssert that we loaded the original certificate
 			cert, err := cfg.GetCertificate(&tls.ClientHelloInfo{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, cert)
 			pCert, err := x509.ParseCertificate(cert.Certificate[0])
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, pCert)
 			assert.Equal(t, test.dns1, pCert.DNSNames[0])
 
@@ -580,18 +580,18 @@ func TestCertificateReload(t *testing.T) {
 			assert.NoError(t, certFile.Truncate(0))
 			assert.NoError(t, keyFile.Truncate(0))
 			_, err = certFile.Seek(0, 0)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = keyFile.Seek(0, 0)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			fdc2, err := os.Open(filepath.Join("testdata", test.cert2))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = io.Copy(certFile, fdc2)
 			assert.NoError(t, err)
 			assert.NoError(t, fdc2.Close())
 
 			fdk2, err := os.Open(filepath.Join("testdata", test.key2))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = io.Copy(keyFile, fdk2)
 			assert.NoError(t, err)
 			assert.NoError(t, fdk2.Close())
@@ -602,10 +602,10 @@ func TestCertificateReload(t *testing.T) {
 			// Assert that we loaded the new certificate
 			cert, err = cfg.GetCertificate(&tls.ClientHelloInfo{})
 			if test.errText == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, cert)
 				pCert, err = x509.ParseCertificate(cert.Certificate[0])
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, pCert)
 				assert.Equal(t, test.dns2, pCert.DNSNames[0])
 			} else {
@@ -729,7 +729,7 @@ invalid TLS cipher suite: "BAR"`,
 			if test.wantErr != "" {
 				assert.EqualError(t, err, test.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, test.result, config.CipherSuites)
 			}
 		})
@@ -798,7 +798,7 @@ func TestSystemCertPool(t *testing.T) {
 			}
 			c, err := serverConfig.LoadTLSConfig(context.Background())
 			if test.wantErr != nil {
-				assert.ErrorContains(t, err, test.wantErr.Error())
+				require.ErrorContains(t, err, test.wantErr.Error())
 			} else {
 				assert.NotNil(t, c.RootCAs)
 			}

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -109,7 +109,7 @@ func TestExpandNilStructPointersHookFunc(t *testing.T) {
 	conf := NewFromStringMap(stringMap)
 	cfg := &TestConfig{}
 	assert.Nil(t, cfg.Struct)
-	assert.NoError(t, conf.Unmarshal(cfg))
+	require.NoError(t, conf.Unmarshal(cfg))
 	assert.Nil(t, cfg.Boolean)
 	// assert.False(t, *cfg.Boolean)
 	assert.Nil(t, cfg.Struct)
@@ -134,7 +134,7 @@ func TestExpandNilStructPointersHookFuncDefaultNotNilConfigNil(t *testing.T) {
 		Struct:    s1,
 		MapStruct: map[string]*Struct{"struct": s2},
 	}
-	assert.NoError(t, conf.Unmarshal(cfg))
+	require.NoError(t, conf.Unmarshal(cfg))
 	assert.NotNil(t, cfg.Boolean)
 	assert.True(t, *cfg.Boolean)
 	assert.NotNil(t, cfg.Struct)
@@ -149,7 +149,7 @@ func TestUnmarshalWithIgnoreUnused(t *testing.T) {
 		"string":  "this is a string",
 	}
 	conf := NewFromStringMap(stringMap)
-	assert.Error(t, conf.Unmarshal(&TestIDConfig{}))
+	require.Error(t, conf.Unmarshal(&TestIDConfig{}))
 	assert.NoError(t, conf.Unmarshal(&TestIDConfig{}, WithIgnoreUnused()))
 }
 
@@ -208,7 +208,7 @@ func TestMapKeyStringToMapKeyTextUnmarshalerHookFunc(t *testing.T) {
 	conf := NewFromStringMap(stringMap)
 
 	cfg := &TestIDConfig{}
-	assert.NoError(t, conf.Unmarshal(cfg))
+	require.NoError(t, conf.Unmarshal(cfg))
 	assert.True(t, cfg.Boolean)
 	assert.Equal(t, map[TestID]string{"string": "this is a string"}, cfg.Map)
 }
@@ -243,7 +243,7 @@ func TestUintUnmarshalerSuccess(t *testing.T) {
 			cfg := &UintConfig{}
 			err := conf.Unmarshal(cfg)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, cfg.UintTest, uint32(tt.testValue))
 		})
 	}
@@ -264,7 +264,7 @@ func TestUint64Unmarshaler(t *testing.T) {
 	cfg := &Uint64Config{}
 	err := conf.Unmarshal(cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, cfg.UintTest, testValue)
 }
 
@@ -277,7 +277,7 @@ func TestUintUnmarshalerFailure(t *testing.T) {
 	cfg := &UintConfig{}
 	err := conf.Unmarshal(cfg)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("decoding failed due to the following error(s):\n\ncannot parse 'uint_test', %d overflows uint", testValue))
 }
 
@@ -316,7 +316,7 @@ func TestMarshal(t *testing.T) {
 			"string": "this is a string",
 		},
 	}
-	assert.NoError(t, conf.Marshal(cfg))
+	require.NoError(t, conf.Marshal(cfg))
 	assert.Equal(t, true, conf.Get("bool"))
 	assert.Equal(t, map[string]any{"string_": "this is a string"}, conf.Get("map"))
 }
@@ -345,7 +345,7 @@ func TestMarshaler(t *testing.T) {
 			Name: "StructName",
 		},
 	}
-	assert.NoError(t, conf.Marshal(cfg))
+	require.NoError(t, conf.Marshal(cfg))
 	assert.Equal(t, "field", conf.Get("additional"))
 
 	conf = New()
@@ -355,9 +355,9 @@ func TestMarshaler(t *testing.T) {
 	nmCfg := &NestedMarshaler{
 		TestConfig: cfg,
 	}
-	assert.NoError(t, conf.Marshal(nmCfg))
+	require.NoError(t, conf.Marshal(nmCfg))
 	sub, err := conf.Sub("testconfig")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, sub.IsSet("additional"))
 	assert.Equal(t, "field", sub.Get("additional"))
 	varBool := false
@@ -483,7 +483,7 @@ func TestUnmarshaler(t *testing.T) {
 	})
 
 	tc := &testConfig{}
-	assert.NoError(t, cfgMap.Unmarshal(tc))
+	require.NoError(t, cfgMap.Unmarshal(tc))
 	assert.Equal(t, "make sure this is only called directly", tc.Another)
 	assert.Equal(t, "make sure this is called", tc.Next.String)
 	assert.Equal(t, "make sure this is also called", tc.EmbeddedConfig.Some)
@@ -501,7 +501,7 @@ func TestEmbeddedUnmarshaler(t *testing.T) {
 	})
 
 	tc := &testConfigWithoutUnmarshaler{}
-	assert.NoError(t, cfgMap.Unmarshal(tc))
+	require.NoError(t, cfgMap.Unmarshal(tc))
 	assert.Equal(t, "make sure this", tc.Another)
 	assert.Equal(t, "make sure this is called", tc.Next.String)
 	assert.Equal(t, "make sure this is also called", tc.EmbeddedConfig.Some)
@@ -545,7 +545,7 @@ func TestUnmarshalerKeepAlreadyInitialized(t *testing.T) {
 	tc := &testConfig{Next: &nextConfig{
 		private: "keep already configured members",
 	}}
-	assert.NoError(t, cfgMap.Unmarshal(tc))
+	require.NoError(t, cfgMap.Unmarshal(tc))
 	assert.Equal(t, "make sure this is only called directly", tc.Another)
 	assert.Equal(t, "make sure this is called", tc.Next.String)
 	assert.Equal(t, "keep already configured members", tc.Next.private)
@@ -562,7 +562,7 @@ func TestDirectUnmarshaler(t *testing.T) {
 	tc := &testConfig{Next: &nextConfig{
 		private: "keep already configured members",
 	}}
-	assert.NoError(t, tc.Unmarshal(cfgMap))
+	require.NoError(t, tc.Unmarshal(cfgMap))
 	assert.Equal(t, "make sure this is only called directly is only called directly", tc.Another)
 	assert.Equal(t, "make sure this is called", tc.Next.String)
 	assert.Equal(t, "keep already configured members", tc.Next.private)
@@ -588,7 +588,7 @@ func TestUnmarshalerErr(t *testing.T) {
 	})
 
 	tc := &testErrConfig{}
-	assert.EqualError(t, cfgMap.Unmarshal(tc), "decoding failed due to the following error(s):\n\nerror decoding 'err': never works")
+	require.EqualError(t, cfgMap.Unmarshal(tc), "decoding failed due to the following error(s):\n\nerror decoding 'err': never works")
 	assert.Empty(t, tc.Err.Foo)
 }
 
@@ -736,7 +736,7 @@ func TestNestedUnmarshalerImplementations(t *testing.T) {
 
 	// Use a wrapper struct until we deprecate component.UnmarshalConfig
 	w := &Wrapper{}
-	assert.NoError(t, conf.Unmarshal(w))
+	require.NoError(t, conf.Unmarshal(w))
 
 	a := w.A
 	assert.Equal(t, []string{"conf.Unmarshal", "A.Unmarshal"}, a.Modifiers)
@@ -754,14 +754,14 @@ func TestUnmarshalDouble(t *testing.T) {
 		Str string `mapstructure:"str"`
 	}
 	s := &Struct{}
-	assert.NoError(t, conf.Unmarshal(s))
+	require.NoError(t, conf.Unmarshal(s))
 	assert.Equal(t, "test", s.Str)
 
 	type Struct2 struct {
 		Str string `mapstructure:"str"`
 	}
 	s2 := &Struct2{}
-	assert.NoError(t, conf.Unmarshal(s2))
+	require.NoError(t, conf.Unmarshal(s2))
 	assert.Equal(t, "test", s2.Str)
 }
 
@@ -859,14 +859,14 @@ func TestExpandedValue(t *testing.T) {
 	}
 
 	cfgStr := ConfigStr{}
-	assert.NoError(t, cm.Unmarshal(&cfgStr))
+	require.NoError(t, cm.Unmarshal(&cfgStr))
 	assert.Equal(t, "original", cfgStr.Key)
 
 	type ConfigInt struct {
 		Key int `mapstructure:"key"`
 	}
 	cfgInt := ConfigInt{}
-	assert.NoError(t, cm.Unmarshal(&cfgInt))
+	require.NoError(t, cm.Unmarshal(&cfgInt))
 	assert.Equal(t, 0xdeadbeef, cfgInt.Key)
 
 	type ConfigBool struct {
@@ -891,7 +891,7 @@ func TestSubExpandedValue(t *testing.T) {
 	assert.Equal(t, map[string]any{"subsubkey": "value"}, cm.Get("key::subkey"))
 
 	sub, err := cm.Sub("key::subkey")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]any{"subsubkey": "value"}, sub.ToStringMap())
 
 	// This should return value, but currently `Get` does not support keys within expanded values.

--- a/confmap/confmaptest/configtest_test.go
+++ b/confmap/confmaptest/configtest_test.go
@@ -42,9 +42,9 @@ func TestValidateProviderScheme(t *testing.T) {
 	assert.NoError(t, ValidateProviderScheme(&schemeProvider{scheme: "s3"}))
 	assert.NoError(t, ValidateProviderScheme(&schemeProvider{scheme: "a.l-l+"}))
 	// Too short.
-	assert.Error(t, ValidateProviderScheme(&schemeProvider{scheme: "a"}))
+	require.Error(t, ValidateProviderScheme(&schemeProvider{scheme: "a"}))
 	// Invalid first character.
-	assert.Error(t, ValidateProviderScheme(&schemeProvider{scheme: "3s"}))
+	require.Error(t, ValidateProviderScheme(&schemeProvider{scheme: "3s"}))
 	// Invalid underscore character.
 	assert.Error(t, ValidateProviderScheme(&schemeProvider{scheme: "all_"}))
 }

--- a/confmap/provider/envprovider/provider_test.go
+++ b/confmap/provider/envprovider/provider_test.go
@@ -42,7 +42,7 @@ func TestEmptyName(t *testing.T) {
 func TestUnsupportedScheme(t *testing.T) {
 	env := createProvider()
 	_, err := env.Retrieve(context.Background(), "https://", nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.NoError(t, env.Shutdown(context.Background()))
 }
 
@@ -66,7 +66,7 @@ func TestEnv(t *testing.T) {
 	ret, err := env.Retrieve(context.Background(), envSchemePrefix+envName, nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedMap := confmap.NewFromStringMap(map[string]any{
 		"processors::batch":         nil,
 		"exporters::otlp::endpoint": "localhost:4317",
@@ -86,14 +86,14 @@ func TestEnvWithLogger(t *testing.T) {
 	ret, err := env.Retrieve(context.Background(), envSchemePrefix+envName, nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedMap := confmap.NewFromStringMap(map[string]any{
 		"processors::batch":         nil,
 		"exporters::otlp::endpoint": "localhost:4317",
 	})
 	assert.Equal(t, expectedMap.ToStringMap(), retMap.ToStringMap())
 
-	assert.NoError(t, env.Shutdown(context.Background()))
+	require.NoError(t, env.Shutdown(context.Background()))
 	assert.Equal(t, 0, ol.Len())
 }
 
@@ -106,11 +106,11 @@ func TestUnsetEnvWithLoggerWarn(t *testing.T) {
 	ret, err := env.Retrieve(context.Background(), envSchemePrefix+envName, nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedMap := confmap.NewFromStringMap(map[string]any{})
 	assert.Equal(t, expectedMap.ToStringMap(), retMap.ToStringMap())
 
-	assert.NoError(t, env.Shutdown(context.Background()))
+	require.NoError(t, env.Shutdown(context.Background()))
 
 	assert.Equal(t, 1, ol.Len())
 	logLine := ol.All()[0]
@@ -126,7 +126,7 @@ func TestEnvVarNameRestriction(t *testing.T) {
 	env := createProvider()
 	ret, err := env.Retrieve(context.Background(), envSchemePrefix+envName, nil)
 	assert.Equal(t, err, fmt.Errorf("environment variable \"default%%config\" has invalid name: must match regex %s", envvar.ValidationRegexp))
-	assert.NoError(t, env.Shutdown(context.Background()))
+	require.NoError(t, env.Shutdown(context.Background()))
 	assert.Nil(t, ret)
 }
 
@@ -141,11 +141,11 @@ func TestEmptyEnvWithLoggerWarn(t *testing.T) {
 	ret, err := env.Retrieve(context.Background(), envSchemePrefix+envName, nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedMap := confmap.NewFromStringMap(map[string]any{})
 	assert.Equal(t, expectedMap.ToStringMap(), retMap.ToStringMap())
 
-	assert.NoError(t, env.Shutdown(context.Background()))
+	require.NoError(t, env.Shutdown(context.Background()))
 
 	assert.Equal(t, 1, ol.Len())
 	logLine := ol.All()[0]

--- a/confmap/provider/fileprovider/provider_test.go
+++ b/confmap/provider/fileprovider/provider_test.go
@@ -32,16 +32,16 @@ func TestEmptyName(t *testing.T) {
 func TestUnsupportedScheme(t *testing.T) {
 	fp := createProvider()
 	_, err := fp.Retrieve(context.Background(), "https://", nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.NoError(t, fp.Shutdown(context.Background()))
 }
 
 func TestNonExistent(t *testing.T) {
 	fp := createProvider()
 	_, err := fp.Retrieve(context.Background(), fileSchemePrefix+filepath.Join("testdata", "non-existent.yaml"), nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = fp.Retrieve(context.Background(), fileSchemePrefix+absolutePath(t, filepath.Join("testdata", "non-existent.yaml")), nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	require.NoError(t, fp.Shutdown(context.Background()))
 }
 
@@ -67,7 +67,7 @@ func TestRelativePath(t *testing.T) {
 	ret, err := fp.Retrieve(context.Background(), fileSchemePrefix+filepath.Join("testdata", "default-config.yaml"), nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedMap := confmap.NewFromStringMap(map[string]any{
 		"processors::batch":         nil,
 		"exporters::otlp::endpoint": "localhost:4317",
@@ -81,7 +81,7 @@ func TestAbsolutePath(t *testing.T) {
 	ret, err := fp.Retrieve(context.Background(), fileSchemePrefix+absolutePath(t, filepath.Join("testdata", "default-config.yaml")), nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedMap := confmap.NewFromStringMap(map[string]any{
 		"processors::batch":         nil,
 		"exporters::otlp::endpoint": "localhost:4317",

--- a/confmap/provider/internal/configurablehttpprovider/provider_test.go
+++ b/confmap/provider/internal/configurablehttpprovider/provider_test.go
@@ -133,15 +133,15 @@ func TestFunctionalityDownloadFileHTTP(t *testing.T) {
 
 func TestFunctionalityDownloadFileHTTPS(t *testing.T) {
 	certPath, keyPath, err := generateCertificate("localhost")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	invalidCert, err := os.CreateTemp("", "cert*.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = invalidCert.Write([]byte{0, 1, 2})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(answerGet))
 	ts.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
 	ts.StartTLS()
@@ -232,12 +232,12 @@ func TestFunctionalityDownloadFileHTTPS(t *testing.T) {
 func TestUnsupportedScheme(t *testing.T) {
 	fp := New(HTTPScheme, confmaptest.NewNopProviderSettings())
 	_, err := fp.Retrieve(context.Background(), "https://...", nil)
-	assert.Error(t, err)
-	assert.NoError(t, fp.Shutdown(context.Background()))
+	require.Error(t, err)
+	require.NoError(t, fp.Shutdown(context.Background()))
 
 	fp = New(HTTPSScheme, confmaptest.NewNopProviderSettings())
 	_, err = fp.Retrieve(context.Background(), "http://...", nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.NoError(t, fp.Shutdown(context.Background()))
 }
 
@@ -257,7 +257,7 @@ func TestRetrieveFromShutdownServer(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	ts.Close()
 	_, err := fp.Retrieve(context.Background(), ts.URL, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	require.NoError(t, fp.Shutdown(context.Background()))
 }
 
@@ -268,7 +268,7 @@ func TestNonExistent(t *testing.T) {
 	}))
 	defer ts.Close()
 	_, err := fp.Retrieve(context.Background(), ts.URL, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	require.NoError(t, fp.Shutdown(context.Background()))
 }
 

--- a/confmap/provider/yamlprovider/provider_test.go
+++ b/confmap/provider/yamlprovider/provider_test.go
@@ -21,7 +21,7 @@ func TestValidateProviderScheme(t *testing.T) {
 func TestEmpty(t *testing.T) {
 	sp := createProvider()
 	_, err := sp.Retrieve(context.Background(), "", nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.NoError(t, sp.Shutdown(context.Background()))
 }
 
@@ -39,9 +39,9 @@ func TestInvalidYAML(t *testing.T) {
 func TestOneValue(t *testing.T) {
 	sp := createProvider()
 	ret, err := sp.Retrieve(context.Background(), "yaml:processors::batch::timeout: 2s", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"processors": map[string]any{
 			"batch": map[string]any{
@@ -55,9 +55,9 @@ func TestOneValue(t *testing.T) {
 func TestNamedComponent(t *testing.T) {
 	sp := createProvider()
 	ret, err := sp.Retrieve(context.Background(), "yaml:processors::batch/foo::timeout: 3s", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"processors": map[string]any{
 			"batch/foo": map[string]any{
@@ -71,9 +71,9 @@ func TestNamedComponent(t *testing.T) {
 func TestMapEntry(t *testing.T) {
 	sp := createProvider()
 	ret, err := sp.Retrieve(context.Background(), "yaml:processors: {batch/foo::timeout: 3s, batch::timeout: 2s}", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"processors": map[string]any{
 			"batch/foo": map[string]any{
@@ -90,9 +90,9 @@ func TestMapEntry(t *testing.T) {
 func TestArrayEntry(t *testing.T) {
 	sp := createProvider()
 	ret, err := sp.Retrieve(context.Background(), "yaml:service::extensions: [zpages, zpages/foo]", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"service": map[string]any{
 			"extensions": []any{
@@ -107,9 +107,9 @@ func TestArrayEntry(t *testing.T) {
 func TestNewLine(t *testing.T) {
 	sp := createProvider()
 	ret, err := sp.Retrieve(context.Background(), "yaml:processors::batch/foo::timeout: 3s\nprocessors::batch::timeout: 2s", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"processors": map[string]any{
 			"batch/foo": map[string]any{
@@ -126,9 +126,9 @@ func TestNewLine(t *testing.T) {
 func TestDotSeparator(t *testing.T) {
 	sp := createProvider()
 	ret, err := sp.Retrieve(context.Background(), "yaml:processors.batch.timeout: 4s", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	retMap, err := ret.AsConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]any{"processors.batch.timeout": "4s"}, retMap.ToStringMap())
 	assert.NoError(t, sp.Shutdown(context.Background()))
 }

--- a/confmap/provider_test.go
+++ b/confmap/provider_test.go
@@ -60,7 +60,7 @@ func TestNewRetrievedFromYAMLInvalidYAMLBytes(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = ret.AsConf()
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	str, err := ret.AsString()
 	require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestNewRetrievedFromYAMLInvalidAsMap(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = ret.AsConf()
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	str, err := ret.AsString()
 	require.NoError(t, err)

--- a/confmap/resolver_test.go
+++ b/confmap/resolver_test.go
@@ -327,27 +327,27 @@ func TestResolver(t *testing.T) {
 		ConverterFactories: nil})
 	require.NoError(t, err)
 	_, errN := resolver.Resolve(context.Background())
-	assert.NoError(t, errN)
+	require.NoError(t, errN)
 	assert.Equal(t, int32(0), numCalls.Load())
 
 	errW := <-resolver.Watch()
-	assert.NoError(t, errW)
+	require.NoError(t, errW)
 
 	// Repeat Resolve/Watch.
 
 	_, errN = resolver.Resolve(context.Background())
-	assert.NoError(t, errN)
+	require.NoError(t, errN)
 	assert.Equal(t, int32(1), numCalls.Load())
 
 	errW = <-resolver.Watch()
-	assert.NoError(t, errW)
+	require.NoError(t, errW)
 
 	_, errN = resolver.Resolve(context.Background())
-	assert.NoError(t, errN)
+	require.NoError(t, errN)
 	assert.Equal(t, int32(2), numCalls.Load())
 
 	errC := resolver.Shutdown(context.Background())
-	assert.NoError(t, errC)
+	require.NoError(t, errC)
 	assert.Equal(t, int32(3), numCalls.Load())
 }
 
@@ -382,7 +382,7 @@ func TestResolverShutdownClosesWatch(t *testing.T) {
 		ConverterFactories: nil})
 	require.NoError(t, err)
 	_, errN := resolver.Resolve(context.Background())
-	assert.NoError(t, errN)
+	require.NoError(t, errN)
 
 	var watcherWG sync.WaitGroup
 	watcherWG.Add(1)
@@ -394,7 +394,7 @@ func TestResolverShutdownClosesWatch(t *testing.T) {
 		watcherWG.Done()
 	}()
 
-	assert.NoError(t, resolver.Shutdown(context.Background()))
+	require.NoError(t, resolver.Shutdown(context.Background()))
 	watcherWG.Wait()
 }
 

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector/internal"
@@ -59,15 +60,15 @@ func TestNewFactoryWithSameTypes(t *testing.T) {
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.TracesToTracesStability())
 	_, err := factory.CreateTracesToTraces(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelBeta, factory.MetricsToMetricsStability())
 	_, err = factory.CreateMetricsToMetrics(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelUnmaintained, factory.LogsToLogsStability())
 	_, err = factory.CreateLogsToLogs(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = factory.CreateTracesToMetrics(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	assert.Equal(t, err, internal.ErrDataTypes(testID, component.DataTypeTraces, component.DataTypeMetrics))
@@ -106,23 +107,23 @@ func TestNewFactoryWithTranslateTypes(t *testing.T) {
 
 	assert.Equal(t, component.StabilityLevelDevelopment, factory.TracesToMetricsStability())
 	_, err = factory.CreateTracesToMetrics(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.TracesToLogsStability())
 	_, err = factory.CreateTracesToLogs(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelBeta, factory.MetricsToTracesStability())
 	_, err = factory.CreateMetricsToTraces(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelStable, factory.MetricsToLogsStability())
 	_, err = factory.CreateMetricsToLogs(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelDeprecated, factory.LogsToTracesStability())
 	_, err = factory.CreateLogsToTraces(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelUnmaintained, factory.LogsToMetricsStability())
 	_, err = factory.CreateLogsToMetrics(context.Background(), Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
@@ -146,30 +147,30 @@ func TestNewFactoryWithAllTypes(t *testing.T) {
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.TracesToTracesStability())
 	_, err := factory.CreateTracesToTraces(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, component.StabilityLevelDevelopment, factory.TracesToMetricsStability())
 	_, err = factory.CreateTracesToMetrics(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, component.StabilityLevelAlpha, factory.TracesToLogsStability())
 	_, err = factory.CreateTracesToLogs(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelBeta, factory.MetricsToTracesStability())
 	_, err = factory.CreateMetricsToTraces(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, component.StabilityLevelBeta, factory.MetricsToMetricsStability())
 	_, err = factory.CreateMetricsToMetrics(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, component.StabilityLevelStable, factory.MetricsToLogsStability())
 	_, err = factory.CreateMetricsToLogs(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelDeprecated, factory.LogsToTracesStability())
 	_, err = factory.CreateLogsToTraces(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, component.StabilityLevelUnmaintained, factory.LogsToMetricsStability())
 	_, err = factory.CreateLogsToMetrics(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, component.StabilityLevelUnmaintained, factory.LogsToLogsStability())
 	_, err = factory.CreateLogsToLogs(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
 	assert.NoError(t, err)
@@ -206,7 +207,7 @@ func TestMakeFactoryMap(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.out, out)
 		})
 	}

--- a/connector/connectorprofiles/connector_test.go
+++ b/connector/connectorprofiles/connector_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentprofiles"
@@ -54,7 +55,7 @@ func TestNewFactoryWithSameTypes(t *testing.T) {
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.ProfilesToProfilesStability())
 	_, err := factory.CreateProfilesToProfiles(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = factory.CreateProfilesToTraces(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	assert.Equal(t, err, internal.ErrDataTypes(testID, componentprofiles.DataTypeProfiles, component.DataTypeTraces))
@@ -83,23 +84,23 @@ func TestNewFactoryWithTranslateTypes(t *testing.T) {
 
 	assert.Equal(t, component.StabilityLevelBeta, factory.TracesToProfilesStability())
 	_, err = factory.CreateTracesToProfiles(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelDevelopment, factory.MetricsToProfilesStability())
 	_, err = factory.CreateMetricsToProfiles(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.LogsToProfilesStability())
 	_, err = factory.CreateLogsToProfiles(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelBeta, factory.ProfilesToTracesStability())
 	_, err = factory.CreateProfilesToTraces(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelDevelopment, factory.ProfilesToMetricsStability())
 	_, err = factory.CreateProfilesToMetrics(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.ProfilesToLogsStability())
 	_, err = factory.CreateProfilesToLogs(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())

--- a/connector/connectorprofiles/profiles_router_test.go
+++ b/connector/connectorprofiles/profiles_router_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -149,7 +150,7 @@ func TestProfilessRouterConsumer(t *testing.T) {
 
 	none, err := r.Consumer()
 	assert.Nil(t, none)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	fake, err := r.Consumer(component.MustNewID("fake"))
 	assert.Nil(t, fake)

--- a/connector/forwardconnector/forward_test.go
+++ b/connector/forwardconnector/forward_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/connector/connectortest"
@@ -27,17 +28,17 @@ func TestForward(t *testing.T) {
 
 	tracesSink := new(consumertest.TracesSink)
 	tracesToTraces, err := f.CreateTracesToTraces(ctx, set, cfg, tracesSink)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tracesToTraces)
 
 	metricsSink := new(consumertest.MetricsSink)
 	metricsToMetrics, err := f.CreateMetricsToMetrics(ctx, set, cfg, metricsSink)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, metricsToMetrics)
 
 	logsSink := new(consumertest.LogsSink)
 	logsToLogs, err := f.CreateLogsToLogs(ctx, set, cfg, logsSink)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, logsToLogs)
 
 	assert.NoError(t, tracesToTraces.Start(ctx, host))

--- a/connector/logs_router_test.go
+++ b/connector/logs_router_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -148,7 +149,7 @@ func TestLogsRouterConsumers(t *testing.T) {
 
 	none, err := r.Consumer()
 	assert.Nil(t, none)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	fake, err := r.Consumer(component.MustNewID("fake"))
 	assert.Nil(t, fake)

--- a/connector/metrics_router_test.go
+++ b/connector/metrics_router_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -148,7 +149,7 @@ func TestMetricsRouterConsumers(t *testing.T) {
 
 	none, err := r.Consumer()
 	assert.Nil(t, none)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	fake, err := r.Consumer(component.MustNewID("fake"))
 	assert.Nil(t, fake)

--- a/connector/traces_router_test.go
+++ b/connector/traces_router_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -148,7 +149,7 @@ func TestTracesRouterConsumer(t *testing.T) {
 
 	none, err := r.Consumer()
 	assert.Nil(t, none)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	fake, err := r.Consumer(component.MustNewID("fake"))
 	assert.Nil(t, fake)

--- a/consumer/consumererror/signalerrors_test.go
+++ b/consumer/consumererror/signalerrors_test.go
@@ -21,7 +21,7 @@ func TestTraces(t *testing.T) {
 	var target Traces
 	assert.False(t, errors.As(nil, &target))
 	assert.False(t, errors.As(err, &target))
-	assert.ErrorAs(t, traceErr, &target)
+	require.ErrorAs(t, traceErr, &target)
 	assert.Equal(t, td, target.Data())
 }
 
@@ -45,7 +45,7 @@ func TestLogs(t *testing.T) {
 	var target Logs
 	assert.False(t, errors.As(nil, &target))
 	assert.False(t, errors.As(err, &target))
-	assert.ErrorAs(t, logsErr, &target)
+	require.ErrorAs(t, logsErr, &target)
 	assert.Equal(t, td, target.Data())
 }
 
@@ -69,7 +69,7 @@ func TestMetrics(t *testing.T) {
 	var target Metrics
 	assert.False(t, errors.As(nil, &target))
 	assert.False(t, errors.As(err, &target))
-	assert.ErrorAs(t, metricErr, &target)
+	require.ErrorAs(t, metricErr, &target)
 	assert.Equal(t, td, target.Data())
 }
 

--- a/consumer/consumerprofiles/profiles_test.go
+++ b/consumer/consumerprofiles/profiles_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pprofile"
@@ -46,6 +47,6 @@ func TestConsumeProfiles(t *testing.T) {
 func TestConsumeProfiles_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	cp, err := NewProfiles(func(context.Context, pprofile.Profiles) error { return want })
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, cp.ConsumeProfiles(context.Background(), pprofile.NewProfiles()))
 }

--- a/consumer/logs_test.go
+++ b/consumer/logs_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/pdata/plog"
 )
@@ -45,6 +46,6 @@ func TestConsumeLogs(t *testing.T) {
 func TestConsumeLogs_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	cp, err := NewLogs(func(context.Context, plog.Logs) error { return want })
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, cp.ConsumeLogs(context.Background(), plog.NewLogs()))
 }

--- a/consumer/metrics_test.go
+++ b/consumer/metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
@@ -45,6 +46,6 @@ func TestConsumeMetrics(t *testing.T) {
 func TestConsumeMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	cp, err := NewMetrics(func(context.Context, pmetric.Metrics) error { return want })
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, cp.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
 }

--- a/consumer/traces_test.go
+++ b/consumer/traces_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
@@ -45,6 +46,6 @@ func TestConsumeTraces(t *testing.T) {
 func TestConsumeTraces_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	cp, err := NewTraces(func(context.Context, ptrace.Traces) error { return want })
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, cp.ConsumeTraces(context.Background(), ptrace.NewTraces()))
 }

--- a/exporter/debugexporter/config_test.go
+++ b/exporter/debugexporter/config_test.go
@@ -18,7 +18,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, confmap.New().Unmarshal(&cfg))
+	require.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -52,7 +52,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			if tt.expectedErr != "" {
 				assert.ErrorContains(t, err, tt.expectedErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.cfg, cfg)
 			}
 		})
@@ -82,7 +82,7 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 
 			conf := confmap.New()
 			err := conf.Marshal(tc.inCfg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			raw := conf.ToStringMap()
 
@@ -93,11 +93,11 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 			err = conf.Unmarshal(outCfg)
 
 			if tc.expectedErr == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.expectedConfig, outCfg)
 				return
 			}
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/exporter/debugexporter/factory_test.go
+++ b/exporter/debugexporter/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -25,7 +26,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	me, err := factory.CreateMetricsExporter(context.Background(), exportertest.NewNopSettings(), cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, me)
 }
 
@@ -34,7 +35,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	te, err := factory.CreateTracesExporter(context.Background(), exportertest.NewNopSettings(), cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, te)
 }
 
@@ -43,6 +44,6 @@ func TestCreateLogsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	te, err := factory.CreateLogsExporter(context.Background(), exportertest.NewNopSettings(), cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, te)
 }

--- a/exporter/debugexporter/internal/normal/logs_test.go
+++ b/exporter/debugexporter/internal/normal/logs_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -111,7 +112,7 @@ log message mykey2=myvalue2 mykey1=myvalue1
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			output, err := NewNormalLogsMarshaler().MarshalLogs(tt.input)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, string(output))
 		})
 	}

--- a/exporter/debugexporter/internal/normal/metrics_test.go
+++ b/exporter/debugexporter/internal/normal/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
@@ -113,7 +114,7 @@ func TestMarshalMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			output, err := NewNormalMetricsMarshaler().MarshalMetrics(tt.input)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, string(output))
 		})
 	}

--- a/exporter/debugexporter/internal/normal/traces_test.go
+++ b/exporter/debugexporter/internal/normal/traces_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
@@ -41,7 +42,7 @@ func TestMarshalTraces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			output, err := NewNormalTracesMarshaler().MarshalTraces(tt.input)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, string(output))
 		})
 	}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -22,9 +23,9 @@ func TestNewFactory(t *testing.T) {
 	assert.EqualValues(t, testType, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 	_, err := factory.CreateTracesExporter(context.Background(), Settings{}, &defaultCfg)
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = factory.CreateMetricsExporter(context.Background(), Settings{}, &defaultCfg)
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = factory.CreateLogsExporter(context.Background(), Settings{}, &defaultCfg)
 	assert.Error(t, err)
 }
@@ -43,11 +44,11 @@ func TestNewFactoryWithOptions(t *testing.T) {
 
 	assert.Equal(t, component.StabilityLevelDevelopment, factory.TracesExporterStability())
 	_, err := factory.CreateTracesExporter(context.Background(), Settings{}, &defaultCfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.MetricsExporterStability())
 	_, err = factory.CreateMetricsExporter(context.Background(), Settings{}, &defaultCfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelDeprecated, factory.LogsExporterStability())
 	_, err = factory.CreateLogsExporter(context.Background(), Settings{}, &defaultCfg)
@@ -85,7 +86,7 @@ func TestMakeFactoryMap(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.out, out)
 		})
 	}

--- a/exporter/exporterbatcher/config_test.go
+++ b/exporter/exporterbatcher/config_test.go
@@ -7,21 +7,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Validate(t *testing.T) {
 	cfg := NewDefaultConfig()
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 
 	cfg.MinSizeItems = -1
-	assert.EqualError(t, cfg.Validate(), "min_size_items must be greater than or equal to zero")
+	require.EqualError(t, cfg.Validate(), "min_size_items must be greater than or equal to zero")
 
 	cfg = NewDefaultConfig()
 	cfg.FlushTimeout = 0
-	assert.EqualError(t, cfg.Validate(), "timeout must be greater than zero")
+	require.EqualError(t, cfg.Validate(), "timeout must be greater than zero")
 
 	cfg.MaxSizeItems = -1
-	assert.EqualError(t, cfg.Validate(), "max_size_items must be greater than or equal to zero")
+	require.EqualError(t, cfg.Validate(), "max_size_items must be greater than or equal to zero")
 
 	cfg = NewDefaultConfig()
 	cfg.MaxSizeItems = 20000

--- a/exporter/exporterhelper/batch_sender_test.go
+++ b/exporter/exporterhelper/batch_sender_test.go
@@ -341,7 +341,7 @@ func TestBatchSender_ConcurrencyLimitReached(t *testing.T) {
 			}, 100*time.Millisecond, 10*time.Millisecond)
 
 			// the 3rd request should be flushed by itself due to flush interval
-			assert.NoError(t, be.send(context.Background(), &fakeRequest{items: 2, sink: sink}))
+			require.NoError(t, be.send(context.Background(), &fakeRequest{items: 2, sink: sink}))
 			assert.Eventually(t, func() bool {
 				return sink.requestsCount.Load() == 2 && sink.itemsCount.Load() == 6
 			}, 100*time.Millisecond, 10*time.Millisecond)
@@ -608,7 +608,7 @@ func TestBatchSenderWithTimeout(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.NoError(t, be.Shutdown(context.Background()))
+	require.NoError(t, be.Shutdown(context.Background()))
 
 	// The sink should not change
 	assert.EqualValues(t, 1, sink.requestsCount.Load())

--- a/exporter/exporterhelper/logs_batch_test.go
+++ b/exporter/exporterhelper/logs_batch_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -18,7 +19,7 @@ func TestMergeLogs(t *testing.T) {
 	lr1 := &logsRequest{ld: testdata.GenerateLogs(2)}
 	lr2 := &logsRequest{ld: testdata.GenerateLogs(3)}
 	res, err := mergeLogs(context.Background(), lr1, lr2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 5, res.(*logsRequest).ld.LogRecordCount())
 }
 
@@ -132,7 +133,7 @@ func TestMergeSplitLogs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := mergeSplitLogs(context.Background(), tt.cfg, tt.lr1, tt.lr2)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, len(tt.expected), len(res))
 			for i, r := range res {
 				assert.Equal(t, tt.expected[i], r.(*logsRequest))

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -86,7 +86,7 @@ func TestLogsExporter_Default(t *testing.T) {
 	ld := plog.NewLogs()
 	le, err := NewLogsExporter(context.Background(), exportertest.NewNopSettings(), &fakeLogsExporterConfig, newPushLogsData(nil))
 	assert.NotNil(t, le)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, le.Capabilities())
 	assert.NoError(t, le.Start(context.Background(), componenttest.NewNopHost()))
@@ -99,7 +99,7 @@ func TestLogsRequestExporter_Default(t *testing.T) {
 	le, err := NewLogsRequestExporter(context.Background(), exportertest.NewNopSettings(),
 		(&fakeRequestConverter{}).requestFromLogsFunc)
 	assert.NotNil(t, le)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, le.Capabilities())
 	assert.NoError(t, le.Start(context.Background(), componenttest.NewNopHost()))
@@ -198,10 +198,10 @@ func TestLogsExporter_pLogModifiedDownStream_WithRecordMetrics(t *testing.T) {
 
 	le, err := NewLogsExporter(context.Background(), exporter.Settings{ID: fakeLogsExporterName, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsExporterConfig, newPushLogsDataModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	assert.NotNil(t, le)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ld := testdata.GenerateLogs(2)
 
-	assert.NoError(t, le.ConsumeLogs(context.Background(), ld))
+	require.NoError(t, le.ConsumeLogs(context.Background(), ld))
 	assert.Equal(t, 0, ld.LogRecordCount())
 	require.NoError(t, tt.CheckExporterLogs(int64(2), 0))
 }
@@ -357,7 +357,7 @@ func TestLogsExporter_WithShutdown_ReturnError(t *testing.T) {
 
 	le, err := NewLogsExporter(context.Background(), exportertest.NewNopSettings(), &fakeLogsExporterConfig, newPushLogsData(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, le)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, want, le.Shutdown(context.Background()))
 }
@@ -369,7 +369,7 @@ func TestLogsRequestExporter_WithShutdown_ReturnError(t *testing.T) {
 	le, err := NewLogsRequestExporter(context.Background(), exportertest.NewNopSettings(),
 		(&fakeRequestConverter{}).requestFromLogsFunc, WithShutdown(shutdownErr))
 	assert.NotNil(t, le)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, want, le.Shutdown(context.Background()))
 }

--- a/exporter/exporterhelper/metrics_batch_test.go
+++ b/exporter/exporterhelper/metrics_batch_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -18,7 +19,7 @@ func TestMergeMetrics(t *testing.T) {
 	mr1 := &metricsRequest{md: testdata.GenerateMetrics(2)}
 	mr2 := &metricsRequest{md: testdata.GenerateMetrics(3)}
 	res, err := mergeMetrics(context.Background(), mr1, mr2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 5, res.(*metricsRequest).md.MetricCount())
 }
 
@@ -133,7 +134,7 @@ func TestMergeSplitMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := mergeSplitMetrics(context.Background(), tt.cfg, tt.mr1, tt.mr2)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, len(tt.expected), len(res))
 			for i := range res {
 				assert.Equal(t, tt.expected[i], res[i].(*metricsRequest))

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -86,7 +86,7 @@ func TestMetricsRequestExporter_NilMetricsConverter(t *testing.T) {
 func TestMetricsExporter_Default(t *testing.T) {
 	md := pmetric.NewMetrics()
 	me, err := NewMetricsExporter(context.Background(), exportertest.NewNopSettings(), &fakeMetricsExporterConfig, newPushMetricsData(nil))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, me)
 
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, me.Capabilities())
@@ -99,7 +99,7 @@ func TestMetricsRequestExporter_Default(t *testing.T) {
 	md := pmetric.NewMetrics()
 	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopSettings(),
 		(&fakeRequestConverter{}).requestFromMetricsFunc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, me)
 
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, me.Capabilities())
@@ -111,7 +111,7 @@ func TestMetricsRequestExporter_Default(t *testing.T) {
 func TestMetricsExporter_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
 	me, err := NewMetricsExporter(context.Background(), exportertest.NewNopSettings(), &fakeMetricsExporterConfig, newPushMetricsData(nil), WithCapabilities(capabilities))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, me)
 
 	assert.Equal(t, capabilities, me.Capabilities())
@@ -121,7 +121,7 @@ func TestMetricsRequestExporter_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
 	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopSettings(),
 		(&fakeRequestConverter{}).requestFromMetricsFunc, WithCapabilities(capabilities))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, me)
 
 	assert.Equal(t, capabilities, me.Capabilities())
@@ -202,7 +202,7 @@ func TestMetricsExporter_pMetricModifiedDownStream_WithRecordMetrics(t *testing.
 	require.NotNil(t, me)
 	md := testdata.GenerateMetrics(2)
 
-	assert.NoError(t, me.ConsumeMetrics(context.Background(), md))
+	require.NoError(t, me.ConsumeMetrics(context.Background(), md))
 	assert.Equal(t, 0, md.MetricCount())
 	require.NoError(t, tt.CheckExporterMetrics(int64(4), 0))
 }

--- a/exporter/exporterhelper/obsexporter_test.go
+++ b/exporter/exporterhelper/obsexporter_test.go
@@ -185,9 +185,9 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	require.NotNil(t, ctx)
 	obsrep.endTracesOp(ctx, 7, nil)
 
-	assert.NoError(t, tt.CheckExporterTraces(7, 0))
-	assert.Error(t, tt.CheckExporterTraces(7, 7))
-	assert.Error(t, tt.CheckExporterTraces(0, 0))
+	require.NoError(t, tt.CheckExporterTraces(7, 0))
+	require.Error(t, tt.CheckExporterTraces(7, 7))
+	require.Error(t, tt.CheckExporterTraces(0, 0))
 	assert.Error(t, tt.CheckExporterTraces(0, 7))
 }
 
@@ -205,9 +205,9 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	require.NotNil(t, ctx)
 	obsrep.endMetricsOp(ctx, 7, nil)
 
-	assert.NoError(t, tt.CheckExporterMetrics(7, 0))
-	assert.Error(t, tt.CheckExporterMetrics(7, 7))
-	assert.Error(t, tt.CheckExporterMetrics(0, 0))
+	require.NoError(t, tt.CheckExporterMetrics(7, 0))
+	require.Error(t, tt.CheckExporterMetrics(7, 7))
+	require.Error(t, tt.CheckExporterMetrics(0, 0))
 	assert.Error(t, tt.CheckExporterMetrics(0, 7))
 }
 
@@ -225,9 +225,9 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	require.NotNil(t, ctx)
 	obsrep.endLogsOp(ctx, 7, nil)
 
-	assert.NoError(t, tt.CheckExporterLogs(7, 0))
-	assert.Error(t, tt.CheckExporterLogs(7, 7))
-	assert.Error(t, tt.CheckExporterLogs(0, 0))
+	require.NoError(t, tt.CheckExporterLogs(7, 0))
+	require.Error(t, tt.CheckExporterLogs(7, 7))
+	require.Error(t, tt.CheckExporterLogs(0, 0))
 	assert.Error(t, tt.CheckExporterLogs(0, 7))
 }
 

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -51,7 +51,7 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 
 	require.LessOrEqual(t, 1, be.queueSender.(*queueSender).queue.Size())
 
-	assert.NoError(t, be.Shutdown(context.Background()))
+	require.NoError(t, be.Shutdown(context.Background()))
 
 	secondMockR.checkNumRequests(t, 1)
 	ocs.checkSendItemsCount(t, 3)
@@ -242,7 +242,7 @@ func TestNoCancellationContext(t *testing.T) {
 	require.Equal(t, deadline, d)
 
 	nctx := context.WithoutCancel(ctx)
-	assert.NoError(t, nctx.Err())
+	require.NoError(t, nctx.Err())
 	d, ok = nctx.Deadline()
 	assert.False(t, ok)
 	assert.True(t, d.IsZero())
@@ -250,15 +250,15 @@ func TestNoCancellationContext(t *testing.T) {
 
 func TestQueueConfig_Validate(t *testing.T) {
 	qCfg := NewDefaultQueueConfig()
-	assert.NoError(t, qCfg.Validate())
+	require.NoError(t, qCfg.Validate())
 
 	qCfg.QueueSize = 0
-	assert.EqualError(t, qCfg.Validate(), "queue size must be positive")
+	require.EqualError(t, qCfg.Validate(), "queue size must be positive")
 
 	qCfg = NewDefaultQueueConfig()
 	qCfg.NumConsumers = 0
 
-	assert.EqualError(t, qCfg.Validate(), "number of queue consumers must be positive")
+	require.EqualError(t, qCfg.Validate(), "number of queue consumers must be positive")
 
 	// Confirm Validate doesn't return error with invalid config when feature is disabled
 	qCfg.Enabled = false
@@ -436,7 +436,7 @@ func TestQueueSenderNoStartShutdown(t *testing.T) {
 		exporterID:             exporterID,
 		exporterCreateSettings: exportertest.NewNopSettings(),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	qs := newQueueSender(queue, set, 1, "", obsrep)
 	assert.NoError(t, qs.Shutdown(context.Background()))
 }

--- a/exporter/exporterhelper/timeout_sender_test.go
+++ b/exporter/exporterhelper/timeout_sender_test.go
@@ -8,17 +8,18 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDefaultTimeoutConfig(t *testing.T) {
 	cfg := NewDefaultTimeoutConfig()
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	assert.Equal(t, TimeoutConfig{Timeout: 5 * time.Second}, cfg)
 }
 
 func TestInvalidTimeout(t *testing.T) {
 	cfg := NewDefaultTimeoutConfig()
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	cfg.Timeout = -1
 	assert.Error(t, cfg.Validate())
 }

--- a/exporter/exporterhelper/traces_batch_test.go
+++ b/exporter/exporterhelper/traces_batch_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -18,7 +19,7 @@ func TestMergeTraces(t *testing.T) {
 	tr1 := &tracesRequest{td: testdata.GenerateTraces(2)}
 	tr2 := &tracesRequest{td: testdata.GenerateTraces(3)}
 	res, err := mergeTraces(context.Background(), tr1, tr2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 5, res.(*tracesRequest).td.SpanCount())
 }
 
@@ -133,7 +134,7 @@ func TestMergeSplitTraces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := mergeSplitTraces(context.Background(), tt.cfg, tt.tr1, tt.tr2)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, len(tt.expected), len(res))
 			for i := range res {
 				assert.Equal(t, tt.expected[i], res[i].(*tracesRequest))

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -82,7 +82,7 @@ func TestTracesExporter_Default(t *testing.T) {
 	td := ptrace.NewTraces()
 	te, err := NewTracesExporter(context.Background(), exportertest.NewNopSettings(), &fakeTracesExporterConfig, newTraceDataPusher(nil))
 	assert.NotNil(t, te)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, te.Capabilities())
 	assert.NoError(t, te.Start(context.Background(), componenttest.NewNopHost()))
@@ -95,7 +95,7 @@ func TestTracesRequestExporter_Default(t *testing.T) {
 	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopSettings(),
 		(&fakeRequestConverter{}).requestFromTracesFunc)
 	assert.NotNil(t, te)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, consumer.Capabilities{MutatesData: false}, te.Capabilities())
 	assert.NoError(t, te.Start(context.Background(), componenttest.NewNopHost()))
@@ -107,7 +107,7 @@ func TestTracesExporter_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
 	te, err := NewTracesExporter(context.Background(), exportertest.NewNopSettings(), &fakeTracesExporterConfig, newTraceDataPusher(nil), WithCapabilities(capabilities))
 	assert.NotNil(t, te)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, capabilities, te.Capabilities())
 }
@@ -117,7 +117,7 @@ func TestTracesRequestExporter_WithCapabilities(t *testing.T) {
 	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopSettings(),
 		(&fakeRequestConverter{}).requestFromTracesFunc, WithCapabilities(capabilities))
 	assert.NotNil(t, te)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, capabilities, te.Capabilities())
 }
@@ -196,10 +196,10 @@ func TestTracesExporter_pLogModifiedDownStream_WithRecordMetrics(t *testing.T) {
 
 	te, err := NewTracesExporter(context.Background(), exporter.Settings{ID: fakeTracesExporterName, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesExporterConfig, newTraceDataPusherModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	assert.NotNil(t, te)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	td := testdata.GenerateTraces(2)
 
-	assert.NoError(t, te.ConsumeTraces(context.Background(), td))
+	require.NoError(t, te.ConsumeTraces(context.Background(), td))
 	assert.Equal(t, 0, td.SpanCount())
 	require.NoError(t, tt.CheckExporterTraces(int64(2), 0))
 }

--- a/exporter/exporterqueue/config_test.go
+++ b/exporter/exporterqueue/config_test.go
@@ -7,18 +7,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestQueueConfig_Validate(t *testing.T) {
 	qCfg := NewDefaultConfig()
-	assert.NoError(t, qCfg.Validate())
+	require.NoError(t, qCfg.Validate())
 
 	qCfg.NumConsumers = 0
-	assert.EqualError(t, qCfg.Validate(), "number of consumers must be positive")
+	require.EqualError(t, qCfg.Validate(), "number of consumers must be positive")
 
 	qCfg = NewDefaultConfig()
 	qCfg.QueueSize = 0
-	assert.EqualError(t, qCfg.Validate(), "queue size must be positive")
+	require.EqualError(t, qCfg.Validate(), "queue size must be positive")
 
 	// Confirm Validate doesn't return error with invalid config when feature is disabled
 	qCfg.Enabled = false

--- a/exporter/exportertest/mock_consumer_test.go
+++ b/exporter/exportertest/mock_consumer_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -46,13 +47,13 @@ func TestIDFromMetrics(t *testing.T) {
 	validData := createMetric(id)
 	metricID, err := idFromMetrics(validData)
 	assert.Equal(t, metricID, id)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test case 2: Missing uniqueIDAttrName attribute
 	invalidData := pmetric.NewMetrics() // Create an invalid pmetric.Metrics object with missing attribute
 	invalidData.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetEmptyHistogram().DataPoints().AppendEmpty().Attributes()
 	_, err = idFromMetrics(invalidData)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is missing", uniqueIDAttrName))
 
 	// Test case 3: Wrong attribute type
@@ -61,7 +62,7 @@ func TestIDFromMetrics(t *testing.T) {
 	wrongAttribute.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().
 		SetEmptyHistogram().DataPoints().AppendEmpty().Attributes().PutInt(uniqueIDAttrName, intID)
 	_, err = idFromMetrics(wrongAttribute)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is wrong type Int", uniqueIDAttrName))
 }
 
@@ -71,13 +72,13 @@ func TestIDFromTraces(t *testing.T) {
 	validData := createTrace(id)
 	traceID, err := idFromTraces(validData)
 	assert.Equal(t, traceID, id)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test case 2: Missing uniqueIDAttrName attribute
 	invalidData := ptrace.NewTraces()
 	invalidData.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().Attributes()
 	_, err = idFromTraces(invalidData)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is missing", uniqueIDAttrName))
 
 	// Test case 3: Wrong attribute type
@@ -86,7 +87,7 @@ func TestIDFromTraces(t *testing.T) {
 	wrongAttribute.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().Attributes().
 		PutInt(uniqueIDAttrName, intID)
 	_, err = idFromTraces(wrongAttribute)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is wrong type Int", uniqueIDAttrName))
 }
 
@@ -96,13 +97,13 @@ func TestIDFromLogs(t *testing.T) {
 	validData := createLog(id)
 	logID, err := idFromLogs(validData)
 	assert.Equal(t, logID, id)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test case 2: Missing uniqueIDAttrName attribute
 	invalidData := plog.NewLogs()
 	invalidData.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Attributes()
 	_, err = idFromLogs(invalidData)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is missing", uniqueIDAttrName))
 
 	// Test case 3: Wrong attribute type
@@ -111,7 +112,7 @@ func TestIDFromLogs(t *testing.T) {
 	wrongAttribute.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Attributes().
 		PutInt(uniqueIDAttrName, intID)
 	_, err = idFromLogs(wrongAttribute)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is wrong type Int", uniqueIDAttrName))
 }
 

--- a/exporter/internal/common/factory_test.go
+++ b/exporter/internal/common/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -19,18 +20,18 @@ func createDefaultConfig() component.Config {
 
 func TestCreateMetricsExporter(t *testing.T) {
 	me, err := CreateMetricsExporter(context.Background(), exportertest.NewNopSettings(), createDefaultConfig(), &Common{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, me)
 }
 
 func TestCreateTracesExporter(t *testing.T) {
 	te, err := CreateTracesExporter(context.Background(), exportertest.NewNopSettings(), createDefaultConfig(), &Common{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, te)
 }
 
 func TestCreateLogsExporter(t *testing.T) {
 	te, err := CreateLogsExporter(context.Background(), exportertest.NewNopSettings(), createDefaultConfig(), &Common{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, te)
 }

--- a/exporter/internal/otlptext/logs_test.go
+++ b/exporter/internal/otlptext/logs_test.go
@@ -65,7 +65,7 @@ func TestLogsText(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewTextLogsMarshaler().MarshalLogs(tt.in)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			out, err := os.ReadFile(filepath.Join("testdata", "logs", tt.out))
 			require.NoError(t, err)
 			expected := strings.ReplaceAll(string(out), "\r", "")

--- a/exporter/internal/otlptext/metrics_test.go
+++ b/exporter/internal/otlptext/metrics_test.go
@@ -46,7 +46,7 @@ func TestMetricsText(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewTextMetricsMarshaler().MarshalMetrics(tt.in)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			out, err := os.ReadFile(filepath.Join("testdata", "metrics", tt.out))
 			require.NoError(t, err)
 			expected := strings.ReplaceAll(string(out), "\r", "")

--- a/exporter/internal/otlptext/traces_test.go
+++ b/exporter/internal/otlptext/traces_test.go
@@ -37,7 +37,7 @@ func TestTracesText(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewTextTracesMarshaler().MarshalTraces(tt.in)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			out, err := os.ReadFile(filepath.Join("testdata", "traces", tt.out))
 			require.NoError(t, err)
 			expected := strings.ReplaceAll(string(out), "\r", "")

--- a/exporter/internal/queue/bounded_memory_queue_test.go
+++ b/exporter/internal/queue/bounded_memory_queue_test.go
@@ -23,7 +23,7 @@ import (
 func TestBoundedQueue(t *testing.T) {
 	q := NewBoundedMemoryQueue[string](MemoryQueueSettings[string]{Sizer: &RequestSizer[string]{}, Capacity: 1})
 
-	assert.NoError(t, q.Offer(context.Background(), "a"))
+	require.NoError(t, q.Offer(context.Background(), "a"))
 
 	numConsumed := 0
 	assert.True(t, q.Consume(func(_ context.Context, item string) error {
@@ -35,11 +35,11 @@ func TestBoundedQueue(t *testing.T) {
 	assert.Equal(t, 0, q.Size())
 
 	// produce two more items. The first one should be accepted, but not consumed.
-	assert.NoError(t, q.Offer(context.Background(), "b"))
+	require.NoError(t, q.Offer(context.Background(), "b"))
 	assert.Equal(t, 1, q.Size())
 
 	// the second should be rejected since the queue is full
-	assert.ErrorIs(t, q.Offer(context.Background(), "c"), ErrQueueIsFull)
+	require.ErrorIs(t, q.Offer(context.Background(), "c"), ErrQueueIsFull)
 	assert.Equal(t, 1, q.Size())
 
 	assert.True(t, q.Consume(func(_ context.Context, item string) error {
@@ -50,7 +50,7 @@ func TestBoundedQueue(t *testing.T) {
 	assert.Equal(t, 2, numConsumed)
 
 	for _, toAddItem := range []string{"d", "e", "f"} {
-		assert.NoError(t, q.Offer(context.Background(), toAddItem))
+		require.NoError(t, q.Offer(context.Background(), toAddItem))
 		assert.True(t, q.Consume(func(_ context.Context, item string) error {
 			assert.Equal(t, toAddItem, item)
 			numConsumed++
@@ -58,7 +58,7 @@ func TestBoundedQueue(t *testing.T) {
 		}))
 	}
 	assert.Equal(t, 5, numConsumed)
-	assert.NoError(t, q.Shutdown(context.Background()))
+	require.NoError(t, q.Shutdown(context.Background()))
 	assert.False(t, q.Consume(func(_ context.Context, item string) error {
 		panic(item)
 	}))
@@ -75,7 +75,7 @@ func TestShutdownWhileNotEmpty(t *testing.T) {
 
 	assert.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
 	for i := 0; i < 10; i++ {
-		assert.NoError(t, q.Offer(context.Background(), strconv.FormatInt(int64(i), 10)))
+		require.NoError(t, q.Offer(context.Background(), strconv.FormatInt(int64(i), 10)))
 	}
 	assert.NoError(t, q.Shutdown(context.Background()))
 
@@ -150,9 +150,9 @@ func TestZeroSizeNoConsumers(t *testing.T) {
 	q := NewBoundedMemoryQueue[string](MemoryQueueSettings[string]{Sizer: &RequestSizer[string]{}, Capacity: 0})
 
 	err := q.Start(context.Background(), componenttest.NewNopHost())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.ErrorIs(t, q.Offer(context.Background(), "a"), ErrQueueIsFull) // in process
+	require.ErrorIs(t, q.Offer(context.Background(), "a"), ErrQueueIsFull) // in process
 
 	assert.NoError(t, q.Shutdown(context.Background()))
 }

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -148,16 +148,16 @@ func TestPersistentQueue_FullCapacity(t *testing.T) {
 			req := newTracesRequest(1, 10)
 
 			// First request is picked by the consumer. Wait until the consumer is blocked on done.
-			assert.NoError(t, pq.Offer(context.Background(), req))
+			require.NoError(t, pq.Offer(context.Background(), req))
 			start <- struct{}{}
 			close(start)
 
 			for i := 0; i < 10; i++ {
 				result := pq.Offer(context.Background(), newTracesRequest(1, 10))
 				if i < 5 {
-					assert.NoError(t, result)
+					require.NoError(t, result)
 				} else {
-					assert.ErrorIs(t, result, ErrQueueIsFull)
+					require.ErrorIs(t, result, ErrQueueIsFull)
 				}
 			}
 			assert.Equal(t, 5*tt.sizeMultiplier, pq.Size())
@@ -219,7 +219,7 @@ func TestPersistentQueue_ConsumersProducers(t *testing.T) {
 				})
 
 			for i := 0; i < c.numMessagesProduced; i++ {
-				assert.NoError(t, pq.Offer(context.Background(), req))
+				require.NoError(t, pq.Offer(context.Background(), req))
 			}
 
 			assert.Eventually(t, func() bool {
@@ -309,10 +309,10 @@ func TestToStorageClient(t *testing.T) {
 
 			// verify
 			if tt.expectedError != nil {
-				assert.ErrorIs(t, err, tt.expectedError)
+				require.ErrorIs(t, err, tt.expectedError)
 				assert.Nil(t, client)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, client)
 			}
 		})
@@ -327,7 +327,7 @@ func TestInvalidStorageExtensionType(t *testing.T) {
 	extConfig := factory.CreateDefaultConfig()
 	settings := extensiontest.NewNopSettings()
 	extension, err := factory.CreateExtension(context.Background(), settings, extConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var extensions = map[component.ID]component.Component{
 		storageID: extension,
 	}
@@ -338,7 +338,7 @@ func TestInvalidStorageExtensionType(t *testing.T) {
 	client, err := toStorageClient(context.Background(), storageID, host, ownerID, component.DataTypeTraces)
 
 	// we should get an error about the extension type
-	assert.ErrorIs(t, err, errWrongExtensionType)
+	require.ErrorIs(t, err, errWrongExtensionType)
 	assert.Nil(t, client)
 }
 
@@ -439,7 +439,7 @@ func TestPersistentQueue_CorruptedData(t *testing.T) {
 			}
 
 			// Cannot close until we corrupt the data because the
-			assert.NoError(t, ps.Shutdown(context.Background()))
+			require.NoError(t, ps.Shutdown(context.Background()))
 
 			// Reload
 			newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
@@ -525,7 +525,7 @@ func TestPersistentQueueStartWithNonDispatched(t *testing.T) {
 		require.Equal(t, 5, ps.Size())
 		return experr.NewShutdownErr(nil)
 	}))
-	assert.NoError(t, ps.Shutdown(context.Background()))
+	require.NoError(t, ps.Shutdown(context.Background()))
 
 	// Reload with extra capacity to make sure we re-enqueue in-progress items.
 	newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 6)
@@ -608,7 +608,7 @@ func TestPersistentQueue_PutCloseReadClose(t *testing.T) {
 	assert.Equal(t, 2, ps.Size())
 	// TODO: Remove this, after the initialization writes the readIndex.
 	_, _, _ = ps.getNextItem(context.Background())
-	assert.NoError(t, ps.Shutdown(context.Background()))
+	require.NoError(t, ps.Shutdown(context.Background()))
 
 	newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
 	require.Equal(t, 2, newPs.Size())
@@ -733,12 +733,12 @@ func TestPersistentQueue_ShutdownWhileConsuming(t *testing.T) {
 	assert.Equal(t, 0, ps.Size())
 	assert.False(t, ps.client.(*mockStorageClient).isClosed())
 
-	assert.NoError(t, ps.Offer(context.Background(), newTracesRequest(5, 10)))
+	require.NoError(t, ps.Offer(context.Background(), newTracesRequest(5, 10)))
 
 	_, onProcessingFinished, ok := ps.getNextItem(context.Background())
 	require.True(t, ok)
 	assert.False(t, ps.client.(*mockStorageClient).isClosed())
-	assert.NoError(t, ps.Shutdown(context.Background()))
+	require.NoError(t, ps.Shutdown(context.Background()))
 	assert.False(t, ps.client.(*mockStorageClient).isClosed())
 	onProcessingFinished(nil)
 	assert.True(t, ps.client.(*mockStorageClient).isClosed())
@@ -852,7 +852,7 @@ func TestPersistentQueue_ItemsCapacityUsageRestoredOnShutdown(t *testing.T) {
 	assert.NoError(t, pq.Offer(context.Background(), newTracesRequest(2, 10)))
 	assert.Equal(t, 100, pq.Size())
 
-	assert.ErrorIs(t, pq.Offer(context.Background(), newTracesRequest(5, 5)), ErrQueueIsFull)
+	require.ErrorIs(t, pq.Offer(context.Background(), newTracesRequest(5, 5)), ErrQueueIsFull)
 	assert.Equal(t, 100, pq.Size())
 
 	assert.True(t, pq.Consume(func(_ context.Context, traces tracesRequest) error {
@@ -861,14 +861,14 @@ func TestPersistentQueue_ItemsCapacityUsageRestoredOnShutdown(t *testing.T) {
 	}))
 	assert.Equal(t, 60, pq.Size())
 
-	assert.NoError(t, pq.Shutdown(context.Background()))
+	require.NoError(t, pq.Shutdown(context.Background()))
 
 	newPQ := createTestPersistentQueueWithItemsCapacity(t, ext, 100)
 
 	// The queue should be restored to the previous size.
 	assert.Equal(t, 60, newPQ.Size())
 
-	assert.NoError(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
+	require.NoError(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
 
 	// Check the combined queue size.
 	assert.Equal(t, 70, newPQ.Size())
@@ -906,14 +906,14 @@ func TestPersistentQueue_ItemsCapacityUsageIsNotPreserved(t *testing.T) {
 	}))
 	assert.Equal(t, 2, pq.Size())
 
-	assert.NoError(t, pq.Shutdown(context.Background()))
+	require.NoError(t, pq.Shutdown(context.Background()))
 
 	newPQ := createTestPersistentQueueWithItemsCapacity(t, ext, 100)
 
 	// The queue items size cannot be restored, fall back to request-based size
 	assert.Equal(t, 2, newPQ.Size())
 
-	assert.NoError(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
+	require.NoError(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
 
 	// Only new items are correctly reflected
 	assert.Equal(t, 12, newPQ.Size())
@@ -933,7 +933,7 @@ func TestPersistentQueue_ItemsCapacityUsageIsNotPreserved(t *testing.T) {
 	assert.Equal(t, 0, newPQ.Size())
 
 	// Adding another batch should update the size accordingly
-	assert.NoError(t, newPQ.Offer(context.Background(), newTracesRequest(5, 5)))
+	require.NoError(t, newPQ.Offer(context.Background(), newTracesRequest(5, 5)))
 	assert.Equal(t, 25, newPQ.Size())
 
 	assert.True(t, newPQ.Consume(func(_ context.Context, traces tracesRequest) error {
@@ -966,7 +966,7 @@ func TestPersistentQueue_RequestCapacityLessAfterRestart(t *testing.T) {
 	}))
 	assert.Equal(t, 3, pq.Size())
 
-	assert.NoError(t, pq.Shutdown(context.Background()))
+	require.NoError(t, pq.Shutdown(context.Background()))
 
 	// The queue is restarted with the less capacity than needed to restore the queued items, but with the same
 	// underlying storage. No need to drop requests that are over capacity since they are already in the storage.
@@ -976,7 +976,7 @@ func TestPersistentQueue_RequestCapacityLessAfterRestart(t *testing.T) {
 	assert.Equal(t, 3, newPQ.Size())
 
 	// Queue is full
-	assert.Error(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
+	require.Error(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
 
 	assert.True(t, newPQ.Consume(func(_ context.Context, traces tracesRequest) error {
 		assert.Equal(t, 20, traces.traces.SpanCount())
@@ -985,7 +985,7 @@ func TestPersistentQueue_RequestCapacityLessAfterRestart(t *testing.T) {
 	assert.Equal(t, 2, newPQ.Size())
 
 	// Still full
-	assert.Error(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
+	require.Error(t, newPQ.Offer(context.Background(), newTracesRequest(2, 5)))
 
 	assert.True(t, newPQ.Consume(func(_ context.Context, traces tracesRequest) error {
 		assert.Equal(t, 25, traces.traces.SpanCount())
@@ -1008,7 +1008,7 @@ func TestPersistentQueue_RestoredUsedSizeIsCorrectedOnDrain(t *testing.T) {
 	assert.Equal(t, 0, pq.Size())
 
 	for i := 0; i < 6; i++ {
-		assert.NoError(t, pq.Offer(context.Background(), newTracesRequest(2, 5)))
+		require.NoError(t, pq.Offer(context.Background(), newTracesRequest(2, 5)))
 	}
 	assert.Equal(t, 60, pq.Size())
 

--- a/exporter/internal/queue/sized_channel_test.go
+++ b/exporter/internal/queue/sized_channel_test.go
@@ -8,23 +8,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSizedCapacityChannel(t *testing.T) {
 	q := newSizedChannel[int](7, nil, 0)
-	assert.NoError(t, q.push(1, 1, nil))
+	require.NoError(t, q.push(1, 1, nil))
 	assert.Equal(t, 1, q.Size())
 	assert.Equal(t, 7, q.Capacity())
 
 	// failed callback should not allow the element to be added
-	assert.Error(t, q.push(2, 2, func() error { return errors.New("failed") }))
+	require.Error(t, q.push(2, 2, func() error { return errors.New("failed") }))
 	assert.Equal(t, 1, q.Size())
 
-	assert.NoError(t, q.push(3, 3, nil))
+	require.NoError(t, q.push(3, 3, nil))
 	assert.Equal(t, 4, q.Size())
 
 	// should not be able to send to the full queue
-	assert.Error(t, q.push(4, 4, nil))
+	require.Error(t, q.push(4, 4, nil))
 	assert.Equal(t, 4, q.Size())
 
 	el, ok := q.pop(func(el int) int64 { return int64(el) })
@@ -45,10 +46,10 @@ func TestSizedCapacityChannel(t *testing.T) {
 
 func TestSizedCapacityChannel_Offer_sizedNotFullButChannelFull(t *testing.T) {
 	q := newSizedChannel[int](1, nil, 0)
-	assert.NoError(t, q.push(1, 1, nil))
+	require.NoError(t, q.push(1, 1, nil))
 
 	q.used.Store(0)
 	err := q.push(1, 1, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrQueueIsFull, err)
 }

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -19,7 +19,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, confmap.New().Unmarshal(&cfg))
+	require.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -78,7 +78,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			if tt.expectedErr != "" {
 				assert.ErrorContains(t, err, tt.expectedErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.cfg, cfg)
 			}
 		})
@@ -126,7 +126,7 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 
 			conf := confmap.New()
 			err := conf.Marshal(tc.inCfg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			raw := conf.ToStringMap()
 
@@ -137,11 +137,11 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 			err = conf.Unmarshal(outCfg)
 
 			if tc.expectedErr == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.expectedConfig, outCfg)
 				return
 			}
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/exporter/loggingexporter/factory_test.go
+++ b/exporter/loggingexporter/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -25,7 +26,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	me, err := factory.CreateMetricsExporter(context.Background(), exportertest.NewNopSettings(), cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, me)
 }
 
@@ -34,7 +35,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	te, err := factory.CreateTracesExporter(context.Background(), exportertest.NewNopSettings(), cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, te)
 }
 
@@ -43,6 +44,6 @@ func TestCreateLogsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	te, err := factory.CreateLogsExporter(context.Background(), exportertest.NewNopSettings(), cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, te)
 }

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -26,7 +26,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, confmap.New().Unmarshal(&cfg))
+	require.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -35,7 +35,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			TimeoutConfig: exporterhelper.TimeoutConfig{

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -27,7 +27,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+	require.NoError(t, componenttest.CheckConfigStruct(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
 	assert.Equal(t, configretry.NewDefaultBackOffConfig(), ocfg.RetryConfig)
@@ -168,13 +168,13 @@ func TestCreateTracesExporter(t *testing.T) {
 			factory := NewFactory()
 			set := exportertest.NewNopSettings()
 			consumer, err := factory.CreateTracesExporter(context.Background(), set, tt.config)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, consumer)
 			err = consumer.Start(context.Background(), componenttest.NewNopHost())
 			if tt.mustFailOnStart {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			// Shutdown is called even when Start fails
 			err = consumer.Shutdown(context.Background())

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -263,14 +263,14 @@ func TestSendTraces(t *testing.T) {
 	}()
 
 	host := componenttest.NewNopHost()
-	assert.NoError(t, exp.Start(context.Background(), host))
+	require.NoError(t, exp.Start(context.Background(), host))
 
 	// Ensure that initially there is no data in the receiver.
 	assert.EqualValues(t, 0, rcv.requestCount.Load())
 
 	// Send empty trace.
 	td := ptrace.NewTraces()
-	assert.NoError(t, exp.ConsumeTraces(context.Background(), td))
+	require.NoError(t, exp.ConsumeTraces(context.Background(), td))
 
 	// Wait until it is received.
 	assert.Eventually(t, func() bool {
@@ -284,7 +284,7 @@ func TestSendTraces(t *testing.T) {
 	td = testdata.GenerateTraces(2)
 
 	err = exp.ConsumeTraces(context.Background(), td)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wait until it is received.
 	assert.Eventually(t, func() bool {
@@ -317,7 +317,7 @@ func TestSendTraces(t *testing.T) {
 	td = testdata.GenerateTraces(2)
 
 	err = exp.ConsumeTraces(context.Background(), td)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, observed.FilterLevelExact(zap.WarnLevel).All(), 1)
 	assert.Contains(t, observed.FilterLevelExact(zap.WarnLevel).All()[0].Message, "Partial success")
 }
@@ -375,14 +375,14 @@ func TestSendTracesWhenEndpointHasHttpScheme(t *testing.T) {
 			}()
 
 			host := componenttest.NewNopHost()
-			assert.NoError(t, exp.Start(context.Background(), host))
+			require.NoError(t, exp.Start(context.Background(), host))
 
 			// Ensure that initially there is no data in the receiver.
 			assert.EqualValues(t, 0, rcv.requestCount.Load())
 
 			// Send empty trace.
 			td := ptrace.NewTraces()
-			assert.NoError(t, exp.ConsumeTraces(context.Background(), td))
+			require.NoError(t, exp.ConsumeTraces(context.Background(), td))
 
 			// Wait until it is received.
 			assert.Eventually(t, func() bool {
@@ -435,14 +435,14 @@ func TestSendMetrics(t *testing.T) {
 
 	host := componenttest.NewNopHost()
 
-	assert.NoError(t, exp.Start(context.Background(), host))
+	require.NoError(t, exp.Start(context.Background(), host))
 
 	// Ensure that initially there is no data in the receiver.
 	assert.EqualValues(t, 0, rcv.requestCount.Load())
 
 	// Send empty metric.
 	md := pmetric.NewMetrics()
-	assert.NoError(t, exp.ConsumeMetrics(context.Background(), md))
+	require.NoError(t, exp.ConsumeMetrics(context.Background(), md))
 
 	// Wait until it is received.
 	assert.Eventually(t, func() bool {
@@ -456,7 +456,7 @@ func TestSendMetrics(t *testing.T) {
 	md = testdata.GenerateMetrics(2)
 
 	err = exp.ConsumeMetrics(context.Background(), md)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wait until it is received.
 	assert.Eventually(t, func() bool {
@@ -482,7 +482,7 @@ func TestSendMetrics(t *testing.T) {
 	md = testdata.GenerateMetrics(2)
 
 	err = exp.ConsumeMetrics(context.Background(), md)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	rcv.setExportError(nil)
 
@@ -498,7 +498,7 @@ func TestSendMetrics(t *testing.T) {
 
 	// Send two metrics.
 	md = testdata.GenerateMetrics(2)
-	assert.NoError(t, exp.ConsumeMetrics(context.Background(), md))
+	require.NoError(t, exp.ConsumeMetrics(context.Background(), md))
 	assert.Len(t, observed.FilterLevelExact(zap.WarnLevel).All(), 1)
 	assert.Contains(t, observed.FilterLevelExact(zap.WarnLevel).All()[0].Message, "Partial success")
 }
@@ -533,24 +533,24 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 
 	host := componenttest.NewNopHost()
 
-	assert.NoError(t, exp.Start(context.Background(), host))
+	require.NoError(t, exp.Start(context.Background(), host))
 
 	// A trace with 2 spans.
 	td := testdata.GenerateTraces(2)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	assert.Error(t, exp.ConsumeTraces(ctx, td))
+	require.Error(t, exp.ConsumeTraces(ctx, td))
 	assert.EqualValues(t, context.DeadlineExceeded, ctx.Err())
 	cancel()
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	assert.Error(t, exp.ConsumeTraces(ctx, td))
+	require.Error(t, exp.ConsumeTraces(ctx, td))
 	assert.EqualValues(t, context.DeadlineExceeded, ctx.Err())
 	cancel()
 
 	startServerAndMakeRequest(t, exp, td, ln)
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	assert.Error(t, exp.ConsumeTraces(ctx, td))
+	require.Error(t, exp.ConsumeTraces(ctx, td))
 	assert.EqualValues(t, context.DeadlineExceeded, ctx.Err())
 	cancel()
 
@@ -561,7 +561,7 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 	startServerAndMakeRequest(t, exp, td, ln)
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	assert.Error(t, exp.ConsumeTraces(ctx, td))
+	require.Error(t, exp.ConsumeTraces(ctx, td))
 	assert.EqualValues(t, context.DeadlineExceeded, ctx.Err())
 	cancel()
 }
@@ -590,7 +590,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 
 	host := componenttest.NewNopHost()
 
-	assert.NoError(t, exp.Start(context.Background(), host))
+	require.NoError(t, exp.Start(context.Background(), host))
 
 	// A trace with 2 spans.
 	td := testdata.GenerateTraces(2)
@@ -610,7 +610,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 	case <-ctx.Done():
 		t.Fail()
 	case <-done:
-		assert.NoError(t, ctx.Err())
+		require.NoError(t, ctx.Err())
 	}
 	cancel()
 }
@@ -641,12 +641,12 @@ func TestSendTracesOnResourceExhaustion(t *testing.T) {
 	}()
 
 	host := componenttest.NewNopHost()
-	assert.NoError(t, exp.Start(context.Background(), host))
+	require.NoError(t, exp.Start(context.Background(), host))
 
 	assert.EqualValues(t, 0, rcv.requestCount.Load())
 
 	td := ptrace.NewTraces()
-	assert.NoError(t, exp.ConsumeTraces(context.Background(), td))
+	require.NoError(t, exp.ConsumeTraces(context.Background(), td))
 
 	assert.Never(t, func() bool {
 		return rcv.requestCount.Load() > 1
@@ -660,7 +660,7 @@ func TestSendTracesOnResourceExhaustion(t *testing.T) {
 	})
 	rcv.setExportError(st.Err())
 
-	assert.NoError(t, exp.ConsumeTraces(context.Background(), td))
+	require.NoError(t, exp.ConsumeTraces(context.Background(), td))
 
 	assert.Eventually(t, func() bool {
 		return rcv.requestCount.Load() > 1
@@ -679,7 +679,7 @@ func startServerAndMakeRequest(t *testing.T, exp exporter.Traces, td ptrace.Trac
 
 	// Resend the request, this should succeed.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	assert.NoError(t, exp.ConsumeTraces(ctx, td))
+	require.NoError(t, exp.ConsumeTraces(ctx, td))
 	cancel()
 
 	// Wait until it is received.
@@ -729,14 +729,14 @@ func TestSendLogData(t *testing.T) {
 
 	host := componenttest.NewNopHost()
 
-	assert.NoError(t, exp.Start(context.Background(), host))
+	require.NoError(t, exp.Start(context.Background(), host))
 
 	// Ensure that initially there is no data in the receiver.
 	assert.EqualValues(t, 0, rcv.requestCount.Load())
 
 	// Send empty request.
 	ld := plog.NewLogs()
-	assert.NoError(t, exp.ConsumeLogs(context.Background(), ld))
+	require.NoError(t, exp.ConsumeLogs(context.Background(), ld))
 
 	// Wait until it is received.
 	assert.Eventually(t, func() bool {
@@ -750,7 +750,7 @@ func TestSendLogData(t *testing.T) {
 	ld = testdata.GenerateLogs(2)
 
 	err = exp.ConsumeLogs(context.Background(), ld)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wait until it is received.
 	assert.Eventually(t, func() bool {
@@ -773,7 +773,7 @@ func TestSendLogData(t *testing.T) {
 	ld = testdata.GenerateLogs(2)
 
 	err = exp.ConsumeLogs(context.Background(), ld)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	rcv.setExportError(nil)
 
@@ -791,7 +791,7 @@ func TestSendLogData(t *testing.T) {
 	ld = testdata.GenerateLogs(2)
 
 	err = exp.ConsumeLogs(context.Background(), ld)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, observed.FilterLevelExact(zap.WarnLevel).All(), 1)
 	assert.Contains(t, observed.FilterLevelExact(zap.WarnLevel).All()[0].Message, "Partial success")
 }

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -24,7 +24,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, confmap.New().Unmarshal(&cfg))
+	require.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 	// Default/Empty config is invalid.
 	assert.Error(t, component.ValidateConfig(cfg))
@@ -35,7 +35,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			RetryConfig: configretry.BackOffConfig{
@@ -122,7 +122,7 @@ func TestUnmarshalEncoding(t *testing.T) {
 			if tt.shouldError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expected, encoding)
 			}
 		})

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -25,7 +25,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+	require.NoError(t, componenttest.CheckConfigStruct(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
 	assert.Equal(t, "", ocfg.ClientConfig.Endpoint)
@@ -181,11 +181,11 @@ func TestCreateTracesExporter(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, consumer)
 			err = consumer.Start(context.Background(), componenttest.NewNopHost())
 			if tt.mustFailOnStart {
-				assert.Error(t, err)
+				require.Error(t, err)
 			}
 
 			err = consumer.Shutdown(context.Background())

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -231,7 +231,7 @@ func TestErrorResponses(t *testing.T) {
 			// generate traces
 			traces := ptrace.NewTraces()
 			err = exp.ConsumeTraces(context.Background(), traces)
-			assert.Error(t, err)
+			require.Error(t, err)
 
 			if test.isPermErr {
 				assert.True(t, consumererror.IsPermanent(err))
@@ -769,7 +769,7 @@ func TestPartialSuccess_longContentLengthHeader(t *testing.T) {
 				// No real error happens for long content length, so the partial
 				// success is handled as success with a warning.
 				err = handlePartialSuccessResponse(resp, handler)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Len(t, observed.FilterLevelExact(zap.WarnLevel).All(), 1)
 				assert.Contains(t, observed.FilterLevelExact(zap.WarnLevel).All()[0].Message, "Partial success")
 			})

--- a/extension/auth/authtest/mock_clientauth_test.go
+++ b/extension/auth/authtest/mock_clientauth_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -20,7 +21,7 @@ func TestNilStartAndShutdown(t *testing.T) {
 	origCtx := context.Background()
 
 	err := m.Start(origCtx, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Shutdown(origCtx)
 	assert.NoError(t, err)
@@ -64,7 +65,7 @@ func TestMockRoundTripper(t *testing.T) {
 				return
 			}
 			assert.NotNil(t, tripper)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// check if the resultant tripper is indeed the one provided
 			_, ok := tripper.(*customRoundTripper)
 			assert.True(t, ok)
@@ -119,7 +120,7 @@ func TestMockPerRPCCredential(t *testing.T) {
 				return
 			}
 			assert.NotNil(t, credential)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// check if the resultant tripper is indeed the one provided
 			_, ok := credential.(*customPerRPCCredentials)
 			assert.True(t, ok)

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 )
@@ -35,7 +36,7 @@ func TestNewFactory(t *testing.T) {
 
 	assert.Equal(t, component.StabilityLevelDevelopment, factory.ExtensionStability())
 	ext, err := factory.CreateExtension(context.Background(), Settings{}, &defaultCfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Same(t, nopExtensionInstance, ext)
 }
 
@@ -69,7 +70,7 @@ func TestMakeFactoryMap(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.out, out)
 		})
 	}

--- a/extension/memorylimiterextension/factory_test.go
+++ b/extension/memorylimiterextension/factory_test.go
@@ -38,10 +38,10 @@ func TestCreateExtension(t *testing.T) {
 	pCfg.CheckInterval = 100 * time.Millisecond
 
 	tp, err := factory.CreateExtension(context.Background(), extensiontest.NewNopSettings(), cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tp)
 	// test if we can shutdown a monitoring routine that has not started
-	assert.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
+	require.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
 	assert.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 
 	assert.NoError(t, tp.Shutdown(context.Background()))

--- a/extension/memorylimiterextension/memorylimiter_test.go
+++ b/extension/memorylimiterextension/memorylimiter_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -82,7 +83,7 @@ func TestMemoryPressureResponse(t *testing.T) {
 			if tt.expectError {
 				assert.True(t, mustRefuse)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.NoError(t, ml.Shutdown(ctx))
 		})

--- a/extension/zpagesextension/config_test.go
+++ b/extension/zpagesextension/config_test.go
@@ -18,7 +18,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, confmap.New().Unmarshal(&cfg))
+	require.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -31,7 +31,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			ServerConfig: confighttp.ServerConfig{

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -25,7 +25,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	},
 		cfg)
 
-	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+	require.NoError(t, componenttest.CheckConfigStruct(cfg))
 	ext, err := createExtension(context.Background(), extensiontest.NewNopSettings(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)

--- a/featuregate/registry_test.go
+++ b/featuregate/registry_test.go
@@ -23,17 +23,17 @@ func TestRegistry(t *testing.T) {
 
 	const id = "foo"
 	g, err := r.Register(id, StageBeta, WithRegisterDescription("Test Gate"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.VisitAll(func(gate *Gate) {
 		assert.Equal(t, id, gate.ID())
 	})
 	assert.True(t, g.IsEnabled())
 
-	assert.NoError(t, r.Set(id, false))
+	require.NoError(t, r.Set(id, false))
 	assert.False(t, g.IsEnabled())
 
 	_, err = r.Register(id, StageBeta)
-	assert.ErrorIs(t, err, ErrAlreadyRegistered)
+	require.ErrorIs(t, err, ErrAlreadyRegistered)
 	assert.Panics(t, func() {
 		r.MustRegister(id, StageBeta)
 	})
@@ -41,20 +41,20 @@ func TestRegistry(t *testing.T) {
 
 func TestRegistryApplyError(t *testing.T) {
 	r := NewRegistry()
-	assert.Error(t, r.Set("foo", true))
+	require.Error(t, r.Set("foo", true))
 	r.MustRegister("bar", StageAlpha)
 
-	assert.Error(t, r.Set("foo", true))
+	require.Error(t, r.Set("foo", true))
 	_, err := r.Register("foo", StageStable)
-	assert.Error(t, err)
-	assert.Error(t, r.Set("foo", true))
+	require.Error(t, err)
+	require.Error(t, r.Set("foo", true))
 	r.MustRegister("foo", StageStable, WithRegisterToVersion("v1.0.0"))
-	assert.Error(t, r.Set("foo", false))
+	require.Error(t, r.Set("foo", false))
 
-	assert.Error(t, r.Set("deprecated", true))
+	require.Error(t, r.Set("deprecated", true))
 	_, err = r.Register("deprecated", StageDeprecated)
-	assert.Error(t, err)
-	assert.Error(t, r.Set("deprecated", true))
+	require.Error(t, err)
+	require.Error(t, r.Set("deprecated", true))
 	r.MustRegister("deprecated", StageDeprecated, WithRegisterToVersion("v1.0.0"))
 	assert.Error(t, r.Set("deprecated", true))
 }
@@ -63,7 +63,7 @@ func TestRegistryApply(t *testing.T) {
 	r := NewRegistry()
 	fooGate := r.MustRegister("foo", StageAlpha, WithRegisterDescription("Test Gate"))
 	assert.False(t, fooGate.IsEnabled())
-	assert.NoError(t, r.Set(fooGate.ID(), true))
+	require.NoError(t, r.Set(fooGate.ID(), true))
 	assert.True(t, fooGate.IsEnabled())
 }
 
@@ -195,7 +195,7 @@ func TestRegisterGateLifecycle(t *testing.T) {
 			r.MustRegister("existing.gate", StageBeta)
 			if tc.shouldErr {
 				_, err := r.Register(tc.id, tc.stage, tc.opts...)
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Panics(t, func() {
 					r.MustRegister(tc.id, tc.stage, tc.opts...)
 				})

--- a/filter/config_test.go
+++ b/filter/config_test.go
@@ -46,7 +46,7 @@ func TestConfig(t *testing.T) {
 			assert.Equal(t, expCfg, actualCfg)
 
 			for _, cfg := range actualCfg {
-				assert.NoError(t, cfg.Validate())
+				require.NoError(t, cfg.Validate())
 			}
 			fs := CreateFilter(actualCfg)
 			assert.NotNil(t, fs)
@@ -68,7 +68,7 @@ func TestMatches(t *testing.T) {
 	}
 
 	for _, c := range cfg {
-		assert.NoError(t, c.Validate())
+		require.NoError(t, c.Validate())
 	}
 	fs := CreateFilter(cfg)
 

--- a/internal/cgroups/cgroups_test.go
+++ b/internal/cgroups/cgroups_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCGroups(t *testing.T) {
@@ -50,7 +51,7 @@ func TestNewCGroups(t *testing.T) {
 
 	cgroups, err := NewCGroups(cgroupsProcMountInfoPath, cgroupsProcCGroupPath)
 	assert.Equal(t, len(testTable), len(cgroups))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, tt := range testTable {
 		cgroup, exists := cgroups[tt.subsys]
@@ -113,7 +114,7 @@ func TestCGroupsMemoryQuota(t *testing.T) {
 	quota, defined, err := cgroups.MemoryQuota()
 	assert.Equal(t, int64(-1), quota, "nonexistent")
 	assert.False(t, defined, "nonexistent")
-	assert.NoError(t, err, "nonexistent")
+	require.NoError(t, err, "nonexistent")
 
 	for _, tt := range testTable {
 		cgroupPath := filepath.Join(testDataCGroupsPath, tt.name)
@@ -209,7 +210,7 @@ func TestCGroupsMemoryQuotaV2(t *testing.T) {
 	quota, defined, err := memoryQuotaV2("nonexistent", "nonexistent")
 	assert.Equal(t, int64(-1), quota, "nonexistent")
 	assert.False(t, defined, "nonexistent")
-	assert.NoError(t, err, "nonexistent")
+	require.NoError(t, err, "nonexistent")
 
 	cgroupBasePath := filepath.Join(testDataCGroupsPath, "v2")
 	for _, tt := range testTable {

--- a/internal/cgroups/mountpoint_test.go
+++ b/internal/cgroups/mountpoint_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMountPointFromLine(t *testing.T) {
@@ -90,7 +91,7 @@ func TestNewMountPointFromLineErr(t *testing.T) {
 	for i, line := range linesWithInvalidIDs {
 		mountPoint, err := NewMountPointFromLine(line)
 		assert.Nil(t, mountPoint, "[%d] %q", i, line)
-		assert.Error(t, err, line)
+		require.Error(t, err, line)
 	}
 
 	linesWithInvalidFields := []string{
@@ -115,7 +116,7 @@ func TestMountPointTranslate(t *testing.T) {
 	cgroupMountPoint, err := NewMountPointFromLine(line)
 
 	assert.NotNil(t, cgroupMountPoint)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testTable := []struct {
 		name            string
@@ -151,7 +152,7 @@ func TestMountPointTranslateError(t *testing.T) {
 	cgroupMountPoint, err := NewMountPointFromLine(line)
 
 	assert.NotNil(t, cgroupMountPoint)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	inaccessiblePaths := []string{
 		"/",

--- a/internal/e2e/opaque_test.go
+++ b/internal/e2e/opaque_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/confmap"
@@ -24,7 +25,7 @@ var example = TestStruct{
 
 func TestConfMapMarshalConfigOpaque(t *testing.T) {
 	conf := confmap.New()
-	assert.NoError(t, conf.Marshal(example))
+	require.NoError(t, conf.Marshal(example))
 	assert.Equal(t, "[REDACTED]", conf.Get("opaque"))
 	assert.Equal(t, "plain", conf.Get("plain"))
 }

--- a/internal/e2e/otlphttp_test.go
+++ b/internal/e2e/otlphttp_test.go
@@ -62,7 +62,7 @@ func TestTraceNoBackend(t *testing.T) {
 func TestTraceInvalidUrl(t *testing.T) {
 	exp := startTracesExporter(t, "http:/\\//this_is_an/*/invalid_url", "")
 	td := testdata.GenerateTraces(1)
-	assert.Error(t, exp.ConsumeTraces(context.Background(), td))
+	require.Error(t, exp.ConsumeTraces(context.Background(), td))
 
 	exp = startTracesExporter(t, "", "http:/\\//this_is_an/*/invalid_url")
 	td = testdata.GenerateTraces(1)
@@ -111,7 +111,7 @@ func TestTraceRoundTrip(t *testing.T) {
 			exp := startTracesExporter(t, tt.baseURL, tt.overrideURL)
 
 			td := testdata.GenerateTraces(1)
-			assert.NoError(t, exp.ConsumeTraces(context.Background(), td))
+			require.NoError(t, exp.ConsumeTraces(context.Background(), td))
 			require.Eventually(t, func() bool {
 				return sink.SpanCount() > 0
 			}, 1*time.Second, 10*time.Millisecond)
@@ -164,7 +164,7 @@ func TestMetricsRoundTrip(t *testing.T) {
 			exp := startMetricsExporter(t, tt.baseURL, tt.overrideURL)
 
 			md := testdata.GenerateMetrics(1)
-			assert.NoError(t, exp.ConsumeMetrics(context.Background(), md))
+			require.NoError(t, exp.ConsumeMetrics(context.Background(), md))
 			require.Eventually(t, func() bool {
 				return sink.DataPointCount() > 0
 			}, 1*time.Second, 10*time.Millisecond)
@@ -217,7 +217,7 @@ func TestLogsRoundTrip(t *testing.T) {
 			exp := startLogsExporter(t, tt.baseURL, tt.overrideURL)
 
 			md := testdata.GenerateLogs(1)
-			assert.NoError(t, exp.ConsumeLogs(context.Background(), md))
+			require.NoError(t, exp.ConsumeLogs(context.Background(), md))
 			require.Eventually(t, func() bool {
 				return sink.LogRecordCount() > 0
 			}, 1*time.Second, 10*time.Millisecond)

--- a/internal/fanoutconsumer/logs_test.go
+++ b/internal/fanoutconsumer/logs_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -221,7 +222,7 @@ func TestLogsWhenErrors(t *testing.T) {
 	ld := testdata.GenerateLogs(1)
 
 	for i := 0; i < 2; i++ {
-		assert.Error(t, lfc.ConsumeLogs(context.Background(), ld))
+		require.Error(t, lfc.ConsumeLogs(context.Background(), ld))
 	}
 
 	assert.Equal(t, ld, p3.AllLogs()[0])

--- a/internal/fanoutconsumer/metrics_test.go
+++ b/internal/fanoutconsumer/metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -221,7 +222,7 @@ func TestMetricsWhenErrors(t *testing.T) {
 	md := testdata.GenerateMetrics(1)
 
 	for i := 0; i < 2; i++ {
-		assert.Error(t, mfc.ConsumeMetrics(context.Background(), md))
+		require.Error(t, mfc.ConsumeMetrics(context.Background(), md))
 	}
 
 	assert.Equal(t, md, p3.AllMetrics()[0])

--- a/internal/fanoutconsumer/profiles_test.go
+++ b/internal/fanoutconsumer/profiles_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerprofiles"
@@ -223,7 +224,7 @@ func TestProfilesWhenErrors(t *testing.T) {
 	td := testdata.GenerateProfiles(1)
 
 	for i := 0; i < 2; i++ {
-		assert.Error(t, tfc.ConsumeProfiles(context.Background(), td))
+		require.Error(t, tfc.ConsumeProfiles(context.Background(), td))
 	}
 
 	assert.Equal(t, td, p3.AllProfiles()[0])

--- a/internal/fanoutconsumer/traces_test.go
+++ b/internal/fanoutconsumer/traces_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -222,7 +223,7 @@ func TestTracesWhenErrors(t *testing.T) {
 	td := testdata.GenerateTraces(1)
 
 	for i := 0; i < 2; i++ {
-		assert.Error(t, tfc.ConsumeTraces(context.Background(), td))
+		require.Error(t, tfc.ConsumeTraces(context.Background(), td))
 	}
 
 	assert.Equal(t, td, p3.AllTraces()[0])

--- a/internal/iruntime/mem_info_test.go
+++ b/internal/iruntime/mem_info_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadMemInfo(t *testing.T) {
 	vmStat, err := readMemInfo()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Positive(t, vmStat)
 }

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -38,7 +38,7 @@ func TestNewSharedComponentsCreateError(t *testing.T) {
 		func() (*baseComponent, error) { return nil, myErr },
 		newNopTelemetrySettings(),
 	)
-	assert.ErrorIs(t, err, myErr)
+	require.ErrorIs(t, err, myErr)
 	assert.Empty(t, comps.components)
 }
 
@@ -64,7 +64,7 @@ func TestSharedComponentsLoadOrStore(t *testing.T) {
 	assert.Same(t, got, gotSecond)
 
 	// Shutdown nop will remove
-	assert.NoError(t, got.Shutdown(context.Background()))
+	require.NoError(t, got.Shutdown(context.Background()))
 	assert.Empty(t, comps.components)
 	gotThird, err := comps.LoadOrStore(
 		id,
@@ -99,13 +99,13 @@ func TestSharedComponent(t *testing.T) {
 	assert.Equal(t, wantErr, got.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Equal(t, 1, calledStart)
 	// Second time is not called anymore.
-	assert.NoError(t, got.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, got.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Equal(t, 1, calledStart)
 	// first time, shutdown is called.
 	assert.Equal(t, wantErr, got.Shutdown(context.Background()))
 	assert.Equal(t, 1, calledStop)
 	// Second time is not called anymore.
-	assert.NoError(t, got.Shutdown(context.Background()))
+	require.NoError(t, got.Shutdown(context.Background()))
 	assert.Equal(t, 1, calledStop)
 }
 

--- a/otelcol/buffered_core_test.go
+++ b/otelcol/buffered_core_test.go
@@ -102,6 +102,6 @@ func Test_bufferedCore_TakeLogs(t *testing.T) {
 	assert.Equal(t, expected, bc.TakeLogs())
 	assert.Nil(t, bc.logs)
 
-	assert.Error(t, bc.Write(e, fields))
+	require.Error(t, bc.Write(e, fields))
 	assert.Nil(t, bc.TakeLogs())
 }

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -165,7 +165,7 @@ func (e statusWatcherExtension) ComponentStatusChanged(source *componentstatus.I
 
 func TestComponentStatusWatcher(t *testing.T) {
 	factories, err := nopFactories()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Use a processor factory that creates "unhealthy" processor: one that
 	// always reports StatusRecoverableError after successful Start.

--- a/otelcol/internal/grpclog/logger_test.go
+++ b/otelcol/internal/grpclog/logger_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/grpclog"
@@ -65,7 +66,7 @@ func TestGRPCLogger(t *testing.T) {
 
 			// create new collector zap logger
 			logger, err := test.cfg.Build(hook)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// create GRPCLogger
 			glogger := SetLogger(logger, test.cfg.Level.Level())
@@ -77,7 +78,7 @@ func TestGRPCLogger(t *testing.T) {
 			assert.Equal(t, obsInfo, test.infoLogged)
 			assert.Equal(t, obsWarn, test.warnLogged)
 			// match the file name and line number of Warning() call above
-			assert.Contains(t, callerInfo, "internal/grpclog/logger_test.go:76")
+			assert.Contains(t, callerInfo, "internal/grpclog/logger_test.go:77")
 		})
 	}
 }

--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	factories, err := NopFactories()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cfg, err := LoadConfig(filepath.Join("testdata", "config.yaml"), factories)
 	require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestLoadConfig(t *testing.T) {
 
 func TestLoadConfigAndValidate(t *testing.T) {
 	factories, err := NopFactories()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cfgValidate, errValidate := LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
 	require.NoError(t, errValidate)

--- a/otelcol/unmarshaler_test.go
+++ b/otelcol/unmarshaler_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestUnmarshalEmpty(t *testing.T) {
 	factories, err := nopFactories()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = unmarshal(confmap.New(), factories)
 	assert.NoError(t, err)
@@ -27,7 +27,7 @@ func TestUnmarshalEmpty(t *testing.T) {
 
 func TestUnmarshalEmptyAllSections(t *testing.T) {
 	factories, err := nopFactories()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	conf := confmap.NewFromStringMap(map[string]any{
 		"receivers":  nil,
@@ -38,7 +38,7 @@ func TestUnmarshalEmptyAllSections(t *testing.T) {
 		"service":    nil,
 	})
 	cfg, err := unmarshal(conf, factories)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	zapProdCfg := zap.NewProductionConfig()
 	assert.Equal(t, telemetry.LogsConfig{
@@ -61,7 +61,7 @@ func TestUnmarshalEmptyAllSections(t *testing.T) {
 
 func TestUnmarshalUnknownTopLevel(t *testing.T) {
 	factories, err := nopFactories()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	conf := confmap.NewFromStringMap(map[string]any{
 		"unknown_section": nil,

--- a/pdata/internal/data/profileid_test.go
+++ b/pdata/internal/data/profileid_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProfileID(t *testing.T) {
@@ -26,13 +27,13 @@ func TestProfileIDMarshal(t *testing.T) {
 	tid := ProfileID([16]byte{})
 	n, err := tid.MarshalTo(buf)
 	assert.EqualValues(t, 0, n)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tid = [16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}
 	n, err = tid.MarshalTo(buf)
 	assert.EqualValues(t, 16, n)
 	assert.EqualValues(t, []byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}, buf[0:16])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = tid.MarshalTo(buf[0:1])
 	assert.Error(t, err)
@@ -42,7 +43,7 @@ func TestProfileIDMarshalJSON(t *testing.T) {
 	tid := ProfileID([16]byte{})
 	json, err := tid.MarshalJSON()
 	assert.EqualValues(t, []byte(`""`), json)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tid = [16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}
 	json, err = tid.MarshalJSON()
@@ -55,44 +56,44 @@ func TestProfileIDUnmarshal(t *testing.T) {
 
 	tid := ProfileID{}
 	err := tid.Unmarshal(buf[0:16])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, buf, tid)
 
 	err = tid.Unmarshal(buf[0:0])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [16]byte{}, tid)
 
 	err = tid.Unmarshal(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [16]byte{}, tid)
 }
 
 func TestProfileIDUnmarshalJSON(t *testing.T) {
 	tid := ProfileID([16]byte{})
 	err := tid.UnmarshalJSON([]byte(`""`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [16]byte{}, tid)
 
 	err = tid.UnmarshalJSON([]byte(`""""`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	tidBytes := [16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}
 	err = tid.UnmarshalJSON([]byte(`"12345678123456781234567812345678"`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, tidBytes, tid)
 
 	err = tid.UnmarshalJSON([]byte(`12345678123456781234567812345678`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, tidBytes, tid)
 
 	err = tid.UnmarshalJSON([]byte(`"nothex"`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = tid.UnmarshalJSON([]byte(`"1"`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = tid.UnmarshalJSON([]byte(`"123"`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = tid.UnmarshalJSON([]byte(`"`))
 	assert.Error(t, err)

--- a/pdata/internal/data/spanid_test.go
+++ b/pdata/internal/data/spanid_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSpanID(t *testing.T) {
@@ -26,11 +27,11 @@ func TestSpanIDMarshal(t *testing.T) {
 	sid := SpanID([8]byte{})
 	n, err := sid.MarshalTo(buf)
 	assert.EqualValues(t, 0, n)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sid = [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
 	n, err = sid.MarshalTo(buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, 8, n)
 	assert.EqualValues(t, []byte{1, 2, 3, 4, 5, 6, 7, 8}, buf[0:8])
 
@@ -42,7 +43,7 @@ func TestSpanIDMarshalJSON(t *testing.T) {
 	sid := SpanID([8]byte{})
 	json, err := sid.MarshalJSON()
 	assert.EqualValues(t, []byte(`""`), json)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sid = [8]byte{0x12, 0x23, 0xAD, 0x12, 0x23, 0xAD, 0x12, 0x23}
 	json, err = sid.MarshalJSON()
@@ -55,15 +56,15 @@ func TestSpanIDUnmarshal(t *testing.T) {
 
 	sid := SpanID{}
 	err := sid.Unmarshal(buf[0:8])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [8]byte{0x12, 0x23, 0xAD, 0x12, 0x23, 0xAD, 0x12, 0x23}, sid)
 
 	err = sid.Unmarshal(buf[0:0])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [8]byte{}, sid)
 
 	err = sid.Unmarshal(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [8]byte{}, sid)
 
 	err = sid.Unmarshal(buf[0:3])
@@ -73,25 +74,25 @@ func TestSpanIDUnmarshal(t *testing.T) {
 func TestSpanIDUnmarshalJSON(t *testing.T) {
 	sid := SpanID{}
 	err := sid.UnmarshalJSON([]byte(`""`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [8]byte{}, sid)
 
 	err = sid.UnmarshalJSON([]byte(`"1234567812345678"`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [8]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}, sid)
 
 	err = sid.UnmarshalJSON([]byte(`1234567812345678`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [8]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}, sid)
 
 	err = sid.UnmarshalJSON([]byte(`"nothex"`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = sid.UnmarshalJSON([]byte(`"1"`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = sid.UnmarshalJSON([]byte(`"123"`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = sid.UnmarshalJSON([]byte(`"`))
 	assert.Error(t, err)

--- a/pdata/internal/data/traceid_test.go
+++ b/pdata/internal/data/traceid_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTraceID(t *testing.T) {
@@ -26,13 +27,13 @@ func TestTraceIDMarshal(t *testing.T) {
 	tid := TraceID([16]byte{})
 	n, err := tid.MarshalTo(buf)
 	assert.EqualValues(t, 0, n)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tid = [16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}
 	n, err = tid.MarshalTo(buf)
 	assert.EqualValues(t, 16, n)
 	assert.EqualValues(t, []byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}, buf[0:16])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = tid.MarshalTo(buf[0:1])
 	assert.Error(t, err)
@@ -42,7 +43,7 @@ func TestTraceIDMarshalJSON(t *testing.T) {
 	tid := TraceID([16]byte{})
 	json, err := tid.MarshalJSON()
 	assert.EqualValues(t, []byte(`""`), json)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tid = [16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}
 	json, err = tid.MarshalJSON()
@@ -55,44 +56,44 @@ func TestTraceIDUnmarshal(t *testing.T) {
 
 	tid := TraceID{}
 	err := tid.Unmarshal(buf[0:16])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, buf, tid)
 
 	err = tid.Unmarshal(buf[0:0])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [16]byte{}, tid)
 
 	err = tid.Unmarshal(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [16]byte{}, tid)
 }
 
 func TestTraceIDUnmarshalJSON(t *testing.T) {
 	tid := TraceID([16]byte{})
 	err := tid.UnmarshalJSON([]byte(`""`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, [16]byte{}, tid)
 
 	err = tid.UnmarshalJSON([]byte(`""""`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	tidBytes := [16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}
 	err = tid.UnmarshalJSON([]byte(`"12345678123456781234567812345678"`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, tidBytes, tid)
 
 	err = tid.UnmarshalJSON([]byte(`12345678123456781234567812345678`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, tidBytes, tid)
 
 	err = tid.UnmarshalJSON([]byte(`"nothex"`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = tid.UnmarshalJSON([]byte(`"1"`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = tid.UnmarshalJSON([]byte(`"123"`))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = tid.UnmarshalJSON([]byte(`"`))
 	assert.Error(t, err)

--- a/pdata/internal/json/attribute_test.go
+++ b/pdata/internal/json/attribute_test.go
@@ -8,6 +8,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 )
@@ -151,7 +152,7 @@ func TestReadAttributeUnknownField(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	value := ReadAttribute(iter)
 	//  unknown fields should not be an error
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, otlpcommon.KeyValue{}, value)
 }
 
@@ -162,7 +163,7 @@ func TestReadAttributeValueUnknownField(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	value := ReadAttribute(iter)
 	//  unknown fields should not be an error
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, otlpcommon.KeyValue{Key: "test"}, value)
 }
 
@@ -172,7 +173,7 @@ func TestReadValueUnknownField(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	value := &otlpcommon.AnyValue{}
 	ReadValue(iter, value)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpcommon.AnyValue{}, value)
 }
 
@@ -192,7 +193,7 @@ func TestReadArrayUnknownField(t *testing.T) {
 	iter := jsoniter.ConfigFastest.BorrowIterator([]byte(jsonStr))
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	value := readArray(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpcommon.ArrayValue{}, value)
 }
 
@@ -201,7 +202,7 @@ func TestReadKvlistValueUnknownField(t *testing.T) {
 	iter := jsoniter.ConfigFastest.BorrowIterator([]byte(jsonStr))
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	value := readKvlistValue(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpcommon.KeyValueList{}, value)
 }
 
@@ -212,7 +213,7 @@ func TestReadArrayValueInvalidArrayValue(t *testing.T) {
 
 	value := &otlpcommon.AnyValue{}
 	ReadValue(iter, value)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpcommon.AnyValue{
 		Value: &otlpcommon.AnyValue_ArrayValue{
 			ArrayValue: &otlpcommon.ArrayValue{},
@@ -227,7 +228,7 @@ func TestReadKvlistValueInvalidArrayValue(t *testing.T) {
 
 	value := &otlpcommon.AnyValue{}
 	ReadValue(iter, value)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpcommon.AnyValue{
 		Value: &otlpcommon.AnyValue_KvlistValue{
 			KvlistValue: &otlpcommon.KeyValueList{},

--- a/pdata/internal/json/enum_test.go
+++ b/pdata/internal/json/enum_test.go
@@ -8,6 +8,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadEnumValue(t *testing.T) {
@@ -67,7 +68,7 @@ func TestReadEnumValue(t *testing.T) {
 				assert.Error(t, iter.Error)
 				return
 			}
-			assert.NoError(t, iter.Error)
+			require.NoError(t, iter.Error)
 			assert.Equal(t, tt.want, val)
 		})
 	}

--- a/pdata/internal/json/number_test.go
+++ b/pdata/internal/json/number_test.go
@@ -8,6 +8,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadInt32(t *testing.T) {
@@ -57,7 +58,7 @@ func TestReadInt32(t *testing.T) {
 				assert.Error(t, iter.Error)
 				return
 			}
-			assert.NoError(t, iter.Error)
+			require.NoError(t, iter.Error)
 			assert.Equal(t, tt.want, val)
 		})
 	}
@@ -110,7 +111,7 @@ func TestReadUint32(t *testing.T) {
 				assert.Error(t, iter.Error)
 				return
 			}
-			assert.NoError(t, iter.Error)
+			require.NoError(t, iter.Error)
 			assert.Equal(t, tt.want, val)
 		})
 	}
@@ -163,7 +164,7 @@ func TestReadInt64(t *testing.T) {
 				assert.Error(t, iter.Error)
 				return
 			}
-			assert.NoError(t, iter.Error)
+			require.NoError(t, iter.Error)
 			assert.Equal(t, tt.want, val)
 		})
 	}
@@ -216,7 +217,7 @@ func TestReadUint64(t *testing.T) {
 				assert.Error(t, iter.Error)
 				return
 			}
-			assert.NoError(t, iter.Error)
+			require.NoError(t, iter.Error)
 			assert.Equal(t, tt.want, val)
 		})
 	}
@@ -269,7 +270,7 @@ func TestReadFloat64(t *testing.T) {
 				assert.Error(t, iter.Error)
 				return
 			}
-			assert.NoError(t, iter.Error)
+			require.NoError(t, iter.Error)
 			assert.InDelta(t, tt.want, val, 0.01)
 		})
 	}

--- a/pdata/internal/json/resource_test.go
+++ b/pdata/internal/json/resource_test.go
@@ -8,6 +8,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlpresource "go.opentelemetry.io/collector/pdata/internal/data/protogen/resource/v1"
@@ -60,7 +61,7 @@ func TestReadResource(t *testing.T) {
 			defer jsoniter.ConfigFastest.ReturnIterator(iter)
 			got := &otlpresource.Resource{}
 			ReadResource(iter, got)
-			assert.NoError(t, iter.Error)
+			require.NoError(t, iter.Error)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pdata/internal/json/scope_test.go
+++ b/pdata/internal/json/scope_test.go
@@ -8,6 +8,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 )
@@ -111,7 +112,7 @@ func TestReadScope(t *testing.T) {
 			defer jsoniter.ConfigFastest.ReturnIterator(iter)
 			got := &otlpcommon.InstrumentationScope{}
 			ReadScope(iter, got)
-			assert.NoError(t, iter.Error)
+			require.NoError(t, iter.Error)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
@@ -305,7 +306,7 @@ func TestMap_Range(t *testing.T) {
 		"k_empty":  nil,
 	}
 	am := NewMap()
-	assert.NoError(t, am.FromRaw(rawMap))
+	require.NoError(t, am.FromRaw(rawMap))
 	assert.Equal(t, 5, am.Len())
 
 	calls := 0
@@ -325,17 +326,17 @@ func TestMap_Range(t *testing.T) {
 
 func TestMap_FromRaw(t *testing.T) {
 	am := NewMap()
-	assert.NoError(t, am.FromRaw(map[string]any{}))
+	require.NoError(t, am.FromRaw(map[string]any{}))
 	assert.Equal(t, 0, am.Len())
 	am.PutEmpty("k")
 	assert.Equal(t, 1, am.Len())
 
-	assert.NoError(t, am.FromRaw(nil))
+	require.NoError(t, am.FromRaw(nil))
 	assert.Equal(t, 0, am.Len())
 	am.PutEmpty("k")
 	assert.Equal(t, 1, am.Len())
 
-	assert.NoError(t, am.FromRaw(map[string]any{
+	require.NoError(t, am.FromRaw(map[string]any{
 		"k_string": "123",
 		"k_int":    123,
 		"k_double": 1.23,

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -224,11 +224,11 @@ func TestNilOrigSetValue(t *testing.T) {
 	assert.Equal(t, []byte{1, 2, 3}, av.Bytes().AsRaw())
 
 	av = NewValueEmpty()
-	assert.NoError(t, av.SetEmptyMap().FromRaw(map[string]any{"k": "v"}))
+	require.NoError(t, av.SetEmptyMap().FromRaw(map[string]any{"k": "v"}))
 	assert.Equal(t, map[string]any{"k": "v"}, av.Map().AsRaw())
 
 	av = NewValueEmpty()
-	assert.NoError(t, av.SetEmptySlice().FromRaw([]any{int64(1), "val"}))
+	require.NoError(t, av.SetEmptySlice().FromRaw([]any{int64(1), "val"}))
 	assert.Equal(t, []any{int64(1), "val"}, av.Slice().AsRaw())
 }
 
@@ -545,7 +545,7 @@ func TestNewValueFromRaw(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual := NewValueEmpty()
-			assert.NoError(t, actual.FromRaw(tt.input))
+			require.NoError(t, actual.FromRaw(tt.input))
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pdata/plog/json_test.go
+++ b/pdata/plog/json_test.go
@@ -48,10 +48,10 @@ var logsOTLP = func() Logs {
 func TestLogsJSON(t *testing.T) {
 	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalLogs(logsOTLP)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	decoder := &JSONUnmarshaler{}
 	got, err := decoder.UnmarshalLogs(jsonBuf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, logsOTLP, got)
 }
 
@@ -60,14 +60,14 @@ var logsJSON = `{"resourceLogs":[{"resource":{"attributes":[{"key":"host.name","
 func TestJSONUnmarshal(t *testing.T) {
 	decoder := &JSONUnmarshaler{}
 	got, err := decoder.UnmarshalLogs([]byte(logsJSON))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, logsOTLP, got)
 }
 
 func TestJSONMarshal(t *testing.T) {
 	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalLogs(logsOTLP)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, logsJSON, string(jsonBuf))
 }
 
@@ -84,7 +84,7 @@ func TestUnmarshalJsoniterLogsData(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewLogs()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewLogs(), val)
 }
 
@@ -94,7 +94,7 @@ func TestUnmarshalJsoniterResourceLogs(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewResourceLogs()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewResourceLogs(), val)
 }
 
@@ -104,7 +104,7 @@ func TestUnmarshalJsoniterScopeLogs(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewScopeLogs()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewScopeLogs(), val)
 }
 
@@ -114,7 +114,7 @@ func TestUnmarshalJsoniterLogRecord(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewLogRecord()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewLogRecord(), val)
 }
 
@@ -141,7 +141,7 @@ func BenchmarkJSONUnmarshal(b *testing.B) {
 
 	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalLogs(logsOTLP)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 	decoder := &JSONUnmarshaler{}
 
 	b.ResetTimer()

--- a/pdata/plog/logs_test.go
+++ b/pdata/plog/logs_test.go
@@ -9,6 +9,7 @@ import (
 
 	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -84,23 +85,23 @@ func TestResourceLogsWireCompatibility(t *testing.T) {
 
 	// Marshal its underlying ProtoBuf to wire.
 	wire1, err := gogoproto.Marshal(logs.getOrig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, wire1)
 
 	// Unmarshal from the wire to OTLP Protobuf in goproto's representation.
 	var goprotoMessage emptypb.Empty
 	err = goproto.Unmarshal(wire1, &goprotoMessage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Marshal to the wire again.
 	wire2, err := goproto.Marshal(&goprotoMessage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, wire2)
 
 	// Unmarshal from the wire into gogoproto's representation.
 	var gogoprotoRS2 otlpcollectorlog.ExportLogsServiceRequest
 	err = gogoproto.Unmarshal(wire2, &gogoprotoRS2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Now compare that the original and final ProtoBuf messages are the same.
 	// This proves that goproto and gogoproto marshaling/unmarshaling are wire compatible.

--- a/pdata/plog/plogotlp/grpc_test.go
+++ b/pdata/plog/plogotlp/grpc_test.go
@@ -43,7 +43,7 @@ func TestGrpc(t *testing.T) {
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, cc.Close())
 	})
@@ -51,7 +51,7 @@ func TestGrpc(t *testing.T) {
 	logClient := NewGRPCClient(cc)
 
 	resp, err := logClient.Export(context.Background(), generateLogsRequest())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, NewExportResponse(), resp)
 }
 
@@ -75,7 +75,7 @@ func TestGrpcError(t *testing.T) {
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, cc.Close())
 	})

--- a/pdata/plog/plogotlp/request_test.go
+++ b/pdata/plog/plogotlp/request_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _ json.Unmarshaler = ExportRequest{}
@@ -46,10 +47,10 @@ func TestRequestToPData(t *testing.T) {
 
 func TestRequestJSON(t *testing.T) {
 	lr := NewExportRequest()
-	assert.NoError(t, lr.UnmarshalJSON(logsRequestJSON))
+	require.NoError(t, lr.UnmarshalJSON(logsRequestJSON))
 	assert.Equal(t, "test_log_record", lr.Logs().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().AsString())
 
 	got, err := lr.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, strings.Join(strings.Fields(string(logsRequestJSON)), ""), string(got))
 }

--- a/pdata/plog/plogotlp/response_test.go
+++ b/pdata/plog/plogotlp/response_test.go
@@ -9,6 +9,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _ json.Unmarshaler = ExportResponse{}
@@ -17,7 +18,7 @@ var _ json.Marshaler = ExportResponse{}
 func TestExportResponseJSON(t *testing.T) {
 	jsonStr := `{"partialSuccess": {"rejectedLogRecords":1, "errorMessage":"nothing"}}`
 	val := NewExportResponse()
-	assert.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
+	require.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
 	expected := NewExportResponse()
 	expected.PartialSuccess().SetRejectedLogRecords(1)
 	expected.PartialSuccess().SetErrorMessage("nothing")
@@ -27,7 +28,7 @@ func TestExportResponseJSON(t *testing.T) {
 func TestUnmarshalJSONExportResponse(t *testing.T) {
 	jsonStr := `{"extra":"", "partialSuccess": {}}`
 	val := NewExportResponse()
-	assert.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
+	require.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
 	assert.Equal(t, NewExportResponse(), val)
 }
 
@@ -37,6 +38,6 @@ func TestUnmarshalJsoniterExportPartialSuccess(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewExportPartialSuccess()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewExportPartialSuccess(), val)
 }

--- a/pdata/pmetric/json_test.go
+++ b/pdata/pmetric/json_test.go
@@ -9,6 +9,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -32,11 +33,11 @@ var metricsJSON = `{"resourceMetrics":[{"resource":{"attributes":[{"key":"host.n
 func TestMetricsJSON(t *testing.T) {
 	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalMetrics(metricsOTLP)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	decoder := &JSONUnmarshaler{}
 	got, err := decoder.UnmarshalMetrics(jsonBuf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, metricsOTLP, got)
 }
@@ -44,7 +45,7 @@ func TestMetricsJSON(t *testing.T) {
 func TestMetricsJSON_Marshal(t *testing.T) {
 	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalMetrics(metricsOTLP)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, metricsJSON, string(jsonBuf))
 }
 
@@ -302,10 +303,10 @@ func Test_jsonUnmarshaler_UnmarshalMetrics(t *testing.T) {
 			encoder := &JSONMarshaler{}
 			m := tt.args.md()
 			jsonBuf, err := encoder.MarshalMetrics(m)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			decoder := JSONUnmarshaler{}
 			got, err := decoder.UnmarshalMetrics(jsonBuf)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.EqualValues(t, m, got)
 		})
 	}
@@ -317,7 +318,7 @@ func TestUnmarshalJsoniterMetricsData(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewMetrics()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, NewMetrics(), val)
 }
 
@@ -327,7 +328,7 @@ func TestUnmarshalJsoniterResourceMetrics(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewResourceMetrics()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpmetrics.ResourceMetrics{SchemaUrl: "schema"}, val.orig)
 }
 
@@ -337,7 +338,7 @@ func TestUnmarshalJsoniterScopeMetrics(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewScopeMetrics()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpmetrics.ScopeMetrics{SchemaUrl: "schema"}, val.orig)
 }
 
@@ -418,7 +419,7 @@ func TestUnmarshalJsoniterMetric(t *testing.T) {
 		jsoniter.ConfigFastest.ReturnIterator(iter)
 		val := NewMetric()
 		val.unmarshalJsoniter(iter)
-		assert.NoError(t, iter.Error)
+		require.NoError(t, iter.Error)
 		assert.EqualValues(t, tt.args.want, val.orig)
 	}
 }
@@ -429,7 +430,7 @@ func TestUnmarshalJsoniterNumberDataPoint(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewNumberDataPoint()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, NewNumberDataPoint(), val)
 }
 
@@ -439,7 +440,7 @@ func TestUnmarshalJsoniterHistogramDataPoint(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewHistogramDataPoint()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpmetrics.HistogramDataPoint{Count: 3}, val.orig)
 }
 
@@ -449,7 +450,7 @@ func TestUnmarshalJsoniterExponentialHistogramDataPoint(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewExponentialHistogramDataPoint()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpmetrics.ExponentialHistogramDataPoint{Count: 3}, val.orig)
 }
 
@@ -459,7 +460,7 @@ func TestUnmarshalJsoniterExponentialHistogramDataPointBuckets(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewExponentialHistogramDataPointBuckets()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpmetrics.ExponentialHistogramDataPoint_Buckets{Offset: 3, BucketCounts: []uint64{1, 2}}, val.orig)
 }
 
@@ -469,7 +470,7 @@ func TestUnmarshalJsoniterSummaryDataPoint(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewSummaryDataPoint()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpmetrics.SummaryDataPoint{
 		Count: 3,
 		Sum:   3.14,
@@ -482,7 +483,7 @@ func TestUnmarshalJsoniterQuantileValue(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewSummaryDataPointValueAtQuantile()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, &otlpmetrics.SummaryDataPoint_ValueAtQuantile{
 		Quantile: 0.314,
 		Value:    3,
@@ -551,6 +552,6 @@ func TestExemplar(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewExemplar()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.EqualValues(t, NewExemplar(), val)
 }

--- a/pdata/pmetric/metrics_test.go
+++ b/pdata/pmetric/metrics_test.go
@@ -9,6 +9,7 @@ import (
 
 	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -35,23 +36,23 @@ func TestResourceMetricsWireCompatibility(t *testing.T) {
 
 	// Marshal its underlying ProtoBuf to wire.
 	wire1, err := gogoproto.Marshal(metrics.getOrig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, wire1)
 
 	// Unmarshal from the wire to OTLP Protobuf in goproto's representation.
 	var goprotoMessage emptypb.Empty
 	err = goproto.Unmarshal(wire1, &goprotoMessage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Marshal to the wire again.
 	wire2, err := goproto.Marshal(&goprotoMessage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, wire2)
 
 	// Unmarshal from the wire into gogoproto's representation.
 	var gogoprotoRM otlpcollectormetrics.ExportMetricsServiceRequest
 	err = gogoproto.Unmarshal(wire2, &gogoprotoRM)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Now compare that the original and final ProtoBuf messages are the same.
 	// This proves that goproto and gogoproto marshaling/unmarshaling are wire compatible.

--- a/pdata/pmetric/pmetricotlp/grpc_test.go
+++ b/pdata/pmetric/pmetricotlp/grpc_test.go
@@ -43,7 +43,7 @@ func TestGrpc(t *testing.T) {
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, cc.Close())
 	})
@@ -51,7 +51,7 @@ func TestGrpc(t *testing.T) {
 	logClient := NewGRPCClient(cc)
 
 	resp, err := logClient.Export(context.Background(), generateMetricsRequest())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, NewExportResponse(), resp)
 }
 
@@ -75,7 +75,7 @@ func TestGrpcError(t *testing.T) {
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, cc.Close())
 	})

--- a/pdata/pmetric/pmetricotlp/request_test.go
+++ b/pdata/pmetric/pmetricotlp/request_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _ json.Unmarshaler = ExportRequest{}
@@ -42,10 +43,10 @@ func TestRequestToPData(t *testing.T) {
 
 func TestRequestJSON(t *testing.T) {
 	mr := NewExportRequest()
-	assert.NoError(t, mr.UnmarshalJSON(metricsRequestJSON))
+	require.NoError(t, mr.UnmarshalJSON(metricsRequestJSON))
 	assert.Equal(t, "test_metric", mr.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
 
 	got, err := mr.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, strings.Join(strings.Fields(string(metricsRequestJSON)), ""), string(got))
 }

--- a/pdata/pmetric/pmetricotlp/response_test.go
+++ b/pdata/pmetric/pmetricotlp/response_test.go
@@ -9,6 +9,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _ json.Unmarshaler = ExportResponse{}
@@ -17,7 +18,7 @@ var _ json.Marshaler = ExportResponse{}
 func TestExportResponseJSON(t *testing.T) {
 	jsonStr := `{"partialSuccess": {"rejectedDataPoints":1, "errorMessage":"nothing"}}`
 	val := NewExportResponse()
-	assert.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
+	require.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
 	expected := NewExportResponse()
 	expected.PartialSuccess().SetRejectedDataPoints(1)
 	expected.PartialSuccess().SetErrorMessage("nothing")
@@ -27,7 +28,7 @@ func TestExportResponseJSON(t *testing.T) {
 func TestUnmarshalJSONExportResponse(t *testing.T) {
 	jsonStr := `{"extra":"", "partialSuccess": {}}`
 	val := NewExportResponse()
-	assert.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
+	require.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
 	assert.Equal(t, NewExportResponse(), val)
 }
 
@@ -37,6 +38,6 @@ func TestUnmarshalJsoniterExportPartialSuccess(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewExportPartialSuccess()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewExportPartialSuccess(), val)
 }

--- a/pdata/pprofile/json_test.go
+++ b/pdata/pprofile/json_test.go
@@ -8,6 +8,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1experimental"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -133,14 +134,14 @@ var profilesJSON = `{"resourceProfiles":[{"resource":{"attributes":[{"key":"host
 func TestJSONUnmarshal(t *testing.T) {
 	decoder := &JSONUnmarshaler{}
 	got, err := decoder.UnmarshalProfiles([]byte(profilesJSON))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, profilesOTLP, got)
 }
 
 func TestJSONMarshal(t *testing.T) {
 	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalProfiles(profilesOTLP)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, profilesJSON, string(jsonBuf))
 }
 
@@ -157,7 +158,7 @@ func TestUnmarshalJsoniterProfileData(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewProfiles()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, 1, val.ResourceProfiles().Len())
 }
 
@@ -177,7 +178,7 @@ func TestUnmarshalJsoniterResourceProfiles(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewResourceProfiles()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewResourceProfiles(), val)
 }
 
@@ -187,7 +188,7 @@ func TestUnmarshalJsoniterScopeProfiles(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewScopeProfiles()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewScopeProfiles(), val)
 }
 
@@ -197,7 +198,7 @@ func TestUnmarshalJsoniterProfile(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewProfile()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewProfile(), val)
 }
 
@@ -207,7 +208,7 @@ func TestUnmarshalJsoniterValueType(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewValueType()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewValueType(), val)
 }
 
@@ -217,7 +218,7 @@ func TestUnmarshalJsoniterSample(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewSample()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewSample(), val)
 }
 
@@ -227,7 +228,7 @@ func TestUnmarshalJsoniterMapping(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewMapping()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewMapping(), val)
 }
 
@@ -237,7 +238,7 @@ func TestUnmarshalJsoniterLocation(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewLocation()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewLocation(), val)
 }
 
@@ -247,7 +248,7 @@ func TestUnmarshalJsoniterLine(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewLine()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewLine(), val)
 }
 
@@ -257,7 +258,7 @@ func TestUnmarshalJsoniterFunction(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewFunction()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewFunction(), val)
 }
 
@@ -267,7 +268,7 @@ func TestUnmarshalJsoniterAttributeUnit(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewAttributeUnit()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewAttributeUnit(), val)
 }
 
@@ -277,7 +278,7 @@ func TestUnmarshalJsoniterLink(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewLink()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewLink(), val)
 }
 
@@ -307,7 +308,7 @@ func TestUnmarshalJsoniterLabel(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewLabel()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewLabel(), val)
 }
 
@@ -316,7 +317,7 @@ func BenchmarkJSONUnmarshal(b *testing.B) {
 
 	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalProfiles(profilesOTLP)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 	decoder := &JSONUnmarshaler{}
 
 	b.ResetTimer()

--- a/pdata/pprofile/pprofileotlp/grpc_test.go
+++ b/pdata/pprofile/pprofileotlp/grpc_test.go
@@ -43,7 +43,7 @@ func TestGrpc(t *testing.T) {
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, cc.Close())
 	})
@@ -51,7 +51,7 @@ func TestGrpc(t *testing.T) {
 	logClient := NewGRPCClient(cc)
 
 	resp, err := logClient.Export(context.Background(), generateProfilesRequest())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, NewExportResponse(), resp)
 }
 
@@ -75,7 +75,7 @@ func TestGrpcError(t *testing.T) {
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, cc.Close())
 	})

--- a/pdata/pprofile/pprofileotlp/request_test.go
+++ b/pdata/pprofile/pprofileotlp/request_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _ json.Unmarshaler = ExportRequest{}
@@ -50,10 +51,10 @@ func TestRequestToPData(t *testing.T) {
 
 func TestRequestJSON(t *testing.T) {
 	tr := NewExportRequest()
-	assert.NoError(t, tr.UnmarshalJSON(profilesRequestJSON))
+	require.NoError(t, tr.UnmarshalJSON(profilesRequestJSON))
 	assert.Equal(t, uint64(42), tr.Profiles().ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).Profile().Sample().At(0).LocationsStartIndex())
 
 	got, err := tr.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, strings.Join(strings.Fields(string(profilesRequestJSON)), ""), string(got))
 }

--- a/pdata/pprofile/pprofileotlp/response_test.go
+++ b/pdata/pprofile/pprofileotlp/response_test.go
@@ -9,6 +9,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _ json.Unmarshaler = ExportResponse{}
@@ -17,7 +18,7 @@ var _ json.Marshaler = ExportResponse{}
 func TestExportResponseJSON(t *testing.T) {
 	jsonStr := `{"partialSuccess": {"rejectedProfiles":1, "errorMessage":"nothing"}}`
 	val := NewExportResponse()
-	assert.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
+	require.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
 	expected := NewExportResponse()
 	expected.PartialSuccess().SetRejectedProfiles(1)
 	expected.PartialSuccess().SetErrorMessage("nothing")
@@ -27,7 +28,7 @@ func TestExportResponseJSON(t *testing.T) {
 func TestUnmarshalJSONExportResponse(t *testing.T) {
 	jsonStr := `{"extra":"", "partialSuccess": {}}`
 	val := NewExportResponse()
-	assert.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
+	require.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
 	assert.Equal(t, NewExportResponse(), val)
 }
 
@@ -37,6 +38,6 @@ func TestUnmarshalJsoniterExportPartialSuccess(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewExportPartialSuccess()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewExportPartialSuccess(), val)
 }

--- a/pdata/ptrace/json_test.go
+++ b/pdata/ptrace/json_test.go
@@ -8,6 +8,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
@@ -93,14 +94,14 @@ var tracesJSON = `{"resourceSpans":[{"resource":{"attributes":[{"key":"host.name
 func TestJSONUnmarshal(t *testing.T) {
 	decoder := &JSONUnmarshaler{}
 	got, err := decoder.UnmarshalTraces([]byte(tracesJSON))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, tracesOTLP, got)
 }
 
 func TestJSONMarshal(t *testing.T) {
 	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalTraces(tracesOTLP)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, tracesJSON, string(jsonBuf))
 }
 
@@ -117,7 +118,7 @@ func TestUnmarshalJsoniterTraceData(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewTraces()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, 1, val.ResourceSpans().Len())
 }
 
@@ -127,7 +128,7 @@ func TestUnmarshalJsoniterResourceSpans(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewResourceSpans()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewResourceSpans(), val)
 }
 
@@ -137,7 +138,7 @@ func TestUnmarshalJsoniterScopeSpans(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewScopeSpans()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewScopeSpans(), val)
 }
 
@@ -147,7 +148,7 @@ func TestUnmarshalJsoniterSpan(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewSpan()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewSpan(), val)
 }
 
@@ -187,7 +188,7 @@ func TestUnmarshalJsoniterSpanStatus(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewStatus()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewStatus(), val)
 }
 
@@ -197,7 +198,7 @@ func TestUnmarshalJsoniterSpanLink(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewSpanLink()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewSpanLink(), val)
 }
 
@@ -227,7 +228,7 @@ func TestUnmarshalJsoniterSpanEvent(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewSpanEvent()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewSpanEvent(), val)
 }
 
@@ -236,7 +237,7 @@ func BenchmarkJSONUnmarshal(b *testing.B) {
 
 	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalTraces(tracesOTLP)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 	decoder := &JSONUnmarshaler{}
 
 	b.ResetTimer()

--- a/pdata/ptrace/ptraceotlp/grpc_test.go
+++ b/pdata/ptrace/ptraceotlp/grpc_test.go
@@ -43,7 +43,7 @@ func TestGrpc(t *testing.T) {
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, cc.Close())
 	})
@@ -51,7 +51,7 @@ func TestGrpc(t *testing.T) {
 	logClient := NewGRPCClient(cc)
 
 	resp, err := logClient.Export(context.Background(), generateTracesRequest())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, NewExportResponse(), resp)
 }
 
@@ -75,7 +75,7 @@ func TestGrpcError(t *testing.T) {
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, cc.Close())
 	})

--- a/pdata/ptrace/ptraceotlp/request_test.go
+++ b/pdata/ptrace/ptraceotlp/request_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _ json.Unmarshaler = ExportRequest{}
@@ -46,10 +47,10 @@ func TestRequestToPData(t *testing.T) {
 
 func TestRequestJSON(t *testing.T) {
 	tr := NewExportRequest()
-	assert.NoError(t, tr.UnmarshalJSON(tracesRequestJSON))
+	require.NoError(t, tr.UnmarshalJSON(tracesRequestJSON))
 	assert.Equal(t, "test_span", tr.Traces().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
 
 	got, err := tr.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, strings.Join(strings.Fields(string(tracesRequestJSON)), ""), string(got))
 }

--- a/pdata/ptrace/ptraceotlp/response_test.go
+++ b/pdata/ptrace/ptraceotlp/response_test.go
@@ -9,6 +9,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _ json.Unmarshaler = ExportResponse{}
@@ -17,7 +18,7 @@ var _ json.Marshaler = ExportResponse{}
 func TestExportResponseJSON(t *testing.T) {
 	jsonStr := `{"partialSuccess": {"rejectedSpans":1, "errorMessage":"nothing"}}`
 	val := NewExportResponse()
-	assert.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
+	require.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
 	expected := NewExportResponse()
 	expected.PartialSuccess().SetRejectedSpans(1)
 	expected.PartialSuccess().SetErrorMessage("nothing")
@@ -27,7 +28,7 @@ func TestExportResponseJSON(t *testing.T) {
 func TestUnmarshalJSONExportResponse(t *testing.T) {
 	jsonStr := `{"extra":"", "partialSuccess": {}}`
 	val := NewExportResponse()
-	assert.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
+	require.NoError(t, val.UnmarshalJSON([]byte(jsonStr)))
 	assert.Equal(t, NewExportResponse(), val)
 }
 
@@ -37,6 +38,6 @@ func TestUnmarshalJsoniterExportPartialSuccess(t *testing.T) {
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)
 	val := NewExportPartialSuccess()
 	val.unmarshalJsoniter(iter)
-	assert.NoError(t, iter.Error)
+	require.NoError(t, iter.Error)
 	assert.Equal(t, NewExportPartialSuccess(), val)
 }

--- a/pdata/ptrace/traces_test.go
+++ b/pdata/ptrace/traces_test.go
@@ -9,6 +9,7 @@ import (
 
 	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -85,23 +86,23 @@ func TestResourceSpansWireCompatibility(t *testing.T) {
 
 	// Marshal its underlying ProtoBuf to wire.
 	wire1, err := gogoproto.Marshal(traces.getOrig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, wire1)
 
 	// Unmarshal from the wire to OTLP Protobuf in goproto's representation.
 	var goprotoMessage emptypb.Empty
 	err = goproto.Unmarshal(wire1, &goprotoMessage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Marshal to the wire again.
 	wire2, err := goproto.Marshal(&goprotoMessage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, wire2)
 
 	// Unmarshal from the wire into gogoproto's representation.
 	var gogoprotoRS2 otlpcollectortrace.ExportTraceServiceRequest
 	err = gogoproto.Unmarshal(wire2, &gogoprotoRS2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Now compare that the original and final ProtoBuf messages are the same.
 	// This proves that goproto and gogoproto marshaling/unmarshaling are wire compatible.

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -100,7 +100,7 @@ func TestBatchProcessorSpansDelivered(t *testing.T) {
 			spans.At(spanIndex).SetName(getTestSpanName(requestNum, spanIndex))
 		}
 		td.ResourceSpans().At(0).CopyTo(sentResourceSpans.AppendEmpty())
-		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
+		require.NoError(t, batcher.ConsumeTraces(context.Background(), td))
 	}
 
 	// Added to test logic that check for empty resources.
@@ -141,7 +141,7 @@ func TestBatchProcessorSpansDeliveredEnforceBatchSize(t *testing.T) {
 		for spanIndex := 0; spanIndex < spansPerRequest; spanIndex++ {
 			spans.At(spanIndex).SetName(getTestSpanName(requestNum, spanIndex))
 		}
-		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
+		require.NoError(t, batcher.ConsumeTraces(context.Background(), td))
 	}
 
 	// Added to test logic that check for empty resources.
@@ -188,7 +188,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		td := testdata.GenerateTraces(spansPerRequest)
 
-		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
+		require.NoError(t, batcher.ConsumeTraces(context.Background(), td))
 	}
 
 	require.NoError(t, batcher.Shutdown(context.Background()))
@@ -310,7 +310,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 	sizeSum := 0
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		td := testdata.GenerateTraces(spansPerRequest)
-		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
+		require.NoError(t, batcher.ConsumeTraces(context.Background(), td))
 	}
 
 	require.NoError(t, batcher.Shutdown(context.Background()))
@@ -445,7 +445,7 @@ func TestBatchProcessorSentByTimeout(t *testing.T) {
 
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		td := testdata.GenerateTraces(spansPerRequest)
-		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
+		require.NoError(t, batcher.ConsumeTraces(context.Background(), td))
 	}
 
 	// Wait for at least one batch to be sent.
@@ -494,7 +494,7 @@ func TestBatchProcessorTraceSendWhenClosing(t *testing.T) {
 	spansPerRequest := 10
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		td := testdata.GenerateTraces(spansPerRequest)
-		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
+		require.NoError(t, batcher.ConsumeTraces(context.Background(), td))
 	}
 
 	require.NoError(t, batcher.Shutdown(context.Background()))
@@ -530,7 +530,7 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 			metrics.At(metricIndex).SetName(getTestMetricName(requestNum, metricIndex))
 		}
 		md.ResourceMetrics().At(0).CopyTo(sentResourceMetrics.AppendEmpty())
-		assert.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
+		require.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
 	}
 
 	// Added to test case with empty resources sent.
@@ -580,7 +580,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		md := testdata.GenerateMetrics(metricsPerRequest)
 		size += sizer.MetricsSize(md)
-		assert.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
+		require.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
 	}
 	require.NoError(t, batcher.Shutdown(context.Background()))
 
@@ -711,7 +711,7 @@ func TestBatchMetricsProcessor_Timeout(t *testing.T) {
 	start := time.Now()
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		md := testdata.GenerateMetrics(metricsPerRequest)
-		assert.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
+		require.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
 	}
 
 	// Wait for at least one batch to be sent.
@@ -759,7 +759,7 @@ func TestBatchMetricProcessor_Shutdown(t *testing.T) {
 
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		md := testdata.GenerateMetrics(metricsPerRequest)
-		assert.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
+		require.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
 	}
 
 	require.NoError(t, batcher.Shutdown(context.Background()))
@@ -912,7 +912,7 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 			logs.At(logIndex).SetSeverityText(getTestLogSeverityText(requestNum, logIndex))
 		}
 		ld.ResourceLogs().At(0).CopyTo(sentResourceLogs.AppendEmpty())
-		assert.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
+		require.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
 	}
 
 	// Added to test case with empty resources sent.
@@ -960,7 +960,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		ld := testdata.GenerateLogs(logsPerRequest)
 		size += sizer.LogsSize(ld)
-		assert.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
+		require.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
 	}
 	require.NoError(t, batcher.Shutdown(context.Background()))
 
@@ -1072,7 +1072,7 @@ func TestBatchLogsProcessor_Timeout(t *testing.T) {
 	start := time.Now()
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		ld := testdata.GenerateLogs(logsPerRequest)
-		assert.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
+		require.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
 	}
 
 	// Wait for at least one batch to be sent.
@@ -1120,7 +1120,7 @@ func TestBatchLogProcessor_Shutdown(t *testing.T) {
 
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		ld := testdata.GenerateLogs(logsPerRequest)
-		assert.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
+		require.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
 	}
 
 	require.NoError(t, batcher.Shutdown(context.Background()))
@@ -1242,7 +1242,7 @@ func TestBatchProcessorSpansBatchedByMetadata(t *testing.T) {
 		// use round-robin to assign context.
 		num := requestNum % len(callCtxs)
 		expectByContext[num] += spansPerRequest
-		assert.NoError(t, batcher.ConsumeTraces(callCtxs[num], td))
+		require.NoError(t, batcher.ConsumeTraces(callCtxs[num], td))
 	}
 
 	require.NoError(t, batcher.Shutdown(context.Background()))
@@ -1299,7 +1299,7 @@ func TestBatchProcessorMetadataCardinalityLimit(t *testing.T) {
 			}),
 		})
 
-		assert.NoError(t, batcher.ConsumeTraces(ctx, td))
+		require.NoError(t, batcher.ConsumeTraces(ctx, td))
 	}
 
 	td := testdata.GenerateTraces(1)
@@ -1310,7 +1310,7 @@ func TestBatchProcessorMetadataCardinalityLimit(t *testing.T) {
 	})
 	err = batcher.ConsumeTraces(ctx, td)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.True(t, consumererror.IsPermanent(err))
 	assert.Contains(t, err.Error(), "too many")
 
@@ -1339,7 +1339,7 @@ func TestBatchZeroConfig(t *testing.T) {
 		cnt := logsPerRequest + requestNum
 		expect += cnt
 		ld := testdata.GenerateLogs(cnt)
-		assert.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
+		require.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
 	}
 
 	// Wait for all batches.
@@ -1377,7 +1377,7 @@ func TestBatchSplitOnly(t *testing.T) {
 
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		ld := testdata.GenerateLogs(logsPerRequest)
-		assert.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
+		require.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
 	}
 
 	// Wait for all batches.

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -18,7 +18,7 @@ import (
 func TestUnmarshalDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, confmap.New().Unmarshal(&cfg))
+	require.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -27,7 +27,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			SendBatchSize:            uint32(10000),

--- a/processor/memorylimiterprocessor/factory_test.go
+++ b/processor/memorylimiterprocessor/factory_test.go
@@ -39,19 +39,19 @@ func TestCreateProcessor(t *testing.T) {
 	pCfg.CheckInterval = 100 * time.Millisecond
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tp)
 	// test if we can shutdown a monitoring routine that has not started
-	assert.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
-	assert.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
+	require.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
+	require.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 
 	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, mp)
-	assert.NoError(t, mp.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, mp.Start(context.Background(), componenttest.NewNopHost()))
 
 	lp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, lp)
 	assert.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -59,7 +59,7 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NoError(t, tp.Shutdown(context.Background()))
 	assert.NoError(t, mp.Shutdown(context.Background()))
 	// verify that no monitoring routine is running
-	assert.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
+	require.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
 
 	// start and shutdown a new monitoring routine
 	assert.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -193,7 +193,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 			if tt.expectError {
 				assert.Equal(t, memorylimiter.ErrDataRefused, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.NoError(t, mp.Shutdown(ctx))
 		})
@@ -283,7 +283,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 			if tt.expectError {
 				assert.Equal(t, memorylimiter.ErrDataRefused, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.NoError(t, tp.Shutdown(ctx))
 		})
@@ -373,7 +373,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 			if tt.expectError {
 				assert.Equal(t, memorylimiter.ErrDataRefused, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.NoError(t, tp.Shutdown(ctx))
 		})

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -23,9 +24,9 @@ func TestNewFactory(t *testing.T) {
 	assert.EqualValues(t, testType, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 	_, err := factory.CreateTracesProcessor(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = factory.CreateMetricsProcessor(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = factory.CreateLogsProcessor(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
 	assert.Error(t, err)
 }
@@ -44,11 +45,11 @@ func TestNewFactoryWithOptions(t *testing.T) {
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.TracesProcessorStability())
 	_, err := factory.CreateTracesProcessor(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelBeta, factory.MetricsProcessorStability())
 	_, err = factory.CreateMetricsProcessor(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelUnmaintained, factory.LogsProcessorStability())
 	_, err = factory.CreateLogsProcessor(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
@@ -86,7 +87,7 @@ func TestMakeFactoryMap(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.out, out)
 		})
 	}

--- a/processor/processorhelper/logs_test.go
+++ b/processor/processorhelper/logs_test.go
@@ -39,7 +39,7 @@ func TestNewLogsProcessor_WithOptions(t *testing.T) {
 		WithStart(func(context.Context, component.Host) error { return want }),
 		WithShutdown(func(context.Context) error { return want }),
 		WithCapabilities(consumer.Capabilities{MutatesData: false}))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, want, lp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Equal(t, want, lp.Shutdown(context.Background()))

--- a/processor/processorhelper/metrics_test.go
+++ b/processor/processorhelper/metrics_test.go
@@ -39,7 +39,7 @@ func TestNewMetricsProcessor_WithOptions(t *testing.T) {
 		WithStart(func(context.Context, component.Host) error { return want }),
 		WithShutdown(func(context.Context) error { return want }),
 		WithCapabilities(consumer.Capabilities{MutatesData: false}))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, want, mp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Equal(t, want, mp.Shutdown(context.Background()))

--- a/processor/processorhelper/obsreport_test.go
+++ b/processor/processorhelper/obsreport_test.go
@@ -110,23 +110,23 @@ func TestCheckProcessorTracesViews(t *testing.T) {
 		ProcessorID:             processorID,
 		ProcessorCreateSettings: processor.Settings{ID: processorID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	por.TracesAccepted(context.Background(), 7)
 	por.TracesRefused(context.Background(), 8)
 	por.TracesDropped(context.Background(), 9)
 
-	assert.NoError(t, tt.CheckProcessorTraces(7, 8, 9))
-	assert.Error(t, tt.CheckProcessorTraces(0, 0, 0))
-	assert.Error(t, tt.CheckProcessorTraces(7, 0, 0))
-	assert.Error(t, tt.CheckProcessorTraces(0, 8, 0))
-	assert.Error(t, tt.CheckProcessorTraces(0, 0, 9))
-	assert.Error(t, tt.CheckProcessorTraces(0, 0, 0))
-	assert.Error(t, tt.CheckProcessorTraces(7, 8, 0))
-	assert.Error(t, tt.CheckProcessorTraces(7, 0, 9))
-	assert.Error(t, tt.CheckProcessorTraces(7, 0, 0))
-	assert.Error(t, tt.CheckProcessorTraces(0, 8, 9))
-	assert.Error(t, tt.CheckProcessorTraces(0, 8, 0))
+	require.NoError(t, tt.CheckProcessorTraces(7, 8, 9))
+	require.Error(t, tt.CheckProcessorTraces(0, 0, 0))
+	require.Error(t, tt.CheckProcessorTraces(7, 0, 0))
+	require.Error(t, tt.CheckProcessorTraces(0, 8, 0))
+	require.Error(t, tt.CheckProcessorTraces(0, 0, 9))
+	require.Error(t, tt.CheckProcessorTraces(0, 0, 0))
+	require.Error(t, tt.CheckProcessorTraces(7, 8, 0))
+	require.Error(t, tt.CheckProcessorTraces(7, 0, 9))
+	require.Error(t, tt.CheckProcessorTraces(7, 0, 0))
+	require.Error(t, tt.CheckProcessorTraces(0, 8, 9))
+	require.Error(t, tt.CheckProcessorTraces(0, 8, 0))
 	assert.Error(t, tt.CheckProcessorTraces(0, 0, 9))
 }
 
@@ -139,23 +139,23 @@ func TestCheckProcessorMetricsViews(t *testing.T) {
 		ProcessorID:             processorID,
 		ProcessorCreateSettings: processor.Settings{ID: processorID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	por.MetricsAccepted(context.Background(), 7)
 	por.MetricsRefused(context.Background(), 8)
 	por.MetricsDropped(context.Background(), 9)
 
-	assert.NoError(t, tt.CheckProcessorMetrics(7, 8, 9))
-	assert.Error(t, tt.CheckProcessorMetrics(0, 0, 0))
-	assert.Error(t, tt.CheckProcessorMetrics(7, 0, 0))
-	assert.Error(t, tt.CheckProcessorMetrics(0, 8, 0))
-	assert.Error(t, tt.CheckProcessorMetrics(0, 0, 9))
-	assert.Error(t, tt.CheckProcessorMetrics(0, 0, 0))
-	assert.Error(t, tt.CheckProcessorMetrics(7, 8, 0))
-	assert.Error(t, tt.CheckProcessorMetrics(7, 0, 9))
-	assert.Error(t, tt.CheckProcessorMetrics(7, 0, 0))
-	assert.Error(t, tt.CheckProcessorMetrics(0, 8, 9))
-	assert.Error(t, tt.CheckProcessorMetrics(0, 8, 0))
+	require.NoError(t, tt.CheckProcessorMetrics(7, 8, 9))
+	require.Error(t, tt.CheckProcessorMetrics(0, 0, 0))
+	require.Error(t, tt.CheckProcessorMetrics(7, 0, 0))
+	require.Error(t, tt.CheckProcessorMetrics(0, 8, 0))
+	require.Error(t, tt.CheckProcessorMetrics(0, 0, 9))
+	require.Error(t, tt.CheckProcessorMetrics(0, 0, 0))
+	require.Error(t, tt.CheckProcessorMetrics(7, 8, 0))
+	require.Error(t, tt.CheckProcessorMetrics(7, 0, 9))
+	require.Error(t, tt.CheckProcessorMetrics(7, 0, 0))
+	require.Error(t, tt.CheckProcessorMetrics(0, 8, 9))
+	require.Error(t, tt.CheckProcessorMetrics(0, 8, 0))
 	assert.Error(t, tt.CheckProcessorMetrics(0, 0, 9))
 }
 
@@ -168,23 +168,23 @@ func TestCheckProcessorLogViews(t *testing.T) {
 		ProcessorID:             processorID,
 		ProcessorCreateSettings: processor.Settings{ID: processorID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	por.LogsAccepted(context.Background(), 7)
 	por.LogsRefused(context.Background(), 8)
 	por.LogsDropped(context.Background(), 9)
 
-	assert.NoError(t, tt.CheckProcessorLogs(7, 8, 9))
-	assert.Error(t, tt.CheckProcessorLogs(0, 0, 0))
-	assert.Error(t, tt.CheckProcessorLogs(7, 0, 0))
-	assert.Error(t, tt.CheckProcessorLogs(0, 8, 0))
-	assert.Error(t, tt.CheckProcessorLogs(0, 0, 9))
-	assert.Error(t, tt.CheckProcessorLogs(0, 0, 0))
-	assert.Error(t, tt.CheckProcessorLogs(7, 8, 0))
-	assert.Error(t, tt.CheckProcessorLogs(7, 0, 9))
-	assert.Error(t, tt.CheckProcessorLogs(7, 0, 0))
-	assert.Error(t, tt.CheckProcessorLogs(0, 8, 9))
-	assert.Error(t, tt.CheckProcessorLogs(0, 8, 0))
+	require.NoError(t, tt.CheckProcessorLogs(7, 8, 9))
+	require.Error(t, tt.CheckProcessorLogs(0, 0, 0))
+	require.Error(t, tt.CheckProcessorLogs(7, 0, 0))
+	require.Error(t, tt.CheckProcessorLogs(0, 8, 0))
+	require.Error(t, tt.CheckProcessorLogs(0, 0, 9))
+	require.Error(t, tt.CheckProcessorLogs(0, 0, 0))
+	require.Error(t, tt.CheckProcessorLogs(7, 8, 0))
+	require.Error(t, tt.CheckProcessorLogs(7, 0, 9))
+	require.Error(t, tt.CheckProcessorLogs(7, 0, 0))
+	require.Error(t, tt.CheckProcessorLogs(0, 8, 9))
+	require.Error(t, tt.CheckProcessorLogs(0, 8, 0))
 	assert.Error(t, tt.CheckProcessorLogs(0, 0, 9))
 }
 
@@ -204,7 +204,7 @@ func TestNoMetrics(t *testing.T) {
 			ProcessorID:             processorID,
 			ProcessorCreateSettings: processor.Settings{ID: processorID, TelemetrySettings: set, BuildInfo: component.NewDefaultBuildInfo()},
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		por.TracesAccepted(context.Background(), accepted)
 		por.TracesRefused(context.Background(), refused)
@@ -226,7 +226,7 @@ func TestNoMetrics(t *testing.T) {
 			ProcessorID:             processorID,
 			ProcessorCreateSettings: processor.Settings{ID: processorID, TelemetrySettings: set, BuildInfo: component.NewDefaultBuildInfo()},
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		por.MetricsAccepted(context.Background(), accepted)
 		por.MetricsRefused(context.Background(), refused)
@@ -248,7 +248,7 @@ func TestNoMetrics(t *testing.T) {
 			ProcessorID:             processorID,
 			ProcessorCreateSettings: processor.Settings{ID: processorID, TelemetrySettings: set, BuildInfo: component.NewDefaultBuildInfo()},
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		por.LogsAccepted(context.Background(), accepted)
 		por.LogsRefused(context.Background(), refused)

--- a/processor/processorhelper/traces_test.go
+++ b/processor/processorhelper/traces_test.go
@@ -39,7 +39,7 @@ func TestNewTracesProcessor_WithOptions(t *testing.T) {
 		WithStart(func(context.Context, component.Host) error { return want }),
 		WithShutdown(func(context.Context) error { return want }),
 		WithCapabilities(consumer.Capabilities{MutatesData: false}))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, want, tp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Equal(t, want, tp.Shutdown(context.Background()))

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -26,7 +26,7 @@ func TestUnmarshalDefaultConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
 
@@ -35,7 +35,7 @@ func TestUnmarshalConfigOnlyGRPC(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyGRPC := factory.CreateDefaultConfig().(*Config)
 	defaultOnlyGRPC.HTTP = nil
@@ -47,7 +47,7 @@ func TestUnmarshalConfigOnlyHTTP(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyHTTP := factory.CreateDefaultConfig().(*Config)
 	defaultOnlyHTTP.GRPC = nil
@@ -59,7 +59,7 @@ func TestUnmarshalConfigOnlyHTTPNull(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyHTTP := factory.CreateDefaultConfig().(*Config)
 	defaultOnlyHTTP.GRPC = nil
@@ -71,7 +71,7 @@ func TestUnmarshalConfigOnlyHTTPEmptyMap(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyHTTP := factory.CreateDefaultConfig().(*Config)
 	defaultOnlyHTTP.GRPC = nil
@@ -83,7 +83,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			Protocols: Protocols{
@@ -149,7 +149,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 	assert.Equal(t,
 		&Config{
 			Protocols: Protocols{
@@ -193,7 +193,7 @@ func TestUnmarshalConfigEmptyProtocols(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(&cfg))
+	require.NoError(t, cm.Unmarshal(&cfg))
 	assert.EqualError(t, component.ValidateConfig(cfg), "must specify at least one protocol when using the OTLP receiver")
 }
 
@@ -230,6 +230,6 @@ func TestUnmarshalConfigInvalidSignalPath(t *testing.T) {
 func TestUnmarshalConfigEmpty(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, confmap.New().Unmarshal(&cfg))
+	require.NoError(t, confmap.New().Unmarshal(&cfg))
 	assert.EqualError(t, component.ValidateConfig(cfg), "must specify at least one protocol when using the OTLP receiver")
 }

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -37,19 +37,19 @@ func TestCreateSameReceiver(t *testing.T) {
 	creationSet := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, tReceiver)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, mReceiver)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	lReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, lReceiver)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	pReceiver, err := factory.CreateProfilesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, pReceiver)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Same(t, tReceiver, mReceiver)
 	assert.Same(t, tReceiver, lReceiver)
@@ -139,7 +139,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if tt.wantStartErr {
 				assert.Error(t, tr.Start(context.Background(), componenttest.NewNopHost()))
 			} else {
@@ -233,7 +233,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if tt.wantStartErr {
 				assert.Error(t, mr.Start(context.Background(), componenttest.NewNopHost()))
 			} else {
@@ -327,7 +327,7 @@ func TestCreateLogReceiver(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if tt.wantStartErr {
 				assert.Error(t, mr.Start(context.Background(), componenttest.NewNopHost()))
 			} else {
@@ -420,7 +420,7 @@ func TestCreateProfilesReceiver(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if tt.wantStartErr {
 				assert.Error(t, tr.Start(context.Background(), componenttest.NewNopHost()))
 			} else {

--- a/receiver/otlpreceiver/internal/logs/otlp_test.go
+++ b/receiver/otlpreceiver/internal/logs/otlp_test.go
@@ -46,7 +46,7 @@ func TestExport_EmptyRequest(t *testing.T) {
 
 	logClient := makeLogsServiceClient(t, logSink)
 	resp, err := logClient.Export(context.Background(), plogotlp.NewExportRequest())
-	assert.NoError(t, err, "Failed to export trace: %v", err)
+	require.NoError(t, err, "Failed to export trace: %v", err)
 	assert.NotNil(t, resp, "The response is missing")
 }
 
@@ -56,7 +56,7 @@ func TestExport_NonPermanentErrorConsumer(t *testing.T) {
 
 	logClient := makeLogsServiceClient(t, consumertest.NewErr(errors.New("my error")))
 	resp, err := logClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Unavailable desc = my error")
+	require.EqualError(t, err, "rpc error: code = Unavailable desc = my error")
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, plogotlp.ExportResponse{}, resp)
 }
@@ -67,7 +67,7 @@ func TestExport_PermanentErrorConsumer(t *testing.T) {
 
 	logClient := makeLogsServiceClient(t, consumertest.NewErr(consumererror.NewPermanent(errors.New("my error"))))
 	resp, err := logClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Internal desc = Permanent error: my error")
+	require.EqualError(t, err, "rpc error: code = Internal desc = Permanent error: my error")
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, plogotlp.ExportResponse{}, resp)
 }

--- a/receiver/otlpreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp_test.go
@@ -56,7 +56,7 @@ func TestExport_NonPermanentErrorConsumer(t *testing.T) {
 
 	metricsClient := makeMetricsServiceClient(t, consumertest.NewErr(errors.New("my error")))
 	resp, err := metricsClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Unavailable desc = my error")
+	require.EqualError(t, err, "rpc error: code = Unavailable desc = my error")
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, pmetricotlp.ExportResponse{}, resp)
 }
@@ -67,7 +67,7 @@ func TestExport_PermanentErrorConsumer(t *testing.T) {
 
 	metricsClient := makeMetricsServiceClient(t, consumertest.NewErr(consumererror.NewPermanent(errors.New("my error"))))
 	resp, err := metricsClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Internal desc = Permanent error: my error")
+	require.EqualError(t, err, "rpc error: code = Internal desc = Permanent error: my error")
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, pmetricotlp.ExportResponse{}, resp)
 }

--- a/receiver/otlpreceiver/internal/profiles/otlp_test.go
+++ b/receiver/otlpreceiver/internal/profiles/otlp_test.go
@@ -41,7 +41,7 @@ func TestExport_EmptyRequest(t *testing.T) {
 	profileSink := new(consumertest.ProfilesSink)
 	profileClient := makeProfileServiceClient(t, profileSink)
 	resp, err := profileClient.Export(context.Background(), pprofileotlp.NewExportRequest())
-	assert.NoError(t, err, "Failed to export profile: %v", err)
+	require.NoError(t, err, "Failed to export profile: %v", err)
 	assert.NotNil(t, resp, "The response is missing")
 }
 
@@ -51,7 +51,7 @@ func TestExport_NonPermanentErrorConsumer(t *testing.T) {
 
 	profileClient := makeProfileServiceClient(t, consumertest.NewErr(errors.New("my error")))
 	resp, err := profileClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Unavailable desc = my error")
+	require.EqualError(t, err, "rpc error: code = Unavailable desc = my error")
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, pprofileotlp.ExportResponse{}, resp)
 }
@@ -61,7 +61,7 @@ func TestExport_PermanentErrorConsumer(t *testing.T) {
 
 	profileClient := makeProfileServiceClient(t, consumertest.NewErr(consumererror.NewPermanent(errors.New("my error"))))
 	resp, err := profileClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Internal desc = Permanent error: my error")
+	require.EqualError(t, err, "rpc error: code = Internal desc = Permanent error: my error")
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, pprofileotlp.ExportResponse{}, resp)
 }

--- a/receiver/otlpreceiver/internal/trace/otlp_test.go
+++ b/receiver/otlpreceiver/internal/trace/otlp_test.go
@@ -44,7 +44,7 @@ func TestExport_EmptyRequest(t *testing.T) {
 	traceSink := new(consumertest.TracesSink)
 	traceClient := makeTraceServiceClient(t, traceSink)
 	resp, err := traceClient.Export(context.Background(), ptraceotlp.NewExportRequest())
-	assert.NoError(t, err, "Failed to export trace: %v", err)
+	require.NoError(t, err, "Failed to export trace: %v", err)
 	assert.NotNil(t, resp, "The response is missing")
 }
 
@@ -54,7 +54,7 @@ func TestExport_NonPermanentErrorConsumer(t *testing.T) {
 
 	traceClient := makeTraceServiceClient(t, consumertest.NewErr(errors.New("my error")))
 	resp, err := traceClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Unavailable desc = my error")
+	require.EqualError(t, err, "rpc error: code = Unavailable desc = my error")
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, ptraceotlp.ExportResponse{}, resp)
 }
@@ -64,7 +64,7 @@ func TestExport_PermanentErrorConsumer(t *testing.T) {
 
 	traceClient := makeTraceServiceClient(t, consumertest.NewErr(consumererror.NewPermanent(errors.New("my error"))))
 	resp, err := traceClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Internal desc = Permanent error: my error")
+	require.EqualError(t, err, "rpc error: code = Internal desc = Permanent error: my error")
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, ptraceotlp.ExportResponse{}, resp)
 }

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -134,11 +134,11 @@ func TestJsonHttp(t *testing.T) {
 				respBytes := doHTTPRequest(t, url, tt.encoding, tt.contentType, dr.jsonBytes, tt.expectedStatusCode)
 				if tt.err == nil {
 					tr := ptraceotlp.NewExportResponse()
-					assert.NoError(t, tr.UnmarshalJSON(respBytes), "Unable to unmarshal response to Response")
+					require.NoError(t, tr.UnmarshalJSON(respBytes), "Unable to unmarshal response to Response")
 					sink.checkData(t, dr.data, 1)
 				} else {
 					errStatus := &spb.Status{}
-					assert.NoError(t, json.Unmarshal(respBytes, errStatus))
+					require.NoError(t, json.Unmarshal(respBytes, errStatus))
 					if s, ok := status.FromError(tt.err); ok {
 						assert.True(t, proto.Equal(errStatus, s.Proto()))
 					} else {
@@ -391,11 +391,11 @@ func TestProtoHttp(t *testing.T) {
 				respBytes := doHTTPRequest(t, url, tt.encoding, "application/x-protobuf", dr.protoBytes, tt.expectedStatusCode)
 				if tt.err == nil {
 					tr := ptraceotlp.NewExportResponse()
-					assert.NoError(t, tr.UnmarshalProto(respBytes))
+					require.NoError(t, tr.UnmarshalProto(respBytes))
 					sink.checkData(t, dr.data, 1)
 				} else {
 					errStatus := &spb.Status{}
-					assert.NoError(t, proto.Unmarshal(respBytes, errStatus))
+					require.NoError(t, proto.Unmarshal(respBytes, errStatus))
 					if s, ok := status.FromError(tt.err); ok {
 						assert.True(t, proto.Equal(errStatus, s.Proto()))
 					} else {
@@ -669,10 +669,10 @@ func TestOTLPReceiverHTTPTracesIngestTest(t *testing.T) {
 		if ingestionState.expectedCode == codes.OK {
 			require.Equal(t, 200, resp.StatusCode)
 			tr := ptraceotlp.NewExportResponse()
-			assert.NoError(t, tr.UnmarshalProto(respBytes))
+			require.NoError(t, tr.UnmarshalProto(respBytes))
 		} else {
 			errStatus := &spb.Status{}
-			assert.NoError(t, proto.Unmarshal(respBytes, errStatus))
+			require.NoError(t, proto.Unmarshal(respBytes, errStatus))
 			assert.Equal(t, ingestionState.expectedStatusCode, resp.StatusCode)
 			assert.Equal(t, ingestionState.expectedCode, codes.Code(errStatus.Code))
 		}
@@ -1063,7 +1063,7 @@ func TestShutdown(t *testing.T) {
 	// Now shutdown the receiver, while continuing sending traces to it.
 	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelFn()
-	assert.NoError(t, r.Shutdown(ctx))
+	require.NoError(t, r.Shutdown(ctx))
 
 	// Remember how many spans the sink received. This number should not change after this
 	// point because after Shutdown() returns the component is not allowed to produce

--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -23,9 +24,9 @@ func TestNewFactory(t *testing.T) {
 	assert.EqualValues(t, testType, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 	_, err := factory.CreateTracesReceiver(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = factory.CreateMetricsReceiver(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = factory.CreateLogsReceiver(context.Background(), Settings{}, &defaultCfg, consumertest.NewNop())
 	assert.Error(t, err)
 }
@@ -44,11 +45,11 @@ func TestNewFactoryWithOptions(t *testing.T) {
 
 	assert.Equal(t, component.StabilityLevelDeprecated, factory.TracesReceiverStability())
 	_, err := factory.CreateTracesReceiver(context.Background(), Settings{}, &defaultCfg, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.MetricsReceiverStability())
 	_, err = factory.CreateMetricsReceiver(context.Background(), Settings{}, &defaultCfg, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelStable, factory.LogsReceiverStability())
 	_, err = factory.CreateLogsReceiver(context.Background(), Settings{}, &defaultCfg, nil)
@@ -86,7 +87,7 @@ func TestMakeFactoryMap(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.out, out)
 		})
 	}

--- a/receiver/receiverhelper/obsreport_test.go
+++ b/receiver/receiverhelper/obsreport_test.go
@@ -248,9 +248,9 @@ func TestCheckReceiverTracesViews(t *testing.T) {
 	require.NotNil(t, ctx)
 	rec.EndTracesOp(ctx, format, 7, nil)
 
-	assert.NoError(t, tt.CheckReceiverTraces(transport, 7, 0))
-	assert.Error(t, tt.CheckReceiverTraces(transport, 7, 7))
-	assert.Error(t, tt.CheckReceiverTraces(transport, 0, 0))
+	require.NoError(t, tt.CheckReceiverTraces(transport, 7, 0))
+	require.Error(t, tt.CheckReceiverTraces(transport, 7, 7))
+	require.Error(t, tt.CheckReceiverTraces(transport, 0, 0))
 	assert.Error(t, tt.CheckReceiverTraces(transport, 0, 7))
 }
 
@@ -269,9 +269,9 @@ func TestCheckReceiverMetricsViews(t *testing.T) {
 	require.NotNil(t, ctx)
 	rec.EndMetricsOp(ctx, format, 7, nil)
 
-	assert.NoError(t, tt.CheckReceiverMetrics(transport, 7, 0))
-	assert.Error(t, tt.CheckReceiverMetrics(transport, 7, 7))
-	assert.Error(t, tt.CheckReceiverMetrics(transport, 0, 0))
+	require.NoError(t, tt.CheckReceiverMetrics(transport, 7, 0))
+	require.Error(t, tt.CheckReceiverMetrics(transport, 7, 7))
+	require.Error(t, tt.CheckReceiverMetrics(transport, 0, 0))
 	assert.Error(t, tt.CheckReceiverMetrics(transport, 0, 7))
 }
 
@@ -290,9 +290,9 @@ func TestCheckReceiverLogsViews(t *testing.T) {
 	require.NotNil(t, ctx)
 	rec.EndLogsOp(ctx, format, 7, nil)
 
-	assert.NoError(t, tt.CheckReceiverLogs(transport, 7, 0))
-	assert.Error(t, tt.CheckReceiverLogs(transport, 7, 7))
-	assert.Error(t, tt.CheckReceiverLogs(transport, 0, 0))
+	require.NoError(t, tt.CheckReceiverLogs(transport, 7, 0))
+	require.Error(t, tt.CheckReceiverLogs(transport, 7, 7))
+	require.Error(t, tt.CheckReceiverLogs(transport, 0, 0))
 	assert.Error(t, tt.CheckReceiverLogs(transport, 0, 7))
 }
 

--- a/receiver/receivertest/contract_checker.go
+++ b/receiver/receivertest/contract_checker.go
@@ -193,7 +193,7 @@ func checkConsumeContractScenario(params CheckConsumeContractParams, decisionFun
 	}
 
 	err = receiver.Shutdown(ctx)
-	assert.NoError(params.T, err)
+	require.NoError(params.T, err)
 
 	// Print some stats to help debug test failures.
 	fmt.Printf(

--- a/receiver/scrapererror/scrapeerror_test.go
+++ b/receiver/scrapererror/scrapeerror_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScrapeErrorsAddPartial(t *testing.T) {
@@ -89,10 +90,10 @@ func TestScrapeErrorsCombine(t *testing.T) {
 	for _, tt := range testCases {
 		scrapeErrs := tt.errs()
 		if tt.expectNil {
-			assert.NoError(t, scrapeErrs.Combine())
+			require.NoError(t, scrapeErrs.Combine())
 			continue
 		}
-		assert.EqualError(t, scrapeErrs.Combine(), tt.expectedErr)
+		require.EqualError(t, scrapeErrs.Combine(), tt.expectedErr)
 		if tt.expectedScrape {
 			var partialScrapeErr PartialScrapeError
 			if !errors.As(scrapeErrs.Combine(), &partialScrapeErr) {

--- a/receiver/scraperhelper/obsreport_test.go
+++ b/receiver/scraperhelper/obsreport_test.go
@@ -105,9 +105,9 @@ func TestCheckScraperMetricsViews(t *testing.T) {
 	require.NotNil(t, ctx)
 	s.EndMetricsOp(ctx, 7, nil)
 
-	assert.NoError(t, tt.CheckScraperMetrics(receiverID, scraperID, 7, 0))
-	assert.Error(t, tt.CheckScraperMetrics(receiverID, scraperID, 7, 7))
-	assert.Error(t, tt.CheckScraperMetrics(receiverID, scraperID, 0, 0))
+	require.NoError(t, tt.CheckScraperMetrics(receiverID, scraperID, 7, 0))
+	require.Error(t, tt.CheckScraperMetrics(receiverID, scraperID, 7, 7))
+	require.Error(t, tt.CheckScraperMetrics(receiverID, scraperID, 0, 0))
 	assert.Error(t, tt.CheckScraperMetrics(receiverID, scraperID, 0, 7))
 }
 

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -224,7 +224,7 @@ func configureMetricOptions(t *testing.T, test metricsTestCase, initializeChs []
 		scrapeMetricsChs[i] = make(chan int)
 		tsm := &testScrapeMetrics{ch: scrapeMetricsChs[i], err: test.scrapeErr}
 		scp, err := NewScraper(component.MustNewType("scraper"), tsm.scrape, scraperOptions...)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		metricOptions = append(metricOptions, AddScraper(scp))
 	}
@@ -326,7 +326,7 @@ func TestSingleScrapePerInterval(t *testing.T) {
 	tickerCh := make(chan time.Time)
 
 	scp, err := NewScraper(component.MustNewType("scaper"), tsm.scrape)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	receiver, err := NewScraperControllerReceiver(
 		cfg,
@@ -383,7 +383,7 @@ func TestScrapeControllerStartsOnInit(t *testing.T) {
 
 	assert.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()), "Must not error on start")
 	<-time.After(500 * time.Nanosecond)
-	assert.NoError(t, r.Shutdown(context.Background()), "Must not have errored on shutdown")
+	require.NoError(t, r.Shutdown(context.Background()), "Must not have errored on shutdown")
 	assert.Equal(t, 1, tsm.timesScrapeCalled, "Must have been called as soon as the controller started")
 }
 

--- a/semconv/semconv_test.go
+++ b/semconv/semconv_test.go
@@ -10,6 +10,7 @@ import (
 
 	version "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllSemConvFilesAreCrated(t *testing.T) {
@@ -17,13 +18,13 @@ func TestAllSemConvFilesAreCrated(t *testing.T) {
 	var expectedFiles = []string{"generated_resource.go", "generated_trace.go", "schema.go", "nonstandard.go"}
 
 	files, err := os.ReadDir(".")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	constraints, err := version.NewConstraint("> v1.16.0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	attrgroupconstraints, err := version.NewConstraint("> v1.22.0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, f := range files {
 		if !f.IsDir() {
@@ -31,7 +32,7 @@ func TestAllSemConvFilesAreCrated(t *testing.T) {
 		}
 
 		ver, err := version.NewVersion(f.Name())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		expected := make([]string, len(expectedFiles))
 		copy(expected, expectedFiles)

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -284,7 +284,7 @@ func TestNotifyConfig(t *testing.T) {
 				BuildInfo:  component.NewDefaultBuildInfo(),
 				Extensions: builders.NewExtension(tt.extensionsConfigs, tt.factories),
 			}, tt.serviceExtensions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			errs := extensions.NotifyConfig(context.Background(), confmap.NewFromStringMap(map[string]interface{}{}))
 			assert.Equal(t, tt.want, errs)
 		})
@@ -434,7 +434,7 @@ func TestStatusReportedOnStartupShutdown(t *testing.T) {
 				[]component.ID{compID},
 				WithReporter(rep),
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			rep.Ready()
 

--- a/service/internal/builders/connector_test.go
+++ b/service/internal/builders/connector_test.go
@@ -290,67 +290,67 @@ func TestConnectorBuilderMissingConfig(t *testing.T) {
 	missingID := component.MustNewIDWithName("all", "missing")
 
 	t2t, err := bErr.CreateTracesToTraces(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, t2t)
 
 	t2m, err := bErr.CreateTracesToMetrics(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, t2m)
 
 	t2l, err := bErr.CreateTracesToLogs(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, t2l)
 
 	t2p, err := bErr.CreateTracesToProfiles(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, t2p)
 
 	m2t, err := bErr.CreateMetricsToTraces(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, m2t)
 
 	m2m, err := bErr.CreateMetricsToMetrics(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, m2m)
 
 	m2l, err := bErr.CreateMetricsToLogs(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, m2l)
 
 	m2p, err := bErr.CreateMetricsToProfiles(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, m2p)
 
 	l2t, err := bErr.CreateLogsToTraces(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, l2t)
 
 	l2m, err := bErr.CreateLogsToMetrics(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, l2m)
 
 	l2l, err := bErr.CreateLogsToLogs(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, l2l)
 
 	l2p, err := bErr.CreateLogsToProfiles(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, l2p)
 
 	p2t, err := bErr.CreateProfilesToTraces(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, p2t)
 
 	p2m, err := bErr.CreateProfilesToMetrics(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, p2m)
 
 	p2l, err := bErr.CreateProfilesToLogs(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, p2l)
 
 	p2p, err := bErr.CreateProfilesToProfiles(context.Background(), createConnectorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "connector \"all/missing\" is not configured")
+	require.EqualError(t, err, "connector \"all/missing\" is not configured")
 	assert.Nil(t, p2p)
 }
 

--- a/service/internal/builders/exporter_test.go
+++ b/service/internal/builders/exporter_test.go
@@ -65,37 +65,37 @@ func TestExporterBuilder(t *testing.T) {
 
 			te, err := b.CreateTraces(context.Background(), createExporterSettings(tt.id))
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, te)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopExporterInstance, te)
 			}
 
 			me, err := b.CreateMetrics(context.Background(), createExporterSettings(tt.id))
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, me)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopExporterInstance, me)
 			}
 
 			le, err := b.CreateLogs(context.Background(), createExporterSettings(tt.id))
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, le)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopExporterInstance, le)
 			}
 
 			pe, err := b.CreateProfiles(context.Background(), createExporterSettings(tt.id))
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, pe)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopExporterInstance, pe)
 			}
 		})
@@ -121,19 +121,19 @@ func TestExporterBuilderMissingConfig(t *testing.T) {
 	missingID := component.MustNewIDWithName("all", "missing")
 
 	te, err := bErr.CreateTraces(context.Background(), createExporterSettings(missingID))
-	assert.EqualError(t, err, "exporter \"all/missing\" is not configured")
+	require.EqualError(t, err, "exporter \"all/missing\" is not configured")
 	assert.Nil(t, te)
 
 	me, err := bErr.CreateMetrics(context.Background(), createExporterSettings(missingID))
-	assert.EqualError(t, err, "exporter \"all/missing\" is not configured")
+	require.EqualError(t, err, "exporter \"all/missing\" is not configured")
 	assert.Nil(t, me)
 
 	le, err := bErr.CreateLogs(context.Background(), createExporterSettings(missingID))
-	assert.EqualError(t, err, "exporter \"all/missing\" is not configured")
+	require.EqualError(t, err, "exporter \"all/missing\" is not configured")
 	assert.Nil(t, le)
 
 	pe, err := bErr.CreateProfiles(context.Background(), createExporterSettings(missingID))
-	assert.EqualError(t, err, "exporter \"all/missing\" is not configured")
+	require.EqualError(t, err, "exporter \"all/missing\" is not configured")
 	assert.Nil(t, pe)
 }
 

--- a/service/internal/builders/extension_test.go
+++ b/service/internal/builders/extension_test.go
@@ -37,7 +37,7 @@ func TestExtensionBuilder(t *testing.T) {
 	b := NewExtension(cfgs, factories)
 
 	e, err := b.Create(context.Background(), createExtensionSettings(testID))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, e)
 
 	// Check that the extension has access to the resource attributes.
@@ -46,11 +46,11 @@ func TestExtensionBuilder(t *testing.T) {
 	assert.Equal(t, 0, nop.Settings.Resource.Attributes().Len())
 
 	missingType, err := b.Create(context.Background(), createExtensionSettings(unknownID))
-	assert.EqualError(t, err, "extension factory not available for: \"unknown\"")
+	require.EqualError(t, err, "extension factory not available for: \"unknown\"")
 	assert.Nil(t, missingType)
 
 	missingCfg, err := b.Create(context.Background(), createExtensionSettings(component.NewIDWithName(testType, "foo")))
-	assert.EqualError(t, err, "extension \"test/foo\" is not configured")
+	require.EqualError(t, err, "extension \"test/foo\" is not configured")
 	assert.Nil(t, missingCfg)
 }
 

--- a/service/internal/builders/processor_test.go
+++ b/service/internal/builders/processor_test.go
@@ -96,37 +96,37 @@ func TestProcessorBuilder(t *testing.T) {
 
 			te, err := b.CreateTraces(context.Background(), createProcessorSettings(tt.id), tt.nextTraces)
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, te)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopProcessorInstance, te)
 			}
 
 			me, err := b.CreateMetrics(context.Background(), createProcessorSettings(tt.id), tt.nextMetrics)
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, me)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopProcessorInstance, me)
 			}
 
 			le, err := b.CreateLogs(context.Background(), createProcessorSettings(tt.id), tt.nextLogs)
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, le)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopProcessorInstance, le)
 			}
 
 			pe, err := b.CreateProfiles(context.Background(), createProcessorSettings(tt.id), tt.nextProfiles)
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, pe)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopProcessorInstance, pe)
 			}
 		})
@@ -152,19 +152,19 @@ func TestProcessorBuilderMissingConfig(t *testing.T) {
 	missingID := component.MustNewIDWithName("all", "missing")
 
 	te, err := bErr.CreateTraces(context.Background(), createProcessorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "processor \"all/missing\" is not configured")
+	require.EqualError(t, err, "processor \"all/missing\" is not configured")
 	assert.Nil(t, te)
 
 	me, err := bErr.CreateMetrics(context.Background(), createProcessorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "processor \"all/missing\" is not configured")
+	require.EqualError(t, err, "processor \"all/missing\" is not configured")
 	assert.Nil(t, me)
 
 	le, err := bErr.CreateLogs(context.Background(), createProcessorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "processor \"all/missing\" is not configured")
+	require.EqualError(t, err, "processor \"all/missing\" is not configured")
 	assert.Nil(t, le)
 
 	pe, err := bErr.CreateProfiles(context.Background(), createProcessorSettings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "processor \"all/missing\" is not configured")
+	require.EqualError(t, err, "processor \"all/missing\" is not configured")
 	assert.Nil(t, pe)
 }
 

--- a/service/internal/builders/receiver_test.go
+++ b/service/internal/builders/receiver_test.go
@@ -96,37 +96,37 @@ func TestReceiverBuilder(t *testing.T) {
 
 			te, err := b.CreateTraces(context.Background(), settings(tt.id), tt.nextTraces)
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, te)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopReceiverInstance, te)
 			}
 
 			me, err := b.CreateMetrics(context.Background(), settings(tt.id), tt.nextMetrics)
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, me)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopReceiverInstance, me)
 			}
 
 			le, err := b.CreateLogs(context.Background(), settings(tt.id), tt.nextLogs)
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, le)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopReceiverInstance, le)
 			}
 
 			pe, err := b.CreateProfiles(context.Background(), settings(tt.id), tt.nextProfiles)
 			if tt.err != "" {
-				assert.EqualError(t, err, tt.err)
+				require.EqualError(t, err, tt.err)
 				assert.Nil(t, pe)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, nopReceiverInstance, pe)
 			}
 		})
@@ -152,19 +152,19 @@ func TestReceiverBuilderMissingConfig(t *testing.T) {
 	missingID := component.MustNewIDWithName("all", "missing")
 
 	te, err := bErr.CreateTraces(context.Background(), settings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "receiver \"all/missing\" is not configured")
+	require.EqualError(t, err, "receiver \"all/missing\" is not configured")
 	assert.Nil(t, te)
 
 	me, err := bErr.CreateMetrics(context.Background(), settings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "receiver \"all/missing\" is not configured")
+	require.EqualError(t, err, "receiver \"all/missing\" is not configured")
 	assert.Nil(t, me)
 
 	le, err := bErr.CreateLogs(context.Background(), settings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "receiver \"all/missing\" is not configured")
+	require.EqualError(t, err, "receiver \"all/missing\" is not configured")
 	assert.Nil(t, le)
 
 	pe, err := bErr.CreateProfiles(context.Background(), settings(missingID), consumertest.NewNop())
-	assert.EqualError(t, err, "receiver \"all/missing\" is not configured")
+	require.EqualError(t, err, "receiver \"all/missing\" is not configured")
 	assert.Nil(t, pe)
 }
 

--- a/service/internal/capabilityconsumer/capabilities_test.go
+++ b/service/internal/capabilityconsumer/capabilities_test.go
@@ -25,7 +25,7 @@ func TestLogs(t *testing.T) {
 	wrap := NewLogs(sink, consumer.Capabilities{MutatesData: true})
 	assert.Equal(t, consumer.Capabilities{MutatesData: true}, wrap.Capabilities())
 
-	assert.NoError(t, wrap.ConsumeLogs(context.Background(), testdata.GenerateLogs(1)))
+	require.NoError(t, wrap.ConsumeLogs(context.Background(), testdata.GenerateLogs(1)))
 	assert.Len(t, sink.AllLogs(), 1)
 	assert.Equal(t, testdata.GenerateLogs(1), sink.AllLogs()[0])
 }
@@ -40,7 +40,7 @@ func TestMetrics(t *testing.T) {
 	wrap := NewMetrics(sink, consumer.Capabilities{MutatesData: true})
 	assert.Equal(t, consumer.Capabilities{MutatesData: true}, wrap.Capabilities())
 
-	assert.NoError(t, wrap.ConsumeMetrics(context.Background(), testdata.GenerateMetrics(1)))
+	require.NoError(t, wrap.ConsumeMetrics(context.Background(), testdata.GenerateMetrics(1)))
 	assert.Len(t, sink.AllMetrics(), 1)
 	assert.Equal(t, testdata.GenerateMetrics(1), sink.AllMetrics()[0])
 }
@@ -55,7 +55,7 @@ func TestTraces(t *testing.T) {
 	wrap := NewTraces(sink, consumer.Capabilities{MutatesData: true})
 	assert.Equal(t, consumer.Capabilities{MutatesData: true}, wrap.Capabilities())
 
-	assert.NoError(t, wrap.ConsumeTraces(context.Background(), testdata.GenerateTraces(1)))
+	require.NoError(t, wrap.ConsumeTraces(context.Background(), testdata.GenerateTraces(1)))
 	assert.Len(t, sink.AllTraces(), 1)
 	assert.Equal(t, testdata.GenerateTraces(1), sink.AllTraces()[0])
 }
@@ -70,7 +70,7 @@ func TestProfiles(t *testing.T) {
 	wrap := NewProfiles(sink, consumer.Capabilities{MutatesData: true})
 	assert.Equal(t, consumer.Capabilities{MutatesData: true}, wrap.Capabilities())
 
-	assert.NoError(t, wrap.ConsumeProfiles(context.Background(), testdata.GenerateProfiles(1)))
+	require.NoError(t, wrap.ConsumeProfiles(context.Background(), testdata.GenerateProfiles(1)))
 	assert.Len(t, sink.AllProfiles(), 1)
 	assert.Equal(t, testdata.GenerateProfiles(1), sink.AllProfiles()[0])
 }

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -197,11 +197,11 @@ func TestGraphStartStopCycle(t *testing.T) {
 	pg.componentGraph.SetEdge(simple.Edge{F: c1, T: p1}) // loop back
 
 	err := pg.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), `topo: no topological ordering: cyclic components`)
 
 	err = pg.ShutdownAll(context.Background(), statustest.NewNopStatusReporter())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), `topo: no topological ordering: cyclic components`)
 }
 
@@ -224,7 +224,7 @@ func TestGraphStartStopComponentError(t *testing.T) {
 		F: r1,
 		T: e1,
 	})
-	assert.EqualError(t, pg.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}), "foo")
+	require.EqualError(t, pg.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}), "foo")
 	assert.EqualError(t, pg.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()), "bar")
 }
 
@@ -986,7 +986,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 
 			assert.Equal(t, len(tt.pipelineConfigs), len(pg.pipelines))
 
-			assert.NoError(t, pg.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
+			require.NoError(t, pg.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
 
 			mutatingPipelines := make(map[component.ID]bool, len(tt.pipelineConfigs))
 
@@ -1103,23 +1103,23 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 			allReceivers := pg.getReceivers()
 			for _, c := range allReceivers[component.DataTypeTraces] {
 				tracesReceiver := c.(*testcomponents.ExampleReceiver)
-				assert.NoError(t, tracesReceiver.ConsumeTraces(context.Background(), testdata.GenerateTraces(1)))
+				require.NoError(t, tracesReceiver.ConsumeTraces(context.Background(), testdata.GenerateTraces(1)))
 			}
 			for _, c := range allReceivers[component.DataTypeMetrics] {
 				metricsReceiver := c.(*testcomponents.ExampleReceiver)
-				assert.NoError(t, metricsReceiver.ConsumeMetrics(context.Background(), testdata.GenerateMetrics(1)))
+				require.NoError(t, metricsReceiver.ConsumeMetrics(context.Background(), testdata.GenerateMetrics(1)))
 			}
 			for _, c := range allReceivers[component.DataTypeLogs] {
 				logsReceiver := c.(*testcomponents.ExampleReceiver)
-				assert.NoError(t, logsReceiver.ConsumeLogs(context.Background(), testdata.GenerateLogs(1)))
+				require.NoError(t, logsReceiver.ConsumeLogs(context.Background(), testdata.GenerateLogs(1)))
 			}
 			for _, c := range allReceivers[componentprofiles.DataTypeProfiles] {
 				profilesReceiver := c.(*testcomponents.ExampleReceiver)
-				assert.NoError(t, profilesReceiver.ConsumeProfiles(context.Background(), testdata.GenerateProfiles(1)))
+				require.NoError(t, profilesReceiver.ConsumeProfiles(context.Background(), testdata.GenerateProfiles(1)))
 			}
 
 			// Shut down the entire component graph
-			assert.NoError(t, pg.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
+			require.NoError(t, pg.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 
 			// Check each pipeline individually, ensuring that all components are stopped.
 			for pipelineID := range tt.pipelineConfigs {
@@ -1380,12 +1380,12 @@ func TestConnectorRouter(t *testing.T) {
 	tracesLeft := allExporters[component.DataTypeTraces][expLeftID].(*testcomponents.ExampleExporter)
 
 	// Consume 1, validate it went right
-	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
+	require.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
 	assert.Len(t, tracesRight.Traces, 1)
 	assert.Empty(t, tracesLeft.Traces)
 
 	// Consume 1, validate it went left
-	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
+	require.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
 	assert.Len(t, tracesRight.Traces, 1)
 	assert.Len(t, tracesLeft.Traces, 1)
 
@@ -1402,12 +1402,12 @@ func TestConnectorRouter(t *testing.T) {
 	metricsLeft := allExporters[component.DataTypeMetrics][expLeftID].(*testcomponents.ExampleExporter)
 
 	// Consume 1, validate it went right
-	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
+	require.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
 	assert.Len(t, metricsRight.Metrics, 1)
 	assert.Empty(t, metricsLeft.Metrics)
 
 	// Consume 1, validate it went left
-	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
+	require.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
 	assert.Len(t, metricsRight.Metrics, 1)
 	assert.Len(t, metricsLeft.Metrics, 1)
 
@@ -1424,12 +1424,12 @@ func TestConnectorRouter(t *testing.T) {
 	logsLeft := allExporters[component.DataTypeLogs][expLeftID].(*testcomponents.ExampleExporter)
 
 	// Consume 1, validate it went right
-	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
+	require.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
 	assert.Len(t, logsRight.Logs, 1)
 	assert.Empty(t, logsLeft.Logs)
 
 	// Consume 1, validate it went left
-	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
+	require.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
 	assert.Len(t, logsRight.Logs, 1)
 	assert.Len(t, logsLeft.Logs, 1)
 
@@ -1446,12 +1446,12 @@ func TestConnectorRouter(t *testing.T) {
 	profilesLeft := allExporters[componentprofiles.DataTypeProfiles][expLeftID].(*testcomponents.ExampleExporter)
 
 	// Consume 1, validate it went right
-	assert.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
+	require.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
 	assert.Len(t, profilesRight.Profiles, 1)
 	assert.Empty(t, profilesLeft.Profiles)
 
 	// Consume 1, validate it went left
-	assert.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
+	require.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
 	assert.Len(t, profilesRight.Profiles, 1)
 	assert.Len(t, profilesLeft.Profiles, 1)
 
@@ -2730,8 +2730,8 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 				},
 			}
 			pipelines, err := Build(context.Background(), set)
-			assert.NoError(t, err)
-			assert.Error(t, pipelines.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
+			require.NoError(t, err)
+			require.Error(t, pipelines.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
 			assert.Error(t, pipelines.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 		})
 
@@ -2744,8 +2744,8 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 				},
 			}
 			pipelines, err := Build(context.Background(), set)
-			assert.NoError(t, err)
-			assert.Error(t, pipelines.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
+			require.NoError(t, err)
+			require.Error(t, pipelines.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
 			assert.Error(t, pipelines.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 		})
 
@@ -2758,8 +2758,8 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 				},
 			}
 			pipelines, err := Build(context.Background(), set)
-			assert.NoError(t, err)
-			assert.Error(t, pipelines.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
+			require.NoError(t, err)
+			require.Error(t, pipelines.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
 			assert.Error(t, pipelines.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 		})
 
@@ -2778,8 +2778,8 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 					},
 				}
 				pipelines, err := Build(context.Background(), set)
-				assert.NoError(t, err)
-				assert.Error(t, pipelines.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
+				require.NoError(t, err)
+				require.Error(t, pipelines.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})}))
 				assert.Error(t, pipelines.ShutdownAll(context.Background(), statustest.NewNopStatusReporter()))
 			})
 		}

--- a/service/internal/resource/config_test.go
+++ b/service/internal/resource/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 
 	"go.opentelemetry.io/collector/component"
@@ -92,7 +93,7 @@ func TestNew(t *testing.T) {
 
 				// Check that the value is a valid UUID.
 				_, err := uuid.Parse(got["service.instance.id"])
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				// Remove so that we can compare the rest of the map.
 				delete(got, "service.instance.id")

--- a/service/internal/testcomponents/example_connector_test.go
+++ b/service/internal/testcomponents/example_connector_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 )
@@ -16,10 +17,10 @@ func TestExampleConnector(t *testing.T) {
 	conn := &ExampleConnector{}
 	host := componenttest.NewNopHost()
 	assert.False(t, conn.Started())
-	assert.NoError(t, conn.Start(context.Background(), host))
+	require.NoError(t, conn.Start(context.Background(), host))
 	assert.True(t, conn.Started())
 
 	assert.False(t, conn.Stopped())
-	assert.NoError(t, conn.Shutdown(context.Background()))
+	require.NoError(t, conn.Shutdown(context.Background()))
 	assert.True(t, conn.Stopped())
 }

--- a/service/internal/testcomponents/example_exporter_test.go
+++ b/service/internal/testcomponents/example_exporter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -20,26 +21,26 @@ func TestExampleExporter(t *testing.T) {
 	exp := &ExampleExporter{}
 	host := componenttest.NewNopHost()
 	assert.False(t, exp.Started())
-	assert.NoError(t, exp.Start(context.Background(), host))
+	require.NoError(t, exp.Start(context.Background(), host))
 	assert.True(t, exp.Started())
 
 	assert.Empty(t, exp.Traces)
-	assert.NoError(t, exp.ConsumeTraces(context.Background(), ptrace.Traces{}))
+	require.NoError(t, exp.ConsumeTraces(context.Background(), ptrace.Traces{}))
 	assert.Len(t, exp.Traces, 1)
 
 	assert.Empty(t, exp.Metrics)
-	assert.NoError(t, exp.ConsumeMetrics(context.Background(), pmetric.Metrics{}))
+	require.NoError(t, exp.ConsumeMetrics(context.Background(), pmetric.Metrics{}))
 	assert.Len(t, exp.Metrics, 1)
 
 	assert.Empty(t, exp.Logs)
-	assert.NoError(t, exp.ConsumeLogs(context.Background(), plog.Logs{}))
+	require.NoError(t, exp.ConsumeLogs(context.Background(), plog.Logs{}))
 	assert.Len(t, exp.Logs, 1)
 
 	assert.Empty(t, exp.Profiles)
-	assert.NoError(t, exp.ConsumeProfiles(context.Background(), pprofile.Profiles{}))
+	require.NoError(t, exp.ConsumeProfiles(context.Background(), pprofile.Profiles{}))
 	assert.Len(t, exp.Profiles, 1)
 
 	assert.False(t, exp.Stopped())
-	assert.NoError(t, exp.Shutdown(context.Background()))
+	require.NoError(t, exp.Shutdown(context.Background()))
 	assert.True(t, exp.Stopped())
 }

--- a/service/internal/testcomponents/example_processor_test.go
+++ b/service/internal/testcomponents/example_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 )
@@ -16,10 +17,10 @@ func TestExampleProcessor(t *testing.T) {
 	prc := &ExampleProcessor{}
 	host := componenttest.NewNopHost()
 	assert.False(t, prc.Started())
-	assert.NoError(t, prc.Start(context.Background(), host))
+	require.NoError(t, prc.Start(context.Background(), host))
 	assert.True(t, prc.Started())
 
 	assert.False(t, prc.Stopped())
-	assert.NoError(t, prc.Shutdown(context.Background()))
+	require.NoError(t, prc.Shutdown(context.Background()))
 	assert.True(t, prc.Stopped())
 }

--- a/service/internal/testcomponents/example_receiver_test.go
+++ b/service/internal/testcomponents/example_receiver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 )
@@ -16,10 +17,10 @@ func TestExampleReceiver(t *testing.T) {
 	rcv := &ExampleReceiver{}
 	host := componenttest.NewNopHost()
 	assert.False(t, rcv.Started())
-	assert.NoError(t, rcv.Start(context.Background(), host))
+	require.NoError(t, rcv.Start(context.Background(), host))
 	assert.True(t, rcv.Started())
 
 	assert.False(t, rcv.Stopped())
-	assert.NoError(t, rcv.Shutdown(context.Background()))
+	require.NoError(t, rcv.Shutdown(context.Background()))
 	assert.True(t, rcv.Stopped())
 }

--- a/service/internal/testcomponents/example_router_test.go
+++ b/service/internal/testcomponents/example_router_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -24,11 +25,11 @@ func TestExampleRouter(t *testing.T) {
 	conn := &ExampleRouter{}
 	host := componenttest.NewNopHost()
 	assert.False(t, conn.Started())
-	assert.NoError(t, conn.Start(context.Background(), host))
+	require.NoError(t, conn.Start(context.Background(), host))
 	assert.True(t, conn.Started())
 
 	assert.False(t, conn.Stopped())
-	assert.NoError(t, conn.Shutdown(context.Background()))
+	require.NoError(t, conn.Shutdown(context.Background()))
 	assert.True(t, conn.Stopped())
 }
 
@@ -51,16 +52,16 @@ func TestTracesRouter(t *testing.T) {
 	cfg := ExampleRouterConfig{Traces: &LeftRightConfig{Left: leftID, Right: rightID}}
 	tr, err := ExampleRouterFactory.CreateTracesToTraces(
 		context.Background(), connectortest.NewNopSettings(), cfg, router)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, tr.Capabilities().MutatesData)
 
 	td := testdata.GenerateTraces(1)
 
-	assert.NoError(t, tr.ConsumeTraces(context.Background(), td))
+	require.NoError(t, tr.ConsumeTraces(context.Background(), td))
 	assert.Len(t, sinkRight.AllTraces(), 1)
 	assert.Empty(t, sinkLeft.AllTraces())
 
-	assert.NoError(t, tr.ConsumeTraces(context.Background(), td))
+	require.NoError(t, tr.ConsumeTraces(context.Background(), td))
 	assert.Len(t, sinkRight.AllTraces(), 1)
 	assert.Len(t, sinkLeft.AllTraces(), 1)
 
@@ -90,16 +91,16 @@ func TestMetricsRouter(t *testing.T) {
 	cfg := ExampleRouterConfig{Metrics: &LeftRightConfig{Left: leftID, Right: rightID}}
 	mr, err := ExampleRouterFactory.CreateMetricsToMetrics(
 		context.Background(), connectortest.NewNopSettings(), cfg, router)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mr.Capabilities().MutatesData)
 
 	md := testdata.GenerateMetrics(1)
 
-	assert.NoError(t, mr.ConsumeMetrics(context.Background(), md))
+	require.NoError(t, mr.ConsumeMetrics(context.Background(), md))
 	assert.Len(t, sinkRight.AllMetrics(), 1)
 	assert.Empty(t, sinkLeft.AllMetrics())
 
-	assert.NoError(t, mr.ConsumeMetrics(context.Background(), md))
+	require.NoError(t, mr.ConsumeMetrics(context.Background(), md))
 	assert.Len(t, sinkRight.AllMetrics(), 1)
 	assert.Len(t, sinkLeft.AllMetrics(), 1)
 
@@ -129,16 +130,16 @@ func TestLogsRouter(t *testing.T) {
 	cfg := ExampleRouterConfig{Logs: &LeftRightConfig{Left: leftID, Right: rightID}}
 	lr, err := ExampleRouterFactory.CreateLogsToLogs(
 		context.Background(), connectortest.NewNopSettings(), cfg, router)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, lr.Capabilities().MutatesData)
 
 	ld := testdata.GenerateLogs(1)
 
-	assert.NoError(t, lr.ConsumeLogs(context.Background(), ld))
+	require.NoError(t, lr.ConsumeLogs(context.Background(), ld))
 	assert.Len(t, sinkRight.AllLogs(), 1)
 	assert.Empty(t, sinkLeft.AllLogs())
 
-	assert.NoError(t, lr.ConsumeLogs(context.Background(), ld))
+	require.NoError(t, lr.ConsumeLogs(context.Background(), ld))
 	assert.Len(t, sinkRight.AllLogs(), 1)
 	assert.Len(t, sinkLeft.AllLogs(), 1)
 
@@ -168,16 +169,16 @@ func TestProfilesRouter(t *testing.T) {
 	cfg := ExampleRouterConfig{Profiles: &LeftRightConfig{Left: leftID, Right: rightID}}
 	tr, err := ExampleRouterFactory.CreateProfilesToProfiles(
 		context.Background(), connectortest.NewNopSettings(), cfg, router)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, tr.Capabilities().MutatesData)
 
 	td := testdata.GenerateProfiles(1)
 
-	assert.NoError(t, tr.ConsumeProfiles(context.Background(), td))
+	require.NoError(t, tr.ConsumeProfiles(context.Background(), td))
 	assert.Len(t, sinkRight.AllProfiles(), 1)
 	assert.Empty(t, sinkLeft.AllProfiles())
 
-	assert.NoError(t, tr.ConsumeProfiles(context.Background(), td))
+	require.NoError(t, tr.ConsumeProfiles(context.Background(), td))
 	assert.Len(t, sinkRight.AllProfiles(), 1)
 	assert.Len(t, sinkLeft.AllProfiles(), 1)
 

--- a/service/internal/zpages/templates_test.go
+++ b/service/internal/zpages/templates_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const tmplBody = `
@@ -36,7 +37,7 @@ func TestTemplateFuncs(t *testing.T) {
 		Index:   32,
 		Element: [2]string{"key", "value"},
 	}
-	assert.NoError(t, tmpl.Execute(buf, input))
+	require.NoError(t, tmpl.Execute(buf, input))
 	assert.EqualValues(t, want, buf.String())
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -628,9 +628,7 @@ func assertZPages(t *testing.T, zpagesAddr string) {
 	testZPagePathFn := func(t *testing.T, path string) {
 		client := &http.Client{}
 		resp, err := client.Get("http://" + zpagesAddr + path)
-		if !assert.NoError(t, err, "error retrieving zpage at %q", path) {
-			return
-		}
+		require.NoError(t, err, "error retrieving zpage at %q", path)
 		assert.Equal(t, http.StatusOK, resp.StatusCode, "unsuccessful zpage %q GET", path)
 		assert.NoError(t, resp.Body.Close())
 	}

--- a/service/telemetry/internal/otelinit/config_test.go
+++ b/service/telemetry/internal/otelinit/config_test.go
@@ -534,7 +534,7 @@ func TestMetricReader(t *testing.T) {
 
 			defer func() {
 				if gotReader != nil {
-					assert.NoError(t, gotReader.Shutdown(context.Background()))
+					require.NoError(t, gotReader.Shutdown(context.Background()))
 				}
 				if server != nil {
 					assert.NoError(t, server.Shutdown(context.Background()))

--- a/service/telemetry/telemetry_test.go
+++ b/service/telemetry/telemetry_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -56,10 +57,10 @@ func TestTelemetryConfiguration(t *testing.T) {
 			set := Settings{ZapOptions: []zap.Option{}}
 			logger, err := f.CreateLogger(context.Background(), set, tt.cfg)
 			if tt.success {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, logger)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, logger)
 			}
 		})
@@ -114,7 +115,7 @@ func TestSampledLogger(t *testing.T) {
 			ctx := context.Background()
 			set := Settings{ZapOptions: []zap.Option{}}
 			logger, err := f.CreateLogger(ctx, set, tt.cfg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, logger)
 		})
 	}


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [require-error](https://github.com/Antonboom/testifylint?tab=readme-ov-file#require-error) rule from [testifylint](https://github.com/Antonboom/testifylint)