### PR TITLE
[processorhelper] deprecated accepted/refused/dropped metrics

### DIFF
--- a/.chloggen/codeboten_deprecate-metrics.yaml
+++ b/.chloggen/codeboten_deprecate-metrics.yaml
@@ -1,0 +1,36 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: processorhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: deprecate accepted/refused/dropped metrics
+
+# One or more tracking issues or pull requests related to the change
+issues: [11201]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The following metrics are being deprecated as they were only used in a single
+  processor:
+    - `otelcol_processor_accepted_log_records`
+    - `otelcol_processor_accepted_metric_points`
+    - `otelcol_processor_accepted_spans`
+    - `otelcol_processor_dropped_log_records`
+    - `otelcol_processor_dropped_metric_points`
+    - `otelcol_processor_dropped_spans`
+    - `otelcol_processor_refused_log_records`
+    - `otelcol_processor_refused_metric_points`
+    - `otelcol_processor_refused_spans`
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/memorylimiterprocessor/memorylimiter.go
+++ b/processor/memorylimiterprocessor/memorylimiter.go
@@ -58,12 +58,14 @@ func (p *memoryLimiterProcessor) processTraces(ctx context.Context, td ptrace.Tr
 		// 	to a receiver (ie.: a receiver is on the call stack). For now it
 		// 	assumes that the pipeline is properly configured and a receiver is on the
 		// 	callstack and that the receiver will correctly retry the refused data again.
+		// nolint SA1019
 		p.obsrep.TracesRefused(ctx, numSpans)
 		return td, memorylimiter.ErrDataRefused
 	}
 
 	// Even if the next consumer returns error record the data as accepted by
 	// this processor.
+	// nolint SA1019
 	p.obsrep.TracesAccepted(ctx, numSpans)
 	return td, nil
 }
@@ -76,12 +78,14 @@ func (p *memoryLimiterProcessor) processMetrics(ctx context.Context, md pmetric.
 		// 	to a receiver (ie.: a receiver is on the call stack). For now it
 		// 	assumes that the pipeline is properly configured and a receiver is on the
 		// 	callstack.
+		// nolint SA1019
 		p.obsrep.MetricsRefused(ctx, numDataPoints)
 		return md, memorylimiter.ErrDataRefused
 	}
 
 	// Even if the next consumer returns error record the data as accepted by
 	// this processor.
+	// nolint SA1019
 	p.obsrep.MetricsAccepted(ctx, numDataPoints)
 	return md, nil
 }
@@ -94,12 +98,14 @@ func (p *memoryLimiterProcessor) processLogs(ctx context.Context, ld plog.Logs) 
 		// 	to a receiver (ie.: a receiver is on the call stack). For now it
 		// 	assumes that the pipeline is properly configured and a receiver is on the
 		// 	callstack.
+		// nolint SA1019
 		p.obsrep.LogsRefused(ctx, numRecords)
 		return ld, memorylimiter.ErrDataRefused
 	}
 
 	// Even if the next consumer returns error record the data as accepted by
 	// this processor.
+	// nolint SA1019
 	p.obsrep.LogsAccepted(ctx, numRecords)
 	return ld, nil
 }

--- a/processor/processorhelper/documentation.md
+++ b/processor/processorhelper/documentation.md
@@ -8,7 +8,7 @@ The following telemetry is emitted by this component.
 
 ### otelcol_processor_accepted_log_records
 
-Number of log records successfully pushed into the next component in the pipeline.
+Number of log records successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -16,7 +16,7 @@ Number of log records successfully pushed into the next component in the pipelin
 
 ### otelcol_processor_accepted_metric_points
 
-Number of metric points successfully pushed into the next component in the pipeline.
+Number of metric points successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -24,7 +24,7 @@ Number of metric points successfully pushed into the next component in the pipel
 
 ### otelcol_processor_accepted_spans
 
-Number of spans successfully pushed into the next component in the pipeline.
+Number of spans successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -32,7 +32,7 @@ Number of spans successfully pushed into the next component in the pipeline.
 
 ### otelcol_processor_dropped_log_records
 
-Number of log records that were dropped.
+Number of log records that were dropped. [deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -40,7 +40,7 @@ Number of log records that were dropped.
 
 ### otelcol_processor_dropped_metric_points
 
-Number of metric points that were dropped.
+Number of metric points that were dropped. [deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -48,7 +48,7 @@ Number of metric points that were dropped.
 
 ### otelcol_processor_dropped_spans
 
-Number of spans that were dropped.
+Number of spans that were dropped. [deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -72,7 +72,7 @@ Number of items emitted from the processor. [alpha]
 
 ### otelcol_processor_refused_log_records
 
-Number of log records that were rejected by the next component in the pipeline.
+Number of log records that were rejected by the next component in the pipeline. [deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -80,7 +80,7 @@ Number of log records that were rejected by the next component in the pipeline.
 
 ### otelcol_processor_refused_metric_points
 
-Number of metric points that were rejected by the next component in the pipeline.
+Number of metric points that were rejected by the next component in the pipeline. [deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -88,7 +88,7 @@ Number of metric points that were rejected by the next component in the pipeline
 
 ### otelcol_processor_refused_spans
 
-Number of spans that were rejected by the next component in the pipeline.
+Number of spans that were rejected by the next component in the pipeline. [deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |

--- a/processor/processorhelper/internal/metadata/generated_telemetry.go
+++ b/processor/processorhelper/internal/metadata/generated_telemetry.go
@@ -65,37 +65,37 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.ProcessorAcceptedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_accepted_log_records",
-		metric.WithDescription("Number of log records successfully pushed into the next component in the pipeline."),
+		metric.WithDescription("Number of log records successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorAcceptedMetricPoints, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_accepted_metric_points",
-		metric.WithDescription("Number of metric points successfully pushed into the next component in the pipeline."),
+		metric.WithDescription("Number of metric points successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorAcceptedSpans, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_accepted_spans",
-		metric.WithDescription("Number of spans successfully pushed into the next component in the pipeline."),
+		metric.WithDescription("Number of spans successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorDroppedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_dropped_log_records",
-		metric.WithDescription("Number of log records that were dropped."),
+		metric.WithDescription("Number of log records that were dropped. [deprecated since v0.110.0]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorDroppedMetricPoints, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_dropped_metric_points",
-		metric.WithDescription("Number of metric points that were dropped."),
+		metric.WithDescription("Number of metric points that were dropped. [deprecated since v0.110.0]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorDroppedSpans, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_dropped_spans",
-		metric.WithDescription("Number of spans that were dropped."),
+		metric.WithDescription("Number of spans that were dropped. [deprecated since v0.110.0]"),
 		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
@@ -113,19 +113,19 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_refused_log_records",
-		metric.WithDescription("Number of log records that were rejected by the next component in the pipeline."),
+		metric.WithDescription("Number of log records that were rejected by the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedMetricPoints, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_refused_metric_points",
-		metric.WithDescription("Number of metric points that were rejected by the next component in the pipeline."),
+		metric.WithDescription("Number of metric points that were rejected by the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedSpans, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_refused_spans",
-		metric.WithDescription("Number of spans that were rejected by the next component in the pipeline."),
+		metric.WithDescription("Number of spans that were rejected by the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)

--- a/processor/processorhelper/metadata.yaml
+++ b/processor/processorhelper/metadata.yaml
@@ -33,6 +33,9 @@ telemetry:
     processor_accepted_spans:
       enabled: true
       description: Number of spans successfully pushed into the next component in the pipeline.
+      stability:
+        level: deprecated
+        from: v0.110.0
       unit: "{spans}"
       sum:
         value_type: int
@@ -41,6 +44,9 @@ telemetry:
     processor_refused_spans:
       enabled: true
       description: Number of spans that were rejected by the next component in the pipeline.
+      stability:
+        level: deprecated
+        from: v0.110.0
       unit: "{spans}"
       sum:
         value_type: int
@@ -49,6 +55,9 @@ telemetry:
     processor_dropped_spans:
       enabled: true
       description: Number of spans that were dropped.
+      stability:
+        level: deprecated
+        from: v0.110.0
       unit: "{spans}"
       sum:
         value_type: int
@@ -57,6 +66,9 @@ telemetry:
     processor_accepted_metric_points:
       enabled: true
       description: Number of metric points successfully pushed into the next component in the pipeline.
+      stability:
+        level: deprecated
+        from: v0.110.0
       unit: "{datapoints}"
       sum:
         value_type: int
@@ -65,6 +77,9 @@ telemetry:
     processor_refused_metric_points:
       enabled: true
       description: Number of metric points that were rejected by the next component in the pipeline.
+      stability:
+        level: deprecated
+        from: v0.110.0
       unit: "{datapoints}"
       sum:
         value_type: int
@@ -73,6 +88,9 @@ telemetry:
     processor_dropped_metric_points:
       enabled: true
       description: Number of metric points that were dropped.
+      stability:
+        level: deprecated
+        from: v0.110.0
       unit: "{datapoints}"
       sum:
         value_type: int
@@ -81,6 +99,9 @@ telemetry:
     processor_accepted_log_records:
       enabled: true
       description: Number of log records successfully pushed into the next component in the pipeline.
+      stability:
+        level: deprecated
+        from: v0.110.0
       unit: "{records}"
       sum:
         value_type: int
@@ -89,6 +110,9 @@ telemetry:
     processor_refused_log_records:
       enabled: true
       description: Number of log records that were rejected by the next component in the pipeline.
+      stability:
+        level: deprecated
+        from: v0.110.0
       unit: "{records}"
       sum:
         value_type: int
@@ -97,6 +121,9 @@ telemetry:
     processor_dropped_log_records:
       enabled: true
       description: Number of log records that were dropped.
+      stability:
+        level: deprecated
+        from: v0.110.0
       unit: "{records}"
       sum:
         value_type: int

--- a/processor/processorhelper/obsreport.go
+++ b/processor/processorhelper/obsreport.go
@@ -88,46 +88,64 @@ func (or *ObsReport) recordData(ctx context.Context, dataType component.DataType
 }
 
 // TracesAccepted reports that the trace data was accepted.
+//
+// Deprecated: [v0.110.0] Processor helper automatically calculates incoming/outgoing metrics only.
 func (or *ObsReport) TracesAccepted(ctx context.Context, numSpans int) {
 	or.recordData(ctx, component.DataTypeTraces, int64(numSpans), int64(0), int64(0))
 }
 
 // TracesRefused reports that the trace data was refused.
+//
+// Deprecated: [v0.110.0] Processor helper automatically calculates incoming/outgoing metrics only.
 func (or *ObsReport) TracesRefused(ctx context.Context, numSpans int) {
 	or.recordData(ctx, component.DataTypeTraces, int64(0), int64(numSpans), int64(0))
 }
 
 // TracesDropped reports that the trace data was dropped.
+//
+// Deprecated: [v0.110.0] Processor helper automatically calculates incoming/outgoing metrics only.
 func (or *ObsReport) TracesDropped(ctx context.Context, numSpans int) {
 	or.recordData(ctx, component.DataTypeTraces, int64(0), int64(0), int64(numSpans))
 }
 
 // MetricsAccepted reports that the metrics were accepted.
+//
+// Deprecated: [v0.110.0] Processor helper automatically calculates incoming/outgoing metrics only.
 func (or *ObsReport) MetricsAccepted(ctx context.Context, numPoints int) {
 	or.recordData(ctx, component.DataTypeMetrics, int64(numPoints), int64(0), int64(0))
 }
 
 // MetricsRefused reports that the metrics were refused.
+//
+// Deprecated: [v0.110.0] Processor helper automatically calculates incoming/outgoing metrics only.
 func (or *ObsReport) MetricsRefused(ctx context.Context, numPoints int) {
 	or.recordData(ctx, component.DataTypeMetrics, int64(0), int64(numPoints), int64(0))
 }
 
 // MetricsDropped reports that the metrics were dropped.
+//
+// Deprecated: [v0.110.0] Processor helper automatically calculates incoming/outgoing metrics only.
 func (or *ObsReport) MetricsDropped(ctx context.Context, numPoints int) {
 	or.recordData(ctx, component.DataTypeMetrics, int64(0), int64(0), int64(numPoints))
 }
 
 // LogsAccepted reports that the logs were accepted.
+//
+// Deprecated: [v0.110.0] Processor helper automatically calculates incoming/outgoing metrics only.
 func (or *ObsReport) LogsAccepted(ctx context.Context, numRecords int) {
 	or.recordData(ctx, component.DataTypeLogs, int64(numRecords), int64(0), int64(0))
 }
 
 // LogsRefused reports that the logs were refused.
+//
+// Deprecated: [v0.110.0] Processor helper automatically calculates incoming/outgoing metrics only.
 func (or *ObsReport) LogsRefused(ctx context.Context, numRecords int) {
 	or.recordData(ctx, component.DataTypeLogs, int64(0), int64(numRecords), int64(0))
 }
 
 // LogsDropped reports that the logs were dropped.
+//
+// Deprecated: [v0.110.0] Processor helper automatically calculates incoming/outgoing metrics only.
 func (or *ObsReport) LogsDropped(ctx context.Context, numRecords int) {
 	or.recordData(ctx, component.DataTypeLogs, int64(0), int64(0), int64(numRecords))
 }


### PR DESCRIPTION
These were only used by the memory limiter processor and were never automatically calculated by the processorhelper. It's better to move them to processor specific metrics that can be managed within the component itself.
