### PR TITLE
[chore][exporter/otlphttpexporter] Generalize `composeSignalURL`

### DIFF
--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -49,7 +49,12 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func composeSignalURL(oCfg *Config, signalOverrideURL string, signalName string) (string, error) {
+// composeSignalURL composes the final URL for the signal (traces, metrics, logs) based on the configuration.
+// oCfg is the configuration of the exporter.
+// signalOverrideURL is the URL specified in the signal specific configuration (empty if not specified).
+// signalName is the name of the signal, e.g. "traces", "metrics", "logs".
+// signalVersion is the version of the signal, e.g. "v1" or "v1development".
+func composeSignalURL(oCfg *Config, signalOverrideURL string, signalName string, signalVersion string) (string, error) {
 	switch {
 	case signalOverrideURL != "":
 		_, err := url.Parse(signalOverrideURL)
@@ -61,9 +66,9 @@ func composeSignalURL(oCfg *Config, signalOverrideURL string, signalName string)
 		return "", fmt.Errorf("either endpoint or %s_endpoint must be specified", signalName)
 	default:
 		if strings.HasSuffix(oCfg.Endpoint, "/") {
-			return oCfg.Endpoint + "v1/" + signalName, nil
+			return oCfg.Endpoint + signalVersion + "/" + signalName, nil
 		}
-		return oCfg.Endpoint + "/v1/" + signalName, nil
+		return oCfg.Endpoint + "/" + signalVersion + "/" + signalName, nil
 	}
 }
 
@@ -78,7 +83,7 @@ func createTracesExporter(
 	}
 	oCfg := cfg.(*Config)
 
-	oce.tracesURL, err = composeSignalURL(oCfg, oCfg.TracesEndpoint, "traces")
+	oce.tracesURL, err = composeSignalURL(oCfg, oCfg.TracesEndpoint, "traces", "v1")
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +109,7 @@ func createMetricsExporter(
 	}
 	oCfg := cfg.(*Config)
 
-	oce.metricsURL, err = composeSignalURL(oCfg, oCfg.MetricsEndpoint, "metrics")
+	oce.metricsURL, err = composeSignalURL(oCfg, oCfg.MetricsEndpoint, "metrics", "v1")
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +135,7 @@ func createLogsExporter(
 	}
 	oCfg := cfg.(*Config)
 
-	oce.logsURL, err = composeSignalURL(oCfg, oCfg.LogsEndpoint, "logs")
+	oce.logsURL, err = composeSignalURL(oCfg, oCfg.LogsEndpoint, "logs", "v1")
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -215,13 +215,19 @@ func TestComposeSignalURL(t *testing.T) {
 
 	// Has slash at end
 	cfg.ClientConfig.Endpoint = "http://localhost:4318/"
-	url, err := composeSignalURL(cfg, "", "traces")
+	url, err := composeSignalURL(cfg, "", "traces", "v1")
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:4318/v1/traces", url)
 
 	// No slash at end
 	cfg.ClientConfig.Endpoint = "http://localhost:4318"
-	url, err = composeSignalURL(cfg, "", "traces")
+	url, err = composeSignalURL(cfg, "", "traces", "v1")
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:4318/v1/traces", url)
+
+	// Different version
+	cfg.ClientConfig.Endpoint = "http://localhost:4318"
+	url, err = composeSignalURL(cfg, "", "traces", "v2")
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:4318/v2/traces", url)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Split off from #11131. Prepares OTLP HTTP exporter for supporting profiles (which uses `/v1development`)
