### PR TITLE
[chore] fix TestProcessTelemetryWithHostProc test

### DIFF
--- a/service/internal/proctelemetry/process_telemetry_linux_test.go
+++ b/service/internal/proctelemetry/process_telemetry_linux_test.go
@@ -39,7 +39,7 @@ func TestProcessTelemetryWithHostProc(t *testing.T) {
 		} else {
 			metricValue = metric.Metric[0].GetGauge().GetValue()
 		}
-		if strings.HasPrefix(metricName, "process_uptime") || strings.HasPrefix(metricName, "process_cpu_seconds") {
+		if strings.HasPrefix(metricName, "otelcol_process_uptime") || strings.HasPrefix(metricName, "otelcol_process_cpu_seconds") {
 			// This likely will still be zero when running the test.
 			assert.GreaterOrEqual(t, metricValue, float64(0), metricName)
 			continue


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fixes failing unit test TestProcessTelemetryWithHostProc under service/internal/proctelemetry/process_telemetry_linux_test.go due to incorrect metric name 
<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes [#11221](https://github.com/open-telemetry/opentelemetry-collector/issues/11221)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
unit tests

<!--Describe the documentation added.-->
#### Documentation
none
<!--Please delete paragraphs that you did not use before submitting.-->
