### PR TITLE
[chore]: remove testifylint from Makefile

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -36,9 +36,6 @@ MULTIMOD     := $(TOOLS_BIN_DIR)/multimod
 PORTO        := $(TOOLS_BIN_DIR)/porto
 SEMCONVGEN   := $(TOOLS_BIN_DIR)/semconvgen
 SEMCONVKIT   := $(TOOLS_BIN_DIR)/semconvkit
-TESTIFYLINT  := $(TOOLS_BIN_DIR)/testifylint
-
-TESTIFYLINT_OPT?= --enable-all
 
 .PHONY: install-tools
 install-tools: $(TOOLS_BIN_NAMES)
@@ -91,9 +88,3 @@ impi: $(IMPI)
 .PHONY: moddownload
 moddownload:
 	$(GOCMD) mod download
-
-.PHONY: testifylint-fix
-testifylint-fix:$(TESTIFYLINT)
-	@echo "running $(TESTIFYLINT)"
-	@$(TESTIFYLINT) $(TESTIFYLINT_OPT) -fix ./...
-

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -5,7 +5,6 @@ go 1.22.1
 toolchain go1.22.7
 
 require (
-	github.com/Antonboom/testifylint v1.4.3
 	github.com/a8m/envsubst v1.4.2
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.60.1
@@ -30,6 +29,7 @@ require (
 	github.com/Abirdcfly/dupword v0.0.14 // indirect
 	github.com/Antonboom/errname v0.1.13 // indirect
 	github.com/Antonboom/nilnil v0.1.9 // indirect
+	github.com/Antonboom/testifylint v1.4.3 // indirect
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/Crocmagnon/fatcontext v0.4.0 // indirect
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 // indirect

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -11,7 +11,6 @@ package tools // import "go.opentelemetry.io/collector/internal/tools"
 // This ensures that all systems use the same version of tools in addition to regular dependencies.
 
 import (
-	_ "github.com/Antonboom/testifylint"
 	_ "github.com/a8m/envsubst/cmd/envsubst"
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"


### PR DESCRIPTION
#### Description

All Testifylint rules are now fixed and ensured to be applied with golangci-lint. 
This removes the helper configuration in Makefile and tools module.