### PR TITLE
[exporterhelper] Remove deprecated aliases for Queue/TimeoutSettings

### DIFF
--- a/.chloggen/exporterhelper-remove-deprecated.yaml
+++ b/.chloggen/exporterhelper-remove-deprecated.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removed deprecated `QueueTimeout`/`TimeoutSettings` aliases in favor of `QueueConfig`/`TimeoutConfig`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11264, 6767]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "`NewDefaultQueueSettings` and `NewDefaultTimeoutSettings` have been similarly renamed."
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -27,8 +27,8 @@ func WithShutdown(shutdown component.ShutdownFunc) Option {
 	return internal.WithShutdown(shutdown)
 }
 
-// WithTimeout overrides the default TimeoutSettings for an exporter.
-// The default TimeoutSettings is 5 seconds.
+// WithTimeout overrides the default TimeoutConfig for an exporter.
+// The default TimeoutConfig is 5 seconds.
 func WithTimeout(timeoutConfig TimeoutConfig) Option {
 	return internal.WithTimeout(timeoutConfig)
 }

--- a/exporter/exporterhelper/internal/queue_sender.go
+++ b/exporter/exporterhelper/internal/queue_sender.go
@@ -22,9 +22,6 @@ import (
 
 const defaultQueueSize = 1000
 
-// Deprecated: [v0.110.0] Use QueueConfig instead.
-type QueueSettings = QueueConfig
-
 // QueueConfig defines configuration for queueing batches before sending to the consumerSender.
 type QueueConfig struct {
 	// Enabled indicates whether to not enqueue batches before sending to the consumerSender.
@@ -38,11 +35,6 @@ type QueueConfig struct {
 	// StorageID if not empty, enables the persistent storage and uses the component specified
 	// as a storage extension for the persistent queue
 	StorageID *component.ID `mapstructure:"storage"`
-}
-
-// Deprecated: [v0.110.0] Use NewDefaultQueueConfig instead.
-func NewDefaultQueueSettings() QueueSettings {
-	return NewDefaultQueueConfig()
 }
 
 // NewDefaultQueueConfig returns the default config for QueueConfig.

--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -5,16 +5,8 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 
 import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 
-// Deprecated: [v0.110.0] Use QueueConfig instead.
-type QueueSettings = internal.QueueConfig
-
 // QueueConfig defines configuration for queueing batches before sending to the consumerSender.
 type QueueConfig = internal.QueueConfig
-
-// Deprecated: [v0.110.0] Use NewDefaultQueueConfig instead.
-func NewDefaultQueueSettings() QueueSettings {
-	return internal.NewDefaultQueueConfig()
-}
 
 // NewDefaultQueueConfig returns the default config for QueueConfig.
 func NewDefaultQueueConfig() QueueConfig {

--- a/exporter/exporterhelper/timeout_sender.go
+++ b/exporter/exporterhelper/timeout_sender.go
@@ -7,15 +7,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 )
 
-// Deprecated: [v0.110.0] Use TimeoutConfig instead.
-type TimeoutSettings = TimeoutConfig
-
 type TimeoutConfig = internal.TimeoutConfig
-
-// Deprecated: [v0.110.0] Use NewDefaultTimeoutConfig instead.
-func NewDefaultTimeoutSettings() TimeoutSettings {
-	return internal.NewDefaultTimeoutConfig()
-}
 
 // NewDefaultTimeoutConfig returns the default config for TimeoutConfig.
 func NewDefaultTimeoutConfig() TimeoutConfig {


### PR DESCRIPTION
#### Description

Follow-up to #11132 now that 0.110 has been released.

#### Link to tracking issue

Should be the final step for #6767.
