### PR TITLE
Split receiver factory so the stable one isn't aware of profiles

### DIFF
--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receiver // import "go.opentelemetry.io/collector/receiver"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver/internal"
+)
+
+// Factory is a factory interface for receivers.
+//
+// This interface cannot be directly implemented. Implementations must
+// use the NewReceiverFactory to implement it.
+type Factory interface {
+	component.Factory
+
+	// CreateTracesReceiver creates a TracesReceiver based on this config.
+	// If the receiver type does not support traces,
+	// this function returns the error [pipeline.ErrSignalNotSupported].
+	// Implementers can assume `nextConsumer` is never nil.
+	CreateTracesReceiver(ctx context.Context, set Settings, cfg component.Config, nextConsumer consumer.Traces) (Traces, error)
+
+	// TracesReceiverStability gets the stability level of the TracesReceiver.
+	TracesReceiverStability() component.StabilityLevel
+
+	// CreateMetricsReceiver creates a MetricsReceiver based on this config.
+	// If the receiver type does not support metrics,
+	// this function returns the error [pipeline.ErrSignalNotSupported].
+	// Implementers can assume `nextConsumer` is never nil.
+	CreateMetricsReceiver(ctx context.Context, set Settings, cfg component.Config, nextConsumer consumer.Metrics) (Metrics, error)
+
+	// MetricsReceiverStability gets the stability level of the MetricsReceiver.
+	MetricsReceiverStability() component.StabilityLevel
+
+	// CreateLogsReceiver creates a LogsReceiver based on this config.
+	// If the receiver type does not support logs,
+	// this function returns the error [pipeline.ErrSignalNotSupported].
+	// Implementers can assume `nextConsumer` is never nil.
+	CreateLogsReceiver(ctx context.Context, set Settings, cfg component.Config, nextConsumer consumer.Logs) (Logs, error)
+
+	// LogsReceiverStability gets the stability level of the LogsReceiver.
+	LogsReceiverStability() component.StabilityLevel
+}
+
+// FactoryOption apply changes to ReceiverOptions.
+type FactoryOption = internal.FactoryOption

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumerprofiles"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/internal/testutil"
+	"go.opentelemetry.io/collector/receiver/receiverprofiles"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -47,7 +48,7 @@ func TestCreateSameReceiver(t *testing.T) {
 	assert.NotNil(t, lReceiver)
 	require.NoError(t, err)
 
-	pReceiver, err := factory.CreateProfilesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
+	pReceiver, err := factory.(receiverprofiles.Factory).CreateProfilesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, pReceiver)
 	require.NoError(t, err)
 
@@ -415,7 +416,7 @@ func TestCreateProfilesReceiver(t *testing.T) {
 	creationSet := receivertest.NewNopSettings()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tr, err := factory.CreateProfilesReceiver(ctx, creationSet, tt.cfg, tt.sink)
+			tr, err := factory.(receiverprofiles.Factory).CreateProfilesReceiver(ctx, creationSet, tt.cfg, tt.sink)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -34,15 +34,6 @@ type Logs = internal.Logs
 // Settings configures Receiver creators.
 type Settings = internal.Settings
 
-// Factory is factory interface for receivers.
-//
-// This interface cannot be directly implemented. Implementations must
-// use the NewReceiverFactory to implement it.
-type Factory = internal.Factory
-
-// FactoryOption apply changes to ReceiverOptions.
-type FactoryOption = internal.FactoryOption
-
 // CreateTracesFunc is the equivalent of Factory.CreateTraces.
 type CreateTracesFunc = internal.CreateTracesFunc
 

--- a/receiver/receiverprofiles/factory.go
+++ b/receiver/receiverprofiles/factory.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receiverprofiles // import "go.opentelemetry.io/collector/receiver/receiverprofiles"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumerprofiles"
+	"go.opentelemetry.io/collector/receiver"
+)
+
+// Factory is a factory interface for receivers that implement profiles.
+//
+// This interface cannot be directly implemented. Implementations must
+// use the NewReceiverFactory to implement it.
+type Factory interface {
+	component.Factory
+
+	// CreateProfilesReceiver creates a ProfilesReceiver based on this config.
+	// If the receiver type does not support tracing or if the config is not valid
+	// an error will be returned instead. `nextConsumer` is never nil.
+	CreateProfilesReceiver(ctx context.Context, set receiver.Settings, cfg component.Config, nextConsumer consumerprofiles.Profiles) (Profiles, error)
+
+	// ProfilesReceiverStability gets the stability level of the ProfilesReceiver.
+	ProfilesReceiverStability() component.StabilityLevel
+}

--- a/receiver/receiverprofiles/receiver_test.go
+++ b/receiver/receiverprofiles/receiver_test.go
@@ -26,8 +26,8 @@ func TestNewFactoryWithProfiles(t *testing.T) {
 	assert.EqualValues(t, testType, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	assert.Equal(t, component.StabilityLevelAlpha, factory.ProfilesReceiverStability())
-	_, err := factory.CreateProfilesReceiver(context.Background(), receiver.Settings{}, &defaultCfg, nil)
+	assert.Equal(t, component.StabilityLevelAlpha, factory.(Factory).ProfilesReceiverStability())
+	_, err := factory.(Factory).CreateProfilesReceiver(context.Background(), receiver.Settings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 }
 

--- a/receiver/receivertest/nop_receiver_test.go
+++ b/receiver/receivertest/nop_receiver_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver/receiverprofiles"
 )
 
 var nopType = component.MustNewType("nop")
@@ -39,7 +40,7 @@ func TestNewNopFactory(t *testing.T) {
 	assert.NoError(t, logs.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, logs.Shutdown(context.Background()))
 
-	profiles, err := factory.CreateProfilesReceiver(context.Background(), NewNopSettings(), cfg, consumertest.NewNop())
+	profiles, err := factory.(receiverprofiles.Factory).CreateProfilesReceiver(context.Background(), NewNopSettings(), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.NoError(t, profiles.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, profiles.Shutdown(context.Background()))

--- a/service/internal/builders/receiver.go
+++ b/service/internal/builders/receiver.go
@@ -100,8 +100,13 @@ func (b *ReceiverBuilder) CreateProfiles(ctx context.Context, set receiver.Setti
 		return nil, fmt.Errorf("receiver factory not available for: %q", set.ID)
 	}
 
-	logStabilityLevel(set.Logger, f.ProfilesReceiverStability())
-	return f.CreateProfilesReceiver(ctx, set, cfg, next)
+	pf, ok := f.(receiverprofiles.Factory)
+	if !ok {
+		return nil, fmt.Errorf("receiver cannot receive profiles")
+	}
+
+	logStabilityLevel(set.Logger, pf.ProfilesReceiverStability())
+	return pf.CreateProfilesReceiver(ctx, set, cfg, next)
 }
 
 func (b *ReceiverBuilder) Factory(componentType component.Type) component.Factory {

--- a/service/internal/builders/receiver_test.go
+++ b/service/internal/builders/receiver_test.go
@@ -207,7 +207,7 @@ func TestNewNopReceiverConfigsAndFactories(t *testing.T) {
 	require.NoError(t, err)
 	assert.IsType(t, logs, bLogs)
 
-	profiles, err := factory.CreateProfilesReceiver(context.Background(), set, cfg, consumertest.NewNop())
+	profiles, err := factory.(receiverprofiles.Factory).CreateProfilesReceiver(context.Background(), set, cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	bProfiles, err := builder.CreateProfiles(context.Background(), set, consumertest.NewNop())
 	require.NoError(t, err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is an alternative solution for #11254.