### PR TITLE
[configgrpc] Replace deprecated ToClientConn and ToServer with new API

### DIFF
--- a/.chloggen/configgrpc-option-refactor.yaml
+++ b/.chloggen/configgrpc-option-refactor.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Replace ToClientConn and ToServer with ToClientConnWithOptions and ToServerWithOptions.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11271, 9480]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `ClientConfig.ToClientConn` and `ServerConfig.ToServer` were deprecated in v0.110.0 in favor of
+  `ClientConfig.ToClientConnWithOptions` and `ServerConfig.ToServerWithOptions` which use a more
+  flexible option type. The original functions are now removed, and the new ones are renamed to the
+  old names. The `WithOptions` names are kept as deprecated aliases for now.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -222,27 +222,7 @@ func (gcs *ClientConfig) isSchemeHTTPS() bool {
 	return strings.HasPrefix(gcs.Endpoint, "https://")
 }
 
-// ToClientConn creates a client connection to the given target. By default, it's
-// a non-blocking dial (the function won't wait for connections to be
-// established, and connecting happens in the background). To make it a blocking
-// dial, use grpc.WithBlock() dial option.
-//
-// Deprecated: [v0.110.0] If providing a [grpc.DialOption], use [ClientConfig.ToClientConnWithOptions]
-// with [WithGrpcDialOption] instead.
-func (gcs *ClientConfig) ToClientConn(
-	ctx context.Context,
-	host component.Host,
-	settings component.TelemetrySettings,
-	grpcOpts ...grpc.DialOption,
-) (*grpc.ClientConn, error) {
-	var extraOpts []ToClientConnOption
-	for _, grpcOpt := range grpcOpts {
-		extraOpts = append(extraOpts, WithGrpcDialOption(grpcOpt))
-	}
-	return gcs.ToClientConnWithOptions(ctx, host, settings, extraOpts...)
-}
-
-// ToClientConnOption is a sealed interface wrapping options for [ClientConfig.ToClientConnWithOptions].
+// ToClientConnOption is a sealed interface wrapping options for [ClientConfig.ToClientConn].
 type ToClientConnOption interface {
 	isToClientConnOption()
 }
@@ -257,9 +237,11 @@ func WithGrpcDialOption(opt grpc.DialOption) ToClientConnOption {
 }
 func (grpcDialOptionWrapper) isToClientConnOption() {}
 
-// ToClientConnWithOptions is the same as [ClientConfig.ToClientConn], but uses the [ToClientConnOption] interface for options.
-// This method will eventually replace [ClientConfig.ToClientConn].
-func (gcs *ClientConfig) ToClientConnWithOptions(
+// ToClientConn creates a client connection to the given target. By default, it's
+// a non-blocking dial (the function won't wait for connections to be
+// established, and connecting happens in the background). To make it a blocking
+// dial, use the WithGrpcDiqlOption(grpc.WithBlock()) option.
+func (gcs *ClientConfig) ToClientConn(
 	ctx context.Context,
 	host component.Host,
 	settings component.TelemetrySettings,
@@ -270,6 +252,18 @@ func (gcs *ClientConfig) ToClientConnWithOptions(
 		return nil, err
 	}
 	return grpc.NewClient(gcs.sanitizedEndpoint(), grpcOpts...)
+}
+
+// ToClientConnWithOptions is the same as [ClientConfig.ToClientConn].
+//
+// Deprecated: [v0.111.0] Use [ClientConfig.ToClientConn] instead.
+func (gcs *ClientConfig) ToClientConnWithOptions(
+	ctx context.Context,
+	host component.Host,
+	settings component.TelemetrySettings,
+	extraOpts ...ToClientConnOption,
+) (*grpc.ClientConn, error) {
+	return gcs.ToClientConn(ctx, host, settings, extraOpts...)
 }
 
 func (gcs *ClientConfig) getGrpcDialOptions(
@@ -383,24 +377,7 @@ func (gss *ServerConfig) Validate() error {
 	return nil
 }
 
-// ToServer returns a [grpc.Server] for the configuration
-//
-// Deprecated: [v0.110.0] If providing a [grpc.ServerOption], use [ServerConfig.ToServerWithOptions]
-// with [WithGrpcServerOption] instead.
-func (gss *ServerConfig) ToServer(
-	ctx context.Context,
-	host component.Host,
-	settings component.TelemetrySettings,
-	grpcOpts ...grpc.ServerOption,
-) (*grpc.Server, error) {
-	var extraOpts []ToServerOption
-	for _, grpcOpt := range grpcOpts {
-		extraOpts = append(extraOpts, WithGrpcServerOption(grpcOpt))
-	}
-	return gss.ToServerWithOptions(ctx, host, settings, extraOpts...)
-}
-
-// ToServerOption is a sealed interface wrapping options for [ServerConfig.ToServerWithOptions].
+// ToServerOption is a sealed interface wrapping options for [ServerConfig.ToServer].
 type ToServerOption interface {
 	isToServerOption()
 }
@@ -415,9 +392,8 @@ func WithGrpcServerOption(opt grpc.ServerOption) ToServerOption {
 }
 func (grpcServerOptionWrapper) isToServerOption() {}
 
-// ToServerWithOptions is the same as [ServerConfig.ToServer], but uses the [ToServerOption] interface for options.
-// This method will eventually replace [ServerConfig.ToServer].
-func (gss *ServerConfig) ToServerWithOptions(
+// ToServer returns a [grpc.Server] for the configuration.
+func (gss *ServerConfig) ToServer(
 	_ context.Context,
 	host component.Host,
 	settings component.TelemetrySettings,
@@ -428,6 +404,18 @@ func (gss *ServerConfig) ToServerWithOptions(
 		return nil, err
 	}
 	return grpc.NewServer(grpcOpts...), nil
+}
+
+// ToServerWithOptions is the same as [ServerConfig.ToServer].
+//
+// Deprecated: [v0.111.0] Use [ServerConfig.ToServer] instead.
+func (gss *ServerConfig) ToServerWithOptions(
+	ctx context.Context,
+	host component.Host,
+	settings component.TelemetrySettings,
+	extraOpts ...ToServerOption,
+) (*grpc.Server, error) {
+	return gss.ToServer(ctx, host, settings, extraOpts...)
 }
 
 func (gss *ServerConfig) getGrpcServerOptions(

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -60,7 +60,7 @@ func newExporter(cfg component.Config, set exporter.Settings) *baseExporter {
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *baseExporter) start(ctx context.Context, host component.Host) (err error) {
 	agentOpt := configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))
-	if e.clientConn, err = e.config.ClientConfig.ToClientConnWithOptions(ctx, host, e.settings, agentOpt); err != nil {
+	if e.clientConn, err = e.config.ClientConfig.ToClientConn(ctx, host, e.settings, agentOpt); err != nil {
 		return err
 	}
 	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -89,7 +89,7 @@ func (r *otlpReceiver) startGRPCServer(host component.Host) error {
 	}
 
 	var err error
-	if r.serverGRPC, err = r.cfg.GRPC.ToServerWithOptions(context.Background(), host, r.settings.TelemetrySettings); err != nil {
+	if r.serverGRPC, err = r.cfg.GRPC.ToServer(context.Background(), host, r.settings.TelemetrySettings); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### Description

`ClientConfig.ToClientConn` and `ServerConfig.ToServer` were deprecated in v0.110.0 in favor of `ClientConfig.ToClientConnWithOptions` and `ServerConfig.ToServerWithOptions` which use a more flexible option type (#11069). The original functions are now removed, and the new ones are renamed to the old names. The `WithOptions` names are kept as deprecated aliases for now.

Note: The "4 lines missing coverage" are from the `WithOptions` function aliases.

#### Link to tracking issue
Updates #9480

#### Next steps

- `collector-contrib` will need to be updated to rename uses of the `WithOptions` functions
- The newly deprecated aliases will then need to be removed in the next release
