### PR TITLE
[exporter/otlphttpexporter] Use NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -38,6 +38,10 @@ func createDefaultConfig() component.Config {
 	clientConfig.Compression = configcompression.TypeGzip
 	// We almost read 0 bytes, so no need to tune ReadBufferSize.
 	clientConfig.WriteBufferSize = 512 * 1024
+	clientConfig.MaxIdleConns = nil
+	clientConfig.MaxIdleConnsPerHost = nil
+	clientConfig.MaxConnsPerHost = nil
+	clientConfig.IdleConnTimeout = nil
 
 	return &Config{
 		RetryConfig:  configretry.NewDefaultBackOffConfig(),

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
@@ -33,19 +32,18 @@ func NewFactory() exporter.Factory {
 }
 
 func createDefaultConfig() component.Config {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = 30 * time.Second
+	// Default to gzip compression
+	clientConfig.Compression = configcompression.TypeGzip
+	// We almost read 0 bytes, so no need to tune ReadBufferSize.
+	clientConfig.WriteBufferSize = 512 * 1024
+
 	return &Config{
-		RetryConfig: configretry.NewDefaultBackOffConfig(),
-		QueueConfig: exporterhelper.NewDefaultQueueConfig(),
-		Encoding:    EncodingProto,
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint: "",
-			Timeout:  30 * time.Second,
-			Headers:  map[string]configopaque.String{},
-			// Default to gzip compression
-			Compression: configcompression.TypeGzip,
-			// We almost read 0 bytes, so no need to tune ReadBufferSize.
-			WriteBufferSize: 512 * 1024,
-		},
+		RetryConfig:  configretry.NewDefaultBackOffConfig(),
+		QueueConfig:  exporterhelper.NewDefaultQueueConfig(),
+		Encoding:     EncodingProto,
+		ClientConfig: clientConfig,
 	}
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the `confighttp.ClientConfig` struct. The updates to defaults are maintained (Timeout, Compression, WriteBufferSize) whereas the fields that match the default are not manually set anymore (Endpoint, Headers).

It also sets to nil the fields that are set in default but weren't set previously (MaxIdleConns, MaxIdleConnsPerHost, MaxConnsPerHost, IdleConnTimeout) to retain the same behaviour. I am on the fence about this one, should we switch to using the defaults ?

<!-- Issue number if applicable -->
#### Link to tracking issue
#11274

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
