### PR TITLE
[chore][confmap]: print a warning if invalid character is encountered in yaml

### DIFF
--- a/confmap/provider.go
+++ b/confmap/provider.go
@@ -143,6 +143,7 @@ func withStringRepresentation(stringRepresentation string) RetrievedOption {
 func NewRetrievedFromYAML(yamlBytes []byte, opts ...RetrievedOption) (*Retrieved, error) {
 	var rawConf any
 	if err := yaml.Unmarshal(yamlBytes, &rawConf); err != nil {
+		fmt.Printf("unmarshaling from yaml failed: %v\nAttempting to use it as a string verbatim. You can ignore this warning if the collector starts successfully.\n\n", err)
 		// If the string is not valid YAML, we try to use it verbatim as a string.
 		strRep := string(yamlBytes)
 		return NewRetrieved(strRep, append(opts, withStringRepresentation(strRep))...)


### PR DESCRIPTION
#### Description

If you use the following (invalid) configuration and start the collector:
```
receivers:
  receiver:
	  field: val
```
you'll see an error like this:
```
Error: failed to get config: cannot resolve the configuration: retrieved value (type=string) cannot be used as a Conf
2024/09/28 03:11:06 collector server run finished with error: failed to get config: cannot resolve the configuration: retrieved value (type=string) cannot be used as a Conf
```

However, the error message isn’t helpful. The issue arises from an invalid character (a horizontal tab - ASCII code 9) in the YAML, which may not be visible in text editors. It would be beneficial to print a more informative error message when such problems are detected.

This is a side-effect of https://github.com/open-telemetry/opentelemetry-collector/pull/10794.
