### PR TITLE
Remove deprecated `scraperhelper.NewScraperWithComponentType`

### DIFF
--- a/.chloggen/remove-scraper-with-component-type.yaml
+++ b/.chloggen/remove-scraper-with-component-type.yaml
@@ -10,7 +10,7 @@ component: scraperhelper
 note: Remove deprecated function `NewScraperWithComponentType`.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [11294]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/remove-scraper-with-component-type.yaml
+++ b/.chloggen/remove-scraper-with-component-type.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: scraperhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated function `NewScraperWithComponentType`.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/scraperhelper/scraper.go
+++ b/receiver/scraperhelper/scraper.go
@@ -83,11 +83,3 @@ func NewScraper(t component.Type, scrape ScrapeFunc, options ...ScraperOption) (
 
 	return bs, nil
 }
-
-// NewScraperWithComponentType creates a Scraper that calls Scrape at the specified collection interval,
-// reports observability information, and passes the scraped metrics to the next consumer.
-//
-// Deprecated: [v0.110.0] use NewScraper instead.
-func NewScraperWithComponentType(t component.Type, scrape ScrapeFunc, options ...ScraperOption) (Scraper, error) {
-	return NewScraper(t, scrape, options...)
-}


### PR DESCRIPTION
#### Description
Remove deprecated `scraperhelper.NewScraperWithComponentType`

This is the last change for #9473

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #9473
