### PR TITLE
[chore]: use ErrorContains and EqualError

### DIFF
--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -123,8 +123,7 @@ func TestGenerateInvalidOutputPath(t *testing.T) {
 	cfg := newInitializedConfig(t)
 	cfg.Distribution.OutputPath = ":/invalid"
 	err := Generate(cfg)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to create output path")
+	require.ErrorContains(t, err, "failed to create output path")
 }
 
 func TestVersioning(t *testing.T) {

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -251,8 +251,7 @@ func TestOptionsToConfig(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cfg, err := test.options.loadTLSConfig()
 			if test.expectError != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.expectError)
+				assert.ErrorContains(t, err, test.expectError)
 			} else {
 				require.NoError(t, err)
 				assert.NotNil(t, cfg)

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -277,8 +277,7 @@ func TestUintUnmarshalerFailure(t *testing.T) {
 	cfg := &UintConfig{}
 	err := conf.Unmarshal(cfg)
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("decoding failed due to the following error(s):\n\ncannot parse 'uint_test', %d overflows uint", testValue))
+	assert.ErrorContains(t, err, fmt.Sprintf("decoding failed due to the following error(s):\n\ncannot parse 'uint_test', %d overflows uint", testValue))
 }
 
 func TestMapKeyStringToMapKeyTextUnmarshalerHookFuncDuplicateID(t *testing.T) {

--- a/confmap/resolver_test.go
+++ b/confmap/resolver_test.go
@@ -309,7 +309,7 @@ func TestBackwardsCompatibilityForFilePath(t *testing.T) {
 			}
 			require.NoError(t, err)
 			_, err = resolver.Resolve(context.Background())
-			assert.Contains(t, err.Error(), tt.errMessage, tt.name)
+			assert.ErrorContains(t, err, tt.errMessage, tt.name)
 		})
 	}
 }

--- a/consumer/consumererror/signalerrors_test.go
+++ b/consumer/consumererror/signalerrors_test.go
@@ -17,7 +17,7 @@ func TestTraces(t *testing.T) {
 	td := testdata.GenerateTraces(1)
 	err := errors.New("some error")
 	traceErr := NewTraces(err, td)
-	assert.Equal(t, err.Error(), traceErr.Error())
+	require.EqualError(t, err, traceErr.Error())
 	var target Traces
 	assert.False(t, errors.As(nil, &target))
 	assert.False(t, errors.As(err, &target))
@@ -41,7 +41,7 @@ func TestLogs(t *testing.T) {
 	td := testdata.GenerateLogs(1)
 	err := errors.New("some error")
 	logsErr := NewLogs(err, td)
-	assert.Equal(t, err.Error(), logsErr.Error())
+	require.EqualError(t, err, logsErr.Error())
 	var target Logs
 	assert.False(t, errors.As(nil, &target))
 	assert.False(t, errors.As(err, &target))
@@ -65,7 +65,7 @@ func TestMetrics(t *testing.T) {
 	td := testdata.GenerateMetrics(1)
 	err := errors.New("some error")
 	metricErr := NewMetrics(err, td)
-	assert.Equal(t, err.Error(), metricErr.Error())
+	require.EqualError(t, err, metricErr.Error())
 	var target Metrics
 	assert.False(t, errors.As(nil, &target))
 	assert.False(t, errors.As(err, &target))

--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -340,7 +340,7 @@ func WithBatchFuncs(mf exporterbatcher.BatchMergeFunc[internal.Request], msf exp
 func CheckStatus(t *testing.T, sd sdktrace.ReadOnlySpan, err error) {
 	if err != nil {
 		require.Equal(t, codes.Error, sd.Status().Code, "SpanData %v", sd)
-		require.Equal(t, err.Error(), sd.Status().Description, "SpanData %v", sd)
+		require.EqualError(t, err, sd.Status().Description, "SpanData %v", sd)
 	} else {
 		require.Equal(t, codes.Unset, sd.Status().Code, "SpanData %v", sd)
 	}

--- a/exporter/exportertest/mock_consumer_test.go
+++ b/exporter/exportertest/mock_consumer_test.go
@@ -53,8 +53,7 @@ func TestIDFromMetrics(t *testing.T) {
 	invalidData := pmetric.NewMetrics() // Create an invalid pmetric.Metrics object with missing attribute
 	invalidData.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetEmptyHistogram().DataPoints().AppendEmpty().Attributes()
 	_, err = idFromMetrics(invalidData)
-	require.Error(t, err)
-	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is missing", uniqueIDAttrName))
+	require.EqualError(t, err, fmt.Sprintf("invalid data element, attribute %q is missing", uniqueIDAttrName))
 
 	// Test case 3: Wrong attribute type
 	var intID int64 = 12
@@ -62,8 +61,7 @@ func TestIDFromMetrics(t *testing.T) {
 	wrongAttribute.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().
 		SetEmptyHistogram().DataPoints().AppendEmpty().Attributes().PutInt(uniqueIDAttrName, intID)
 	_, err = idFromMetrics(wrongAttribute)
-	require.Error(t, err)
-	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is wrong type Int", uniqueIDAttrName))
+	assert.EqualError(t, err, fmt.Sprintf("invalid data element, attribute %q is wrong type Int", uniqueIDAttrName))
 }
 
 func TestIDFromTraces(t *testing.T) {
@@ -78,8 +76,7 @@ func TestIDFromTraces(t *testing.T) {
 	invalidData := ptrace.NewTraces()
 	invalidData.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().Attributes()
 	_, err = idFromTraces(invalidData)
-	require.Error(t, err)
-	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is missing", uniqueIDAttrName))
+	require.EqualError(t, err, fmt.Sprintf("invalid data element, attribute %q is missing", uniqueIDAttrName))
 
 	// Test case 3: Wrong attribute type
 	var intID int64 = 12
@@ -87,8 +84,7 @@ func TestIDFromTraces(t *testing.T) {
 	wrongAttribute.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().Attributes().
 		PutInt(uniqueIDAttrName, intID)
 	_, err = idFromTraces(wrongAttribute)
-	require.Error(t, err)
-	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is wrong type Int", uniqueIDAttrName))
+	assert.EqualError(t, err, fmt.Sprintf("invalid data element, attribute %q is wrong type Int", uniqueIDAttrName))
 }
 
 func TestIDFromLogs(t *testing.T) {
@@ -103,8 +99,7 @@ func TestIDFromLogs(t *testing.T) {
 	invalidData := plog.NewLogs()
 	invalidData.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Attributes()
 	_, err = idFromLogs(invalidData)
-	require.Error(t, err)
-	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is missing", uniqueIDAttrName))
+	require.EqualError(t, err, fmt.Sprintf("invalid data element, attribute %q is missing", uniqueIDAttrName))
 
 	// Test case 3: Wrong attribute type
 	var intID int64 = 12
@@ -112,8 +107,7 @@ func TestIDFromLogs(t *testing.T) {
 	wrongAttribute.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Attributes().
 		PutInt(uniqueIDAttrName, intID)
 	_, err = idFromLogs(wrongAttribute)
-	require.Error(t, err)
-	assert.Equal(t, err.Error(), fmt.Sprintf("invalid data element, attribute %q is wrong type Int", uniqueIDAttrName))
+	assert.EqualError(t, err, fmt.Sprintf("invalid data element, attribute %q is wrong type Int", uniqueIDAttrName))
 }
 
 func returnNonPermanentError() error {

--- a/internal/memorylimiter/config_test.go
+++ b/internal/memorylimiter/config_test.go
@@ -98,7 +98,6 @@ func TestUnmarshalInvalidConfig(t *testing.T) {
 	require.NoError(t, err)
 	cfg := &Config{}
 	err = cm.Unmarshal(&cfg)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot parse 'limit_mib', -2000 overflows uint")
-	require.Contains(t, err.Error(), "cannot parse 'spike_limit_mib', -2300 overflows uint")
+	require.ErrorContains(t, err, "cannot parse 'limit_mib', -2000 overflows uint")
+	require.ErrorContains(t, err, "cannot parse 'spike_limit_mib', -2300 overflows uint")
 }

--- a/otelcol/command_validate_test.go
+++ b/otelcol/command_validate_test.go
@@ -17,8 +17,7 @@ import (
 func TestValidateSubCommandNoConfig(t *testing.T) {
 	cmd := newValidateSubCommand(CollectorSettings{Factories: nopFactories}, flags(featuregate.GlobalRegistry()))
 	err := cmd.Execute()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "at least one config flag must be provided")
+	require.ErrorContains(t, err, "at least one config flag must be provided")
 }
 
 func TestValidateSubCommandInvalidComponents(t *testing.T) {
@@ -34,6 +33,5 @@ func TestValidateSubCommandInvalidComponents(t *testing.T) {
 		},
 	}}, flags(featuregate.GlobalRegistry()))
 	err := cmd.Execute()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unknown type: \"nosuchprocessor\"")
+	require.ErrorContains(t, err, "unknown type: \"nosuchprocessor\"")
 }

--- a/otelcol/internal/configunmarshaler/configs_test.go
+++ b/otelcol/internal/configunmarshaler/configs_test.go
@@ -136,8 +136,7 @@ func TestUnmarshalError(t *testing.T) {
 				t.Run(tt.name, func(t *testing.T) {
 					cfgs := NewConfigs(tk.factories)
 					err := cfgs.Unmarshal(tt.conf)
-					require.Error(t, err)
-					assert.Contains(t, err.Error(), tt.expectedError)
+					assert.ErrorContains(t, err, tt.expectedError)
 				})
 			}
 		})

--- a/otelcol/unmarshaler_test.go
+++ b/otelcol/unmarshaler_test.go
@@ -67,8 +67,7 @@ func TestUnmarshalUnknownTopLevel(t *testing.T) {
 		"unknown_section": nil,
 	})
 	_, err = unmarshal(conf, factories)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "'' has invalid keys: unknown_section")
+	assert.ErrorContains(t, err, "'' has invalid keys: unknown_section")
 }
 
 func TestPipelineConfigUnmarshalError(t *testing.T) {
@@ -136,8 +135,7 @@ func TestPipelineConfigUnmarshalError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pips := new(pipelines.ConfigWithPipelineID)
 			err := tt.conf.Unmarshal(&pips)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.expectError)
+			assert.ErrorContains(t, err, tt.expectError)
 		})
 	}
 }

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -1273,9 +1273,8 @@ func TestBatchProcessorDuplicateMetadataKeys(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.MetadataKeys = []string{"myTOKEN", "mytoken"}
 	err := cfg.Validate()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "duplicate")
-	require.Contains(t, err.Error(), "mytoken")
+	require.ErrorContains(t, err, "duplicate")
+	require.ErrorContains(t, err, "mytoken")
 }
 
 func TestBatchProcessorMetadataCardinalityLimit(t *testing.T) {
@@ -1312,7 +1311,7 @@ func TestBatchProcessorMetadataCardinalityLimit(t *testing.T) {
 
 	require.Error(t, err)
 	assert.True(t, consumererror.IsPermanent(err))
-	assert.Contains(t, err.Error(), "too many")
+	require.ErrorContains(t, err, "too many")
 
 	require.NoError(t, batcher.Shutdown(context.Background()))
 }

--- a/receiver/scrapererror/partialscrapeerror_test.go
+++ b/receiver/scrapererror/partialscrapeerror_test.go
@@ -15,7 +15,7 @@ func TestPartialScrapeError(t *testing.T) {
 	failed := 2
 	err := errors.New("some error")
 	partialErr := NewPartialScrapeError(err, failed)
-	assert.Equal(t, err.Error(), partialErr.Error())
+	require.EqualError(t, err, partialErr.Error())
 	assert.Equal(t, failed, partialErr.Failed)
 }
 

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -198,12 +198,10 @@ func TestGraphStartStopCycle(t *testing.T) {
 	pg.componentGraph.SetEdge(simple.Edge{F: c1, T: p1}) // loop back
 
 	err := pg.StartAll(context.Background(), &Host{Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {})})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `topo: no topological ordering: cyclic components`)
+	require.ErrorContains(t, err, `topo: no topological ordering: cyclic components`)
 
 	err = pg.ShutdownAll(context.Background(), statustest.NewNopStatusReporter())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `topo: no topological ordering: cyclic components`)
+	assert.ErrorContains(t, err, `topo: no topological ordering: cyclic components`)
 }
 
 func TestGraphStartStopComponentError(t *testing.T) {


### PR DESCRIPTION
#### Description

Testifylint doesn't support it yet. 
This replaces `Contains(t, err.Error()` by `ErrorContains(t, err` and `Equal(t, err.Error()` by `EqualError(t, err`
As they both check for nil error it becomes useless to check it yourself without having defined a custom message

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->
