### PR TITLE
[service] Remove deprecations and continue renames around DataType

### DIFF
--- a/.chloggen/service-continue-getexporters-rename.yaml
+++ b/.chloggen/service-continue-getexporters-rename.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecates `Config.PipelinesWithPipelineID`, `pipelines.ConfigWithPipelineID` and `GetExportersWithSignal` interface implementation. Use `Config.Pipelines`, `pipelines.Config`, and `GetExporters` interface implementation instead.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/service-continue-getexporters-rename.yaml
+++ b/.chloggen/service-continue-getexporters-rename.yaml
@@ -10,7 +10,7 @@ component: service
 note: Deprecates `Config.PipelinesWithPipelineID`, `pipelines.ConfigWithPipelineID` and `GetExportersWithSignal` interface implementation. Use `Config.Pipelines`, `pipelines.Config`, and `GetExporters` interface implementation instead.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [11303]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/internal/e2e/status_test.go
+++ b/internal/e2e/status_test.go
@@ -101,7 +101,7 @@ func Test_ComponentStatusReporting_SharedInstance(t *testing.T) {
 				Level: configtelemetry.LevelNone,
 			},
 		},
-		PipelinesWithPipelineID: pipelines.ConfigWithPipelineID{
+		Pipelines: pipelines.Config{
 			pipeline.MustNewID("traces"): {
 				Receivers: []component.ID{component.NewID(component.MustNewType("test"))},
 				Exporters: []component.ID{component.NewID(nopType)},

--- a/otelcol/config.go
+++ b/otelcol/config.go
@@ -120,7 +120,7 @@ func (cfg *Config) Validate() error {
 
 	// Check that all pipelines reference only configured components.
 	// nolint
-	for pipelineID, pipeline := range cfg.Service.Pipelines {
+	for pipelineID, pipeline := range cfg.Service.PipelinesWithPipelineID {
 		// Validate pipeline receiver name references.
 		for _, ref := range pipeline.Receivers {
 			// Check that the name referenced in the pipeline's receivers exists in the top-level receivers.
@@ -156,7 +156,7 @@ func (cfg *Config) Validate() error {
 	}
 
 	// Check that all pipelines reference only configured components.
-	for pipelineID, pipeline := range cfg.Service.PipelinesWithPipelineID {
+	for pipelineID, pipeline := range cfg.Service.Pipelines {
 		// Validate pipeline receiver name references.
 		for _, ref := range pipeline.Receivers {
 			// Check that the name referenced in the pipeline's receivers exists in the top-level receivers.

--- a/otelcol/config_test.go
+++ b/otelcol/config_test.go
@@ -100,7 +100,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-receiver-reference",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.PipelinesWithPipelineID[pipeline.MustNewID("traces")]
+				pipe := cfg.Service.Pipelines[pipeline.MustNewID("traces")]
 				pipe.Receivers = append(pipe.Receivers, component.MustNewIDWithName("nop", "2"))
 				return cfg
 			},
@@ -110,7 +110,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-processor-reference",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.PipelinesWithPipelineID[pipeline.MustNewID("traces")]
+				pipe := cfg.Service.Pipelines[pipeline.MustNewID("traces")]
 				pipe.Processors = append(pipe.Processors, component.MustNewIDWithName("nop", "2"))
 				return cfg
 			},
@@ -120,7 +120,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-exporter-reference",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.PipelinesWithPipelineID[pipeline.MustNewID("traces")]
+				pipe := cfg.Service.Pipelines[pipeline.MustNewID("traces")]
 				pipe.Exporters = append(pipe.Exporters, component.MustNewIDWithName("nop", "2"))
 				return cfg
 			},
@@ -187,7 +187,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg := generateConfig()
 				cfg.Receivers[component.MustNewID("nop2")] = &errConfig{}
 				cfg.Connectors[component.MustNewID("nop2")] = &errConfig{}
-				pipe := cfg.Service.PipelinesWithPipelineID[pipeline.MustNewID("traces")]
+				pipe := cfg.Service.Pipelines[pipeline.MustNewID("traces")]
 				pipe.Receivers = append(pipe.Receivers, component.MustNewIDWithName("nop", "2"))
 				pipe.Exporters = append(pipe.Exporters, component.MustNewIDWithName("nop", "2"))
 				return cfg
@@ -200,7 +200,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg := generateConfig()
 				cfg.Exporters[component.MustNewID("nop2")] = &errConfig{}
 				cfg.Connectors[component.MustNewID("nop2")] = &errConfig{}
-				pipe := cfg.Service.PipelinesWithPipelineID[pipeline.MustNewID("traces")]
+				pipe := cfg.Service.Pipelines[pipeline.MustNewID("traces")]
 				pipe.Receivers = append(pipe.Receivers, component.MustNewIDWithName("nop", "2"))
 				pipe.Exporters = append(pipe.Exporters, component.MustNewIDWithName("nop", "2"))
 				return cfg
@@ -211,7 +211,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-connector-reference-as-receiver",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.PipelinesWithPipelineID[pipeline.MustNewID("traces")]
+				pipe := cfg.Service.Pipelines[pipeline.MustNewID("traces")]
 				pipe.Receivers = append(pipe.Receivers, component.MustNewIDWithName("nop", "conn2"))
 				return cfg
 			},
@@ -221,7 +221,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-connector-reference-as-receiver",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.PipelinesWithPipelineID[pipeline.MustNewID("traces")]
+				pipe := cfg.Service.Pipelines[pipeline.MustNewID("traces")]
 				pipe.Exporters = append(pipe.Exporters, component.MustNewIDWithName("nop", "conn2"))
 				return cfg
 			},
@@ -231,7 +231,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-service-config",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.Service.PipelinesWithPipelineID = nil
+				cfg.Service.Pipelines = nil
 				return cfg
 			},
 			expected: fmt.Errorf(`service::pipelines config validation failed: %w`, errors.New(`service must have at least one pipeline`)),
@@ -290,7 +290,7 @@ func generateConfig() *Config {
 				},
 			},
 			Extensions: []component.ID{component.MustNewID("nop")},
-			PipelinesWithPipelineID: pipelines.ConfigWithPipelineID{
+			Pipelines: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop")},

--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -49,14 +49,14 @@ func TestLoadConfig(t *testing.T) {
 	// Verify service.
 	require.Len(t, cfg.Service.Extensions, 1)
 	assert.Contains(t, cfg.Service.Extensions, component.MustNewID("nop"))
-	require.Len(t, cfg.Service.PipelinesWithPipelineID, 1)
+	require.Len(t, cfg.Service.Pipelines, 1)
 	assert.Equal(t,
 		&pipelines.PipelineConfig{
 			Receivers:  []component.ID{component.MustNewID("nop")},
 			Processors: []component.ID{component.MustNewID("nop")},
 			Exporters:  []component.ID{component.MustNewID("nop")},
 		},
-		cfg.Service.PipelinesWithPipelineID[pipeline.MustNewID("traces")],
+		cfg.Service.Pipelines[pipeline.MustNewID("traces")],
 		"Did not load pipeline config correctly")
 }
 

--- a/otelcol/unmarshaler_test.go
+++ b/otelcol/unmarshaler_test.go
@@ -133,7 +133,7 @@ func TestPipelineConfigUnmarshalError(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			pips := new(pipelines.ConfigWithPipelineID)
+			pips := new(pipelines.Config)
 			err := tt.conf.Unmarshal(&pips)
 			assert.ErrorContains(t, err, tt.expectError)
 		})

--- a/service/config.go
+++ b/service/config.go
@@ -20,13 +20,12 @@ type Config struct {
 	Extensions extensions.Config `mapstructure:"extensions"`
 
 	// Pipelines are the set of data pipelines configured for the service.
-	//
-	// Deprecated: [v0.110.0] Use PipelinesWithPipelineID instead
-	// nolint
-	Pipelines pipelines.Config `mapstructure:"-"`
+	Pipelines pipelines.Config `mapstructure:"pipelines"`
 
 	// Pipelines are the set of data pipelines configured for the service.
-	PipelinesWithPipelineID pipelines.ConfigWithPipelineID `mapstructure:"pipelines"`
+	//
+	// Deprecated: [v0.111.0] Use Pipelines instead.
+	PipelinesWithPipelineID pipelines.ConfigWithPipelineID `mapstructure:"-"` // nolint
 }
 
 func (cfg *Config) Validate() error {
@@ -34,12 +33,12 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("service::pipelines config validation failed: cannot configure both Pipelines and PipelinesWithPipelineID")
 	}
 
-	if len(cfg.Pipelines) > 0 {
-		if err := cfg.Pipelines.Validate(); err != nil {
+	if len(cfg.PipelinesWithPipelineID) > 0 {
+		if err := cfg.PipelinesWithPipelineID.Validate(); err != nil {
 			return fmt.Errorf("service::pipelines config validation failed: %w", err)
 		}
 	} else {
-		if err := cfg.PipelinesWithPipelineID.Validate(); err != nil {
+		if err := cfg.Pipelines.Validate(); err != nil {
 			return fmt.Errorf("service::pipelines config validation failed: %w", err)
 		}
 	}

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -44,7 +44,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "duplicate-processor-reference",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.PipelinesWithPipelineID[pipeline.MustNewID("traces")]
+				pipe := cfg.Pipelines[pipeline.MustNewID("traces")]
 				pipe.Processors = append(pipe.Processors, pipe.Processors...)
 				return cfg
 			},
@@ -54,7 +54,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-service-pipeline-type",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.PipelinesWithPipelineID[pipeline.MustNewID("wrongtype")] = &pipelines.PipelineConfig{
+				cfg.Pipelines[pipeline.MustNewID("wrongtype")] = &pipelines.PipelineConfig{
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop")},
 					Exporters:  []component.ID{component.MustNewID("nop")},
@@ -107,7 +107,7 @@ func generateConfig() *Config {
 			},
 		},
 		Extensions: extensions.Config{component.MustNewID("nop")},
-		PipelinesWithPipelineID: pipelines.ConfigWithPipelineID{
+		Pipelines: pipelines.Config{
 			pipeline.MustNewID("traces"): {
 				Receivers:  []component.ID{component.MustNewID("nop")},
 				Processors: []component.ID{component.MustNewID("nop")},

--- a/service/go.mod
+++ b/service/go.mod
@@ -28,7 +28,6 @@ require (
 	go.opentelemetry.io/collector/extension/zpagesextension v0.110.0
 	go.opentelemetry.io/collector/featuregate v1.16.0
 	go.opentelemetry.io/collector/internal/globalgates v0.110.0
-	go.opentelemetry.io/collector/internal/globalsignal v0.110.0
 	go.opentelemetry.io/collector/pdata v1.16.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.110.0
 	go.opentelemetry.io/collector/pdata/testdata v0.110.0
@@ -96,6 +95,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v1.16.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.110.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.110.0 // indirect
+	go.opentelemetry.io/collector/internal/globalsignal v0.110.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0 // indirect
 	go.opentelemetry.io/contrib/zpages v0.55.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.6.0 // indirect

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -49,7 +49,7 @@ type Settings struct {
 	ConnectorBuilder *builders.ConnectorBuilder
 
 	// PipelineConfigs is a map of component.ID to PipelineConfig.
-	PipelineConfigs pipelines.ConfigWithPipelineID
+	PipelineConfigs pipelines.Config
 
 	ReportStatus status.ServiceStatusFunc
 }

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -230,12 +230,12 @@ func TestGraphStartStopComponentError(t *testing.T) {
 func TestConnectorPipelinesGraph(t *testing.T) {
 	tests := []struct {
 		name                string
-		pipelineConfigs     pipelines.ConfigWithPipelineID
+		pipelineConfigs     pipelines.Config
 		expectedPerExporter int // requires symmetry in Pipelines
 	}{
 		{
 			name: "pipelines_simple.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -261,7 +261,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_simple_mutate.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewIDWithName("exampleprocessor", "mutate")},
@@ -287,7 +287,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_simple_multi_proc.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor"), component.MustNewIDWithName("exampleprocessor", "mutate")},
@@ -313,7 +313,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_simple_no_proc.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers: []component.ID{component.MustNewID("examplereceiver")},
 					Exporters: []component.ID{component.MustNewID("exampleexporter")},
@@ -335,7 +335,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_multi.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver"), component.MustNewIDWithName("examplereceiver", "1")},
 					Processors: []component.ID{component.MustNewIDWithName("exampleprocessor", "mutate"), component.MustNewID("exampleprocessor")},
@@ -361,7 +361,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_multi_no_proc.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers: []component.ID{component.MustNewID("examplereceiver"), component.MustNewIDWithName("examplereceiver", "1")},
 					Exporters: []component.ID{component.MustNewID("exampleexporter"), component.MustNewIDWithName("exampleexporter", "1")},
@@ -383,7 +383,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "multi_pipeline_receivers_and_exporters.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewIDWithName("exampleprocessor", "mutate")},
@@ -425,7 +425,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_simple_traces.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -441,7 +441,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_simple_metrics.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -457,7 +457,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_simple_logs.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("logs", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -473,7 +473,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_simple_profiles.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("profiles", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -489,7 +489,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_fork_merge_traces.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -515,7 +515,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_fork_merge_metrics.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -541,7 +541,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_fork_merge_logs.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("logs", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -567,7 +567,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_fork_merge_profiles.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("profiles", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -593,7 +593,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_translate_from_traces.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -619,7 +619,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_translate_from_metrics.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("metrics"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -645,7 +645,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_translate_from_logs.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("logs"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -671,7 +671,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_translate_from_profiles.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -697,7 +697,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_matrix_immutable.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -743,7 +743,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_matrix_mutable.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewIDWithName("exampleprocessor", "mutate")},
@@ -789,7 +789,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_lanes.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers: []component.ID{component.MustNewID("examplereceiver")},
 					Exporters: []component.ID{component.MustNewID("mockforward")},
@@ -827,7 +827,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_mutate_traces.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -853,7 +853,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_mutate_metrics.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -879,7 +879,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_mutate_logs.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("logs", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -905,7 +905,7 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 		},
 		{
 			name: "pipelines_conn_mutate_profiles.yaml",
-			pipelineConfigs: pipelines.ConfigWithPipelineID{
+			pipelineConfigs: pipelines.Config{
 				pipeline.MustNewIDWithName("profiles", "in"): {
 					Receivers:  []component.ID{component.MustNewID("examplereceiver")},
 					Processors: []component.ID{component.MustNewID("exampleprocessor")},
@@ -1313,7 +1313,7 @@ func TestConnectorRouter(t *testing.T) {
 				testcomponents.ExampleRouterFactory.Type(): testcomponents.ExampleRouterFactory,
 			},
 		),
-		PipelineConfigs: pipelines.ConfigWithPipelineID{
+		PipelineConfigs: pipelines.Config{
 			tracesInID: {
 				Receivers: []component.ID{rcvrID},
 				Exporters: []component.ID{routeTracesID},
@@ -1480,7 +1480,7 @@ func TestGraphBuildErrors(t *testing.T) {
 		processorCfgs map[component.ID]component.Config
 		exporterCfgs  map[component.ID]component.Config
 		connectorCfgs map[component.ID]component.Config
-		pipelineCfgs  pipelines.ConfigWithPipelineID
+		pipelineCfgs  pipelines.Config
 		expected      string
 	}{
 		{
@@ -1491,7 +1491,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): badExporterFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("logs"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1507,7 +1507,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): badExporterFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("metrics"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1523,7 +1523,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): badExporterFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1539,7 +1539,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): badExporterFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("profiles"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1558,7 +1558,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("logs"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("bf")},
@@ -1578,7 +1578,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("metrics"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("bf")},
@@ -1598,7 +1598,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("bf")},
@@ -1618,7 +1618,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("profiles"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("bf")},
@@ -1635,7 +1635,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("logs"): {
 					Receivers: []component.ID{component.MustNewID("bf")},
 					Exporters: []component.ID{component.MustNewID("nop")},
@@ -1651,7 +1651,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("metrics"): {
 					Receivers: []component.ID{component.MustNewID("bf")},
 					Exporters: []component.ID{component.MustNewID("nop")},
@@ -1667,7 +1667,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers: []component.ID{component.MustNewID("bf")},
 					Exporters: []component.ID{component.MustNewID("nop")},
@@ -1683,7 +1683,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("profiles"): {
 					Receivers: []component.ID{component.MustNewID("bf")},
 					Exporters: []component.ID{component.MustNewID("nop")},
@@ -1702,7 +1702,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1725,7 +1725,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1748,7 +1748,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1771,7 +1771,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1794,7 +1794,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1817,7 +1817,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1840,7 +1840,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1863,7 +1863,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1886,7 +1886,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("logs", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1909,7 +1909,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("logs", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1932,7 +1932,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("logs", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1955,7 +1955,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("logs", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -1978,7 +1978,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("profiles", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -2001,7 +2001,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("profiles", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -2024,7 +2024,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("profiles", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -2047,7 +2047,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("bf"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("profiles", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("bf")},
@@ -2070,7 +2070,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewIDWithName("nop", "conn"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewIDWithName("nop", "conn")},
@@ -2089,7 +2089,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewIDWithName("nop", "conn"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "out"): {
 					Receivers: []component.ID{component.MustNewIDWithName("nop", "conn")},
 					Exporters: []component.ID{component.MustNewID("nop")},
@@ -2108,7 +2108,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("mockforward"): mfConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("mockforward")},
@@ -2135,7 +2135,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("mockforward"): mfConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("mockforward")},
@@ -2165,7 +2165,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewIDWithName("nop", "conn"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers:  []component.ID{component.MustNewIDWithName("nop", "conn")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2191,7 +2191,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewIDWithName("nop", "conn"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("metrics"): {
 					Receivers:  []component.ID{component.MustNewIDWithName("nop", "conn")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2217,7 +2217,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewIDWithName("nop", "conn"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("logs"): {
 					Receivers:  []component.ID{component.MustNewIDWithName("nop", "conn")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2243,7 +2243,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewIDWithName("nop", "conn"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("profiles"): {
 					Receivers:  []component.ID{component.MustNewIDWithName("nop", "conn")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2271,7 +2271,7 @@ func TestGraphBuildErrors(t *testing.T) {
 				component.MustNewIDWithName("nop", "conn1"): nopConnectorFactory.CreateDefaultConfig(),
 				component.MustNewIDWithName("nop", "conn2"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2316,7 +2316,7 @@ func TestGraphBuildErrors(t *testing.T) {
 				component.MustNewIDWithName("nop", "conn1"): nopConnectorFactory.CreateDefaultConfig(),
 				component.MustNewIDWithName("nop", "conn2"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("metrics", "in"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2361,7 +2361,7 @@ func TestGraphBuildErrors(t *testing.T) {
 				component.MustNewIDWithName("nop", "conn1"): nopConnectorFactory.CreateDefaultConfig(),
 				component.MustNewIDWithName("nop", "conn2"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("logs", "in"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2406,7 +2406,7 @@ func TestGraphBuildErrors(t *testing.T) {
 				component.MustNewIDWithName("nop", "conn1"): nopConnectorFactory.CreateDefaultConfig(),
 				component.MustNewIDWithName("nop", "conn2"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("profiles", "in"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2452,7 +2452,7 @@ func TestGraphBuildErrors(t *testing.T) {
 				component.MustNewIDWithName("nop", "forkagain"): nopConnectorFactory.CreateDefaultConfig(),
 				component.MustNewIDWithName("nop", "rawlog"):    nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2506,7 +2506,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("nop"), component.MustNewIDWithName("nop", "1")},
@@ -2522,7 +2522,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("unknown"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("traces"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("unknown")},
@@ -2541,7 +2541,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("metrics"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop"), component.MustNewIDWithName("nop", "1")},
@@ -2561,7 +2561,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("metrics"): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("unknown")},
@@ -2578,7 +2578,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("logs"): {
 					Receivers: []component.ID{component.MustNewID("nop"), component.MustNewIDWithName("nop", "1")},
 					Exporters: []component.ID{component.MustNewID("nop")},
@@ -2594,7 +2594,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			exporterCfgs: map[component.ID]component.Config{
 				component.MustNewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewID("logs"): {
 					Receivers: []component.ID{component.MustNewID("unknown")},
 					Exporters: []component.ID{component.MustNewID("nop")},
@@ -2613,7 +2613,7 @@ func TestGraphBuildErrors(t *testing.T) {
 			connectorCfgs: map[component.ID]component.Config{
 				component.MustNewID("unknown"): nopConnectorFactory.CreateDefaultConfig(),
 			},
-			pipelineCfgs: pipelines.ConfigWithPipelineID{
+			pipelineCfgs: pipelines.Config{
 				pipeline.MustNewIDWithName("traces", "in"): {
 					Receivers: []component.ID{component.MustNewID("nop")},
 					Exporters: []component.ID{component.MustNewID("unknown")},
@@ -2721,7 +2721,7 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 	dataTypes := []pipeline.Signal{pipeline.SignalTraces, pipeline.SignalMetrics, pipeline.SignalLogs}
 	for _, dt := range dataTypes {
 		t.Run(dt.String()+"/receiver", func(t *testing.T) {
-			set.PipelineConfigs = pipelines.ConfigWithPipelineID{
+			set.PipelineConfigs = pipelines.Config{
 				pipeline.NewID(dt): {
 					Receivers:  []component.ID{component.MustNewID("nop"), component.MustNewID("err")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2735,7 +2735,7 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 		})
 
 		t.Run(dt.String()+"/processor", func(t *testing.T) {
-			set.PipelineConfigs = pipelines.ConfigWithPipelineID{
+			set.PipelineConfigs = pipelines.Config{
 				pipeline.NewID(dt): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop"), component.MustNewID("err")},
@@ -2749,7 +2749,7 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 		})
 
 		t.Run(dt.String()+"/exporter", func(t *testing.T) {
-			set.PipelineConfigs = pipelines.ConfigWithPipelineID{
+			set.PipelineConfigs = pipelines.Config{
 				pipeline.NewID(dt): {
 					Receivers:  []component.ID{component.MustNewID("nop")},
 					Processors: []component.ID{component.MustNewID("nop")},
@@ -2764,7 +2764,7 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 
 		for _, dt2 := range dataTypes {
 			t.Run(dt.String()+"/"+dt2.String()+"/connector", func(t *testing.T) {
-				set.PipelineConfigs = pipelines.ConfigWithPipelineID{
+				set.PipelineConfigs = pipelines.Config{
 					pipeline.NewIDWithName(dt, "in"): {
 						Receivers:  []component.ID{component.MustNewID("nop")},
 						Processors: []component.ID{component.MustNewID("nop")},
@@ -2971,7 +2971,7 @@ func (g *Graph) getReceivers() map[pipeline.Signal]map[component.ID]component.Co
 // However, within an individual pipeline, we expect:
 // - E instances of the connector as a receiver.
 // - R instances of the connector as an exporter.
-func expectedInstances(m pipelines.ConfigWithPipelineID, pID pipeline.ID) (int, int) {
+func expectedInstances(m pipelines.Config, pID pipeline.ID) (int, int) {
 	exConnectorType := component.MustNewType("exampleconnector")
 	var r, e int
 	for _, rID := range m[pID].Receivers {

--- a/service/pipelines/config.go
+++ b/service/pipelines/config.go
@@ -19,9 +19,7 @@ var (
 )
 
 // Config defines the configurable settings for service telemetry.
-//
-// Deprecated: [v0.110.0] Use ConfigWithPipelineID instead
-type Config map[component.ID]*PipelineConfig
+type Config map[pipeline.ID]*PipelineConfig
 
 func (cfg Config) Validate() error {
 	// Must have at least one pipeline.
@@ -32,23 +30,23 @@ func (cfg Config) Validate() error {
 	// Check that all pipelines have at least one receiver and one exporter, and they reference
 	// only configured components.
 	for pipelineID, p := range cfg {
-		switch pipelineID.Type() {
-		// nolint
-		case component.DataTypeTraces, component.DataTypeMetrics, component.DataTypeLogs, componentprofiles.DataTypeProfiles:
+		switch pipelineID.Signal() {
+		case pipeline.SignalTraces, pipeline.SignalMetrics, pipeline.SignalLogs, componentprofiles.SignalProfiles:
 			// Continue
 		default:
-			return fmt.Errorf("pipeline %q: unknown datatype %q", pipelineID, pipelineID.Type())
+			return fmt.Errorf("pipeline %q: unknown signal %q", pipelineID.String(), pipelineID.Signal())
 		}
 
 		// Validate pipeline has at least one receiver.
 		if err := p.Validate(); err != nil {
-			return fmt.Errorf("pipeline %q: %w", pipelineID, err)
+			return fmt.Errorf("pipeline %q: %w", pipelineID.String(), err)
 		}
 	}
 
 	return nil
 }
 
+// Deprecated: [v0.111.0] Use Config instead
 type ConfigWithPipelineID map[pipeline.ID]*PipelineConfig
 
 func (cfg ConfigWithPipelineID) Validate() error {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -219,7 +219,6 @@ func TestServiceGetExtensions(t *testing.T) {
 	assert.Contains(t, extMap, component.NewID(nopType))
 }
 
-// nolint
 func TestServiceGetExporters(t *testing.T) {
 	srv, err := New(context.Background(), newNopSettings(), newNopConfig())
 	require.NoError(t, err)
@@ -229,24 +228,24 @@ func TestServiceGetExporters(t *testing.T) {
 		assert.NoError(t, srv.Shutdown(context.Background()))
 	})
 
+	// nolint
 	expMap := srv.host.GetExporters()
 
-	v, ok := expMap[component.DataTypeTraces]
+	v, ok := expMap[pipeline.SignalTraces]
 	assert.True(t, ok)
 	assert.NotNil(t, v)
 
 	assert.Len(t, expMap, 4)
-	assert.Len(t, expMap[component.DataTypeTraces], 1)
-	assert.Contains(t, expMap[component.DataTypeTraces], component.NewID(nopType))
-	assert.Len(t, expMap[component.DataTypeMetrics], 1)
-	assert.Contains(t, expMap[component.DataTypeMetrics], component.NewID(nopType))
-	assert.Len(t, expMap[component.DataTypeLogs], 1)
-	assert.Contains(t, expMap[component.DataTypeLogs], component.NewID(nopType))
-	assert.Len(t, expMap[componentprofiles.DataTypeProfiles], 1)
-	assert.Contains(t, expMap[componentprofiles.DataTypeProfiles], component.NewID(nopType))
+	assert.Len(t, expMap[pipeline.SignalTraces], 1)
+	assert.Contains(t, expMap[pipeline.SignalTraces], component.NewID(nopType))
+	assert.Len(t, expMap[pipeline.SignalMetrics], 1)
+	assert.Contains(t, expMap[pipeline.SignalMetrics], component.NewID(nopType))
+	assert.Len(t, expMap[pipeline.SignalLogs], 1)
+	assert.Contains(t, expMap[pipeline.SignalLogs], component.NewID(nopType))
+	assert.Len(t, expMap[componentprofiles.SignalProfiles], 1)
+	assert.Contains(t, expMap[componentprofiles.SignalProfiles], component.NewID(nopType))
 }
 
-// nolint
 func TestServiceGetExportersWithSignal(t *testing.T) {
 	srv, err := New(context.Background(), newNopSettings(), newNopConfig())
 	require.NoError(t, err)
@@ -256,6 +255,7 @@ func TestServiceGetExportersWithSignal(t *testing.T) {
 		assert.NoError(t, srv.Shutdown(context.Background()))
 	})
 
+	// nolint
 	expMap := srv.host.GetExportersWithSignal()
 
 	v, ok := expMap[pipeline.SignalTraces]
@@ -623,7 +623,7 @@ func newNopSettings() Settings {
 }
 
 func newNopConfig() Config {
-	return newNopConfigPipelineConfigs(pipelines.ConfigWithPipelineID{
+	return newNopConfigPipelineConfigs(pipelines.Config{
 		pipeline.MustNewID("traces"): {
 			Receivers:  []component.ID{component.NewID(nopType)},
 			Processors: []component.ID{component.NewID(nopType)},
@@ -647,10 +647,10 @@ func newNopConfig() Config {
 	})
 }
 
-func newNopConfigPipelineConfigs(pipelineCfgs pipelines.ConfigWithPipelineID) Config {
+func newNopConfigPipelineConfigs(pipelineCfgs pipelines.Config) Config {
 	return Config{
-		Extensions:              extensions.Config{component.NewID(nopType)},
-		PipelinesWithPipelineID: pipelineCfgs,
+		Extensions: extensions.Config{component.NewID(nopType)},
+		Pipelines:  pipelineCfgs,
 		Telemetry: telemetry.Config{
 			Logs: telemetry.LogsConfig{
 				Level:       zapcore.InfoLevel,

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -277,7 +277,7 @@ func TestServiceGetExportersWithSignal(t *testing.T) {
 // and another service with a valid config can be started right after.
 func TestServiceTelemetryCleanupOnError(t *testing.T) {
 	invalidCfg := newNopConfig()
-	invalidCfg.PipelinesWithPipelineID[pipeline.MustNewID("traces")].Processors[0] = component.MustNewID("invalid")
+	invalidCfg.Pipelines[pipeline.MustNewID("traces")].Processors[0] = component.MustNewID("invalid")
 	// Create a service with an invalid config and expect an error
 	_, err := New(context.Background(), newNopSettings(), invalidCfg)
 	require.Error(t, err)


### PR DESCRIPTION
#### Description

Continues deprecation/rename processor for `Config.PipelinesWithPipelineID`, `pipelines.ConfigWithPipelineID` and `GetExportersWithSignal`.


#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9429