### PR TITLE
[receivertest] Continue DataType deprecations in receivertest

### DIFF
--- a/.chloggen/receivertest-continue-deprecation-2.yaml
+++ b/.chloggen/receivertest-continue-deprecation-2.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: receivertest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecated `NewNopFactoryForTypeWithSignal`. Use `NewNopFactoryForType` instead.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/receivertest-continue-deprecation-2.yaml
+++ b/.chloggen/receivertest-continue-deprecation-2.yaml
@@ -10,7 +10,7 @@ component: receivertest
 note: Deprecated `NewNopFactoryForTypeWithSignal`. Use `NewNopFactoryForType` instead.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [11304]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/receivertest-continue-deprecation.yaml
+++ b/.chloggen/receivertest-continue-deprecation.yaml
@@ -10,7 +10,7 @@ component: receivertest
 note: Remove deprecated `CheckConsumeContractParams.DataType`. Use `CheckConsumeContractParams.Signal` instead.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [11304]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/receivertest-continue-deprecation.yaml
+++ b/.chloggen/receivertest-continue-deprecation.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: receivertest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `CheckConsumeContractParams.DataType`. Use `CheckConsumeContractParams.Signal` instead.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -95,5 +95,3 @@ replace go.opentelemetry.io/collector/receiver/receiverprofiles => ../../receive
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
-
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/internal/globalsignal v0.110.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.110.0 // indirect

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.16.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.110.0 // indirect

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -93,5 +93,3 @@ replace go.opentelemetry.io/collector/exporter/exporterprofiles => ../exporterpr
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
-
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/exporter/exporterprofiles/go.mod
+++ b/exporter/exporterprofiles/go.mod
@@ -68,5 +68,3 @@ replace go.opentelemetry.io/collector/receiver/receiverprofiles => ../../receive
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
-
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -83,5 +83,3 @@ replace go.opentelemetry.io/collector/receiver/receiverprofiles => ../receiver/r
 replace go.opentelemetry.io/collector/exporter/exporterprofiles => ./exporterprofiles
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../internal/globalsignal
-
-replace go.opentelemetry.io/collector/component/componentprofiles => ../component/componentprofiles

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.110.0 // indirect
 	golang.org/x/net v0.28.0 // indirect

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.16.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.110.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.110.0 // indirect

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -98,5 +98,3 @@ replace go.opentelemetry.io/collector/exporter/exporterprofiles => ../exporterpr
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
-
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -88,5 +88,3 @@ replace go.opentelemetry.io/collector/exporter/exporterprofiles => ../exporterpr
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
-
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.110.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.110.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.110.0 // indirect

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -127,8 +127,6 @@ replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
 
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles
-
 replace go.opentelemetry.io/collector => ../..
 
 replace go.opentelemetry.io/collector/component/componentstatus => ../../component/componentstatus

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/client v1.16.0 // indirect
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.16.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.110.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -128,8 +128,6 @@ replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
 
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles
-
 retract (
 	v0.76.0 // Depends on retracted pdata v1.0.0-rc10 module, use v0.76.1
 	v0.69.0 // Release failed, use v0.69.1

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/collector/client v1.16.0 // indirect
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.110.0 // indirect

--- a/otelcol/factories_test.go
+++ b/otelcol/factories_test.go
@@ -38,7 +38,7 @@ func nopFactories() (Factories, error) {
 		factories.ExtensionModules[ext.Type()] = "go.opentelemetry.io/collector/extension/extensiontest v1.2.3"
 	}
 
-	if factories.Receivers, err = receiver.MakeFactoryMap(receivertest.NewNopFactory(), receivertest.NewNopFactoryForTypeWithSignal(pipeline.SignalLogs)); err != nil {
+	if factories.Receivers, err = receiver.MakeFactoryMap(receivertest.NewNopFactory(), receivertest.NewNopFactoryForType(pipeline.SignalLogs)); err != nil {
 		return Factories{}, err
 	}
 	factories.ReceiverModules = make(map[component.Type]string, len(factories.Receivers))

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -6,12 +6,10 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.110.0
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.110.0
 	go.opentelemetry.io/collector/consumer v0.110.0
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.110.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.110.0
-	go.opentelemetry.io/collector/internal/globalsignal v0.110.0
 	go.opentelemetry.io/collector/pdata v1.16.0
 	go.opentelemetry.io/collector/pipeline v0.110.0
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.110.0
@@ -34,6 +32,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.opentelemetry.io/collector/internal/globalsignal v0.110.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.110.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -66,5 +66,3 @@ retract v0.76.0 // Depends on retracted pdata v1.0.0-rc10 module
 replace go.opentelemetry.io/collector/pipeline => ../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../internal/globalsignal
-
-replace go.opentelemetry.io/collector/component/componentprofiles => ../component/componentprofiles

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -76,5 +76,3 @@ replace go.opentelemetry.io/collector/receiver/receiverprofiles => ../receiverpr
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
-
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.110.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/internal/globalsignal v0.110.0 // indirect

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/collector/client v1.16.0 // indirect
-	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.16.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.16.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.110.0 // indirect

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -125,8 +125,6 @@ replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
 
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles
-
 retract (
 	v0.76.0 // Depends on retracted pdata v1.0.0-rc10 module, use v0.76.1
 	v0.69.0 // Release failed, use v0.69.1

--- a/receiver/receiverprofiles/go.mod
+++ b/receiver/receiverprofiles/go.mod
@@ -58,5 +58,3 @@ replace go.opentelemetry.io/collector/consumer/consumertest => ../../consumer/co
 replace go.opentelemetry.io/collector/pipeline => ../../pipeline
 
 replace go.opentelemetry.io/collector/internal/globalsignal => ../../internal/globalsignal
-
-replace go.opentelemetry.io/collector/component/componentprofiles => ../../component/componentprofiles

--- a/receiver/receivertest/contract_checker.go
+++ b/receiver/receivertest/contract_checker.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componentprofiles"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -56,13 +55,7 @@ type CheckConsumeContractParams struct {
 	T *testing.T
 	// Factory that allows to create a receiver.
 	Factory receiver.Factory
-
-	// DataType to test for.
-	//
-	// Deprecated: [v0.110.0] Use Signal instead.
-	DataType component.DataType // nolint
-
-	Signal pipeline.Signal
+	Signal  pipeline.Signal
 	// Config of the receiver to use.
 	Config component.Config
 	// Generator that can send data to the receiver.
@@ -118,21 +111,7 @@ func checkConsumeContractScenario(params CheckConsumeContractParams, decisionFun
 	// Create and start the receiver.
 	var receiver component.Component
 	var err error
-
-	s := params.Signal
-	// nolint
-	switch params.DataType {
-	case component.DataTypeTraces:
-		s = pipeline.SignalTraces
-	case component.DataTypeMetrics:
-		s = pipeline.SignalMetrics
-	case component.DataTypeLogs:
-		s = pipeline.SignalLogs
-	case componentprofiles.DataTypeProfiles:
-		s = componentprofiles.SignalProfiles
-	}
-
-	switch s {
+	switch params.Signal {
 	case pipeline.SignalLogs:
 		receiver, err = params.Factory.CreateLogs(ctx, NewNopSettings(), params.Config, consumer)
 	case pipeline.SignalTraces:

--- a/receiver/receivertest/nop_receiver.go
+++ b/receiver/receivertest/nop_receiver.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerprofiles"
-	"go.opentelemetry.io/collector/internal/globalsignal"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverprofiles"
@@ -43,15 +42,7 @@ func NewNopFactory() receiver.Factory {
 
 // NewNopFactoryForType returns a receiver.Factory that constructs nop receivers supporting only the
 // given data type.
-//
-// Deprecated: [v0.110.0] Use NewNopFactoryForTypeWithSignal instead
-func NewNopFactoryForType(dataType component.DataType) receiver.Factory {
-	return NewNopFactoryForTypeWithSignal(globalsignal.MustNewSignal(dataType.String()))
-}
-
-// NewNopFactoryForTypeWithSignal returns a receiver.Factory that constructs nop receivers supporting only the
-// given signal.
-func NewNopFactoryForTypeWithSignal(signal pipeline.Signal) receiver.Factory {
+func NewNopFactoryForType(signal pipeline.Signal) receiver.Factory {
 	var factoryOpt receiver.FactoryOption
 	switch signal {
 	case pipeline.SignalTraces:
@@ -66,6 +57,14 @@ func NewNopFactoryForTypeWithSignal(signal pipeline.Signal) receiver.Factory {
 
 	componentType := component.MustNewType(defaultComponentType.String() + "_" + signal.String())
 	return receiver.NewFactory(componentType, func() component.Config { return &nopConfig{} }, factoryOpt)
+}
+
+// NewNopFactoryForTypeWithSignal returns a receiver.Factory that constructs nop receivers supporting only the
+// given signal.
+//
+// Deprecated: [v0.111.0] Use NewNopFactoryForType instead
+func NewNopFactoryForTypeWithSignal(signal pipeline.Signal) receiver.Factory {
+	return NewNopFactoryForType(signal)
 }
 
 type nopConfig struct{}


### PR DESCRIPTION
#### Description

Continues deprecation/rename processor for `NewNopFactoryForTypeWithSignal` and `CheckConsumeContractParams.DataType`.

#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9429