### PR TITLE
[exporter] Continue DataType rename in exporter

### DIFF
--- a/.chloggen/exportertest-continue-deprecations-2.yaml
+++ b/.chloggen/exportertest-continue-deprecations-2.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterqueue
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `Settings.DataType`. Use `Settings.Signal` instead.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11305]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/exportertest-continue-deprecations.yaml
+++ b/.chloggen/exportertest-continue-deprecations.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exportertest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `CheckConsumeContractParams.DataType`. Use `CheckConsumeContractParams.Signal` instead.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11305]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterqueue/queue.go
+++ b/exporter/exporterqueue/queue.go
@@ -9,7 +9,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/internal/queue"
-	"go.opentelemetry.io/collector/internal/globalsignal"
 	"go.opentelemetry.io/collector/pipeline"
 )
 
@@ -26,10 +25,6 @@ type Queue[T any] queue.Queue[T]
 
 // Settings defines settings for creating a queue.
 type Settings struct {
-
-	// Deprecated: [v0.110.0] Use Signal instead
-	DataType component.DataType // nolint
-
 	Signal           pipeline.Signal
 	ExporterSettings exporter.Settings
 }
@@ -80,14 +75,10 @@ func NewPersistentQueueFactory[T itemsCounter](storageID *component.ID, factoryS
 		return NewMemoryQueueFactory[T]()
 	}
 	return func(_ context.Context, set Settings, cfg Config) Queue[T] {
-		signal := set.Signal
-		if set.DataType.String() != "" {
-			signal = globalsignal.MustNewSignal(set.DataType.String())
-		}
 		return queue.NewPersistentQueue[T](queue.PersistentQueueSettings[T]{
 			Sizer:            sizerFromConfig[T](cfg),
 			Capacity:         capacityFromConfig(cfg),
-			Signal:           signal,
+			Signal:           set.Signal,
 			StorageID:        *storageID,
 			Marshaler:        factorySettings.Marshaler,
 			Unmarshaler:      factorySettings.Unmarshaler,

--- a/exporter/exportertest/contract_checker.go
+++ b/exporter/exportertest/contract_checker.go
@@ -33,13 +33,7 @@ type uniqueIDAttrVal string
 type CheckConsumeContractParams struct {
 	T                    *testing.T
 	NumberOfTestElements int
-	// DataType to test for.
-	//
-	// Deprecated: [v0.110.0] Use Signal instead
-	// nolint
-	DataType component.DataType
-
-	Signal pipeline.Signal
+	Signal               pipeline.Signal
 	// ExporterFactory to create an exporter to be tested.
 	ExporterFactory exporter.Factory
 	ExporterConfig  component.Config

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -14,7 +14,6 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.110.0
 	go.opentelemetry.io/collector/extension v0.110.0
 	go.opentelemetry.io/collector/extension/experimental/storage v0.110.0
-	go.opentelemetry.io/collector/internal/globalsignal v0.110.0
 	go.opentelemetry.io/collector/pdata v1.16.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.110.0
 	go.opentelemetry.io/collector/pdata/testdata v0.110.0
@@ -43,6 +42,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/component/componentprofiles v0.110.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.110.0 // indirect
+	go.opentelemetry.io/collector/internal/globalsignal v0.110.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.110.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/text v0.17.0 // indirect


### PR DESCRIPTION
#### Description

Continues DataType deprecation/rename in exporter for `Settings.DataType` and `CheckConsumeContractParams.DataType`.

#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9429