### PR TITLE
(batchprocessor): Multi/single-shard consistent start method and field names

### DIFF
--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -61,13 +61,19 @@ type batchProcessor struct {
 
 	telemetry *batchProcessorTelemetry
 
-	//  batcher will be either *singletonBatcher or *multiBatcher
+	// batcher will be either *singletonBatcher or *multiBatcher
 	batcher batcher
 }
 
+// batcher is describes a *singletonBatcher or *multiBatcher.
 type batcher interface {
+	// start initializes background resources used by this batcher.
 	start(ctx context.Context) error
+
+	// consume incorporates a new item of data into the pending batch.
 	consume(ctx context.Context, data any) error
+
+	// currentMetadataCardinality returns the number of shards.
 	currentMetadataCardinality() int
 }
 


### PR DESCRIPTION
#### Description
There are two implementations of the `batcher` interface with several inconsistencies. Notably, the single-shard case would start a goroutine before `Start()` is called, which can be confusing when the goroutine leak checker notices it. This makes the single-shard batcher wait until Start() to create its single shard. A confusing field name `batcher` in this case becomes `single`, and a new field is added for use in start named `processor` to create the new shard.

For the multi-shard batcher, `start()` does nothing, but this structure confusingly embeds the batchProcessor. Rename the field `processor` for consistency with the single-shard case.

#### Link to tracking issue
Part of #11308.

