### PR TITLE
docs: Fix metadata/headers example on confighttp README [chore]

### DIFF
--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -111,7 +111,7 @@ processors:
   attributes:
     actions:
       - key: http.client_ip
-        from_context: X-Forwarded-For
+        from_context: metadata.x-forwarded-for
         action: upsert
 ```
 


### PR DESCRIPTION
#### Description

Documentation fix: The example for using attributesprocessor to add the value of an incoming HTTP header missed the `metadata.` prefix and the lowercasing of the header name.

Fix the example in config/confighttp/README.md.
