### PR TITLE
[chore]: deprecate and remove BuildProcessorMetricName

### DIFF
--- a/.chloggen/deprecate-buildprocessormetricname.yaml
+++ b/.chloggen/deprecate-buildprocessormetricname.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: processorhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate BuildProcessorMetricName as it's no longer needed since introduction of mdatagen
+
+# One or more tracking issues or pull requests related to the change
+issues: [11302]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/processorhelper/obsreport.go
+++ b/processor/processorhelper/obsreport.go
@@ -17,9 +17,7 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper/internal/metadata"
 )
 
-// BuildCustomMetricName is used to be build a metric name following
-// the standards used in the Collector. The configType should be the same
-// value used to identify the type on the config.
+// Deprecated: [v0.111.0] no longer needed. To be removed in future.
 func BuildCustomMetricName(configType, metric string) string {
 	componentPrefix := internal.ProcessorMetricPrefix
 	if !strings.HasSuffix(componentPrefix, internal.MetricNameSep) {


### PR DESCRIPTION
This helper is no longer needed since introduction of `mdatagen`.

Relates https://github.com/open-telemetry/opentelemetry-collector/issues/11302