### PR TITLE
(exporterhelper) Retry sender: fail request if context timeout < next retry

### DIFF
--- a/.chloggen/retry_sender_fail_fast.yaml
+++ b/.chloggen/retry_sender_fail_fast.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: exporterhelper
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Retry sender: fail fast when the context timeout is shorter than the next retry interval.
+note: Retry sender will fail fast when the context timeout is shorter than the next retry interval.
 
 # One or more tracking issues or pull requests related to the change
 issues: [11183]

--- a/.chloggen/retry_sender_fail_fast.yaml
+++ b/.chloggen/retry_sender_fail_fast.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Retry sender: fail fast when the context timeout is shorter than the next retry interval.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11183]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -277,7 +277,7 @@ func TestRetryWithContextTimeout(t *testing.T) {
 
 	// First attempt after 100ms is attempted
 	rCfg.InitialInterval = 100 * time.Millisecond
-	rCfg.RandomizationFactor = 1
+	rCfg.RandomizationFactor = 0
 	// Second attempt is at twice the testTimeout
 	rCfg.Multiplier = float64(2 * testTimeout / rCfg.InitialInterval)
 	qCfg := exporterqueue.NewDefaultConfig()

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -303,7 +303,7 @@ func TestRetryWithContextTimeout(t *testing.T) {
 		defer cancel()
 		err := be.Send(ctx, mockR)
 		require.Error(t, err)
-		require.Equal(t, err.Error(), "request will be cancelled before next retry: transient error")
+		require.Equal(t, "request will be cancelled before next retry: transient error", err.Error())
 	})
 	assert.Len(t, observed.All(), 2)
 	assert.Equal(t, "Exporting failed. Will retry the request after interval.", observed.All()[0].Message)


### PR DESCRIPTION
#### Description
The retry sender will delay until the context is canceled, where instead it could fail fast with a transient error and a clear message that no more retries are possible given the configuration.

#### Link to tracking issue
Part of #11183 

#### Testing
One new test.
