### PR TITLE
[chore][graph] Remove connectorNode's separate baseConsumer

### DIFF
--- a/service/internal/graph/consumer.go
+++ b/service/internal/graph/consumer.go
@@ -4,7 +4,9 @@
 package graph // import "go.opentelemetry.io/collector/service/internal/graph"
 
 import (
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumerprofiles"
 )
 
 // baseConsumer redeclared here since not public in consumer package. May consider to make that public.
@@ -14,4 +16,24 @@ type baseConsumer interface {
 
 type consumerNode interface {
 	getConsumer() baseConsumer
+}
+
+type componentTraces struct {
+	component.Component
+	consumer.Traces
+}
+
+type componentMetrics struct {
+	component.Component
+	consumer.Metrics
+}
+
+type componentLogs struct {
+	component.Component
+	consumer.Logs
+}
+
+type componentProfiles struct {
+	component.Component
+	consumerprofiles.Profiles
 }

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -17,7 +17,6 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/connector"
-	"go.opentelemetry.io/collector/connector/connectorprofiles"
 	"go.opentelemetry.io/collector/connector/connectortest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -832,17 +831,9 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 						require.Empty(t, e.Logs)
 						require.Empty(t, e.Profiles)
 					case *connectorNode:
-						// connector needs to be unwrapped to access component as ExampleConnector
-						switch ct := c.Component.(type) {
-						case connector.Traces:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Started())
-						case connector.Metrics:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Started())
-						case connector.Logs:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Started())
-						case connectorprofiles.Profiles:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Started())
-						}
+						exConn := unwrapExampleConnector(c)
+						require.NotNil(t, exConn)
+						require.True(t, exConn.Started())
 					default:
 						require.Fail(t, fmt.Sprintf("unexpected type %T", c))
 					}
@@ -857,17 +848,9 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 					case *receiverNode:
 						require.True(t, c.Component.(*testcomponents.ExampleReceiver).Started())
 					case *connectorNode:
-						// connector needs to be unwrapped to access component as ExampleConnector
-						switch ct := c.Component.(type) {
-						case connector.Traces:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Started())
-						case connector.Metrics:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Started())
-						case connector.Logs:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Started())
-						case connectorprofiles.Profiles:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Started())
-						}
+						exConn := unwrapExampleConnector(c)
+						require.NotNil(t, exConn)
+						require.True(t, exConn.Started())
 					default:
 						require.Fail(t, fmt.Sprintf("unexpected type %T", c))
 					}
@@ -937,17 +920,9 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 					case *receiverNode:
 						require.True(t, c.Component.(*testcomponents.ExampleReceiver).Stopped())
 					case *connectorNode:
-						// connector needs to be unwrapped to access component as ExampleConnector
-						switch ct := c.Component.(type) {
-						case connector.Traces:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Stopped())
-						case connector.Metrics:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Stopped())
-						case connector.Logs:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Stopped())
-						case connectorprofiles.Profiles:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Stopped())
-						}
+						exConn := unwrapExampleConnector(c)
+						require.NotNil(t, exConn)
+						require.True(t, exConn.Stopped())
 					default:
 						require.Fail(t, fmt.Sprintf("unexpected type %T", c))
 					}
@@ -963,17 +938,9 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 						e := c.Component.(*testcomponents.ExampleExporter)
 						require.True(t, e.Stopped())
 					case *connectorNode:
-						// connector needs to be unwrapped to access component as ExampleConnector
-						switch ct := c.Component.(type) {
-						case connector.Traces:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Stopped())
-						case connector.Metrics:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Stopped())
-						case connector.Logs:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Stopped())
-						case connectorprofiles.Profiles:
-							require.True(t, ct.(*testcomponents.ExampleConnector).Stopped())
-						}
+						exConn := unwrapExampleConnector(c)
+						require.NotNil(t, exConn)
+						require.True(t, exConn.Stopped())
 					default:
 						require.Fail(t, fmt.Sprintf("unexpected type %T", c))
 					}

--- a/service/internal/graph/util_test.go
+++ b/service/internal/graph/util_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/processor/processorprofiles"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverprofiles"
+	"go.opentelemetry.io/collector/service/internal/testcomponents"
 	"go.opentelemetry.io/collector/service/pipelines"
 )
 
@@ -144,6 +145,29 @@ func expectedInstances(m pipelines.Config, pID pipeline.ID) (int, int) {
 		e += len(typeMap)
 	}
 	return r, e
+}
+
+// connector needs to be unwrapped to access component as ExampleConnector
+func unwrapExampleConnector(c *connectorNode) *testcomponents.ExampleConnector {
+	switch ct := c.Component.(type) {
+	case componentTraces: // consumes traces, emits traces
+		return ct.Component.(*testcomponents.ExampleConnector)
+	case connector.Traces: // consumes traces, emits something else
+		return ct.(*testcomponents.ExampleConnector)
+	case componentMetrics: // consumes metrics, emits metrics
+		return ct.Component.(*testcomponents.ExampleConnector)
+	case connector.Metrics: // consumes metrics, emits something else
+		return ct.(*testcomponents.ExampleConnector)
+	case componentLogs: // consumes logs, emits logs
+		return ct.Component.(*testcomponents.ExampleConnector)
+	case connector.Logs: // consumes logs, emits something else
+		return ct.(*testcomponents.ExampleConnector)
+	case componentProfiles: // consumes profiles, emits profiles
+		return ct.Component.(*testcomponents.ExampleConnector)
+	case connectorprofiles.Profiles: // consumes profiles, emits something else
+		return ct.(*testcomponents.ExampleConnector)
+	}
+	return nil
 }
 
 func newBadReceiverFactory() receiver.Factory {


### PR DESCRIPTION
Follows #11330

Currently, `connectorNode` contains separate `component.Component` and `baseConsumer` fields. These fields are essentially two representations of the same component, but `baseConsumer` may be wrapped in another consumer that inherits capabilities. Rather than maintain two separate handles, this PR switches to a unified field. I believe this change helps normalize the connector node with other types of consumer nodes and will enable further refactoring opportunities.