### PR TITLE
Fix data race condition, concurrent writes to the err variable, causes Undefined Behavior

### DIFF
--- a/.chloggen/fix-ub-proc-helper.yaml
+++ b/.chloggen/fix-ub-proc-helper.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: processorhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix data race condition, concurrent writes to the err variable, causes UB
+
+# One or more tracking issues or pull requests related to the change
+issues: [11350]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fix-ub-proc-helper.yaml
+++ b/.chloggen/fix-ub-proc-helper.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: processorhelper
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix data race condition, concurrent writes to the err variable, causes UB
+note: Fix data race condition, concurrent writes to the err variable, causes UB (Undefined Behavior)
 
 # One or more tracking issues or pull requests related to the change
 issues: [11350]

--- a/processor/processorhelper/logs.go
+++ b/processor/processorhelper/logs.go
@@ -51,13 +51,14 @@ func NewLogs(
 		span.AddEvent("Start processing.", eventOptions)
 		recordsIn := ld.LogRecordCount()
 
-		ld, err = logsFunc(ctx, ld)
+		var errFunc error
+		ld, errFunc = logsFunc(ctx, ld)
 		span.AddEvent("End processing.", eventOptions)
-		if err != nil {
-			if errors.Is(err, ErrSkipProcessingData) {
+		if errFunc != nil {
+			if errors.Is(errFunc, ErrSkipProcessingData) {
 				return nil
 			}
-			return err
+			return errFunc
 		}
 		recordsOut := ld.LogRecordCount()
 		obs.recordInOut(ctx, recordsIn, recordsOut)

--- a/processor/processorhelper/metrics.go
+++ b/processor/processorhelper/metrics.go
@@ -51,13 +51,14 @@ func NewMetrics(
 		span.AddEvent("Start processing.", eventOptions)
 		pointsIn := md.DataPointCount()
 
-		md, err = metricsFunc(ctx, md)
+		var errFunc error
+		md, errFunc = metricsFunc(ctx, md)
 		span.AddEvent("End processing.", eventOptions)
-		if err != nil {
-			if errors.Is(err, ErrSkipProcessingData) {
+		if errFunc != nil {
+			if errors.Is(errFunc, ErrSkipProcessingData) {
 				return nil
 			}
-			return err
+			return errFunc
 		}
 		pointsOut := md.DataPointCount()
 		obs.recordInOut(ctx, pointsIn, pointsOut)

--- a/processor/processorhelper/traces.go
+++ b/processor/processorhelper/traces.go
@@ -51,13 +51,14 @@ func NewTraces(
 		span.AddEvent("Start processing.", eventOptions)
 		spansIn := td.SpanCount()
 
-		td, err = tracesFunc(ctx, td)
+		var errFunc error
+		td, errFunc = tracesFunc(ctx, td)
 		span.AddEvent("End processing.", eventOptions)
-		if err != nil {
-			if errors.Is(err, ErrSkipProcessingData) {
+		if errFunc != nil {
+			if errors.Is(errFunc, ErrSkipProcessingData) {
 				return nil
 			}
-			return err
+			return errFunc
 		}
 		spansOut := td.SpanCount()
 		obs.recordInOut(ctx, spansIn, spansOut)


### PR DESCRIPTION
The main issue is that after https://github.com/open-telemetry/opentelemetry-collector/pull/10910 the err variable is shared between requests because it uses the same address as the err defined outside the func.

This is an UB because we are overwriting memory and will cause crashes like https://github.com/open-telemetry/opentelemetry-collector/pull/11335, where the check for not nil happens then gets overwrite with nil and crashes.

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/11350