### PR TITLE
[cmd/builder] Update default configuration to use v1.17.0

### DIFF
--- a/.chloggen/mx-psi_update-default-builder-config.yaml
+++ b/.chloggen/mx-psi_update-default-builder-config.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: cmd/builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix default configuration for builder for httpprovider, httpsprovider, and yamlprovider.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11357]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -33,7 +33,7 @@ connectors:
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.17.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.17.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.111.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.111.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.111.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.17.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.17.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.17.0
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Update default configuration to use v1.17.0 for confmap providers.

#### Link to tracking issue

This is what is making open-telemetry/opentelemetry-collector-contrib#35605 fail
