### PR TITLE
[configgrpc] Remove deprecated aliases

### DIFF
--- a/.chloggen/configgrpc-remove-deprecated.yaml
+++ b/.chloggen/configgrpc-remove-deprecated.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removed deprecated `ClientConfig.ToClientConnWithOptions`/`ServerConfig.ToServerWithOptions`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11359, 9480]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "These methods were renamed to `ClientConfig.ToClientConn`/`ServerConfig.ToServer` in v0.111.0."
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -264,18 +264,6 @@ func (gcs *ClientConfig) ToClientConn(
 	return grpc.NewClient(gcs.sanitizedEndpoint(), grpcOpts...)
 }
 
-// ToClientConnWithOptions is the same as [ClientConfig.ToClientConn].
-//
-// Deprecated: [v0.111.0] Use [ClientConfig.ToClientConn] instead.
-func (gcs *ClientConfig) ToClientConnWithOptions(
-	ctx context.Context,
-	host component.Host,
-	settings component.TelemetrySettings,
-	extraOpts ...ToClientConnOption,
-) (*grpc.ClientConn, error) {
-	return gcs.ToClientConn(ctx, host, settings, extraOpts...)
-}
-
 func (gcs *ClientConfig) getGrpcDialOptions(
 	ctx context.Context,
 	host component.Host,
@@ -406,18 +394,6 @@ func (gss *ServerConfig) ToServer(
 		return nil, err
 	}
 	return grpc.NewServer(grpcOpts...), nil
-}
-
-// ToServerWithOptions is the same as [ServerConfig.ToServer].
-//
-// Deprecated: [v0.111.0] Use [ServerConfig.ToServer] instead.
-func (gss *ServerConfig) ToServerWithOptions(
-	ctx context.Context,
-	host component.Host,
-	settings component.TelemetrySettings,
-	extraOpts ...ToServerOption,
-) (*grpc.Server, error) {
-	return gss.ToServer(ctx, host, settings, extraOpts...)
 }
 
 func (gss *ServerConfig) getGrpcServerOptions(


### PR DESCRIPTION
#### Description

This PR removes `ClientConfig.ToClientConnWithOptions`/`ServerConfig.ToServerWithOptions`, deprecated aliases of `ClientConfig.ToClientConn`/`ServerConfig.ToServer`, which were introduced in v0.111.0. This was part of the three step process to change the option type used by these methods (introduce new methods using the new option type and deprecate the old ones / remove old methods, rename new methods to the old names, add deprecated aliases for the new names / remove aliases).

#### Link to tracking issue

Fixes #9480
