### PR TITLE
[exporter/otlp] Report runtime status

### DIFF
--- a/.chloggen/exp-status.yaml
+++ b/.chloggen/exp-status.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add runtime status reporting for OTLP exporters.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9957]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -59,7 +59,7 @@ func createTraces(
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
 	return exporterhelper.NewTraces(ctx, set, cfg,
-		oce.pushTraces,
+		oce.pushTracesWithStatus,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.RetryConfig),
@@ -78,7 +78,7 @@ func createMetrics(
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
 	return exporterhelper.NewMetrics(ctx, set, cfg,
-		oce.pushMetrics,
+		oce.pushMetricsWithStatus,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.RetryConfig),
@@ -97,7 +97,7 @@ func createLogs(
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
 	return exporterhelper.NewLogs(ctx, set, cfg,
-		oce.pushLogs,
+		oce.pushLogsWithStatus,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.RetryConfig),
@@ -116,7 +116,7 @@ func createProfilesExporter(
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
 	return exporterhelperprofiles.NewProfilesExporter(ctx, set, cfg,
-		oce.pushProfiles,
+		oce.pushProfilesWithStatus,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
 		exporterhelper.WithRetry(oCfg.RetryConfig),

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector v0.114.0
 	go.opentelemetry.io/collector/component v0.114.0
+	go.opentelemetry.io/collector/component/componentstatus v0.114.0
 	go.opentelemetry.io/collector/component/componenttest v0.114.0
 	go.opentelemetry.io/collector/config/configauth v0.114.0
 	go.opentelemetry.io/collector/config/configcompression v1.20.0

--- a/exporter/otlpexporter/go.sum
+++ b/exporter/otlpexporter/go.sum
@@ -60,6 +60,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.opentelemetry.io/collector/component/componentstatus v0.114.0 h1:y9my/xink8KB5lK8zFAjgB2+pEh0QYy5TM972fxZY9w=
+go.opentelemetry.io/collector/component/componentstatus v0.114.0/go.mod h1:RIoeCYZpPaae7QLE/1RacqzhHuXBmzRAk9H/EwYtIIs=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.56.0 h1:yMkBS9yViCc7U7yeLzJPM2XizlfdVvBRSmsQDWu6qc0=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.56.0/go.mod h1:n8MR6/liuGB5EmTETUBeU5ZgqMOlqKRxUaqPQBOANZ8=
 go.opentelemetry.io/otel v1.32.0 h1:WnBN+Xjcteh0zdk01SVqV55d/m62NJLJdIyb4y/WO5U=

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -1095,7 +1095,7 @@ func TestComponentStatus(t *testing.T) {
 				exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 				require.NoError(t, err)
 				require.NotNil(t, exp)
-				assert.NoError(t, exp.Start(context.Background(), host))
+				require.NoError(t, exp.Start(context.Background(), host))
 
 				defer func() {
 					assert.NoError(t, exp.Shutdown(context.Background()))
@@ -1136,7 +1136,7 @@ func TestComponentStatus(t *testing.T) {
 				exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 				require.NoError(t, err)
 				require.NotNil(t, exp)
-				assert.NoError(t, exp.Start(context.Background(), host))
+				require.NoError(t, exp.Start(context.Background(), host))
 
 				defer func() {
 					assert.NoError(t, exp.Shutdown(context.Background()))
@@ -1176,7 +1176,7 @@ func TestComponentStatus(t *testing.T) {
 				exp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
 				require.NoError(t, err)
 				require.NotNil(t, exp)
-				assert.NoError(t, exp.Start(context.Background(), host))
+				require.NoError(t, exp.Start(context.Background(), host))
 
 				defer func() {
 					assert.NoError(t, exp.Shutdown(context.Background()))

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -1049,21 +1049,6 @@ func TestComponentStatus(t *testing.T) {
 			componentStatus: componentstatus.StatusOK,
 		},
 		{
-			name:            "Permission Denied",
-			exportError:     status.Error(codes.PermissionDenied, "permission denied"),
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
-			name:            "Not Found",
-			exportError:     status.Error(codes.NotFound, "not found"),
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
-			name:            "Unauthenticated",
-			exportError:     status.Error(codes.Unauthenticated, "unauthenticated"),
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
 			name:            "Resource Exhausted",
 			exportError:     status.Error(codes.ResourceExhausted, "resource exhausted"),
 			componentStatus: componentstatus.StatusRecoverableError,
@@ -1092,7 +1077,7 @@ func TestComponentStatus(t *testing.T) {
 				set := exportertest.NewNopSettings()
 				host := &testHost{Host: componenttest.NewNopHost()}
 
-				exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
+				exp, err := factory.CreateTraces(context.Background(), set, cfg)
 				require.NoError(t, err)
 				require.NotNil(t, exp)
 				require.NoError(t, exp.Start(context.Background(), host))
@@ -1133,7 +1118,7 @@ func TestComponentStatus(t *testing.T) {
 				set := exportertest.NewNopSettings()
 				host := &testHost{Host: componenttest.NewNopHost()}
 
-				exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
+				exp, err := factory.CreateMetrics(context.Background(), set, cfg)
 				require.NoError(t, err)
 				require.NotNil(t, exp)
 				require.NoError(t, exp.Start(context.Background(), host))
@@ -1173,7 +1158,7 @@ func TestComponentStatus(t *testing.T) {
 				set := exportertest.NewNopSettings()
 				host := &testHost{Host: componenttest.NewNopHost()}
 
-				exp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
+				exp, err := factory.CreateLogs(context.Background(), set, cfg)
 				require.NoError(t, err)
 				require.NotNil(t, exp)
 				require.NoError(t, exp.Start(context.Background(), host))

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -90,7 +90,7 @@ func createTraces(
 	}
 
 	return exporterhelper.NewTraces(ctx, set, cfg,
-		oce.pushTraces,
+		oce.pushTracesWithStatus,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// explicitly disable since we rely on http.Client timeout logic.
@@ -116,7 +116,7 @@ func createMetrics(
 	}
 
 	return exporterhelper.NewMetrics(ctx, set, cfg,
-		oce.pushMetrics,
+		oce.pushMetricsWithStatus,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// explicitly disable since we rely on http.Client timeout logic.
@@ -141,7 +141,7 @@ func createLogs(
 	}
 
 	return exporterhelper.NewLogs(ctx, set, cfg,
-		oce.pushLogs,
+		oce.pushLogsWithStatus,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// explicitly disable since we rely on http.Client timeout logic.
@@ -167,7 +167,7 @@ func createProfiles(
 	}
 
 	return exporterhelperprofiles.NewProfilesExporter(ctx, set, cfg,
-		oce.pushProfiles,
+		oce.pushProfilesWithStatus,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// explicitly disable since we rely on http.Client timeout logic.

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector v0.114.0
 	go.opentelemetry.io/collector/component v0.114.0
+	go.opentelemetry.io/collector/component/componentstatus v0.114.0
 	go.opentelemetry.io/collector/component/componenttest v0.114.0
 	go.opentelemetry.io/collector/config/configcompression v1.20.0
 	go.opentelemetry.io/collector/config/confighttp v0.114.0

--- a/exporter/otlphttpexporter/go.sum
+++ b/exporter/otlphttpexporter/go.sum
@@ -64,6 +64,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.opentelemetry.io/collector/component/componentstatus v0.114.0 h1:y9my/xink8KB5lK8zFAjgB2+pEh0QYy5TM972fxZY9w=
+go.opentelemetry.io/collector/component/componentstatus v0.114.0/go.mod h1:RIoeCYZpPaae7QLE/1RacqzhHuXBmzRAk9H/EwYtIIs=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 h1:UP6IpuHFkUgOQL9FFQFrZ+5LiwhhYRbi7VZSIx6Nj5s=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0/go.mod h1:qxuZLtbq5QDtdeSHsS7bcf6EH6uO6jUAgk764zd3rhM=
 go.opentelemetry.io/otel v1.32.0 h1:WnBN+Xjcteh0zdk01SVqV55d/m62NJLJdIyb4y/WO5U=

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -43,6 +44,7 @@ type baseExporter struct {
 	logsURL     string
 	profilesURL string
 	logger      *zap.Logger
+	host        component.Host
 	settings    component.TelemetrySettings
 	// Default user-agent header.
 	userAgent string
@@ -87,6 +89,7 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) error {
 		return err
 	}
 	e.client = client
+	e.host = host
 	return nil
 }
 
@@ -173,7 +176,10 @@ func (e *baseExporter) pushProfiles(ctx context.Context, td pprofile.Profiles) e
 	return e.export(ctx, e.profilesURL, request, e.profilesPartialSuccessHandler)
 }
 
-func (e *baseExporter) export(ctx context.Context, url string, request []byte, partialSuccessHandler partialSuccessHandler) error {
+func (e *baseExporter) export(ctx context.Context, url string, request []byte, partialSuccessHandler partialSuccessHandler) (err error) {
+	defer func() {
+		e.reportStatusFromError(err)
+	}()
 	e.logger.Debug("Preparing to make HTTP request", zap.String("url", url))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(request))
 	if err != nil {
@@ -222,6 +228,10 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 	}
 	formattedErr = httphelper.NewStatusFromMsgAndHTTPCode(errString, resp.StatusCode).Err()
 
+	if isComponentPermanentError(resp.StatusCode) {
+		componentstatus.ReportStatus(e.host, componentstatus.NewPermanentErrorEvent(formattedErr))
+	}
+
 	if isRetryableStatusCode(resp.StatusCode) {
 		// A retry duration of 0 seconds will trigger the default backoff policy
 		// of our caller (retry handler).
@@ -242,6 +252,14 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 	return consumererror.NewPermanent(formattedErr)
 }
 
+func (e *baseExporter) reportStatusFromError(err error) {
+	if err != nil {
+		componentstatus.ReportStatus(e.host, componentstatus.NewRecoverableErrorEvent(err))
+		return
+	}
+	componentstatus.ReportStatus(e.host, componentstatus.NewEvent(componentstatus.StatusOK))
+}
+
 // Determine if the status code is retryable according to the specification.
 // For more, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#failures-1
 func isRetryableStatusCode(code int) bool {
@@ -253,6 +271,31 @@ func isRetryableStatusCode(code int) bool {
 	case http.StatusServiceUnavailable:
 		return true
 	case http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+// A component status of PermanentError indicates the component is in a state that will require user
+// intervention to fix. Typically this is a misconfiguration detected at runtime. A component
+// PermanentError has different semantics than a consumererror. For more information, see:
+// https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-status.md
+func isComponentPermanentError(code int) bool {
+	switch code {
+	case http.StatusUnauthorized:
+		return true
+	case http.StatusForbidden:
+		return true
+	case http.StatusNotFound:
+		return true
+	case http.StatusMethodNotAllowed:
+		return true
+	case http.StatusRequestEntityTooLarge:
+		return true
+	case http.StatusRequestURITooLong:
+		return true
+	case http.StatusRequestHeaderFieldsTooLarge:
 		return true
 	default:
 		return false

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -228,10 +228,6 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 	}
 	formattedErr = httphelper.NewStatusFromMsgAndHTTPCode(errString, resp.StatusCode).Err()
 
-	if isComponentPermanentError(resp.StatusCode) {
-		componentstatus.ReportStatus(e.host, componentstatus.NewPermanentErrorEvent(formattedErr))
-	}
-
 	if isRetryableStatusCode(resp.StatusCode) {
 		// A retry duration of 0 seconds will trigger the default backoff policy
 		// of our caller (retry handler).
@@ -271,31 +267,6 @@ func isRetryableStatusCode(code int) bool {
 	case http.StatusServiceUnavailable:
 		return true
 	case http.StatusGatewayTimeout:
-		return true
-	default:
-		return false
-	}
-}
-
-// A component status of PermanentError indicates the component is in a state that will require user
-// intervention to fix. Typically this is a misconfiguration detected at runtime. A component
-// PermanentError has different semantics than a consumererror. For more information, see:
-// https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-status.md
-func isComponentPermanentError(code int) bool {
-	switch code {
-	case http.StatusUnauthorized:
-		return true
-	case http.StatusForbidden:
-		return true
-	case http.StatusNotFound:
-		return true
-	case http.StatusMethodNotAllowed:
-		return true
-	case http.StatusRequestEntityTooLarge:
-		return true
-	case http.StatusRequestURITooLong:
-		return true
-	case http.StatusRequestHeaderFieldsTooLarge:
 		return true
 	default:
 		return false

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -1151,46 +1151,6 @@ func TestComponentStatus(t *testing.T) {
 			componentStatus: componentstatus.StatusOK,
 		},
 		{
-			name:            "401",
-			responseStatus:  http.StatusUnauthorized,
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
-			name:            "403",
-			responseStatus:  http.StatusForbidden,
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
-			name:            "404",
-			responseStatus:  http.StatusNotFound,
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
-			name:            "405",
-			responseStatus:  http.StatusMethodNotAllowed,
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
-			name:            "413",
-			responseStatus:  http.StatusRequestEntityTooLarge,
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
-			name:            "414",
-			responseStatus:  http.StatusRequestURITooLong,
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
-			name:            "419",
-			responseStatus:  http.StatusTooManyRequests,
-			componentStatus: componentstatus.StatusRecoverableError,
-		},
-		{
-			name:            "431",
-			responseStatus:  http.StatusRequestHeaderFieldsTooLarge,
-			componentStatus: componentstatus.StatusPermanentError,
-		},
-		{
 			name:            "503",
 			responseStatus:  http.StatusServiceUnavailable,
 			componentStatus: componentstatus.StatusRecoverableError,

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -1200,7 +1200,7 @@ func TestComponentStatus(t *testing.T) {
 	t.Run("traces", func(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				srv := createBackend("/v1/traces", func(writer http.ResponseWriter, request *http.Request) {
+				srv := createBackend("/v1/traces", func(writer http.ResponseWriter, _ *http.Request) {
 					writer.WriteHeader(tt.responseStatus)
 				})
 				defer srv.Close()
@@ -1227,7 +1227,7 @@ func TestComponentStatus(t *testing.T) {
 				traces := ptrace.NewTraces()
 				err = exp.ConsumeTraces(context.Background(), traces)
 				if tt.componentStatus != componentstatus.StatusOK {
-					assert.Error(t, err)
+					require.Error(t, err)
 				}
 				assert.Equal(t, tt.componentStatus, host.lastStatus)
 			})
@@ -1237,7 +1237,7 @@ func TestComponentStatus(t *testing.T) {
 	t.Run("metrics", func(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				srv := createBackend("/v1/metrics", func(writer http.ResponseWriter, request *http.Request) {
+				srv := createBackend("/v1/metrics", func(writer http.ResponseWriter, _ *http.Request) {
 					writer.WriteHeader(tt.responseStatus)
 				})
 				defer srv.Close()
@@ -1264,7 +1264,7 @@ func TestComponentStatus(t *testing.T) {
 				metrics := pmetric.NewMetrics()
 				err = exp.ConsumeMetrics(context.Background(), metrics)
 				if tt.componentStatus != componentstatus.StatusOK {
-					assert.Error(t, err)
+					require.Error(t, err)
 				}
 				assert.Equal(t, tt.componentStatus, host.lastStatus)
 			})
@@ -1274,7 +1274,7 @@ func TestComponentStatus(t *testing.T) {
 	t.Run("logs", func(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				srv := createBackend("/v1/logs", func(writer http.ResponseWriter, request *http.Request) {
+				srv := createBackend("/v1/logs", func(writer http.ResponseWriter, _ *http.Request) {
 					writer.WriteHeader(tt.responseStatus)
 				})
 				defer srv.Close()
@@ -1301,7 +1301,7 @@ func TestComponentStatus(t *testing.T) {
 				logs := plog.NewLogs()
 				err = exp.ConsumeLogs(context.Background(), logs)
 				if tt.componentStatus != componentstatus.StatusOK {
-					assert.Error(t, err)
+					require.Error(t, err)
 				}
 				assert.Equal(t, tt.componentStatus, host.lastStatus)
 			})

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -1167,7 +1167,7 @@ func TestComponentStatus(t *testing.T) {
 
 				cfg := &Config{
 					Encoding:       EncodingProto,
-					TracesEndpoint: fmt.Sprintf("%s/v1/traces", srv.URL),
+					TracesEndpoint: srv.URL + "%s/v1/traces",
 				}
 
 				set := exportertest.NewNopSettings()
@@ -1204,7 +1204,7 @@ func TestComponentStatus(t *testing.T) {
 
 				cfg := &Config{
 					Encoding:        EncodingProto,
-					MetricsEndpoint: fmt.Sprintf("%s/v1/metrics", srv.URL),
+					MetricsEndpoint: srv.URL + "%s/v1/metrics",
 				}
 
 				set := exportertest.NewNopSettings()
@@ -1241,7 +1241,7 @@ func TestComponentStatus(t *testing.T) {
 
 				cfg := &Config{
 					Encoding:     EncodingProto,
-					LogsEndpoint: fmt.Sprintf("%s/v1/logs", srv.URL),
+					LogsEndpoint: srv.URL + "%s/v1/logs",
 				}
 
 				set := exportertest.NewNopSettings()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds runtime status reporting for the otlp and otlphttp exporters. It's an updated version of #8788 which was one of several approaches experimented with to add this functionality. This work was paused to allow the [consumererror](https://github.com/open-telemetry/opentelemetry-collector/pull/9041) work to evolve, as it appeared as though there might be a way to uniformly apply the same logic to all exporters (via the exporterhelper), but that work has taken a different direction, and it looks like a uniform approach will not be possible.

This PR implements runtime status reporting as discussed in #9957. The choices for which statuses represent permanent errors are up for debate, but the key point is that a permanent error is an error discovered at runtime that will require user intervention to fix.

This implementation makes use of the finite state machine that underlies the status reporting system. The finite state machine will ensure that:
- Only changes in status are reported. Repeat reports of the same status will no-op.
- If a component transitions into a PermanentError all further status reports will no-op.

This means the exporter does not have to reason about current or previous statuses. It can report status based on its current view of the world and the status reporting system will handle the rest. Flapping between recoverable and ok is meant to be handled by watchers consuming status events. The healthcheckv2extension handles this by using a time based approach (e.g. recovery interval). Other watchers may choose to handle this situation differently.

For more information on status reporting, the state machine, etc see: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-status.md

While all components report status during start and shutdown (via automation), this is the first component to report runtime status. This will allow the [healthcheckv2extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckv2extension) to replace the currently non-functioning `check_collector_pipeline` capability of the original [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension) and should serve as an example for other components that wish to report runtime status moving forward.


<!-- Issue number if applicable -->
#### Link to tracking issue
Implements #9957 for the otlp and otlphttp exporters

<!--Describe what testing was performed and which tests were added.-->
#### Testing
units/manual

<!--Describe the documentation added.-->
#### Documentation
code comments

<!--Please delete paragraphs that you did not use before submitting.-->
