### PR TITLE
[chore] docs: Revert "update cmd/builder documentation for docker image"

### DIFF
--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -57,34 +57,11 @@ $ /tmp/dist/otelcol-custom --config=/tmp/otelcol.yaml
 
 ## Installation
 
-There are three supported ways to install the builder:
-1. Via official release Docker images (recommended)
-2. Via official release binaries (recommended)
-3. Through `go install` (not recommended)
+There are two supported ways to install the builder: via the official releases (recommended) and through `go install`.
 
-### Official release Docker image
+### Official releases
 
-You will find the official docker images at [DockerHub](https://hub.docker.com/r/otel/opentelemetry-collector-builder). 
-
-Pull the image via tagged version number (e.g. v0.110.0) or 'latest'. You may also specify platform, although Docker will handle this automatically as it is a multi-platform build.
-
-```
-docker pull otel/opentelemetry-collector-builder:latest
-```
-
-The included builder configuration file/manifest should be replaced by mounting a file from your local filesystem to the docker container; the default location is `/build/builder-config.yaml`. If you mount a file at a different location inside the container, your `builder.config.yaml` must be specified as a command line argument to ocb. Additionally, the output folder must also be mounted from your local system to the docker container. This output directory must be specified in your `builder-config.yaml` file as it cannot be set via the command-line arguments.
-
-Assuming you are running this image in your working directory, have a `builder-config.yaml` file located in this folder, the `dist.output_path` item inside your `builder-config.yaml` is set to `./otelcol-dev`, and you wish to output the binary/go module files to a folder named `output`, the command would look as follows:
-
-```
-docker run -v "$(pwd)/builder-config.yaml:/build/builder-config.yaml" -v "$(pwd)/output:/build/otelcol-dev" otel/opentelemetry-collector-builder:latest
-```
-
-Additional arguments may be passed to ocb on the command line as specified below, but if you wish to do this, you must make sure to pass the `--config` argument, as this is specified as an additional `CMD`, not an entrypoint. 
-
-### Official release binaries 
-
-This is the recommended installation method for the binary. Download the binary for your respective platform from the ["Releases"](https://github.com/open-telemetry/opentelemetry-collector-releases/releases?q=cmd/builder) page.
+This is the recommended installation method. Download the binary for your respective platform from the ["Releases"](https://github.com/open-telemetry/opentelemetry-collector-releases/releases?q=cmd/builder) page.
 
 ### `go install`
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -74,32 +74,22 @@ It is possible that a core approver isn't a contrib approver. In that case, the 
 ## Producing the artifacts
 The last step of the release process creates artifacts for the new version of the collector and publishes images to Dockerhub. The steps in this portion of the release are done in the [opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) repo.
 
-**NOTE: Step 1 of this section is updated!**
+1. Update the `./distributions/**/manifest.yaml` files to include the new release version.
 
-1. Run the "Update Version" workflow under [opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) repo. Make sure to enter the previous (current) and the new (updated) version numbers, including the leading 'v'. This will automate the following steps:
-   
-   1. Update the `./distributions/**/manifest.yaml` files to include the new release version.
+2. Update the builder version in `OTELCOL_BUILDER_VERSION` to the new release in the `Makefile`. While this might not be strictly necessary for every release, this is a good practice.
 
-   2. Update the default `./cmd/builder/builder-config.yaml` used for ocb Docker image build to include the new release version
-
-   3. Update the builder version in `OTELCOL_BUILDER_VERSION` to the new release in the `Makefile`. While this might not be strictly necessary for every release, this is a good practice.
-
-   4. Create a pull request with these changes 
-
-2. Review the automatic pull request that is created and ensure the build completes successfully. See [example](https://github.com/open-telemetry/opentelemetry-collector-releases/pull/71).
+3. Create a pull request with the change and ensure the build completes successfully. See [example](https://github.com/open-telemetry/opentelemetry-collector-releases/pull/71).
    -  🛑 **Do not move forward until this PR is merged.** 🛑
 
-3. Check out the commit created by merging the PR and tag with the new release version by running the `make push-tags TAG=v0.85.0` command. If you set your remote using `https` you need to include `REMOTE=https://github.com/open-telemetry/opentelemetry-collector-releases.git` in each command. Wait for the new tag build to pass successfully.
+4. Check out the commit created by merging the PR and tag with the new release version by running the `make push-tags TAG=v0.85.0` command. If you set your remote using `https` you need to include `REMOTE=https://github.com/open-telemetry/opentelemetry-collector-releases.git` in each command. Wait for the new tag build to pass successfully.
 
-4. Ensure the "Release Core", "Release Contrib", "Release k8s", and "Builder - Release" actions pass, this will
+5. Ensure the "Release Core", "Release Contrib", "Release k8s", and "Builder - Release" actions pass, this will
 
     1. push new container images to `https://hub.docker.com/repository/docker/otel/opentelemetry-collector`, `https://hub.docker.com/repository/docker/otel/opentelemetry-collector-contrib` and `https://hub.docker.com/repository/docker/otel/opentelemetry-collector-k8s`
 
     2. create a Github release for the tag and push all the build artifacts to the Github release. See [example](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/workflows/release-core.yaml).
 
     3. build and release ocb binaries under a separate tagged Github release, e.g. `cmd/builder/v0.85.0`
-
-    4. build and push ocb Docker images to `https://hub.docker.com/r/otel/opentelemetry-collector-builder` and the GitHub Container Registry within the releases repository
 
 ## Troubleshooting
 


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector#11234

The PR to publish container images for builder https://github.com/open-telemetry/opentelemetry-collector-releases/pull/671 has not been merged yet (neither has the one adding "Update version" workflow https://github.com/open-telemetry/opentelemetry-collector-releases/pull/684). We should only publish these docs after the images are published.

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/11347