### PR TITLE
[exporter] exporter queue Read()

### DIFF
--- a/exporter/internal/queue/bounded_memory_queue.go
+++ b/exporter/internal/queue/bounded_memory_queue.go
@@ -44,7 +44,7 @@ func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
 // The call blocks until there is an item available or the queue is stopped.
 // The function returns true when an item is consumed or false if the queue is stopped and emptied.
 func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T) error) bool {
-	_, item, ok := q.GetNextItem()
+	_, item, ok := q.Read(context.Background())
 	if !ok {
 		return false
 	}
@@ -53,7 +53,7 @@ func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T) err
 	return true
 }
 
-func (q *boundedMemoryQueue[T]) GetNextItem() (uint64, T, bool) {
+func (q *boundedMemoryQueue[T]) Read(_ context.Context) (uint64, T, bool) {
 	item, ok := q.sizedChannel.pop(func(el memQueueEl[T]) int64 { return q.sizer.Sizeof(el.req) })
 	return 0, item.req, ok
 }

--- a/exporter/internal/queue/bounded_memory_queue.go
+++ b/exporter/internal/queue/bounded_memory_queue.go
@@ -40,9 +40,9 @@ func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
 	return q.sizedChannel.push(memQueueEl[T]{ctx: ctx, req: req}, q.sizer.Sizeof(req), nil)
 }
 
-func (q *boundedMemoryQueue[T]) Read(_ context.Context) (uint64, T, bool) {
+func (q *boundedMemoryQueue[T]) Read(_ context.Context) (uint64, context.Context, T, bool) {
 	item, ok := q.sizedChannel.pop(func(el memQueueEl[T]) int64 { return q.sizer.Sizeof(el.req) })
-	return 0, item.req, ok
+	return 0, item.ctx, item.req, ok
 }
 
 // Should be called to remove the item of the given index from the queue once processing is finished.

--- a/exporter/internal/queue/bounded_memory_queue.go
+++ b/exporter/internal/queue/bounded_memory_queue.go
@@ -40,19 +40,6 @@ func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
 	return q.sizedChannel.push(memQueueEl[T]{ctx: ctx, req: req}, q.sizer.Sizeof(req), nil)
 }
 
-// Consume applies the provided function on the head of queue.
-// The call blocks until there is an item available or the queue is stopped.
-// The function returns true when an item is consumed or false if the queue is stopped and emptied.
-func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T) error) bool {
-	_, item, ok := q.Read(context.Background())
-	if !ok {
-		return false
-	}
-	// the memory queue doesn't handle consume errors
-	_ = consumeFunc(context.Background(), item)
-	return true
-}
-
 func (q *boundedMemoryQueue[T]) Read(_ context.Context) (uint64, T, bool) {
 	item, ok := q.sizedChannel.pop(func(el memQueueEl[T]) int64 { return q.sizer.Sizeof(el.req) })
 	return 0, item.req, ok

--- a/exporter/internal/queue/bounded_memory_queue_test.go
+++ b/exporter/internal/queue/bounded_memory_queue_test.go
@@ -26,7 +26,7 @@ func TestBoundedQueue(t *testing.T) {
 	require.NoError(t, q.Offer(context.Background(), "a"))
 
 	numConsumed := 0
-	assert.True(t, q.Consume(func(_ context.Context, item string) error {
+	assert.True(t, consume(q, func(_ context.Context, item string) error {
 		assert.Equal(t, "a", item)
 		numConsumed++
 		return nil
@@ -42,7 +42,7 @@ func TestBoundedQueue(t *testing.T) {
 	require.ErrorIs(t, q.Offer(context.Background(), "c"), ErrQueueIsFull)
 	assert.Equal(t, 1, q.Size())
 
-	assert.True(t, q.Consume(func(_ context.Context, item string) error {
+	assert.True(t, consume(q, func(_ context.Context, item string) error {
 		assert.Equal(t, "b", item)
 		numConsumed++
 		return nil
@@ -51,7 +51,7 @@ func TestBoundedQueue(t *testing.T) {
 
 	for _, toAddItem := range []string{"d", "e", "f"} {
 		require.NoError(t, q.Offer(context.Background(), toAddItem))
-		assert.True(t, q.Consume(func(_ context.Context, item string) error {
+		assert.True(t, consume(q, func(_ context.Context, item string) error {
 			assert.Equal(t, toAddItem, item)
 			numConsumed++
 			return nil
@@ -59,7 +59,7 @@ func TestBoundedQueue(t *testing.T) {
 	}
 	assert.Equal(t, 5, numConsumed)
 	require.NoError(t, q.Shutdown(context.Background()))
-	assert.False(t, q.Consume(func(_ context.Context, item string) error {
+	assert.False(t, consume(q, func(_ context.Context, item string) error {
 		panic(item)
 	}))
 }
@@ -82,7 +82,7 @@ func TestShutdownWhileNotEmpty(t *testing.T) {
 	assert.Equal(t, 10, q.Size())
 	numConsumed := 0
 	for i := 0; i < 10; i++ {
-		assert.True(t, q.Consume(func(_ context.Context, item string) error {
+		assert.True(t, consume(q, func(_ context.Context, item string) error {
 			assert.Equal(t, strconv.FormatInt(int64(i), 10), item)
 			numConsumed++
 			return nil
@@ -91,7 +91,7 @@ func TestShutdownWhileNotEmpty(t *testing.T) {
 	assert.Equal(t, 10, numConsumed)
 	assert.Equal(t, 0, q.Size())
 
-	assert.False(t, q.Consume(func(_ context.Context, item string) error {
+	assert.False(t, consume(q, func(_ context.Context, item string) error {
 		panic(item)
 	}))
 }

--- a/exporter/internal/queue/consumers.go
+++ b/exporter/internal/queue/consumers.go
@@ -40,9 +40,12 @@ func (qc *Consumers[T]) Start(ctx context.Context, host component.Host) error {
 			startWG.Done()
 			defer qc.stopWG.Done()
 			for {
-				if !qc.queue.Consume(qc.consumeFunc) {
+				index, req, ok := qc.queue.Read(context.Background())
+				if !ok {
 					return
 				}
+				consumeErr := qc.consumeFunc(context.Background(), req)
+				qc.queue.OnProcessingFinished(index, consumeErr)
 			}
 		}()
 	}

--- a/exporter/internal/queue/consumers.go
+++ b/exporter/internal/queue/consumers.go
@@ -40,11 +40,11 @@ func (qc *Consumers[T]) Start(ctx context.Context, host component.Host) error {
 			startWG.Done()
 			defer qc.stopWG.Done()
 			for {
-				index, req, ok := qc.queue.Read(context.Background())
+				index, ctx, req, ok := qc.queue.Read(context.Background())
 				if !ok {
 					return
 				}
-				consumeErr := qc.consumeFunc(context.Background(), req)
+				consumeErr := qc.consumeFunc(ctx, req)
 				qc.queue.OnProcessingFinished(index, consumeErr)
 			}
 		}()

--- a/exporter/internal/queue/persistent_queue.go
+++ b/exporter/internal/queue/persistent_queue.go
@@ -287,7 +287,7 @@ func (pq *persistentQueue[T]) putInternal(ctx context.Context, req T) error {
 	return nil
 }
 
-func (pq *persistentQueue[T]) Read(ctx context.Context) (uint64, T, bool) {
+func (pq *persistentQueue[T]) Read(ctx context.Context) (uint64, context.Context, T, bool) {
 	for {
 		var (
 			index    uint64
@@ -303,10 +303,10 @@ func (pq *persistentQueue[T]) Read(ctx context.Context) (uint64, T, bool) {
 			return size
 		})
 		if !ok {
-			return 0, req, false
+			return 0, nil, req, false
 		}
 		if consumed {
-			return index, req, true
+			return index, nil, req, true
 		}
 
 		// If ok && !consumed, it means we are stopped. In this case, we still process all the other events

--- a/exporter/internal/queue/persistent_queue.go
+++ b/exporter/internal/queue/persistent_queue.go
@@ -189,20 +189,6 @@ func (pq *persistentQueue[T]) restoreQueueSizeFromStorage(ctx context.Context) (
 	return bytesToItemIndex(val)
 }
 
-// Consume applies the provided function on the head of queue.
-// The call blocks until there is an item available or the queue is stopped.
-// The function returns true when an item is consumed or false if the queue is stopped.
-func (pq *persistentQueue[T]) Consume(consumeFunc func(context.Context, T) error) bool {
-	index, _, req, ok := pq.Read(context.Background())
-	if !ok {
-		return false
-	}
-	consumeErr := consumeFunc(context.Background(), req)
-	pq.OnProcessingFinished(index, consumeErr)
-	return true
-
-}
-
 func (pq *persistentQueue[T]) Shutdown(ctx context.Context) error {
 	// If the queue is not initialized, there is nothing to shut down.
 	if pq.client == nil {

--- a/exporter/internal/queue/persistent_queue.go
+++ b/exporter/internal/queue/persistent_queue.go
@@ -193,7 +193,7 @@ func (pq *persistentQueue[T]) restoreQueueSizeFromStorage(ctx context.Context) (
 // The call blocks until there is an item available or the queue is stopped.
 // The function returns true when an item is consumed or false if the queue is stopped.
 func (pq *persistentQueue[T]) Consume(consumeFunc func(context.Context, T) error) bool {
-	index, req, ok := pq.Read(context.Background())
+	index, _, req, ok := pq.Read(context.Background())
 	if !ok {
 		return false
 	}
@@ -306,7 +306,7 @@ func (pq *persistentQueue[T]) Read(ctx context.Context) (uint64, context.Context
 			return 0, nil, req, false
 		}
 		if consumed {
-			return index, nil, req, true
+			return index, context.TODO(), req, true
 		}
 
 		// If ok && !consumed, it means we are stopped. In this case, we still process all the other events

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -463,13 +463,13 @@ func TestPersistentQueue_CurrentlyProcessedItems(t *testing.T) {
 	requireCurrentlyDispatchedItemsEqual(t, ps, []uint64{})
 
 	// Takes index 0 in process.
-	_, readReq, found := ps.GetNextItem()
+	_, readReq, found := ps.getNextItem(context.Background())
 	require.True(t, found)
 	assert.Equal(t, req, readReq)
 	requireCurrentlyDispatchedItemsEqual(t, ps, []uint64{0})
 
 	// This takes item 1 to process.
-	secondIndex, secondReadReq, found := ps.GetNextItem()
+	secondIndex, secondReadReq, found := ps.getNextItem(context.Background())
 	require.True(t, found)
 	assert.Equal(t, req, secondReadReq)
 	requireCurrentlyDispatchedItemsEqual(t, ps, []uint64{0, 1})
@@ -608,7 +608,7 @@ func TestPersistentQueue_PutCloseReadClose(t *testing.T) {
 	assert.NoError(t, ps.Offer(context.Background(), req))
 	assert.Equal(t, 2, ps.Size())
 	// TODO: Remove this, after the initialization writes the readIndex.
-	_, _, _ = ps.GetNextItem()
+	_, _, _ = ps.getNextItem(context.Background())
 	require.NoError(t, ps.Shutdown(context.Background()))
 
 	newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
@@ -736,7 +736,7 @@ func TestPersistentQueue_ShutdownWhileConsuming(t *testing.T) {
 
 	require.NoError(t, ps.Offer(context.Background(), newTracesRequest(5, 10)))
 
-	index, _, ok := ps.GetNextItem()
+	index, _, ok := ps.getNextItem(context.Background())
 	require.True(t, ok)
 	assert.False(t, ps.client.(*mockStorageClient).isClosed())
 	require.NoError(t, ps.Shutdown(context.Background()))

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -463,13 +463,13 @@ func TestPersistentQueue_CurrentlyProcessedItems(t *testing.T) {
 	requireCurrentlyDispatchedItemsEqual(t, ps, []uint64{})
 
 	// Takes index 0 in process.
-	_, readReq, found := ps.getNextItem(context.Background())
+	_, readReq, found := ps.GetNextItem()
 	require.True(t, found)
 	assert.Equal(t, req, readReq)
 	requireCurrentlyDispatchedItemsEqual(t, ps, []uint64{0})
 
 	// This takes item 1 to process.
-	secondIndex, secondReadReq, found := ps.getNextItem(context.Background())
+	secondIndex, secondReadReq, found := ps.GetNextItem()
 	require.True(t, found)
 	assert.Equal(t, req, secondReadReq)
 	requireCurrentlyDispatchedItemsEqual(t, ps, []uint64{0, 1})
@@ -608,7 +608,7 @@ func TestPersistentQueue_PutCloseReadClose(t *testing.T) {
 	assert.NoError(t, ps.Offer(context.Background(), req))
 	assert.Equal(t, 2, ps.Size())
 	// TODO: Remove this, after the initialization writes the readIndex.
-	_, _, _ = ps.getNextItem(context.Background())
+	_, _, _ = ps.GetNextItem()
 	require.NoError(t, ps.Shutdown(context.Background()))
 
 	newPs := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
@@ -736,7 +736,7 @@ func TestPersistentQueue_ShutdownWhileConsuming(t *testing.T) {
 
 	require.NoError(t, ps.Offer(context.Background(), newTracesRequest(5, 10)))
 
-	index, _, ok := ps.getNextItem(context.Background())
+	index, _, ok := ps.GetNextItem()
 	require.True(t, ok)
 	assert.False(t, ps.client.(*mockStorageClient).isClosed())
 	require.NoError(t, ps.Shutdown(context.Background()))

--- a/exporter/internal/queue/queue.go
+++ b/exporter/internal/queue/queue.go
@@ -25,10 +25,6 @@ type Queue[T any] interface {
 	// without violating capacity restrictions. If success returns no error.
 	// It returns ErrQueueIsFull if no space is currently available.
 	Offer(ctx context.Context, item T) error
-	// Consume applies the provided function on the head of queue.
-	// The call blocks until there is an item available or the queue is stopped.
-	// The function returns true when an item is consumed or false if the queue is stopped.
-	Consume(func(ctx context.Context, item T) error) bool
 	// Size returns the current Size of the queue
 	Size() int
 	// Capacity returns the capacity of the queue.

--- a/exporter/internal/queue/queue.go
+++ b/exporter/internal/queue/queue.go
@@ -33,6 +33,10 @@ type Queue[T any] interface {
 	Size() int
 	// Capacity returns the capacity of the queue.
 	Capacity() int
+	// GetNextItem pulls the next available item from the queue along with its index. Once processing is
+	// finished, the index should be called with OnProcessingFinished to clean up the storage. If no new
+	// item is available, returns false.
+	GetNextItem() (uint64, T, bool)
 	// Should be called to remove the item of the given index from the queue once processing is finished.
 	OnProcessingFinished(index uint64, consumeErr error)
 }

--- a/exporter/internal/queue/queue.go
+++ b/exporter/internal/queue/queue.go
@@ -33,7 +33,7 @@ type Queue[T any] interface {
 	// finished, the index should be called with OnProcessingFinished to clean up the storage.
 	// The function blocks until an item is available or if the queue is stopped.
 	// Returns false if reading failed or if the queue is stopped.
-	Read(context.Context) (uint64, T, bool)
+	Read(context.Context) (uint64, context.Context, T, bool)
 	// Should be called to remove the item of the given index from the queue once processing is finished.
 	OnProcessingFinished(index uint64, consumeErr error)
 }

--- a/exporter/internal/queue/queue.go
+++ b/exporter/internal/queue/queue.go
@@ -30,8 +30,9 @@ type Queue[T any] interface {
 	// Capacity returns the capacity of the queue.
 	Capacity() int
 	// Read pulls the next available item from the queue along with its index. Once processing is
-	// finished, the index should be called with OnProcessingFinished to clean up the storage. If no new
-	// item is available, returns false.
+	// finished, the index should be called with OnProcessingFinished to clean up the storage.
+	// The function blocks until an item is available or if the queue is stopped.
+	// Returns false if reading failed or if the queue is stopped.
 	Read(context.Context) (uint64, T, bool)
 	// Should be called to remove the item of the given index from the queue once processing is finished.
 	OnProcessingFinished(index uint64, consumeErr error)

--- a/exporter/internal/queue/queue.go
+++ b/exporter/internal/queue/queue.go
@@ -33,10 +33,10 @@ type Queue[T any] interface {
 	Size() int
 	// Capacity returns the capacity of the queue.
 	Capacity() int
-	// GetNextItem pulls the next available item from the queue along with its index. Once processing is
+	// Read pulls the next available item from the queue along with its index. Once processing is
 	// finished, the index should be called with OnProcessingFinished to clean up the storage. If no new
 	// item is available, returns false.
-	GetNextItem() (uint64, T, bool)
+	Read(context.Context) (uint64, T, bool)
 	// Should be called to remove the item of the given index from the queue once processing is finished.
 	OnProcessingFinished(index uint64, consumeErr error)
 }

--- a/exporter/internal/queue/queue_test.go
+++ b/exporter/internal/queue/queue_test.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"context"
+)
+
+func consume[T any](q Queue[T], consumeFunc func(context.Context, T) error) bool {
+	index, req, ok := q.Read(context.Background())
+	if !ok {
+		return false
+	}
+	consumeErr := consumeFunc(context.Background(), req)
+	q.OnProcessingFinished(index, consumeErr)
+	return true
+}

--- a/exporter/internal/queue/queue_test.go
+++ b/exporter/internal/queue/queue_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func consume[T any](q Queue[T], consumeFunc func(context.Context, T) error) bool {
-	index, req, ok := q.Read(context.Background())
+	index, ctx, req, ok := q.Read(context.Background())
 	if !ok {
 		return false
 	}
-	consumeErr := consumeFunc(context.Background(), req)
+	consumeErr := consumeFunc(ctx, req)
 	q.OnProcessingFinished(index, consumeErr)
 	return true
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds a public function `GetNextItem` to queue (both persistent queue and bounded memory queue)

Why this change?
Instead of blocking until consumption of the item is done, we would like to separate the API for reading and committing consumption.

Before:
`Consume(consumeFunc)`

After:
`idx, item = Read()`
`OnProcessingFinished(idx)`

<!-- Issue number if applicable -->
#### Link to tracking issue

https://github.com/open-telemetry/opentelemetry-collector/issues/8122
https://github.com/open-telemetry/opentelemetry-collector/issues/10368

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
