### PR TITLE
Hide profiles behind a feature gate

### DIFF
--- a/.chloggen/profiles-featuregate.yaml
+++ b/.chloggen/profiles-featuregate.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Hide profiles support behind a feature gate while it remains alpha.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11477]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/service/pipelines/config.go
+++ b/service/pipelines/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/pipeline/pipelineprofiles"
 )
@@ -16,6 +17,14 @@ var (
 	errMissingServicePipelines         = errors.New("service must have at least one pipeline")
 	errMissingServicePipelineReceivers = errors.New("must have at least one receiver")
 	errMissingServicePipelineExporters = errors.New("must have at least one exporter")
+
+	serviceProfileSupportGateID = "service.profilesSupport"
+	serviceProfileSupportGate   = featuregate.GlobalRegistry().MustRegister(
+		serviceProfileSupportGateID,
+		featuregate.StageAlpha,
+		featuregate.WithRegisterFromVersion("v0.112.0"),
+		featuregate.WithRegisterDescription("Controls whether profiles support can be enabled"),
+	)
 )
 
 // Config defines the configurable settings for service telemetry.
@@ -31,8 +40,16 @@ func (cfg Config) Validate() error {
 	// only configured components.
 	for pipelineID, p := range cfg {
 		switch pipelineID.Signal() {
-		case pipeline.SignalTraces, pipeline.SignalMetrics, pipeline.SignalLogs, pipelineprofiles.SignalProfiles:
+		case pipeline.SignalTraces, pipeline.SignalMetrics, pipeline.SignalLogs:
 			// Continue
+		case pipelineprofiles.SignalProfiles:
+			if !serviceProfileSupportGate.IsEnabled() {
+				return fmt.Errorf(
+					"pipeline %q: profiling signal support is at alpha level, gated under the %q feature gate",
+					pipelineID.String(),
+					serviceProfileSupportGateID,
+				)
+			}
 		default:
 			return fmt.Errorf("pipeline %q: unknown signal %q", pipelineID.String(), pipelineID.Signal())
 		}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This hides profiles support behind a feature gate, so folks have to enable them explicitly to be able to use them.