### PR TITLE
[chore] ensure test is testing ipv6 addressing

### DIFF
--- a/service/internal/promtest/server_util.go
+++ b/service/internal/promtest/server_util.go
@@ -4,6 +4,7 @@
 package promtest // import "go.opentelemetry.io/collector/service/internal/promtest"
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"testing"
@@ -14,7 +15,9 @@ import (
 )
 
 func GetAvailableLocalIPv6AddressPrometheus(t testing.TB) *config.Prometheus {
-	return addrToPrometheus(testutil.GetAvailableLocalIPv6Address(t))
+	p := addrToPrometheus(testutil.GetAvailableLocalIPv6Address(t))
+	p.Host = ptr(fmt.Sprintf("[%s]", *p.Host))
+	return p
 }
 
 func GetAvailableLocalAddressPrometheus(t testing.TB) *config.Prometheus {
@@ -31,7 +34,17 @@ func addrToPrometheus(address string) *config.Prometheus {
 		return nil
 	}
 	return &config.Prometheus{
-		Host: &host,
-		Port: &portInt,
+		Host:              &host,
+		Port:              &portInt,
+		WithoutScopeInfo:  ptr(true),
+		WithoutUnits:      ptr(true),
+		WithoutTypeSuffix: ptr(true),
+		WithResourceConstantLabels: &config.IncludeExclude{
+			Excluded: []string{},
+		},
 	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }


### PR DESCRIPTION
This ensures that the ipv6 hostname includes a `[]` around the host, otherwise this confuses the net library that tries to start a server.
