### PR TITLE
[chore] Remove deprecated documentation

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,7 +1,0 @@
-# Monitoring
-
-To learn how to monitor the Collector using its own telemetry, see the [Internal
-telemetry] page.
-
-[Internal telemetry]:
-  https://opentelemetry.io/docs/collector/internal-telemetry/#use-internal-telemetry-to-monitor-the-collector

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,0 @@
-# Troubleshooting
-
-To troubleshoot the Collector, see the [Troubleshooting] page.
-
-[Troubleshooting]: https://opentelemetry.io/docs/collector/troubleshooting/


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Removes pages that were moved to opentelemetry.io. These pages now live at:

- https://opentelemetry.io/docs/collector/internal-telemetry/#use-internal-telemetry-to-monitor-the-collector
- https://opentelemetry.io/docs/collector/troubleshooting/

Neither of the md docs in opentelemetry-collector are among the top 10 most visited pages according to Github traffic stats (we don't have visibility into individual pages, only the top 10)
