### PR TITLE
[consumer] Mark module as stable

### DIFF
--- a/.chloggen/mx-psi_consumer-1.0.yaml
+++ b/.chloggen/mx-psi_consumer-1.0.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: consumer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark consumer as stable.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9046]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/versions.yaml
+++ b/versions.yaml
@@ -19,6 +19,7 @@ module-sets:
       - go.opentelemetry.io/collector/config/configretry
       - go.opentelemetry.io/collector/config/configtls
       - go.opentelemetry.io/collector/config/confignet
+      - go.opentelemetry.io/collector/consumer
   beta:
     version: v0.111.0
     modules:
@@ -38,7 +39,6 @@ module-sets:
       - go.opentelemetry.io/collector/connector/connectortest
       - go.opentelemetry.io/collector/connector/connectorprofiles
       - go.opentelemetry.io/collector/connector/forwardconnector
-      - go.opentelemetry.io/collector/consumer
       - go.opentelemetry.io/collector/consumer/consumerprofiles
       - go.opentelemetry.io/collector/consumer/consumererror
       - go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Mark `consumer` module as stable. This is now possible after #11491, since `consumererror` is a separate module now.

#### Link to tracking issue
Fixes #9046
