### PR TITLE
[chore] Add missing API changelog for configcompression

### DIFF
--- a/.chloggen/configcompression-include-lz4-compression.yaml
+++ b/.chloggen/configcompression-include-lz4-compression.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: "configcompression"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for lz4 compression
+
+# One or more tracking issues or pull requests related to the change
+issues: [9128]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`make check-changes PREVIOUS_VERSION=v1.17.0 MODSET=stable` returned that a v1.18.0 release is necessary due to changes in configcompression. This adds a missing changelog entry for the module since the other changelog entry only mentions confighttp.
