### PR TITLE
[exporterqueue] Default Batcher that reads from the queue, batches and exports

### DIFF
--- a/exporter/internal/queue/batcher.go
+++ b/exporter/internal/queue/batcher.go
@@ -1,0 +1,277 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
+	"go.opentelemetry.io/collector/exporter/internal"
+)
+
+type batch struct {
+	ctx     context.Context
+	req     internal.Request
+	idxList []uint64
+}
+
+type Batcher struct {
+	cfg exporterbatcher.Config
+
+	queue      Queue[internal.Request]
+	maxWorkers int
+	workerPool chan bool
+
+	exportFunc func(context.Context, internal.Request) error
+
+	batchListMu sync.Mutex
+	batchList   []batch
+	lastFlushed time.Time
+	timer       *time.Timer
+	shutdownCh  chan bool
+
+	stopWG sync.WaitGroup
+}
+
+func NewBatcher(cfg exporterbatcher.Config, queue Queue[internal.Request],
+	maxWorkers int, exportFunc func(context.Context, internal.Request) error) *Batcher {
+	return &Batcher{
+		cfg:        cfg,
+		queue:      queue,
+		maxWorkers: maxWorkers,
+		exportFunc: exportFunc,
+		stopWG:     sync.WaitGroup{},
+		batchList:  make([]batch, 0),
+		shutdownCh: make(chan bool, 1),
+	}
+}
+
+// If precondition.s pass, flushIfNecessary() take an item from the head of batch list and exports it.
+func (qb *Batcher) flushIfNecessary(timeout bool, force bool) {
+	qb.batchListMu.Lock()
+
+	if len(qb.batchList) == 0 || qb.batchList[0].req == nil {
+		qb.resetTimer()
+		qb.batchListMu.Unlock()
+		return
+	}
+
+	if !force && timeout && time.Since(qb.lastFlushed) < qb.cfg.FlushTimeout {
+		qb.batchListMu.Unlock()
+		return
+	}
+
+	// If item size is over the threshold, there is another flusher that is already triggered.
+	if !force && timeout && qb.batchList[0].req.ItemsCount() >= qb.cfg.MinSizeItems {
+		qb.batchListMu.Unlock()
+		return
+	}
+
+	if !force && !timeout && qb.batchList[0].req.ItemsCount() < qb.cfg.MinSizeItems {
+		qb.batchListMu.Unlock()
+		return
+	}
+
+	flushedBatch := qb.batchList[0]
+	qb.batchList = qb.batchList[1:]
+	qb.lastFlushed = time.Now()
+	qb.resetTimer()
+
+	qb.batchListMu.Unlock()
+	err := qb.exportFunc(flushedBatch.ctx, flushedBatch.req)
+	for _, idx := range flushedBatch.idxList {
+		qb.queue.OnProcessingFinished(idx, err)
+	}
+}
+
+// push() adds a new item to the batchList.
+func (qb *Batcher) push(req internal.Request, idx uint64) (int, error) {
+	qb.batchListMu.Lock()
+	defer qb.batchListMu.Unlock()
+
+	// If batching is not enabled.
+	if !qb.cfg.Enabled {
+		qb.batchList = append(
+			qb.batchList,
+			batch{
+				req:     req,
+				ctx:     context.Background(),
+				idxList: []uint64{idx}})
+		return 1, nil
+	}
+
+	if qb.cfg.MaxSizeItems > 0 {
+		if len(qb.batchList) == 0 {
+			qb.batchList = append(qb.batchList, batch{
+				req:     nil,
+				ctx:     context.Background(),
+				idxList: []uint64{idx}})
+		}
+
+		var (
+			reqs []internal.Request
+			err  error
+		)
+		if qb.batchList[len(qb.batchList)-1].req == nil {
+			reqs, err = req.MergeSplit(context.Background(), qb.cfg.MaxSizeConfig, nil)
+		} else {
+			reqs, err = qb.batchList[len(qb.batchList)-1].req.MergeSplit(context.Background(),
+				qb.cfg.MaxSizeConfig, req)
+		}
+
+		if err != nil || len(reqs) == 0 {
+			return 0, err
+		}
+
+		qb.batchList[len(qb.batchList)-1] = batch{
+			req:     reqs[0],
+			ctx:     context.Background(),
+			idxList: []uint64{idx},
+		}
+		for i := 1; i < len(reqs); i++ {
+			qb.batchList = append(qb.batchList, batch{
+				req:     reqs[i],
+				ctx:     context.Background(),
+				idxList: []uint64{idx}})
+		}
+
+		// Force flush the last batch if there was a split.
+		if len(reqs) > 1 && qb.batchList[len(qb.batchList)-1].req.ItemsCount() < qb.cfg.MinSizeItems {
+			lastBatch := qb.batchList[len(qb.batchList)-1]
+			qb.batchList = qb.batchList[0 : len(qb.batchList)-1]
+
+			err := qb.exportFunc(lastBatch.ctx, lastBatch.req)
+			for _, idx := range lastBatch.idxList {
+				qb.queue.OnProcessingFinished(idx, err)
+			}
+
+			return len(reqs) - 1, nil
+		}
+		return len(reqs), nil
+	}
+
+	if len(qb.batchList) == 0 {
+		qb.batchList = append(
+			qb.batchList,
+			batch{
+				req:     req,
+				ctx:     context.Background(),
+				idxList: []uint64{idx}})
+	} else {
+		lastItem := len(qb.batchList) - 1
+		mergedReq, err := qb.batchList[lastItem].req.Merge(context.Background(), req)
+		if err != nil {
+			return 0, err
+		}
+		qb.batchList[lastItem].req = mergedReq
+		qb.batchList[lastItem].idxList = append(qb.batchList[lastItem].idxList, idx)
+	}
+	if qb.batchList[len(qb.batchList)-1].req.ItemsCount() >= qb.cfg.MinSizeItems {
+		return 1, nil
+	}
+	return 0, nil
+
+}
+
+func (qb *Batcher) resetTimer() {
+	if qb.cfg.Enabled {
+		qb.timer.Reset(qb.cfg.FlushTimeout)
+	}
+}
+
+// allocateFlusher() starts a goroutine that calls flushIfNecessary(). It blocks until a worker is available.
+func (qb *Batcher) allocateFlusher(timeout bool) {
+	// maxWorker = 0 means we don't limit the number of flushers.
+	if qb.maxWorkers == 0 {
+		qb.stopWG.Add(1)
+		go func() {
+			qb.flushIfNecessary(timeout /*timeout*/, false /*force*/)
+			qb.stopWG.Done()
+		}()
+		return
+	}
+
+	qb.stopWG.Add(1)
+	<-qb.workerPool
+	go func() {
+		qb.flushIfNecessary(timeout /*timeout*/, false /*force*/)
+		qb.workerPool <- true
+		qb.stopWG.Done()
+	}()
+}
+
+// Start ensures that queue and all consumers are started.
+func (qb *Batcher) Start(ctx context.Context, host component.Host) error {
+	if err := qb.queue.Start(ctx, host); err != nil {
+		return err
+	}
+
+	if qb.cfg.Enabled {
+		qb.timer = time.NewTimer(qb.cfg.FlushTimeout)
+	} else {
+		qb.timer = time.NewTimer(math.MaxInt)
+		qb.timer.Stop()
+	}
+
+	qb.workerPool = make(chan bool, qb.maxWorkers)
+	for i := 0; i < qb.maxWorkers; i++ {
+		qb.workerPool <- true
+	}
+
+	// This goroutine keeps reading until flush is triggered because of request size.
+	qb.stopWG.Add(1)
+	go func() {
+		defer qb.stopWG.Done()
+		for {
+			idx, _, req, ok := qb.queue.Read(context.Background())
+
+			if !ok {
+				qb.shutdownCh <- true
+				qb.flushIfNecessary(false /*timeout*/, true /*force*/)
+				return
+			}
+
+			flushCount, err := qb.push(req, idx)
+			if err != nil {
+				qb.queue.OnProcessingFinished(idx, err)
+			}
+
+			if flushCount > 0 {
+				for i := 1; i < flushCount; i++ {
+					qb.allocateFlusher(false /*timeout*/)
+				}
+				// allocateFlusher() blocks until the number of flushers are under the threshold.
+				// This ensures that reading slows down when we are too busy sending.
+				qb.allocateFlusher(false /*timeout*/)
+			}
+		}
+	}()
+
+	qb.stopWG.Add(1)
+	go func() {
+		defer qb.stopWG.Done()
+		for {
+			select {
+			case <-qb.shutdownCh:
+				return
+			case <-qb.timer.C:
+				qb.allocateFlusher(true /*timeout*/)
+			}
+		}
+	}()
+	return nil
+}
+
+// Shutdown ensures that queue and all Batcher are stopped.
+func (qb *Batcher) Shutdown(ctx context.Context) error {
+	if err := qb.queue.Shutdown(ctx); err != nil {
+		return err
+	}
+	qb.stopWG.Wait()
+	return nil
+}

--- a/exporter/internal/queue/batcher_test.go
+++ b/exporter/internal/queue/batcher_test.go
@@ -1,0 +1,291 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
+	"go.opentelemetry.io/collector/exporter/internal"
+)
+
+func testExportFunc(ctx context.Context, req internal.Request) error {
+	return req.Export(ctx)
+}
+
+func TestBatcher_Merge(t *testing.T) {
+	cfg := exporterbatcher.NewDefaultConfig()
+	cfg.MinSizeItems = 10
+	cfg.FlushTimeout = 100 * time.Millisecond
+
+	tests := []struct {
+		name       string
+		batcherCfg exporterbatcher.Config
+	}{
+		{
+			name:       "split_disabled",
+			batcherCfg: cfg,
+		},
+		{
+			name: "split_high_limit",
+			batcherCfg: func() exporterbatcher.Config {
+				c := cfg
+				c.MaxSizeItems = 1000
+				return c
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := NewBoundedMemoryQueue[internal.Request](
+				MemoryQueueSettings[internal.Request]{
+					Sizer:    &RequestSizer[internal.Request]{},
+					Capacity: 10,
+				})
+			maxWorkers := 1
+			ba := NewBatcher(cfg, q, maxWorkers, testExportFunc)
+
+			require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+			t.Cleanup(func() {
+				require.NoError(t, ba.Shutdown(context.Background()))
+			})
+
+			sink := newFakeRequestSink()
+
+			require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 8, sink: sink}))
+			require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 3, sink: sink}))
+
+			// the first two requests should be merged into one and sent by reaching the minimum items size
+			assert.Eventually(t, func() bool {
+				return sink.requestsCount.Load() == 1 && sink.itemsCount.Load() == 11
+			}, 50*time.Millisecond, 10*time.Millisecond)
+
+			require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 3, sink: sink}))
+			require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 1, sink: sink}))
+
+			// the third and fifth requests should be sent by reaching the timeout
+			// the fourth request should be ignored because of the merge error.
+			time.Sleep(50 * time.Millisecond)
+
+			// should be ignored because of the merge error.
+			require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 3, sink: sink,
+				mergeErr: errors.New("merge error")}))
+
+			assert.Equal(t, int64(1), sink.requestsCount.Load())
+			assert.Eventually(t, func() bool {
+				return sink.requestsCount.Load() == 2 && sink.itemsCount.Load() == 15
+			}, 100*time.Millisecond, 10*time.Millisecond)
+		})
+	}
+}
+
+func TestBatcher_BatchExportError(t *testing.T) {
+	cfg := exporterbatcher.NewDefaultConfig()
+	cfg.MinSizeItems = 10
+	cfg.FlushTimeout = 10 * time.Second // so batches are never flushed because of timeout for this test.
+	tests := []struct {
+		name             string
+		batcherCfg       exporterbatcher.Config
+		expectedRequests int64
+		expectedItems    int64
+	}{
+		{
+			name:       "merge_only",
+			batcherCfg: cfg,
+		},
+		{
+			name: "merge_without_split_triggered",
+			batcherCfg: func() exporterbatcher.Config {
+				c := cfg
+				c.MaxSizeItems = 200
+				return c
+			}(),
+		},
+		{
+			name: "merge_with_split_triggered",
+			batcherCfg: func() exporterbatcher.Config {
+				c := cfg
+				c.MaxSizeItems = 20
+				return c
+			}(),
+			expectedRequests: 1,
+			expectedItems:    20,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := NewBoundedMemoryQueue[internal.Request](
+				MemoryQueueSettings[internal.Request]{
+					Sizer:    &RequestSizer[internal.Request]{},
+					Capacity: 10,
+				})
+
+			maxWorkers := 1
+			ba := NewBatcher(tt.batcherCfg, q, maxWorkers, testExportFunc)
+
+			require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+			t.Cleanup(func() {
+				require.NoError(t, ba.Shutdown(context.Background()))
+			})
+
+			sink := newFakeRequestSink()
+
+			require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 4, sink: sink}))
+			require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 4, sink: sink}))
+
+			// the first two requests should be blocked because they don't hit the size threshold.
+			time.Sleep(50 * time.Millisecond)
+			assert.Equal(t, int64(0), sink.requestsCount.Load())
+
+			// the third request should trigger the export and cause an error.
+			errReq := &fakeRequest{items: 20, exportErr: errors.New("transient error"), sink: sink}
+			require.NoError(t, q.Offer(context.Background(), errReq))
+
+			// the batch should be dropped since the queue doesn't have requeuing enabled.
+			assert.Eventually(t, func() bool {
+				return sink.requestsCount.Load() == tt.expectedRequests &&
+					sink.itemsCount.Load() == tt.expectedItems &&
+					q.Size() == 0
+			}, 100*time.Millisecond, 10*time.Millisecond)
+		})
+	}
+}
+
+func TestBatcher_MergeOrSplit(t *testing.T) {
+	cfg := exporterbatcher.NewDefaultConfig()
+	cfg.MinSizeItems = 5
+	cfg.MaxSizeItems = 10
+	cfg.FlushTimeout = 100 * time.Millisecond
+
+	q := NewBoundedMemoryQueue[internal.Request](
+		MemoryQueueSettings[internal.Request]{
+			Sizer:    &RequestSizer[internal.Request]{},
+			Capacity: 10,
+		})
+	maxWorkers := 1
+	ba := NewBatcher(cfg, q, maxWorkers, testExportFunc)
+
+	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, ba.Shutdown(context.Background()))
+	})
+
+	sink := newFakeRequestSink()
+
+	// should be sent right away by reaching the minimum items size.
+	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 8, sink: sink}))
+	assert.Eventually(t, func() bool {
+		return sink.requestsCount.Load() == 1 && sink.itemsCount.Load() == 8
+	}, 50*time.Millisecond, 10*time.Millisecond)
+
+	// big request should be broken down into two requests, both are sent right away.
+	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 17, sink: sink}))
+	assert.Eventually(t, func() bool {
+		return sink.requestsCount.Load() == 3 && sink.itemsCount.Load() == 25
+	}, 50*time.Millisecond, 10*time.Millisecond)
+
+	// request that cannot be split should be dropped.
+	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 11, sink: sink,
+		mergeErr: errors.New("split error")}))
+
+	// big request should be broken down into two requests, both are sent right away.
+	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 13, sink: sink}))
+
+	assert.Eventually(t, func() bool {
+		return sink.requestsCount.Load() == 5 && sink.itemsCount.Load() == 38
+	}, 50*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestBatcher_Shutdown(t *testing.T) {
+	batchCfg := exporterbatcher.NewDefaultConfig()
+	batchCfg.MinSizeItems = 10
+	q := NewBoundedMemoryQueue[internal.Request](
+		MemoryQueueSettings[internal.Request]{
+			Sizer:    &RequestSizer[internal.Request]{},
+			Capacity: 10,
+		})
+	maxWorkers := 1
+	ba := NewBatcher(batchCfg, q, maxWorkers, testExportFunc)
+
+	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+
+	sink := newFakeRequestSink()
+	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 3, sink: sink}))
+
+	// To make the request reached the batchSender before shutdown.
+	time.Sleep(50 * time.Millisecond)
+
+	require.NoError(t, ba.Shutdown(context.Background()))
+
+	// shutdown should force sending the batch
+	assert.Equal(t, int64(1), sink.requestsCount.Load())
+	assert.Equal(t, int64(3), sink.itemsCount.Load())
+}
+
+func TestBatcher_UnstartedShutdown(t *testing.T) {
+	batchCfg := exporterbatcher.NewDefaultConfig()
+	batchCfg.MinSizeItems = 10
+	q := NewBoundedMemoryQueue[internal.Request](
+		MemoryQueueSettings[internal.Request]{
+			Sizer:    &RequestSizer[internal.Request]{},
+			Capacity: 10,
+		})
+	maxWorkers := 1
+	ba := NewBatcher(batchCfg, q, maxWorkers, testExportFunc)
+
+	err := ba.Shutdown(context.Background())
+	require.NoError(t, err)
+}
+
+func TestBatchSenderTimerFlush(t *testing.T) {
+	bCfg := exporterbatcher.NewDefaultConfig()
+	bCfg.MinSizeItems = 8
+	bCfg.FlushTimeout = 100 * time.Millisecond
+	q := NewBoundedMemoryQueue[internal.Request](
+		MemoryQueueSettings[internal.Request]{
+			Sizer:    &RequestSizer[internal.Request]{},
+			Capacity: 10,
+		})
+	maxWorkers := 1
+	ba := NewBatcher(bCfg, q, maxWorkers, testExportFunc)
+
+	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+	sink := newFakeRequestSink()
+	time.Sleep(50 * time.Millisecond)
+
+	// Send 2 concurrent requests that should be merged in one batch and sent immediately
+	go func() {
+		assert.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 4, sink: sink}))
+	}()
+	go func() {
+		assert.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 4, sink: sink}))
+	}()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.LessOrEqual(c, int64(1), sink.requestsCount.Load())
+		assert.EqualValues(c, 8, sink.itemsCount.Load())
+	}, 30*time.Millisecond, 5*time.Millisecond)
+
+	// Send another request that should be flushed after 100ms instead of 50ms since last flush
+	go func() {
+		assert.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 4, sink: sink}))
+	}()
+
+	// Confirm that it is not flushed in 50ms
+	time.Sleep(60 * time.Millisecond)
+	assert.LessOrEqual(t, int64(1), sink.requestsCount.Load())
+	assert.EqualValues(t, 8, sink.itemsCount.Load())
+
+	// Confirm that it is flushed after 100ms (using 60+50=110 here to be safe)
+	time.Sleep(50 * time.Millisecond)
+	assert.LessOrEqual(t, int64(2), sink.requestsCount.Load())
+	assert.EqualValues(t, 12, sink.itemsCount.Load())
+	require.NoError(t, ba.Shutdown(context.Background()))
+}

--- a/exporter/internal/queue/fake_request.go
+++ b/exporter/internal/queue/fake_request.go
@@ -1,0 +1,122 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
+	"go.opentelemetry.io/collector/exporter/internal"
+)
+
+type fakeRequestSink struct {
+	requestsCount *atomic.Int64
+	itemsCount    *atomic.Int64
+}
+
+func newFakeRequestSink() *fakeRequestSink {
+	return &fakeRequestSink{
+		requestsCount: new(atomic.Int64),
+		itemsCount:    new(atomic.Int64),
+	}
+}
+
+type fakeRequest struct {
+	items     int
+	exportErr error
+	mergeErr  error
+	delay     time.Duration
+	sink      *fakeRequestSink
+}
+
+func (r *fakeRequest) Export(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(r.delay):
+	}
+	if r.exportErr != nil {
+		return r.exportErr
+	}
+	if r.sink != nil {
+		r.sink.requestsCount.Add(1)
+		r.sink.itemsCount.Add(int64(r.items))
+	}
+	return nil
+}
+
+func (r *fakeRequest) ItemsCount() int {
+	return r.items
+}
+
+func (r *fakeRequest) Merge(_ context.Context,
+	r2 internal.Request) (internal.Request, error) {
+	if r == nil {
+		return r2, nil
+	}
+	fr2 := r2.(*fakeRequest)
+	if fr2.mergeErr != nil {
+		return nil, fr2.mergeErr
+	}
+	return &fakeRequest{
+		items:     r.items + fr2.items,
+		sink:      r.sink,
+		exportErr: fr2.exportErr,
+		delay:     r.delay + fr2.delay,
+	}, nil
+}
+
+func (r *fakeRequest) MergeSplit(ctx context.Context, cfg exporterbatcher.MaxSizeConfig,
+	r2 internal.Request) ([]internal.Request, error) {
+	if r.mergeErr != nil {
+		return nil, r.mergeErr
+	}
+
+	maxItems := cfg.MaxSizeItems
+	if maxItems == 0 {
+		r, err := r.Merge(ctx, r2)
+		return []internal.Request{r}, err
+	}
+
+	var fr2 *fakeRequest
+	if r2 == nil {
+		fr2 = &fakeRequest{sink: r.sink, exportErr: r.exportErr, delay: r.delay}
+	} else {
+		if r2.(*fakeRequest).mergeErr != nil {
+			return nil, r2.(*fakeRequest).mergeErr
+		}
+		fr2 = r2.(*fakeRequest)
+		fr2 = &fakeRequest{items: fr2.items, sink: fr2.sink, exportErr: fr2.exportErr, delay: fr2.delay}
+	}
+	var res []internal.Request
+
+	// fill fr1 to maxItems if it's not nil
+
+	r = &fakeRequest{items: r.items, sink: r.sink, exportErr: r.exportErr, delay: r.delay}
+	if fr2.items <= maxItems-r.items {
+		r.items += fr2.items
+		if fr2.exportErr != nil {
+			r.exportErr = fr2.exportErr
+		}
+		return []internal.Request{r}, nil
+	}
+	// if split is needed, we don't propagate exportErr from fr2 to fr1 to test more cases
+	fr2.items -= maxItems - r.items
+	r.items = maxItems
+	res = append(res, r)
+
+	// split fr2 to maxItems
+	for {
+		if fr2.items <= maxItems {
+			res = append(res, &fakeRequest{items: fr2.items, sink: fr2.sink, exportErr: fr2.exportErr, delay: fr2.delay})
+			break
+		}
+		res = append(res, &fakeRequest{items: maxItems, sink: fr2.sink, exportErr: fr2.exportErr, delay: fr2.delay})
+		fr2.items -= maxItems
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
#### Description

This PR implements a new component that pulls from `queue_sender`. This component will replace `consumers` in `queue_sender`

The idea is that instead of allocating a group of reading goroutine and block them until the corresponding batch gets flushed, we now use a goroutine to read and then use the same goroutine go flush while allocating new goroutine to read.

Design doc:
https://docs.google.com/document/d/1y5jt7bQ6HWt04MntF8CjUwMBBeNiJs2gV4uUZfJjAsE/edit?usp=sharing


<!-- Issue number if applicable -->
#### Link to tracking issue

https://github.com/open-telemetry/opentelemetry-collector/issues/8122
https://github.com/open-telemetry/opentelemetry-collector/issues/10368

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
