### PR TITLE
[chore] Promote Damien Mathieu to triager role

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Here is a list of community roles with current and previous members:
 - Triagers ([@open-telemetry/collector-triagers](https://github.com/orgs/open-telemetry/teams/collector-triagers)):
 
   - [Andrzej Stencel](https://github.com/andrzej-stencel), Elastic
+  - [Damien Mathieu](https://github.com/dmathieu), Elastic
   - Actively seeking contributors to triage issues
 
 - Emeritus Triagers:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Promotes @dmathieu to triager. His contributions have helped add support for the profiling signal and have placed him [among the top 5 (non-bot) committers in the last 6 months](https://github.com/open-telemetry/opentelemetry-collector/graphs/contributors?from=4%2F20%2F2024).

You can see a list of his contributions [here](https://github.com/open-telemetry/opentelemetry-collector/pulls?q=is%3Apr+author%3Admathieu+).
