### PR TITLE
[chore] Update leaf module versions to commits with pseudo version dependencies

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/pdata v1.17.0
 	go.uber.org/goleak v1.3.0
 )

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -10,12 +10,12 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0
 	go.opentelemetry.io/collector/confmap v1.17.0
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/filter v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/receiver v0.111.0
 	go.opentelemetry.io/collector/semconv v0.111.0
 	go.opentelemetry.io/otel/metric v1.31.0
@@ -45,7 +45,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0 // indirect

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -25,7 +25,7 @@ require (
 	go.opentelemetry.io/collector/extension/memorylimiterextension v0.111.0
 	go.opentelemetry.io/collector/extension/zpagesextension v0.111.0
 	go.opentelemetry.io/collector/otelcol v0.111.0
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/processor/batchprocessor v0.111.0
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.111.0
 	go.opentelemetry.io/collector/receiver v0.111.0
@@ -93,13 +93,13 @@ require (
 	go.opentelemetry.io/collector/config/configtls v1.17.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.111.0 // indirect
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.111.0 // indirect
-	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021181817-007f06b7c4a8 // indirect
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021235809-403c782d50c6 // indirect
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0 // indirect
-	go.opentelemetry.io/collector/exporter/exporterhelper/exporterhelperprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/exporter/exporterhelper/exporterhelperprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/exporter/exportertest v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.111.0 // indirect
@@ -111,9 +111,9 @@ require (
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.111.0 // indirect
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/processor/processorprofiles v0.111.0 // indirect
-	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.111.0 // indirect
 	go.opentelemetry.io/collector/service v0.111.0 // indirect

--- a/connector/connectorprofiles/go.mod
+++ b/connector/connectorprofiles/go.mod
@@ -7,13 +7,13 @@ require (
 	go.opentelemetry.io/collector v0.111.0
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/connector v0.111.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6
 )
 
 require (

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/connector v0.111.0
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.111.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/collector v0.111.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.111.0 // indirect
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/otel v1.31.0 // indirect
 	go.opentelemetry.io/otel/metric v1.31.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.31.0 // indirect

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -7,8 +7,8 @@ require (
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/confmap v1.17.0
 	go.opentelemetry.io/collector/connector v0.111.0
-	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
@@ -36,7 +36,7 @@ require (
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/otel v1.31.0 // indirect
 	go.opentelemetry.io/otel/metric v1.31.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.31.0 // indirect

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector v0.111.0
 	go.opentelemetry.io/collector/component v0.111.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0

--- a/consumer/consumererror/consumererrorprofiles/go.mod
+++ b/consumer/consumererror/consumererrorprofiles/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0
 )

--- a/consumer/consumerprofiles/go.mod
+++ b/consumer/consumerprofiles/go.mod
@@ -10,7 +10,7 @@ replace go.opentelemetry.io/collector/consumer => ../
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0
 )
 

--- a/consumer/consumertest/go.mod
+++ b/consumer/consumertest/go.mod
@@ -6,7 +6,7 @@ replace go.opentelemetry.io/collector/consumer => ../
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0
 	go.opentelemetry.io/collector/confmap v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/exporter v0.111.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
@@ -36,7 +36,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.17.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0 // indirect
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.111.0 // indirect

--- a/exporter/exporterhelper/exporterhelperprofiles/go.mod
+++ b/exporter/exporterhelper/exporterhelperprofiles/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/config/configretry v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/exporter v0.111.0
@@ -16,7 +16,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exportertest v0.111.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0
 	go.opentelemetry.io/otel/trace v1.31.0

--- a/exporter/exporterprofiles/go.mod
+++ b/exporter/exporterprofiles/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/pdata v1.17.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
 	go.opentelemetry.io/otel v1.31.0 // indirect

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/config/configretry v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/exporter v0.111.0
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.111.0

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -8,8 +8,8 @@ require (
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/config/configretry v1.17.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.111.0
 	go.opentelemetry.io/collector/extension v0.111.0

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -30,8 +30,8 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -13,10 +13,10 @@ require (
 	go.opentelemetry.io/collector/config/configretry v1.17.0
 	go.opentelemetry.io/collector/config/configtls v1.17.0
 	go.opentelemetry.io/collector/confmap v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/exporter v0.111.0
-	go.opentelemetry.io/collector/exporter/exporterhelper/exporterhelperprofiles v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/exporter/exporterhelper/exporterhelperprofiles v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.111.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
@@ -54,14 +54,14 @@ require (
 	go.opentelemetry.io/collector/config/confignet v1.17.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension/experimental/storage v0.111.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.111.0 // indirect
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/receiver v0.111.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.111.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.56.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -12,10 +12,10 @@ require (
 	go.opentelemetry.io/collector/config/configretry v1.17.0
 	go.opentelemetry.io/collector/config/configtls v1.17.0
 	go.opentelemetry.io/collector/confmap v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/exporter v0.111.0
-	go.opentelemetry.io/collector/exporter/exporterhelper/exporterhelperprofiles v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/exporter/exporterhelper/exporterhelperprofiles v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.111.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
@@ -54,14 +54,14 @@ require (
 	go.opentelemetry.io/collector/config/configauth v0.111.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension/experimental/storage v0.111.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.111.0 // indirect
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/receiver v0.111.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.111.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/component/componentstatus v0.111.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -15,8 +15,8 @@ require (
 	go.opentelemetry.io/collector/config/configtls v1.17.0
 	go.opentelemetry.io/collector/confmap v1.17.0
 	go.opentelemetry.io/collector/connector v0.111.0
-	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/exporter v0.111.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.111.0
@@ -80,20 +80,20 @@ require (
 	go.opentelemetry.io/collector/config/confignet v1.17.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.111.0 // indirect
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/consumererrorprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
-	go.opentelemetry.io/collector/exporter/exporterhelper/exporterhelperprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/exporter/exporterhelper/exporterhelperprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension/experimental/storage v0.111.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.111.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.17.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/processor/processorprofiles v0.111.0 // indirect
-	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.111.0 // indirect
 	go.opentelemetry.io/contrib/config v0.10.0 // indirect

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -10,14 +10,14 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0
 	go.opentelemetry.io/collector/confmap v1.17.0
 	go.opentelemetry.io/collector/connector v0.111.0
-	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/exporter v0.111.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.111.0
 	go.opentelemetry.io/collector/extension v0.111.0
 	go.opentelemetry.io/collector/featuregate v1.17.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/receiver v0.111.0
 	go.opentelemetry.io/collector/service v0.111.0
 	go.opentelemetry.io/contrib/config v0.10.0
@@ -69,8 +69,8 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector v0.111.0 // indirect
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0 // indirect
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.111.0 // indirect
@@ -78,7 +78,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.17.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0 // indirect
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/processor/processorprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.111.0 // indirect

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -11,14 +11,14 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.17.0
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.17.0
 	go.opentelemetry.io/collector/connector v0.111.0
-	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/exporter v0.111.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.111.0
 	go.opentelemetry.io/collector/extension v0.111.0
 	go.opentelemetry.io/collector/otelcol v0.111.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/receiver v0.111.0
 	go.opentelemetry.io/collector/service v0.111.0
 	go.uber.org/goleak v1.3.0
@@ -66,8 +66,8 @@ require (
 	go.opentelemetry.io/collector/component/componentstatus v0.111.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0 // indirect
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0 // indirect
 	go.opentelemetry.io/collector/exporter/exporterprofiles v0.111.0 // indirect
@@ -76,7 +76,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.17.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0 // indirect
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/processor/processorprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.111.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.111.0 // indirect

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -8,13 +8,13 @@ require (
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0
 	go.opentelemetry.io/collector/confmap v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021093951-f2b31d131ae2
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/metric v1.31.0
 	go.opentelemetry.io/otel/sdk/metric v1.31.0

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
-	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/metric v1.31.0
 	go.opentelemetry.io/otel/sdk/metric v1.31.0

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -7,14 +7,14 @@ require (
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0
 	go.opentelemetry.io/collector/confmap v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021093951-f2b31d131ae2
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/internal/memorylimiter v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/metric v1.31.0
 	go.opentelemetry.io/otel/sdk/metric v1.31.0

--- a/processor/processorprofiles/go.mod
+++ b/processor/processorprofiles/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6
 )
 
 require (
@@ -19,7 +19,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/pdata v1.17.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
 	go.opentelemetry.io/otel v1.31.0 // indirect

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -7,14 +7,14 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/component/componentstatus v0.111.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/pdata v1.17.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/processor/processorprofiles v0.111.0
 	go.uber.org/goleak v1.3.0
 )

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021093951-f2b31d131ae2
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.111.0
 	go.opentelemetry.io/collector/confmap v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/receiver v0.111.0
 	go.uber.org/goleak v1.3.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -15,7 +15,7 @@ require (
 	go.opentelemetry.io/collector/config/confignet v1.17.0
 	go.opentelemetry.io/collector/config/configtls v1.17.0
 	go.opentelemetry.io/collector/confmap v1.17.0
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021093951-f2b31d131ae2
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0

--- a/receiver/receiverprofiles/go.mod
+++ b/receiver/receiverprofiles/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/pdata v1.17.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0 // indirect
 	go.opentelemetry.io/otel v1.31.0 // indirect

--- a/service/go.mod
+++ b/service/go.mod
@@ -17,8 +17,8 @@ require (
 	go.opentelemetry.io/collector/confmap v1.17.0
 	go.opentelemetry.io/collector/connector v0.111.0
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.111.0
-	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/consumer v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.111.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.111.0
 	go.opentelemetry.io/collector/exporter v0.111.0
@@ -32,10 +32,10 @@ require (
 	go.opentelemetry.io/collector/pdata/pprofile v0.111.0
 	go.opentelemetry.io/collector/pdata/testdata v0.111.0
 	go.opentelemetry.io/collector/pipeline v0.111.0
-	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021181817-007f06b7c4a8
-	go.opentelemetry.io/collector/processor v0.111.1-0.20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/pipeline/pipelineprofiles v0.0.0-20241021235809-403c782d50c6
+	go.opentelemetry.io/collector/processor v0.111.1-0.20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/processor/processorprofiles v0.111.0
-	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021181817-007f06b7c4a8
+	go.opentelemetry.io/collector/processor/processortest v0.0.0-20241021235809-403c782d50c6
 	go.opentelemetry.io/collector/receiver v0.111.0
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.111.0
 	go.opentelemetry.io/collector/semconv v0.111.0
@@ -97,7 +97,7 @@ require (
 	go.opentelemetry.io/collector/config/configopaque v1.17.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.17.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.111.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021181817-007f06b7c4a8 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.0.0-20241021235809-403c782d50c6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.111.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 // indirect
 	go.opentelemetry.io/contrib/zpages v0.56.0 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Say we have three modules, A, B, and C, with dependencies C->B->A. If we are on commit 1, and make a new commit, 2, where we change the dependencies such that the go.mod files read C@2->B@1->A@1, we will still get a failure, because at commit 1 we had not yet made the changes necessary to properly resolve these modules. Specifically, at commit 2 we have B@1->A@#, where A@# is not externally-resolvable.

We therefore need to make a new commit 3, where we can have C@2->B@2->A@2, and at commit 2 all modules are externally-resolvable.

This PR is a necessary update to https://github.com/open-telemetry/opentelemetry-collector/pull/11503.

When running `make update-otel` in contrib, I am seeing the following errors:

```
go: downloading go.opentelemetry.io/collector/connector/connectortest v0.0.0-20241021181817-007f06b7c4a8
go: go.opentelemetry.io/collector/pipeline/pipelineprofiles@v0.111.0: reading go.opentelemetry.io/collector/pipeline/pipelineprofiles/go.mod at revision pipeline/pipelineprofiles/v0.111.0: unknown revision pipeline/pipelineprofiles/v0.111.0
```

connectortest has an indirect dependency on pipelineprofiles, and at commit `007f06b7c4a8` pipelineprofiles is versioned at v0.111.0. The latest commit, `403c782d50c6`, will version it at `007f06b7c4a8`. Since pipelineprofiles has no dependencies, this will not result in any issues.