### PR TITLE
Add UnmarshalText for StabilityLevel

### DIFF
--- a/.chloggen/stabilityunmarshal.yaml
+++ b/.chloggen/stabilityunmarshal.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add UnmarshalText for StabilityLevel
+
+# One or more tracking issues or pull requests related to the change
+issues: [11520]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -39,7 +39,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name:    "testdata/invalid_stability.yaml",
-			wantErr: "decoding failed due to the following error(s):\n\nerror decoding 'status.stability': invalid stability level: incorrectstability",
+			wantErr: "decoding failed due to the following error(s):\n\nerror decoding 'status.stability': unsupported stability level: \"incorrectstability\"",
 		},
 		{
 			name:    "testdata/no_stability_component.yaml",

--- a/component/component.go
+++ b/component/component.go
@@ -7,6 +7,8 @@ package component // import "go.opentelemetry.io/collector/component"
 
 import (
 	"context"
+	"fmt"
+	"strings"
 )
 
 // Component is either a receiver, exporter, processor, connector, or an extension.
@@ -118,6 +120,29 @@ const (
 	StabilityLevelBeta
 	StabilityLevelStable
 )
+
+func (sl *StabilityLevel) UnmarshalText(in []byte) error {
+	str := strings.ToLower(string(in))
+	switch str {
+	case "undefined":
+		*sl = StabilityLevelUndefined
+	case "unmaintained":
+		*sl = StabilityLevelUnmaintained
+	case "deprecated":
+		*sl = StabilityLevelDeprecated
+	case "development":
+		*sl = StabilityLevelDevelopment
+	case "alpha":
+		*sl = StabilityLevelAlpha
+	case "beta":
+		*sl = StabilityLevelBeta
+	case "stable":
+		*sl = StabilityLevelStable
+	default:
+		return fmt.Errorf("unsupported stability level: %q", string(in))
+	}
+	return nil
+}
 
 func (sl StabilityLevel) String() string {
 	switch sl {

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -10,22 +10,74 @@ import (
 )
 
 func TestKindString(t *testing.T) {
-	assert.EqualValues(t, "", Kind(0).String())
-	assert.EqualValues(t, "Receiver", KindReceiver.String())
-	assert.EqualValues(t, "Processor", KindProcessor.String())
-	assert.EqualValues(t, "Exporter", KindExporter.String())
-	assert.EqualValues(t, "Extension", KindExtension.String())
-	assert.EqualValues(t, "Connector", KindConnector.String())
-	assert.EqualValues(t, "", Kind(100).String())
+	assert.Equal(t, "", Kind(0).String())
+	assert.Equal(t, "Receiver", KindReceiver.String())
+	assert.Equal(t, "Processor", KindProcessor.String())
+	assert.Equal(t, "Exporter", KindExporter.String())
+	assert.Equal(t, "Extension", KindExtension.String())
+	assert.Equal(t, "Connector", KindConnector.String())
+	assert.Equal(t, "", Kind(100).String())
+}
+
+func TestStabilityLevelUnmarshal(t *testing.T) {
+	tests := []struct {
+		input       string
+		output      StabilityLevel
+		expectedErr string
+	}{
+		{
+			input:  "Undefined",
+			output: StabilityLevelUndefined,
+		},
+		{
+			input:  "UnmaintaineD",
+			output: StabilityLevelUnmaintained,
+		},
+		{
+			input:  "DepreCated",
+			output: StabilityLevelDeprecated,
+		},
+		{
+			input:  "Development",
+			output: StabilityLevelDevelopment,
+		},
+		{
+			input:  "alpha",
+			output: StabilityLevelAlpha,
+		},
+		{
+			input:  "BETA",
+			output: StabilityLevelBeta,
+		},
+		{
+			input:  "sTABLe",
+			output: StabilityLevelStable,
+		},
+		{
+			input:       "notfound",
+			expectedErr: "unsupported stability level: \"notfound\"",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			var sl StabilityLevel
+			err := sl.UnmarshalText([]byte(test.input))
+			if test.expectedErr != "" {
+				assert.EqualError(t, err, test.expectedErr)
+			} else {
+				assert.Equal(t, test.output, sl)
+			}
+		})
+	}
 }
 
 func TestStabilityLevelString(t *testing.T) {
-	assert.EqualValues(t, "Undefined", StabilityLevelUndefined.String())
-	assert.EqualValues(t, "Unmaintained", StabilityLevelUnmaintained.String())
-	assert.EqualValues(t, "Deprecated", StabilityLevelDeprecated.String())
-	assert.EqualValues(t, "Development", StabilityLevelDevelopment.String())
-	assert.EqualValues(t, "Alpha", StabilityLevelAlpha.String())
-	assert.EqualValues(t, "Beta", StabilityLevelBeta.String())
-	assert.EqualValues(t, "Stable", StabilityLevelStable.String())
-	assert.EqualValues(t, "", StabilityLevel(100).String())
+	assert.Equal(t, "Undefined", StabilityLevelUndefined.String())
+	assert.Equal(t, "Unmaintained", StabilityLevelUnmaintained.String())
+	assert.Equal(t, "Deprecated", StabilityLevelDeprecated.String())
+	assert.Equal(t, "Development", StabilityLevelDevelopment.String())
+	assert.Equal(t, "Alpha", StabilityLevelAlpha.String())
+	assert.Equal(t, "Beta", StabilityLevelBeta.String())
+	assert.Equal(t, "Stable", StabilityLevelStable.String())
+	assert.Equal(t, "", StabilityLevel(100).String())
 }


### PR DESCRIPTION
This PR also starts using the fact that StabilityLevel implements UnmarshalText and cleans up the mdatagen stability structure.