### PR TITLE
[exporterqueue] Bare minimum frame of queue batcher + unit test.

### DIFF
--- a/exporter/internal/queue/batcher.go
+++ b/exporter/internal/queue/batcher.go
@@ -73,12 +73,6 @@ func (qb *BaseBatcher) flushAsync(batchToFlush batch) {
 
 // Shutdown ensures that queue and all Batcher are stopped.
 func (qb *BaseBatcher) Shutdown(ctx context.Context) error {
-	// TODO: queue shutdown is done here to keep the behavior similar to queue consumer.
-	// However batcher should not be responsible for shutting down the queue. Move this up to
-	// queue sender once queue consumer is cleaned up.
-	if err := qb.queue.Shutdown(ctx); err != nil {
-		return err
-	}
 	qb.stopWG.Wait()
 	return nil
 }

--- a/exporter/internal/queue/batcher.go
+++ b/exporter/internal/queue/batcher.go
@@ -1,0 +1,141 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
+	"go.opentelemetry.io/collector/exporter/internal"
+)
+
+type batch struct {
+	ctx     context.Context
+	req     internal.Request
+	idxList []uint64
+}
+
+type Batcher struct {
+	batchCfg exporterbatcher.Config
+
+	queue      Queue[internal.Request]
+	maxWorkers int
+
+	exportFunc func(context.Context, internal.Request) error
+
+	readingBatch *batch
+	timer        *time.Timer
+	shutdownCh   chan bool
+
+	stopWG sync.WaitGroup
+}
+
+func NewBatcher(batchCfg exporterbatcher.Config, queue Queue[internal.Request],
+	maxWorkers int, exportFunc func(context.Context, internal.Request) error) *Batcher {
+	return &Batcher{
+		batchCfg:   batchCfg,
+		queue:      queue,
+		maxWorkers: maxWorkers,
+		exportFunc: exportFunc,
+		stopWG:     sync.WaitGroup{},
+		shutdownCh: make(chan bool, 1),
+	}
+}
+
+// If preconditions pass, flush() take an item from the head of batch list and exports it.
+func (qb *Batcher) flush(batchToFlush batch) {
+	err := qb.exportFunc(batchToFlush.ctx, batchToFlush.req)
+	for _, idx := range batchToFlush.idxList {
+		qb.queue.OnProcessingFinished(idx, err)
+	}
+}
+
+// allocateFlusher() starts a goroutine that calls flushIfNecessary(). It blocks until a worker is available.
+func (qb *Batcher) allocateFlusher(batchToFlush batch) {
+	// maxWorker = 0 means we don't limit the number of flushers.
+	if qb.maxWorkers == 0 {
+		qb.stopWG.Add(1)
+		go func() {
+			qb.flush(batchToFlush)
+			qb.stopWG.Done()
+		}()
+		return
+	}
+	panic("not implemented")
+}
+
+// Start ensures that queue and all consumers are started.
+func (qb *Batcher) Start(ctx context.Context, host component.Host) error {
+	if err := qb.queue.Start(ctx, host); err != nil {
+		return err
+	}
+
+	if qb.batchCfg.Enabled {
+		panic("not implemented")
+	}
+
+	// Timer doesn't do anything yet, but adding it so compiler won't complain about qb.timer.C
+	qb.timer = time.NewTimer(math.MaxInt)
+	qb.timer.Stop()
+
+	if qb.maxWorkers != 0 {
+		panic("not implemented")
+	}
+
+	// This goroutine keeps reading until flush is triggered because of request size.
+	qb.stopWG.Add(1)
+	go func() {
+		defer qb.stopWG.Done()
+		for {
+			idx, _, req, ok := qb.queue.Read(context.Background())
+
+			if !ok {
+				qb.shutdownCh <- true
+				if qb.readingBatch != nil {
+					panic("batching is supported yet so reading batch should always be nil")
+				}
+
+				return
+			}
+			if !qb.batchCfg.Enabled {
+				qb.readingBatch = &batch{
+					req:     req,
+					ctx:     context.Background(),
+					idxList: []uint64{idx}}
+				qb.allocateFlusher(*qb.readingBatch)
+				qb.readingBatch = nil
+			} else {
+				panic("not implemented")
+			}
+		}
+	}()
+
+	qb.stopWG.Add(1)
+	go func() {
+		defer qb.stopWG.Done()
+		for {
+			select {
+			case <-qb.shutdownCh:
+				return
+			case <-qb.timer.C:
+				panic("batching is not yet implemented. Having timer here just so compiler won't complain")
+			}
+
+		}
+	}()
+	return nil
+}
+
+// Shutdown ensures that queue and all Batcher are stopped.
+func (qb *Batcher) Shutdown(ctx context.Context) error {
+	if err := qb.queue.Shutdown(ctx); err != nil {
+		return err
+	}
+	qb.stopWG.Wait()
+	return nil
+}

--- a/exporter/internal/queue/batcher.go
+++ b/exporter/internal/queue/batcher.go
@@ -68,7 +68,7 @@ func (qb *BaseBatcher) flushAsync(batchToFlush batch) {
 }
 
 // Shutdown ensures that queue and all Batcher are stopped.
-func (qb *BaseBatcher) Shutdown(ctx context.Context) error {
+func (qb *BaseBatcher) Shutdown(_ context.Context) error {
 	qb.stopWG.Wait()
 	return nil
 }

--- a/exporter/internal/queue/batcher.go
+++ b/exporter/internal/queue/batcher.go
@@ -5,9 +5,7 @@ package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
 
 import (
 	"context"
-	"math"
 	"sync"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
@@ -20,32 +18,39 @@ type batch struct {
 	idxList []uint64
 }
 
-// TODO
-type Batcher struct {
-	batchCfg exporterbatcher.Config
-
-	queue      Queue[internal.Request]
-	maxWorkers int
-
-	currentBatch *batch // the batch that is being built
-	timer        *time.Timer
-	shutdownCh   chan bool
-
-	stopWG sync.WaitGroup
+// Batcher is in charge of reading items from the queue and send them out asynchronously.
+type Batcher interface {
+	component.Component
 }
 
-func NewBatcher(batchCfg exporterbatcher.Config, queue Queue[internal.Request], maxWorkers int) *Batcher {
-	return &Batcher{
-		batchCfg:   batchCfg,
-		queue:      queue,
-		maxWorkers: maxWorkers,
-		stopWG:     sync.WaitGroup{},
-		shutdownCh: make(chan bool, 1),
+type BaseBatcher struct {
+	batchCfg   exporterbatcher.Config
+	queue      Queue[internal.Request]
+	maxWorkers int
+	stopWG     sync.WaitGroup
+}
+
+func NewBatcher(batchCfg exporterbatcher.Config, queue Queue[internal.Request], maxWorkers int) Batcher {
+	if maxWorkers != 0 {
+		panic("not implemented")
+	}
+
+	if batchCfg.Enabled {
+		panic("not implemented")
+	}
+
+	return &DisabledBatcher{
+		BaseBatcher{
+			batchCfg:   batchCfg,
+			queue:      queue,
+			maxWorkers: maxWorkers,
+			stopWG:     sync.WaitGroup{},
+		},
 	}
 }
 
-// flush take an item from the head of batch list and exports it.
-func (qb *Batcher) flush(batchToFlush batch) {
+// flush exports the incoming batch synchronously.
+func (qb *BaseBatcher) flush(batchToFlush batch) {
 	err := batchToFlush.req.Export(batchToFlush.ctx)
 	for _, idx := range batchToFlush.idxList {
 		qb.queue.OnProcessingFinished(idx, err)
@@ -53,7 +58,7 @@ func (qb *Batcher) flush(batchToFlush batch) {
 }
 
 // flushAsync starts a goroutine that calls flushIfNecessary. It blocks until a worker is available.
-func (qb *Batcher) flushAsync(batchToFlush batch) {
+func (qb *BaseBatcher) flushAsync(batchToFlush batch) {
 	// maxWorker = 0 means we don't limit the number of flushers.
 	if qb.maxWorkers == 0 {
 		qb.stopWG.Add(1)
@@ -66,77 +71,8 @@ func (qb *Batcher) flushAsync(batchToFlush batch) {
 	panic("not implemented")
 }
 
-// Start ensures that queue and all consumers are started.
-func (qb *Batcher) Start(ctx context.Context, host component.Host) error {
-	// TODO: queue start is done here to keep the behavior similar to queue consumer.
-	// However batcher should not be responsible for starting down the queue. Move this up to
-	// queue sender once queue consumer is cleaned up.
-	if err := qb.queue.Start(ctx, host); err != nil {
-		return err
-	}
-
-	if qb.batchCfg.Enabled {
-		panic("not implemented")
-	}
-
-	// Timer doesn't do anything yet, but adding it so compiler won't complain about qb.timer.C
-	qb.timer = time.NewTimer(math.MaxInt)
-	qb.timer.Stop()
-
-	if qb.maxWorkers != 0 {
-		panic("not implemented")
-	}
-
-	// This goroutine reads and then flushes if request reaches size limit. There are two operations in this
-	// goroutine that could be blocking:
-	// 1. Reading from the queue is blocked until the queue is non-empty or until the queue is stopped.
-	// 2. flushAsync() blocks until there are idle workers in the worker pool.
-	qb.stopWG.Add(1)
-	go func() {
-		defer qb.stopWG.Done()
-		for {
-			idx, _, req, ok := qb.queue.Read(context.Background())
-
-			if !ok {
-				qb.shutdownCh <- true
-				if qb.currentBatch != nil {
-					panic("batching is not supported yet so reading batch should always be nil")
-				}
-				return
-			}
-			if !qb.batchCfg.Enabled {
-				qb.currentBatch = &batch{
-					req:     req,
-					ctx:     context.Background(),
-					idxList: []uint64{idx}}
-				qb.flushAsync(*qb.currentBatch)
-				qb.currentBatch = nil
-			} else {
-				panic("not implemented")
-			}
-		}
-	}()
-
-	// The following goroutine is in charge of listening to timer and shutdown signal. This is a separate goroutine
-	// from the reading-flushing, because we want to keep timer separate blocking operations.
-	qb.stopWG.Add(1)
-	go func() {
-		defer qb.stopWG.Done()
-		for {
-			select {
-			case <-qb.shutdownCh:
-				return
-			case <-qb.timer.C:
-				panic("batching is not yet implemented. Having timer here just so compiler won't complain")
-			}
-
-		}
-	}()
-	return nil
-}
-
 // Shutdown ensures that queue and all Batcher are stopped.
-func (qb *Batcher) Shutdown(ctx context.Context) error {
+func (qb *BaseBatcher) Shutdown(ctx context.Context) error {
 	// TODO: queue shutdown is done here to keep the behavior similar to queue consumer.
 	// However batcher should not be responsible for shutting down the queue. Move this up to
 	// queue sender once queue consumer is cleaned up.

--- a/exporter/internal/queue/batcher_test.go
+++ b/exporter/internal/queue/batcher_test.go
@@ -17,10 +17,6 @@ import (
 	"go.opentelemetry.io/collector/exporter/internal"
 )
 
-func testExportFunc(ctx context.Context, req internal.Request) error {
-	return req.Export(ctx)
-}
-
 func TestBatcher_BatchNotEnabled_InfiniteWorkerPool(t *testing.T) {
 	cfg := exporterbatcher.NewDefaultConfig()
 	cfg.Enabled = false
@@ -32,7 +28,7 @@ func TestBatcher_BatchNotEnabled_InfiniteWorkerPool(t *testing.T) {
 		})
 
 	maxWorkers := 0
-	ba := NewBatcher(cfg, q, maxWorkers, testExportFunc)
+	ba := NewBatcher(cfg, q, maxWorkers)
 
 	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {

--- a/exporter/internal/queue/batcher_test.go
+++ b/exporter/internal/queue/batcher_test.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
+	"go.opentelemetry.io/collector/exporter/internal"
+)
+
+func testExportFunc(ctx context.Context, req internal.Request) error {
+	return req.Export(ctx)
+}
+
+func TestBatcher_BatchNotEnabled_InfiniteWorkerPool(t *testing.T) {
+	cfg := exporterbatcher.NewDefaultConfig()
+	cfg.Enabled = false
+
+	q := NewBoundedMemoryQueue[internal.Request](
+		MemoryQueueSettings[internal.Request]{
+			Sizer:    &RequestSizer[internal.Request]{},
+			Capacity: 10,
+		})
+
+	maxWorkers := 0
+	ba := NewBatcher(cfg, q, maxWorkers, testExportFunc)
+
+	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, ba.Shutdown(context.Background()))
+	})
+
+	sink := newFakeRequestSink()
+
+	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 8, sink: sink}))
+	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 8, exportErr: errors.New("transient error"), sink: sink}))
+	assert.Eventually(t, func() bool {
+		return sink.requestsCount.Load() == 1 && sink.itemsCount.Load() == 8
+	}, 20*time.Millisecond, 10*time.Millisecond)
+
+	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 17, sink: sink}))
+	assert.Eventually(t, func() bool {
+		return sink.requestsCount.Load() == 2 && sink.itemsCount.Load() == 25
+	}, 20*time.Millisecond, 10*time.Millisecond)
+
+	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 13, sink: sink}))
+
+	assert.Eventually(t, func() bool {
+		return sink.requestsCount.Load() == 3 && sink.itemsCount.Load() == 38
+	}, 20*time.Millisecond, 10*time.Millisecond)
+}

--- a/exporter/internal/queue/disabled_batcher.go
+++ b/exporter/internal/queue/disabled_batcher.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+// DisabledBatcher is a special-case of Batcher that has no size limit for sending. Any items read from the queue will
+// be sent out (asynchronously) immediately regardless of the size.
+type DisabledBatcher struct {
+	BaseBatcher
+}
+
+// Start starts the goroutine that reads from the queue and flushes asynchronously.
+func (qb *DisabledBatcher) Start(ctx context.Context, host component.Host) error {
+	// TODO: queue start is done here to keep the behavior similar to queue consumer.
+	// However batcher should not be responsible for starting or shuttting down the queue. Move this up to
+	// queue sender once queue consumer is cleaned up.
+	if err := qb.queue.Start(ctx, host); err != nil {
+		return err
+	}
+
+	// This goroutine reads and then flushes.
+	// 1. Reading from the queue is blocked until the queue is non-empty or until the queue is stopped.
+	// 2. flushAsync() blocks until there are idle workers in the worker pool.
+	qb.stopWG.Add(1)
+	go func() {
+		defer qb.stopWG.Done()
+		for {
+			idx, _, req, ok := qb.queue.Read(context.Background())
+			if !ok {
+				return
+			}
+			qb.flushAsync(batch{
+				req:     req,
+				ctx:     context.Background(),
+				idxList: []uint64{idx}})
+		}
+	}()
+	return nil
+}

--- a/exporter/internal/queue/disabled_batcher.go
+++ b/exporter/internal/queue/disabled_batcher.go
@@ -16,14 +16,7 @@ type DisabledBatcher struct {
 }
 
 // Start starts the goroutine that reads from the queue and flushes asynchronously.
-func (qb *DisabledBatcher) Start(ctx context.Context, host component.Host) error {
-	// TODO: queue start is done here to keep the behavior similar to queue consumer.
-	// However batcher should not be responsible for starting or shuttting down the queue. Move this up to
-	// queue sender once queue consumer is cleaned up.
-	if err := qb.queue.Start(ctx, host); err != nil {
-		return err
-	}
-
+func (qb *DisabledBatcher) Start(_ context.Context, _ component.Host) error {
 	// This goroutine reads and then flushes.
 	// 1. Reading from the queue is blocked until the queue is non-empty or until the queue is stopped.
 	// 2. flushAsync() blocks until there are idle workers in the worker pool.

--- a/exporter/internal/queue/disabled_batcher_test.go
+++ b/exporter/internal/queue/disabled_batcher_test.go
@@ -44,18 +44,18 @@ func TestDisabledBatcher_InfiniteWorkerPool(t *testing.T) {
 	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 8, exportErr: errors.New("transient error"), sink: sink}))
 	assert.Eventually(t, func() bool {
 		return sink.requestsCount.Load() == 1 && sink.itemsCount.Load() == 8
-	}, 20*time.Millisecond, 10*time.Millisecond)
+	}, 30*time.Millisecond, 10*time.Millisecond)
 
 	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 17, sink: sink}))
 	assert.Eventually(t, func() bool {
 		return sink.requestsCount.Load() == 2 && sink.itemsCount.Load() == 25
-	}, 20*time.Millisecond, 10*time.Millisecond)
+	}, 30*time.Millisecond, 10*time.Millisecond)
 
 	require.NoError(t, q.Offer(context.Background(), &fakeRequest{items: 13, sink: sink}))
 
 	assert.Eventually(t, func() bool {
 		return sink.requestsCount.Load() == 3 && sink.itemsCount.Load() == 38
-	}, 20*time.Millisecond, 10*time.Millisecond)
+	}, 30*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestDisabledBatcher_LimitedWorkerNotImplemented(t *testing.T) {

--- a/exporter/internal/queue/disabled_batcher_test.go
+++ b/exporter/internal/queue/disabled_batcher_test.go
@@ -28,7 +28,8 @@ func TestDisabledBatcher_InfiniteWorkerPool(t *testing.T) {
 		})
 
 	maxWorkers := 0
-	ba := NewBatcher(cfg, q, maxWorkers)
+	ba, err := NewBatcher(cfg, q, maxWorkers)
+	require.Nil(t, err)
 
 	require.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
@@ -55,4 +56,34 @@ func TestDisabledBatcher_InfiniteWorkerPool(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return sink.requestsCount.Load() == 3 && sink.itemsCount.Load() == 38
 	}, 20*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestDisabledBatcher_LimitedWorkerNotImplemented(t *testing.T) {
+	cfg := exporterbatcher.NewDefaultConfig()
+	cfg.Enabled = false
+	maxWorkers := 1
+
+	q := NewBoundedMemoryQueue[internal.Request](
+		MemoryQueueSettings[internal.Request]{
+			Sizer:    &RequestSizer[internal.Request]{},
+			Capacity: 10,
+		})
+
+	_, err := NewBatcher(cfg, q, maxWorkers)
+	require.NotNil(t, err)
+}
+
+func TestDisabledBatcher_BatchingNotImplemented(t *testing.T) {
+	cfg := exporterbatcher.NewDefaultConfig()
+	cfg.Enabled = true
+	maxWorkers := 0
+
+	q := NewBoundedMemoryQueue[internal.Request](
+		MemoryQueueSettings[internal.Request]{
+			Sizer:    &RequestSizer[internal.Request]{},
+			Capacity: 10,
+		})
+
+	_, err := NewBatcher(cfg, q, maxWorkers)
+	require.NotNil(t, err)
 }

--- a/exporter/internal/queue/disabled_batcher_test.go
+++ b/exporter/internal/queue/disabled_batcher_test.go
@@ -29,7 +29,7 @@ func TestDisabledBatcher_InfiniteWorkerPool(t *testing.T) {
 
 	maxWorkers := 0
 	ba, err := NewBatcher(cfg, q, maxWorkers)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
@@ -70,7 +70,7 @@ func TestDisabledBatcher_LimitedWorkerNotImplemented(t *testing.T) {
 		})
 
 	_, err := NewBatcher(cfg, q, maxWorkers)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestDisabledBatcher_BatchingNotImplemented(t *testing.T) {
@@ -85,5 +85,5 @@ func TestDisabledBatcher_BatchingNotImplemented(t *testing.T) {
 		})
 
 	_, err := NewBatcher(cfg, q, maxWorkers)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }

--- a/exporter/internal/queue/disabled_batcher_test.go
+++ b/exporter/internal/queue/disabled_batcher_test.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/internal"
 )
 
-func TestBatcher_BatchNotEnabled_InfiniteWorkerPool(t *testing.T) {
+func TestDisabledBatcher_InfiniteWorkerPool(t *testing.T) {
 	cfg := exporterbatcher.NewDefaultConfig()
 	cfg.Enabled = false
 

--- a/exporter/internal/queue/disabled_batcher_test.go
+++ b/exporter/internal/queue/disabled_batcher_test.go
@@ -30,8 +30,10 @@ func TestDisabledBatcher_InfiniteWorkerPool(t *testing.T) {
 	maxWorkers := 0
 	ba := NewBatcher(cfg, q, maxWorkers)
 
+	require.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
+		require.NoError(t, q.Shutdown(context.Background()))
 		require.NoError(t, ba.Shutdown(context.Background()))
 	})
 

--- a/exporter/internal/queue/fake_request.go
+++ b/exporter/internal/queue/fake_request.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
+	"go.opentelemetry.io/collector/exporter/internal"
+)
+
+type fakeRequestSink struct {
+	requestsCount *atomic.Int64
+	itemsCount    *atomic.Int64
+}
+
+func newFakeRequestSink() *fakeRequestSink {
+	return &fakeRequestSink{
+		requestsCount: new(atomic.Int64),
+		itemsCount:    new(atomic.Int64),
+	}
+}
+
+type fakeRequest struct {
+	items     int
+	exportErr error
+	delay     time.Duration
+	sink      *fakeRequestSink
+}
+
+func (r *fakeRequest) Export(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(r.delay):
+	}
+	if r.exportErr != nil {
+		return r.exportErr
+	}
+	if r.sink != nil {
+		r.sink.requestsCount.Add(1)
+		r.sink.itemsCount.Add(int64(r.items))
+	}
+	return nil
+}
+
+func (r *fakeRequest) ItemsCount() int {
+	return r.items
+}
+
+func (r *fakeRequest) Merge(_ context.Context,
+	_ internal.Request) (internal.Request, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *fakeRequest) MergeSplit(_ context.Context, _ exporterbatcher.MaxSizeConfig,
+	_ internal.Request) ([]internal.Request, error) {
+	return nil, errors.New("not implemented")
+}


### PR DESCRIPTION
#### Description

This PR is a bare minimum implementation of a component called queue batcher. On completion, this component will replace `consumers` in `queue_sender`, and thus moving queue-batch from a pulling model instead of pushing model.

Limitations of the current code
* This implements only the case where batching is disabled, which means no merge of splitting of requests + no timeout flushing.
* This implementation does not enforce an upper bound on concurrency

All these code paths are marked as panic currently, and they will be replaced with actual implementation in coming PRs. This PR is split from https://github.com/open-telemetry/opentelemetry-collector/pull/11507 for easier review.

Design doc:
https://docs.google.com/document/d/1y5jt7bQ6HWt04MntF8CjUwMBBeNiJs2gV4uUZfJjAsE/edit?usp=sharing


<!-- Issue number if applicable -->
#### Link to tracking issue

https://github.com/open-telemetry/opentelemetry-collector/issues/8122
https://github.com/open-telemetry/opentelemetry-collector/issues/10368

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
