### PR TITLE
[chore]: enable usestdlibvars linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,6 +143,7 @@ linters:
     - unconvert
     - unused
     - unparam
+    - usestdlibvars
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -1169,7 +1169,7 @@ func TestServerAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	// tt
-	srv.Handler.ServeHTTP(&httptest.ResponseRecorder{}, httptest.NewRequest("GET", "/", nil))
+	srv.Handler.ServeHTTP(&httptest.ResponseRecorder{}, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	// verify
 	assert.True(t, handlerCalled)
@@ -1215,7 +1215,7 @@ func TestFailedServerAuth(t *testing.T) {
 
 	// tt
 	response := &httptest.ResponseRecorder{}
-	srv.Handler.ServeHTTP(response, httptest.NewRequest("GET", "/", nil))
+	srv.Handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	// verify
 	assert.Equal(t, http.StatusUnauthorized, response.Result().StatusCode)
@@ -1404,7 +1404,7 @@ func TestAuthWithQueryParams(t *testing.T) {
 	require.NoError(t, err)
 
 	// tt
-	srv.Handler.ServeHTTP(&httptest.ResponseRecorder{}, httptest.NewRequest("GET", "/?auth=1", nil))
+	srv.Handler.ServeHTTP(&httptest.ResponseRecorder{}, httptest.NewRequest(http.MethodGet, "/?auth=1", nil))
 
 	// verify
 	assert.True(t, handlerCalled)

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -255,7 +255,7 @@ func TestErrorResponses(t *testing.T) {
 
 func TestErrorResponseInvalidResponseBody(t *testing.T) {
 	resp := &http.Response{
-		StatusCode:    400,
+		StatusCode:    http.StatusBadRequest,
 		Body:          io.NopCloser(badReader{}),
 		ContentLength: 100,
 	}
@@ -294,7 +294,7 @@ func TestUserAgent(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				srv := createBackend("/v1/traces", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Contains(t, request.Header.Get("user-agent"), tt.expectedUA)
-					writer.WriteHeader(200)
+					writer.WriteHeader(http.StatusOK)
 				})
 				defer srv.Close()
 
@@ -328,7 +328,7 @@ func TestUserAgent(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				srv := createBackend("/v1/metrics", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Contains(t, request.Header.Get("user-agent"), tt.expectedUA)
-					writer.WriteHeader(200)
+					writer.WriteHeader(http.StatusOK)
 				})
 				defer srv.Close()
 
@@ -362,7 +362,7 @@ func TestUserAgent(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				srv := createBackend("/v1/logs", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Contains(t, request.Header.Get("user-agent"), tt.expectedUA)
-					writer.WriteHeader(200)
+					writer.WriteHeader(http.StatusOK)
 				})
 				defer srv.Close()
 
@@ -398,7 +398,7 @@ func TestUserAgent(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				srv := createBackend("/v1development/profiles", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Contains(t, request.Header.Get("user-agent"), test.expectedUA)
-					writer.WriteHeader(200)
+					writer.WriteHeader(http.StatusOK)
 				})
 				defer srv.Close()
 
@@ -1013,7 +1013,7 @@ func TestEncoding(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				srv := createBackend("/v1/traces", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Contains(t, request.Header.Get("content-type"), tt.expectedEncoding)
-					writer.WriteHeader(200)
+					writer.WriteHeader(http.StatusOK)
 				})
 				defer srv.Close()
 
@@ -1044,7 +1044,7 @@ func TestEncoding(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				srv := createBackend("/v1/metrics", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Contains(t, request.Header.Get("content-type"), tt.expectedEncoding)
-					writer.WriteHeader(200)
+					writer.WriteHeader(http.StatusOK)
 				})
 				defer srv.Close()
 
@@ -1075,7 +1075,7 @@ func TestEncoding(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				srv := createBackend("/v1/logs", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Contains(t, request.Header.Get("content-type"), tt.expectedEncoding)
-					writer.WriteHeader(200)
+					writer.WriteHeader(http.StatusOK)
 				})
 				defer srv.Close()
 
@@ -1108,7 +1108,7 @@ func TestEncoding(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				srv := createBackend("/v1development/profiles", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Contains(t, request.Header.Get("content-type"), test.expectedEncoding)
-					writer.WriteHeader(200)
+					writer.WriteHeader(http.StatusOK)
 				})
 				defer srv.Close()
 

--- a/receiver/otlpreceiver/fuzz_test.go
+++ b/receiver/otlpreceiver/fuzz_test.go
@@ -19,7 +19,7 @@ import (
 
 func FuzzReceiverHandlers(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, data []byte, pb bool, handler int) {
-		req, err := http.NewRequest("POST", "", bytes.NewReader(data))
+		req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(data))
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
#### Description

[usestdlibvars](https://golangci-lint.run/usage/linters/#usestdlibvars) is a linter that detect the possibility to use variables/constants from the Go standard library.