### PR TITLE
Fix calling count methods on nil pdata and pprofile structs

### DIFF
--- a/.chloggen/pdata-nil-count.yaml
+++ b/.chloggen/pdata-nil-count.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix calling `LogRecordCount`, `MetricCount`, `DataPointCount` and `SpanCount` for nil `Logs`, `Metrics` and `Traces` structs
+
+# One or more tracking issues or pull requests related to the change
+issues: [11558]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/pprofile-nil-count.yaml
+++ b/.chloggen/pprofile-nil-count.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pprofile
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix calling `SampleCount` for nil `Profiles` structs
+
+# One or more tracking issues or pull requests related to the change
+issues: [11558]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pdata/plog/logs.go
+++ b/pdata/plog/logs.go
@@ -42,6 +42,10 @@ func (ms Logs) CopyTo(dest Logs) {
 
 // LogRecordCount calculates the total number of log records.
 func (ms Logs) LogRecordCount() int {
+	if ms.getOrig() == nil {
+		return 0
+	}
+
 	logCount := 0
 	rss := ms.ResourceLogs()
 	for i := 0; i < rss.Len(); i++ {

--- a/pdata/plog/logs_test.go
+++ b/pdata/plog/logs_test.go
@@ -19,7 +19,10 @@ import (
 )
 
 func TestLogRecordCount(t *testing.T) {
-	logs := NewLogs()
+	var logs Logs
+	assert.EqualValues(t, 0, logs.LogRecordCount())
+
+	logs = NewLogs()
 	assert.EqualValues(t, 0, logs.LogRecordCount())
 
 	rl := logs.ResourceLogs().AppendEmpty()

--- a/pdata/pmetric/metrics.go
+++ b/pdata/pmetric/metrics.go
@@ -47,6 +47,10 @@ func (ms Metrics) ResourceMetrics() ResourceMetricsSlice {
 
 // MetricCount calculates the total number of metrics.
 func (ms Metrics) MetricCount() int {
+	if ms.getOrig() == nil {
+		return 0
+	}
+
 	metricCount := 0
 	rms := ms.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
@@ -62,6 +66,10 @@ func (ms Metrics) MetricCount() int {
 
 // DataPointCount calculates the total number of data points.
 func (ms Metrics) DataPointCount() (dataPointCount int) {
+	if ms.getOrig() == nil {
+		return 0
+	}
+
 	rms := ms.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)

--- a/pdata/pmetric/metrics_test.go
+++ b/pdata/pmetric/metrics_test.go
@@ -60,7 +60,10 @@ func TestResourceMetricsWireCompatibility(t *testing.T) {
 }
 
 func TestMetricCount(t *testing.T) {
-	md := NewMetrics()
+	var md Metrics
+	assert.EqualValues(t, 0, md.MetricCount())
+
+	md = NewMetrics()
 	assert.EqualValues(t, 0, md.MetricCount())
 
 	rms := md.ResourceMetrics()
@@ -91,7 +94,10 @@ func TestMetricCountWithEmpty(t *testing.T) {
 }
 
 func TestMetricAndDataPointCount(t *testing.T) {
-	md := NewMetrics()
+	var md Metrics
+	assert.EqualValues(t, 0, md.DataPointCount())
+
+	md = NewMetrics()
 	dps := md.DataPointCount()
 	assert.EqualValues(t, 0, dps)
 

--- a/pdata/pprofile/profiles.go
+++ b/pdata/pprofile/profiles.go
@@ -52,6 +52,10 @@ func (ms Profiles) MarkReadOnly() {
 
 // SampleCount calculates the total number of samples.
 func (ms Profiles) SampleCount() int {
+	if ms.getOrig() == nil {
+		return 0
+	}
+
 	sampleCount := 0
 	rps := ms.ResourceProfiles()
 	for i := 0; i < rps.Len(); i++ {

--- a/pdata/pprofile/profiles_test.go
+++ b/pdata/pprofile/profiles_test.go
@@ -26,7 +26,10 @@ func TestReadOnlyProfilesInvalidUsage(t *testing.T) {
 }
 
 func TestSampleCount(t *testing.T) {
-	profiles := NewProfiles()
+	var profiles Profiles
+	assert.EqualValues(t, 0, profiles.SampleCount())
+
+	profiles = NewProfiles()
 	assert.EqualValues(t, 0, profiles.SampleCount())
 
 	rs := profiles.ResourceProfiles().AppendEmpty()

--- a/pdata/ptrace/traces.go
+++ b/pdata/ptrace/traces.go
@@ -42,6 +42,10 @@ func (ms Traces) CopyTo(dest Traces) {
 
 // SpanCount calculates the total number of spans.
 func (ms Traces) SpanCount() int {
+	if ms.getOrig() == nil {
+		return 0
+	}
+
 	spanCount := 0
 	rss := ms.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {

--- a/pdata/ptrace/traces_test.go
+++ b/pdata/ptrace/traces_test.go
@@ -19,7 +19,10 @@ import (
 )
 
 func TestSpanCount(t *testing.T) {
-	traces := NewTraces()
+	var traces Traces
+	assert.EqualValues(t, 0, traces.SpanCount())
+
+	traces = NewTraces()
 	assert.EqualValues(t, 0, traces.SpanCount())
 
 	rs := traces.ResourceSpans().AppendEmpty()


### PR DESCRIPTION
#### Description

I am working on a profiles receiver, and while writing tests for it, I noticed I must set the signal struct to something not nil, I'd get panics due to `getOrig()` being nil.

This change allows calling count methods for nil signal structs, so we can look for the count of data being sent as a nil-comparison.