### PR TITLE
[chore]: enable whitespace linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -144,6 +144,7 @@ linters:
     - unused
     - unparam
     - usestdlibvars
+    - whitespace
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/cmd/mdatagen/internal/embedded_templates_test.go
+++ b/cmd/mdatagen/internal/embedded_templates_test.go
@@ -48,5 +48,4 @@ func TestEnsureTemplatesLoaded(t *testing.T) {
 		return nil
 	}))
 	assert.Equal(t, len(templateFiles), count, "Must match the expected number of calls")
-
 }

--- a/cmd/mdatagen/internal/samplereceiver/metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/metrics_test.go
@@ -104,5 +104,4 @@ func TestComponentTelemetry(t *testing.T) {
 		},
 	})
 	require.NoError(t, tt.Shutdown(context.Background()))
-
 }

--- a/component/componentstatus/instance_test.go
+++ b/component/componentstatus/instance_test.go
@@ -92,5 +92,4 @@ func TestAllPipelineIDs(t *testing.T) {
 		return false
 	})
 	assert.Equal(t, 1, count)
-
 }

--- a/component/componenttest/configtest.go
+++ b/component/componenttest/configtest.go
@@ -65,10 +65,8 @@ func validateConfigDataType(t reflect.Type) error {
 
 // checkStructFieldTags inspects the tags of a struct field.
 func checkStructFieldTags(f reflect.StructField) error {
-
 	tagValue := f.Tag.Get("mapstructure")
 	if tagValue == "" {
-
 		// Ignore special types.
 		switch f.Type.Kind() {
 		case reflect.Interface, reflect.Chan, reflect.Func, reflect.Uintptr, reflect.UnsafePointer:

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -39,5 +39,4 @@ func (ct *Type) UnmarshalText(in []byte) error {
 		return nil
 	}
 	return fmt.Errorf("unsupported compression type %q", typ)
-
 }

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -560,7 +560,6 @@ func TestGRPCServerWarning(t *testing.T) {
 			require.Len(t, observed.FilterLevelExact(zap.WarnLevel).All(), test.len)
 		})
 	}
-
 }
 
 func TestGRPCServerSettingsError(t *testing.T) {

--- a/config/confighttp/compressor_test.go
+++ b/config/confighttp/compressor_test.go
@@ -49,7 +49,6 @@ func BenchmarkCompression(b *testing.B) {
 		b.Run(fmt.Sprint(benchmark.name), func(b *testing.B) {
 			benchmark.function(b, benchmark.codec, &buffer, payload)
 		})
-
 	}
 }
 

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -220,7 +220,6 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 			assert.EqualValues(t, 0, transport.MaxConnsPerHost)
 			assert.EqualValues(t, 90*time.Second, transport.IdleConnTimeout)
 			assert.False(t, transport.DisableKeepAlives)
-
 		})
 	}
 }
@@ -554,7 +553,6 @@ func TestHTTPServerWarning(t *testing.T) {
 			require.Len(t, observed.FilterLevelExact(zap.WarnLevel).All(), tt.len)
 		})
 	}
-
 }
 
 func TestHttpReception(t *testing.T) {
@@ -1279,7 +1277,6 @@ func TestServerWithDecoder(t *testing.T) {
 	srv.Handler.ServeHTTP(response, req)
 	// verify
 	assert.Equal(t, http.StatusOK, response.Result().StatusCode)
-
 }
 
 func TestServerWithDecompression(t *testing.T) {
@@ -1497,7 +1494,6 @@ func BenchmarkHttpRequest(b *testing.B) {
 			if !bb.clientPerThread {
 				c, err = hcs.ToClient(context.Background(), componenttest.NewNopHost(), nilProvidersSettings)
 				require.NoError(b, err)
-
 			}
 			b.RunParallel(func(pb *testing.PB) {
 				if c == nil {

--- a/config/configretry/backoff.go
+++ b/config/configretry/backoff.go
@@ -68,7 +68,6 @@ func (bs *BackOffConfig) Validate() error {
 		if bs.MaxElapsedTime < bs.MaxInterval {
 			return errors.New("'max_elapsed_time' must not be less than 'max_interval'")
 		}
-
 	}
 	return nil
 }

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -327,7 +327,6 @@ func TestLoadTLSServerConfig(t *testing.T) {
 }
 
 func TestLoadTLSServerConfigReload(t *testing.T) {
-
 	tmpCaPath := createTempClientCaFile(t)
 
 	overwriteClientCA(t, tmpCaPath, "ca-1.crt")
@@ -358,7 +357,6 @@ func TestLoadTLSServerConfigReload(t *testing.T) {
 }
 
 func TestLoadTLSServerConfigFailingReload(t *testing.T) {
-
 	tmpCaPath := createTempClientCaFile(t)
 
 	overwriteClientCA(t, tmpCaPath, "ca-1.crt")
@@ -389,7 +387,6 @@ func TestLoadTLSServerConfigFailingReload(t *testing.T) {
 }
 
 func TestLoadTLSServerConfigFailingInitialLoad(t *testing.T) {
-
 	tmpCaPath := createTempClientCaFile(t)
 
 	overwriteClientCA(t, tmpCaPath, "testCA-bad.txt")
@@ -405,7 +402,6 @@ func TestLoadTLSServerConfigFailingInitialLoad(t *testing.T) {
 }
 
 func TestLoadTLSServerConfigWrongPath(t *testing.T) {
-
 	tmpCaPath := createTempClientCaFile(t)
 
 	tlsSetting := ServerConfig{
@@ -419,7 +415,6 @@ func TestLoadTLSServerConfigWrongPath(t *testing.T) {
 }
 
 func TestLoadTLSServerConfigFailing(t *testing.T) {
-
 	tmpCaPath := createTempClientCaFile(t)
 
 	overwriteClientCA(t, tmpCaPath, "ca-1.crt")

--- a/config/internal/warning_test.go
+++ b/config/internal/warning_test.go
@@ -54,5 +54,4 @@ func TestShouldWarn(t *testing.T) {
 			assert.Equal(t, shouldWarn(test.endpoint), test.warn)
 		})
 	}
-
 }

--- a/confmap/provider/internal/configurablehttpprovider/provider.go
+++ b/confmap/provider/internal/configurablehttpprovider/provider.go
@@ -80,7 +80,6 @@ func (fmp *provider) createClient() (*http.Client, error) {
 }
 
 func (fmp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
-
 	if !strings.HasPrefix(uri, string(fmp.scheme)+":") {
 		return nil, fmt.Errorf("%q uri is not supported by %q provider", uri, string(fmp.scheme))
 	}

--- a/confmap/provider_test.go
+++ b/confmap/provider_test.go
@@ -157,5 +157,4 @@ func TestNewRetrievedFromYAMLString(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/exporter/debugexporter/config_test.go
+++ b/exporter/debugexporter/config_test.go
@@ -79,7 +79,6 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-
 			conf := confmap.New()
 			err := conf.Marshal(tc.inCfg)
 			require.NoError(t, err)

--- a/exporter/debugexporter/internal/otlptext/databuffer.go
+++ b/exporter/debugexporter/internal/otlptext/databuffer.go
@@ -350,7 +350,6 @@ func (b *dataBuffer) logProfileMappings(ms pprofile.MappingSlice) {
 		b.logEntry("        Has filenames: %t", mapping.HasFilenames())
 		b.logEntry("        Has line numbers: %t", mapping.HasLineNumbers())
 		b.logEntry("        Has inline frames: %t", mapping.HasInlineFrames())
-
 	}
 }
 

--- a/exporter/debugexporter/internal/otlptext/traces_test.go
+++ b/exporter/debugexporter/internal/otlptext/traces_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestTracesText(t *testing.T) {
-
 	tests := []struct {
 		name string
 		in   ptrace.Traces

--- a/exporter/exporterhelper/exporterhelperprofiles/profiles_batch_test.go
+++ b/exporter/exporterhelper/exporterhelperprofiles/profiles_batch_test.go
@@ -124,7 +124,6 @@ func TestMergeSplitProfiles(t *testing.T) {
 				assert.Equal(t, tt.expected[i], r.(*profilesRequest))
 			}
 		})
-
 	}
 }
 

--- a/exporter/exporterhelper/internal/queue_sender_test.go
+++ b/exporter/exporterhelper/internal/queue_sender_test.go
@@ -317,7 +317,6 @@ func TestQueueRetryWithDisabledQueue(t *testing.T) {
 			require.NoError(t, be.Shutdown(context.Background()))
 		})
 	}
-
 }
 
 func TestQueueFailedRequestDropped(t *testing.T) {

--- a/exporter/exporterhelper/logs_batch_test.go
+++ b/exporter/exporterhelper/logs_batch_test.go
@@ -126,7 +126,6 @@ func TestMergeSplitLogs(t *testing.T) {
 				assert.Equal(t, tt.expected[i], r.(*logsRequest))
 			}
 		})
-
 	}
 }
 

--- a/exporter/exportertest/mock_consumer_test.go
+++ b/exporter/exportertest/mock_consumer_test.go
@@ -129,11 +129,9 @@ func TestConsumeLogsNonPermanent(t *testing.T) {
 	assert.Equal(t, 0, mc.reqCounter.error.permanent)
 	assert.Equal(t, 0, mc.reqCounter.success)
 	assert.Equal(t, 1, mc.reqCounter.total)
-
 }
 
 func TestConsumeLogsPermanent(t *testing.T) {
-
 	mc := newMockConsumer(returnPermanentError)
 	validData := createLog("logId")
 	err := mc.ConsumeLogs(context.Background(), validData)
@@ -144,7 +142,6 @@ func TestConsumeLogsPermanent(t *testing.T) {
 	assert.Equal(t, 1, mc.reqCounter.error.permanent)
 	assert.Equal(t, 0, mc.reqCounter.success)
 	assert.Equal(t, 1, mc.reqCounter.total)
-
 }
 
 func TestConsumeLogsSuccess(t *testing.T) {
@@ -158,7 +155,6 @@ func TestConsumeLogsSuccess(t *testing.T) {
 	assert.Equal(t, 0, mc.reqCounter.error.permanent)
 	assert.Equal(t, 1, mc.reqCounter.success)
 	assert.Equal(t, 1, mc.reqCounter.total)
-
 }
 
 func TestConsumeTracesNonPermanent(t *testing.T) {
@@ -172,11 +168,9 @@ func TestConsumeTracesNonPermanent(t *testing.T) {
 	assert.Equal(t, 0, mc.reqCounter.error.permanent)
 	assert.Equal(t, 0, mc.reqCounter.success)
 	assert.Equal(t, 1, mc.reqCounter.total)
-
 }
 
 func TestConsumeTracesPermanent(t *testing.T) {
-
 	mc := newMockConsumer(returnPermanentError)
 	validData := createTrace("traceId")
 	err := mc.ConsumeTraces(context.Background(), validData)
@@ -187,7 +181,6 @@ func TestConsumeTracesPermanent(t *testing.T) {
 	assert.Equal(t, 1, mc.reqCounter.error.permanent)
 	assert.Equal(t, 0, mc.reqCounter.success)
 	assert.Equal(t, 1, mc.reqCounter.total)
-
 }
 
 func TestConsumeTracesSuccess(t *testing.T) {
@@ -201,7 +194,6 @@ func TestConsumeTracesSuccess(t *testing.T) {
 	assert.Equal(t, 0, mc.reqCounter.error.permanent)
 	assert.Equal(t, 1, mc.reqCounter.success)
 	assert.Equal(t, 1, mc.reqCounter.total)
-
 }
 func TestConsumeMetricsNonPermanent(t *testing.T) {
 	mc := newMockConsumer(returnNonPermanentError)
@@ -214,7 +206,6 @@ func TestConsumeMetricsNonPermanent(t *testing.T) {
 	assert.Equal(t, 0, mc.reqCounter.error.permanent)
 	assert.Equal(t, 0, mc.reqCounter.success)
 	assert.Equal(t, 1, mc.reqCounter.total)
-
 }
 
 func TestConsumeMetricsPermanent(t *testing.T) {
@@ -228,7 +219,6 @@ func TestConsumeMetricsPermanent(t *testing.T) {
 	assert.Equal(t, 1, mc.reqCounter.error.permanent)
 	assert.Equal(t, 0, mc.reqCounter.success)
 	assert.Equal(t, 1, mc.reqCounter.total)
-
 }
 
 func TestConsumeMetricsSuccess(t *testing.T) {
@@ -242,7 +232,6 @@ func TestConsumeMetricsSuccess(t *testing.T) {
 	assert.Equal(t, 0, mc.reqCounter.error.permanent)
 	assert.Equal(t, 1, mc.reqCounter.success)
 	assert.Equal(t, 1, mc.reqCounter.total)
-
 }
 
 func TestCapabilities(t *testing.T) {

--- a/exporter/internal/queue/default_batcher.go
+++ b/exporter/internal/queue/default_batcher.go
@@ -29,7 +29,6 @@ func (qb *DefaultBatcher) resetTimer() {
 
 // startReadingFlushingGoroutine starts a goroutine that reads and then flushes.
 func (qb *DefaultBatcher) startReadingFlushingGoroutine() {
-
 	qb.stopWG.Add(1)
 	go func() {
 		defer qb.stopWG.Done()

--- a/exporter/internal/queue/persistent_queue.go
+++ b/exporter/internal/queue/persistent_queue.go
@@ -382,7 +382,6 @@ func (pq *persistentQueue[T]) OnProcessingFinished(index uint64, consumeErr erro
 
 	// Ensure the used size and the channel size are in sync.
 	pq.sizedChannel.syncSize()
-
 }
 
 // retrieveAndEnqueueNotDispatchedReqs gets the items for which sending was not finished, cleans the storage

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -190,7 +190,6 @@ func TestPersistentQueue_Shutdown(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		assert.NoError(t, pq.Offer(context.Background(), req))
 	}
-
 }
 
 func TestPersistentQueue_ConsumersProducers(t *testing.T) {

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -139,7 +139,6 @@ func TestUnmarshalInvalidConfig(t *testing.T) {
 			assert.ErrorContains(t, component.ValidateConfig(cfg), tt.errorMsg)
 		})
 	}
-
 }
 
 func TestValidDNSEndpoint(t *testing.T) {

--- a/extension/auth/client_test.go
+++ b/extension/auth/client_test.go
@@ -115,5 +115,4 @@ func TestWithPerRPCCredentials(t *testing.T) {
 	assert.True(t, called)
 	assert.NotNil(t, p)
 	assert.NoError(t, err)
-
 }

--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -45,7 +45,6 @@ type registerableTracerProvider interface {
 }
 
 func (zpe *zpagesExtension) Start(ctx context.Context, host component.Host) error {
-
 	zPagesMux := http.NewServeMux()
 
 	sdktracer, ok := zpe.telemetry.TracerProvider.(registerableTracerProvider)

--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -41,7 +41,6 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 		Long:  "Outputs available components in this collector distribution including their stability levels. The output format is not stable and can change between releases.",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-
 			factories, err := set.Factories()
 			if err != nil {
 				return fmt.Errorf("failed to initialize factories: %w", err)

--- a/otelcol/unmarshaler.go
+++ b/otelcol/unmarshaler.go
@@ -27,7 +27,6 @@ type configSettings struct {
 // unmarshal the configSettings from a confmap.Conf.
 // After the config is unmarshalled, `Validate()` must be called to validate.
 func unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
-
 	telFactory := telemetry.NewFactory()
 	defaultTelConfig := *telFactory.CreateDefaultConfig().(*telemetry.Config)
 

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -72,7 +72,6 @@ func TestValueReadOnly(t *testing.T) {
 	v.CopyTo(v2)
 	assert.Equal(t, v.AsRaw(), v2.AsRaw())
 	assert.Panics(t, func() { v2.CopyTo(v) })
-
 }
 
 func TestValueType(t *testing.T) {

--- a/pdata/plog/pb_test.go
+++ b/pdata/plog/pb_test.go
@@ -29,7 +29,6 @@ func TestProtoSizer(t *testing.T) {
 	bytes, err := marshaler.MarshalLogs(ld)
 	require.NoError(t, err)
 	assert.Equal(t, len(bytes), size)
-
 }
 
 func TestProtoSizerEmptyLogs(t *testing.T) {

--- a/pdata/pprofile/pprofileotlp/response.go
+++ b/pdata/pprofile/pprofileotlp/response.go
@@ -65,7 +65,6 @@ func (ms ExportResponse) unmarshalJsoniter(iter *jsoniter.Iterator) {
 		}
 		return true
 	})
-
 }
 
 // PartialSuccess returns the ExportLogsPartialSuccess associated with this ExportResponse.

--- a/pdata/ptrace/ptraceotlp/response.go
+++ b/pdata/ptrace/ptraceotlp/response.go
@@ -65,7 +65,6 @@ func (ms ExportResponse) unmarshalJsoniter(iter *jsoniter.Iterator) {
 		}
 		return true
 	})
-
 }
 
 // PartialSuccess returns the ExportLogsPartialSuccess associated with this ExportResponse.

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -51,7 +51,6 @@ func TestValidateConfig_ValidBatchSizes(t *testing.T) {
 		SendBatchMaxSize: 1000,
 	}
 	assert.NoError(t, cfg.Validate())
-
 }
 
 func TestValidateConfig_InvalidBatchSize(t *testing.T) {

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -141,7 +141,6 @@ func TestUnmarshalConfig(t *testing.T) {
 				},
 			},
 		}, cfg)
-
 }
 
 func TestUnmarshalConfigUnix(t *testing.T) {

--- a/receiver/otlpreceiver/fuzz_test.go
+++ b/receiver/otlpreceiver/fuzz_test.go
@@ -52,6 +52,5 @@ func FuzzReceiverHandlers(f *testing.F) {
 			httpLogsReceiver := logs.New(r.nextLogs, r.obsrepHTTP)
 			handleLogs(resp, req, httpLogsReceiver)
 		}
-
 	})
 }

--- a/receiver/receiverprofiles/profiles.go
+++ b/receiver/receiverprofiles/profiles.go
@@ -113,5 +113,4 @@ func NewFactory(cfgType component.Type, createDefaultConfig component.CreateDefa
 	}
 	opts.factory.Factory = receiver.NewFactory(cfgType, createDefaultConfig, opts.opts...)
 	return opts.factory
-
 }

--- a/receiver/receivertest/contract_checker_test.go
+++ b/receiver/receivertest/contract_checker_test.go
@@ -230,7 +230,6 @@ func createLog(
 // TestConsumeContract is an example of testing of the receiver for the contract between the
 // receiver and next consumer.
 func TestConsumeContract(t *testing.T) {
-
 	// Number of log records to send per scenario.
 	const logsPerTest = 100
 
@@ -253,7 +252,6 @@ func TestConsumeContract(t *testing.T) {
 // TestConsumeMetricsContract is an example of testing of the receiver for the contract between the
 // receiver and next consumer.
 func TestConsumeMetricsContract(t *testing.T) {
-
 	// Number of metric data points to send per scenario.
 	const metricsPerTest = 100
 
@@ -276,7 +274,6 @@ func TestConsumeMetricsContract(t *testing.T) {
 // TestConsumeTracesContract is an example of testing of the receiver for the contract between the
 // receiver and next consumer.
 func TestConsumeTracesContract(t *testing.T) {
-
 	// Number of trace spans to send per scenario.
 	const spansPerTest = 100
 

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -78,7 +78,6 @@ func NewScraperControllerReceiver(
 	nextConsumer consumer.Metrics,
 	options ...ScraperControllerOption,
 ) (component.Component, error) {
-
 	if cfg.CollectionInterval <= 0 {
 		return nil, errors.New("collection_interval must be a positive duration")
 	}

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -313,7 +313,6 @@ func newConfigWatcherExtension(fn func() error) *configWatcherExtension {
 	}
 
 	return comp
-
 }
 
 func newConfigWatcherExtensionFactory(name component.Type, fn func() error) extension.Factory {

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -1234,7 +1234,6 @@ func TestConnectorRouter(t *testing.T) {
 	assert.NoError(t, profilesReceiver.ConsumeProfiles(ctx, testdata.GenerateProfiles(1)))
 	assert.Len(t, profilesRight.Profiles, 3)
 	assert.Len(t, profilesLeft.Profiles, 2)
-
 }
 
 func TestGraphBuildErrors(t *testing.T) {

--- a/service/internal/graph/lifecycle_test.go
+++ b/service/internal/graph/lifecycle_test.go
@@ -287,7 +287,6 @@ func TestGraphFailToStartAndShutdown(t *testing.T) {
 }
 
 func TestStatusReportedOnStartupShutdown(t *testing.T) {
-
 	rNoErr := &testNode{id: component.MustNewIDWithName("r_no_err", "1")}
 	rStErr := &testNode{id: component.MustNewIDWithName("r_st_err", "1"), startErr: assert.AnError}
 	rSdErr := &testNode{id: component.MustNewIDWithName("r_sd_err", "1"), shutdownErr: assert.AnError}
@@ -318,7 +317,6 @@ func TestStatusReportedOnStartupShutdown(t *testing.T) {
 				assert.Equal(t, ev1.Err(), ev2.Err())
 			}
 		}
-
 	}
 
 	for _, tt := range []struct {

--- a/service/internal/resource/config_test.go
+++ b/service/internal/resource/config_test.go
@@ -103,7 +103,6 @@ func TestNew(t *testing.T) {
 			assert.EqualValues(t, tt.want, got)
 		})
 	}
-
 }
 
 func pdataFromSdk(res *sdkresource.Resource) pcommon.Resource {

--- a/service/internal/status/status_test.go
+++ b/service/internal/status/status_test.go
@@ -175,7 +175,6 @@ func TestValidSeqsToStopped(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestStatusFuncs(t *testing.T) {

--- a/service/telemetry/logger.go
+++ b/service/telemetry/logger.go
@@ -74,7 +74,6 @@ func newLogger(ctx context.Context, set Settings, cfg Config) (*zap.Logger, log.
 				),
 			)
 		}))
-
 	}
 
 	if cfg.Logs.Sampling != nil && cfg.Logs.Sampling.Enabled {

--- a/service/telemetry/metrics.go
+++ b/service/telemetry/metrics.go
@@ -52,7 +52,6 @@ func newMeterProvider(set meterProviderSettings, disableHighCardinality bool) (m
 		}
 		if server != nil {
 			mp.servers = append(mp.servers, server)
-
 		}
 		opts = append(opts, sdkmetric.WithReader(r))
 	}

--- a/service/telemetry/metrics_test.go
+++ b/service/telemetry/metrics_test.go
@@ -182,7 +182,6 @@ func TestTelemetryInit(t *testing.T) {
 				require.InDelta(t, metricValue.value, mf.Metric[0].Counter.GetValue(), 0.01, "value for metric %q was different than expected", metricName)
 			}
 		})
-
 	}
 }
 


### PR DESCRIPTION
#### Description

[whitespace](https://golangci-lint.run/usage/linters/#whitespace) is a linter that checks for unnecessary newlines at the start and end of functions.