### PR TITLE
[docs] Fix link in scraping-receivers.md

### DIFF
--- a/docs/scraping-receivers.md
+++ b/docs/scraping-receivers.md
@@ -24,7 +24,7 @@ defines stability guarantees and provides guidelines for metric updates.
 Each built-in scraping metrics receiver has a `metadata.yaml` file that MUST define all the metrics emitted by the 
 receiver. The file is being used to generate an API for metrics recording, user settings to customize the emitted 
 metrics and user documentation. The file schema is defined in 
-https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/mdatagen/metadata-schema.yaml
+https://github.com/open-telemetry/opentelemetry-collector/blob/main/cmd/mdatagen/metadata-schema.yaml
 Defining a metric in `metadata.yaml` DOES NOT guarantee that the metric will always be produced by the receiver. In
 some cases it may be impossible to fetch particular metrics from a system in a particular state.
 


### PR DESCRIPTION
Trying to reference docs on internal metrics and found the current link sends you to `404 - page not found` since the page seems to have moved from `opentelemetry-collector-contrib` to `opentelemetry-collector` repo

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
