### PR TITLE
[telemetry] rename memorylimiter metrics to include memory_limiter infix

### DIFF
--- a/processor/memorylimiterprocessor/README.md
+++ b/processor/memorylimiterprocessor/README.md
@@ -7,7 +7,7 @@
 | Distributions | [core], [contrib], [k8s] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector?query=is%3Aissue%20is%3Aopen%20label%3Aprocessor%2Fmemorylimiter%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector/issues?q=is%3Aopen+is%3Aissue+label%3Aprocessor%2Fmemorylimiter) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector?query=is%3Aissue%20is%3Aclosed%20label%3Aprocessor%2Fmemorylimiter%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector/issues?q=is%3Aclosed+is%3Aissue+label%3Aprocessor%2Fmemorylimiter) |
 
-[beta]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#beta
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [k8s]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-k8s

--- a/processor/memorylimiterprocessor/documentation.md
+++ b/processor/memorylimiterprocessor/documentation.md
@@ -6,7 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### otelcol_processor_accepted_log_records
+### otelcol_processor_memory_limiter_accepted_log_records
 
 Number of log records successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]
 
@@ -14,7 +14,7 @@ Number of log records successfully pushed into the next component in the pipelin
 | ---- | ----------- | ---------- | --------- |
 | {records} | Sum | Int | true |
 
-### otelcol_processor_accepted_metric_points
+### otelcol_processor_memory_limiter_accepted_metric_points
 
 Number of metric points successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]
 
@@ -22,7 +22,7 @@ Number of metric points successfully pushed into the next component in the pipel
 | ---- | ----------- | ---------- | --------- |
 | {datapoints} | Sum | Int | true |
 
-### otelcol_processor_accepted_spans
+### otelcol_processor_memory_limiter_accepted_spans
 
 Number of spans successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]
 
@@ -30,7 +30,7 @@ Number of spans successfully pushed into the next component in the pipeline. [de
 | ---- | ----------- | ---------- | --------- |
 | {spans} | Sum | Int | true |
 
-### otelcol_processor_refused_log_records
+### otelcol_processor_memory_limiter_refused_log_records
 
 Number of log records that were rejected by the next component in the pipeline. [deprecated since v0.110.0]
 
@@ -38,7 +38,7 @@ Number of log records that were rejected by the next component in the pipeline. 
 | ---- | ----------- | ---------- | --------- |
 | {records} | Sum | Int | true |
 
-### otelcol_processor_refused_metric_points
+### otelcol_processor_memory_limiter_refused_metric_points
 
 Number of metric points that were rejected by the next component in the pipeline. [deprecated since v0.110.0]
 
@@ -46,7 +46,7 @@ Number of metric points that were rejected by the next component in the pipeline
 | ---- | ----------- | ---------- | --------- |
 | {datapoints} | Sum | Int | true |
 
-### otelcol_processor_refused_spans
+### otelcol_processor_memory_limiter_refused_spans
 
 Number of spans that were rejected by the next component in the pipeline. [deprecated since v0.110.0]
 

--- a/processor/memorylimiterprocessor/generated_component_telemetry_test.go
+++ b/processor/memorylimiterprocessor/generated_component_telemetry_test.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
@@ -25,19 +24,14 @@ type componentTestTelemetry struct {
 }
 
 func (tt *componentTestTelemetry) NewSettings() processor.Settings {
-	set := processortest.NewNopSettings()
-	set.TelemetrySettings = tt.newTelemetrySettings()
-	set.ID = component.NewID(component.MustNewType("memory_limiter"))
-	return set
-}
-
-func (tt *componentTestTelemetry) newTelemetrySettings() component.TelemetrySettings {
-	set := componenttest.NewNopTelemetrySettings()
-	set.MeterProvider = tt.meterProvider
-	set.LeveledMeterProvider = func(_ configtelemetry.Level) metric.MeterProvider {
+	settings := processortest.NewNopSettings()
+	settings.MeterProvider = tt.meterProvider
+	settings.LeveledMeterProvider = func(_ configtelemetry.Level) metric.MeterProvider {
 		return tt.meterProvider
 	}
-	return set
+	settings.ID = component.NewID(component.MustNewType("memory_limiter"))
+
+	return settings
 }
 
 func setupTestTelemetry() componentTestTelemetry {

--- a/processor/memorylimiterprocessor/generated_component_test.go
+++ b/processor/memorylimiterprocessor/generated_component_test.go
@@ -40,21 +40,21 @@ func TestComponentLifecycle(t *testing.T) {
 		{
 			name: "logs",
 			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
-				return factory.CreateLogs(ctx, set, cfg, consumertest.NewNop())
+				return factory.CreateLogsProcessor(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 
 		{
 			name: "metrics",
 			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
-				return factory.CreateMetrics(ctx, set, cfg, consumertest.NewNop())
+				return factory.CreateMetricsProcessor(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 
 		{
 			name: "traces",
 			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
-				return factory.CreateTraces(ctx, set, cfg, consumertest.NewNop())
+				return factory.CreateTracesProcessor(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 	}

--- a/processor/memorylimiterprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/memorylimiterprocessor/internal/metadata/generated_telemetry.go
@@ -28,14 +28,14 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter                         metric.Meter
-	ProcessorAcceptedLogRecords   metric.Int64Counter
-	ProcessorAcceptedMetricPoints metric.Int64Counter
-	ProcessorAcceptedSpans        metric.Int64Counter
-	ProcessorRefusedLogRecords    metric.Int64Counter
-	ProcessorRefusedMetricPoints  metric.Int64Counter
-	ProcessorRefusedSpans         metric.Int64Counter
-	meters                        map[configtelemetry.Level]metric.Meter
+	meter                                      metric.Meter
+	ProcessorMemoryLimiterAcceptedLogRecords   metric.Int64Counter
+	ProcessorMemoryLimiterAcceptedMetricPoints metric.Int64Counter
+	ProcessorMemoryLimiterAcceptedSpans        metric.Int64Counter
+	ProcessorMemoryLimiterRefusedLogRecords    metric.Int64Counter
+	ProcessorMemoryLimiterRefusedMetricPoints  metric.Int64Counter
+	ProcessorMemoryLimiterRefusedSpans         metric.Int64Counter
+	meters                                     map[configtelemetry.Level]metric.Meter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -58,38 +58,38 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meters[configtelemetry.LevelBasic] = LeveledMeter(settings, configtelemetry.LevelBasic)
 	var err, errs error
-	builder.ProcessorAcceptedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
-		"otelcol_processor_accepted_log_records",
+	builder.ProcessorMemoryLimiterAcceptedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
+		"otelcol_processor_memory_limiter_accepted_log_records",
 		metric.WithDescription("Number of log records successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorAcceptedMetricPoints, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
-		"otelcol_processor_accepted_metric_points",
+	builder.ProcessorMemoryLimiterAcceptedMetricPoints, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
+		"otelcol_processor_memory_limiter_accepted_metric_points",
 		metric.WithDescription("Number of metric points successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorAcceptedSpans, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
-		"otelcol_processor_accepted_spans",
+	builder.ProcessorMemoryLimiterAcceptedSpans, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
+		"otelcol_processor_memory_limiter_accepted_spans",
 		metric.WithDescription("Number of spans successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorRefusedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
-		"otelcol_processor_refused_log_records",
+	builder.ProcessorMemoryLimiterRefusedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
+		"otelcol_processor_memory_limiter_refused_log_records",
 		metric.WithDescription("Number of log records that were rejected by the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorRefusedMetricPoints, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
-		"otelcol_processor_refused_metric_points",
+	builder.ProcessorMemoryLimiterRefusedMetricPoints, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
+		"otelcol_processor_memory_limiter_refused_metric_points",
 		metric.WithDescription("Number of metric points that were rejected by the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorRefusedSpans, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
-		"otelcol_processor_refused_spans",
+	builder.ProcessorMemoryLimiterRefusedSpans, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
+		"otelcol_processor_memory_limiter_refused_spans",
 		metric.WithDescription("Number of spans that were rejected by the next component in the pipeline. [deprecated since v0.110.0]"),
 		metric.WithUnit("{spans}"),
 	)

--- a/processor/memorylimiterprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/memorylimiterprocessor/internal/metadata/generated_telemetry_test.go
@@ -14,7 +14,6 @@ import (
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
@@ -68,7 +67,13 @@ func TestProviders(t *testing.T) {
 }
 
 func TestNewTelemetryBuilder(t *testing.T) {
-	set := componenttest.NewNopTelemetrySettings()
+	set := component.TelemetrySettings{
+		LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
+			return mockMeterProvider{}
+		},
+		MeterProvider:  mockMeterProvider{},
+		TracerProvider: mockTracerProvider{},
+	}
 	applied := false
 	_, err := NewTelemetryBuilder(set, telemetryBuilderOptionFunc(func(b *TelemetryBuilder) {
 		applied = true

--- a/processor/memorylimiterprocessor/metadata.yaml
+++ b/processor/memorylimiterprocessor/metadata.yaml
@@ -17,7 +17,7 @@ tests:
 
 telemetry:
   metrics:
-    processor_accepted_spans:
+    processor_memory_limiter_accepted_spans:
       enabled: true
       description: Number of spans successfully pushed into the next component in the pipeline.
       stability:
@@ -28,7 +28,7 @@ telemetry:
         value_type: int
         monotonic: true
 
-    processor_refused_spans:
+    processor_memory_limiter_refused_spans:
       enabled: true
       description: Number of spans that were rejected by the next component in the pipeline.
       stability:
@@ -39,7 +39,7 @@ telemetry:
         value_type: int
         monotonic: true
 
-    processor_accepted_metric_points:
+    processor_memory_limiter_accepted_metric_points:
       enabled: true
       description: Number of metric points successfully pushed into the next component in the pipeline.
       stability:
@@ -50,7 +50,7 @@ telemetry:
         value_type: int
         monotonic: true
 
-    processor_refused_metric_points:
+    processor_memory_limiter_refused_metric_points:
       enabled: true
       description: Number of metric points that were rejected by the next component in the pipeline.
       stability:
@@ -61,7 +61,7 @@ telemetry:
         value_type: int
         monotonic: true
 
-    processor_accepted_log_records:
+    processor_memory_limiter_accepted_log_records:
       enabled: true
       description: Number of log records successfully pushed into the next component in the pipeline.
       stability:
@@ -72,7 +72,7 @@ telemetry:
         value_type: int
         monotonic: true
 
-    processor_refused_log_records:
+    processor_memory_limiter_refused_log_records:
       enabled: true
       description: Number of log records that were rejected by the next component in the pipeline.
       stability:

--- a/processor/memorylimiterprocessor/obsreport.go
+++ b/processor/memorylimiterprocessor/obsreport.go
@@ -36,11 +36,11 @@ func newObsReport(set processor.Settings) (*obsReport, error) {
 func (or *obsReport) accepted(ctx context.Context, num int, signal pipeline.Signal) {
 	switch signal {
 	case pipeline.SignalTraces:
-		or.telemetryBuilder.ProcessorAcceptedSpans.Add(ctx, int64(num), or.otelAttrs)
+		or.telemetryBuilder.ProcessorMemoryLimiterAcceptedSpans.Add(ctx, int64(num), or.otelAttrs)
 	case pipeline.SignalMetrics:
-		or.telemetryBuilder.ProcessorAcceptedMetricPoints.Add(ctx, int64(num), or.otelAttrs)
+		or.telemetryBuilder.ProcessorMemoryLimiterAcceptedMetricPoints.Add(ctx, int64(num), or.otelAttrs)
 	case pipeline.SignalLogs:
-		or.telemetryBuilder.ProcessorAcceptedLogRecords.Add(ctx, int64(num), or.otelAttrs)
+		or.telemetryBuilder.ProcessorMemoryLimiterAcceptedLogRecords.Add(ctx, int64(num), or.otelAttrs)
 	}
 }
 
@@ -48,10 +48,10 @@ func (or *obsReport) accepted(ctx context.Context, num int, signal pipeline.Sign
 func (or *obsReport) refused(ctx context.Context, num int, signal pipeline.Signal) {
 	switch signal {
 	case pipeline.SignalTraces:
-		or.telemetryBuilder.ProcessorRefusedSpans.Add(ctx, int64(num), or.otelAttrs)
+		or.telemetryBuilder.ProcessorMemoryLimiterRefusedSpans.Add(ctx, int64(num), or.otelAttrs)
 	case pipeline.SignalMetrics:
-		or.telemetryBuilder.ProcessorRefusedMetricPoints.Add(ctx, int64(num), or.otelAttrs)
+		or.telemetryBuilder.ProcessorMemoryLimiterRefusedMetricPoints.Add(ctx, int64(num), or.otelAttrs)
 	case pipeline.SignalLogs:
-		or.telemetryBuilder.ProcessorRefusedLogRecords.Add(ctx, int64(num), or.otelAttrs)
+		or.telemetryBuilder.ProcessorMemoryLimiterRefusedLogRecords.Add(ctx, int64(num), or.otelAttrs)
 	}
 }


### PR DESCRIPTION
#### Description

Deprecated metrics used exclusively in memory limiter processor now have an infix of `memory_limiter`. For example, `otelcol_processor_accepted_spans` is now `otelcol_processor_memory_limiter_accepted_spans`.

#### Link to tracking issue
- Fixes #11203 
- Replaces #11280 
