### PR TITLE
(batchprocessor): Move single shard batcher creation to the constructor

### DIFF
--- a/.chloggen/batch-processor-init-single-shard.yaml
+++ b/.chloggen/batch-processor-init-single-shard.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: batchprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move single shard batcher creation to the constructor
+
+# One or more tracking issues or pull requests related to the change
+issues: [11594]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -129,6 +129,7 @@ func newBatchProcessor[T any](set processor.Settings, cfg *Config, batchFunc fun
 	if len(mks) == 0 {
 		bp.batcher = &singleShardBatcher[T]{
 			processor: bp,
+			single:    bp.newShard(nil),
 		}
 	} else {
 		bp.batcher = &multiShardBatcher[T]{
@@ -277,7 +278,6 @@ type singleShardBatcher[T any] struct {
 }
 
 func (sb *singleShardBatcher[T]) start(context.Context) error {
-	sb.single = sb.processor.newShard(nil)
 	sb.single.start()
 	return nil
 }


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The single-shard batcher is currently created and started in the start function. If the consume function is called before the start function, sb.single will be nil and it will panic. I'm not sure if that can happen in the Otel collector but it might happen in distributions that have a different runtime (such as Alloy - Grafana's distribution).

I think that conceptually, it's better to create the shard in the constructor and start it in the start function. 

PS: I did not create an entry in the changelog because the initial [PR](https://github.com/open-telemetry/opentelemetry-collector/pull/11314) for this change didn't but let me know if I should add one.

Credits also to @thampiotr for this fix
