### PR TITLE
[chore] fix: pin markdown-link-check to v3.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "markdown-link-check": "^3.11.2"
+    "markdown-link-check": "3.12.2"
   }
 }


### PR DESCRIPTION
To prevent it from using v3.13.x which is currently broken by https://github.com/tcort/markdown-link-check/issues/368.