### PR TITLE
[receiver/scraperhelper] exit before scraping if the receiver was shutdown

### DIFF
--- a/.chloggen/initial_delay_shutdown.yaml
+++ b/.chloggen/initial_delay_shutdown.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: scraperhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: If the scraper shuts down, do not scrape first.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11632]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When the scraper is shutting down, it currently will scrape at least once.
+  With this change, upon receiving a shutdown order, the receiver's scraperhelper will exit immediately.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -161,7 +161,12 @@ func (sc *controller) Shutdown(ctx context.Context) error {
 func (sc *controller) startScraping() {
 	go func() {
 		if sc.initialDelay > 0 {
-			<-time.After(sc.initialDelay)
+			select {
+			case <-time.After(sc.initialDelay):
+			case <-sc.done:
+				sc.terminated <- struct{}{}
+				return
+			}
 		}
 
 		if sc.tickerCh == nil {


### PR DESCRIPTION

#### Description
exit before scraping if the receiver was shutdown, do not wait the initial delay.

