### PR TITLE
[configtls] [config/configgrpc] Use configtls.NewDefaultClientConfig(), configtls.NewDefaultConfig() and configtls.NewDefaultServerConfig()

### DIFF
--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -388,9 +388,14 @@ func TestGrpcClientConfigInvalidBalancer(t *testing.T) {
 
 func TestGRPCClientSettingsError(t *testing.T) {
 	tlsClientConfigCADoesntExist := configtls.NewDefaultClientConfig()
-	tlsConfig := configtls.NewDefaultConfig()
-	tlsConfig.CAFile = "/doesnt/exist"
-	tlsClientConfigCADoesntExist.Config = tlsConfig
+	tlsConfigWithCAFile := configtls.NewDefaultConfig()
+	tlsConfigWithCAFile.CAFile = "/doesnt/exist"
+	tlsClientConfigCADoesntExist.Config = tlsConfigWithCAFile
+
+	tlsClientConfigCertDoesntExist := configtls.NewDefaultClientConfig()
+	tlsConfigWithCertFile := configtls.NewDefaultConfig()
+	tlsConfigWithCertFile.CertFile = "/doesnt/exist"
+	tlsClientConfigCertDoesntExist.Config = tlsConfigWithCertFile
 
 	tlsClientConfigWithInsecure := configtls.NewDefaultClientConfig()
 	tlsClientConfigWithInsecure.Insecure = true
@@ -415,7 +420,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				Headers:     nil,
 				Endpoint:    "",
 				Compression: "",
-				TLSSetting:  tlsClientConfigCADoesntExist,
+				TLSSetting:  tlsClientConfigCertDoesntExist,
 				Keepalive:   nil,
 			},
 		},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
[config/configgrpc] Changes to move away from manually creating configtls.ClientConfig, configtls.Config and configtls.ServerConfig in favor of using configtls.NewDefaultClientConfig, configtls.NewDefaultClientConfig(), configtls.NewDefaultConfig() and configtls.NewDefaultServerConfig() respectively.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/11383

