### PR TITLE
Add local module replacement to ocb template

### DIFF
--- a/.chloggen/add-local-module-replace-ocb-converter-provider.yaml
+++ b/.chloggen/add-local-module-replace-ocb-converter-provider.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: cmd/builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow for replacing of local Providers and Converters when building custom collector with ocb.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11649]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Use the property `path` under `gomod` to replace an go module with a local folder in
+  builder-config.yaml. Ex:
+  ```
+  providers:
+    - gomod: module.url/my/custom/provider v1.2.3
+      path: /path/to/local/provider
+  ```
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -34,10 +34,10 @@ require (
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 )
 
-{{- range .Providers}}
+{{- range .Converters}}
 {{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
-{{- range .Converters}}
+{{- range .Providers}}
 {{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
 {{- range .Connectors}}

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -34,6 +34,12 @@ require (
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 )
 
+{{- range .Providers}}
+{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{- end}}
+{{- range .Converters}}
+{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{- end}}
 {{- range .Connectors}}
 {{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}

--- a/service/telemetry/metrics_test.go
+++ b/service/telemetry/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -201,11 +202,31 @@ func createTestMetrics(t *testing.T, mp metric.MeterProvider) {
 }
 
 func getMetricsFromPrometheus(t *testing.T, endpoint string) map[string]*io_prometheus_client.MetricFamily {
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	var (
+		req *http.Request
+		err error
+		rr  *http.Response
+	)
+	req, err = http.NewRequest(http.MethodGet, endpoint, nil)
 	require.NoError(t, err)
 
-	rr, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
+	maxRetries := 5
+	for i := 0; i < maxRetries; i++ {
+		rr, err = client.Do(req)
+		if err == nil && rr.StatusCode == http.StatusOK {
+			break
+		}
+
+		if i < maxRetries-1 {
+			time.Sleep(2 * time.Second) // Wait before retrying
+		}
+	}
+	require.NoError(t, err, "failed to get metrics from Prometheus after %d attempts", maxRetries)
+	require.Equal(t, http.StatusOK, rr.StatusCode, "unexpected status code after %d attempts", maxRetries)
+	defer rr.Body.Close()
 
 	var parser expfmt.TextParser
 	parsed, err := parser.TextToMetricFamilies(rr.Body)

--- a/service/telemetry/metrics_test.go
+++ b/service/telemetry/metrics_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -202,31 +201,11 @@ func createTestMetrics(t *testing.T, mp metric.MeterProvider) {
 }
 
 func getMetricsFromPrometheus(t *testing.T, endpoint string) map[string]*io_prometheus_client.MetricFamily {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	var (
-		req *http.Request
-		err error
-		rr  *http.Response
-	)
-	req, err = http.NewRequest(http.MethodGet, endpoint, nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	require.NoError(t, err)
 
-	maxRetries := 5
-	for i := 0; i < maxRetries; i++ {
-		rr, err = client.Do(req)
-		if err == nil && rr.StatusCode == http.StatusOK {
-			break
-		}
-
-		if i < maxRetries-1 {
-			time.Sleep(2 * time.Second) // Wait before retrying
-		}
-	}
-	require.NoError(t, err, "failed to get metrics from Prometheus after %d attempts", maxRetries)
-	require.Equal(t, http.StatusOK, rr.StatusCode, "unexpected status code after %d attempts", maxRetries)
-	defer rr.Body.Close()
+	rr, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
 
 	var parser expfmt.TextParser
 	parsed, err := parser.TextToMetricFamilies(rr.Body)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds ability to replace Providers and Converters with local paths when building custom collector in ocb
<!-- Issue number if applicable -->
#### Link to tracking issue
Closes #11649

<!--Describe what testing was performed and which tests were added.-->
#### Testing
local build of ocb with locally downloaded converter and provider (can add this type of test to github actions if others think it is necessary)
<!--Describe the documentation added.-->
#### Documentation
.chloggen file
<!--Please delete paragraphs that you did not use before submitting.-->
