### PR TITLE
Deprecate Scraper.ID func, pass type when register Scraper

### DIFF
--- a/.chloggen/rm-scraper-id.yaml
+++ b/.chloggen/rm-scraper-id.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: scraperhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate Scraper.ID func, pass type when register Scraper
+
+# One or more tracking issues or pull requests related to the change
+issues: [11238]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/scraperhelper/scraper.go
+++ b/receiver/scraperhelper/scraper.go
@@ -24,7 +24,7 @@ func (sf ScrapeFunc) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 type Scraper interface {
 	component.Component
 
-	// ID returns the scraper id.
+	// Deprecated: [v0.114.0] use AddScraperWithType.
 	ID() component.ID
 	Scrape(context.Context) (pmetric.Metrics, error)
 }
@@ -67,8 +67,7 @@ func (b *baseScraper) ID() component.ID {
 	return b.id
 }
 
-// NewScraper creates a Scraper that calls Scrape at the specified collection interval,
-// reports observability information, and passes the scraped metrics to the next consumer.
+// Deprecated: [v0.114.0] use NewScraperWithoutType.
 func NewScraper(t component.Type, scrape ScrapeFunc, options ...ScraperOption) (Scraper, error) {
 	if scrape == nil {
 		return nil, errNilFunc
@@ -76,6 +75,22 @@ func NewScraper(t component.Type, scrape ScrapeFunc, options ...ScraperOption) (
 	bs := &baseScraper{
 		ScrapeFunc: scrape,
 		id:         component.NewID(t),
+	}
+	for _, op := range options {
+		op.apply(bs)
+	}
+
+	return bs, nil
+}
+
+// NewScraperWithoutType creates a Scraper that calls Scrape at the specified collection interval,
+// reports observability information, and passes the scraped metrics to the next consumer.
+func NewScraperWithoutType(scrape ScrapeFunc, options ...ScraperOption) (Scraper, error) {
+	if scrape == nil {
+		return nil, errNilFunc
+	}
+	bs := &baseScraper{
+		ScrapeFunc: scrape,
 	}
 	for _, op := range options {
 		op.apply(bs)


### PR DESCRIPTION
Changes interface to get closer to https://github.com/open-telemetry/opentelemetry-collector/pull/11657 