### PR TITLE
update time period before removing an unmaintained component

### DIFF
--- a/.chloggen/codeboten_3months.yaml
+++ b/.chloggen/codeboten_3months.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: shorten time period before removing an unmaintained component from 6 months to 3 months
+
+# One or more tracking issues or pull requests related to the change
+issues: [11664]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/component/component.go
+++ b/component/component.go
@@ -167,7 +167,7 @@ func (sl StabilityLevel) String() string {
 func (sl StabilityLevel) LogMessage() string {
 	switch sl {
 	case StabilityLevelUnmaintained:
-		return "Unmaintained component. Actively looking for contributors. Component will become deprecated after 6 months of remaining unmaintained."
+		return "Unmaintained component. Actively looking for contributors. Component will become deprecated after 3 months of remaining unmaintained."
 	case StabilityLevelDeprecated:
 		return "Deprecated component. Will be removed in future releases."
 	case StabilityLevelDevelopment:

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -84,7 +84,7 @@ func TestStabilityLevelString(t *testing.T) {
 
 func TestStabilityLevelLogMessage(t *testing.T) {
 	assert.Equal(t, "Stability level of component is undefined", StabilityLevelUndefined.LogMessage())
-	assert.Equal(t, "Unmaintained component. Actively looking for contributors. Component will become deprecated after 6 months of remaining unmaintained.", StabilityLevelUnmaintained.LogMessage())
+	assert.Equal(t, "Unmaintained component. Actively looking for contributors. Component will become deprecated after 3 months of remaining unmaintained.", StabilityLevelUnmaintained.LogMessage())
 	assert.Equal(t, "Deprecated component. Will be removed in future releases.", StabilityLevelDeprecated.LogMessage())
 	assert.Equal(t, "Development component. May change in the future.", StabilityLevelDevelopment.LogMessage())
 	assert.Equal(t, "Alpha component. May change in the future.", StabilityLevelAlpha.LogMessage())

--- a/docs/component-stability.md
+++ b/docs/component-stability.md
@@ -72,4 +72,4 @@ The component is planned to be removed in a future version and no further suppor
 
 ### Unmaintained
 
-A component identified as unmaintained does not have an active code owner. Such component may have never been assigned a code owner or a previously active code owner has not responded to requests for feedback within 6 weeks of being contacted. Issues and pull requests for unmaintained components will be labelled as such. After 6 months of being unmaintained, these components will be removed from official distribution. Components that are unmaintained are actively seeking contributors to become code owners.
+A component identified as unmaintained does not have an active code owner. Such component may have never been assigned a code owner or a previously active code owner has not responded to requests for feedback within 6 weeks of being contacted. Issues and pull requests for unmaintained components will be labelled as such. After 3 months of being unmaintained, these components will be removed from official distribution. Components that are unmaintained are actively seeking contributors to become code owners.


### PR DESCRIPTION
After reviewing the 6 month period, the period seems too long to get feedback on whether an unmaintained component should be removed. I'm proposing shortening it to 3 months.
