### PR TITLE
[chore] Use pseudo-versions to require `componenttest`

### DIFF
--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.19.0

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -82,7 +82,7 @@ require (
 	go.opentelemetry.io/collector v0.113.0 // indirect
 	go.opentelemetry.io/collector/client v1.19.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.113.0 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.113.0 // indirect
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.113.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.19.0 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.113.0 // indirect

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/client v1.19.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configauth v0.113.0
 	go.opentelemetry.io/collector/config/configcompression v1.19.0
 	go.opentelemetry.io/collector/config/confignet v1.19.0

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/client v1.19.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configauth v0.113.0
 	go.opentelemetry.io/collector/config/configcompression v1.19.0
 	go.opentelemetry.io/collector/config/configopaque v1.19.0

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/connector v0.113.0
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.113.0
 	go.opentelemetry.io/collector/consumer v0.113.0

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/connector v0.113.0
 	go.opentelemetry.io/collector/connector/connectortest v0.113.0

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/consumer v0.113.0

--- a/exporter/exporterhelper/exporterhelperprofiles/go.mod
+++ b/exporter/exporterhelper/exporterhelperprofiles/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configretry v1.19.0
 	go.opentelemetry.io/collector/consumer v0.113.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.113.0

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configretry v1.19.0
 	go.opentelemetry.io/collector/consumer v0.113.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.113.0

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configretry v1.19.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0
 	go.opentelemetry.io/collector/consumer v0.113.0

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.113.0
 	go.opentelemetry.io/collector/exporter v0.113.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector v0.113.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configauth v0.113.0
 	go.opentelemetry.io/collector/config/configcompression v1.19.0
 	go.opentelemetry.io/collector/config/configgrpc v0.113.0

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector v0.113.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configcompression v1.19.0
 	go.opentelemetry.io/collector/config/confighttp v0.113.0
 	go.opentelemetry.io/collector/config/configopaque v1.19.0

--- a/extension/auth/go.mod
+++ b/extension/auth/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/extension v0.113.0
 	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.67.1

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.uber.org/goleak v1.3.0
 )
 

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/extension v0.113.0
 	go.opentelemetry.io/collector/internal/memorylimiter v0.113.0

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector v0.113.0
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/component/componentstatus v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configauth v0.113.0
 	go.opentelemetry.io/collector/config/confighttp v0.113.0
 	go.opentelemetry.io/collector/confmap v1.19.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector v0.113.0
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/component/componentstatus v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configgrpc v0.113.0
 	go.opentelemetry.io/collector/config/confighttp v0.113.0
 	go.opentelemetry.io/collector/config/configopaque v1.19.0

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/component/componentstatus v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.uber.org/goleak v1.3.0
 )
 

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.113.0 // indirect
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4 // indirect
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.113.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.113.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.113.0 // indirect

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.113.0 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.113.0 // indirect
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0 // indirect
 	go.opentelemetry.io/collector/connector/connectorprofiles v0.113.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.113.0 // indirect

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/client v1.19.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/consumer v0.113.0

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0
 	go.opentelemetry.io/collector/consumer v0.113.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.113.0

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/consumer v0.113.0

--- a/processor/processorhelper/processorhelperprofiles/go.mod
+++ b/processor/processorhelper/processorhelperprofiles/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/consumer v0.113.0
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.113.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.113.0

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/component/componentstatus v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/consumer v0.113.0
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.113.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.113.0

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0
 	go.opentelemetry.io/collector/consumer v0.113.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.113.0

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/consumer v0.113.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.113.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector v0.113.0
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/component/componentstatus v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/configauth v0.113.0
 	go.opentelemetry.io/collector/config/configgrpc v0.113.0
 	go.opentelemetry.io/collector/config/confighttp v0.113.0

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/consumer v0.113.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.113.0
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.113.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector v0.113.0
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/component/componentstatus v0.113.0
-	go.opentelemetry.io/collector/component/componenttest v0.113.0
+	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/config/confighttp v0.113.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0
 	go.opentelemetry.io/collector/confmap v1.19.0


### PR DESCRIPTION
#### Description

My previous PR (#11615) which made `component/componenttest` into its own module tagged it as `v0.113.0` in the requirements of other modules. This works locally because of the `replace` statements, but since the module was never _actually_ released as v0.113.0, this causes issues in contrib (cf. #11509 and #11511).

This PR updates those requirements to use a pseudo-version pointing at a recent commit on main, which should be properly externally resolvable.

#### Link to tracking issue
None.

#### Testing
I removed the `replace` statements for `componenttest`, ran `make gotidy`, which allowed `make otelcorecol` to run successfully. Not sure if this is a thorough enough test however. Once this PR is merged, I will try `make update-otel [...]` on contrib with the appropriate commit ID to check that the issue is resolved.
