### PR TITLE
[chore] Run `make genotelcorecol` to fix "build-and-test / checks"

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
 
       # Generate apidiff states of Main
       - name: Generate-States

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Cache Go
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Cache Go
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Cache Go
         id: go-cache
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Cache Go
         id: go-cache
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Cache Go
         id: go-cache
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Cache Go
         id: go-cache
@@ -194,7 +194,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Cache Go
         id: go-cache
@@ -256,7 +256,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -33,6 +33,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
       - name: Test
         run: make builder-integration-test

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
       - name: Cache Go
         id: go-cache
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Run Contrib Tests
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
 
       - name: Run benchmark
         run: make gobenchmark

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
       # Prepare Core for release.
       #   - Update CHANGELOG.md file, this is done via chloggen
       #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: ~1.22.8
+          go-version: ~1.22.9
           cache: false
       - name: Cache Go
         id: go-cache

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -4,7 +4,7 @@ module go.opentelemetry.io/collector/cmd/otelcorecol
 
 go 1.22.0
 
-toolchain go1.22.8
+toolchain go1.22.9
 
 require (
 	go.opentelemetry.io/collector/component v0.113.0


### PR DESCRIPTION
#### Description

The "build-and-test / checks" CI job specifies `go-version: ~1.22.8`. Today, this started resolving to `1.22.9`, causing [errors in CI](https://github.com/open-telemetry/opentelemetry-collector/actions/runs/11839445874/job/32990922879?pr=11670) because of the `toolchain 1.22.8` directive in `otelcorecol/go.mod`. This PR just updates the directive to fix the error. A more long-term solution may be preferred, such as using exact versions instead of `~` versions in CI.