### PR TITLE
[chore] Use pseudo-versions to require `extensiontest`

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -106,7 +106,7 @@ require (
 	go.opentelemetry.io/collector/extension/auth v0.113.0 // indirect
 	go.opentelemetry.io/collector/extension/experimental/storage v0.113.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.113.0 // indirect
-	go.opentelemetry.io/collector/extension/extensiontest v0.113.0 // indirect
+	go.opentelemetry.io/collector/extension/extensiontest v0.0.0-20241114161639-3fe42eba8085 // indirect
 	go.opentelemetry.io/collector/featuregate v1.19.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.113.0 // indirect
 	go.opentelemetry.io/collector/internal/memorylimiter v0.113.0 // indirect

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/consumer/consumertest v0.113.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.113.0
 	go.opentelemetry.io/collector/extension/experimental/storage v0.113.0
-	go.opentelemetry.io/collector/extension/extensiontest v0.113.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.0.0-20241114161639-3fe42eba8085
 	go.opentelemetry.io/collector/pdata v1.19.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.113.0
 	go.opentelemetry.io/collector/pdata/testdata v0.113.0

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/component/componenttest v0.0.0-20241112045949-9c4c007a12b4
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/extension v0.113.0
-	go.opentelemetry.io/collector/extension/extensiontest v0.113.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.0.0-20241114161639-3fe42eba8085
 	go.opentelemetry.io/collector/internal/memorylimiter v0.113.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.113.0
 	go.opentelemetry.io/collector/confmap v1.19.0
 	go.opentelemetry.io/collector/extension v0.113.0
-	go.opentelemetry.io/collector/extension/extensiontest v0.113.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.0.0-20241114161639-3fe42eba8085
 	go.opentelemetry.io/contrib/zpages v0.56.0
 	go.opentelemetry.io/otel/sdk v1.32.0
 	go.opentelemetry.io/otel/trace v1.32.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -91,7 +91,7 @@ require (
 	go.opentelemetry.io/collector/extension/auth v0.113.0 // indirect
 	go.opentelemetry.io/collector/extension/experimental/storage v0.113.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.113.0 // indirect
-	go.opentelemetry.io/collector/extension/extensiontest v0.113.0 // indirect
+	go.opentelemetry.io/collector/extension/extensiontest v0.0.0-20241114161639-3fe42eba8085 // indirect
 	go.opentelemetry.io/collector/featuregate v1.19.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.113.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.113.0 // indirect

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/exporter v0.113.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.113.0
 	go.opentelemetry.io/collector/extension v0.113.0
-	go.opentelemetry.io/collector/extension/extensiontest v0.113.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.0.0-20241114161639-3fe42eba8085
 	go.opentelemetry.io/collector/featuregate v1.19.0
 	go.opentelemetry.io/collector/pipeline v0.113.0
 	go.opentelemetry.io/collector/processor v0.113.0

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -15,7 +15,7 @@ require (
 	go.opentelemetry.io/collector/exporter v0.113.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.113.0
 	go.opentelemetry.io/collector/extension v0.113.0
-	go.opentelemetry.io/collector/extension/extensiontest v0.113.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.0.0-20241114161639-3fe42eba8085
 	go.opentelemetry.io/collector/otelcol v0.113.0
 	go.opentelemetry.io/collector/pipeline v0.113.0
 	go.opentelemetry.io/collector/processor v0.113.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -27,7 +27,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exportertest v0.113.0
 	go.opentelemetry.io/collector/extension v0.113.0
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.113.0
-	go.opentelemetry.io/collector/extension/extensiontest v0.113.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.0.0-20241114161639-3fe42eba8085
 	go.opentelemetry.io/collector/extension/zpagesextension v0.113.0
 	go.opentelemetry.io/collector/featuregate v1.19.0
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.113.0


### PR DESCRIPTION
#### Description

Now that the PR to split `extensiontest` into its own module (#11629) has landed, we can import the new module in an externally-resolvable way using the pseudo-version corresponding to the merge commit, similar to what I did for `componenttest` (#11668). After the next release (0.114.0), we will be able to use that version number instead for internal imports.
