### PR TITLE
[chore] rename confmap modules to ConfmapConverters and ConfmapProviders

### DIFF
--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -37,16 +37,16 @@ type Config struct {
 	LDFlags              string `mapstructure:"-"`
 	Verbose              bool   `mapstructure:"-"`
 
-	Distribution Distribution `mapstructure:"dist"`
-	Exporters    []Module     `mapstructure:"exporters"`
-	Extensions   []Module     `mapstructure:"extensions"`
-	Receivers    []Module     `mapstructure:"receivers"`
-	Processors   []Module     `mapstructure:"processors"`
-	Connectors   []Module     `mapstructure:"connectors"`
-	Providers    []Module     `mapstructure:"providers"`
-	Converters   []Module     `mapstructure:"converters"`
-	Replaces     []string     `mapstructure:"replaces"`
-	Excludes     []string     `mapstructure:"excludes"`
+	Distribution     Distribution `mapstructure:"dist"`
+	Exporters        []Module     `mapstructure:"exporters"`
+	Extensions       []Module     `mapstructure:"extensions"`
+	Receivers        []Module     `mapstructure:"receivers"`
+	Processors       []Module     `mapstructure:"processors"`
+	Connectors       []Module     `mapstructure:"connectors"`
+	ConfmapProviders []Module     `mapstructure:"providers"`
+	ConfmapConverters       []Module     `mapstructure:"converters"`
+	Replaces         []string     `mapstructure:"replaces"`
+	Excludes         []string     `mapstructure:"excludes"`
 
 	ConfResolver ConfResolver `mapstructure:"conf_resolver"`
 
@@ -112,7 +112,7 @@ func NewDefaultConfig() (*Config, error) {
 			numRetries: 3,
 			wait:       5 * time.Second,
 		},
-		Providers: []Module{
+		ConfmapProviders: []Module{
 			{
 				GoMod: "go.opentelemetry.io/collector/confmap/provider/envprovider " + defaultStableOtelColVersion,
 			},
@@ -143,8 +143,8 @@ func (c *Config) Validate() error {
 		validateModules("exporter", c.Exporters),
 		validateModules("processor", c.Processors),
 		validateModules("connector", c.Connectors),
-		validateModules("provider", c.Providers),
-		validateModules("converter", c.Converters),
+		validateModules("provider", c.ConfmapProviders),
+		validateModules("converter", c.ConfmapConverters),
 	)
 }
 
@@ -193,11 +193,11 @@ func (c *Config) ParseModules() error {
 		return err
 	}
 
-	c.Providers, err = parseModules(c.Providers)
+	c.ConfmapProviders, err = parseModules(c.ConfmapProviders)
 	if err != nil {
 		return err
 	}
-	c.Converters, err = parseModules(c.Converters)
+	c.ConfmapConverters, err = parseModules(c.ConfmapConverters)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func (c *Config) ParseModules() error {
 }
 
 func (c *Config) allComponents() []Module {
-	return slices.Concat[[]Module](c.Exporters, c.Receivers, c.Processors, c.Extensions, c.Connectors, c.Providers, c.Converters)
+	return slices.Concat[[]Module](c.Exporters, c.Receivers, c.Processors, c.Extensions, c.Connectors, c.ConfmapProviders, c.ConfmapConverters)
 }
 
 func validateModules(name string, mods []Module) error {

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -37,16 +37,16 @@ type Config struct {
 	LDFlags              string `mapstructure:"-"`
 	Verbose              bool   `mapstructure:"-"`
 
-	Distribution     Distribution `mapstructure:"dist"`
-	Exporters        []Module     `mapstructure:"exporters"`
-	Extensions       []Module     `mapstructure:"extensions"`
-	Receivers        []Module     `mapstructure:"receivers"`
-	Processors       []Module     `mapstructure:"processors"`
-	Connectors       []Module     `mapstructure:"connectors"`
-	ConfmapProviders []Module     `mapstructure:"providers"`
-	ConfmapConverters       []Module     `mapstructure:"converters"`
-	Replaces         []string     `mapstructure:"replaces"`
-	Excludes         []string     `mapstructure:"excludes"`
+	Distribution      Distribution `mapstructure:"dist"`
+	Exporters         []Module     `mapstructure:"exporters"`
+	Extensions        []Module     `mapstructure:"extensions"`
+	Receivers         []Module     `mapstructure:"receivers"`
+	Processors        []Module     `mapstructure:"processors"`
+	Connectors        []Module     `mapstructure:"connectors"`
+	ConfmapProviders  []Module     `mapstructure:"providers"`
+	ConfmapConverters []Module     `mapstructure:"converters"`
+	Replaces          []string     `mapstructure:"replaces"`
+	Excludes          []string     `mapstructure:"excludes"`
 
 	ConfResolver ConfResolver `mapstructure:"conf_resolver"`
 

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -39,7 +39,7 @@ func TestParseModules(t *testing.T) {
 func TestInvalidConverter(t *testing.T) {
 	// Create a Config instance with invalid Converters
 	config := &Config{
-		Converters: []Module{
+		ConfmapConverters: []Module{
 			{
 				Path: "./invalid/module/path", // Invalid module path to trigger an error
 			},
@@ -103,7 +103,7 @@ func TestMissingModule(t *testing.T) {
 		{
 			cfg: Config{
 				Logger: zap.NewNop(),
-				Providers: []Module{{
+				ConfmapProviders: []Module{{
 					Import: "invalid",
 				}},
 			},
@@ -157,7 +157,7 @@ func TestMissingModule(t *testing.T) {
 		{
 			cfg: Config{
 				Logger: zap.NewNop(),
-				Converters: []Module{{
+				ConfmapConverters: []Module{{
 					Import: "invalid",
 				}},
 			},
@@ -252,14 +252,14 @@ func TestAddsDefaultProviders(t *testing.T) {
 	cfg, err := NewDefaultConfig()
 	require.NoError(t, err)
 	require.NoError(t, cfg.ParseModules())
-	assert.Len(t, cfg.Providers, 5)
+	assert.Len(t, cfg.ConfmapProviders, 5)
 }
 
 func TestSkipsNilFieldValidation(t *testing.T) {
 	cfg, err := NewDefaultConfig()
 	require.NoError(t, err)
-	cfg.Providers = nil
-	cfg.Converters = nil
+	cfg.ConfmapProviders = nil
+	cfg.ConfmapConverters = nil
 	assert.NoError(t, cfg.Validate())
 }
 

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -177,7 +177,7 @@ func TestVersioning(t *testing.T) {
 						GoMod: "go.opentelemetry.io/collector/exporter/otlpexporter v0.112.0",
 					},
 				}
-				cfg.Providers = []Module{}
+				cfg.ConfmapProviders = []Module{}
 				cfg.Replaces = append(cfg.Replaces, replaces...)
 				return cfg
 			},
@@ -194,7 +194,7 @@ func TestVersioning(t *testing.T) {
 						GoMod: "go.opentelemetry.io/collector/exporter/otlpexporter v0.112.0",
 					},
 				}
-				cfg.Providers = []Module{}
+				cfg.ConfmapProviders = []Module{}
 				cfg.Replaces = append(cfg.Replaces, replaces...)
 				return cfg
 			},
@@ -279,7 +279,7 @@ func TestGenerateAndCompile(t *testing.T) {
 				cfg := newTestConfig(t)
 				cfg.Distribution.OutputPath = t.TempDir()
 				cfg.Replaces = append(cfg.Replaces, replaces...)
-				cfg.Providers = []Module{}
+				cfg.ConfmapProviders = []Module{}
 				return cfg
 			},
 		},

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -5,10 +5,10 @@ module {{.Distribution.Module}}
 go 1.22
 
 require (
-	{{- range .Providers}}
+	{{- range .ConfmapConverters}}
 	{{if .GoMod}}{{.GoMod}}{{end}}
 	{{- end}}
-	{{- range .Converters}}
+	{{- range .ConfmapProviders}}
 	{{if .GoMod}}{{.GoMod}}{{end}}
 	{{- end}}
 	{{- range .Connectors}}
@@ -34,10 +34,10 @@ require (
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 )
 
-{{- range .Converters}}
+{{- range .ConfmapConverters}}
 {{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
-{{- range .Providers}}
+{{- range .ConfmapProviders}}
 {{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
 {{- range .Connectors}}

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -8,10 +8,10 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
-	{{- range .Converters}}
+	{{- range .ConfmapConverters}}
 	{{.Name}} "{{.Import}}"
 	{{- end}}	
-	{{- range .Providers}}
+	{{- range .ConfmapProviders}}
 	{{.Name}} "{{.Import}}"
 	{{- end}}
 	"go.opentelemetry.io/collector/otelcol"
@@ -30,13 +30,13 @@ func main() {
 		ConfigProviderSettings: otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
 				ProviderFactories: []confmap.ProviderFactory{
-					{{- range .Providers}}
+					{{- range .ConfmapProviders}}
 					{{.Name}}.NewFactory(),
 					{{- end}}
 				},
-				{{- if .Converters }}
+				{{- if .ConfmapConverters }}
 				ConverterFactories: []confmap.ConverterFactory{
-					{{- range .Converters}}
+					{{- range .ConfmapConverters}}
 					{{.Name}}.NewFactory(),
 					{{- end}}
 				},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
change name in templates and cmd/builder to refer to Providers and Converters as ConfmapProviders and ConfmapConverters
<!-- Issue number if applicable -->
#### Link to tracking issue
as requested here: https://github.com/open-telemetry/opentelemetry-collector/pull/11653#discussion_r1841202325

<!--Describe what testing was performed and which tests were added.-->
#### Testing
existing tests should cover this
<!--Describe the documentation added.-->
#### Documentation
none, internal change and no new code/api
<!--Please delete paragraphs that you did not use before submitting.-->
