### PR TITLE
mdatagen: NewTelemetryBuilder does nil check

### DIFF
--- a/.chloggen/fix_telemetry_panic.yaml
+++ b/.chloggen/fix_telemetry_panic.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The generated NewTelemetryBuilder function in generated_telemetry.go will not panic if a LeveledMeterProvider is missing.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11684]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -84,6 +84,9 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	for _, op := range options {
 		op.apply(&builder)
 	}
+	if settings.LeveledMeterProvider == nil {
+		return nil, errors.New("TelemetrySettings must have a LeveledMeterProvider")
+	}
 	builder.meters[configtelemetry.LevelBasic] = LeveledMeter(settings, configtelemetry.LevelBasic)
 	var err, errs error
 	builder.BatchSizeTriggerSend, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry_test.go
@@ -76,3 +76,9 @@ func TestNewTelemetryBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applied)
 }
+
+func TestNewTelemetryBuilderNoLeveledMeterProvider(t *testing.T) {
+	set := component.TelemetrySettings{}
+	_, err := NewTelemetryBuilder(set)
+	require.Error(t, err, "expected telemetry builder with no LeveledMeter to fail")
+}

--- a/cmd/mdatagen/internal/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/internal/templates/telemetry.go.tmpl
@@ -34,7 +34,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 }
 {{- if .Telemetry.Metrics }}
 
-// TelemetryBuilder provides an interface for components to report telemetry 
+// TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
     meter metric.Meter
@@ -107,6 +107,11 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	for _, op := range options {
 		op.apply(&builder)
 	}
+    {{- if gt (len .Telemetry.Levels) 0 }}
+    if settings.LeveledMeterProvider == nil {
+        return nil, errors.New("TelemetrySettings must have a LeveledMeterProvider")
+    }
+    {{- end }}
     {{- range $level, $val := .Telemetry.Levels }}
     builder.meters[configtelemetry.Level{{ casesTitle $level }}] = LeveledMeter(settings, configtelemetry.Level{{ casesTitle $level }})
     {{- end }}

--- a/cmd/mdatagen/internal/templates/telemetry_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/telemetry_test.go.tmpl
@@ -78,4 +78,12 @@ func TestNewTelemetryBuilder(t *testing.T) {
 	require.True(t, applied)
 }
 
+{{- if gt (len .Telemetry.Levels) 0 }}
+func TestNewTelemetryBuilderNoLeveledMeterProvider(t *testing.T) {
+	set := component.TelemetrySettings{}
+	_, err := NewTelemetryBuilder(set)
+	require.Error(t, err, "expected telemetry builder with no LeveledMeter to fail")
+}
+{{- end }}
+
 {{- end }}

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -98,6 +98,9 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	for _, op := range options {
 		op.apply(&builder)
 	}
+	if settings.LeveledMeterProvider == nil {
+		return nil, errors.New("TelemetrySettings must have a LeveledMeterProvider")
+	}
 	builder.meters[configtelemetry.LevelBasic] = LeveledMeter(settings, configtelemetry.LevelBasic)
 	var err, errs error
 	builder.ExporterEnqueueFailedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry_test.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry_test.go
@@ -76,3 +76,9 @@ func TestNewTelemetryBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applied)
 }
+
+func TestNewTelemetryBuilderNoLeveledMeterProvider(t *testing.T) {
+	set := component.TelemetrySettings{}
+	_, err := NewTelemetryBuilder(set)
+	require.Error(t, err, "expected telemetry builder with no LeveledMeter to fail")
+}

--- a/processor/batchprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/batchprocessor/internal/metadata/generated_telemetry.go
@@ -67,6 +67,9 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	for _, op := range options {
 		op.apply(&builder)
 	}
+	if settings.LeveledMeterProvider == nil {
+		return nil, errors.New("TelemetrySettings must have a LeveledMeterProvider")
+	}
 	builder.meters[configtelemetry.LevelBasic] = LeveledMeter(settings, configtelemetry.LevelBasic)
 	builder.meters[configtelemetry.LevelDetailed] = LeveledMeter(settings, configtelemetry.LevelDetailed)
 	var err, errs error

--- a/processor/batchprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/batchprocessor/internal/metadata/generated_telemetry_test.go
@@ -76,3 +76,9 @@ func TestNewTelemetryBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applied)
 }
+
+func TestNewTelemetryBuilderNoLeveledMeterProvider(t *testing.T) {
+	set := component.TelemetrySettings{}
+	_, err := NewTelemetryBuilder(set)
+	require.Error(t, err, "expected telemetry builder with no LeveledMeter to fail")
+}

--- a/processor/memorylimiterprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/memorylimiterprocessor/internal/metadata/generated_telemetry.go
@@ -56,6 +56,9 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	for _, op := range options {
 		op.apply(&builder)
 	}
+	if settings.LeveledMeterProvider == nil {
+		return nil, errors.New("TelemetrySettings must have a LeveledMeterProvider")
+	}
 	builder.meters[configtelemetry.LevelBasic] = LeveledMeter(settings, configtelemetry.LevelBasic)
 	var err, errs error
 	builder.ProcessorAcceptedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(

--- a/processor/memorylimiterprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/memorylimiterprocessor/internal/metadata/generated_telemetry_test.go
@@ -76,3 +76,9 @@ func TestNewTelemetryBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applied)
 }
+
+func TestNewTelemetryBuilderNoLeveledMeterProvider(t *testing.T) {
+	set := component.TelemetrySettings{}
+	_, err := NewTelemetryBuilder(set)
+	require.Error(t, err, "expected telemetry builder with no LeveledMeter to fail")
+}

--- a/processor/processorhelper/internal/metadata/generated_telemetry.go
+++ b/processor/processorhelper/internal/metadata/generated_telemetry.go
@@ -52,6 +52,9 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	for _, op := range options {
 		op.apply(&builder)
 	}
+	if settings.LeveledMeterProvider == nil {
+		return nil, errors.New("TelemetrySettings must have a LeveledMeterProvider")
+	}
 	builder.meters[configtelemetry.LevelBasic] = LeveledMeter(settings, configtelemetry.LevelBasic)
 	var err, errs error
 	builder.ProcessorIncomingItems, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(

--- a/processor/processorhelper/internal/metadata/generated_telemetry_test.go
+++ b/processor/processorhelper/internal/metadata/generated_telemetry_test.go
@@ -76,3 +76,9 @@ func TestNewTelemetryBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applied)
 }
+
+func TestNewTelemetryBuilderNoLeveledMeterProvider(t *testing.T) {
+	set := component.TelemetrySettings{}
+	_, err := NewTelemetryBuilder(set)
+	require.Error(t, err, "expected telemetry builder with no LeveledMeter to fail")
+}

--- a/receiver/receiverhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/receiverhelper/internal/metadata/generated_telemetry.go
@@ -56,6 +56,9 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	for _, op := range options {
 		op.apply(&builder)
 	}
+	if settings.LeveledMeterProvider == nil {
+		return nil, errors.New("TelemetrySettings must have a LeveledMeterProvider")
+	}
 	builder.meters[configtelemetry.LevelBasic] = LeveledMeter(settings, configtelemetry.LevelBasic)
 	var err, errs error
 	builder.ReceiverAcceptedLogRecords, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(

--- a/receiver/receiverhelper/internal/metadata/generated_telemetry_test.go
+++ b/receiver/receiverhelper/internal/metadata/generated_telemetry_test.go
@@ -76,3 +76,9 @@ func TestNewTelemetryBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applied)
 }
+
+func TestNewTelemetryBuilderNoLeveledMeterProvider(t *testing.T) {
+	set := component.TelemetrySettings{}
+	_, err := NewTelemetryBuilder(set)
+	require.Error(t, err, "expected telemetry builder with no LeveledMeter to fail")
+}

--- a/receiver/scraperhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/scraperhelper/internal/metadata/generated_telemetry.go
@@ -52,6 +52,9 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	for _, op := range options {
 		op.apply(&builder)
 	}
+	if settings.LeveledMeterProvider == nil {
+		return nil, errors.New("TelemetrySettings must have a LeveledMeterProvider")
+	}
 	builder.meters[configtelemetry.LevelBasic] = LeveledMeter(settings, configtelemetry.LevelBasic)
 	var err, errs error
 	builder.ScraperErroredMetricPoints, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(

--- a/receiver/scraperhelper/internal/metadata/generated_telemetry_test.go
+++ b/receiver/scraperhelper/internal/metadata/generated_telemetry_test.go
@@ -76,3 +76,9 @@ func TestNewTelemetryBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applied)
 }
+
+func TestNewTelemetryBuilderNoLeveledMeterProvider(t *testing.T) {
+	set := component.TelemetrySettings{}
+	_, err := NewTelemetryBuilder(set)
+	require.Error(t, err, "expected telemetry builder with no LeveledMeter to fail")
+}

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -123,6 +123,9 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	for _, op := range options {
 		op.apply(&builder)
 	}
+	if settings.LeveledMeterProvider == nil {
+		return nil, errors.New("TelemetrySettings must have a LeveledMeterProvider")
+	}
 	builder.meters[configtelemetry.LevelBasic] = LeveledMeter(settings, configtelemetry.LevelBasic)
 	var err, errs error
 	builder.ProcessCPUSeconds, err = builder.meters[configtelemetry.LevelBasic].Float64ObservableCounter(

--- a/service/internal/metadata/generated_telemetry_test.go
+++ b/service/internal/metadata/generated_telemetry_test.go
@@ -76,3 +76,9 @@ func TestNewTelemetryBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applied)
 }
+
+func TestNewTelemetryBuilderNoLeveledMeterProvider(t *testing.T) {
+	set := component.TelemetrySettings{}
+	_, err := NewTelemetryBuilder(set)
+	require.Error(t, err, "expected telemetry builder with no LeveledMeter to fail")
+}


### PR DESCRIPTION
#### Description
Previously, the NewTelemetryBuilder function would panic if the LeveledMeterProvider function wasn't specified in the settings. This PR adds a nil check to that function, as well as a test that it responds with an error rather than panicking.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #11684

<!--Describe what testing was performed and which tests were added.-->
#### Testing
`make gogenerate`
`make gotest`

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
