### PR TITLE
Fix sample count iteration.

### DIFF
--- a/pdata/pprofile/profiles.go
+++ b/pdata/pprofile/profiles.go
@@ -59,7 +59,7 @@ func (ms Profiles) SampleCount() int {
 		sps := rp.ScopeProfiles()
 		for j := 0; j < sps.Len(); j++ {
 			pcs := sps.At(j).Profiles()
-			for k := 0; j < pcs.Len(); j++ {
+			for k := 0; k < pcs.Len(); k++ {
 				sampleCount += pcs.At(k).Profile().Sample().Len()
 			}
 		}

--- a/pdata/pprofile/profiles_test.go
+++ b/pdata/pprofile/profiles_test.go
@@ -41,6 +41,15 @@ func TestSampleCount(t *testing.T) {
 	ps.Sample().AppendEmpty()
 	assert.EqualValues(t, 1, profiles.SampleCount())
 
+	ils2 := rs.ScopeProfiles().AppendEmpty()
+	assert.EqualValues(t, 1, profiles.SampleCount())
+
+	ps2 := ils2.Profiles().AppendEmpty().Profile()
+	assert.EqualValues(t, 1, profiles.SampleCount())
+
+	ps2.Sample().AppendEmpty()
+	assert.EqualValues(t, 2, profiles.SampleCount())
+
 	rms := profiles.ResourceProfiles()
 	rms.EnsureCapacity(3)
 	rms.AppendEmpty().ScopeProfiles().AppendEmpty()
@@ -48,8 +57,8 @@ func TestSampleCount(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		ilss.AppendEmpty()
 	}
-	// 5 + 1 (from rms.At(0) initialized first)
-	assert.EqualValues(t, 6, profiles.SampleCount())
+	// 5 + 2 (from rms.At(0) and rms.At(1) initialized first)
+	assert.EqualValues(t, 7, profiles.SampleCount())
 }
 
 func TestSampleCountWithEmpty(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Sample count iteration for profiles is incrementing the wrong variable inside the loop, which causes the result to be wrong.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

The refactored unit test covers this case.


