### PR TITLE
[chore] Add all maintainers as codeowners of CODEOWNERS file and RFC folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,7 @@
 #
 
 * @open-telemetry/collector-approvers
+
+# List all maintainers individually so all of them are notified
+.github/CODEOWNERS @codeboten @BogdanDrutu @dmitryax @mx-psi
+docs/rfc           @codeboten @BogdanDrutu @dmitryax @mx-psi


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

I am going to start filing PRs to add codeowners, I want all maintainers to get notified about them.
I also want all maintainers to get notified about all RFCs.
