### PR TITLE
[chore] Use pseudo-versions to require `authtest`

### DIFF
--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -16,7 +16,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v1.20.0
 	go.opentelemetry.io/collector/config/internal v0.114.0
 	go.opentelemetry.io/collector/extension/auth v0.114.0
-	go.opentelemetry.io/collector/extension/auth/authtest v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/extension/auth/authtest v0.0.0-20241120164440-f2e05b5089bb
 	go.opentelemetry.io/collector/pdata v1.20.0
 	go.opentelemetry.io/collector/pdata/testdata v0.114.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.56.0

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -18,7 +18,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v1.20.0
 	go.opentelemetry.io/collector/config/internal v0.114.0
 	go.opentelemetry.io/collector/extension/auth v0.114.0
-	go.opentelemetry.io/collector/extension/auth/authtest v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/extension/auth/authtest v0.0.0-20241120164440-f2e05b5089bb
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0
 	go.opentelemetry.io/otel v1.32.0
 	go.opentelemetry.io/otel/metric v1.32.0


### PR DESCRIPTION
#### Description
Now that #11705 has been merged, splitting the `extension/auth/authtest` package into a separate module, this PR updates imports of the new module to an externally resolvable pseudo-version based on the merge commit (f2e05b5). (See #11668 for context on why this two-step process is necessary.)

#### Link to tracking issue
Resolves #11465
