### PR TITLE
[chore] Run markdown link check if package.json changes

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
     outputs:
-      md: ${{ steps.changes.outputs.md }}
+      files: ${{ steps.changes.outputs.files }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -27,11 +27,17 @@ jobs:
       - name: Get changed files
         id: changes
         run: |
-          echo "md=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)" >> $GITHUB_OUTPUT
+            files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)
+            
+            if [ -z "$files" ] && git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep -q "package.json"; then
+              files="**/*.md"
+            fi
+
+            echo "files=$files" >> $GITHUB_OUTPUT
   check-links:
     runs-on: ubuntu-latest
     needs: changedfiles
-    if: ${{needs.changedfiles.outputs.md}}
+    if: ${{needs.changedfiles.outputs.files}}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -46,5 +52,5 @@ jobs:
           npx --no -- markdown-link-check \
             --verbose \
             --config .github/workflows/check_links_config.json \
-            ${{needs.changedfiles.outputs.md}} \
+            ${{needs.changedfiles.outputs.files}} \
             || { echo "Check that anchor links are lowercase"; exit 1; }


### PR DESCRIPTION
#### Description
This PR will run the "markdown-link-check" tool if the package.json changes even if no markdown files were updated. This will help to confirm that "markdown-link-check" is still working as expected after a version update/pin. 

If 1+ *.md files gets changed AND the package.json gets updated, it will only check the updated files to keep the same behaviour as before. 

If only the package.json gets updated it will test all existing *.md files. 

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/11606 

#### Testing

I tested/reproduced this manually: 

1. *.md file changes, but package.json not: https://github.com/niwoerner/opentelemetry-collector/actions/runs/11959750938
2. *.md file and package.json changes: https://github.com/niwoerner/opentelemetry-collector/actions/runs/11959777300
3. *.md file doesn't change but package.json: https://github.com/niwoerner/opentelemetry-collector/actions/runs/11959797335
