### PR TITLE
[service] update telemetry level to reflect their state

### DIFF
--- a/cmd/mdatagen/internal/testdata/with_telemetry.yaml
+++ b/cmd/mdatagen/internal/testdata/with_telemetry.yaml
@@ -10,5 +10,7 @@ telemetry:
       description: Latency (in microseconds) of a given sampling policy
       unit: µs
       enabled: true
+      stability:
+        level: alpha
       histogram:
         value_type: int

--- a/exporter/exporterhelper/documentation.md
+++ b/exporter/exporterhelper/documentation.md
@@ -8,7 +8,7 @@ The following telemetry is emitted by this component.
 
 ### otelcol_exporter_enqueue_failed_log_records
 
-Number of log records failed to be added to the sending queue.
+Number of log records failed to be added to the sending queue. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -16,7 +16,7 @@ Number of log records failed to be added to the sending queue.
 
 ### otelcol_exporter_enqueue_failed_metric_points
 
-Number of metric points failed to be added to the sending queue.
+Number of metric points failed to be added to the sending queue. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -24,7 +24,7 @@ Number of metric points failed to be added to the sending queue.
 
 ### otelcol_exporter_enqueue_failed_spans
 
-Number of spans failed to be added to the sending queue.
+Number of spans failed to be added to the sending queue. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -32,7 +32,7 @@ Number of spans failed to be added to the sending queue.
 
 ### otelcol_exporter_queue_capacity
 
-Fixed capacity of the retry queue (in batches)
+Fixed capacity of the retry queue (in batches) [alpha]
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -40,7 +40,7 @@ Fixed capacity of the retry queue (in batches)
 
 ### otelcol_exporter_queue_size
 
-Current size of the retry queue (in batches)
+Current size of the retry queue (in batches) [alpha]
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -48,7 +48,7 @@ Current size of the retry queue (in batches)
 
 ### otelcol_exporter_send_failed_log_records
 
-Number of log records in failed attempts to send to destination.
+Number of log records in failed attempts to send to destination. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -56,7 +56,7 @@ Number of log records in failed attempts to send to destination.
 
 ### otelcol_exporter_send_failed_metric_points
 
-Number of metric points in failed attempts to send to destination.
+Number of metric points in failed attempts to send to destination. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -64,7 +64,7 @@ Number of metric points in failed attempts to send to destination.
 
 ### otelcol_exporter_send_failed_spans
 
-Number of spans in failed attempts to send to destination.
+Number of spans in failed attempts to send to destination. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -72,7 +72,7 @@ Number of spans in failed attempts to send to destination.
 
 ### otelcol_exporter_sent_log_records
 
-Number of log record successfully sent to destination.
+Number of log record successfully sent to destination. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -80,7 +80,7 @@ Number of log record successfully sent to destination.
 
 ### otelcol_exporter_sent_metric_points
 
-Number of metric points successfully sent to destination.
+Number of metric points successfully sent to destination. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -88,7 +88,7 @@ Number of metric points successfully sent to destination.
 
 ### otelcol_exporter_sent_spans
 
-Number of spans successfully sent to destination.
+Number of spans successfully sent to destination. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -97,55 +97,55 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.ExporterEnqueueFailedLogRecords, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_exporter_enqueue_failed_log_records",
-		metric.WithDescription("Number of log records failed to be added to the sending queue."),
+		metric.WithDescription("Number of log records failed to be added to the sending queue. [alpha]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterEnqueueFailedMetricPoints, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_exporter_enqueue_failed_metric_points",
-		metric.WithDescription("Number of metric points failed to be added to the sending queue."),
+		metric.WithDescription("Number of metric points failed to be added to the sending queue. [alpha]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterEnqueueFailedSpans, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_exporter_enqueue_failed_spans",
-		metric.WithDescription("Number of spans failed to be added to the sending queue."),
+		metric.WithDescription("Number of spans failed to be added to the sending queue. [alpha]"),
 		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSendFailedLogRecords, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_exporter_send_failed_log_records",
-		metric.WithDescription("Number of log records in failed attempts to send to destination."),
+		metric.WithDescription("Number of log records in failed attempts to send to destination. [alpha]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSendFailedMetricPoints, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_exporter_send_failed_metric_points",
-		metric.WithDescription("Number of metric points in failed attempts to send to destination."),
+		metric.WithDescription("Number of metric points in failed attempts to send to destination. [alpha]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSendFailedSpans, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_exporter_send_failed_spans",
-		metric.WithDescription("Number of spans in failed attempts to send to destination."),
+		metric.WithDescription("Number of spans in failed attempts to send to destination. [alpha]"),
 		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSentLogRecords, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_exporter_sent_log_records",
-		metric.WithDescription("Number of log record successfully sent to destination."),
+		metric.WithDescription("Number of log record successfully sent to destination. [alpha]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSentMetricPoints, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_exporter_sent_metric_points",
-		metric.WithDescription("Number of metric points successfully sent to destination."),
+		metric.WithDescription("Number of metric points successfully sent to destination. [alpha]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSentSpans, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_exporter_sent_spans",
-		metric.WithDescription("Number of spans successfully sent to destination."),
+		metric.WithDescription("Number of spans successfully sent to destination. [alpha]"),
 		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)

--- a/exporter/exporterhelper/metadata.yaml
+++ b/exporter/exporterhelper/metadata.yaml
@@ -11,6 +11,8 @@ telemetry:
   metrics:
     exporter_sent_spans:
       enabled: true
+      stability:
+        level: alpha
       description: Number of spans successfully sent to destination.
       unit: "{spans}"
       sum:
@@ -19,6 +21,8 @@ telemetry:
 
     exporter_send_failed_spans:
       enabled: true
+      stability:
+        level: alpha
       description: Number of spans in failed attempts to send to destination.
       unit: "{spans}"
       sum:
@@ -27,6 +31,8 @@ telemetry:
 
     exporter_enqueue_failed_spans:
       enabled: true
+      stability:
+        level: alpha
       description: Number of spans failed to be added to the sending queue.
       unit: "{spans}"
       sum:
@@ -35,6 +41,8 @@ telemetry:
 
     exporter_sent_metric_points:
       enabled: true
+      stability:
+        level: alpha
       description: Number of metric points successfully sent to destination.
       unit: "{datapoints}"
       sum:
@@ -43,6 +51,8 @@ telemetry:
 
     exporter_send_failed_metric_points:
       enabled: true
+      stability:
+        level: alpha
       description: Number of metric points in failed attempts to send to destination.
       unit: "{datapoints}"
       sum:
@@ -51,6 +61,8 @@ telemetry:
 
     exporter_enqueue_failed_metric_points:
       enabled: true
+      stability:
+        level: alpha
       description: Number of metric points failed to be added to the sending queue.
       unit: "{datapoints}"
       sum:
@@ -59,6 +71,8 @@ telemetry:
 
     exporter_sent_log_records:
       enabled: true
+      stability:
+        level: alpha
       description: Number of log record successfully sent to destination.
       unit: "{records}"
       sum:
@@ -67,6 +81,8 @@ telemetry:
 
     exporter_send_failed_log_records:
       enabled: true
+      stability:
+        level: alpha
       description: Number of log records in failed attempts to send to destination.
       unit: "{records}"
       sum:
@@ -75,6 +91,8 @@ telemetry:
 
     exporter_enqueue_failed_log_records:
       enabled: true
+      stability:
+        level: alpha
       description: Number of log records failed to be added to the sending queue.
       unit: "{records}"
       sum:
@@ -83,6 +101,8 @@ telemetry:
 
     exporter_queue_size:
       enabled: true
+      stability:
+        level: alpha
       description: Current size of the retry queue (in batches)
       unit: "{batches}"
       optional: true
@@ -92,6 +112,8 @@ telemetry:
 
     exporter_queue_capacity:
       enabled: true
+      stability:
+        level: alpha
       description: Fixed capacity of the retry queue (in batches)
       unit: "{batches}"
       optional: true

--- a/receiver/receiverhelper/documentation.md
+++ b/receiver/receiverhelper/documentation.md
@@ -8,7 +8,7 @@ The following telemetry is emitted by this component.
 
 ### otelcol_receiver_accepted_log_records
 
-Number of log records successfully pushed into the pipeline.
+Number of log records successfully pushed into the pipeline. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -16,7 +16,7 @@ Number of log records successfully pushed into the pipeline.
 
 ### otelcol_receiver_accepted_metric_points
 
-Number of metric points successfully pushed into the pipeline.
+Number of metric points successfully pushed into the pipeline. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -24,7 +24,7 @@ Number of metric points successfully pushed into the pipeline.
 
 ### otelcol_receiver_accepted_spans
 
-Number of spans successfully pushed into the pipeline.
+Number of spans successfully pushed into the pipeline. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -32,7 +32,7 @@ Number of spans successfully pushed into the pipeline.
 
 ### otelcol_receiver_refused_log_records
 
-Number of log records that could not be pushed into the pipeline.
+Number of log records that could not be pushed into the pipeline. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -40,7 +40,7 @@ Number of log records that could not be pushed into the pipeline.
 
 ### otelcol_receiver_refused_metric_points
 
-Number of metric points that could not be pushed into the pipeline.
+Number of metric points that could not be pushed into the pipeline. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -48,7 +48,7 @@ Number of metric points that could not be pushed into the pipeline.
 
 ### otelcol_receiver_refused_spans
 
-Number of spans that could not be pushed into the pipeline.
+Number of spans that could not be pushed into the pipeline. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |

--- a/receiver/receiverhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/receiverhelper/internal/metadata/generated_telemetry.go
@@ -55,37 +55,37 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.ReceiverAcceptedLogRecords, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_receiver_accepted_log_records",
-		metric.WithDescription("Number of log records successfully pushed into the pipeline."),
+		metric.WithDescription("Number of log records successfully pushed into the pipeline. [alpha]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverAcceptedMetricPoints, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_receiver_accepted_metric_points",
-		metric.WithDescription("Number of metric points successfully pushed into the pipeline."),
+		metric.WithDescription("Number of metric points successfully pushed into the pipeline. [alpha]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverAcceptedSpans, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_receiver_accepted_spans",
-		metric.WithDescription("Number of spans successfully pushed into the pipeline."),
+		metric.WithDescription("Number of spans successfully pushed into the pipeline. [alpha]"),
 		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverRefusedLogRecords, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_receiver_refused_log_records",
-		metric.WithDescription("Number of log records that could not be pushed into the pipeline."),
+		metric.WithDescription("Number of log records that could not be pushed into the pipeline. [alpha]"),
 		metric.WithUnit("{records}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverRefusedMetricPoints, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_receiver_refused_metric_points",
-		metric.WithDescription("Number of metric points that could not be pushed into the pipeline."),
+		metric.WithDescription("Number of metric points that could not be pushed into the pipeline. [alpha]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverRefusedSpans, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_receiver_refused_spans",
-		metric.WithDescription("Number of spans that could not be pushed into the pipeline."),
+		metric.WithDescription("Number of spans that could not be pushed into the pipeline. [alpha]"),
 		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)

--- a/receiver/receiverhelper/metadata.yaml
+++ b/receiver/receiverhelper/metadata.yaml
@@ -11,6 +11,8 @@ telemetry:
   metrics:
     receiver_accepted_spans:
       enabled: true
+      stability:
+        level: alpha
       description: Number of spans successfully pushed into the pipeline.
       unit: "{spans}"
       sum:
@@ -19,6 +21,8 @@ telemetry:
 
     receiver_refused_spans:
       enabled: true
+      stability:
+        level: alpha
       description: Number of spans that could not be pushed into the pipeline.
       unit: "{spans}"
       sum:
@@ -27,6 +31,8 @@ telemetry:
 
     receiver_accepted_metric_points:
       enabled: true
+      stability:
+        level: alpha
       description: Number of metric points successfully pushed into the pipeline.
       unit: "{datapoints}"
       sum:
@@ -35,6 +41,8 @@ telemetry:
 
     receiver_refused_metric_points:
       enabled: true
+      stability:
+        level: alpha
       description: Number of metric points that could not be pushed into the pipeline.
       unit: "{datapoints}"
       sum:
@@ -43,6 +51,8 @@ telemetry:
 
     receiver_accepted_log_records:
       enabled: true
+      stability:
+        level: alpha
       description: Number of log records successfully pushed into the pipeline.
       unit: "{records}"
       sum:
@@ -51,6 +61,8 @@ telemetry:
 
     receiver_refused_log_records:
       enabled: true
+      stability:
+        level: alpha
       description: Number of log records that could not be pushed into the pipeline.
       unit: "{records}"
       sum:

--- a/receiver/scraperhelper/documentation.md
+++ b/receiver/scraperhelper/documentation.md
@@ -8,7 +8,7 @@ The following telemetry is emitted by this component.
 
 ### otelcol_scraper_errored_metric_points
 
-Number of metric points that were unable to be scraped.
+Number of metric points that were unable to be scraped. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -16,7 +16,7 @@ Number of metric points that were unable to be scraped.
 
 ### otelcol_scraper_scraped_metric_points
 
-Number of metric points successfully scraped.
+Number of metric points successfully scraped. [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |

--- a/receiver/scraperhelper/internal/metadata/generated_telemetry.go
+++ b/receiver/scraperhelper/internal/metadata/generated_telemetry.go
@@ -51,13 +51,13 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.ScraperErroredMetricPoints, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_scraper_errored_metric_points",
-		metric.WithDescription("Number of metric points that were unable to be scraped."),
+		metric.WithDescription("Number of metric points that were unable to be scraped. [alpha]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ScraperScrapedMetricPoints, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64Counter(
 		"otelcol_scraper_scraped_metric_points",
-		metric.WithDescription("Number of metric points successfully scraped."),
+		metric.WithDescription("Number of metric points successfully scraped. [alpha]"),
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)

--- a/receiver/scraperhelper/metadata.yaml
+++ b/receiver/scraperhelper/metadata.yaml
@@ -11,6 +11,8 @@ telemetry:
   metrics:
     scraper_scraped_metric_points:
       enabled: true
+      stability:
+        level: alpha
       description: Number of metric points successfully scraped.
       unit: "{datapoints}"
       sum:
@@ -19,6 +21,8 @@ telemetry:
 
     scraper_errored_metric_points:
       enabled: true
+      stability:
+        level: alpha
       description: Number of metric points that were unable to be scraped.
       unit: "{datapoints}"
       sum:

--- a/service/documentation.md
+++ b/service/documentation.md
@@ -8,7 +8,7 @@ The following telemetry is emitted by this component.
 
 ### otelcol_process_cpu_seconds
 
-Total CPU user and system time in seconds
+Total CPU user and system time in seconds [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -16,7 +16,7 @@ Total CPU user and system time in seconds
 
 ### otelcol_process_memory_rss
 
-Total physical memory (resident set size)
+Total physical memory (resident set size) [alpha]
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -24,7 +24,7 @@ Total physical memory (resident set size)
 
 ### otelcol_process_runtime_heap_alloc_bytes
 
-Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')
+Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc') [alpha]
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -32,7 +32,7 @@ Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')
 
 ### otelcol_process_runtime_total_alloc_bytes
 
-Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
+Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc') [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
@@ -40,7 +40,7 @@ Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalA
 
 ### otelcol_process_runtime_total_sys_memory_bytes
 
-Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')
+Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys') [alpha]
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -48,7 +48,7 @@ Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')
 
 ### otelcol_process_uptime
 
-Uptime of the process
+Uptime of the process [alpha]
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -122,7 +122,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.ProcessCPUSeconds, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Float64ObservableCounter(
 		"otelcol_process_cpu_seconds",
-		metric.WithDescription("Total CPU user and system time in seconds"),
+		metric.WithDescription("Total CPU user and system time in seconds [alpha]"),
 		metric.WithUnit("s"),
 	)
 	errs = errors.Join(errs, err)
@@ -130,7 +130,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ProcessMemoryRss, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64ObservableGauge(
 		"otelcol_process_memory_rss",
-		metric.WithDescription("Total physical memory (resident set size)"),
+		metric.WithDescription("Total physical memory (resident set size) [alpha]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
@@ -138,7 +138,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeHeapAllocBytes, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64ObservableGauge(
 		"otelcol_process_runtime_heap_alloc_bytes",
-		metric.WithDescription("Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')"),
+		metric.WithDescription("Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc') [alpha]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
@@ -146,7 +146,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeTotalAllocBytes, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64ObservableCounter(
 		"otelcol_process_runtime_total_alloc_bytes",
-		metric.WithDescription("Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')"),
+		metric.WithDescription("Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc') [alpha]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
@@ -154,7 +154,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ProcessRuntimeTotalSysMemoryBytes, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Int64ObservableGauge(
 		"otelcol_process_runtime_total_sys_memory_bytes",
-		metric.WithDescription("Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')"),
+		metric.WithDescription("Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys') [alpha]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
@@ -162,7 +162,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ProcessUptime, err = getLeveledMeter(builder.meter, configtelemetry.LevelBasic, settings.MetricsLevel).Float64ObservableCounter(
 		"otelcol_process_uptime",
-		metric.WithDescription("Uptime of the process"),
+		metric.WithDescription("Uptime of the process [alpha]"),
 		metric.WithUnit("s"),
 	)
 	errs = errors.Join(errs, err)

--- a/service/metadata.yaml
+++ b/service/metadata.yaml
@@ -11,6 +11,8 @@ telemetry:
   metrics:
     process_uptime:
       enabled: true
+      stability:
+        level: alpha
       description: Uptime of the process
       unit: s
       sum:
@@ -20,6 +22,8 @@ telemetry:
 
     process_runtime_heap_alloc_bytes:
       enabled: true
+      stability:
+        level: alpha
       description: Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')
       unit: By
       gauge:
@@ -28,6 +32,8 @@ telemetry:
 
     process_runtime_total_alloc_bytes:
       enabled: true
+      stability:
+        level: alpha
       description: Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
       unit: By
       sum:
@@ -37,6 +43,8 @@ telemetry:
 
     process_runtime_total_sys_memory_bytes:
       enabled: true
+      stability:
+        level: alpha
       description: Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')
       unit: By
       gauge:
@@ -45,6 +53,8 @@ telemetry:
 
     process_cpu_seconds:
       enabled: true
+      stability:
+        level: alpha
       description: Total CPU user and system time in seconds
       unit: s
       sum:
@@ -54,6 +64,8 @@ telemetry:
 
     process_memory_rss:
       enabled: true
+      stability:
+        level: alpha
       description: Total physical memory (resident set size)
       unit: By
       gauge:


### PR DESCRIPTION
This sets the level of all metrics that where not previously stabilized as alpha. Since many of these metrics will change as a result of https://github.com/open-telemetry/opentelemetry-collector/pull/11406, it made sense to me to set their stability as alpha.
