### PR TITLE
[chore] Export the confMap Unmarshal function

### DIFF
--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -80,7 +80,7 @@ func (cm *configProvider) Get(ctx context.Context, factories Factories) (*Config
 	}
 
 	var cfg *configSettings
-	if cfg, err = unmarshal(conf, factories); err != nil {
+	if cfg, err = Unmarshal(conf, factories); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal the configuration: %w", err)
 	}
 

--- a/otelcol/configprovider_test.go
+++ b/otelcol/configprovider_test.go
@@ -26,7 +26,7 @@ func newConfig(yamlBytes []byte, factories Factories) (*Config, error) {
 
 	conf := confmap.NewFromStringMap(stringMap)
 
-	cfg, err := unmarshal(conf, factories)
+	cfg, err := Unmarshal(conf, factories)
 	if err != nil {
 		return nil, err
 	}

--- a/otelcol/unmarshaler.go
+++ b/otelcol/unmarshaler.go
@@ -24,9 +24,9 @@ type configSettings struct {
 	Service    service.Config                                `mapstructure:"service"`
 }
 
-// unmarshal the configSettings from a confmap.Conf.
+// Unmarshal the configSettings from a confmap.Conf.
 // After the config is unmarshalled, `Validate()` must be called to validate.
-func unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
+func Unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
 	telFactory := telemetry.NewFactory()
 	defaultTelConfig := *telFactory.CreateDefaultConfig().(*telemetry.Config)
 

--- a/otelcol/unmarshaler_test.go
+++ b/otelcol/unmarshaler_test.go
@@ -21,7 +21,7 @@ func TestUnmarshalEmpty(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	_, err = unmarshal(confmap.New(), factories)
+	_, err = Unmarshal(confmap.New(), factories)
 	assert.NoError(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestUnmarshalEmptyAllSections(t *testing.T) {
 		"extensions": nil,
 		"service":    nil,
 	})
-	cfg, err := unmarshal(conf, factories)
+	cfg, err := Unmarshal(conf, factories)
 	require.NoError(t, err)
 
 	zapProdCfg := zap.NewProductionConfig()
@@ -66,7 +66,7 @@ func TestUnmarshalUnknownTopLevel(t *testing.T) {
 	conf := confmap.NewFromStringMap(map[string]any{
 		"unknown_section": nil,
 	})
-	_, err = unmarshal(conf, factories)
+	_, err = Unmarshal(conf, factories)
 	assert.ErrorContains(t, err, "'' has invalid keys: unknown_section")
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
In Alloy, we have older components using a fork of the opentelemetry collector to access the confmap unmarshal function. In order to reduce our dependencies/maintenance requirement we'd like to get rid of that fork, and exporting this function will help with that goal.

<!--Please delete paragraphs that you did not use before submitting.-->
