### PR TITLE
[WIP][confmap] Enable decoding nil values in confmap

### DIFF
--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -33,7 +33,7 @@ func TestLoadMetadata(t *testing.T) {
 						component.StabilityLevelBeta:        {"traces"},
 						component.StabilityLevelStable:      {"metrics"},
 					},
-					Distributions: []string{},
+					Distributions: nil,
 					Codeowners: &Codeowners{
 						Active: []string{"dmitryax"},
 					},

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -33,7 +33,7 @@ func TestLoadMetadata(t *testing.T) {
 						component.StabilityLevelBeta:        {"traces"},
 						component.StabilityLevelStable:      {"metrics"},
 					},
-					Distributions: nil,
+					Distributions: []string{},
 					Codeowners: &Codeowners{
 						Active: []string{"dmitryax"},
 					},

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -133,7 +133,7 @@ func sanitizeExpanded(a any, useOriginal bool) any {
 		return c
 	case []any:
 		var newSlice []any
-		if reflect.ValueOf(m).IsNil() {
+		if m == nil {
 			return newSlice
 		}
 		newSlice = []any{}

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -330,6 +330,9 @@ func useExpandValue() mapstructure.DecodeHookFuncType {
 // Config{Thing: &SomeStruct{}} instead of Config{Thing: nil}
 func expandNilStructPointersHookFunc() mapstructure.DecodeHookFuncValue {
 	return func(from reflect.Value, to reflect.Value) (any, error) {
+		if !from.IsValid() {
+			return from, nil
+		}
 		// ensure we are dealing with map to map comparison
 		if from.Kind() == reflect.Map && to.Kind() == reflect.Map {
 			toElem := to.Type().Elem()

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -133,6 +133,10 @@ func sanitizeExpanded(a any, useOriginal bool) any {
 		return c
 	case []any:
 		var newSlice []any
+		if reflect.ValueOf(m).IsNil() {
+			return newSlice
+		}
+		newSlice = []any{}
 		for _, e := range m {
 			newSlice = append(newSlice, sanitizeExpanded(e, useOriginal))
 		}
@@ -540,12 +544,10 @@ type Marshaler interface {
 //   - for example, input is {}, then output is Config{ Keys: ["a", "b"]}
 func zeroSliceHookFunc() mapstructure.DecodeHookFuncValue {
 	return func(from reflect.Value, to reflect.Value) (interface{}, error) {
-		if !from.IsValid() {
-			return from, nil
-		}
-
 		if to.CanSet() && to.Kind() == reflect.Slice && from.Kind() == reflect.Slice {
-			to.Set(reflect.MakeSlice(to.Type(), from.Len(), from.Cap()))
+			if !from.IsNil() {
+				to.Set(reflect.MakeSlice(to.Type(), from.Len(), from.Cap()))
+			}
 		}
 
 		return from.Interface(), nil

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -221,6 +221,7 @@ func decodeConfig(m *Conf, result any, errorUnused bool, skipTopLevelUnmarshaler
 			unmarshalerEmbeddedStructsHookFunc(),
 			zeroSliceHookFunc(),
 		),
+		DecodeNil: true,
 	}
 	decoder, err := mapstructure.NewDecoder(dc)
 	if err != nil {
@@ -537,7 +538,9 @@ type Marshaler interface {
 func zeroSliceHookFunc() mapstructure.DecodeHookFuncValue {
 	return func(from reflect.Value, to reflect.Value) (interface{}, error) {
 		if to.CanSet() && to.Kind() == reflect.Slice && from.Kind() == reflect.Slice {
-			to.Set(reflect.MakeSlice(to.Type(), from.Len(), from.Cap()))
+			if !from.IsNil() {
+				to.Set(reflect.MakeSlice(to.Type(), from.Len(), from.Cap()))
+			}
 		}
 
 		return from.Interface(), nil

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -540,10 +540,12 @@ type Marshaler interface {
 //   - for example, input is {}, then output is Config{ Keys: ["a", "b"]}
 func zeroSliceHookFunc() mapstructure.DecodeHookFuncValue {
 	return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+		if !from.IsValid() {
+			return from, nil
+		}
+
 		if to.CanSet() && to.Kind() == reflect.Slice && from.Kind() == reflect.Slice {
-			if !from.IsNil() {
-				to.Set(reflect.MakeSlice(to.Type(), from.Len(), from.Cap()))
-			}
+			to.Set(reflect.MakeSlice(to.Type(), from.Len(), from.Cap()))
 		}
 
 		return from.Interface(), nil

--- a/confmap/confmaptest/configtest_test.go
+++ b/confmap/confmaptest/configtest_test.go
@@ -33,8 +33,7 @@ func TestLoadConf(t *testing.T) {
 func TestToStringMapSanitizeEmptySlice(t *testing.T) {
 	cfg, err := LoadConf(filepath.Join("testdata", "empty-slice.yaml"))
 	require.NoError(t, err)
-	var nilSlice []interface{}
-	assert.Equal(t, map[string]any{"slice": nilSlice}, cfg.ToStringMap())
+	assert.Equal(t, map[string]any{"slice": []interface{}{}}, cfg.ToStringMap())
 }
 
 func TestValidateProviderScheme(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
- This PR is a prelude to https://github.com/open-telemetry/opentelemetry-collector/pull/10260 and towards #10266. We made an upstream patch in https://github.com/mahadzaryab1/mapstructure to allow decoding nil values to enable the use of the `Optional` unmarshaller in https://github.com/open-telemetry/opentelemetry-collector/pull/10260. This PR enables the decoding of nil values in `confmap` to unblock the enablement of optional configs. 

<!-- Issue number if applicable -->
#### Link to tracking issue
Towards #https://github.com/open-telemetry/opentelemetry-collector/issues/10266

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
