### PR TITLE
[chore] Add CI check to enforce merge freezes

### DIFF
--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   check-merge-freeze:
     name: Check
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'release:prepare') }}
+    # This condition is to avoid blocking the PR causing the freeze in the first place.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'release:merge-freeze') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'release:merge-freeze') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: .github/workflows/scripts
       - run: ./.github/workflows/scripts/check-merge-freeze.sh

--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -1,0 +1,22 @@
+name: Merge freeze
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check-merge-freeze:
+    name: Check
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'release:prepare') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/workflows/scripts
+      - run: ./.github/workflows/scripts/check-merge-freeze.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector

--- a/.github/workflows/scripts/check-merge-freeze.sh
+++ b/.github/workflows/scripts/check-merge-freeze.sh
@@ -6,5 +6,6 @@
 BLOCKERS=$( gh pr list --search "label:release:merge-freeze" --json url --jq '.[].url' --repo "${REPO}" )
 if [ "${BLOCKERS}" != "" ]; then
     echo "Merging in main is frozen, as there are open PRs labeled 'release:merge-freeze': ${BLOCKERS}"
+    echo "If you believe this is no longer true, re-run this job to unblock your PR."
     exit 1
 fi

--- a/.github/workflows/scripts/check-merge-freeze.sh
+++ b/.github/workflows/scripts/check-merge-freeze.sh
@@ -3,8 +3,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-BLOCKERS=$( gh pr list --search "label:release:prepare" --json url --jq '.[].url' --repo "${REPO}" )
+BLOCKERS=$( gh pr list --search "label:release:merge-freeze" --json url --jq '.[].url' --repo "${REPO}" )
 if [ "${BLOCKERS}" != "" ]; then
-    echo "Merging in main is frozen while release PR is open: ${BLOCKERS}"
+    echo "Merging in main is frozen, as there are open PRs labeled 'release:merge-freeze': ${BLOCKERS}"
     exit 1
 fi

--- a/.github/workflows/scripts/check-merge-freeze.sh
+++ b/.github/workflows/scripts/check-merge-freeze.sh
@@ -1,7 +1,10 @@
 #!/bin/bash -e
+#
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
-BLOCKERS=$(gh pr list --search "label:release:prepare" --json url --jq '.[].url' --repo "${REPO}")
+BLOCKERS=$( gh pr list --search "label:release:prepare" --json url --jq '.[].url' --repo "${REPO}" )
 if [ "${BLOCKERS}" != "" ]; then
-  echo "Merging in main is frozen by release PR: ${BLOCKERS}"
-  exit 1
+    echo "Merging in main is frozen while release PR is open: ${BLOCKERS}"
+    exit 1
 fi

--- a/.github/workflows/scripts/check-merge-freeze.sh
+++ b/.github/workflows/scripts/check-merge-freeze.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+BLOCKERS=$(gh pr list --search "label:release:prepare" --json url --jq '.[].url' --repo "${REPO}")
+if [ "${BLOCKERS}" != "" ]; then
+  echo "Merging in main is frozen by release PR: ${BLOCKERS}"
+  exit 1
+fi

--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -41,7 +41,8 @@ if [ "${CANDIDATE_BETA}" != "" ]; then
 fi
 git push origin "${BRANCH}"
 
-gh pr create --title "[chore] Prepare release ${RELEASE_VERSION}" --label release:prepare --body "
+# The `release:merge-freeze` label will cause the `check-merge-freeze` workflow to fail, enforcing the freeze.
+gh pr create --title "[chore] Prepare release ${RELEASE_VERSION}" --label release:merge-freeze --body "
 The following commands were run to prepare this release:
 ${COMMANDS}
 "

--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -41,7 +41,7 @@ if [ "${CANDIDATE_BETA}" != "" ]; then
 fi
 git push origin "${BRANCH}"
 
-gh pr create --title "[chore] Prepare release ${RELEASE_VERSION}" --body "
+gh pr create --title "[chore] Prepare release ${RELEASE_VERSION}" --label release:prepare --body "
 The following commands were run to prepare this release:
 ${COMMANDS}
 "


### PR DESCRIPTION
#### Description

As stated in the [Release Procedure document](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/release.md#releasing-opentelemetry-collector), all merging in Core should be halted while the "Prepare release" PR is open. This PR adds a CI job checking the existence of such a PR, allowing us to enforce these freezes automatically.

To make things simple, I decided to distinguish the "Prepare release" PR from others by using a new `prepare:merge-freeze` label. I modified the "Prepare release" action to include that label on the automatically created PR, but in rare cases where maintainers might create the PR themselves, the label can be added manually. Triagers will need to be careful not to accidentally add this label to any random PR to avoid artificial freezes.

Because, in the current state, this CI check is run on each commit of a PR, and at no other time, there is a chance for:
- False positives: If a commit is pushed during a freeze, and the freeze is later rescinded, the PR will remain unmergeable until a new commit is pushed. A simple solution is to re-run the check manually.
- False negatives: If a commit is pushed outside of a freeze, then a freeze is enacted, the PR will remain mergeable despite the freeze. This is more problematic.

To solve this second problem and make this check truly useful, two changes in the repository configuration are necessary:
- the merge queue should be enabled, allowing us to run checks again just before merging;
- this new CI check should be added to the list of required checks for the main branch. 

This will allow us to automatically cancel the merging of PRs during a freeze. A later PR on the community repository should take care of these configuration changes.

Note that another solution to handle outdated CI checks would be to use a tool like [MergeFreeze](https://www.mergefreeze.com), but reading [this document](https://github.com/open-telemetry/community/blob/main/docs/using-github-extensions.md), it sounds like it would be a harder sell with the community than enabling the merge queue.

#### Link to tracking issue
Updates #11707

#### Testing

Simple tests were made on a separate repository to check that enabling the merge queue fixes the false negatives.
