### PR TITLE
Remove memory leak at exporter shutdown

### DIFF
--- a/.chloggen/exporter-shutdown-memory-leak.yaml
+++ b/.chloggen/exporter-shutdown-memory-leak.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix memory leak at exporter shutdown
+
+# One or more tracking issues or pull requests related to the change
+issues: [11401]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -51,7 +51,7 @@ func (tbof telemetryBuilderOptionFunc) apply(mb *TelemetryBuilder) {
 }
 
 // InitExporterQueueCapacity configures the ExporterQueueCapacity metric.
-func (builder *TelemetryBuilder) InitExporterQueueCapacity(cb func() int64, opts ...metric.ObserveOption) error {
+func (builder *TelemetryBuilder) InitExporterQueueCapacity(cb func() int64, opts ...metric.ObserveOption) (metric.Registration, error) {
 	var err error
 	builder.ExporterQueueCapacity, err = builder.meter.Int64ObservableGauge(
 		"otelcol_exporter_queue_capacity",
@@ -59,17 +59,17 @@ func (builder *TelemetryBuilder) InitExporterQueueCapacity(cb func() int64, opts
 		metric.WithUnit("{batches}"),
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+	reg, err := builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
 		o.ObserveInt64(builder.ExporterQueueCapacity, cb(), opts...)
 		return nil
 	}, builder.ExporterQueueCapacity)
-	return err
+	return reg, err
 }
 
 // InitExporterQueueSize configures the ExporterQueueSize metric.
-func (builder *TelemetryBuilder) InitExporterQueueSize(cb func() int64, opts ...metric.ObserveOption) error {
+func (builder *TelemetryBuilder) InitExporterQueueSize(cb func() int64, opts ...metric.ObserveOption) (metric.Registration, error) {
 	var err error
 	builder.ExporterQueueSize, err = builder.meter.Int64ObservableGauge(
 		"otelcol_exporter_queue_size",
@@ -77,13 +77,13 @@ func (builder *TelemetryBuilder) InitExporterQueueSize(cb func() int64, opts ...
 		metric.WithUnit("{batches}"),
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+	reg, err := builder.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
 		o.ObserveInt64(builder.ExporterQueueSize, cb(), opts...)
 		return nil
 	}, builder.ExporterQueueSize)
-	return err
+	return reg, err
 }
 
 // NewTelemetryBuilder provides a struct with methods to update all internal telemetry

--- a/exporter/exporterhelper/internal/queue_sender.go
+++ b/exporter/exporterhelper/internal/queue_sender.go
@@ -73,6 +73,8 @@ type QueueSender struct {
 	traceAttribute attribute.KeyValue
 	consumers      *queue.Consumers[internal.Request]
 
+	shutdownCallbacks []func()
+
 	obsrep     *ObsReport
 	exporterID component.ID
 }
@@ -108,18 +110,37 @@ func (qs *QueueSender) Start(ctx context.Context, host component.Host) error {
 	}
 
 	dataTypeAttr := attribute.String(DataTypeKey, qs.obsrep.Signal.String())
-	return multierr.Append(
-		qs.obsrep.TelemetryBuilder.InitExporterQueueSize(func() int64 { return int64(qs.queue.Size()) },
-			metric.WithAttributeSet(attribute.NewSet(qs.traceAttribute, dataTypeAttr))),
-		qs.obsrep.TelemetryBuilder.InitExporterQueueCapacity(func() int64 { return int64(qs.queue.Capacity()) },
-			metric.WithAttributeSet(attribute.NewSet(qs.traceAttribute))),
-	)
+
+	reg1, err1 := qs.obsrep.TelemetryBuilder.InitExporterQueueSize(func() int64 { return int64(qs.queue.Size()) },
+		metric.WithAttributeSet(attribute.NewSet(qs.traceAttribute, dataTypeAttr)))
+
+	qs.shutdownCallbacks = append(qs.shutdownCallbacks, func() {
+		if reg1 != nil {
+			_ = reg1.Unregister()
+		}
+	})
+
+	reg2, err2 := qs.obsrep.TelemetryBuilder.InitExporterQueueCapacity(func() int64 { return int64(qs.queue.Capacity()) },
+		metric.WithAttributeSet(attribute.NewSet(qs.traceAttribute)))
+
+	qs.shutdownCallbacks = append(qs.shutdownCallbacks, func() {
+		if reg2 != nil {
+			_ = reg2.Unregister()
+		}
+	})
+
+	return multierr.Append(err1, err2)
 }
 
 // Shutdown is invoked during service shutdown.
 func (qs *QueueSender) Shutdown(ctx context.Context) error {
 	// Stop the queue and consumers, this will drain the queue and will call the retry (which is stopped) that will only
 	// try once every request.
+
+	for _, callback := range qs.shutdownCallbacks {
+		callback()
+	}
+
 	if err := qs.queue.Shutdown(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix memory leak at exporter shutdown. At startup time the exporter creates metric callbacks that hold references to the exporter queue, these need to be unregistered at shutdown. 

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #11401

