### PR TITLE
[service]: add new subcommand to examine the initial configuration

### DIFF
--- a/.chloggen/examine-subcommand.yaml
+++ b/.chloggen/examine-subcommand.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: A new subcommand to dump the initial configuration after resolving/merging.
+
+# One or more tracking issues or pull requests related to the change
+issues: [11479]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/otelcol/command.go
+++ b/otelcol/command.go
@@ -38,6 +38,7 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 	}
 	rootCmd.AddCommand(newComponentsCommand(set))
 	rootCmd.AddCommand(newValidateSubCommand(set, flagSet))
+	rootCmd.AddCommand(newExamineSubCommand(set, flagSet))
 	rootCmd.Flags().AddGoFlagSet(flagSet)
 	return rootCmd
 }

--- a/otelcol/command_examine.go
+++ b/otelcol/command_examine.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcol // import "go.opentelemetry.io/collector/otelcol"
+
+import (
+	"flag"
+	"log"
+
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/collector/confmap"
+	"gopkg.in/yaml.v3"
+)
+
+// newExamineSubCommand constructs a new examine sub command using the given CollectorSettings.
+func newExamineSubCommand(set CollectorSettings, flagSet *flag.FlagSet) *cobra.Command {
+	examineCmd := &cobra.Command{
+		Use:   "examine",
+		Short: "Logs the final configuration after all --config sources are resolved and merged",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := updateSettingsUsingFlags(&set, flagSet)
+			if err != nil {
+				return err
+			}
+			resolver, err := confmap.NewResolver(set.ConfigProviderSettings.ResolverSettings)
+			if err != nil {
+				return err
+			}
+			conf, err := resolver.Resolve(cmd.Context())
+			if err != nil {
+				return err
+			}
+			b, err := yaml.Marshal(conf.ToStringMap())
+			if err != nil {
+				return err
+			}
+			log.Printf("%s", b)
+			return nil
+		},
+	}
+	examineCmd.Flags().AddGoFlagSet(flagSet)
+	return examineCmd
+}

--- a/otelcol/command_examine.go
+++ b/otelcol/command_examine.go
@@ -35,7 +35,7 @@ func newExamineSubCommand(set CollectorSettings, flagSet *flag.FlagSet) *cobra.C
 			if err != nil {
 				return err
 			}
-			log.Printf("%s", b)
+			log.Printf("\n%s", b)
 			return nil
 		},
 	}

--- a/otelcol/command_examine_test.go
+++ b/otelcol/command_examine_test.go
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcol // import "go.opentelemetry.io/collector/otelcol"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
+	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+func TestExamineCommand(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		set       confmap.ResolverSettings
+		errString string
+	}{
+		{
+			name:      "no URIs",
+			set:       confmap.ResolverSettings{},
+			errString: "at least one config flag must be provided",
+		},
+		{
+			name: "valid URI - file not found",
+			set: confmap.ResolverSettings{
+				URIs: []string{"file:blabla.yaml"},
+				ProviderFactories: []confmap.ProviderFactory{
+					fileprovider.NewFactory(),
+				},
+				DefaultScheme: "file",
+			},
+			errString: "cannot retrieve the configuration: unable to read the file",
+		},
+		{
+			name: "valid URI",
+			set: confmap.ResolverSettings{
+				URIs: []string{"yaml:processors::batch/foo::timeout: 3s"},
+				ProviderFactories: []confmap.ProviderFactory{
+					yamlprovider.NewFactory(),
+				},
+				DefaultScheme: "yaml",
+			},
+		},
+		{
+			name: "valid URI - no provider set",
+			set: confmap.ResolverSettings{
+				URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
+				DefaultScheme: "yaml",
+			},
+			errString: "at least one Provider must be supplied",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			set := ConfigProviderSettings{
+				ResolverSettings: test.set,
+			}
+
+			cmd := newExamineSubCommand(CollectorSettings{ConfigProviderSettings: set}, flags(featuregate.GlobalRegistry()))
+			err := cmd.Execute()
+			if test.errString != "" {
+				require.ErrorContains(t, err, test.errString)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -9,6 +9,8 @@ require (
 	go.opentelemetry.io/collector/component/componentstatus v0.114.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.114.0
 	go.opentelemetry.io/collector/confmap v1.20.0
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.20.0
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.20.0
 	go.opentelemetry.io/collector/connector v0.114.0
 	go.opentelemetry.io/collector/connector/connectortest v0.114.0
 	go.opentelemetry.io/collector/exporter v0.114.0
@@ -206,3 +208,7 @@ replace go.opentelemetry.io/collector/extension/extensiontest => ../extension/ex
 replace go.opentelemetry.io/collector/extension/auth/authtest => ../extension/auth/authtest
 
 replace go.opentelemetry.io/collector/scraper => ../scraper
+
+replace go.opentelemetry.io/collector/confmap/provider/fileprovider => ../confmap/provider/fileprovider
+
+replace go.opentelemetry.io/collector/confmap/provider/yamlprovider => ../confmap/provider/yamlprovider

--- a/service/README.md
+++ b/service/README.md
@@ -149,3 +149,9 @@ extensions:
 ```bash
    ./otelcorecol validate --config=file:examples/local/otel-config.yaml
 ```
+
+## How to examine the final configuration after merging and resolving from various sources?
+
+```bash
+   ./otelcorecol examine --config=file:file.yaml --config=http:http://remote:8080/config --config=file:file2.yaml
+```


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

**_Why is this useful?_**
- Users might want to examine the config if they face any errors at boot time. This subcommand prints the configuration on stdout after merging and resolving from all the `--config` sources.
- The command prints the configuration even if it's invalid. This can help user to track down any errors if config is fetched from various sources

**_Usage_**

```bash
./otelcorecol examine --config=file:file.yaml --config=http://remote:8080/config --config=file:file2.yaml
```

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #https://github.com/open-telemetry/opentelemetry-collector/issues/11479

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit test cases.

<!--Describe the documentation added.-->
#### Documentation
Updated readme.
<!--Please delete paragraphs that you did not use before submitting.-->
