### PR TITLE
Enable but skip `changelog` workflow in merge queue

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,8 @@ on:
     types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -20,7 +22,7 @@ permissions:
 jobs:
   changelog:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]') }}
 
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
#### Description

In a previous PR (#11797), I removed the `merge_group` trigger from the `changelog` and `api-compatibility` CI checks, which don't work properly in merge queues. However, `changelog` is a required check for the `main` branch, which means Github will wait for the check status to be reported even though the job never started, eventually resulting in a timeout and rejection from the queue. ([see this note in the docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#status-checks-with-github-actions-and-a-merge-queue))

This PR adds the `merge_group` trigger back in `changelog`, but uses an `if` to skip it outside of pull requests (which should count as success for the purposes of the merge queue).
