### PR TITLE
[chore] move explicitly to use ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -53,7 +53,7 @@ jobs:
         run: make -j4 gotest
   arm-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [arm-unittest-matrix]
     steps:
       - name: Print result

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   setup-environment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -39,7 +39,7 @@ jobs:
         run: make gomoddownload
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - name: Checkout Repo
@@ -63,7 +63,7 @@ jobs:
         run: make goimpi
 
   govulncheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
@@ -88,7 +88,7 @@ jobs:
         run: make govulncheck
 
   checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - name: Checkout Repo
@@ -142,7 +142,7 @@ jobs:
   unittest-matrix:
     strategy:
       matrix:
-        runner: [ubuntu-latest]
+        runner: [ubuntu-24.04]
         go-version: ["~1.23", "~1.22"] # 1.20 needs quotes otherwise it's interpreted as 1.2
     runs-on: ${{ matrix.runner }}
     needs: [setup-environment]
@@ -172,7 +172,7 @@ jobs:
           make -j4 gotest
   unittest:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment, unittest-matrix]
     steps:
       - name: Print result
@@ -188,7 +188,7 @@ jobs:
           fi
 
   test-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - name: Checkout Repo
@@ -220,7 +220,7 @@ jobs:
 
   cross-build-collector:
     needs: [setup-environment]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   integration-test:
     name: Integration test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]') }}
 
     env:

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   changedfiles:
     name: changed files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
     outputs:
@@ -37,7 +37,7 @@ jobs:
 
             echo "files=$files" >> $GITHUB_OUTPUT
   check-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changedfiles
     if: ${{needs.changedfiles.outputs.files}}
     steps:

--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check
     # This condition is to avoid blocking the PR causing the freeze in the first place.
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'release:merge-freeze') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
       actions: read # for github/codeql-action/init to get workflow details
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/autobuild to send a status report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   contrib-tests-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Skip Contrib Tests') }}
     strategy:
       fail-fast: false
@@ -54,7 +54,7 @@ jobs:
           make CONTRIB_PATH=$contrib_path SKIP_RESTORE_CONTRIB=true GROUP=${{ matrix.group }} check-contrib
 
   contrib_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Skip Contrib Tests') }}
     needs: [contrib-tests-matrix]
     steps:

--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       latest-version: ${{ steps.check-versions.outputs.latest-version }}
       already-added: ${{ steps.check-versions.outputs.already-added }}
@@ -51,7 +51,7 @@ jobs:
   update-semantic-conventions:
     permissions:
       contents: write # for Git to git push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       needs.check-versions.outputs.already-added != 'true' &&
       needs.check-versions.outputs.already-opened != 'true'

--- a/.github/workflows/milestone-add-to-pr.yml
+++ b/.github/workflows/milestone-add-to-pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-pr:
     if: github.event.pull_request.merged
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   runperf:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   #validate-version format
   validate-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Validate version format
@@ -62,7 +62,7 @@ jobs:
   prepare-release:
     needs:
       - validate-versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   shellcheck:
     name: Shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run ShellCheck

--- a/.github/workflows/sourcecode-release.yaml
+++ b/.github/workflows/sourcecode-release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write # for Git to git push
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency-major-update') && (github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'renovatebot')) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Rather than use ubuntu-latest, which will move over a period of time to ubuntu 24.04, directly move to ubuntu 24.04 to avoid having flaky or unexpected failures.

See https://github.com/actions/runner-images/issues/10636 for context.
