### PR TITLE
add changelog entry for Dockerfile USER_GID as non root

### DIFF
--- a/.chloggen/dockerfile_remove_root_group.yaml
+++ b/.chloggen/dockerfile_remove_root_group.yaml
@@ -7,10 +7,10 @@ change_type: 'enhancement'
 component: container
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Set Dockerfile's USER_GID as non root
+note: "Set Dockerfile's USER_GID as non root. OpenTelemetry Collector releases issue: https://github.com/open-telemetry/opentelemetry-collector-releases/issues/662"
 
 # One or more tracking issues or pull requests related to the change
-issues: [https://github.com/open-telemetry/opentelemetry-collector-releases/issues/662]
+issues: []
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/dockerfile_remove_root_group.yaml
+++ b/.chloggen/dockerfile_remove_root_group.yaml
@@ -10,7 +10,7 @@ component: container
 note: "Set Dockerfile's USER_GID as non root. OpenTelemetry Collector releases issue: https://github.com/open-telemetry/opentelemetry-collector-releases/issues/662"
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [11829]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/dockerfile_remove_root_group.yaml
+++ b/.chloggen/dockerfile_remove_root_group.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: container
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set Dockerfile's USER_GID as non root
+
+# One or more tracking issues or pull requests related to the change
+issues: [https://github.com/open-telemetry/opentelemetry-collector-releases/issues/662]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dockerfile_remove_root_group.yaml
+++ b/.chloggen/dockerfile_remove_root_group.yaml
@@ -4,7 +4,7 @@
 change_type: 'enhancement'
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: container
+component: image
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Set Dockerfile's USER_GID as non root. OpenTelemetry Collector releases issue: https://github.com/open-telemetry/opentelemetry-collector-releases/issues/662"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR just adds a new changelog entry for the changes we are doing in the releases repository: https://github.com/open-telemetry/opentelemetry-collector-releases/pull/738

The main reason is that the `releases` repository does not have any changelog mechanism, but the corresponding change is important enough to make the users aware of. 

- Is this the appropriate approach? Have there been any similar situations in the past?

**My understanding is that this PR should be merged after https://github.com/open-telemetry/opentelemetry-collector-releases/pull/738 but before its next release**

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes 
https://github.com/open-telemetry/opentelemetry-collector-releases/issues/662
