### PR TITLE
[chore] Fix "Prepare Release" action

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -101,7 +101,8 @@ jobs:
       #   - Run make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0 MODSET=beta
       - name: Prepare release for core
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          BOT_GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: open-telemetry/opentelemetry-collector
           CANDIDATE_BETA: ${{ inputs.candidate-beta }}
           CANDIDATE_STABLE: ${{ inputs.candidate-stable }}

--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -41,8 +41,12 @@ if [ "${CANDIDATE_BETA}" != "" ]; then
 fi
 git push origin "${BRANCH}"
 
-# The `release:merge-freeze` label will cause the `check-merge-freeze` workflow to fail, enforcing the freeze.
-gh pr create --title "[chore] Prepare release ${RELEASE_VERSION}" --label release:merge-freeze --body "
+# Use OpenTelemetryBot account to create PR, allowing workflows to run
+PR=$(GITHUB_TOKEN="$BOT_GITHUB_TOKEN" gh pr create --title "[chore] Prepare release ${RELEASE_VERSION}" --body "
 The following commands were run to prepare this release:
 ${COMMANDS}
-"
+")
+
+# The `release:merge-freeze` label will cause the `check-merge-freeze` workflow to fail, enforcing the freeze.
+# The bot does not have permissions to add labels, so this is done using the CI action token.
+gh pr edit "$PR" --add-label release:merge-freeze || echo "Failed to add merge-freeze label"


### PR DESCRIPTION
#### Description

The "Prepare Release" action failed during the latest release process, as the OpenTelemetry Bot, which opens the release PR, does not have the permissions to add the new `release:merge-freeze` label. This PR fixes this by creating the PR with the bot token, then adding the label separately using the regular CI token.

Since we already use default CI tokens on -contrib to add labels, I assume they have the permission to do that on this repo as well. I deemed this simpler than the alternative solutions mentioned in the tracking issue, though I'm not certain it will work.

Note that the tracking issue is a release blocker.

#### Link to tracking issue
Fixes #11808

#### Testing
I'm not sure how I could test this without getting it merged first unfortunately. Once merged, we could try running the action, then closing the resulting PR and issue.
