### PR TITLE
[chore]: enable gofumpt linter in receiver, scraper, semconv and service

### DIFF
--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -46,8 +46,10 @@ type Config struct {
 	Protocols `mapstructure:"protocols"`
 }
 
-var _ component.Config = (*Config)(nil)
-var _ confmap.Unmarshaler = (*Config)(nil)
+var (
+	_ component.Config    = (*Config)(nil)
+	_ confmap.Unmarshaler = (*Config)(nil)
+)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {

--- a/receiver/otlpreceiver/internal/profiles/otlp_test.go
+++ b/receiver/otlpreceiver/internal/profiles/otlp_test.go
@@ -55,6 +55,7 @@ func TestExport_NonPermanentErrorConsumer(t *testing.T) {
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, pprofileotlp.ExportResponse{}, resp)
 }
+
 func TestExport_PermanentErrorConsumer(t *testing.T) {
 	ld := testdata.GenerateProfiles(1)
 	req := pprofileotlp.NewExportRequestFromProfiles(ld)

--- a/receiver/otlpreceiver/internal/trace/otlp_test.go
+++ b/receiver/otlpreceiver/internal/trace/otlp_test.go
@@ -58,6 +58,7 @@ func TestExport_NonPermanentErrorConsumer(t *testing.T) {
 	assert.IsType(t, status.Error(codes.Unknown, ""), err)
 	assert.Equal(t, ptraceotlp.ExportResponse{}, resp)
 }
+
 func TestExport_PermanentErrorConsumer(t *testing.T) {
 	ld := testdata.GenerateTraces(1)
 	req := ptraceotlp.NewExportRequestFromTraces(ld)

--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestNewFactory(t *testing.T) {
-	var testType = component.MustNewType("test")
+	testType := component.MustNewType("test")
 	defaultCfg := struct{}{}
 	f := NewFactory(
 		testType,
@@ -33,7 +33,7 @@ func TestNewFactory(t *testing.T) {
 }
 
 func TestNewFactoryWithOptions(t *testing.T) {
-	var testType = component.MustNewType("test")
+	testType := component.MustNewType("test")
 	defaultCfg := struct{}{}
 	f := NewFactory(
 		testType,

--- a/receiver/receiverprofiles/receiver_test.go
+++ b/receiver/receiverprofiles/receiver_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestNewFactoryWithProfiles(t *testing.T) {
-	var testType = component.MustNewType("test")
+	testType := component.MustNewType("test")
 	defaultCfg := struct{}{}
 	factory := NewFactory(
 		testType,

--- a/receiver/receivertest/contract_checker.go
+++ b/receiver/receivertest/contract_checker.go
@@ -271,8 +271,10 @@ func (ds idSet) union(other idSet) (union idSet, duplicates []UniqueIDAttrVal) {
 // between the receiver and it next consumer.
 type consumeDecisionFunc func(ids idSet) error
 
-var errNonPermanent = errors.New("non permanent error")
-var errPermanent = errors.New("permanent error")
+var (
+	errNonPermanent = errors.New("non permanent error")
+	errPermanent    = errors.New("permanent error")
+)
 
 // randomNonPermanentErrorConsumeDecision is a decision function that succeeds approximately
 // half of the time and fails with a non-permanent error the rest of the time.

--- a/receiver/scraperhelper/config.go
+++ b/receiver/scraperhelper/config.go
@@ -11,9 +11,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-var (
-	errNonPositiveInterval = errors.New("requires positive value")
-)
+var errNonPositiveInterval = errors.New("requires positive value")
 
 // ControllerConfig defines common settings for a scraper controller
 // configuration. Scraper controller receivers can embed this struct, instead

--- a/scraper/factory_test.go
+++ b/scraper/factory_test.go
@@ -20,7 +20,8 @@ var testType = component.MustNewType("test")
 func nopSettings() Settings {
 	return Settings{
 		ID:                component.NewID(testType),
-		TelemetrySettings: componenttest.NewNopTelemetrySettings()}
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
 }
 
 func TestNewFactory(t *testing.T) {
@@ -35,7 +36,7 @@ func TestNewFactory(t *testing.T) {
 }
 
 func TestNewFactoryWithOptions(t *testing.T) {
-	var testType = component.MustNewType("test")
+	testType := component.MustNewType("test")
 	defaultCfg := struct{}{}
 	f := NewFactory(
 		testType,

--- a/semconv/semconv_test.go
+++ b/semconv/semconv_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAllSemConvFilesAreCrated(t *testing.T) {
 	// Files that have to be present in each semconv package
-	var expectedFiles = []string{"generated_resource.go", "generated_trace.go", "schema.go", "nonstandard.go"}
+	expectedFiles := []string{"generated_resource.go", "generated_trace.go", "schema.go", "nonstandard.go"}
 
 	files, err := os.ReadDir(".")
 	require.NoError(t, err)

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestConfigValidate(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name     string // test case name (also file name containing config yaml)
 		cfgFn    func() *Config
 		expected error
@@ -98,11 +98,13 @@ func generateConfig() *Config {
 			},
 			Metrics: telemetry.MetricsConfig{
 				Level: configtelemetry.LevelNormal,
-				Readers: []config.MetricReader{{
-					Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
-						Host: newPtr("localhost"),
-						Port: newPtr(8080),
-					}}}},
+				Readers: []config.MetricReader{
+					{
+						Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
+							Host: newPtr("localhost"),
+							Port: newPtr(8080),
+						}}},
+					},
 				},
 			},
 		},

--- a/service/internal/builders/connector_test.go
+++ b/service/internal/builders/connector_test.go
@@ -490,12 +490,15 @@ type nopConnector struct {
 func createConnectorTracesToTraces(context.Context, connector.Settings, component.Config, consumer.Traces) (connector.Traces, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorTracesToMetrics(context.Context, connector.Settings, component.Config, consumer.Metrics) (connector.Traces, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorTracesToLogs(context.Context, connector.Settings, component.Config, consumer.Logs) (connector.Traces, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorTracesToProfiles(context.Context, connector.Settings, component.Config, consumerprofiles.Profiles) (connector.Traces, error) {
 	return nopConnectorInstance, nil
 }
@@ -503,12 +506,15 @@ func createConnectorTracesToProfiles(context.Context, connector.Settings, compon
 func createConnectorMetricsToTraces(context.Context, connector.Settings, component.Config, consumer.Traces) (connector.Metrics, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorMetricsToMetrics(context.Context, connector.Settings, component.Config, consumer.Metrics) (connector.Metrics, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorMetricsToLogs(context.Context, connector.Settings, component.Config, consumer.Logs) (connector.Metrics, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorMetricsToProfiles(context.Context, connector.Settings, component.Config, consumerprofiles.Profiles) (connector.Metrics, error) {
 	return nopConnectorInstance, nil
 }
@@ -516,12 +522,15 @@ func createConnectorMetricsToProfiles(context.Context, connector.Settings, compo
 func createConnectorLogsToTraces(context.Context, connector.Settings, component.Config, consumer.Traces) (connector.Logs, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorLogsToMetrics(context.Context, connector.Settings, component.Config, consumer.Metrics) (connector.Logs, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorLogsToLogs(context.Context, connector.Settings, component.Config, consumer.Logs) (connector.Logs, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorLogsToProfiles(context.Context, connector.Settings, component.Config, consumerprofiles.Profiles) (connector.Logs, error) {
 	return nopConnectorInstance, nil
 }
@@ -529,12 +538,15 @@ func createConnectorLogsToProfiles(context.Context, connector.Settings, componen
 func createConnectorProfilesToTraces(context.Context, connector.Settings, component.Config, consumer.Traces) (connectorprofiles.Profiles, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorProfilesToMetrics(context.Context, connector.Settings, component.Config, consumer.Metrics) (connectorprofiles.Profiles, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorProfilesToLogs(context.Context, connector.Settings, component.Config, consumer.Logs) (connectorprofiles.Profiles, error) {
 	return nopConnectorInstance, nil
 }
+
 func createConnectorProfilesToProfiles(context.Context, connector.Settings, component.Config, consumerprofiles.Profiles) (connectorprofiles.Profiles, error) {
 	return nopConnectorInstance, nil
 }

--- a/service/internal/builders/extension_test.go
+++ b/service/internal/builders/extension_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestExtensionBuilder(t *testing.T) {
-	var testType = component.MustNewType("test")
+	testType := component.MustNewType("test")
 	defaultCfg := struct{}{}
 	testID := component.NewID(testType)
 	unknownID := component.MustNewID("unknown")

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -603,9 +603,11 @@ func connectorStability(f connector.Factory, expType, recType pipeline.Signal) c
 	return component.StabilityLevelUndefined
 }
 
-var _ getExporters = (*HostWrapper)(nil)
-var _ component.Host = (*HostWrapper)(nil)
-var _ componentstatus.Reporter = (*HostWrapper)(nil)
+var (
+	_ getExporters             = (*HostWrapper)(nil)
+	_ component.Host           = (*HostWrapper)(nil)
+	_ componentstatus.Reporter = (*HostWrapper)(nil)
+)
 
 type HostWrapper struct {
 	*Host

--- a/service/internal/graph/host.go
+++ b/service/internal/graph/host.go
@@ -27,8 +27,10 @@ type getExporters interface {
 	GetExporters() map[pipeline.Signal]map[component.ID]component.Component
 }
 
-var _ getExporters = (*Host)(nil)
-var _ component.Host = (*Host)(nil)
+var (
+	_ getExporters   = (*Host)(nil)
+	_ component.Host = (*Host)(nil)
+)
 
 type Host struct {
 	AsyncErrorChannel chan error
@@ -92,10 +94,8 @@ const (
 	zFeaturePath   = "featurez"
 )
 
-var (
-	// InfoVar is a singleton instance of the Info struct.
-	runtimeInfoVar [][2]string
-)
+// InfoVar is a singleton instance of the Info struct.
+var runtimeInfoVar [][2]string
 
 func init() {
 	runtimeInfoVar = [][2]string{

--- a/service/internal/testcomponents/example_connector.go
+++ b/service/internal/testcomponents/example_connector.go
@@ -187,6 +187,7 @@ func createExampleProfilesToLogs(_ context.Context, set connector.Settings, _ co
 		mutatesData: set.ID.Name() == "mutate",
 	}, nil
 }
+
 func createExampleProfilesToProfiles(_ context.Context, set connector.Settings, _ component.Config, profiles consumerprofiles.Profiles) (connectorprofiles.Profiles, error) {
 	return &ExampleConnector{
 		ConsumeProfilesFunc: profiles.ConsumeProfiles,

--- a/service/internal/testcomponents/example_exporter.go
+++ b/service/internal/testcomponents/example_exporter.go
@@ -45,6 +45,7 @@ func createMetricsExporter(context.Context, exporter.Settings, component.Config)
 func createLogsExporter(context.Context, exporter.Settings, component.Config) (exporter.Logs, error) {
 	return &ExampleExporter{}, nil
 }
+
 func createProfilesExporter(context.Context, exporter.Settings, component.Config) (exporterprofiles.Profiles, error) {
 	return &ExampleExporter{}, nil
 }

--- a/service/pipelines/config_test.go
+++ b/service/pipelines/config_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestConfigValidate(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name     string // test case name (also file name containing config yaml)
 		cfgFn    func(*testing.T) Config
 		expected error

--- a/service/service.go
+++ b/service/service.go
@@ -139,7 +139,6 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 			},
 		),
 	)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SDK: %w", err)
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -58,10 +58,12 @@ type ownMetricsTestCase struct {
 	expectedLabels      map[string]labelValue
 }
 
-var testResourceAttrValue = "resource_attr_test_value" // #nosec G101: Potential hardcoded credentials
-var testInstanceID = "test_instance_id"
-var testServiceVersion = "2022-05-20"
-var testServiceName = "test name"
+var (
+	testResourceAttrValue = "resource_attr_test_value" // #nosec G101: Potential hardcoded credentials
+	testInstanceID        = "test_instance_id"
+	testServiceVersion    = "2022-05-20"
+	testServiceName       = "test name"
+)
 
 // prometheusToOtelConv is used to check that the expected resource labels exist as
 // part of the otel resource attributes.
@@ -71,25 +73,28 @@ var prometheusToOtelConv = map[string]string{
 	"service_version":     "service.version",
 }
 
-const metricsVersion = "test version"
-const otelCommand = "otelcoltest"
+const (
+	metricsVersion = "test version"
+	otelCommand    = "otelcoltest"
+)
 
 func ownMetricsTestCases() []ownMetricsTestCase {
-	return []ownMetricsTestCase{{
-		name:                "no resource",
-		userDefinedResource: nil,
-		// All labels added to all collector metrics by default are listed below.
-		// These labels are hard coded here in order to avoid inadvertent changes:
-		// at this point changing labels should be treated as a breaking changing
-		// and requires a good justification. The reason is that changes to metric
-		// names or labels can break alerting, dashboards, etc that are used to
-		// monitor the Collector in production deployments.
-		expectedLabels: map[string]labelValue{
-			"service_instance_id": {state: labelAnyValue},
-			"service_name":        {label: otelCommand, state: labelSpecificValue},
-			"service_version":     {label: metricsVersion, state: labelSpecificValue},
+	return []ownMetricsTestCase{
+		{
+			name:                "no resource",
+			userDefinedResource: nil,
+			// All labels added to all collector metrics by default are listed below.
+			// These labels are hard coded here in order to avoid inadvertent changes:
+			// at this point changing labels should be treated as a breaking changing
+			// and requires a good justification. The reason is that changes to metric
+			// names or labels can break alerting, dashboards, etc that are used to
+			// monitor the Collector in production deployments.
+			expectedLabels: map[string]labelValue{
+				"service_instance_id": {state: labelAnyValue},
+				"service_name":        {label: otelCommand, state: labelSpecificValue},
+				"service_version":     {label: metricsVersion, state: labelSpecificValue},
+			},
 		},
-	},
 		{
 			name: "resource with custom attr",
 			userDefinedResource: map[string]*string{
@@ -167,7 +172,8 @@ func ownMetricsTestCases() []ownMetricsTestCase {
 				"service_name":        {label: otelCommand, state: labelSpecificValue},
 				"service_version":     {state: labelNotPresent},
 			},
-		}}
+		},
+	}
 }
 
 var (
@@ -397,7 +403,7 @@ func TestExtensionNotificationFailure(t *testing.T) {
 	set := newNopSettings()
 	cfg := newNopConfig()
 
-	var extName = component.MustNewType("configWatcher")
+	extName := component.MustNewType("configWatcher")
 	configWatcherExtensionFactory := newConfigWatcherExtensionFactory(extName)
 	set.ExtensionsConfigs = map[component.ID]component.Config{component.NewID(extName): configWatcherExtensionFactory.CreateDefaultConfig()}
 	set.ExtensionsFactories = map[component.Type]extension.Factory{extName: configWatcherExtensionFactory}
@@ -419,7 +425,7 @@ func TestNilCollectorEffectiveConfig(t *testing.T) {
 	set.CollectorConf = nil
 	cfg := newNopConfig()
 
-	var extName = component.MustNewType("configWatcher")
+	extName := component.MustNewType("configWatcher")
 	configWatcherExtensionFactory := newConfigWatcherExtensionFactory(extName)
 	set.ExtensionsConfigs = map[component.ID]component.Config{component.NewID(extName): configWatcherExtensionFactory.CreateDefaultConfig()}
 	set.ExtensionsFactories = map[component.Type]extension.Factory{extName: configWatcherExtensionFactory}
@@ -683,11 +689,13 @@ func newNopConfigPipelineConfigs(pipelineCfgs pipelines.Config) Config {
 			},
 			Metrics: telemetry.MetricsConfig{
 				Level: configtelemetry.LevelBasic,
-				Readers: []config.MetricReader{{
-					Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
-						Host: newPtr("localhost"),
-						Port: newPtr(8888),
-					}}}},
+				Readers: []config.MetricReader{
+					{
+						Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
+							Host: newPtr("localhost"),
+							Port: newPtr(8888),
+						}}},
+					},
 				},
 			},
 		},

--- a/service/telemetry/config_test.go
+++ b/service/telemetry/config_test.go
@@ -117,11 +117,13 @@ func TestConfigValidate(t *testing.T) {
 			cfg: &Config{
 				Metrics: MetricsConfig{
 					Level: configtelemetry.LevelBasic,
-					Readers: []config.MetricReader{{
-						Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
-							Host: newPtr("127.0.0.1"),
-							Port: newPtr(3333),
-						}}}},
+					Readers: []config.MetricReader{
+						{
+							Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
+								Host: newPtr("127.0.0.1"),
+								Port: newPtr(3333),
+							}}},
+						},
 					},
 				},
 			},

--- a/service/telemetry/factory.go
+++ b/service/telemetry/factory.go
@@ -115,11 +115,13 @@ func createDefaultConfig() component.Config {
 		},
 		Metrics: MetricsConfig{
 			Level: configtelemetry.LevelNormal,
-			Readers: []config.MetricReader{{
-				Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
-					Host: &metricsHost,
-					Port: newPtr(8888),
-				}}}},
+			Readers: []config.MetricReader{
+				{
+					Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
+						Host: &metricsHost,
+						Port: newPtr(8888),
+					}}},
+				},
 			},
 		},
 	}

--- a/service/telemetry/factory_test.go
+++ b/service/telemetry/factory_test.go
@@ -65,11 +65,13 @@ func TestTelemetryConfiguration(t *testing.T) {
 				},
 				Metrics: MetricsConfig{
 					Level: configtelemetry.LevelBasic,
-					Readers: []config.MetricReader{{
-						Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
-							Host: newPtr("127.0.0.1"),
-							Port: newPtr(3333),
-						}}}},
+					Readers: []config.MetricReader{
+						{
+							Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
+								Host: newPtr("127.0.0.1"),
+								Port: newPtr(3333),
+							}}},
+						},
 					},
 				},
 			},
@@ -83,11 +85,13 @@ func TestTelemetryConfiguration(t *testing.T) {
 				},
 				Metrics: MetricsConfig{
 					Level: configtelemetry.LevelBasic,
-					Readers: []config.MetricReader{{
-						Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
-							Host: newPtr("127.0.0.1"),
-							Port: newPtr(3333),
-						}}}},
+					Readers: []config.MetricReader{
+						{
+							Pull: &config.PullMetricReader{Exporter: config.MetricExporter{Prometheus: &config.Prometheus{
+								Host: newPtr("127.0.0.1"),
+								Port: newPtr(3333),
+							}}},
+						},
 					},
 				},
 			},

--- a/service/telemetry/logger.go
+++ b/service/telemetry/logger.go
@@ -33,7 +33,6 @@ func newLogger(set Settings, cfg Config) (*zap.Logger, log.LoggerProvider, error
 	}
 
 	logger, err := zapCfg.Build(set.ZapOptions...)
-
 	if err != nil {
 		return nil, nil, err
 	}

--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -30,9 +30,7 @@ const (
 	b3Propagator           = "b3"
 )
 
-var (
-	errUnsupportedPropagator = errors.New("unsupported trace propagator")
-)
+var errUnsupportedPropagator = errors.New("unsupported trace propagator")
 
 type noopNoContextTracer struct {
 	embedded.Tracer


### PR DESCRIPTION
#### Description

[gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) is a stricter format than gofmt, while being backwards compatible.