### PR TITLE
[chore] Skip TestDefaultBatcher_NoSplit_WithTimeout on Windows

### DIFF
--- a/exporter/internal/queue/default_batcher_test.go
+++ b/exporter/internal/queue/default_batcher_test.go
@@ -145,6 +145,10 @@ func TestDefaultBatcher_NoSplit_TimeoutDisabled(t *testing.T) {
 }
 
 func TestDefaultBatcher_NoSplit_WithTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows, see https://github.com/open-telemetry/opentelemetry-collector/issues/11869")
+	}
+
 	tests := []struct {
 		name       string
 		maxWorkers int


### PR DESCRIPTION
Relates to #11869
