### PR TITLE
[chore]: enable gofumpt globally

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,7 +143,7 @@ linters:
     - errcheck
     - errorlint
     - gocritic
-    - gofmt
+    - gofumpt
     - goimports
     - gosec
     - govet

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -27,6 +27,7 @@ CHECKFILE    := $(TOOLS_BIN_DIR)/checkfile
 CHLOGGEN     := $(TOOLS_BIN_DIR)/chloggen
 CROSSLINK    := $(TOOLS_BIN_DIR)/crosslink
 ENVSUBST     := $(TOOLS_BIN_DIR)/envsubst
+GOFUMPT      := $(TOOLS_BIN_DIR)/gofumpt
 GOIMPORTS    := $(TOOLS_BIN_DIR)/goimports
 GOVULNCHECK  := $(TOOLS_BIN_DIR)/govulncheck
 LINT         := $(TOOLS_BIN_DIR)/golangci-lint
@@ -60,9 +61,7 @@ benchmark:
 	$(GOTEST) -bench=. -run=notests ./... | tee benchmark.txt
 
 .PHONY: fmt
-fmt: $(GOIMPORTS)
-	gofmt -w -s ./
-	$(GOIMPORTS) -w  -local go.opentelemetry.io/collector ./
+fmt: common/gofmt common/goimports common/gofumpt
 
 .PHONY: tidy
 tidy:
@@ -72,6 +71,18 @@ tidy:
 .PHONY: lint
 lint: $(LINT)
 	$(LINT) run
+
+.PHONY: common/gofmt
+common/gofmt:
+	gofmt -w -s ./
+
+.PHONY: common/goimports
+common/goimports: $(GOIMPORTS)
+	$(GOIMPORTS) -w  -local go.opentelemetry.io/collector ./
+
+.PHONY: common/gofumpt
+common/gofumpt: $(GOFUMPT)
+	$(GOFUMPT) -l -w .
 
 .PHONY: govulncheck
 govulncheck: $(GOVULNCHECK)

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/tools v0.28.0
 	golang.org/x/vuln v1.1.3
+	mvdan.cc/gofumpt v0.7.0
 )
 
 require (
@@ -222,7 +223,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.5.1 // indirect
-	mvdan.cc/gofumpt v0.7.0 // indirect
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 )
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -25,6 +25,7 @@ import (
 	_ "golang.org/x/exp/cmd/apidiff"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "golang.org/x/vuln/cmd/govulncheck"
+	_ "mvdan.cc/gofumpt"
 
 	_ "go.opentelemetry.io/collector/internal/tools/semconvkit"
 )


### PR DESCRIPTION
#### Description

[gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) is a stricter format than gofmt, while being backwards compatible.