### PR TITLE
[chore] Fix CI checks job

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -4,7 +4,7 @@ module go.opentelemetry.io/collector/cmd/otelcorecol
 
 go 1.22.0
 
-toolchain go1.22.9
+toolchain go1.22.10
 
 require (
 	go.opentelemetry.io/collector/component v0.115.0


### PR DESCRIPTION
If we run our CI with `go-version: ~1.22.9`, we would need to update the toolchain every time minor go version is released to make the `checks` CI job pass

We probably should do something else with this