### PR TITLE
[chore]: enable partially thelper linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,7 +134,17 @@ linters-settings:
             - "!**/*_test.go"
 
   testifylint:
-    enable-all: true   
+    enable-all: true
+
+  thelper:
+    test:
+      begin: false
+    benchmark:
+      begin: false
+    tb:
+      begin: false
+    fuzz:
+      begin: false
 
 linters:
   enable:
@@ -153,6 +163,7 @@ linters:
     - staticcheck
     - tenv
     - testifylint
+    - thelper
     - unconvert
     - unused
     - unparam

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -107,9 +107,9 @@ var replaceModules = []string{
 	"/service",
 }
 
-func newTestConfig(t testing.TB) *Config {
+func newTestConfig(tb testing.TB) *Config {
 	cfg, err := NewDefaultConfig()
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	cfg.downloadModules.wait = 0
 	cfg.downloadModules.numRetries = 1
 	return cfg

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -446,39 +446,39 @@ func TestDecompressorAvoidDecompressionBomb(t *testing.T) {
 	}
 }
 
-func compressGzip(t testing.TB, body []byte) *bytes.Buffer {
+func compressGzip(tb testing.TB, body []byte) *bytes.Buffer {
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	_, err := gw.Write(body)
-	require.NoError(t, err)
-	require.NoError(t, gw.Close())
+	require.NoError(tb, err)
+	require.NoError(tb, gw.Close())
 	return &buf
 }
 
-func compressZlib(t testing.TB, body []byte) *bytes.Buffer {
+func compressZlib(tb testing.TB, body []byte) *bytes.Buffer {
 	var buf bytes.Buffer
 	zw := zlib.NewWriter(&buf)
 	_, err := zw.Write(body)
-	require.NoError(t, err)
-	require.NoError(t, zw.Close())
+	require.NoError(tb, err)
+	require.NoError(tb, zw.Close())
 	return &buf
 }
 
-func compressSnappy(t testing.TB, body []byte) *bytes.Buffer {
+func compressSnappy(tb testing.TB, body []byte) *bytes.Buffer {
 	var buf bytes.Buffer
 	sw := snappy.NewBufferedWriter(&buf)
 	_, err := sw.Write(body)
-	require.NoError(t, err)
-	require.NoError(t, sw.Close())
+	require.NoError(tb, err)
+	require.NoError(tb, sw.Close())
 	return &buf
 }
 
-func compressZstd(t testing.TB, body []byte) *bytes.Buffer {
+func compressZstd(tb testing.TB, body []byte) *bytes.Buffer {
 	var buf bytes.Buffer
 	zw, _ := zstd.NewWriter(&buf)
 	_, err := zw.Write(body)
-	require.NoError(t, err)
-	require.NoError(t, zw.Close())
+	require.NoError(tb, err)
+	require.NoError(tb, zw.Close())
 	return &buf
 }
 

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -382,12 +382,12 @@ func TestMarshaler(t *testing.T) {
 }
 
 // newConfFromFile creates a new Conf by reading the given file.
-func newConfFromFile(t testing.TB, fileName string) map[string]any {
+func newConfFromFile(tb testing.TB, fileName string) map[string]any {
 	content, err := os.ReadFile(filepath.Clean(fileName))
-	require.NoErrorf(t, err, "unable to read the file %v", fileName)
+	require.NoErrorf(tb, err, "unable to read the file %v", fileName)
 
 	var data map[string]any
-	require.NoError(t, yaml.Unmarshal(content, &data), "unable to parse yaml")
+	require.NoError(tb, yaml.Unmarshal(content, &data), "unable to parse yaml")
 
 	return NewFromStringMap(data).ToStringMap()
 }

--- a/confmap/internal/e2e/types_test.go
+++ b/confmap/internal/e2e/types_test.go
@@ -39,7 +39,7 @@ type TargetConfig[T any] struct {
 	Field T `mapstructure:"field"`
 }
 
-func NewResolver(t testing.TB, path string) *confmap.Resolver {
+func NewResolver(tb testing.TB, path string) *confmap.Resolver {
 	resolver, err := confmap.NewResolver(confmap.ResolverSettings{
 		URIs: []string{filepath.Join("testdata", path)},
 		ProviderFactories: []confmap.ProviderFactory{
@@ -48,7 +48,7 @@ func NewResolver(t testing.TB, path string) *confmap.Resolver {
 		},
 		DefaultScheme: "env",
 	})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return resolver
 }
 

--- a/confmap/resolver_test.go
+++ b/confmap/resolver_test.go
@@ -60,9 +60,9 @@ type fakeProvider struct {
 	logger *zap.Logger
 }
 
-func newFileProvider(t testing.TB) ProviderFactory {
+func newFileProvider(tb testing.TB) ProviderFactory {
 	return newFakeProvider("file", func(_ context.Context, uri string, _ WatcherFunc) (*Retrieved, error) {
-		return NewRetrieved(newConfFromFile(t, uri[5:]))
+		return NewRetrieved(newConfFromFile(tb, uri[5:]))
 	})
 }
 
@@ -76,9 +76,9 @@ func newFakeProvider(scheme string, ret func(ctx context.Context, uri string, wa
 	})
 }
 
-func newObservableFileProvider(t testing.TB) (ProviderFactory, *fakeProvider) {
+func newObservableFileProvider(tb testing.TB) (ProviderFactory, *fakeProvider) {
 	return newObservableProvider("file", func(_ context.Context, uri string, _ WatcherFunc) (*Retrieved, error) {
-		return NewRetrieved(newConfFromFile(t, uri[5:]))
+		return NewRetrieved(newConfFromFile(tb, uri[5:]))
 	})
 }
 

--- a/exporter/exporterhelper/internal/test_util.go
+++ b/exporter/exporterhelper/internal/test_util.go
@@ -11,10 +11,10 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 )
 
-func setFeatureGateForTest(t testing.TB, gate *featuregate.Gate, enabled bool) func() {
+func setFeatureGateForTest(tb testing.TB, gate *featuregate.Gate, enabled bool) func() {
 	originalValue := gate.IsEnabled()
-	require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), enabled))
+	require.NoError(tb, featuregate.GlobalRegistry().Set(gate.ID(), enabled))
 	return func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), originalValue))
+		require.NoError(tb, featuregate.GlobalRegistry().Set(gate.ID(), originalValue))
 	}
 }

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -264,15 +264,15 @@ func createTestPersistentQueueWithClient(client storage.Client) *persistentQueue
 	return pq
 }
 
-func createTestPersistentQueueWithRequestsCapacity(t testing.TB, ext storage.Extension, capacity int64) *persistentQueue[tracesRequest] {
-	return createTestPersistentQueueWithCapacityLimiter(t, ext, &RequestSizer[tracesRequest]{}, capacity)
+func createTestPersistentQueueWithRequestsCapacity(tb testing.TB, ext storage.Extension, capacity int64) *persistentQueue[tracesRequest] {
+	return createTestPersistentQueueWithCapacityLimiter(tb, ext, &RequestSizer[tracesRequest]{}, capacity)
 }
 
-func createTestPersistentQueueWithItemsCapacity(t testing.TB, ext storage.Extension, capacity int64) *persistentQueue[tracesRequest] {
-	return createTestPersistentQueueWithCapacityLimiter(t, ext, &itemsSizer[tracesRequest]{}, capacity)
+func createTestPersistentQueueWithItemsCapacity(tb testing.TB, ext storage.Extension, capacity int64) *persistentQueue[tracesRequest] {
+	return createTestPersistentQueueWithCapacityLimiter(tb, ext, &itemsSizer[tracesRequest]{}, capacity)
 }
 
-func createTestPersistentQueueWithCapacityLimiter(t testing.TB, ext storage.Extension, sizer Sizer[tracesRequest],
+func createTestPersistentQueueWithCapacityLimiter(tb testing.TB, ext storage.Extension, sizer Sizer[tracesRequest],
 	capacity int64,
 ) *persistentQueue[tracesRequest] {
 	pq := NewPersistentQueue[tracesRequest](PersistentQueueSettings[tracesRequest]{
@@ -284,7 +284,7 @@ func createTestPersistentQueueWithCapacityLimiter(t testing.TB, ext storage.Exte
 		Unmarshaler:      unmarshalTracesRequest,
 		ExporterSettings: exportertest.NewNopSettings(),
 	}).(*persistentQueue[tracesRequest])
-	require.NoError(t, pq.Start(context.Background(), &mockHost{ext: map[component.ID]component.Component{{}: ext}}))
+	require.NoError(tb, pq.Start(context.Background(), &mockHost{ext: map[component.ID]component.Component{{}: ext}}))
 	return pq
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -23,16 +23,16 @@ type portpair struct {
 // describing it. The port is available for opening when this function returns
 // provided that there is no race by some other code to grab the same port
 // immediately.
-func GetAvailableLocalAddress(t testing.TB) string {
-	return findAvailable(t, "tcp4")
+func GetAvailableLocalAddress(tb testing.TB) string {
+	return findAvailable(tb, "tcp4")
 }
 
 // GetAvailableLocalIPv6Address is IPv6 version of GetAvailableLocalAddress.
-func GetAvailableLocalIPv6Address(t testing.TB) string {
-	return findAvailable(t, "tcp6")
+func GetAvailableLocalIPv6Address(tb testing.TB) string {
+	return findAvailable(tb, "tcp6")
 }
 
-func findAvailable(t testing.TB, network string) string {
+func findAvailable(tb testing.TB, network string) string {
 	// Retry has been added for windows as net.Listen can return a port that is not actually available. Details can be
 	// found in https://github.com/docker/for-win/issues/3171 but to summarize Hyper-V will reserve ranges of ports
 	// which do not show up under the "netstat -ano" but can only be found by
@@ -41,14 +41,14 @@ func findAvailable(t testing.TB, network string) string {
 	var exclusions []portpair
 	portFound := false
 	if runtime.GOOS == "windows" {
-		exclusions = getExclusionsList(network, t)
+		exclusions = getExclusionsList(tb, network)
 	}
 
 	var endpoint string
 	for !portFound {
-		endpoint = findAvailableAddress(network, t)
+		endpoint = findAvailableAddress(tb, network)
 		_, port, err := net.SplitHostPort(endpoint)
-		require.NoError(t, err)
+		require.NoError(tb, err)
 		portFound = true
 		if runtime.GOOS == "windows" {
 			for _, pair := range exclusions {
@@ -63,7 +63,7 @@ func findAvailable(t testing.TB, network string) string {
 	return endpoint
 }
 
-func findAvailableAddress(network string, t testing.TB) string {
+func findAvailableAddress(tb testing.TB, network string) string {
 	var host string
 	switch network {
 	case "tcp", "tcp4":
@@ -71,20 +71,20 @@ func findAvailableAddress(network string, t testing.TB) string {
 	case "tcp6":
 		host = "[::1]"
 	}
-	require.NotZero(t, host, "network must be either of tcp, tcp4 or tcp6")
+	require.NotZero(tb, host, "network must be either of tcp, tcp4 or tcp6")
 
 	ln, err := net.Listen("tcp", host+":0")
-	require.NoError(t, err, "Failed to get a free local port")
+	require.NoError(tb, err, "Failed to get a free local port")
 	// There is a possible race if something else takes this same port before
 	// the test uses it, however, that is unlikely in practice.
 	defer func() {
-		assert.NoError(t, ln.Close())
+		assert.NoError(tb, ln.Close())
 	}()
 	return ln.Addr().String()
 }
 
 // Get excluded ports on Windows from the command: netsh interface ipv4 show excludedportrange protocol=tcp
-func getExclusionsList(network string, t testing.TB) []portpair {
+func getExclusionsList(tb testing.TB, network string) []portpair {
 	var cmdTCP *exec.Cmd
 	switch network {
 	case "tcp", "tcp4":
@@ -92,32 +92,32 @@ func getExclusionsList(network string, t testing.TB) []portpair {
 	case "tcp6":
 		cmdTCP = exec.Command("netsh", "interface", "ipv6", "show", "excludedportrange", "protocol=tcp")
 	}
-	require.NotZero(t, cmdTCP, "network must be either of tcp, tcp4 or tcp6")
+	require.NotZero(tb, cmdTCP, "network must be either of tcp, tcp4 or tcp6")
 
 	outputTCP, errTCP := cmdTCP.CombinedOutput()
-	require.NoError(t, errTCP)
-	exclusions := createExclusionsList(string(outputTCP), t)
+	require.NoError(tb, errTCP)
+	exclusions := createExclusionsList(tb, string(outputTCP))
 
 	cmdUDP := exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=udp")
 	outputUDP, errUDP := cmdUDP.CombinedOutput()
-	require.NoError(t, errUDP)
-	exclusions = append(exclusions, createExclusionsList(string(outputUDP), t)...)
+	require.NoError(tb, errUDP)
+	exclusions = append(exclusions, createExclusionsList(tb, string(outputUDP))...)
 
 	return exclusions
 }
 
-func createExclusionsList(exclusionsText string, t testing.TB) []portpair {
+func createExclusionsList(tb testing.TB, exclusionsText string) []portpair {
 	var exclusions []portpair
 
 	parts := strings.Split(exclusionsText, "--------")
-	require.Len(t, parts, 3)
+	require.Len(tb, parts, 3)
 	portsText := strings.Split(parts[2], "*")
-	require.Greater(t, len(portsText), 1) // original text may have a suffix like " - Administered port exclusions."
+	require.Greater(tb, len(portsText), 1) // original text may have a suffix like " - Administered port exclusions."
 	lines := strings.Split(portsText[0], "\n")
 	for _, line := range lines {
 		if strings.TrimSpace(line) != "" {
 			entries := strings.Fields(strings.TrimSpace(line))
-			require.Len(t, entries, 2)
+			require.Len(tb, entries, 2)
 			pair := portpair{entries[0], entries[1]}
 			exclusions = append(exclusions, pair)
 		}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -67,9 +67,9 @@ Start Port    End Port
 
 * - Administered port exclusions.
 `
-	exclusions := createExclusionsList(exclusionsText, t)
+	exclusions := createExclusionsList(t, exclusionsText)
 	require.Len(t, exclusions, 2)
 
-	emptyExclusions := createExclusionsList(emptyExclusionsText, t)
+	emptyExclusions := createExclusionsList(t, emptyExclusionsText)
 	require.Empty(t, emptyExclusions)
 }

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -569,9 +569,9 @@ func newEnvProvider() confmap.ProviderFactory {
 	})
 }
 
-func newDefaultConfigProviderSettings(t testing.TB, uris []string) ConfigProviderSettings {
+func newDefaultConfigProviderSettings(tb testing.TB, uris []string) ConfigProviderSettings {
 	fileProvider := newFakeProvider("file", func(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
-		return confmap.NewRetrieved(newConfFromFile(t, uri[5:]))
+		return confmap.NewRetrieved(newConfFromFile(tb, uri[5:]))
 	})
 	return ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
@@ -585,12 +585,12 @@ func newDefaultConfigProviderSettings(t testing.TB, uris []string) ConfigProvide
 }
 
 // newConfFromFile creates a new Conf by reading the given file.
-func newConfFromFile(t testing.TB, fileName string) map[string]any {
+func newConfFromFile(tb testing.TB, fileName string) map[string]any {
 	content, err := os.ReadFile(filepath.Clean(fileName))
-	require.NoErrorf(t, err, "unable to read the file %v", fileName)
+	require.NoErrorf(tb, err, "unable to read the file %v", fileName)
 
 	var data map[string]any
-	require.NoError(t, yaml.Unmarshal(content, &data), "unable to parse yaml")
+	require.NoError(tb, yaml.Unmarshal(content, &data), "unable to parse yaml")
 
 	return confmap.NewFromStringMap(data).ToStringMap()
 }

--- a/service/internal/promtest/server_util.go
+++ b/service/internal/promtest/server_util.go
@@ -13,12 +13,12 @@ import (
 	"go.opentelemetry.io/collector/internal/testutil"
 )
 
-func GetAvailableLocalIPv6AddressPrometheus(t testing.TB) *config.Prometheus {
-	return addrToPrometheus(testutil.GetAvailableLocalIPv6Address(t))
+func GetAvailableLocalIPv6AddressPrometheus(tb testing.TB) *config.Prometheus {
+	return addrToPrometheus(testutil.GetAvailableLocalIPv6Address(tb))
 }
 
-func GetAvailableLocalAddressPrometheus(t testing.TB) *config.Prometheus {
-	return addrToPrometheus(testutil.GetAvailableLocalAddress(t))
+func GetAvailableLocalAddressPrometheus(tb testing.TB) *config.Prometheus {
+	return addrToPrometheus(testutil.GetAvailableLocalAddress(tb))
 }
 
 func addrToPrometheus(address string) *config.Prometheus {


### PR DESCRIPTION
#### Description

[Thelper](https://golangci-lint.run/usage/linters/#thelper) detects tests helpers which is not start with t.Helper() method.

This only enables rules for naming and paramter order