### PR TITLE
[chore]: use testify instead of testing.Fatal or testing.Error

### DIFF
--- a/cmd/builder/internal/command_test.go
+++ b/cmd/builder/internal/command_test.go
@@ -36,20 +36,21 @@ func TestCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Command()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Command() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if !tt.wantErr {
+				require.NoErrorf(t, err, "Command()")
+				assert.Equal(t, tt.want.Aliases, got.Aliases)
+				assert.Equal(t, tt.want.Annotations, got.Annotations)
+				assert.Equal(t, tt.want.ValidArgs, got.ValidArgs)
+				assert.Equal(t, tt.want.ArgAliases, got.ArgAliases)
+				assert.Equal(t, tt.want.Use, got.Use)
+				assert.Equal(t, tt.want.SilenceUsage, got.SilenceUsage)
+				assert.Equal(t, tt.want.SilenceErrors, got.SilenceErrors)
+				assert.True(t, strings.HasPrefix(got.Long, tt.want.Long))
+				assert.Empty(t, got.Short)
+				assert.NotEqual(t, tt.want.HasFlags(), got.Flags().HasFlags())
+			} else {
+				require.Error(t, err)
 			}
-			assert.Equal(t, tt.want.Aliases, got.Aliases)
-			assert.Equal(t, tt.want.Annotations, got.Annotations)
-			assert.Equal(t, tt.want.ValidArgs, got.ValidArgs)
-			assert.Equal(t, tt.want.ArgAliases, got.ArgAliases)
-			assert.Equal(t, tt.want.Use, got.Use)
-			assert.Equal(t, tt.want.SilenceUsage, got.SilenceUsage)
-			assert.Equal(t, tt.want.SilenceErrors, got.SilenceErrors)
-			assert.True(t, strings.HasPrefix(got.Long, tt.want.Long))
-			assert.Empty(t, got.Short)
-			assert.NotEqual(t, tt.want.HasFlags(), got.Flags().HasFlags())
 		})
 	}
 }

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -281,8 +281,11 @@ func TestRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := run(tt.args.ymlPath); (err != nil) != tt.wantErr {
-				t.Errorf("run() error = %v, wantErr %v", err, tt.wantErr)
+			err := run(tt.args.ymlPath)
+			if !tt.wantErr {
+				require.NoError(t, err, "run()")
+			} else {
+				require.Error(t, err)
 			}
 		})
 	}

--- a/config/configgrpc/configgrpc_benchmark_test.go
+++ b/config/configgrpc/configgrpc_benchmark_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mostynb/go-grpc-compression/nonclobbering/snappy"
 	"github.com/mostynb/go-grpc-compression/nonclobbering/zstd"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/encoding/gzip"
@@ -34,27 +35,19 @@ func BenchmarkCompressors(b *testing.B) {
 		for _, compressor := range compressors {
 			fmt.Println(payload.name)
 			messageBytes, err := payload.marshaler.marshal(payload.message)
-			if err != nil {
-				b.Errorf("marshal(_) returned an error")
-			}
+			require.NoError(b, err, "marshal(_) returned an error")
 
 			compressedBytes, err := compress(compressor, messageBytes)
-			if err != nil {
-				b.Errorf("Compressor.Compress(_) returned an error")
-			}
+			require.NoError(b, err, "Compressor.Compress(_) returned an error")
 
 			name := fmt.Sprintf("%v/raw_bytes_%v/compressed_bytes_%v/compressor_%v", payload.name, len(messageBytes), len(compressedBytes), compressor.Name())
 
 			b.Run(name, func(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					if err != nil {
-						b.Errorf("marshal(_) returned an error")
-					}
+					require.NoError(b, err, "marshal(_) returned an error")
 					_, err := compress(compressor, messageBytes)
-					if err != nil {
-						b.Errorf("compress(_) returned an error")
-					}
+					require.NoError(b, err, "compress(_) returned an error")
 				}
 			})
 		}

--- a/config/confighttp/compressor_test.go
+++ b/config/confighttp/compressor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/config/configcompression"
 )
@@ -66,9 +67,7 @@ func benchmarkCompression(b *testing.B, _ configcompression.Type, buf *bytes.Buf
 			enc, _ = zstd.NewWriter(nil, zstd.WithEncoderConcurrency(5))
 			enc.(writeCloserReset).Reset(buf)
 			_, copyErr := io.Copy(enc, stringReadCloser)
-			if copyErr != nil {
-				b.Fatal(copyErr)
-			}
+			require.NoError(b, copyErr)
 		}
 	})
 }
@@ -87,9 +86,7 @@ func benchmarkCompressionNoConcurrency(b *testing.B, _ configcompression.Type, b
 			enc, _ = zstd.NewWriter(nil, zstd.WithEncoderConcurrency(1))
 			enc.(writeCloserReset).Reset(buf)
 			_, copyErr := io.Copy(enc, stringReadCloser)
-			if copyErr != nil {
-				b.Fatal(copyErr)
-			}
+			require.NoError(b, copyErr)
 		}
 	})
 }

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -954,12 +954,9 @@ func verifyCorsResp(t *testing.T, url string, origin string, set *CORSConfig, ex
 	req.Header.Set("Access-Control-Request-Method", "POST")
 
 	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err, "Error sending OPTIONS to http server: %v", err)
-
-	err = resp.Body.Close()
-	if err != nil {
-		t.Errorf("Error closing OPTIONS response body, %v", err)
-	}
+	require.NoError(t, err, "Error sending OPTIONS to http server")
+	require.NotNil(t, resp.Body)
+	require.NoError(t, resp.Body.Close(), "Error closing OPTIONS response body")
 
 	assert.Equal(t, wantStatus, resp.StatusCode)
 
@@ -983,15 +980,12 @@ func verifyCorsResp(t *testing.T, url string, origin string, set *CORSConfig, ex
 
 func verifyHeadersResp(t *testing.T, url string, expected map[string]configopaque.String) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
-	require.NoError(t, err, "Error creating request: %v", err)
+	require.NoError(t, err, "Error creating request")
 
 	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err, "Error sending request to http server: %v", err)
-
-	err = resp.Body.Close()
-	if err != nil {
-		t.Errorf("Error closing response body, %v", err)
-	}
+	require.NoError(t, err, "Error sending request to http server")
+	require.NotNil(t, resp.Body)
+	require.NoError(t, resp.Body.Close(), "Error closing response body")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 

--- a/pdata/plog/fuzz_test.go
+++ b/pdata/plog/fuzz_test.go
@@ -6,6 +6,8 @@ package plog // import "go.opentelemetry.io/collector/pdata/plog"
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var unexpectedBytes = "expected the same bytes from unmarshaling and marshaling."
@@ -19,24 +21,16 @@ func FuzzUnmarshalJsonLogs(f *testing.F) {
 		}
 		m1 := &JSONMarshaler{}
 		b1, err := m1.MarshalLogs(ld1)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		u2 := &JSONUnmarshaler{}
 		ld2, err := u2.UnmarshalLogs(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, err, "failed to unmarshal valid bytes")
 		m2 := &JSONMarshaler{}
 		b2, err := m2.MarshalLogs(ld2)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -49,23 +43,15 @@ func FuzzUnmarshalPBLogs(f *testing.F) {
 		}
 		m1 := &ProtoMarshaler{}
 		b1, err := m1.MarshalLogs(ld1)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		u2 := &ProtoUnmarshaler{}
 		ld2, err := u2.UnmarshalLogs(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, err, "failed to unmarshal valid bytes")
 		m2 := &ProtoMarshaler{}
 		b2, err := m2.MarshalLogs(ld2)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }

--- a/pdata/plog/plogotlp/fuzz_test.go
+++ b/pdata/plog/plogotlp/fuzz_test.go
@@ -6,6 +6,8 @@ package plogotlp // import "go.opentelemetry.io/collector/pdata/plog/plogotlp"
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var unexpectedBytes = "expected the same bytes from unmarshaling and marshaling."
@@ -18,23 +20,14 @@ func FuzzRequestUnmarshalJSON(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportRequest()
-		err = er.UnmarshalJSON(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalJSON(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -46,23 +39,14 @@ func FuzzResponseUnmarshalJSON(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportResponse()
-		err = er.UnmarshalJSON(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalJSON(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -74,22 +58,13 @@ func FuzzRequestUnmarshalProto(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 		er = NewExportRequest()
-		err = er.UnmarshalProto(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalProto(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -101,22 +76,13 @@ func FuzzResponseUnmarshalProto(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportResponse()
-		err = er.UnmarshalProto(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalProto(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }

--- a/pdata/pprofile/fuzz_test.go
+++ b/pdata/pprofile/fuzz_test.go
@@ -6,6 +6,8 @@ package pprofile // import "go.opentelemetry.io/collector/pdata/pprofile"
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var unexpectedBytes = "expected the same bytes from unmarshaling and marshaling."
@@ -19,23 +21,15 @@ func FuzzUnmarshalProfiles(f *testing.F) {
 		}
 		m1 := &JSONMarshaler{}
 		b1, err := m1.MarshalProfiles(ld1)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		u2 := &JSONUnmarshaler{}
 		ld2, err := u2.UnmarshalProfiles(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, err, "failed to unmarshal valid bytes")
 		m2 := &JSONMarshaler{}
 		b2, err := m2.MarshalProfiles(ld2)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }

--- a/pdata/pprofile/pprofileotlp/fuzz_test.go
+++ b/pdata/pprofile/pprofileotlp/fuzz_test.go
@@ -6,6 +6,8 @@ package pprofileotlp // import "go.opentelemetry.io/collector/pdata/pprofile/ppr
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var unexpectedBytes = "expected the same bytes from unmarshaling and marshaling."
@@ -18,23 +20,14 @@ func FuzzRequestUnmarshalJSON(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportRequest()
-		err = er.UnmarshalJSON(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalJSON(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -46,23 +39,14 @@ func FuzzResponseUnmarshalJSON(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportResponse()
-		err = er.UnmarshalJSON(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalJSON(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -74,23 +58,14 @@ func FuzzRequestUnmarshalProto(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportRequest()
-		err = er.UnmarshalProto(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalProto(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -102,22 +77,13 @@ func FuzzResponseUnmarshalProto(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportResponse()
-		err = er.UnmarshalProto(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalProto(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }

--- a/pdata/ptrace/fuzz_test.go
+++ b/pdata/ptrace/fuzz_test.go
@@ -6,6 +6,8 @@ package ptrace // import "go.opentelemetry.io/collector/pdata/ptrace"
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var unexpectedBytes = "expected the same bytes from unmarshaling and marshaling."
@@ -19,24 +21,16 @@ func FuzzUnmarshalJSONTraces(f *testing.F) {
 		}
 		m1 := &JSONMarshaler{}
 		b1, err := m1.MarshalTraces(ld1)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		u2 := &JSONUnmarshaler{}
 		ld2, err := u2.UnmarshalTraces(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, err, "failed to unmarshal valid bytes")
 		m2 := &JSONMarshaler{}
 		b2, err := m2.MarshalTraces(ld2)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -49,23 +43,15 @@ func FuzzUnmarshalPBTraces(f *testing.F) {
 		}
 		m1 := &ProtoMarshaler{}
 		b1, err := m1.MarshalTraces(ld1)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		u2 := &ProtoUnmarshaler{}
 		ld2, err := u2.UnmarshalTraces(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, err, "failed to unmarshal valid bytes")
 		m2 := &ProtoMarshaler{}
 		b2, err := m2.MarshalTraces(ld2)
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }

--- a/pdata/ptrace/ptraceotlp/fuzz_test.go
+++ b/pdata/ptrace/ptraceotlp/fuzz_test.go
@@ -6,6 +6,8 @@ package ptraceotlp // import "go.opentelemetry.io/collector/pdata/ptrace/ptraceo
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var unexpectedBytes = "expected the same bytes from unmarshaling and marshaling."
@@ -18,23 +20,14 @@ func FuzzRequestUnmarshalJSON(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportRequest()
-		err = er.UnmarshalJSON(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalJSON(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -46,23 +39,14 @@ func FuzzResponseUnmarshalJSON(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportResponse()
-		err = er.UnmarshalJSON(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalJSON(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalJSON()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -74,23 +58,14 @@ func FuzzRequestUnmarshalProto(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportRequest()
-		err = er.UnmarshalProto(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalProto(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }
 
@@ -102,22 +77,13 @@ func FuzzResponseUnmarshalProto(f *testing.F) {
 			return
 		}
 		b1, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
 		er = NewExportResponse()
-		err = er.UnmarshalProto(b1)
-		if err != nil {
-			t.Fatalf("failed to unmarshal valid bytes:  %v", err)
-		}
+		require.NoError(t, er.UnmarshalProto(b1), "failed to unmarshal valid bytes")
 		b2, err := er.MarshalProto()
-		if err != nil {
-			t.Fatalf("failed to marshal valid struct:  %v", err)
-		}
+		require.NoError(t, err, "failed to marshal valid struct")
 
-		if !bytes.Equal(b1, b2) {
-			t.Fatalf("%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
-		}
+		require.True(t, bytes.Equal(b1, b2), "%s. \nexpected %d but got %d\n", unexpectedBytes, b1, b2)
 	})
 }


### PR DESCRIPTION
### Description

* uses testify instead of testing.Fatal or testing.Error in processor