### PR TITLE
Add support for providers in components command

### DIFF
--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -33,7 +33,11 @@ func main() {
 					{{- range .ConfmapProviders}}
 					{{.Name}}.NewFactory(),
 					{{- end}}
-				},
+				}, ProviderModules: map[string]string{
+                    {{- range .ConfmapProviders}}
+                    "{{.Name}}": "{{.GoMod}}",
+                    {{- end}}
+                },
 				{{- if .ConfmapConverters }}
 				ConverterFactories: []confmap.ConverterFactory{
 					{{- range .ConfmapConverters}}

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -34,6 +34,12 @@ func main() {
 					httpprovider.NewFactory(),
 					httpsprovider.NewFactory(),
 					yamlprovider.NewFactory(),
+				}, ProviderModules: map[string]string{
+					"envprovider": "go.opentelemetry.io/collector/confmap/provider/envprovider v0.115.0",
+					"fileprovider": "go.opentelemetry.io/collector/confmap/provider/fileprovider v0.115.0",
+					"httpprovider": "go.opentelemetry.io/collector/confmap/provider/httpprovider v0.115.0",
+					"httpsprovider": "go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.115.0",
+					"yamlprovider": "go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.115.0",
 				},
 			},
 		},

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -39,6 +39,10 @@ type ResolverSettings struct {
 	// It is required to have at least one factory.
 	ProviderFactories []ProviderFactory
 
+	// ProviderFactories is a slice of Provider factories.
+	// It is required to have at least one factory.
+	ProviderModules map[string]string
+
 	// DefaultScheme is the scheme that is used if ${} syntax is used but no schema is provided.
 	// If no DefaultScheme is set, ${} with no schema will not be expanded.
 	// It is strongly recommended to set "env" as the default scheme to align with the

--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -31,6 +31,7 @@ type componentsOutput struct {
 	Exporters  []componentWithStability
 	Connectors []componentWithStability
 	Extensions []componentWithStability
+	Providers  []string
 }
 
 // newComponentsCommand constructs a new components command using the given CollectorSettings.
@@ -109,6 +110,14 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 				})
 			}
 			components.BuildInfo = set.BuildInfo
+
+			confmapProviderFactories := set.ConfigProviderSettings.ResolverSettings.ProviderFactories
+			for _, confmapProvider := range confmapProviderFactories {
+				provider := confmapProvider.Create(set.ConfigProviderSettings.ResolverSettings.ProviderSettings)
+				scheme := provider.Scheme()
+				components.Providers = append(components.Providers, scheme)
+			}
+
 			yamlData, err := yaml.Marshal(components)
 			if err != nil {
 				return err

--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -24,6 +24,11 @@ type componentWithStability struct {
 	Stability map[string]string
 }
 
+type componentWithOutStability struct {
+	Name   string
+	Module string
+}
+
 type componentsOutput struct {
 	BuildInfo  component.BuildInfo
 	Receivers  []componentWithStability
@@ -31,7 +36,7 @@ type componentsOutput struct {
 	Exporters  []componentWithStability
 	Connectors []componentWithStability
 	Extensions []componentWithStability
-	Providers  []string
+	Providers  []componentWithOutStability
 }
 
 // newComponentsCommand constructs a new components command using the given CollectorSettings.
@@ -115,7 +120,11 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			for _, confmapProvider := range confmapProviderFactories {
 				provider := confmapProvider.Create(set.ConfigProviderSettings.ResolverSettings.ProviderSettings)
 				scheme := provider.Scheme()
-				components.Providers = append(components.Providers, scheme)
+				module := set.ConfigProviderSettings.ResolverSettings.ProviderModules[scheme+"provider"]
+				components.Providers = append(components.Providers, componentWithOutStability{
+					Name:   scheme,
+					Module: module,
+				})
 			}
 
 			yamlData, err := yaml.Marshal(components)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds support for printing config providers with the `components` command.

<!-- Issue number if applicable -->
#### Link to tracking issue

Related to https://github.com/open-telemetry/opentelemetry-collector/issues/11570

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
