### PR TITLE
[chore]: enable use-any rule from revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,10 +74,6 @@ linters-settings:
       # See https://github.com/open-telemetry/opentelemetry-collector/issues/2789
       - fieldalignment
 
-  revive:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
-
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
@@ -111,6 +107,12 @@ linters-settings:
     sprintf1: true
     # Optimizes into strings concatenation.
     strconcat: true
+
+  revive:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0.8
+    rules:
+      - name: use-any
 
   depguard:
     rules:

--- a/cmd/mdatagen/internal/telemetry.go
+++ b/cmd/mdatagen/internal/telemetry.go
@@ -12,8 +12,8 @@ type Telemetry struct {
 	Metrics map[MetricName]Metric `mapstructure:"metrics"`
 }
 
-func (t Telemetry) Levels() map[string]interface{} {
-	levels := map[string]interface{}{}
+func (t Telemetry) Levels() map[string]any {
+	levels := map[string]any{}
 	for _, m := range t.Metrics {
 		levels[m.Level.String()] = nil
 	}

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -536,7 +536,7 @@ type Marshaler interface {
 // 4. configuration have no `keys` field specified, the output should be default config
 //   - for example, input is {}, then output is Config{ Keys: ["a", "b"]}
 func zeroSliceHookFunc() mapstructure.DecodeHookFuncValue {
-	return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+	return func(from reflect.Value, to reflect.Value) (any, error) {
 		if to.CanSet() && to.Kind() == reflect.Slice && from.Kind() == reflect.Slice {
 			to.Set(reflect.MakeSlice(to.Type(), from.Len(), from.Cap()))
 		}

--- a/confmap/confmaptest/configtest_test.go
+++ b/confmap/confmaptest/configtest_test.go
@@ -33,7 +33,7 @@ func TestLoadConf(t *testing.T) {
 func TestToStringMapSanitizeEmptySlice(t *testing.T) {
 	cfg, err := LoadConf(filepath.Join("testdata", "empty-slice.yaml"))
 	require.NoError(t, err)
-	var nilSlice []interface{}
+	var nilSlice []any
 	assert.Equal(t, map[string]any{"slice": nilSlice}, cfg.ToStringMap())
 }
 

--- a/otelcol/configprovider_test.go
+++ b/otelcol/configprovider_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func newConfig(yamlBytes []byte, factories Factories) (*Config, error) {
-	stringMap := map[string]interface{}{}
+	stringMap := map[string]any{}
 	err := yaml.Unmarshal(yamlBytes, stringMap)
 	if err != nil {
 		return nil, err

--- a/pdata/internal/cmd/pdatagen/internal/pcommon_package.go
+++ b/pdata/internal/cmd/pdatagen/internal/pcommon_package.go
@@ -173,7 +173,7 @@ var byteSlice = &primitiveSliceStruct{
 	packageName:          "pcommon",
 	itemType:             "byte",
 	testOrigVal:          "1, 2, 3",
-	testInterfaceOrigVal: []interface{}{1, 2, 3},
+	testInterfaceOrigVal: []any{1, 2, 3},
 	testSetVal:           "5",
 	testNewVal:           "1, 5, 3",
 }
@@ -183,7 +183,7 @@ var float64Slice = &primitiveSliceStruct{
 	packageName:          "pcommon",
 	itemType:             "float64",
 	testOrigVal:          "1, 2, 3",
-	testInterfaceOrigVal: []interface{}{1, 2, 3},
+	testInterfaceOrigVal: []any{1, 2, 3},
 	testSetVal:           "5",
 	testNewVal:           "1, 5, 3",
 }
@@ -193,7 +193,7 @@ var uInt64Slice = &primitiveSliceStruct{
 	packageName:          "pcommon",
 	itemType:             "uint64",
 	testOrigVal:          "1, 2, 3",
-	testInterfaceOrigVal: []interface{}{1, 2, 3},
+	testInterfaceOrigVal: []any{1, 2, 3},
 	testSetVal:           "5",
 	testNewVal:           "1, 5, 3",
 }
@@ -203,7 +203,7 @@ var int64Slice = &primitiveSliceStruct{
 	packageName:          "pcommon",
 	itemType:             "int64",
 	testOrigVal:          "1, 2, 3",
-	testInterfaceOrigVal: []interface{}{1, 2, 3},
+	testInterfaceOrigVal: []any{1, 2, 3},
 	testSetVal:           "5",
 	testNewVal:           "1, 5, 3",
 }
@@ -213,7 +213,7 @@ var int32Slice = &primitiveSliceStruct{
 	packageName:          "pcommon",
 	itemType:             "int32",
 	testOrigVal:          "1, 2, 3",
-	testInterfaceOrigVal: []interface{}{1, 2, 3},
+	testInterfaceOrigVal: []any{1, 2, 3},
 	testSetVal:           "5",
 	testNewVal:           "1, 5, 3",
 }
@@ -223,7 +223,7 @@ var stringSlice = &primitiveSliceStruct{
 	packageName:          "pcommon",
 	itemType:             "string",
 	testOrigVal:          `"a", "b", "c"`,
-	testInterfaceOrigVal: []interface{}{`"a"`, `"b"`, `"c"`},
+	testInterfaceOrigVal: []any{`"a"`, `"b"`, `"c"`},
 	testSetVal:           `"d"`,
 	testNewVal:           `"a", "d", "c"`,
 }

--- a/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
@@ -16,7 +16,7 @@ type primitiveSliceStruct struct {
 	itemType    string
 
 	testOrigVal          string
-	testInterfaceOrigVal []interface{}
+	testInterfaceOrigVal []any
 	testSetVal           string
 	testNewVal           string
 }

--- a/service/attributes.go
+++ b/service/attributes.go
@@ -9,8 +9,8 @@ import (
 	"go.opentelemetry.io/collector/service/telemetry"
 )
 
-func attributes(res *sdkresource.Resource, cfg telemetry.Config) map[string]interface{} {
-	attrs := map[string]interface{}{}
+func attributes(res *sdkresource.Resource, cfg telemetry.Config) map[string]any {
+	attrs := map[string]any{}
 	for _, r := range res.Attributes() {
 		attrs[string(r.Key)] = r.Value.AsString()
 	}

--- a/service/attributes_test.go
+++ b/service/attributes_test.go
@@ -18,35 +18,35 @@ func TestAttributes(t *testing.T) {
 		name           string
 		cfg            telemetry.Config
 		buildInfo      component.BuildInfo
-		wantAttributes map[string]interface{}
+		wantAttributes map[string]any
 	}{
 		{
 			name:           "no build info and no resource config",
 			cfg:            telemetry.Config{},
-			wantAttributes: map[string]interface{}{"service.name": "", "service.version": "", "service.instance.id": ""},
+			wantAttributes: map[string]any{"service.name": "", "service.version": "", "service.instance.id": ""},
 		},
 		{
 			name:           "build info and no resource config",
 			cfg:            telemetry.Config{},
 			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
-			wantAttributes: map[string]interface{}{"service.name": "otelcoltest", "service.version": "0.0.0-test", "service.instance.id": ""},
+			wantAttributes: map[string]any{"service.name": "otelcoltest", "service.version": "0.0.0-test", "service.instance.id": ""},
 		},
 		{
 			name:           "no build info and resource config",
 			cfg:            telemetry.Config{Resource: map[string]*string{"service.name": newPtr("resource.name"), "service.version": newPtr("resource.version"), "test": newPtr("test")}},
-			wantAttributes: map[string]interface{}{"service.name": "resource.name", "service.version": "resource.version", "test": "test", "service.instance.id": ""},
+			wantAttributes: map[string]any{"service.name": "resource.name", "service.version": "resource.version", "test": "test", "service.instance.id": ""},
 		},
 		{
 			name:           "build info and resource config",
 			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
 			cfg:            telemetry.Config{Resource: map[string]*string{"service.name": newPtr("resource.name"), "service.version": newPtr("resource.version"), "test": newPtr("test")}},
-			wantAttributes: map[string]interface{}{"service.name": "resource.name", "service.version": "resource.version", "test": "test", "service.instance.id": ""},
+			wantAttributes: map[string]any{"service.name": "resource.name", "service.version": "resource.version", "test": "test", "service.instance.id": ""},
 		},
 		{
 			name:           "deleting a nil value",
 			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
 			cfg:            telemetry.Config{Resource: map[string]*string{"service.name": nil, "service.version": newPtr("resource.version"), "test": newPtr("test")}},
-			wantAttributes: map[string]interface{}{"service.version": "resource.version", "test": "test", "service.instance.id": ""},
+			wantAttributes: map[string]any{"service.version": "resource.version", "test": "test", "service.instance.id": ""},
 		},
 	}
 	for _, tt := range tests {

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -285,7 +285,7 @@ func TestNotifyConfig(t *testing.T) {
 				Extensions: builders.NewExtension(tt.extensionsConfigs, tt.factories),
 			}, tt.serviceExtensions)
 			require.NoError(t, err)
-			errs := extensions.NotifyConfig(context.Background(), confmap.NewFromStringMap(map[string]interface{}{}))
+			errs := extensions.NotifyConfig(context.Background(), confmap.NewFromStringMap(map[string]any{}))
 			assert.Equal(t, tt.want, errs)
 		})
 	}


### PR DESCRIPTION
#### Description
Activates and apply use-any rule from revive to use any instead of interface{}

Also moves revive config later in the list to try to keep alphabetical order.