### PR TITLE
[chore] Merge freeze check uses title to find Release PRs

### DIFF
--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -11,7 +11,9 @@ jobs:
   check-merge-freeze:
     name: Check
     # This condition is to avoid blocking the PR causing the freeze in the first place.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'release:merge-freeze') }}
+    if: |
+      (!startsWith(github.event.pull_request.title || github.event.merge_group.head_commit.message, '[chore] Prepare release')) ||
+      (github.event.pull_request.user.login || github.event.merge_group.head_commit.author.name) != 'opentelemetrybot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -2,7 +2,7 @@ name: Merge freeze
 
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled, enqueued]
     branches: [main]
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -101,8 +101,7 @@ jobs:
       #   - Run make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0 MODSET=beta
       - name: Prepare release for core
         env:
-          BOT_GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
           REPO: open-telemetry/opentelemetry-collector
           CANDIDATE_BETA: ${{ inputs.candidate-beta }}
           CANDIDATE_STABLE: ${{ inputs.candidate-stable }}

--- a/.github/workflows/scripts/check-merge-freeze.sh
+++ b/.github/workflows/scripts/check-merge-freeze.sh
@@ -3,9 +3,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-BLOCKERS=$( gh pr list --search "label:release:merge-freeze" --json url --jq '.[].url' --repo "${REPO}" )
+BLOCKERS=$( gh pr list -A opentelemetrybot -S "[chore] Prepare release" --json url -q '.[].url' -R "${REPO}" )
 if [ "${BLOCKERS}" != "" ]; then
-    echo "Merging in main is frozen, as there are open PRs labeled 'release:merge-freeze': ${BLOCKERS}"
+    echo "Merging in main is frozen, as there are open \"Prepare release\" PRs: ${BLOCKERS}"
     echo "If you believe this is no longer true, re-run this job to unblock your PR."
     exit 1
 fi

--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -42,11 +42,8 @@ fi
 git push origin "${BRANCH}"
 
 # Use OpenTelemetryBot account to create PR, allowing workflows to run
-PR=$(GITHUB_TOKEN="$BOT_GITHUB_TOKEN" gh pr create --title "[chore] Prepare release ${RELEASE_VERSION}" --body "
+# The title must match the checks in check-merge-freeze.yml
+gh pr create --title "[chore] Prepare release ${RELEASE_VERSION}" --body "
 The following commands were run to prepare this release:
 ${COMMANDS}
-")
-
-# The `release:merge-freeze` label will cause the `check-merge-freeze` workflow to fail, enforcing the freeze.
-# The bot does not have permissions to add labels, so this is done using the CI action token.
-gh pr edit "$PR" --add-label release:merge-freeze || echo "Failed to add merge-freeze label"
+"


### PR DESCRIPTION
#### Description

The last attempt at making the Merge freeze check work in release PRs failed (#11906). This PR tries a different approach: it changes the criteria of the Merge freeze check, so that a freeze is enacted iff there is an open PR authored by @opentelemetrybot whose title contains "[chore] Prepare release" (note that if it weren't for the author, this PR would qualify).

This PR additionally reverts #11849, so no label is added to the release PR. I also added the `pull_request.enqueued` trigger, taking inspiration [from Merge Freeze](https://docs.mergefreeze.com/github-merge-queue#how-it-works), to see if it could help reject PRs earlier.

I tried to make sure the freeze check would be properly skipped for the release PR itself, both in PR checks and in the merge queue, but given the state of Github's documentation, I'm not very confident about this.

Notably, these is an edge case where I'm not sure what would happen: what if another PR gets added to the merge queue at the same time as the release PR? How many times would the "merge_group" check run, and with what values for "github.event.merge_group.head_commit"? Would both PR be booted out of the queue (not great)? Would both be accepted (way worse)? Does it depend on the order?

#### Link to tracking issue
Fixes #11906 and fixed #11808

#### Testing
As always with this, it's pretty much impossible to test before merging. Once merged, I strongly recommend we do the following test to make sure that this issue does not block the real release process again:
- Create two dummy PRs that change nothing of consequence: the freeze check should pass
- Run the "Prepare release" action
- Rerun the freeze check on one of the dummy PRs: it should now fail
- Approve the second PR and try to merge it: it should be booted out of the merge queue
- Close all test PRs

This unfortunately does not test whether the release PR gets merged properly, but I don't see how to test until the next release process, unfortunately.