### PR TITLE
[chore] Create gotest-with-junit Makefile target

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -169,7 +169,7 @@ jobs:
           key: unittest-${{ runner.os }}-${{ matrix.runner }}-go-build-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
         run: |
-          JUNIT_OUT_DIR=${{ github.workspace }}/internal/tools/testresults make -j4 gotest-with-junit
+          make -j4 gotest-with-junit
       - name: list files
         run: git ls-files . --exclude-standard --others
   unittest:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -168,8 +168,10 @@ jobs:
           path: ~/.cache/go-build
           key: unittest-${{ runner.os }}-${{ matrix.runner }}-go-build-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
+        env:
+          JUNIT_OUT_DIR: internal/tools/testresults/
         run: |
-          make -j4 gotest
+          JUNIT_OUT_DIR=${{ env.JUNIT_OUT_DIR }} make -j4 gotest-with-junit
   unittest:
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -169,7 +169,7 @@ jobs:
           key: unittest-${{ runner.os }}-${{ matrix.runner }}-go-build-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
         env:
-          JUNIT_OUT_DIR: internal/tools/testresults/
+          JUNIT_OUT_DIR: internal/tools/testresults
         run: |
           JUNIT_OUT_DIR=${{ env.JUNIT_OUT_DIR }} make -j4 gotest-with-junit
   unittest:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -168,10 +168,10 @@ jobs:
           path: ~/.cache/go-build
           key: unittest-${{ runner.os }}-${{ matrix.runner }}-go-build-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
-        env:
-          JUNIT_OUT_DIR: internal/tools/testresults
         run: |
-          JUNIT_OUT_DIR=${{ env.JUNIT_OUT_DIR }} make -j4 gotest-with-junit
+          JUNIT_OUT_DIR=${{ github.workspace }}/internal/tools/testresults make -j4 gotest-with-junit
+      - name: list files
+        run: git ls-files . --exclude-standard --others
   unittest:
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -170,8 +170,11 @@ jobs:
       - name: Run Unit Tests
         run: |
           make -j4 gotest-with-junit
-      - name: list files
-        run: git ls-files . --exclude-standard --others
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ runner.os }}-${{ matrix.runner }}-${{ matrix.go-version }}
+          path: internal/tools/testresults/
+          retention-days: 4
   unittest:
     if: always()
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ gotest-with-cover:
 	@$(MAKE) for-all-target TARGET="test-with-cover"
 	$(GOCMD) tool covdata textfmt -i=./coverage/unit -o ./coverage.txt
 
+.PHONY: gotest-with-junit
+gotest-with-junit:
+	@$(MAKE) for-all-target TARGET="test-with-junit"
+
 .PHONY: gotestifylint-fix
 gotestifylint-fix:
 	$(MAKE) for-all-target TARGET="testifylint-fix"

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -62,7 +62,7 @@ test-with-cover: $(GOTESTSUM)
 
 .PHONY: test-with-junit
 test-with-junit: $(GOTESTSUM)
-	mkdir -p $(TOOLS_MOD_DIR)/testresults
+	mkdir -p $(JUNIT_OUT_DIR)
 	$(GOTESTSUM) --packages="./..." --junitfile $(JUNIT_OUT_DIR)/$(CURR_MOD)-junit.xml -- $(GOTEST_OPT) ./...
 
 .PHONY: benchmark

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -22,6 +22,8 @@ TOOLS_PKG_NAMES := $(shell grep -E $(TOOLS_MOD_REGEX) < $(TOOLS_MOD_DIR)/tools.g
 TOOLS_BIN_NAMES := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(shell echo $(TOOLS_PKG_NAMES))))
 CHLOGGEN_CONFIG := .chloggen/config.yaml
 
+JUNIT_OUT_DIR ?= $(TOOLS_MOD_DIR)/testresults/
+
 ADDLICENSE   := $(TOOLS_BIN_DIR)/addlicense
 APIDIFF      := $(TOOLS_BIN_DIR)/apidiff
 CHECKFILE    := $(TOOLS_BIN_DIR)/checkfile
@@ -61,7 +63,7 @@ test-with-cover: $(GOTESTSUM)
 .PHONY: test-with-junit
 test-with-junit: $(GOTESTSUM)
 	mkdir -p $(TOOLS_MOD_DIR)/testresults
-	$(GOTESTSUM) --packages="./..." --junitfile $(TOOLS_MOD_DIR)/testresults/$(CURR_MOD)-junit.xml -- $(GOTEST_OPT) ./...
+	$(GOTESTSUM) --packages="./..." --junitfile $(JUNIT_OUT_DIR)/$(CURR_MOD)-junit.xml -- $(GOTEST_OPT) ./...
 
 .PHONY: benchmark
 benchmark: $(GOTESTSUM)

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -21,7 +21,7 @@ TOOLS_MOD_REGEX := "\s+_\s+\".*\""
 TOOLS_PKG_NAMES := $(shell grep -E $(TOOLS_MOD_REGEX) < $(TOOLS_MOD_DIR)/tools.go | tr -d " _\"" | grep -vE '/v[0-9]+$$')
 TOOLS_BIN_NAMES := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(shell echo $(TOOLS_PKG_NAMES))))
 CHLOGGEN_CONFIG := .chloggen/config.yaml
-
+# no trailing slash
 JUNIT_OUT_DIR ?= $(TOOLS_MOD_DIR)/testresults
 
 ADDLICENSE   := $(TOOLS_BIN_DIR)/addlicense

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -22,7 +22,7 @@ TOOLS_PKG_NAMES := $(shell grep -E $(TOOLS_MOD_REGEX) < $(TOOLS_MOD_DIR)/tools.g
 TOOLS_BIN_NAMES := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(shell echo $(TOOLS_PKG_NAMES))))
 CHLOGGEN_CONFIG := .chloggen/config.yaml
 
-JUNIT_OUT_DIR ?= $(TOOLS_MOD_DIR)/testresults/
+JUNIT_OUT_DIR ?= $(TOOLS_MOD_DIR)/testresults
 
 ADDLICENSE   := $(TOOLS_BIN_DIR)/addlicense
 APIDIFF      := $(TOOLS_BIN_DIR)/apidiff

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -4,6 +4,8 @@ ALL_PKGS := $(sort $(shell go list ./...))
 # COVER_PKGS is the list of packages to include in the coverage
 COVER_PKGS := $(shell go list ./... | tr "\n" ",")
 
+CURR_MOD := $(shell go list -m | tr '/' '-' )
+
 GOTEST_TIMEOUT?=240s
 GOTEST_OPT?= -race -timeout $(GOTEST_TIMEOUT)
 GOCMD?= go
@@ -55,6 +57,11 @@ test: $(GOTESTSUM)
 test-with-cover: $(GOTESTSUM)
 	mkdir -p $(PWD)/coverage/unit
 	$(GOTESTSUM) --packages="./..." -- $(GOTEST_OPT) -cover -covermode=atomic -coverpkg $(COVER_PKGS) -args -test.gocoverdir="$(PWD)/coverage/unit"
+
+.PHONY: test-with-junit
+test-with-junit: $(GOTESTSUM)
+	mkdir -p $(TOOLS_MOD_DIR)/testresults
+	$(GOTESTSUM) --packages="./..." --junitfile $(TOOLS_MOD_DIR)/testresults/$(CURR_MOD)-junit.xml -- $(GOTEST_OPT) ./...
 
 .PHONY: benchmark
 benchmark: $(GOTESTSUM)


### PR DESCRIPTION
Creates a target to output junit files from testing.  This PR also starts to use it in CI - we don't consume the Junits yet but it would be easy to add on.  This will be useful for a number of CI/Devx initiatives in the future.

My company, Datadog, plans to use this information to track the build stability of our code in contrib, as well as the stability of code we depend on here in collector.