### PR TITLE
[chore] call npm with ci instead of install

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Render .chloggen changelog entries
         run: make chlog-preview > changelog_preview.md
       - name: Install markdown-link-check
-        run: npm install
+        run: npm ci
       - name: Run markdown-link-check
         run: |
           npx --no -- markdown-link-check \

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -29,13 +29,13 @@ jobs:
       - name: Get changed files
         id: changes
         run: |
-            files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)
-            
-            if [ -z "$files" ] && git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep -q "package.json"; then
-              files="**/*.md"
-            fi
+          files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)
 
-            echo "files=$files" >> $GITHUB_OUTPUT
+          if [ -z "$files" ] && git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep -q "package.json"; then
+            files="**/*.md"
+          fi
+
+          echo "files=$files" >> $GITHUB_OUTPUT
   check-links:
     runs-on: ubuntu-latest
     needs: changedfiles
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install markdown-link-check
-        run: npm install
+        run: npm ci
 
       - name: Run markdown-link-check
         run: |


### PR DESCRIPTION
This is as recommended to address a warning about pinning npm install documented in https://github.com/ossf/scorecard/discussions/4422
