### PR TITLE
[chore] Remove impossible infinite workers use-case for Batcher

### DIFF
--- a/exporter/internal/queue/default_batcher_test.go
+++ b/exporter/internal/queue/default_batcher_test.go
@@ -28,10 +28,6 @@ func TestDefaultBatcher_NoSplit_MinThresholdZero_TimeoutDisabled(t *testing.T) {
 		maxWorkers int
 	}{
 		{
-			name:       "infinate_workers",
-			maxWorkers: 0,
-		},
-		{
 			name:       "one_worker",
 			maxWorkers: 1,
 		},
@@ -89,10 +85,6 @@ func TestDefaultBatcher_NoSplit_TimeoutDisabled(t *testing.T) {
 		name       string
 		maxWorkers int
 	}{
-		{
-			name:       "infinate_workers",
-			maxWorkers: 0,
-		},
 		{
 			name:       "one_worker",
 			maxWorkers: 1,
@@ -162,10 +154,6 @@ func TestDefaultBatcher_NoSplit_WithTimeout(t *testing.T) {
 		maxWorkers int
 	}{
 		{
-			name:       "infinate_workers",
-			maxWorkers: 0,
-		},
-		{
 			name:       "one_worker",
 			maxWorkers: 1,
 		},
@@ -230,10 +218,6 @@ func TestDefaultBatcher_Split_TimeoutDisabled(t *testing.T) {
 		name       string
 		maxWorkers int
 	}{
-		{
-			name:       "infinate_workers",
-			maxWorkers: 0,
-		},
 		{
 			name:       "one_worker",
 			maxWorkers: 1,

--- a/exporter/internal/queue/disabled_batcher_test.go
+++ b/exporter/internal/queue/disabled_batcher_test.go
@@ -27,10 +27,6 @@ func TestDisabledBatcher_Basic(t *testing.T) {
 		maxWorkers int
 	}{
 		{
-			name:       "infinate_workers",
-			maxWorkers: 0,
-		},
-		{
 			name:       "one_worker",
 			maxWorkers: 1,
 		},


### PR DESCRIPTION
It is impossible to configure infinite workers today, see https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterqueue/config.go#L41