### PR TITLE
[chore]: reenable default revive rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,7 +107,50 @@ linters-settings:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.8
     rules:
+      # Blank import should be only in a main or test package, or have a comment justifying it.
+      - name: blank-imports
+      # context.Context() should be the first parameter of a function when provided as argument.
+      - name: context-as-argument
+      # Basic types should not be used as a key in `context.WithValue`
+      - name: context-keys-type
+      # Importing with `.` makes the programs much harder to understand
+      - name: dot-imports
+      # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+      - name: empty-block
+      # for better readability, variables of type `error` must be named with the prefix `err`.
+      - name: error-naming
+      # for better readability, the errors should be last in the list of returned values by a function.
+      - name: error-return
+      # for better readability, error messages should not be capitalized or end with punctuation or a newline.
+      - name: error-strings
+      # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+      - name: errorf
+      # incrementing an integer variable by 1 is recommended to be done using the `++` operator
+      - name: increment-decrement
+      # highlights redundant else-blocks that can be eliminated from the code
+      - name: indent-error-flow
+      # This rule suggests a shorter way of writing ranges that do not use the second value.
+      - name: range
+      # receiver names in a method should reflect the struct name (p for Person, for example)
+      - name: receiver-naming
+      # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
+      - name: redefines-builtin-id
+      # redundant else-blocks that can be eliminated from the code.
+      - name: superfluous-else
+      # prevent confusing name for variables when using `time` package
+      - name: time-naming
+      # warns when an exported function or method returns a value of an un-exported type.
+      - name: unexported-return
+      # spots and proposes to remove unreachable code. also helps to spot errors
+      - name: unreachable-code
+      # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+      - name: unused-parameter
+      # Since Go 1.18, interface{} has an alias: any. This rule proposes to replace instances of interface{} with any.
       - name: use-any
+      # report when a variable declaration can be simplified
+      - name: var-declaration
+      # warns when initialism, variable or package naming conventions are not followed.
+      - name: var-naming
 
   depguard:
     rules:

--- a/client/doc_test.go
+++ b/client/doc_test.go
@@ -15,7 +15,7 @@ import (
 
 func Example_receiver() {
 	// Your receiver get a next consumer when it's constructed
-	next, err := consumer.NewTraces(func(ctx context.Context, td ptrace.Traces) error {
+	next, err := consumer.NewTraces(func(_ context.Context, _ ptrace.Traces) error {
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
#### Description

By default revive enables a list of rules. 
When a list of rules are defined thay are the only one enabled.
This reenable this default list