### PR TITLE
[confmap] Automatically invoke `Validate()` during `Conf.Unmarshal`

### DIFF
--- a/.chloggen/tyler.confmap-configvalidator.yaml
+++ b/.chloggen/tyler.confmap-configvalidator.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ability for confmap to invoke `ConfigValidator.Validate` as part of `conf.Unmarshal`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12031]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/knadh/koanf/maps"
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/v2"
+	"go.uber.org/multierr"
 
 	encoder "go.opentelemetry.io/collector/confmap/internal/mapstructure"
 )
@@ -77,6 +78,77 @@ func (fn unmarshalOptionFunc) apply(set *unmarshalOption) {
 	fn(set)
 }
 
+// ConfigValidator defines an optional interface for configurations to implement to do validation.
+type ConfigValidator interface {
+	// Validate the configuration and returns an error if invalid.
+	Validate() error
+}
+
+// As interface types are only used for static typing, a common idiom to find the reflection Type
+// for an interface type Foo is to use a *Foo value.
+var configValidatorType = reflect.TypeOf((*ConfigValidator)(nil)).Elem()
+
+func validate(v reflect.Value) error {
+	// Validate the value itself.
+	k := v.Kind()
+	switch k {
+	case reflect.Invalid:
+		return nil
+	case reflect.Ptr, reflect.Interface:
+		return validate(v.Elem())
+	case reflect.Struct:
+		var errs error
+		errs = multierr.Append(errs, callValidateIfPossible(v))
+		// Reflect on the pointed data and check each of its fields.
+		for i := 0; i < v.NumField(); i++ {
+			if !v.Type().Field(i).IsExported() {
+				continue
+			}
+			errs = multierr.Append(errs, validate(v.Field(i)))
+		}
+		return errs
+	case reflect.Slice, reflect.Array:
+		var errs error
+		errs = multierr.Append(errs, callValidateIfPossible(v))
+		// Reflect on the pointed data and check each of its fields.
+		for i := 0; i < v.Len(); i++ {
+			errs = multierr.Append(errs, validate(v.Index(i)))
+		}
+		return errs
+	case reflect.Map:
+		var errs error
+		errs = multierr.Append(errs, callValidateIfPossible(v))
+		iter := v.MapRange()
+		for iter.Next() {
+			errs = multierr.Append(errs, validate(iter.Key()))
+			errs = multierr.Append(errs, validate(iter.Value()))
+		}
+		return errs
+	default:
+		return callValidateIfPossible(v)
+	}
+}
+
+func callValidateIfPossible(v reflect.Value) error {
+	// If the value type implements ConfigValidator just call Validate
+	if v.Type().Implements(configValidatorType) {
+		return v.Interface().(ConfigValidator).Validate()
+	}
+
+	// If the pointer type implements ConfigValidator call Validate on the pointer to the current value.
+	if reflect.PointerTo(v.Type()).Implements(configValidatorType) {
+		// If not addressable, then create a new *V pointer and set the value to current v.
+		if !v.CanAddr() {
+			pv := reflect.New(reflect.PointerTo(v.Type()).Elem())
+			pv.Elem().Set(v)
+			v = pv.Elem()
+		}
+		return v.Addr().Interface().(ConfigValidator).Validate()
+	}
+
+	return nil
+}
+
 // Unmarshal unmarshalls the config into a struct using the given options.
 // Tags on the fields of the structure must be properly set.
 func (l *Conf) Unmarshal(result any, opts ...UnmarshalOption) error {
@@ -84,7 +156,11 @@ func (l *Conf) Unmarshal(result any, opts ...UnmarshalOption) error {
 	for _, opt := range opts {
 		opt.apply(&set)
 	}
-	return decodeConfig(l, result, !set.ignoreUnused, l.skipTopLevelUnmarshaler)
+	err := decodeConfig(l, result, !set.ignoreUnused, l.skipTopLevelUnmarshaler)
+	if err != nil {
+		return err
+	}
+	return validate(reflect.ValueOf(result))
 }
 
 type marshalOption struct{}

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -60,7 +60,8 @@ type UnmarshalOption interface {
 }
 
 type unmarshalOption struct {
-	ignoreUnused bool
+	ignoreUnused   bool
+	invokeValidate bool
 }
 
 // WithIgnoreUnused sets an option to ignore errors if existing
@@ -69,6 +70,16 @@ type unmarshalOption struct {
 func WithIgnoreUnused() UnmarshalOption {
 	return unmarshalOptionFunc(func(uo *unmarshalOption) {
 		uo.ignoreUnused = true
+	})
+}
+
+// WithInvokeValidate sets an option to invoke the Validate method
+// of unmarshalled types that implement ConfigValidator.
+// When used, config validation with be executed automatically
+// as part of unmarshalling.
+func WithInvokeValidate() UnmarshalOption {
+	return unmarshalOptionFunc(func(uo *unmarshalOption) {
+		uo.invokeValidate = true
 	})
 }
 
@@ -160,7 +171,11 @@ func (l *Conf) Unmarshal(result any, opts ...UnmarshalOption) error {
 	if err != nil {
 		return err
 	}
-	return validate(reflect.ValueOf(result))
+
+	if set.invokeValidate {
+		return validate(reflect.ValueOf(result))
+	}
+	return nil
 }
 
 type marshalOption struct{}


### PR DESCRIPTION
#### Description

Duplicate `component.ConfigValidator` into `confmap`.  Add capability for `ConfigValidator.Validate` to be invoked as part of unmarshal. Add a new `UnmarshalOption` to allow controlling if validation is invoked.

If we like this feature, we'll need to do some refactoring to how `otelcol` unmarshals if we want to take advantage of it. See https://github.com/open-telemetry/opentelemetry-collector/issues/11524#issuecomment-2574045326. After implementing it I'm still not convinced this solution is better than what we already have.

#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/11524

#### Testing

Added new unit tests.  Tested manually using local build.

#### Documentation

Added godoc comments.