### PR TITLE
[chore] Fix check merge freeze job

### DIFF
--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -24,7 +24,7 @@ jobs:
     # This condition is to avoid blocking the PR causing the freeze in the first place.
     if: |
       (!startsWith(github.event.pull_request.title || github.event.merge_group.head_commit.message, '[chore] Prepare release')) ||
-      (github.event.pull_request.user.login || github.event.merge_group.head_commit.author.name) != 'opentelemetrybot'
+      (github.event.pull_request.user.name || github.event.merge_group.head_commit.author.name) != 'OpenTelemetry Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
To unblock https://github.com/open-telemetry/opentelemetry-collector/pull/12043, which is always rejected on the queue.

Apparently, `github.event.merge_group.head_commit.author.name` is `OpenTelemetry Bot` not `opentelemetrybot`. See https://github.com/open-telemetry/opentelemetry-collector/actions/runs/12658978490/job/35277057933. 

Since `github.event.merge_group.head_commit.author` doesn't have `login` field, I've switched the condition to use the `name` field on both `github.event.pull_request.user` and  `github.event.merge_group.head_commit.author`