### PR TITLE
[chore] Fix check merge freeze job again

### DIFF
--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -24,7 +24,7 @@ jobs:
     # This condition is to avoid blocking the PR causing the freeze in the first place.
     if: |
       (!startsWith(github.event.pull_request.title || github.event.merge_group.head_commit.message, '[chore] Prepare release')) ||
-      (github.event.pull_request.user.name || github.event.merge_group.head_commit.author.name) != 'OpenTelemetry Bot'
+      (!(github.event.pull_request.user.login == 'opentelemetrybot' || github.event.merge_group.head_commit.author.name == 'OpenTelemetry Bot'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
In https://github.com/open-telemetry/opentelemetry-collector/pull/12045, I assumed that `github.event.pull_request.user.name` would be present, but apparently it's empty. So we need to switch back to using `github.event.pull_request.user.login`.

This fix is already applied in https://github.com/open-telemetry/opentelemetry-collector/pull/12043