### PR TITLE
Support unix socket for OTLP with gRPC export of internal telemetry

### DIFF
--- a/.chloggen/intenal-telemetry-unix.yaml
+++ b/.chloggen/intenal-telemetry-unix.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: support unix socket as internal telemetry endpoint for the gRPC OTLP exporter
+
+# One or more tracking issues or pull requests related to the change
+issues: [12059]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/service/telemetry/internal/otelinit/config.go
+++ b/service/telemetry/internal/otelinit/config.go
@@ -208,7 +208,9 @@ func initPeriodicExporter(ctx context.Context, exporter config.MetricExporter, o
 }
 
 func normalizeEndpoint(endpoint string) string {
-	if !strings.HasPrefix(endpoint, "https://") && !strings.HasPrefix(endpoint, "http://") {
+	if !strings.HasPrefix(endpoint, "https://") &&
+		!strings.HasPrefix(endpoint, "http://") &&
+		!strings.HasPrefix(endpoint, "unix:") {
 		return "http://" + endpoint
 	}
 	return endpoint
@@ -273,6 +275,9 @@ func initOTLPHTTPExporter(ctx context.Context, otlpConfig *config.OTLPMetric) (s
 		u, err := url.ParseRequestURI(normalizeEndpoint(otlpConfig.Endpoint))
 		if err != nil {
 			return nil, err
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, fmt.Errorf("unsupported scheme %q", u.Scheme)
 		}
 		opts = append(opts, otlpmetrichttp.WithEndpoint(u.Host))
 

--- a/service/telemetry/internal/otelinit/config_test.go
+++ b/service/telemetry/internal/otelinit/config_test.go
@@ -412,6 +412,25 @@ func TestMetricReader(t *testing.T) {
 			wantReader: sdkmetric.NewPeriodicReader(otlpHTTPExporter),
 		},
 		{
+			name: "periodic/otlp-http-exporter-unix-socket-endpoint",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "http/protobuf",
+							Endpoint:    "unix:collector.sock",
+							Compression: strPtr("gzip"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("unsupported scheme \"unix\""),
+		},
+		{
 			name: "periodic/otlp-http-invalid-endpoint",
 			reader: config.MetricReader{
 				Periodic: &config.PeriodicMetricReader{
@@ -528,6 +547,25 @@ func TestMetricReader(t *testing.T) {
 				},
 			},
 			wantErr: errors.New("unsupported temporality preference \"invalid\""),
+		},
+		{
+			name: "periodic/otlp-http-unix-socket-endpoint",
+			reader: config.MetricReader{
+				Periodic: &config.PeriodicMetricReader{
+					Exporter: config.MetricExporter{
+						OTLP: &config.OTLPMetric{
+							Protocol:    "grpc/protobuf",
+							Endpoint:    "unix:collector.sock",
+							Compression: strPtr("gzip"),
+							Timeout:     intPtr(1000),
+							Headers: map[string]string{
+								"test": "test1",
+							},
+						},
+					},
+				},
+			},
+			wantReader: sdkmetric.NewPeriodicReader(otlpGRPCExporter),
 		},
 		{
 			name: "periodic/otlp-grpc-good-ca-certificate",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This allows specifying a unix socket for the internal telemetry OTLP endpoint, when using gRPC.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #11941
