### PR TITLE
[chore]: enable early-return from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,6 +115,9 @@ linters-settings:
       - name: context-keys-type
       # Importing with `.` makes the programs much harder to understand
       - name: dot-imports
+      - name: early-return
+        arguments:
+          - "preserveScope"
       # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
       - name: empty-block
       # for better readability, variables of type `error` must be named with the prefix `err`.
@@ -137,6 +140,8 @@ linters-settings:
       - name: redefines-builtin-id
       # redundant else-blocks that can be eliminated from the code.
       - name: superfluous-else
+        arguments:
+          - "preserveScope"
       # prevent confusing name for variables when using `time` package
       - name: time-naming
       # warns when an exported function or method returns a value of an un-exported type.

--- a/processor/memorylimiterprocessor/internal/mock_exporter.go
+++ b/processor/memorylimiterprocessor/internal/mock_exporter.go
@@ -28,13 +28,12 @@ func (e *MockExporter) Capabilities() consumer.Capabilities {
 func (e *MockExporter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	e.acceptedLogCount.Add(int64(ld.LogRecordCount()))
 
-	if e.destAvailable.Load() {
-		// Destination is available, immediately deliver.
-		e.deliveredLogCount.Add(int64(ld.LogRecordCount()))
-	} else {
+	if !e.destAvailable.Load() {
 		// Destination is not available. Queue the logs in the exporter.
 		return e.Logs.ConsumeLogs(ctx, ld)
 	}
+	// Destination is available, immediately deliver.
+	e.deliveredLogCount.Add(int64(ld.LogRecordCount()))
 	return nil
 }
 

--- a/service/extensions/graph.go
+++ b/service/extensions/graph.go
@@ -40,11 +40,11 @@ func computeOrder(exts *Extensions) ([]component.ID, error) {
 		n := nodes[extID]
 		if dep, ok := ext.(extensioncapabilities.Dependent); ok {
 			for _, depID := range dep.Dependencies() {
-				if d, ok := nodes[depID]; ok {
-					graph.SetEdge(graph.NewEdge(d, n))
-				} else {
+				d, ok := nodes[depID]
+				if !ok {
 					return nil, fmt.Errorf("unable to find extension %s on which extension %s depends", depID, extID)
 				}
+				graph.SetEdge(graph.NewEdge(d, n))
 			}
 		}
 	}


### PR DESCRIPTION
#### Description 

[early-return](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return): In Go it is idiomatic to minimize nesting statements, a typical example is to avoid if-then-else constructions.