### PR TITLE
[chore]: enable unnecessary-stmt from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,6 +146,7 @@ linters-settings:
       - name: time-naming
       # warns when an exported function or method returns a value of an un-exported type.
       - name: unexported-return
+      - name: unnecessary-stmt
       # spots and proposes to remove unreachable code. also helps to spot errors
       - name: unreachable-code
       # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.

--- a/service/telemetry/internal/otelinit/config.go
+++ b/service/telemetry/internal/otelinit/config.go
@@ -239,7 +239,6 @@ func initOTLPgRPCExporter(ctx context.Context, otlpConfig *config.OTLPMetric) (s
 		case "gzip":
 			opts = append(opts, otlpmetricgrpc.WithCompressor(*otlpConfig.Compression))
 		case "none":
-			break
 		default:
 			return nil, fmt.Errorf("unsupported compression %q", *otlpConfig.Compression)
 		}


### PR DESCRIPTION
#### Description 

[unnecessary-stmt](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt): This rule suggests to remove redundant statements like a break at the end of a case block, for improving the code's readability.