### PR TITLE
[chore] [processor/memory_limiter] docs: fix default value of `spike_limit_percentage`

### DIFF
--- a/processor/memorylimiterprocessor/README.md
+++ b/processor/memorylimiterprocessor/README.md
@@ -101,7 +101,7 @@ This option is used to calculate `memory_limit` from the total available memory.
 For instance setting of 75% with the total memory of 1GiB will result in the limit of 750 MiB.
 The fixed memory setting (`limit_mib`) takes precedence
 over the percentage configuration.
-- `spike_limit_percentage` (default = 0): Maximum spike expected between the
+- `spike_limit_percentage` (default = 20% of `limit_percentage`): Maximum spike expected between the
 measurements of memory usage. The value must be less than `limit_percentage`.
 This option is used to calculate `spike_limit_mib` from the total available memory.
 For instance setting of 25% with the total memory of 1GiB will result in the spike limit of 250MiB.


### PR DESCRIPTION
Verified with this config:

```yaml
processors:
  memory_limiter:
    check_interval: 1s
    limit_percentage: 50
```

Output:

```console
2025-01-10T10:55:58.072+0100    info    memorylimiter@v0.117.0/memorylimiter.go:151     Using percentage memory limiter {"kind": "processor", "name": "memory_limiter", "pipeline": "logs", "total_memory_mib": 31755, "limit_percentage": 50, "spike_limit_percentage": 0}
2025-01-10T10:55:58.072+0100    info    memorylimiter@v0.117.0/memorylimiter.go:75      Memory limiter configured       {"kind": "processor", "name": "memory_limiter", "pipeline": "logs", "limit_mib": 15877, "spike_limit_mib": 3175, "check_interval": 1}
```