### PR TITLE
[otelcoltest] Add DefaultScheme to test ConfigProvider

### DIFF
--- a/.chloggen/mx-psi_default-provider.yaml
+++ b/.chloggen/mx-psi_default-provider.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otelcoltest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set `DefaultScheme` to `env` in the test `ConfigProvider` to replicate the default provider used by the Collector.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12066]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/otelcol/otelcoltest/config.go
+++ b/otelcol/otelcoltest/config.go
@@ -25,6 +25,7 @@ func LoadConfig(fileName string, factories otelcol.Factories) (*otelcol.Config, 
 				yamlprovider.NewFactory(),
 				httpprovider.NewFactory(),
 			},
+			DefaultScheme: "env",
 		},
 	})
 	if err != nil {

--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -88,7 +88,7 @@ func TestLoadConfigEnv(t *testing.T) {
 			cfg, err := LoadConfigAndValidate(tt.file, factories)
 			require.NoError(t, err)
 
-			assert.Equal(t, cfg.Service.Pipelines[pipeline.NewID(pipeline.SignalTraces)].Receivers, []component.ID{component.MustNewID("nop")})
+			assert.Equal(t, []component.ID{component.MustNewID("nop")}, cfg.Service.Pipelines[pipeline.NewID(pipeline.SignalTraces)].Receivers)
 		})
 	}
 }

--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -72,3 +72,23 @@ func TestLoadConfigAndValidate(t *testing.T) {
 
 	assert.Equal(t, cfg, cfgValidate)
 }
+
+func TestLoadConfigEnv(t *testing.T) {
+	factories, err := NopFactories()
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		file string
+	}{
+		{file: filepath.Join("testdata", "config_env.yaml")},
+		{file: filepath.Join("testdata", "config_default_scheme.yaml")},
+	} {
+		t.Run(tt.file, func(t *testing.T) {
+			t.Setenv("RECEIVERS", "[nop]")
+			cfg, err := LoadConfigAndValidate(tt.file, factories)
+			require.NoError(t, err)
+
+			assert.Equal(t, cfg.Service.Pipelines[pipeline.NewID(pipeline.SignalTraces)].Receivers, []component.ID{component.MustNewID("nop")})
+		})
+	}
+}

--- a/otelcol/otelcoltest/testdata/config_default_scheme.yaml
+++ b/otelcol/otelcoltest/testdata/config_default_scheme.yaml
@@ -1,0 +1,11 @@
+receivers:
+    nop:
+
+exporters:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: ${RECEIVERS}
+            exporters: [nop]

--- a/otelcol/otelcoltest/testdata/config_env.yaml
+++ b/otelcol/otelcoltest/testdata/config_env.yaml
@@ -1,0 +1,11 @@
+receivers:
+    nop:
+
+exporters:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: ${env:RECEIVERS}
+            exporters: [nop]


### PR DESCRIPTION
#### Description

<!-- Issue number if applicable -->

Adds `DefaultScheme` to test `otelcol.ConfigProvider`, so that the test behavior is equivalent to the real thing.

#### Link to tracking issue

Relates to open-telemetry/opentelemetry-collector-contrib/pull/37122

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->

Added a test that failed before adding the DefaultScheme.
