### PR TITLE
[chore] Add test to validate expected component instances

### DIFF
--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -302,7 +302,7 @@ func (g *Graph) buildComponents(ctx context.Context, set Settings) error {
 				MutatesData: g.pipelines[n.pipelineID].fanOutNode.getConsumer().Capabilities().MutatesData,
 			}
 			for _, proc := range g.pipelines[n.pipelineID].processors {
-				capability.MutatesData = capability.MutatesData || proc.getConsumer().Capabilities().MutatesData
+				capability.MutatesData = capability.MutatesData || proc.(*processorNode).getConsumer().Capabilities().MutatesData
 			}
 			next := g.nextConsumers(n.ID())[0]
 			switch n.pipelineID.Signal() {
@@ -379,7 +379,7 @@ type pipelineNodes struct {
 	*capabilitiesNode
 
 	// The order of processors is very important. Therefore use a slice for processors.
-	processors []*processorNode
+	processors []graph.Node
 
 	// Emits to exporters.
 	*fanOutNode

--- a/service/internal/graph/zpages.go
+++ b/service/internal/graph/zpages.go
@@ -41,7 +41,7 @@ func (g *Graph) HandleZPages(w http.ResponseWriter, r *http.Request) {
 		}
 		procIDs := make([]string, 0, len(p.processors))
 		for _, c := range p.processors {
-			procIDs = append(procIDs, c.componentID.String())
+			procIDs = append(procIDs, c.(*processorNode).componentID.String())
 		}
 		exprIDs := make([]string, 0, len(p.exporters))
 		for _, c := range p.exporters {


### PR DESCRIPTION
Subset of #12057

This PR adds a test to validate the expected number of instances of each component. This framework becomes more useful once singleton components are explicitly supported.