### PR TITLE
[chore] Add `local` folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin/
 dist/
 .tools/
+local
 
 # GoLand IDEA
 /.idea/


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Contrib has this folder, and I find it helpful for stashing working files (e.g. config files) for testing running the Collector from a binary.

Happy to take another approach if someone is doing something else to store files used to test the Collector locally.
