### PR TITLE
[POC][exporter] exporter batcher - byte size based batching

### DIFF
--- a/exporter/exporterbatcher/config.go
+++ b/exporter/exporterbatcher/config.go
@@ -31,6 +31,7 @@ type MinSizeConfig struct {
 	// sent regardless of the timeout. There is no guarantee that the batch size always greater than this value.
 	// This option requires the Request to implement RequestItemsCounter interface. Otherwise, it will be ignored.
 	MinSizeItems int `mapstructure:"min_size_items"`
+	MinSizeBytes int `mapstructure:"min_size_bytes"`
 }
 
 // MaxSizeConfig defines the configuration for the maximum number of items in a batch.
@@ -41,17 +42,31 @@ type MaxSizeConfig struct {
 	// If the batch size exceeds this value, it will be broken up into smaller batches if possible.
 	// Setting this value to zero disables the maximum size limit.
 	MaxSizeItems int `mapstructure:"max_size_items"`
+	MaxSizeBytes int `mapstructure:"max_size_bytes"`
 }
 
 func (c Config) Validate() error {
+	if c.MinSizeBytes != 0 && c.MinSizeItems != 0 || c.MinSizeBytes != 0 && c.MaxSizeItems != 0 || c.MinSizeItems != 0 && c.MaxSizeBytes != 0 {
+		return errors.New("size limit and bytes limit cannot be specified at the same time")
+	}
+
 	if c.MinSizeItems < 0 {
 		return errors.New("min_size_items must be greater than or equal to zero")
+	}
+	if c.MinSizeBytes < 0 {
+		return errors.New("min_size_bytes must be greater than or equal to zero")
 	}
 	if c.MaxSizeItems < 0 {
 		return errors.New("max_size_items must be greater than or equal to zero")
 	}
+	if c.MaxSizeBytes < 0 {
+		return errors.New("max_size_bytes must be greater than or equal to zero")
+	}
 	if c.MaxSizeItems != 0 && c.MaxSizeItems < c.MinSizeItems {
 		return errors.New("max_size_items must be greater than or equal to min_size_items")
+	}
+	if c.MaxSizeBytes != 0 && c.MaxSizeBytes < c.MinSizeBytes {
+		return errors.New("max_size_bytes must be greater than or equal to min_size_bytes")
 	}
 	if c.FlushTimeout <= 0 {
 		return errors.New("timeout must be greater than zero")

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -418,6 +418,10 @@ func (mer *mockErrorRequest) ItemsCount() int {
 	return 7
 }
 
+func (mer *mockErrorRequest) ByteSize() int {
+	return 7
+}
+
 func (mer *mockErrorRequest) MergeSplit(context.Context, exporterbatcher.MaxSizeConfig, internal.Request) ([]internal.Request, error) {
 	return nil, nil
 }
@@ -461,6 +465,10 @@ func (m *mockRequest) checkNumRequests(t *testing.T, want int) {
 }
 
 func (m *mockRequest) ItemsCount() int {
+	return m.cnt
+}
+
+func (m *mockRequest) ByteSize() int {
 	return m.cnt
 }
 

--- a/exporter/exporterhelper/logs_batch.go
+++ b/exporter/exporterhelper/logs_batch.go
@@ -6,6 +6,7 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 import (
 	"context"
 	"errors"
+	math_bits "math/bits"
 
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -23,11 +24,144 @@ func (req *logsRequest) MergeSplit(_ context.Context, cfg exporterbatcher.MaxSiz
 		}
 	}
 
-	if cfg.MaxSizeItems == 0 {
-		req2.ld.ResourceLogs().MoveAndAppendTo(req.ld.ResourceLogs())
+	if cfg.MaxSizeItems == 0 && cfg.MaxSizeBytes == 0 {
+		if req2 != nil {
+			req2.ld.ResourceLogs().MoveAndAppendTo(req.ld.ResourceLogs())
+		}
 		return []Request{req}, nil
 	}
+	if cfg.MaxSizeBytes > 0 {
+		return req.mergeSplitBasedOnByteSize(cfg, req2)
+	}
+	return req.mergeSplitBasedOnItemCount(cfg, req2)
+}
 
+func (req *logsRequest) mergeSplitBasedOnByteSize(cfg exporterbatcher.MaxSizeConfig, req2 *logsRequest) ([]Request, error) {
+	var (
+		res          []Request
+		destReq      *logsRequest
+		capacityLeft = cfg.MaxSizeBytes
+	)
+	for _, srcReq := range []*logsRequest{req, req2} {
+		if srcReq == nil {
+			continue
+		}
+
+		ByteSize := srcReq.ByteSize()
+		if ByteSize <= capacityLeft {
+			if destReq == nil {
+				destReq = srcReq
+			} else {
+				destReq.updateCachedByteSize(ByteSize)
+				srcReq.ld.ResourceLogs().MoveAndAppendTo(destReq.ld.ResourceLogs())
+			}
+			capacityLeft -= ByteSize
+			continue
+		}
+
+		for {
+			srcReq.invalidateCachedByteSize()
+			extractedLogs, capacityReached := extractLogsBasedOnByteSize(srcReq.ld, capacityLeft)
+
+			if extractedLogs.LogRecordCount() == 0 {
+				break
+			}
+			if destReq == nil {
+				destReq = &logsRequest{
+					ld:     extractedLogs,
+					pusher: srcReq.pusher,
+				}
+			} else {
+				destReq.updateCachedByteSize(logsMarshaler.LogsSize(extractedLogs))
+				extractedLogs.ResourceLogs().MoveAndAppendTo(destReq.ld.ResourceLogs())
+			}
+			// Create new batch once capacity is reached.
+			if capacityReached {
+				res = append(res, destReq)
+				destReq = nil
+				capacityLeft = cfg.MaxSizeBytes
+			} else {
+				capacityLeft = cfg.MaxSizeBytes - destReq.ByteSize()
+			}
+		}
+	}
+
+	if destReq != nil {
+		res = append(res, destReq)
+	}
+	return res, nil
+}
+
+// extractLogs extracts logs from the input logs and returns a new logs with the specified number of log records.
+func extractLogsBasedOnByteSize(srcLogs plog.Logs, capacity int) (plog.Logs, bool) {
+	capacityReached := false
+	destLogs := plog.NewLogs()
+	capacityLeft := capacity - logsMarshaler.LogsSize(destLogs)
+	srcLogs.ResourceLogs().RemoveIf(func(srcRL plog.ResourceLogs) bool {
+		if capacityReached {
+			return false
+		}
+		needToExtract := logsMarshaler.ResourceLogsSize(srcRL) > capacityLeft
+		if needToExtract {
+			srcRL, capacityReached = extractResourceLogsBasedOnByteSize(srcRL, capacityLeft)
+			if srcRL.ScopeLogs().Len() == 0 {
+				return false
+			}
+		}
+		capacityLeft -= deltaCapacity(logsMarshaler.ResourceLogsSize(srcRL))
+		srcRL.MoveTo(destLogs.ResourceLogs().AppendEmpty())
+		return !needToExtract
+	})
+	return destLogs, capacityReached
+}
+
+// extractResourceLogs extracts resource logs and returns a new resource logs with the specified number of log records.
+func extractResourceLogsBasedOnByteSize(srcRL plog.ResourceLogs, capacity int) (plog.ResourceLogs, bool) {
+	capacityReached := false
+	destRL := plog.NewResourceLogs()
+	destRL.SetSchemaUrl(srcRL.SchemaUrl())
+	srcRL.Resource().CopyTo(destRL.Resource())
+	capacityLeft := capacity - logsMarshaler.ResourceLogsSize(destRL)
+	srcRL.ScopeLogs().RemoveIf(func(srcSL plog.ScopeLogs) bool {
+		if capacityReached {
+			return false
+		}
+		needToExtract := logsMarshaler.ScopeLogsSize(srcSL) > capacityLeft
+		if needToExtract {
+			srcSL, capacityReached = extractScopeLogsBasedOnByteSize(srcSL, capacityLeft)
+			if srcSL.LogRecords().Len() == 0 {
+				return false
+			}
+		}
+
+		capacityLeft -= deltaCapacity(logsMarshaler.ScopeLogsSize(srcSL))
+		srcSL.MoveTo(destRL.ScopeLogs().AppendEmpty())
+		return !needToExtract
+	})
+	return destRL, capacityReached
+}
+
+// extractScopeLogs extracts scope logs and returns a new scope logs with the specified number of log records.
+func extractScopeLogsBasedOnByteSize(srcSL plog.ScopeLogs, capacity int) (plog.ScopeLogs, bool) {
+	capacityReached := false
+	destSL := plog.NewScopeLogs()
+	destSL.SetSchemaUrl(srcSL.SchemaUrl())
+	srcSL.Scope().CopyTo(destSL.Scope())
+	capacityLeft := capacity - logsMarshaler.ScopeLogsSize(destSL)
+
+	srcSL.LogRecords().RemoveIf(func(srcLR plog.LogRecord) bool {
+		if capacityReached || logsMarshaler.LogRecordSize(srcLR) > capacityLeft {
+			capacityReached = true
+			return false
+		}
+		capacityLeft -= deltaCapacity(logsMarshaler.LogRecordSize(srcLR))
+		srcLR.MoveTo(destSL.LogRecords().AppendEmpty())
+		return true
+	})
+	return destSL, capacityReached
+}
+
+func (req *logsRequest) mergeSplitBasedOnItemCount(cfg exporterbatcher.MaxSizeConfig, req2 *logsRequest) ([]Request, error) {
 	var (
 		res          []Request
 		destReq      *logsRequest
@@ -73,6 +207,11 @@ func (req *logsRequest) MergeSplit(_ context.Context, cfg exporterbatcher.MaxSiz
 		res = append(res, destReq)
 	}
 	return res, nil
+}
+
+// deltaCapacity() returns the delta size of a proto slice when a new item is added.
+func deltaCapacity(newItemSize int) int {
+	return 1 + newItemSize + int(math_bits.Len64(uint64(newItemSize|1)+6)/7)
 }
 
 // extractLogs extracts logs from the input logs and returns a new logs with the specified number of log records.

--- a/exporter/exporterhelper/logs_batch_test.go
+++ b/exporter/exporterhelper/logs_batch_test.go
@@ -31,7 +31,7 @@ func TestMergeLogsInvalidInput(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMergeSplitLogs(t *testing.T) {
+func TestMergeSplitLogsBasedOnItemCount(t *testing.T) {
 	tests := []struct {
 		name     string
 		cfg      exporterbatcher.MaxSizeConfig
@@ -123,7 +123,7 @@ func TestMergeSplitLogs(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, len(tt.expected), len(res))
 			for i, r := range res {
-				assert.Equal(t, tt.expected[i], r.(*logsRequest))
+				assert.Equal(t, tt.expected[i].ld, r.(*logsRequest).ld)
 			}
 		})
 	}
@@ -150,5 +150,189 @@ func TestExtractLogs(t *testing.T) {
 		extractedLogs := extractLogs(ld, i)
 		assert.Equal(t, i, extractedLogs.LogRecordCount())
 		assert.Equal(t, 10-i, ld.LogRecordCount())
+	}
+}
+
+func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
+	// Magic number is the byte size testdata.GenerateLogs(10)
+	tests := []struct {
+		name     string
+		cfg      exporterbatcher.MaxSizeConfig
+		lr1      internal.Request
+		lr2      internal.Request
+		expected []*logsRequest
+	}{
+		{
+			name:     "both_requests_empty",
+			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeBytes: logsMarshaler.LogsSize(testdata.GenerateLogs(10))},
+			lr1:      &logsRequest{ld: plog.NewLogs()},
+			lr2:      &logsRequest{ld: plog.NewLogs()},
+			expected: []*logsRequest{{ld: plog.NewLogs()}},
+		},
+		{
+			name:     "first_request_empty",
+			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeBytes: logsMarshaler.LogsSize(testdata.GenerateLogs(10))},
+			lr1:      &logsRequest{ld: plog.NewLogs()},
+			lr2:      &logsRequest{ld: testdata.GenerateLogs(5)},
+			expected: []*logsRequest{{ld: testdata.GenerateLogs(5)}},
+		},
+		{
+			name:     "first_empty_second_nil",
+			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeBytes: logsMarshaler.LogsSize(testdata.GenerateLogs(10))},
+			lr1:      &logsRequest{ld: plog.NewLogs()},
+			lr2:      nil,
+			expected: []*logsRequest{{ld: plog.NewLogs()}},
+		},
+		{
+			name: "merge_only",
+			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeBytes: logsMarshaler.LogsSize(testdata.GenerateLogs(11))},
+			lr1:  &logsRequest{ld: testdata.GenerateLogs(4)},
+			lr2:  &logsRequest{ld: testdata.GenerateLogs(6)},
+			expected: []*logsRequest{{ld: func() plog.Logs {
+				logs := testdata.GenerateLogs(4)
+				testdata.GenerateLogs(6).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
+				return logs
+			}()}},
+		},
+		{
+			name: "split_only",
+			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeBytes: logsMarshaler.LogsSize(testdata.GenerateLogs(4))},
+			lr1:  &logsRequest{ld: plog.NewLogs()},
+			lr2:  &logsRequest{ld: testdata.GenerateLogs(10)},
+			expected: []*logsRequest{
+				{ld: testdata.GenerateLogs(4)},
+				{ld: testdata.GenerateLogs(4)},
+				{ld: testdata.GenerateLogs(2)},
+			},
+		},
+		{
+			name: "merge_and_split",
+			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeBytes: (logsMarshaler.LogsSize(testdata.GenerateLogs(10)) + logsMarshaler.LogsSize(testdata.GenerateLogs(11))) / 2},
+			lr1:  &logsRequest{ld: testdata.GenerateLogs(8)},
+			lr2:  &logsRequest{ld: testdata.GenerateLogs(20)},
+			expected: []*logsRequest{
+				{ld: func() plog.Logs {
+					logs := testdata.GenerateLogs(8)
+					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
+					return logs
+				}()},
+				{ld: testdata.GenerateLogs(10)},
+				{ld: testdata.GenerateLogs(8)},
+			},
+		},
+		{
+			name: "scope_logs_split",
+			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeBytes: logsMarshaler.LogsSize(testdata.GenerateLogs(4))},
+			lr1: &logsRequest{ld: func() plog.Logs {
+				ld := testdata.GenerateLogs(4)
+				ld.ResourceLogs().At(0).ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("extra log")
+				return ld
+			}()},
+			lr2: &logsRequest{ld: testdata.GenerateLogs(2)},
+			expected: []*logsRequest{
+				{ld: testdata.GenerateLogs(4)},
+				{ld: func() plog.Logs {
+					ld := testdata.GenerateLogs(0)
+					ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().AppendEmpty().Body().SetStr("extra log")
+					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(ld.ResourceLogs())
+					return ld
+				}()},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.lr1.MergeSplit(context.Background(), tt.cfg, tt.lr2)
+			require.NoError(t, err)
+			assert.Equal(t, len(tt.expected), len(res))
+			for i, r := range res {
+				assert.Equal(t, tt.expected[i].ld, r.(*logsRequest).ld)
+				assert.Equal(t, r.(*logsRequest).ByteSize(), logsMarshaler.LogsSize(r.(*logsRequest).ld))
+			}
+		})
+	}
+}
+
+func BenchmarkSplittingBasedOnItemCountManySmallLogs(b *testing.B) {
+	cfg := exporterbatcher.MaxSizeConfig{MaxSizeItems: 10000}
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(10)}
+		for j := 0; j < 1000; j++ {
+			lr2 := &logsRequest{ld: testdata.GenerateLogs(10)}
+			lr1.MergeSplit(context.Background(), cfg, lr2)
+		}
+	}
+}
+
+func BenchmarkSplittingBasedOnByteSizeManySmallLogs(b *testing.B) {
+	cfg := exporterbatcher.MaxSizeConfig{MaxSizeBytes: 1010000}
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(10)}
+		for j := 0; j < 1000; j++ {
+			lr2 := &logsRequest{ld: testdata.GenerateLogs(10)}
+			lr1.MergeSplit(context.Background(), cfg, lr2)
+		}
+	}
+}
+
+func BenchmarkSplittingBasedOnItemCountManyLogsSlightlyAboveLimit(b *testing.B) {
+	cfg := exporterbatcher.MaxSizeConfig{MaxSizeItems: 10000}
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(10001)}
+		for j := 0; j < 10; j++ {
+			lr2 := &logsRequest{ld: testdata.GenerateLogs(10001)}
+			lr1.MergeSplit(context.Background(), cfg, lr2)
+		}
+	}
+}
+
+func BenchmarkSplittingBasedOnByteSizeManyLogsSlightlyAboveLimit(b *testing.B) {
+	cfg := exporterbatcher.MaxSizeConfig{MaxSizeBytes: logsMarshaler.LogsSize(testdata.GenerateLogs(10000))}
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(10001)}
+		for j := 0; j < 10; j++ {
+			lr2 := &logsRequest{ld: testdata.GenerateLogs(10001)}
+			lr1.MergeSplit(context.Background(), cfg, lr2)
+		}
+	}
+}
+
+func BenchmarkSplittingBasedOnItemCountManyLogsSlightlyBelowLimit(b *testing.B) {
+	cfg := exporterbatcher.MaxSizeConfig{MaxSizeItems: 10000}
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(9999)}
+		for j := 0; j < 10; j++ {
+			lr2 := &logsRequest{ld: testdata.GenerateLogs(9999)}
+			lr1.MergeSplit(context.Background(), cfg, lr2)
+		}
+	}
+}
+
+func BenchmarkSplittingBasedOnByteSizeManyLogsSlightlyBelowLimit(b *testing.B) {
+	cfg := exporterbatcher.MaxSizeConfig{MaxSizeBytes: logsMarshaler.LogsSize(testdata.GenerateLogs(10000))}
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(9999)}
+		for j := 0; j < 10; j++ {
+			lr2 := &logsRequest{ld: testdata.GenerateLogs(9999)}
+			lr1.MergeSplit(context.Background(), cfg, lr2)
+		}
+	}
+}
+
+func BenchmarkSplittingBasedOnItemCountHugeLog(b *testing.B) {
+	cfg := exporterbatcher.MaxSizeConfig{MaxSizeItems: 10000}
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(1)}
+		lr2 := &logsRequest{ld: testdata.GenerateLogs(100000)}
+		lr1.MergeSplit(context.Background(), cfg, lr2)
+	}
+}
+
+func BenchmarkSplittingBasedOnByteSizeHugeLog(b *testing.B) {
+	cfg := exporterbatcher.MaxSizeConfig{MaxSizeBytes: logsMarshaler.LogsSize(testdata.GenerateLogs(10000))}
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(1)}
+		lr2 := &logsRequest{ld: testdata.GenerateLogs(100000)}
+		lr1.MergeSplit(context.Background(), cfg, lr2)
 	}
 }

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -66,6 +66,10 @@ func (req *metricsRequest) ItemsCount() int {
 	return req.md.DataPointCount()
 }
 
+func (req *metricsRequest) ByteSize() int {
+	return metricsMarshaler.MetricsSize(req.md)
+}
+
 type metricsExporter struct {
 	*internal.BaseExporter
 	consumer.Metrics

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -66,6 +66,10 @@ func (req *tracesRequest) ItemsCount() int {
 	return req.td.SpanCount()
 }
 
+func (req *tracesRequest) ByteSize() int {
+	return tracesMarshaler.TracesSize(req.td)
+}
+
 type tracesExporter struct {
 	*internal.BaseExporter
 	consumer.Traces

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -69,6 +69,10 @@ func (req *profilesRequest) ItemsCount() int {
 	return req.pd.SampleCount()
 }
 
+func (req *profilesRequest) ByteSize() int {
+	return req.pd.SampleCount()
+}
+
 type profileExporter struct {
 	*internal.BaseExporter
 	xconsumer.Profiles

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
@@ -155,6 +155,10 @@ func (req *dummyRequest) ItemsCount() int {
 	return 1
 }
 
+func (req *dummyRequest) ByteSize() int {
+	return 1
+}
+
 func (req *dummyRequest) MergeSplit(_ context.Context, _ exporterbatcher.MaxSizeConfig, _ exporterhelper.Request) (
 	[]exporterhelper.Request, error,
 ) {

--- a/exporter/internal/request.go
+++ b/exporter/internal/request.go
@@ -19,6 +19,8 @@ type Request interface {
 	// sent. For example, for OTLP exporter, this value represents the number of spans,
 	// metric data points or log records.
 	ItemsCount() int
+	// ByteSize returns the serialized size of the request.
+	ByteSize() int
 	// MergeSplit is a function that merge and/or splits this request with another one into multiple requests based on the
 	// configured limit provided in MaxSizeConfig.
 	// MergeSplit does not split if all fields in MaxSizeConfig are not initialized (zero).

--- a/pdata/plog/pb.go
+++ b/pdata/plog/pb.go
@@ -22,6 +22,18 @@ func (e *ProtoMarshaler) LogsSize(ld Logs) int {
 	return pb.Size()
 }
 
+func (e *ProtoMarshaler) ResourceLogsSize(rl ResourceLogs) int {
+	return rl.orig.Size()
+}
+
+func (e *ProtoMarshaler) ScopeLogsSize(sl ScopeLogs) int {
+	return sl.orig.Size()
+}
+
+func (e *ProtoMarshaler) LogRecordSize(lr LogRecord) int {
+	return lr.orig.Size()
+}
+
 var _ Unmarshaler = (*ProtoUnmarshaler)(nil)
 
 type ProtoUnmarshaler struct{}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
## Description

This is an POC of serialized size based batching (version 2)

Configuration is supported via an additional field to `MaxSizeConfig`.
```
type MaxSizeConfig struct {
	MaxSizeItems int `mapstructure:"max_size_items"`
	MaxSizeBytes int `mapstructure:"max_size_bytes"`
}
```
We will validate that at most one of the above fields are specified (TODO) and switch between item count-based batching vs. byte size-based batching accordingly.

To get the byte size of otlp protos, this PR updates `pdata/internal/cmd/pdatagen/internal/templates/message.go.tmpl` to expose an interface `Size()`. This change will apply to all `pdatagen`-generated files.

-------------------------------------------------------------------------------------------------------------------------

## Getting serialized byte size

Getting serialized byte size is an expensive operation that gets repeatedly invoked during bytes based merge-splitting. The POC shows two optimizations that improves by 1. reducing size calculation times 2. reducing size calculation cost

### Caching size in `Request`

We repeated call `request.ByteSize()` while merg-splitting. By caching previous result in `request.ByteSize()`, we were able to improve the performance especially for the case where many requests are merged into a single batch.

```
BenchmarkSplittingBasedOnItemCountManySmallLogs-10                 	     324	   3729469 ns/op
/*Before*/ BenchmarkSplittingBasedOnByteSizeManySmallLogs-10         	       9	 120696384 ns/op
/*After*/ BenchmarkSplittingBasedOnByteSizeManySmallLogs-10                  358	   2906934 ns/op
```

### Proto size caculation

While filling the batch, we repeated evaluate size of new items and the remaining space, and both calculations are expensive. This PR shows an optimization that calculates remaining space iteratively using new item size:

```
remaning -= (1 + sizeof(newItem) + sov(sizeof(newItem)))
```

where

```
func sov(x uint64) (n int) {
	return (math_bits.Len64(x|1) + 6) / 7
}
```

This helped significantly improve the performance. For benchmark result without this optimization, see https://github.com/open-telemetry/opentelemetry-collector/pull/12017. 

## Performance Benchmark

### Benchmark 1 - 1000 small requests merge into one batch
This benchmark merges 1000 requests x 10 logs / request. The accumulated batch is ~1MB
```
BenchmarkSplittingBasedOnItemCountManySmallLogs-10                 	     328	   3556645 ns/op
BenchmarkSplittingBasedOnByteSizeManySmallLogs-10                  	     447	   2689311 ns/op
```


### Benchmark 2 - Every incoming request causes a split

**Case 1**: Merging 10 request, where each contains 10001 logs / ~ 1 MB and is slightly above the limit
```
BenchmarkSplittingBasedOnItemCountManyLogsSlightlyAboveLimit-10    	      45	  24271094 ns/op
BenchmarkSplittingBasedOnByteSizeManyLogsSlightlyAboveLimit-10     	      31	  35001137 ns/op
```

**Case 2**: Merging 10 request, where each contains 9999 logs / ~ 1 MB and is slightly below the limit
```
BenchmarkSplittingBasedOnItemCountManyLogsSlightlyBelowLimit-10    	      52	  21750268 ns/op
BenchmarkSplittingBasedOnByteSizeManyLogsSlightlyBelowLimit-10     	      38	  28904701 ns/op
```

### Benchmark 3 - A huge request splits into 10 batches
This benchmark merge splits a request with 100000 logs / ~10MB in to 10 batches.
```
BenchmarkSplittingBasedOnItemCountHugeLog-10                       	      43	  29004844 ns/op
BenchmarkSplittingBasedOnByteSizeHugeLog-10                        	      15	  66705669 ns/op
```




<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #3262

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->

TODO: ByteSize() should return int64 instead of int

