### PR TITLE
[mdatagen] update other lifecycle generated tests to not be impacted by fieldalignment

### DIFF
--- a/.chloggen/fieldalignment_generated_others.yaml
+++ b/.chloggen/fieldalignment_generated_others.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: apply fieldalignment to generated code
+
+# One or more tracking issues or pull requests related to the change
+issues: [12125]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/sampleprocessor/generated_component_test.go
+++ b/cmd/mdatagen/internal/sampleprocessor/generated_component_test.go
@@ -34,8 +34,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {
-		name     string
 		createFn func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error)
+		name     string
 	}{
 
 		{

--- a/cmd/mdatagen/internal/samplereceiver/generated_component_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/generated_component_test.go
@@ -29,8 +29,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {
-		name     string
 		createFn func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error)
+		name     string
 	}{
 
 		{

--- a/cmd/mdatagen/internal/samplescraper/generated_component_test.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_component_test.go
@@ -28,8 +28,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {
-		name     string
 		createFn func(ctx context.Context, set scraper.Settings, cfg component.Config) (component.Component, error)
+		name     string
 	}{
 
 		{

--- a/cmd/mdatagen/internal/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/component_test.go.tmpl
@@ -171,8 +171,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct{
-		name string
 		createFn func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error)
+		name string
 	}{
 {{ if supportsLogs }}
 		{
@@ -266,8 +266,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct{
-		name string
 		createFn func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error)
+		name string
 	}{
 {{ if supportsLogs }}
 		{
@@ -335,8 +335,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct{
-		name string
 		createFn func(ctx context.Context, set scraper.Settings, cfg component.Config) (component.Component, error)
+		name string
 	}{
 {{ if supportsLogs }}
 		{
@@ -440,8 +440,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct{
-		name string
 		createFn func(ctx context.Context, set connector.Settings, cfg component.Config) (component.Component, error)
+		name string
 	}{
 {{ if supportsLogsToLogs }}
 		{

--- a/connector/forwardconnector/generated_component_test.go
+++ b/connector/forwardconnector/generated_component_test.go
@@ -30,8 +30,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {
-		name     string
 		createFn func(ctx context.Context, set connector.Settings, cfg component.Config) (component.Component, error)
+		name     string
 	}{
 
 		{

--- a/processor/batchprocessor/generated_component_test.go
+++ b/processor/batchprocessor/generated_component_test.go
@@ -33,8 +33,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {
-		name     string
 		createFn func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error)
+		name     string
 	}{
 
 		{

--- a/processor/memorylimiterprocessor/generated_component_test.go
+++ b/processor/memorylimiterprocessor/generated_component_test.go
@@ -33,8 +33,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {
-		name     string
 		createFn func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error)
+		name     string
 	}{
 
 		{

--- a/receiver/nopreceiver/generated_component_test.go
+++ b/receiver/nopreceiver/generated_component_test.go
@@ -28,8 +28,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {
-		name     string
 		createFn func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error)
+		name     string
 	}{
 
 		{

--- a/receiver/otlpreceiver/generated_component_test.go
+++ b/receiver/otlpreceiver/generated_component_test.go
@@ -28,8 +28,8 @@ func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {
-		name     string
 		createFn func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error)
+		name     string
 	}{
 
 		{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
update other lifecycle generated tests to not be impacted by fieldalignment

<!-- Issue number if applicable -->
#### Link to tracking issue
See #12121 for original PR.
