### PR TITLE
[chore]: enable nolintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,6 +91,9 @@ linters-settings:
     ignore-words:
       - cancelled
 
+  nolintlint:
+    require-specific: true
+
   perfsprint:
     # Optimizes even if it requires an int or uint type cast.
     int-conversion: true
@@ -204,6 +207,7 @@ linters:
     - gosec
     - govet
     - misspell
+    - nolintlint
     - perfsprint
     - revive
     - staticcheck

--- a/client/doc_test.go
+++ b/client/doc_test.go
@@ -35,7 +35,7 @@ func Example_receiver() {
 
 	// Extract the client information based on your original context and set it
 	// to Addr
-	// nolint
+	//nolint:govet
 	cl.Addr = &net.IPAddr{
 		IP: net.IPv4(1, 2, 3, 4),
 	}

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -151,8 +151,8 @@ func (c *Config) Validate() error {
 // SetGoPath sets go path
 func (c *Config) SetGoPath() error {
 	if !c.SkipCompilation || !c.SkipGetModules {
-		// #nosec G204
-		if _, err := exec.Command(c.Distribution.Go, "env").CombinedOutput(); err != nil { // nolint G204
+		//nolint:gosec // #nosec G204
+		if _, err := exec.Command(c.Distribution.Go, "env").CombinedOutput(); err != nil {
 			path, err := exec.LookPath("go")
 			if err != nil {
 				return ErrGoNotFound

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -36,7 +36,7 @@ func runGoCommand(cfg *Config, args ...string) ([]byte, error) {
 		cfg.Logger.Info("Running go subcommand.", zap.Any("arguments", args))
 	}
 
-	// #nosec G204 -- cfg.Distribution.Go is trusted to be a safe path and the caller is assumed to have carried out necessary input validation
+	//nolint:gosec // #nosec G204 -- cfg.Distribution.Go is trusted to be a safe path and the caller is assumed to have carried out necessary input validation
 	cmd := exec.Command(cfg.Distribution.Go, args...)
 	cmd.Dir = cfg.Distribution.OutputPath
 

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -403,7 +403,7 @@ func TestReplaceStatementsAreComplete(t *testing.T) {
 
 func verifyGoMod(t *testing.T, dir string, replaceMods map[string]bool) {
 	gomodpath := path.Join(dir, "go.mod")
-	// #nosec G304 We control this path and generate the file inside, so we can assume it is safe.
+	//nolint:gosec // #nosec G304 We control this path and generate the file inside, so we can assume it is safe.
 	gomod, err := os.ReadFile(gomodpath)
 	require.NoError(t, err)
 

--- a/cmd/mdatagen/internal/command.go
+++ b/cmd/mdatagen/internal/command.go
@@ -383,7 +383,7 @@ func executeTemplate(tmplFile string, md Metadata, goPackage string) ([]byte, er
 func inlineReplace(tmplFile string, outputFile string, md Metadata, start string, end string, goPackage string) error {
 	var readmeContents []byte
 	var err error
-	if readmeContents, err = os.ReadFile(outputFile); err != nil { // nolint: gosec
+	if readmeContents, err = os.ReadFile(outputFile); err != nil { //nolint:gosec
 		return err
 	}
 

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -164,7 +164,7 @@ foo
 				require.FileExists(t, filepath.Join(tmpdir, generatedPackageDir, "generated_metrics.go"))
 				require.FileExists(t, filepath.Join(tmpdir, generatedPackageDir, "generated_metrics_test.go"))
 				require.FileExists(t, filepath.Join(tmpdir, "documentation.md"))
-				contents, err = os.ReadFile(filepath.Join(tmpdir, generatedPackageDir, "generated_metrics.go")) // nolint: gosec
+				contents, err = os.ReadFile(filepath.Join(tmpdir, generatedPackageDir, "generated_metrics.go")) //nolint:gosec
 				require.NoError(t, err)
 				if tt.wantMetricsContext {
 					require.Contains(t, string(contents), "\"context\"")
@@ -188,7 +188,7 @@ foo
 				require.FileExists(t, filepath.Join(tmpdir, generatedPackageDir, "generated_telemetry.go"))
 				require.FileExists(t, filepath.Join(tmpdir, generatedPackageDir, "generated_telemetry_test.go"))
 				require.FileExists(t, filepath.Join(tmpdir, "documentation.md"))
-				contents, err = os.ReadFile(filepath.Join(tmpdir, generatedPackageDir, "generated_telemetry.go")) // nolint: gosec
+				contents, err = os.ReadFile(filepath.Join(tmpdir, generatedPackageDir, "generated_telemetry.go")) //nolint:gosec
 				require.NoError(t, err)
 				if tt.wantMetricsContext {
 					require.Contains(t, string(contents), "\"context\"")
@@ -206,25 +206,25 @@ foo
 
 			if tt.wantStatusGenerated {
 				require.FileExists(t, filepath.Join(tmpdir, generatedPackageDir, "generated_status.go"))
-				contents, err = os.ReadFile(filepath.Join(tmpdir, "README.md")) // nolint: gosec
+				contents, err = os.ReadFile(filepath.Join(tmpdir, "README.md")) //nolint:gosec
 				require.NoError(t, err)
 				require.NotContains(t, string(contents), "foo")
 			} else {
 				require.NoFileExists(t, filepath.Join(tmpdir, generatedPackageDir, "generated_status.go"))
-				contents, err = os.ReadFile(filepath.Join(tmpdir, "README.md")) // nolint: gosec
+				contents, err = os.ReadFile(filepath.Join(tmpdir, "README.md")) //nolint:gosec
 				require.NoError(t, err)
 				require.Contains(t, string(contents), "foo")
 			}
 
 			require.FileExists(t, filepath.Join(tmpdir, "generated_component_test.go"))
-			contents, err = os.ReadFile(filepath.Join(tmpdir, "generated_component_test.go")) // nolint: gosec
+			contents, err = os.ReadFile(filepath.Join(tmpdir, "generated_component_test.go")) //nolint:gosec
 			require.NoError(t, err)
 			require.Contains(t, string(contents), "func Test")
 			_, err = parser.ParseFile(token.NewFileSet(), "", contents, parser.DeclarationErrors)
 			require.NoError(t, err)
 
 			require.FileExists(t, filepath.Join(tmpdir, "generated_package_test.go"))
-			contents, err = os.ReadFile(filepath.Join(tmpdir, "generated_package_test.go")) // nolint: gosec
+			contents, err = os.ReadFile(filepath.Join(tmpdir, "generated_package_test.go")) //nolint:gosec
 			require.NoError(t, err)
 			require.Contains(t, string(contents), "func TestMain")
 			_, err = parser.ParseFile(token.NewFileSet(), "", contents, parser.DeclarationErrors)
@@ -481,7 +481,7 @@ Some info about a component
 			require.NoError(t, err)
 
 			require.FileExists(t, filepath.Join(tmpdir, "README.md"))
-			got, err := os.ReadFile(filepath.Join(tmpdir, "README.md")) // nolint: gosec
+			got, err := os.ReadFile(filepath.Join(tmpdir, "README.md")) //nolint:gosec
 			require.NoError(t, err)
 			got = bytes.ReplaceAll(got, []byte("\r\n"), []byte("\n"))
 			expected, err := os.ReadFile(filepath.Join("testdata", tt.outputFile))
@@ -569,7 +569,7 @@ const (
 			err := generateFile("templates/status.go.tmpl",
 				filepath.Join(tmpdir, "generated_status.go"), tt.md, "metadata")
 			require.NoError(t, err)
-			actual, err := os.ReadFile(filepath.Join(tmpdir, "generated_status.go")) // nolint: gosec
+			actual, err := os.ReadFile(filepath.Join(tmpdir, "generated_status.go")) //nolint:gosec
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, string(actual))
 		})
@@ -657,7 +657,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 			err := generateFile("templates/telemetry.go.tmpl",
 				filepath.Join(tmpdir, "generated_telemetry.go"), tt.md, "metadata")
 			require.NoError(t, err)
-			actual, err := os.ReadFile(filepath.Join(tmpdir, "generated_telemetry.go")) // nolint: gosec
+			actual, err := os.ReadFile(filepath.Join(tmpdir, "generated_telemetry.go")) //nolint:gosec
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, string(actual))
 		})

--- a/cmd/mdatagen/internal/lint.go
+++ b/cmd/mdatagen/internal/lint.go
@@ -19,7 +19,7 @@ func FormatIdentifier(s string, exported bool) (string, error) {
 	// Convert various characters to . for strings.Title to operate on.
 	replace := strings.NewReplacer("_", ".", "-", ".", "<", ".", ">", ".", "/", ".", ":", ".")
 	str := replace.Replace(s)
-	str = strings.Title(str) // nolint SA1019
+	str = strings.Title(str) //nolint:staticcheck // SA1019
 	str = strings.ReplaceAll(str, ".", "")
 
 	var word string

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -198,7 +198,7 @@ func (mvt *ValueType) UnmarshalText(text []byte) error {
 
 // String returns capitalized name of the ValueType.
 func (mvt ValueType) String() string {
-	return strings.Title(strings.ToLower(mvt.ValueType.String())) // nolint SA1019
+	return strings.Title(strings.ToLower(mvt.ValueType.String())) //nolint:staticcheck // SA1019
 }
 
 // Primitive returns name of primitive type for the ValueType.

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -189,7 +189,7 @@ func TestHTTPCustomDecompression(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	decoders := map[string]func(io.ReadCloser) (io.ReadCloser, error){
-		"custom-encoding": func(io.ReadCloser) (io.ReadCloser, error) { // nolint: unparam
+		"custom-encoding": func(io.ReadCloser) (io.ReadCloser, error) { //nolint:unparam
 			return io.NopCloser(strings.NewReader("decompressed body")), nil
 		},
 	}

--- a/confmap/internal/e2e/fuzz_test.go
+++ b/confmap/internal/e2e/fuzz_test.go
@@ -19,16 +19,16 @@ func targetNested[T any](t *testing.T, value string) {
 	resolver := NewResolver(t, "types_expand.yaml")
 
 	// Use os.Setenv so we can check the error and return instead of failing the fuzzing.
-	os.Setenv("ENV", "${env:ENV2}") // nolint:tenv
+	os.Setenv("ENV", "${env:ENV2}") //nolint:tenv
 	defer os.Unsetenv("ENV")
-	err := os.Setenv("ENV2", value) // nolint:tenv
+	err := os.Setenv("ENV2", value) //nolint:tenv
 	defer os.Unsetenv("ENV2")
 	if err != nil {
 		return
 	}
 	confNested, errResolveNested := resolver.Resolve(context.Background())
 
-	err = os.Setenv("ENV", value) // nolint:tenv
+	err = os.Setenv("ENV", value) //nolint:tenv
 	if err != nil {
 		return
 	}

--- a/exporter/exporterqueue/persistent_queue.go
+++ b/exporter/exporterqueue/persistent_queue.go
@@ -164,7 +164,7 @@ func (pq *persistentQueue[T]) initPersistentContiguousStorage(ctx context.Contex
 			queueSize = restoredQueueSize
 		}
 	}
-	// nolint: gosec
+	//nolint:gosec
 	pq.queueSize = int64(queueSize)
 }
 
@@ -209,7 +209,7 @@ func (pq *persistentQueue[T]) backupQueueSize(ctx context.Context) error {
 		return nil
 	}
 
-	// nolint: gosec
+	//nolint:gosec
 	return pq.client.Set(ctx, queueSizeKey, itemIndexToBytes(uint64(pq.queueSize)))
 }
 
@@ -519,7 +519,7 @@ func bytesToItemIndex(buf []byte) (uint64, error) {
 func itemIndexArrayToBytes(arr []uint64) []byte {
 	size := len(arr)
 	buf := make([]byte, 0, 4+size*8)
-	// nolint: gosec
+	//nolint:gosec
 	buf = binary.LittleEndian.AppendUint32(buf, uint32(size))
 	for _, item := range arr {
 		buf = binary.LittleEndian.AppendUint64(buf, item)

--- a/internal/memorylimiter/iruntime/total_memory_linux.go
+++ b/internal/memorylimiter/iruntime/total_memory_linux.go
@@ -49,6 +49,6 @@ func TotalMemory() (uint64, error) {
 		return totalMem, nil
 	}
 
-	// nolint:gosec
+	//nolint:gosec
 	return uint64(memoryQuota), nil
 }

--- a/internal/tools/semconvkit/main.go
+++ b/internal/tools/semconvkit/main.go
@@ -40,7 +40,7 @@ func render(src, dest string, data *SemanticConventions) error {
 	}
 	for _, tmpl := range tmpls.Templates() {
 		target := filepath.Join(dest, strings.TrimSuffix(tmpl.Name(), ".tmpl"))
-		// nolint: gosec
+		//nolint:gosec
 		wr, err := os.Create(target)
 		if err != nil {
 			return err

--- a/pdata/pcommon/timestamp.go
+++ b/pdata/pcommon/timestamp.go
@@ -13,13 +13,13 @@ type Timestamp uint64
 
 // NewTimestampFromTime constructs a new Timestamp from the provided time.Time.
 func NewTimestampFromTime(t time.Time) Timestamp {
-	// nolint:gosec
+	//nolint:gosec
 	return Timestamp(uint64(t.UnixNano()))
 }
 
 // AsTime converts this to a time.Time.
 func (ts Timestamp) AsTime() time.Time {
-	// nolint:gosec
+	//nolint:gosec
 	return time.Unix(0, int64(ts)).UTC()
 }
 

--- a/pdata/pcommon/timestamp_test.go
+++ b/pdata/pcommon/timestamp_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUnixNanosConverters(t *testing.T) {
 	t1 := time.Date(2020, 3, 24, 1, 13, 23, 789, time.UTC)
-	// nolint:gosec
+	//nolint:gosec
 	tun := Timestamp(t1.UnixNano())
 
 	assert.EqualValues(t, uint64(1585012403000000789), tun)

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -148,7 +148,7 @@ func (v Value) FromRaw(iv any) error {
 	case int64:
 		v.SetInt(tv)
 	case uint:
-		// nolint:gosec
+		//nolint:gosec
 		v.SetInt(int64(tv))
 	case uint8:
 		v.SetInt(int64(tv))
@@ -157,7 +157,7 @@ func (v Value) FromRaw(iv any) error {
 	case uint32:
 		v.SetInt(int64(tv))
 	case uint64:
-		// nolint:gosec
+		//nolint:gosec
 		v.SetInt(int64(tv))
 	case float32:
 		v.SetDouble(float64(tv))

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -52,7 +52,7 @@ func TestNoDataLoss(t *testing.T) {
 	runtime.ReadMemStats(&ms)
 
 	// Set the limit to current usage plus expected increase. This means initially we will not be limited.
-	// nolint:gosec
+	//nolint:gosec
 	cfg.MemoryLimitMiB = uint32(ms.Alloc/(1024*1024) + expectedMemoryIncreaseMiB)
 	cfg.MemorySpikeLimitMiB = 1
 

--- a/service/internal/graph/node.go
+++ b/service/internal/graph/node.go
@@ -17,6 +17,6 @@ func (n nodeID) ID() int64 {
 func newNodeID(parts ...string) nodeID {
 	h := fnv.New64a()
 	h.Write([]byte(strings.Join(parts, "|")))
-	// nolint:gosec
+	//nolint:gosec
 	return nodeID(h.Sum64())
 }

--- a/service/internal/proctelemetry/process_telemetry.go
+++ b/service/internal/proctelemetry/process_telemetry.go
@@ -68,7 +68,7 @@ func RegisterProcessMetrics(cfg component.TelemetrySettings, opts ...RegisterOpt
 		ctx = context.WithValue(ctx, common.EnvKey, common.EnvMap{common.HostProcEnvKey: set.hostProc})
 	}
 	pm.context = ctx
-	// nolint:gosec
+	//nolint:gosec
 	pm.proc, err = process.NewProcessWithContext(pm.context, int32(os.Getpid()))
 	if err != nil {
 		return err
@@ -94,7 +94,7 @@ func (pm *processMetrics) updateAllocMem() int64 {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 	pm.readMemStatsIfNeeded()
-	// nolint:gosec
+	//nolint:gosec
 	return int64(pm.ms.Alloc)
 }
 
@@ -102,7 +102,7 @@ func (pm *processMetrics) updateTotalAllocMem() int64 {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 	pm.readMemStatsIfNeeded()
-	// nolint:gosec
+	//nolint:gosec
 	return int64(pm.ms.TotalAlloc)
 }
 
@@ -110,7 +110,7 @@ func (pm *processMetrics) updateSysMem() int64 {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 	pm.readMemStatsIfNeeded()
-	// nolint:gosec
+	//nolint:gosec
 	return int64(pm.ms.Sys)
 }
 
@@ -129,7 +129,7 @@ func (pm *processMetrics) updateRSSMemory() int64 {
 	if err != nil {
 		return 0
 	}
-	// nolint:gosec
+	//nolint:gosec
 	return int64(mem.RSS)
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -208,7 +208,7 @@ func logsAboutMeterProvider(logger *zap.Logger, cfg telemetry.MetricsConfig, mp 
 		return
 	}
 
-	//nolint
+	//nolint:staticcheck
 	if len(cfg.Address) != 0 {
 		logger.Warn("service::telemetry::metrics::address is being deprecated in favor of service::telemetry::metrics::readers")
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -59,7 +59,7 @@ type ownMetricsTestCase struct {
 }
 
 var (
-	testResourceAttrValue = "resource_attr_test_value" // #nosec G101: Potential hardcoded credentials
+	testResourceAttrValue = "resource_attr_test_value"
 	testInstanceID        = "test_instance_id"
 	testServiceVersion    = "2022-05-20"
 	testServiceName       = "test name"
@@ -234,7 +234,7 @@ func TestServiceGetExporters(t *testing.T) {
 		assert.NoError(t, srv.Shutdown(context.Background()))
 	})
 
-	// nolint
+	//nolint:staticcheck
 	expMap := srv.host.GetExporters()
 
 	v, ok := expMap[pipeline.SignalTraces]


### PR DESCRIPTION
#### Description

[nolintlint](https://golangci-lint.run/usage/linters/#nolintlint): Reports ill-formed or insufficient nolint directives.