### PR TITLE
[chore][exporter][batcher] Improve exporter.request merge splitting performance by caching items count

### DIFF
--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -25,14 +25,16 @@ var (
 )
 
 type logsRequest struct {
-	ld     plog.Logs
-	pusher consumer.ConsumeLogsFunc
+	ld               plog.Logs
+	pusher           consumer.ConsumeLogsFunc
+	cachedItemsCount int
 }
 
 func newLogsRequest(ld plog.Logs, pusher consumer.ConsumeLogsFunc) Request {
 	return &logsRequest{
-		ld:     ld,
-		pusher: pusher,
+		ld:               ld,
+		pusher:           pusher,
+		cachedItemsCount: -1,
 	}
 }
 
@@ -63,7 +65,14 @@ func (req *logsRequest) Export(ctx context.Context) error {
 }
 
 func (req *logsRequest) ItemsCount() int {
-	return req.ld.LogRecordCount()
+	if req.cachedItemsCount == -1 {
+		req.cachedItemsCount = req.ld.LogRecordCount()
+	}
+	return req.cachedItemsCount
+}
+
+func (req *logsRequest) setCachedItemsCount(count int) {
+	req.cachedItemsCount = count
 }
 
 type logsExporter struct {

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -25,14 +25,16 @@ var (
 )
 
 type metricsRequest struct {
-	md     pmetric.Metrics
-	pusher consumer.ConsumeMetricsFunc
+	md               pmetric.Metrics
+	pusher           consumer.ConsumeMetricsFunc
+	cachedItemsCount int
 }
 
 func newMetricsRequest(md pmetric.Metrics, pusher consumer.ConsumeMetricsFunc) Request {
 	return &metricsRequest{
-		md:     md,
-		pusher: pusher,
+		md:               md,
+		pusher:           pusher,
+		cachedItemsCount: -1,
 	}
 }
 
@@ -63,7 +65,14 @@ func (req *metricsRequest) Export(ctx context.Context) error {
 }
 
 func (req *metricsRequest) ItemsCount() int {
-	return req.md.DataPointCount()
+	if req.cachedItemsCount == -1 {
+		req.cachedItemsCount = req.md.DataPointCount()
+	}
+	return req.cachedItemsCount
+}
+
+func (req *metricsRequest) setCachedItemsCount(count int) {
+	req.cachedItemsCount = count
 }
 
 type metricsExporter struct {

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -25,14 +25,16 @@ var (
 )
 
 type tracesRequest struct {
-	td     ptrace.Traces
-	pusher consumer.ConsumeTracesFunc
+	td               ptrace.Traces
+	pusher           consumer.ConsumeTracesFunc
+	cachedItemsCount int
 }
 
 func newTracesRequest(td ptrace.Traces, pusher consumer.ConsumeTracesFunc) Request {
 	return &tracesRequest{
-		td:     td,
-		pusher: pusher,
+		td:               td,
+		pusher:           pusher,
+		cachedItemsCount: -1,
 	}
 }
 
@@ -63,7 +65,14 @@ func (req *tracesRequest) Export(ctx context.Context) error {
 }
 
 func (req *tracesRequest) ItemsCount() int {
-	return req.td.SpanCount()
+	if req.cachedItemsCount == -1 {
+		req.cachedItemsCount = req.td.SpanCount()
+	}
+	return req.cachedItemsCount
+}
+
+func (req *tracesRequest) setCachedItemsCount(count int) {
+	req.cachedItemsCount = count
 }
 
 type tracesExporter struct {

--- a/exporter/exporterhelper/traces_batch.go
+++ b/exporter/exporterhelper/traces_batch.go
@@ -38,11 +38,13 @@ func (req *tracesRequest) MergeSplit(_ context.Context, cfg exporterbatcher.MaxS
 			continue
 		}
 
-		srcCount := srcReq.td.SpanCount()
+		srcCount := srcReq.ItemsCount()
 		if srcCount <= capacityLeft {
 			if destReq == nil {
 				destReq = srcReq
 			} else {
+				destReq.setCachedItemsCount(srcCount)
+				srcReq.setCachedItemsCount(0)
 				srcReq.td.ResourceSpans().MoveAndAppendTo(destReq.td.ResourceSpans())
 			}
 			capacityLeft -= srcCount
@@ -51,16 +53,21 @@ func (req *tracesRequest) MergeSplit(_ context.Context, cfg exporterbatcher.MaxS
 
 		for {
 			extractedTraces := extractTraces(srcReq.td, capacityLeft)
-			if extractedTraces.SpanCount() == 0 {
+			extractedCount := extractedTraces.SpanCount()
+			if extractedCount == 0 {
 				break
 			}
-			capacityLeft -= extractedTraces.SpanCount()
+
 			if destReq == nil {
-				destReq = newTracesRequest(extractedTraces, srcReq.pusher).(*tracesRequest)
+				destReq = &tracesRequest{td: extractedTraces, pusher: srcReq.pusher, cachedItemsCount: extractedCount}
 			} else {
+				destReq.setCachedItemsCount(destReq.ItemsCount() + extractedCount)
+				srcReq.setCachedItemsCount(srcReq.ItemsCount() - extractedCount)
 				extractedTraces.ResourceSpans().MoveAndAppendTo(destReq.td.ResourceSpans())
 			}
+
 			// Create new batch once capacity is reached.
+			capacityLeft -= extractedCount
 			if capacityLeft == 0 {
 				res = append(res, destReq)
 				destReq = nil


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR improves item-based merge splitting by caching item count in `exporter.request`. Benchmarks shows benefits the case where many requests are merged in the same batch. We observed roughly 30 - 75% latency improvement.

| Event Type              | Before (ns/merge) | After (ns/merge) | Diff percentage |
| :---------------- | :------: | :----: | ----: |
| Logs       |   3643.971   | 2513.947 | -31% |
| Metrics  |   24550.572  | 5847.417 | -76% |
| Traces   |  5172.710 | 3233.694  | -37% |


<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/12137

<!--Describe what testing was performed and which tests were added.-->
#### Testing

This PR adds four benchmarks for each event type

1. 1000 requests are merged into the same batch.
2. every incoming request is slightly above the limit and will cause a split.
3. the incoming request is split into 10 batches

Benchmark 1 is designed to test the performance of merging, while Benchmark 2 and 3 are primarily designed to test the performance of splitting. Benchmarks indicate that the optimization implemented in this PR improves merging performance.

Before:
```
BenchmarkSplittingBasedOnItemCountManySmallLogs-10                    	     316	   3643971 ns/op
BenchmarkSplittingBasedOnItemCountManyLogsSlightlyAboveLimit-10       	      43	  25643229 ns/op
BenchmarkSplittingBasedOnItemCountHugeLogs-10                         	      39	  27257268 ns/op
BenchmarkSplittingBasedOnItemCountManySmallMetrics-10                 	      43	  24783318 ns/op
BenchmarkSplittingBasedOnItemCountManyMetricsSlightlyAboveLimit-10    	      16	  67046630 ns/op
BenchmarkSplittingBasedOnItemCountHugeMetrics-10                      	      13	  81208615 ns/op
BenchmarkSplittingBasedOnItemCountManySmallTraces-10                  	     235	   5172710 ns/op
BenchmarkSplittingBasedOnItemCountManyTracesSlightlyAboveLimit-10     	      37	  31968305 ns/op
BenchmarkSplittingBasedOnItemCountHugeTraces-10                       	      30	  35512446 ns/op
```

After:
```
BenchmarkSplittingBasedOnItemCountManySmallLogs-10                    	     507	   2513947 ns/op
BenchmarkSplittingBasedOnItemCountManyLogsSlightlyAboveLimit-10       	      40	  26553098 ns/op
BenchmarkSplittingBasedOnItemCountHugeLogs-10                         	      38	  27769027 ns/op
BenchmarkSplittingBasedOnItemCountManySmallMetrics-10                 	     189	   5847417 ns/op
BenchmarkSplittingBasedOnItemCountManyMetricsSlightlyAboveLimit-10    	      16	  63132219 ns/op
BenchmarkSplittingBasedOnItemCountHugeMetrics-10                      	      14	  81363741 ns/op
BenchmarkSplittingBasedOnItemCountManySmallTraces-10                  	     367	   3253624 ns/op
BenchmarkSplittingBasedOnItemCountManyTracesSlightlyAboveLimit-10     	      38	  32017175 ns/op
BenchmarkSplittingBasedOnItemCountHugeTraces-10                       	      31	  34387539 ns/op
```

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
