### PR TITLE
[cmd/mdatagen] Remove dead field telemetry::level

### DIFF
--- a/cmd/mdatagen/internal/telemetry.go
+++ b/cmd/mdatagen/internal/telemetry.go
@@ -3,12 +3,7 @@
 
 package internal // import "go.opentelemetry.io/collector/cmd/mdatagen/internal"
 
-import (
-	"go.opentelemetry.io/collector/config/configtelemetry"
-)
-
 type Telemetry struct {
-	Level   configtelemetry.Level `mapstructure:"level"`
 	Metrics map[MetricName]Metric `mapstructure:"metrics"`
 }
 

--- a/processor/batchprocessor/metadata.yaml
+++ b/processor/batchprocessor/metadata.yaml
@@ -10,7 +10,6 @@ status:
 tests:
 
 telemetry:
-  level: normal
   metrics:
     processor_batch_batch_size_trigger_send:
       enabled: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Removes `telemetry::level`, which is unused. If this was intended to serve as the 'minimum level' for a component, I can handle that on #12143

#### Link to tracking issue

Updates #11061
