### PR TITLE
[chore][testonly][exporter] Use new{Logs,Metrics,Traces}Request instead of &{logs,metrics,traces}Request{}

### DIFF
--- a/exporter/exporterhelper/logs_batch.go
+++ b/exporter/exporterhelper/logs_batch.go
@@ -56,7 +56,7 @@ func (req *logsRequest) MergeSplit(_ context.Context, cfg exporterbatcher.MaxSiz
 			}
 			capacityLeft -= extractedLogs.LogRecordCount()
 			if destReq == nil {
-				destReq = &logsRequest{ld: extractedLogs, pusher: srcReq.pusher}
+				destReq = newLogsRequest(extractedLogs, srcReq.pusher).(*logsRequest)
 			} else {
 				extractedLogs.ResourceLogs().MoveAndAppendTo(destReq.ld.ResourceLogs())
 			}

--- a/exporter/exporterhelper/logs_batch_test.go
+++ b/exporter/exporterhelper/logs_batch_test.go
@@ -17,16 +17,16 @@ import (
 )
 
 func TestMergeLogs(t *testing.T) {
-	lr1 := &logsRequest{ld: testdata.GenerateLogs(2)}
-	lr2 := &logsRequest{ld: testdata.GenerateLogs(3)}
+	lr1 := newLogsRequest(testdata.GenerateLogs(2), nil)
+	lr2 := newLogsRequest(testdata.GenerateLogs(3), nil)
 	res, err := lr1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{}, lr2)
 	require.NoError(t, err)
 	require.Equal(t, 5, res[0].(*logsRequest).ld.LogRecordCount())
 }
 
 func TestMergeLogsInvalidInput(t *testing.T) {
-	lr1 := &tracesRequest{td: testdata.GenerateTraces(2)}
-	lr2 := &logsRequest{ld: testdata.GenerateLogs(3)}
+	lr1 := newTracesRequest(testdata.GenerateTraces(2), nil)
+	lr2 := newLogsRequest(testdata.GenerateLogs(3), nil)
 	_, err := lr1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{}, lr2)
 	require.Error(t, err)
 }
@@ -42,78 +42,78 @@ func TestMergeSplitLogs(t *testing.T) {
 		{
 			name:     "both_requests_empty",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			lr1:      &logsRequest{ld: plog.NewLogs()},
-			lr2:      &logsRequest{ld: plog.NewLogs()},
-			expected: []*logsRequest{{ld: plog.NewLogs()}},
+			lr1:      newLogsRequest(plog.NewLogs(), nil),
+			lr2:      newLogsRequest(plog.NewLogs(), nil),
+			expected: []*logsRequest{newLogsRequest(plog.NewLogs(), nil).(*logsRequest)},
 		},
 		{
 			name:     "first_request_empty",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			lr1:      &logsRequest{ld: plog.NewLogs()},
-			lr2:      &logsRequest{ld: testdata.GenerateLogs(5)},
-			expected: []*logsRequest{{ld: testdata.GenerateLogs(5)}},
+			lr1:      newLogsRequest(plog.NewLogs(), nil),
+			lr2:      newLogsRequest(testdata.GenerateLogs(5), nil),
+			expected: []*logsRequest{newLogsRequest(testdata.GenerateLogs(5), nil).(*logsRequest)},
 		},
 		{
 			name:     "first_empty_second_nil",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			lr1:      &logsRequest{ld: plog.NewLogs()},
+			lr1:      newLogsRequest(plog.NewLogs(), nil),
 			lr2:      nil,
-			expected: []*logsRequest{{ld: plog.NewLogs()}},
+			expected: []*logsRequest{newLogsRequest(plog.NewLogs(), nil).(*logsRequest)},
 		},
 		{
 			name: "merge_only",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			lr1:  &logsRequest{ld: testdata.GenerateLogs(4)},
-			lr2:  &logsRequest{ld: testdata.GenerateLogs(6)},
-			expected: []*logsRequest{{ld: func() plog.Logs {
+			lr1:  newLogsRequest(testdata.GenerateLogs(4), nil),
+			lr2:  newLogsRequest(testdata.GenerateLogs(6), nil),
+			expected: []*logsRequest{newLogsRequest(func() plog.Logs {
 				logs := testdata.GenerateLogs(4)
 				testdata.GenerateLogs(6).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
 				return logs
-			}()}},
+			}(), nil).(*logsRequest)},
 		},
 		{
 			name: "split_only",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 4},
-			lr1:  &logsRequest{ld: plog.NewLogs()},
-			lr2:  &logsRequest{ld: testdata.GenerateLogs(10)},
+			lr1:  newLogsRequest(plog.NewLogs(), nil),
+			lr2:  newLogsRequest(testdata.GenerateLogs(10), nil),
 			expected: []*logsRequest{
-				{ld: testdata.GenerateLogs(4)},
-				{ld: testdata.GenerateLogs(4)},
-				{ld: testdata.GenerateLogs(2)},
+				newLogsRequest(testdata.GenerateLogs(4), nil).(*logsRequest),
+				newLogsRequest(testdata.GenerateLogs(4), nil).(*logsRequest),
+				newLogsRequest(testdata.GenerateLogs(2), nil).(*logsRequest),
 			},
 		},
 		{
 			name: "merge_and_split",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			lr1:  &logsRequest{ld: testdata.GenerateLogs(8)},
-			lr2:  &logsRequest{ld: testdata.GenerateLogs(20)},
+			lr1:  newLogsRequest(testdata.GenerateLogs(8), nil),
+			lr2:  newLogsRequest(testdata.GenerateLogs(20), nil),
 			expected: []*logsRequest{
-				{ld: func() plog.Logs {
+				newLogsRequest(func() plog.Logs {
 					logs := testdata.GenerateLogs(8)
 					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
 					return logs
-				}()},
-				{ld: testdata.GenerateLogs(10)},
-				{ld: testdata.GenerateLogs(8)},
+				}(), nil).(*logsRequest),
+				newLogsRequest(testdata.GenerateLogs(10), nil).(*logsRequest),
+				newLogsRequest(testdata.GenerateLogs(8), nil).(*logsRequest),
 			},
 		},
 		{
 			name: "scope_logs_split",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 4},
-			lr1: &logsRequest{ld: func() plog.Logs {
+			lr1: newLogsRequest(func() plog.Logs {
 				ld := testdata.GenerateLogs(4)
 				ld.ResourceLogs().At(0).ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("extra log")
 				return ld
-			}()},
-			lr2: &logsRequest{ld: testdata.GenerateLogs(2)},
+			}(), nil),
+			lr2: newLogsRequest(testdata.GenerateLogs(2), nil),
 			expected: []*logsRequest{
-				{ld: testdata.GenerateLogs(4)},
-				{ld: func() plog.Logs {
+				newLogsRequest(testdata.GenerateLogs(4), nil).(*logsRequest),
+				newLogsRequest(func() plog.Logs {
 					ld := testdata.GenerateLogs(0)
 					ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().AppendEmpty().Body().SetStr("extra log")
 					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(ld.ResourceLogs())
 					return ld
-				}()},
+				}(), nil).(*logsRequest),
 			},
 		},
 	}
@@ -130,16 +130,16 @@ func TestMergeSplitLogs(t *testing.T) {
 }
 
 func TestMergeSplitLogsInputNotModifiedIfErrorReturned(t *testing.T) {
-	r1 := &logsRequest{ld: testdata.GenerateLogs(18)}
-	r2 := &tracesRequest{td: testdata.GenerateTraces(3)}
+	r1 := newLogsRequest(testdata.GenerateLogs(18), nil)
+	r2 := newTracesRequest(testdata.GenerateTraces(3), nil)
 	_, err := r1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{MaxSizeItems: 10}, r2)
 	require.Error(t, err)
 	assert.Equal(t, 18, r1.ItemsCount())
 }
 
 func TestMergeSplitLogsInvalidInput(t *testing.T) {
-	r1 := &tracesRequest{td: testdata.GenerateTraces(2)}
-	r2 := &logsRequest{ld: testdata.GenerateLogs(3)}
+	r1 := newTracesRequest(testdata.GenerateTraces(2), nil)
+	r2 := newLogsRequest(testdata.GenerateLogs(3), nil)
 	_, err := r1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{}, r2)
 	require.Error(t, err)
 }

--- a/exporter/exporterhelper/metrics_batch.go
+++ b/exporter/exporterhelper/metrics_batch.go
@@ -56,7 +56,7 @@ func (req *metricsRequest) MergeSplit(_ context.Context, cfg exporterbatcher.Max
 			}
 			capacityLeft -= extractedMetrics.DataPointCount()
 			if destReq == nil {
-				destReq = &metricsRequest{md: extractedMetrics, pusher: srcReq.pusher}
+				destReq = newMetricsRequest(extractedMetrics, srcReq.pusher).(*metricsRequest)
 			} else {
 				extractedMetrics.ResourceMetrics().MoveAndAppendTo(destReq.md.ResourceMetrics())
 			}

--- a/exporter/exporterhelper/metrics_batch_test.go
+++ b/exporter/exporterhelper/metrics_batch_test.go
@@ -16,16 +16,16 @@ import (
 )
 
 func TestMergeMetrics(t *testing.T) {
-	mr1 := &metricsRequest{md: testdata.GenerateMetrics(2)}
-	mr2 := &metricsRequest{md: testdata.GenerateMetrics(3)}
+	mr1 := newMetricsRequest(testdata.GenerateMetrics(2), nil)
+	mr2 := newMetricsRequest(testdata.GenerateMetrics(3), nil)
 	res, err := mr1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{}, mr2)
 	require.NoError(t, err)
 	assert.Equal(t, 5, res[0].(*metricsRequest).md.MetricCount())
 }
 
 func TestMergeMetricsInvalidInput(t *testing.T) {
-	mr1 := &tracesRequest{td: testdata.GenerateTraces(2)}
-	mr2 := &metricsRequest{md: testdata.GenerateMetrics(3)}
+	mr1 := newTracesRequest(testdata.GenerateTraces(2), nil)
+	mr2 := newMetricsRequest(testdata.GenerateMetrics(3), nil)
 	_, err := mr1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{}, mr2)
 	require.Error(t, err)
 }
@@ -41,79 +41,79 @@ func TestMergeSplitMetrics(t *testing.T) {
 		{
 			name:     "both_requests_empty",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			mr1:      &metricsRequest{md: pmetric.NewMetrics()},
-			mr2:      &metricsRequest{md: pmetric.NewMetrics()},
-			expected: []*metricsRequest{{md: pmetric.NewMetrics()}},
+			mr1:      newMetricsRequest(pmetric.NewMetrics(), nil),
+			mr2:      newMetricsRequest(pmetric.NewMetrics(), nil),
+			expected: []*metricsRequest{newMetricsRequest(pmetric.NewMetrics(), nil).(*metricsRequest)},
 		},
 		{
 			name:     "first_request_empty",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			mr1:      &metricsRequest{md: pmetric.NewMetrics()},
-			mr2:      &metricsRequest{md: testdata.GenerateMetrics(5)},
-			expected: []*metricsRequest{{md: testdata.GenerateMetrics(5)}},
+			mr1:      newMetricsRequest(pmetric.NewMetrics(), nil),
+			mr2:      newMetricsRequest(testdata.GenerateMetrics(5), nil),
+			expected: []*metricsRequest{newMetricsRequest(testdata.GenerateMetrics(5), nil).(*metricsRequest)},
 		},
 		{
 			name:     "first_empty_second_nil",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			mr1:      &metricsRequest{md: pmetric.NewMetrics()},
+			mr1:      newMetricsRequest(pmetric.NewMetrics(), nil),
 			mr2:      nil,
-			expected: []*metricsRequest{{md: pmetric.NewMetrics()}},
+			expected: []*metricsRequest{newMetricsRequest(pmetric.NewMetrics(), nil).(*metricsRequest)},
 		},
 		{
 			name: "merge_only",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 60},
-			mr1:  &metricsRequest{md: testdata.GenerateMetrics(10)},
-			mr2:  &metricsRequest{md: testdata.GenerateMetrics(14)},
-			expected: []*metricsRequest{{md: func() pmetric.Metrics {
+			mr1:  newMetricsRequest(testdata.GenerateMetrics(10), nil),
+			mr2:  newMetricsRequest(testdata.GenerateMetrics(14), nil),
+			expected: []*metricsRequest{newMetricsRequest(func() pmetric.Metrics {
 				metrics := testdata.GenerateMetrics(10)
 				testdata.GenerateMetrics(14).ResourceMetrics().MoveAndAppendTo(metrics.ResourceMetrics())
 				return metrics
-			}()}},
+			}(), nil).(*metricsRequest)},
 		},
 		{
 			name: "split_only",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 14},
-			mr1:  &metricsRequest{md: pmetric.NewMetrics()},
-			mr2:  &metricsRequest{md: testdata.GenerateMetrics(15)}, // 15 metrics, 30 data points
+			mr1:  newMetricsRequest(pmetric.NewMetrics(), nil),
+			mr2:  newMetricsRequest(testdata.GenerateMetrics(15), nil), // 15 metrics, 30 data points
 			expected: []*metricsRequest{
-				{md: testdata.GenerateMetrics(7)}, // 7 metrics, 14 data points
-				{md: testdata.GenerateMetrics(7)}, // 7 metrics, 14 data points
-				{md: testdata.GenerateMetrics(1)}, // 1 metric, 2 data points
+				newMetricsRequest(testdata.GenerateMetrics(7), nil).(*metricsRequest), // 7 metrics, 14 data points
+				newMetricsRequest(testdata.GenerateMetrics(7), nil).(*metricsRequest), // 7 metrics, 14 data points
+				newMetricsRequest(testdata.GenerateMetrics(1), nil).(*metricsRequest), // 1 metric, 2 data points
 			},
 		},
 		{
 			name: "split_and_merge",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 28},
-			mr1:  &metricsRequest{md: testdata.GenerateMetrics(7)},  // 7 metrics, 14 data points
-			mr2:  &metricsRequest{md: testdata.GenerateMetrics(25)}, // 25 metrics, 50 data points
+			mr1:  newMetricsRequest(testdata.GenerateMetrics(7), nil),  // 7 metrics, 14 data points
+			mr2:  newMetricsRequest(testdata.GenerateMetrics(25), nil), // 25 metrics, 50 data points
 			expected: []*metricsRequest{
-				{md: func() pmetric.Metrics {
+				newMetricsRequest(func() pmetric.Metrics {
 					metrics := testdata.GenerateMetrics(7)
 					testdata.GenerateMetrics(7).ResourceMetrics().MoveAndAppendTo(metrics.ResourceMetrics())
 					return metrics
-				}()},
-				{md: testdata.GenerateMetrics(14)}, // 14 metrics, 28 data points
-				{md: testdata.GenerateMetrics(4)},  // 4 metrics, 8 data points
+				}(), nil).(*metricsRequest),
+				newMetricsRequest(testdata.GenerateMetrics(14), nil).(*metricsRequest), // 14 metrics, 28 data points
+				newMetricsRequest(testdata.GenerateMetrics(4), nil).(*metricsRequest),  // 4 metrics, 8 data points
 			},
 		},
 		{
 			name: "scope_metrics_split",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 8},
-			mr1: &metricsRequest{md: func() pmetric.Metrics {
+			mr1: newMetricsRequest(func() pmetric.Metrics {
 				md := testdata.GenerateMetrics(4)
 				extraScopeMetrics := md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty()
 				testdata.GenerateMetrics(4).ResourceMetrics().At(0).ScopeMetrics().At(0).MoveTo(extraScopeMetrics)
 				extraScopeMetrics.Scope().SetName("extra scope")
 				return md
-			}()},
+			}(), nil),
 			mr2: nil,
 			expected: []*metricsRequest{
-				{md: testdata.GenerateMetrics(4)},
-				{md: func() pmetric.Metrics {
+				newMetricsRequest(testdata.GenerateMetrics(4), nil).(*metricsRequest),
+				newMetricsRequest(func() pmetric.Metrics {
 					md := testdata.GenerateMetrics(4)
 					md.ResourceMetrics().At(0).ScopeMetrics().At(0).Scope().SetName("extra scope")
 					return md
-				}()},
+				}(), nil).(*metricsRequest),
 			},
 		},
 	}
@@ -130,16 +130,16 @@ func TestMergeSplitMetrics(t *testing.T) {
 }
 
 func TestMergeSplitMetricsInputNotModifiedIfErrorReturned(t *testing.T) {
-	r1 := &metricsRequest{md: testdata.GenerateMetrics(18)} // 18 metrics, 36 data points
-	r2 := &logsRequest{ld: testdata.GenerateLogs(3)}
+	r1 := newMetricsRequest(testdata.GenerateMetrics(18), nil) // 18 metrics, 36 data points
+	r2 := newLogsRequest(testdata.GenerateLogs(3), nil)
 	_, err := r1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{MaxSizeItems: 10}, r2)
 	require.Error(t, err)
 	assert.Equal(t, 36, r1.ItemsCount())
 }
 
 func TestMergeSplitMetricsInvalidInput(t *testing.T) {
-	r1 := &tracesRequest{td: testdata.GenerateTraces(2)}
-	r2 := &metricsRequest{md: testdata.GenerateMetrics(3)}
+	r1 := newTracesRequest(testdata.GenerateTraces(2), nil)
+	r2 := newMetricsRequest(testdata.GenerateMetrics(3), nil)
 	_, err := r1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{MaxSizeItems: 10}, r2)
 	require.Error(t, err)
 }

--- a/exporter/exporterhelper/traces_batch.go
+++ b/exporter/exporterhelper/traces_batch.go
@@ -56,7 +56,7 @@ func (req *tracesRequest) MergeSplit(_ context.Context, cfg exporterbatcher.MaxS
 			}
 			capacityLeft -= extractedTraces.SpanCount()
 			if destReq == nil {
-				destReq = &tracesRequest{td: extractedTraces, pusher: srcReq.pusher}
+				destReq = newTracesRequest(extractedTraces, srcReq.pusher).(*tracesRequest)
 			} else {
 				extractedTraces.ResourceSpans().MoveAndAppendTo(destReq.td.ResourceSpans())
 			}

--- a/exporter/exporterhelper/traces_batch_test.go
+++ b/exporter/exporterhelper/traces_batch_test.go
@@ -16,16 +16,16 @@ import (
 )
 
 func TestMergeTraces(t *testing.T) {
-	tr1 := &tracesRequest{td: testdata.GenerateTraces(2)}
-	tr2 := &tracesRequest{td: testdata.GenerateTraces(3)}
+	tr1 := newTracesRequest(testdata.GenerateTraces(2), nil)
+	tr2 := newTracesRequest(testdata.GenerateTraces(3), nil)
 	res, err := tr1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{}, tr2)
 	require.NoError(t, err)
 	assert.Equal(t, 5, res[0].(*tracesRequest).td.SpanCount())
 }
 
 func TestMergeTracesInvalidInput(t *testing.T) {
-	tr1 := &logsRequest{ld: testdata.GenerateLogs(2)}
-	tr2 := &tracesRequest{td: testdata.GenerateTraces(3)}
+	tr1 := newLogsRequest(testdata.GenerateLogs(2), nil)
+	tr2 := newTracesRequest(testdata.GenerateTraces(3), nil)
 	_, err := tr1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{}, tr2)
 	require.Error(t, err)
 }
@@ -41,86 +41,86 @@ func TestMergeSplitTraces(t *testing.T) {
 		{
 			name:     "both_requests_empty",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			tr1:      &tracesRequest{td: ptrace.NewTraces()},
-			tr2:      &tracesRequest{td: ptrace.NewTraces()},
-			expected: []*tracesRequest{{td: ptrace.NewTraces()}},
+			tr1:      newTracesRequest(ptrace.NewTraces(), nil),
+			tr2:      newTracesRequest(ptrace.NewTraces(), nil),
+			expected: []*tracesRequest{newTracesRequest(ptrace.NewTraces(), nil).(*tracesRequest)},
 		},
 		{
 			name:     "first_request_empty",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			tr1:      &tracesRequest{td: ptrace.NewTraces()},
-			tr2:      &tracesRequest{td: testdata.GenerateTraces(5)},
-			expected: []*tracesRequest{{td: testdata.GenerateTraces(5)}},
+			tr1:      newTracesRequest(ptrace.NewTraces(), nil),
+			tr2:      newTracesRequest(testdata.GenerateTraces(5), nil),
+			expected: []*tracesRequest{newTracesRequest(testdata.GenerateTraces(5), nil).(*tracesRequest)},
 		},
 		{
 			name:     "second_request_empty",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			tr1:      &tracesRequest{td: testdata.GenerateTraces(5)},
-			tr2:      &tracesRequest{td: ptrace.NewTraces()},
-			expected: []*tracesRequest{{td: testdata.GenerateTraces(5)}},
+			tr1:      newTracesRequest(testdata.GenerateTraces(5), nil),
+			tr2:      newTracesRequest(ptrace.NewTraces(), nil),
+			expected: []*tracesRequest{newTracesRequest(testdata.GenerateTraces(5), nil).(*tracesRequest)},
 		},
 		{
 			name:     "first_empty_second_nil",
 			cfg:      exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			tr1:      &tracesRequest{td: ptrace.NewTraces()},
+			tr1:      newTracesRequest(ptrace.NewTraces(), nil),
 			tr2:      nil,
-			expected: []*tracesRequest{{td: ptrace.NewTraces()}},
+			expected: []*tracesRequest{newTracesRequest(ptrace.NewTraces(), nil).(*tracesRequest)},
 		},
 		{
 			name: "merge_only",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			tr1:  &tracesRequest{td: testdata.GenerateTraces(5)},
-			tr2:  &tracesRequest{td: testdata.GenerateTraces(5)},
-			expected: []*tracesRequest{{td: func() ptrace.Traces {
+			tr1:  newTracesRequest(testdata.GenerateTraces(5), nil),
+			tr2:  newTracesRequest(testdata.GenerateTraces(5), nil),
+			expected: []*tracesRequest{newTracesRequest(func() ptrace.Traces {
 				td := testdata.GenerateTraces(5)
 				testdata.GenerateTraces(5).ResourceSpans().MoveAndAppendTo(td.ResourceSpans())
 				return td
-			}()}},
+			}(), nil).(*tracesRequest)},
 		},
 		{
 			name: "split_only",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 4},
-			tr1:  &tracesRequest{td: ptrace.NewTraces()},
-			tr2:  &tracesRequest{td: testdata.GenerateTraces(10)},
+			tr1:  newTracesRequest(ptrace.NewTraces(), nil),
+			tr2:  newTracesRequest(testdata.GenerateTraces(10), nil),
 			expected: []*tracesRequest{
-				{td: testdata.GenerateTraces(4)},
-				{td: testdata.GenerateTraces(4)},
-				{td: testdata.GenerateTraces(2)},
+				newTracesRequest(testdata.GenerateTraces(4), nil).(*tracesRequest),
+				newTracesRequest(testdata.GenerateTraces(4), nil).(*tracesRequest),
+				newTracesRequest(testdata.GenerateTraces(2), nil).(*tracesRequest),
 			},
 		},
 		{
 			name: "split_and_merge",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			tr1:  &tracesRequest{td: testdata.GenerateTraces(4)},
-			tr2:  &tracesRequest{td: testdata.GenerateTraces(20)},
+			tr1:  newTracesRequest(testdata.GenerateTraces(4), nil),
+			tr2:  newTracesRequest(testdata.GenerateTraces(20), nil),
 			expected: []*tracesRequest{
-				{td: func() ptrace.Traces {
+				newTracesRequest(func() ptrace.Traces {
 					td := testdata.GenerateTraces(4)
 					testdata.GenerateTraces(6).ResourceSpans().MoveAndAppendTo(td.ResourceSpans())
 					return td
-				}()},
-				{td: testdata.GenerateTraces(10)},
-				{td: testdata.GenerateTraces(4)},
+				}(), nil).(*tracesRequest),
+				newTracesRequest(testdata.GenerateTraces(10), nil).(*tracesRequest),
+				newTracesRequest(testdata.GenerateTraces(4), nil).(*tracesRequest),
 			},
 		},
 		{
 			name: "scope_spans_split",
 			cfg:  exporterbatcher.MaxSizeConfig{MaxSizeItems: 10},
-			tr1: &tracesRequest{td: func() ptrace.Traces {
+			tr1: newTracesRequest(func() ptrace.Traces {
 				td := testdata.GenerateTraces(10)
 				extraScopeTraces := testdata.GenerateTraces(5)
 				extraScopeTraces.ResourceSpans().At(0).ScopeSpans().At(0).Scope().SetName("extra scope")
 				extraScopeTraces.ResourceSpans().MoveAndAppendTo(td.ResourceSpans())
 				return td
-			}()},
+			}(), nil),
 			tr2: nil,
 			expected: []*tracesRequest{
-				{td: testdata.GenerateTraces(10)},
-				{td: func() ptrace.Traces {
+				newTracesRequest(testdata.GenerateTraces(10), nil).(*tracesRequest),
+				newTracesRequest(func() ptrace.Traces {
 					td := testdata.GenerateTraces(5)
 					td.ResourceSpans().At(0).ScopeSpans().At(0).Scope().SetName("extra scope")
 					return td
-				}()},
+				}(), nil).(*tracesRequest),
 			},
 		},
 	}
@@ -137,16 +137,16 @@ func TestMergeSplitTraces(t *testing.T) {
 }
 
 func TestMergeSplitTracesInputNotModifiedIfErrorReturned(t *testing.T) {
-	r1 := &tracesRequest{td: testdata.GenerateTraces(18)}
-	r2 := &logsRequest{ld: testdata.GenerateLogs(3)}
+	r1 := newTracesRequest(testdata.GenerateTraces(18), nil)
+	r2 := newLogsRequest(testdata.GenerateLogs(3), nil)
 	_, err := r1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{MaxSizeItems: 10}, r2)
 	require.Error(t, err)
 	assert.Equal(t, 18, r1.ItemsCount())
 }
 
 func TestMergeSplitTracesInvalidInput(t *testing.T) {
-	r1 := &tracesRequest{td: testdata.GenerateTraces(2)}
-	r2 := &metricsRequest{md: testdata.GenerateMetrics(3)}
+	r1 := newTracesRequest(testdata.GenerateTraces(2), nil)
+	r2 := newMetricsRequest(testdata.GenerateMetrics(3), nil)
 	_, err := r1.MergeSplit(context.Background(), exporterbatcher.MaxSizeConfig{MaxSizeItems: 10}, r2)
 	require.Error(t, err)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

As part of the effort to cache request size to improve merge splitting performance
(See https://github.com/open-telemetry/opentelemetry-collector/issues/12137 and https://github.com/open-telemetry/opentelemetry-collector/pull/12136),  we want to make sure requests are created from create function instead of getting initialized via struct directly.

* `newLogsRequest` instead of `&logsRequest{}`
* `newMetrcsRequest` instead of `&metricsRequest{}`
* `newTracesRequest` instead of `&tracesRequest{}`



<!-- Issue number if applicable -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector/issues/12137

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
