### PR TITLE
[exporter][batcher] Add the API ByteSize() to exporter.Request

### DIFF
--- a/.chloggen/add-byte-size-to-exporter-request-api.yaml
+++ b/.chloggen/add-byte-size-to-exporter-request-api.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added a new API ByteSize() to exporter.request
+
+# One or more tracking issues or pull requests related to the change
+issues: [3265]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -168,6 +168,10 @@ func (mer *mockErrorRequest) ItemsCount() int {
 	return 7
 }
 
+func (mer *mockErrorRequest) ByteSize() int {
+	return 7
+}
+
 func (mer *mockErrorRequest) MergeSplit(context.Context, exporterbatcher.MaxSizeConfig, internal.Request) ([]internal.Request, error) {
 	return nil, nil
 }
@@ -211,6 +215,10 @@ func (m *mockRequest) checkOneRequests(t *testing.T) {
 }
 
 func (m *mockRequest) ItemsCount() int {
+	return m.cnt
+}
+
+func (m *mockRequest) ByteSize() int {
 	return m.cnt
 }
 

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -72,6 +72,10 @@ func (req *logsRequest) setCachedItemsCount(count int) {
 	req.cachedItemsCount = count
 }
 
+func (req *logsRequest) ByteSize() int {
+	return logsMarshaler.LogsSize(req.ld)
+}
+
 type logsExporter struct {
 	*internal.BaseExporter
 	consumer.Logs

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -47,6 +47,8 @@ var (
 
 func TestLogsRequest(t *testing.T) {
 	lr := newLogsRequest(testdata.GenerateLogs(1), nil)
+	assert.Equal(t, 1, lr.ItemsCount())
+	assert.Equal(t, logsMarshaler.LogsSize(testdata.GenerateLogs(1)), lr.ByteSize())
 
 	logErr := consumererror.NewLogs(errors.New("some error"), plog.NewLogs())
 	assert.EqualValues(

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -48,7 +48,7 @@ var (
 func TestLogsRequest(t *testing.T) {
 	lr := newLogsRequest(testdata.GenerateLogs(1), nil)
 	assert.Equal(t, 1, lr.ItemsCount())
-	assert.Equal(t, logsMarshaler.LogsSize(testdata.GenerateLogs(1)), lr.ByteSize())
+	assert.Equal(t, 160, lr.ByteSize())
 
 	logErr := consumererror.NewLogs(errors.New("some error"), plog.NewLogs())
 	assert.EqualValues(

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -72,6 +72,10 @@ func (req *metricsRequest) setCachedItemsCount(count int) {
 	req.cachedItemsCount = count
 }
 
+func (req *metricsRequest) ByteSize() int {
+	return metricsMarshaler.MetricsSize(req.md)
+}
+
 type metricsExporter struct {
 	*internal.BaseExporter
 	consumer.Metrics

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -48,7 +48,7 @@ var (
 func TestMetricsRequest(t *testing.T) {
 	mr := newMetricsRequest(testdata.GenerateMetrics(1), nil)
 	assert.Equal(t, 2, mr.ItemsCount())
-	assert.Equal(t, metricsMarshaler.MetricsSize(testdata.GenerateMetrics(1)), mr.ByteSize())
+	assert.Equal(t, 183, mr.ByteSize())
 
 	metricsErr := consumererror.NewMetrics(errors.New("some error"), pmetric.NewMetrics())
 	assert.EqualValues(

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -47,6 +47,8 @@ var (
 
 func TestMetricsRequest(t *testing.T) {
 	mr := newMetricsRequest(testdata.GenerateMetrics(1), nil)
+	assert.Equal(t, 2, mr.ItemsCount())
+	assert.Equal(t, metricsMarshaler.MetricsSize(testdata.GenerateMetrics(1)), mr.ByteSize())
 
 	metricsErr := consumererror.NewMetrics(errors.New("some error"), pmetric.NewMetrics())
 	assert.EqualValues(

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -72,6 +72,10 @@ func (req *tracesRequest) setCachedItemsCount(count int) {
 	req.cachedItemsCount = count
 }
 
+func (req *tracesRequest) ByteSize() int {
+	return tracesMarshaler.TracesSize(req.td)
+}
+
 type tracesExporter struct {
 	*internal.BaseExporter
 	consumer.Traces

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -46,10 +46,12 @@ var (
 )
 
 func TestTracesRequest(t *testing.T) {
-	mr := newTracesRequest(testdata.GenerateTraces(1), nil)
+	tr := newTracesRequest(testdata.GenerateTraces(1), nil)
+	assert.Equal(t, 1, tr.ItemsCount())
+	assert.Equal(t, tracesMarshaler.TracesSize(testdata.GenerateTraces(1)), tr.ByteSize())
 
 	traceErr := consumererror.NewTraces(errors.New("some error"), ptrace.NewTraces())
-	assert.EqualValues(t, newTracesRequest(ptrace.NewTraces(), nil), mr.(RequestErrorHandler).OnError(traceErr))
+	assert.EqualValues(t, newTracesRequest(ptrace.NewTraces(), nil), tr.(RequestErrorHandler).OnError(traceErr))
 }
 
 func TestTraces_InvalidName(t *testing.T) {

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -48,7 +48,7 @@ var (
 func TestTracesRequest(t *testing.T) {
 	tr := newTracesRequest(testdata.GenerateTraces(1), nil)
 	assert.Equal(t, 1, tr.ItemsCount())
-	assert.Equal(t, tracesMarshaler.TracesSize(testdata.GenerateTraces(1)), tr.ByteSize())
+	assert.Equal(t, 240, tr.ByteSize())
 
 	traceErr := consumererror.NewTraces(errors.New("some error"), ptrace.NewTraces())
 	assert.EqualValues(t, newTracesRequest(ptrace.NewTraces(), nil), tr.(RequestErrorHandler).OnError(traceErr))

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -75,6 +75,10 @@ func (req *profilesRequest) setCachedItemsCount(count int) {
 	req.cachedItemsCount = count
 }
 
+func (req *profilesRequest) ByteSize() int {
+	return profilesMarshaler.ProfilesSize(req.pd)
+}
+
 type profileExporter struct {
 	*internal.BaseExporter
 	xconsumer.Profiles

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
@@ -144,4 +144,5 @@ func TestMergeSplitManySmallLogs(t *testing.T) {
 		merged = append(merged[0:len(merged)-1], res...)
 	}
 	assert.Len(t, merged, 2)
+}
 

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
@@ -144,4 +144,4 @@ func TestMergeSplitManySmallLogs(t *testing.T) {
 		merged = append(merged[0:len(merged)-1], res...)
 	}
 	assert.Len(t, merged, 2)
-}
+

--- a/exporter/exporterhelper/xexporterhelper/profiles_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_test.go
@@ -46,7 +46,7 @@ var fakeProfilesExporterConfig = struct{}{}
 func TestProfilesRequest(t *testing.T) {
 	pr := newProfilesRequest(testdata.GenerateProfiles(1), nil)
 	assert.Equal(t, 1, pr.ItemsCount())
-	assert.Equal(t, profilesMarshaler.ProfilesSize(testdata.GenerateProfiles(1)), pr.ByteSize())
+	assert.Equal(t, 122, pr.ByteSize())
 
 	profileErr := xconsumererror.NewProfiles(errors.New("some error"), pprofile.NewProfiles())
 	assert.EqualValues(

--- a/exporter/exporterhelper/xexporterhelper/profiles_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_test.go
@@ -44,13 +44,15 @@ const (
 var fakeProfilesExporterConfig = struct{}{}
 
 func TestProfilesRequest(t *testing.T) {
-	lr := newProfilesRequest(testdata.GenerateProfiles(1), nil)
+	pr := newProfilesRequest(testdata.GenerateProfiles(1), nil)
+	assert.Equal(t, 1, pr.ItemsCount())
+	assert.Equal(t, profilesMarshaler.ProfilesSize(testdata.GenerateProfiles(1)), pr.ByteSize())
 
 	profileErr := xconsumererror.NewProfiles(errors.New("some error"), pprofile.NewProfiles())
 	assert.EqualValues(
 		t,
 		newProfilesRequest(pprofile.NewProfiles(), nil),
-		lr.(exporterhelper.RequestErrorHandler).OnError(profileErr),
+		pr.(exporterhelper.RequestErrorHandler).OnError(profileErr),
 	)
 }
 

--- a/exporter/internal/request.go
+++ b/exporter/internal/request.go
@@ -16,9 +16,10 @@ type Request interface {
 	// Export exports the request to an external endpoint.
 	Export(ctx context.Context) error
 	// ItemsCount returns a number of basic items in the request where item is the smallest piece of data that can be
-	// sent. For example, for OTLP exporter, this value represents the number of spans,
-	// metric data points or log records.
+	// sent. For example, for OTLP exporter, this value represents the number of spans, metric data points or log records.
 	ItemsCount() int
+	// ByteSize returns the serialized byte size of of the request.
+	ByteSize() int
 	// MergeSplit is a function that merge and/or splits this request with another one into multiple requests based on the
 	// configured limit provided in MaxSizeConfig.
 	// MergeSplit does not split if all fields in MaxSizeConfig are not initialized (zero).

--- a/exporter/internal/request.go
+++ b/exporter/internal/request.go
@@ -16,7 +16,8 @@ type Request interface {
 	// Export exports the request to an external endpoint.
 	Export(ctx context.Context) error
 	// ItemsCount returns a number of basic items in the request where item is the smallest piece of data that can be
-	// sent. For example, for OTLP exporter, this value represents the number of spans, metric data points or log records.
+	// sent. For example, for OTLP exporter, this value represents the number of spans,
+	// metric data points or log records.
 	ItemsCount() int
 	// ByteSize returns the serialized byte size of of the request.
 	ByteSize() int

--- a/exporter/internal/requesttest/fake_request.go
+++ b/exporter/internal/requesttest/fake_request.go
@@ -30,6 +30,10 @@ func (s *Sink) ItemsCount() int64 {
 	return s.itemsCount.Load()
 }
 
+func (s *Sink) ByteSize() int64 {
+	return s.itemsCount.Load()
+}
+
 func NewSink() *Sink {
 	return &Sink{
 		requestsCount: new(atomic.Int64),
@@ -95,6 +99,10 @@ func (r *FakeRequest) OnError(err error) internal.Request {
 }
 
 func (r *FakeRequest) ItemsCount() int {
+	return r.Items
+}
+
+func (r *FakeRequest) ByteSize() int {
 	return r.Items
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds the API to `ByteSize()` to `exporter.Request`

<!-- Issue number if applicable -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector/issues/3262

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
