### PR TITLE
[cmd/mdatagen] Allow passing SDK metric options to SetupTelemetry

### DIFF
--- a/.chloggen/mx-psi_setup-telemetry-options.yaml
+++ b/.chloggen/mx-psi_setup-telemetry-options.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow passing OTel Metric SDK options to the generated `SetupTelemetry` function.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12160]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
@@ -29,14 +29,30 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func SetupTelemetry() Telemetry {
+type SetupTelemetryOption struct {
+	sdkMetricOption *sdkmetric.Option
+}
+
+func WithSDKMetricOption(option sdkmetric.Option) SetupTelemetryOption {
+	return SetupTelemetryOption{sdkMetricOption: &option}
+}
+
+func SetupTelemetry(options ...SetupTelemetryOption) Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
+
+	sdkMetricOptions := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	for _, option := range options {
+		if option.sdkMetricOption != nil {
+			sdkMetricOptions = append(sdkMetricOptions, *option.sdkMetricOption)
+		}
+	}
+
 	return Telemetry{
 		Reader:       reader,
 		SpanRecorder: spanRecorder,
 
-		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		meterProvider: sdkmetric.NewMeterProvider(sdkMetricOptions...),
 		traceProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder)),
 	}
 }

--- a/cmd/mdatagen/internal/templates/telemetrytest.go.tmpl
+++ b/cmd/mdatagen/internal/templates/telemetrytest.go.tmpl
@@ -31,14 +31,30 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func SetupTelemetry() Telemetry {
+type SetupTelemetryOption struct {
+   sdkMetricOption *sdkmetric.Option
+}
+
+func WithSDKMetricOption(option sdkmetric.Option) SetupTelemetryOption {
+	return SetupTelemetryOption{sdkMetricOption: &option}
+}
+
+func SetupTelemetry(options ...SetupTelemetryOption) Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
+
+	sdkMetricOptions := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	for _, option := range options {
+		if option.sdkMetricOption != nil {
+			sdkMetricOptions = append(sdkMetricOptions, *option.sdkMetricOption)
+		}
+	}
+
 	return Telemetry{
 		Reader:        reader,
 		SpanRecorder:  spanRecorder,
 
-		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		meterProvider: sdkmetric.NewMeterProvider(sdkMetricOptions...),
 		traceProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder)),
 	}
 }

--- a/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest.go
@@ -29,14 +29,30 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func SetupTelemetry() Telemetry {
+type SetupTelemetryOption struct {
+	sdkMetricOption *sdkmetric.Option
+}
+
+func WithSDKMetricOption(option sdkmetric.Option) SetupTelemetryOption {
+	return SetupTelemetryOption{sdkMetricOption: &option}
+}
+
+func SetupTelemetry(options ...SetupTelemetryOption) Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
+
+	sdkMetricOptions := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	for _, option := range options {
+		if option.sdkMetricOption != nil {
+			sdkMetricOptions = append(sdkMetricOptions, *option.sdkMetricOption)
+		}
+	}
+
 	return Telemetry{
 		Reader:       reader,
 		SpanRecorder: spanRecorder,
 
-		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		meterProvider: sdkmetric.NewMeterProvider(sdkMetricOptions...),
 		traceProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder)),
 	}
 }

--- a/processor/batchprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/batchprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -29,14 +29,30 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func SetupTelemetry() Telemetry {
+type SetupTelemetryOption struct {
+	sdkMetricOption *sdkmetric.Option
+}
+
+func WithSDKMetricOption(option sdkmetric.Option) SetupTelemetryOption {
+	return SetupTelemetryOption{sdkMetricOption: &option}
+}
+
+func SetupTelemetry(options ...SetupTelemetryOption) Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
+
+	sdkMetricOptions := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	for _, option := range options {
+		if option.sdkMetricOption != nil {
+			sdkMetricOptions = append(sdkMetricOptions, *option.sdkMetricOption)
+		}
+	}
+
 	return Telemetry{
 		Reader:       reader,
 		SpanRecorder: spanRecorder,
 
-		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		meterProvider: sdkmetric.NewMeterProvider(sdkMetricOptions...),
 		traceProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder)),
 	}
 }

--- a/processor/memorylimiterprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/memorylimiterprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -29,14 +29,30 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func SetupTelemetry() Telemetry {
+type SetupTelemetryOption struct {
+	sdkMetricOption *sdkmetric.Option
+}
+
+func WithSDKMetricOption(option sdkmetric.Option) SetupTelemetryOption {
+	return SetupTelemetryOption{sdkMetricOption: &option}
+}
+
+func SetupTelemetry(options ...SetupTelemetryOption) Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
+
+	sdkMetricOptions := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	for _, option := range options {
+		if option.sdkMetricOption != nil {
+			sdkMetricOptions = append(sdkMetricOptions, *option.sdkMetricOption)
+		}
+	}
+
 	return Telemetry{
 		Reader:       reader,
 		SpanRecorder: spanRecorder,
 
-		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		meterProvider: sdkmetric.NewMeterProvider(sdkMetricOptions...),
 		traceProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder)),
 	}
 }

--- a/processor/processorhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/processorhelper/internal/metadatatest/generated_telemetrytest.go
@@ -29,14 +29,30 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func SetupTelemetry() Telemetry {
+type SetupTelemetryOption struct {
+	sdkMetricOption *sdkmetric.Option
+}
+
+func WithSDKMetricOption(option sdkmetric.Option) SetupTelemetryOption {
+	return SetupTelemetryOption{sdkMetricOption: &option}
+}
+
+func SetupTelemetry(options ...SetupTelemetryOption) Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
+
+	sdkMetricOptions := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	for _, option := range options {
+		if option.sdkMetricOption != nil {
+			sdkMetricOptions = append(sdkMetricOptions, *option.sdkMetricOption)
+		}
+	}
+
 	return Telemetry{
 		Reader:       reader,
 		SpanRecorder: spanRecorder,
 
-		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		meterProvider: sdkmetric.NewMeterProvider(sdkMetricOptions...),
 		traceProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder)),
 	}
 }

--- a/receiver/receiverhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/receiver/receiverhelper/internal/metadatatest/generated_telemetrytest.go
@@ -29,14 +29,30 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func SetupTelemetry() Telemetry {
+type SetupTelemetryOption struct {
+	sdkMetricOption *sdkmetric.Option
+}
+
+func WithSDKMetricOption(option sdkmetric.Option) SetupTelemetryOption {
+	return SetupTelemetryOption{sdkMetricOption: &option}
+}
+
+func SetupTelemetry(options ...SetupTelemetryOption) Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
+
+	sdkMetricOptions := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	for _, option := range options {
+		if option.sdkMetricOption != nil {
+			sdkMetricOptions = append(sdkMetricOptions, *option.sdkMetricOption)
+		}
+	}
+
 	return Telemetry{
 		Reader:       reader,
 		SpanRecorder: spanRecorder,
 
-		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		meterProvider: sdkmetric.NewMeterProvider(sdkMetricOptions...),
 		traceProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder)),
 	}
 }

--- a/scraper/scraperhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/scraper/scraperhelper/internal/metadatatest/generated_telemetrytest.go
@@ -27,14 +27,30 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func SetupTelemetry() Telemetry {
+type SetupTelemetryOption struct {
+	sdkMetricOption *sdkmetric.Option
+}
+
+func WithSDKMetricOption(option sdkmetric.Option) SetupTelemetryOption {
+	return SetupTelemetryOption{sdkMetricOption: &option}
+}
+
+func SetupTelemetry(options ...SetupTelemetryOption) Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
+
+	sdkMetricOptions := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	for _, option := range options {
+		if option.sdkMetricOption != nil {
+			sdkMetricOptions = append(sdkMetricOptions, *option.sdkMetricOption)
+		}
+	}
+
 	return Telemetry{
 		Reader:       reader,
 		SpanRecorder: spanRecorder,
 
-		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		meterProvider: sdkmetric.NewMeterProvider(sdkMetricOptions...),
 		traceProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder)),
 	}
 }

--- a/service/internal/metadatatest/generated_telemetrytest.go
+++ b/service/internal/metadatatest/generated_telemetrytest.go
@@ -27,14 +27,30 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func SetupTelemetry() Telemetry {
+type SetupTelemetryOption struct {
+	sdkMetricOption *sdkmetric.Option
+}
+
+func WithSDKMetricOption(option sdkmetric.Option) SetupTelemetryOption {
+	return SetupTelemetryOption{sdkMetricOption: &option}
+}
+
+func SetupTelemetry(options ...SetupTelemetryOption) Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
+
+	sdkMetricOptions := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	for _, option := range options {
+		if option.sdkMetricOption != nil {
+			sdkMetricOptions = append(sdkMetricOptions, *option.sdkMetricOption)
+		}
+	}
+
 	return Telemetry{
 		Reader:       reader,
 		SpanRecorder: spanRecorder,
 
-		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		meterProvider: sdkmetric.NewMeterProvider(sdkMetricOptions...),
 		traceProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder)),
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Allows passing `sdkmetric.Option`s to `SetupTelemetry`. This is needed for removing usage of `MetricsLevel` on some tests in contrib such as https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/a151d166411c4e6e83324fff117d6fd49db751e8/exporter/prometheusremotewriteexporter/exporter_test.go#L743-L744

#### Link to tracking issue

Relates to #11061
