### PR TITLE
[chore] Always initialize cachedItemsCount, it is used in observability sender

### DIFF
--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -34,7 +34,7 @@ func newLogsRequest(ld plog.Logs, pusher consumer.ConsumeLogsFunc) Request {
 	return &logsRequest{
 		ld:               ld,
 		pusher:           pusher,
-		cachedItemsCount: -1,
+		cachedItemsCount: ld.LogRecordCount(),
 	}
 }
 
@@ -65,9 +65,6 @@ func (req *logsRequest) Export(ctx context.Context) error {
 }
 
 func (req *logsRequest) ItemsCount() int {
-	if req.cachedItemsCount == -1 {
-		req.cachedItemsCount = req.ld.LogRecordCount()
-	}
 	return req.cachedItemsCount
 }
 

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -34,7 +34,7 @@ func newMetricsRequest(md pmetric.Metrics, pusher consumer.ConsumeMetricsFunc) R
 	return &metricsRequest{
 		md:               md,
 		pusher:           pusher,
-		cachedItemsCount: -1,
+		cachedItemsCount: md.DataPointCount(),
 	}
 }
 
@@ -65,9 +65,6 @@ func (req *metricsRequest) Export(ctx context.Context) error {
 }
 
 func (req *metricsRequest) ItemsCount() int {
-	if req.cachedItemsCount == -1 {
-		req.cachedItemsCount = req.md.DataPointCount()
-	}
 	return req.cachedItemsCount
 }
 

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -34,7 +34,7 @@ func newTracesRequest(td ptrace.Traces, pusher consumer.ConsumeTracesFunc) Reque
 	return &tracesRequest{
 		td:               td,
 		pusher:           pusher,
-		cachedItemsCount: -1,
+		cachedItemsCount: td.SpanCount(),
 	}
 }
 
@@ -65,9 +65,6 @@ func (req *tracesRequest) Export(ctx context.Context) error {
 }
 
 func (req *tracesRequest) ItemsCount() int {
-	if req.cachedItemsCount == -1 {
-		req.cachedItemsCount = req.td.SpanCount()
-	}
 	return req.cachedItemsCount
 }
 


### PR DESCRIPTION
During https://github.com/open-telemetry/opentelemetry-collector/pull/12136 discussion, it was noted that the count may not always be called, but that is not true since we always call it in the observability sender. This PR only simplifies the logic and ensure we always have the right number.