### PR TITLE
[chore] Replace AssertMetrics with AssertEqualMetric series functions

### DIFF
--- a/cmd/mdatagen/internal/samplereceiver/metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/metrics_test.go
@@ -30,39 +30,22 @@ func TestComponentTelemetry(t *testing.T) {
 	factory := NewFactory()
 	receiver, err := factory.CreateMetrics(context.Background(), tt.NewSettings(), componenttest.NewNopHost(), new(consumertest.MetricsSink))
 	require.NoError(t, err)
-	tt.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_batch_size_trigger_send",
-			Description: "Number of times the batch was sent due to a size trigger [deprecated since v0.110.0]",
-			Unit:        "{times}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value: 1,
-					},
-				},
+	metadatatest.AssertEqualBatchSizeTriggerSend(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value: 1,
 			},
-		},
-		{
-			Name:        "otelcol_process_runtime_total_alloc_bytes",
-			Description: "Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')",
-			Unit:        "By",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value: 2,
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualProcessRuntimeTotalAllocBytes(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value: 2,
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
 	rcv, ok := receiver.(nopReceiver)
 	require.True(t, ok)
 	rcv.initOptionalMetric()
+	// TODO: this needs to be replaces once the optional metric is supported in AssertMetricEqual functions.
 	tt.AssertMetrics(t, []metricdata.Metrics{
 		{
 			Name:        "otelcol_batch_size_trigger_send",

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -209,80 +209,52 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 		}
 	}
 
-	tel.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_batch_batch_send_size_bytes",
-			Description: "Number of bytes in batch that was sent. Only available on detailed level.",
-			Unit:        "By",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-						Count:      uint64(expectedBatchesNum),
-						Bounds: []float64{
-							10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000,
-							100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
-							1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000,
-						},
-						BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-						Sum:          int64(sizeSum),
-						Min:          metricdata.NewExtrema(int64(sizeSum / expectedBatchesNum)),
-						Max:          metricdata.NewExtrema(int64(sizeSum / expectedBatchesNum)),
-					},
+	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel.Telemetry,
+		[]metricdata.HistogramDataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
+				Count:      uint64(expectedBatchesNum),
+				Bounds: []float64{
+					10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000,
+					100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
+					1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000,
 				},
+				BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Sum:          int64(sizeSum),
+				Min:          metricdata.NewExtrema(int64(sizeSum / expectedBatchesNum)),
+				Max:          metricdata.NewExtrema(int64(sizeSum / expectedBatchesNum)),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_batch_send_size",
-			Description: "Number of units in the batch",
-			Unit:        "{units}",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{
-					{
-						Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
-						Count:        uint64(expectedBatchesNum),
-						Bounds:       []float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000},
-						BucketCounts: []uint64{0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-						Sum:          int64(sink.SpanCount()),
-						Min:          metricdata.NewExtrema(int64(sendBatchSize)),
-						Max:          metricdata.NewExtrema(int64(sendBatchSize)),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel.Telemetry,
+		[]metricdata.HistogramDataPoint[int64]{
+			{
+				Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
+				Count:        uint64(expectedBatchesNum),
+				Bounds:       []float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000},
+				BucketCounts: []uint64{0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Sum:          int64(sink.SpanCount()),
+				Min:          metricdata.NewExtrema(int64(sendBatchSize)),
+				Max:          metricdata.NewExtrema(int64(sendBatchSize)),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_batch_size_trigger_send",
-			Description: "Number of times the batch was sent due to a size trigger",
-			Unit:        "{times}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      int64(expectedBatchesNum),
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      int64(expectedBatchesNum),
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_metadata_cardinality",
-			Description: "Number of distinct metadata value combinations being processed",
-			Unit:        "{combinations}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: false,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      1,
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      1,
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
+
 	require.NoError(t, tel.Shutdown(context.Background()))
 }
 
@@ -336,95 +308,52 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 		sizeSum += sizer.TracesSize(td)
 	}
 
-	tel.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_batch_batch_send_size_bytes",
-			Description: "Number of bytes in batch that was sent. Only available on detailed level.",
-			Unit:        "By",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-						Count:      uint64(expectedBatchesNum),
-						Bounds: []float64{
-							10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000,
-							100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
-							1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000,
-						},
-						BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, uint64(expectedBatchesNum - 1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-						Sum:          int64(sizeSum),
-						Min:          metricdata.NewExtrema(int64(minSize)),
-						Max:          metricdata.NewExtrema(int64(maxSize)),
-					},
+	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel.Telemetry,
+		[]metricdata.HistogramDataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
+				Count:      uint64(expectedBatchesNum),
+				Bounds: []float64{
+					10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000,
+					100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
+					1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000,
 				},
+				BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, uint64(expectedBatchesNum - 1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Sum:          int64(sizeSum),
+				Min:          metricdata.NewExtrema(int64(minSize)),
+				Max:          metricdata.NewExtrema(int64(maxSize)),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_batch_send_size",
-			Description: "Number of units in the batch",
-			Unit:        "{units}",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{
-					{
-						Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
-						Count:        uint64(expectedBatchesNum),
-						Bounds:       []float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000},
-						BucketCounts: []uint64{0, 1, uint64(expectedBatchesNum - 1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-						Sum:          int64(sink.SpanCount()),
-						Min:          metricdata.NewExtrema(int64(sendBatchSize - 1)),
-						Max:          metricdata.NewExtrema(int64(cfg.SendBatchMaxSize)),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel.Telemetry,
+		[]metricdata.HistogramDataPoint[int64]{
+			{
+				Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
+				Count:        uint64(expectedBatchesNum),
+				Bounds:       []float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000},
+				BucketCounts: []uint64{0, 1, uint64(expectedBatchesNum - 1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Sum:          int64(sink.SpanCount()),
+				Min:          metricdata.NewExtrema(int64(sendBatchSize - 1)),
+				Max:          metricdata.NewExtrema(int64(cfg.SendBatchMaxSize)),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_batch_size_trigger_send",
-			Description: "Number of times the batch was sent due to a size trigger",
-			Unit:        "{times}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      int64(expectedBatchesNum - 1),
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      int64(expectedBatchesNum - 1),
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_timeout_trigger_send",
-			Description: "Number of times the batch was sent due to a timeout trigger",
-			Unit:        "{times}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      1,
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      1,
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_metadata_cardinality",
-			Description: "Number of distinct metadata value combinations being processed",
-			Unit:        "{combinations}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: false,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      1,
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-					},
-				},
-			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
+
 	require.NoError(t, tel.Shutdown(context.Background()))
 }
 
@@ -596,80 +525,52 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 		}
 	}
 
-	tel.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_batch_batch_send_size_bytes",
-			Description: "Number of bytes in batch that was sent. Only available on detailed level.",
-			Unit:        "By",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-						Count:      uint64(expectedBatchesNum),
-						Bounds: []float64{
-							10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000,
-							100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
-							1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000,
-						},
-						BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-						Sum:          int64(size),
-						Min:          metricdata.NewExtrema(int64(size / int(expectedBatchesNum))),
-						Max:          metricdata.NewExtrema(int64(size / int(expectedBatchesNum))),
-					},
+	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel.Telemetry,
+		[]metricdata.HistogramDataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
+				Count:      uint64(expectedBatchesNum),
+				Bounds: []float64{
+					10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000,
+					100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
+					1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000,
 				},
+				BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Sum:          int64(size),
+				Min:          metricdata.NewExtrema(int64(size / int(expectedBatchesNum))),
+				Max:          metricdata.NewExtrema(int64(size / int(expectedBatchesNum))),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_batch_send_size",
-			Description: "Number of units in the batch",
-			Unit:        "{units}",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{
-					{
-						Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
-						Count:        uint64(expectedBatchesNum),
-						Bounds:       []float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000},
-						BucketCounts: []uint64{0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-						Sum:          int64(sink.DataPointCount()),
-						Min:          metricdata.NewExtrema(int64(cfg.SendBatchSize)),
-						Max:          metricdata.NewExtrema(int64(cfg.SendBatchSize)),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel.Telemetry,
+		[]metricdata.HistogramDataPoint[int64]{
+			{
+				Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
+				Count:        uint64(expectedBatchesNum),
+				Bounds:       []float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000},
+				BucketCounts: []uint64{0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Sum:          int64(sink.DataPointCount()),
+				Min:          metricdata.NewExtrema(int64(cfg.SendBatchSize)),
+				Max:          metricdata.NewExtrema(int64(cfg.SendBatchSize)),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_batch_size_trigger_send",
-			Description: "Number of times the batch was sent due to a size trigger",
-			Unit:        "{times}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      int64(expectedBatchesNum),
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      int64(expectedBatchesNum),
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_metadata_cardinality",
-			Description: "Number of distinct metadata value combinations being processed",
-			Unit:        "{combinations}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: false,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      1,
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      1,
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
+
 	require.NoError(t, tel.Shutdown(context.Background()))
 }
 
@@ -972,80 +873,52 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 		}
 	}
 
-	tel.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_batch_batch_send_size_bytes",
-			Description: "Number of bytes in batch that was sent. Only available on detailed level.",
-			Unit:        "By",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-						Count:      uint64(expectedBatchesNum),
-						Bounds: []float64{
-							10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000,
-							100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
-							1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000,
-						},
-						BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-						Sum:          int64(size),
-						Min:          metricdata.NewExtrema(int64(size / int(expectedBatchesNum))),
-						Max:          metricdata.NewExtrema(int64(size / int(expectedBatchesNum))),
-					},
+	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel.Telemetry,
+		[]metricdata.HistogramDataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
+				Count:      uint64(expectedBatchesNum),
+				Bounds: []float64{
+					10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000,
+					100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
+					1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000,
 				},
+				BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Sum:          int64(size),
+				Min:          metricdata.NewExtrema(int64(size / int(expectedBatchesNum))),
+				Max:          metricdata.NewExtrema(int64(size / int(expectedBatchesNum))),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_batch_send_size",
-			Description: "Number of units in the batch",
-			Unit:        "{units}",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{
-					{
-						Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
-						Count:        uint64(expectedBatchesNum),
-						Bounds:       []float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000},
-						BucketCounts: []uint64{0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-						Sum:          int64(sink.LogRecordCount()),
-						Min:          metricdata.NewExtrema(int64(cfg.SendBatchSize)),
-						Max:          metricdata.NewExtrema(int64(cfg.SendBatchSize)),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel.Telemetry,
+		[]metricdata.HistogramDataPoint[int64]{
+			{
+				Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
+				Count:        uint64(expectedBatchesNum),
+				Bounds:       []float64{10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000},
+				BucketCounts: []uint64{0, 0, uint64(expectedBatchesNum), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Sum:          int64(sink.LogRecordCount()),
+				Min:          metricdata.NewExtrema(int64(cfg.SendBatchSize)),
+				Max:          metricdata.NewExtrema(int64(cfg.SendBatchSize)),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_batch_size_trigger_send",
-			Description: "Number of times the batch was sent due to a size trigger",
-			Unit:        "{times}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      int64(expectedBatchesNum),
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      int64(expectedBatchesNum),
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_batch_metadata_cardinality",
-			Description: "Number of distinct metadata value combinations being processed",
-			Unit:        "{combinations}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: false,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      1,
-						Attributes: attribute.NewSet(attribute.String("processor", "batch")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+
+	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      1,
+				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
+
 	require.NoError(t, tel.Shutdown(context.Background()))
 }
 

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -227,53 +227,14 @@ func TestMetricsTelemetry(t *testing.T) {
 	}
 	require.NoError(t, metrics.Shutdown(context.Background()))
 
-	tel.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_accepted_metric_points",
-			Description: "Number of metric points successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      10,
-						Attributes: attribute.NewSet(attribute.String("processor", "memory_limiter")),
-					},
-				},
+	metadatatest.AssertEqualProcessorAcceptedMetricPoints(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      10,
+				Attributes: attribute.NewSet(attribute.String("processor", "memory_limiter")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_incoming_items",
-			Description: "Number of items passed to the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      10,
-						Attributes: attribute.NewSet(attribute.String("processor", "memory_limiter"), attribute.String("otel.signal", "metrics")),
-					},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_processor_outgoing_items",
-			Description: "Number of items emitted from the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      10,
-						Attributes: attribute.NewSet(attribute.String("processor", "memory_limiter"), attribute.String("otel.signal", "metrics")),
-					},
-				},
-			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
+
 	require.NoError(t, tel.Shutdown(context.Background()))
 }
 

--- a/processor/processorhelper/logs_test.go
+++ b/processor/processorhelper/logs_test.go
@@ -128,38 +128,20 @@ func TestLogs_RecordInOut(t *testing.T) {
 	assert.NoError(t, lp.ConsumeLogs(context.Background(), incomingLogs))
 	assert.NoError(t, lp.Shutdown(context.Background()))
 
-	testTelemetry.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_incoming_items",
-			Description: "Number of items passed to the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      3,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
-					},
-				},
+	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      3,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_outgoing_items",
-			Description: "Number of items emitted from the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      1,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      1,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
 }
 
 func TestLogs_RecordIn_ErrorOut(t *testing.T) {
@@ -184,36 +166,18 @@ func TestLogs_RecordIn_ErrorOut(t *testing.T) {
 	require.Error(t, lp.ConsumeLogs(context.Background(), incomingLogs))
 	require.NoError(t, lp.Shutdown(context.Background()))
 
-	testTelemetry.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_incoming_items",
-			Description: "Number of items passed to the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      3,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
-					},
-				},
+	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      3,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_outgoing_items",
-			Description: "Number of items emitted from the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      0,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      0,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
 }

--- a/processor/processorhelper/metrics_test.go
+++ b/processor/processorhelper/metrics_test.go
@@ -128,38 +128,20 @@ func TestMetrics_RecordInOut(t *testing.T) {
 	assert.NoError(t, mp.ConsumeMetrics(context.Background(), incomingMetrics))
 	assert.NoError(t, mp.Shutdown(context.Background()))
 
-	testTelemetry.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_incoming_items",
-			Description: "Number of items passed to the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      2,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
-					},
-				},
+	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      2,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_outgoing_items",
-			Description: "Number of items emitted from the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      3,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      3,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
 }
 
 func TestMetrics_RecordIn_ErrorOut(t *testing.T) {
@@ -183,36 +165,18 @@ func TestMetrics_RecordIn_ErrorOut(t *testing.T) {
 	require.Error(t, mp.ConsumeMetrics(context.Background(), incomingMetrics))
 	require.NoError(t, mp.Shutdown(context.Background()))
 
-	testTelemetry.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_incoming_items",
-			Description: "Number of items passed to the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      2,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
-					},
-				},
+	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      2,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_outgoing_items",
-			Description: "Number of items emitted from the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      0,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      0,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
 }

--- a/processor/processorhelper/traces_test.go
+++ b/processor/processorhelper/traces_test.go
@@ -130,38 +130,20 @@ func TestTraces_RecordInOut(t *testing.T) {
 	assert.NoError(t, tp.ConsumeTraces(context.Background(), incomingTraces))
 	assert.NoError(t, tp.Shutdown(context.Background()))
 
-	testTelemetry.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_incoming_items",
-			Description: "Number of items passed to the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      4,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
-					},
-				},
+	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      4,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_outgoing_items",
-			Description: "Number of items emitted from the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      1,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      1,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
 }
 
 func TestTraces_RecordIn_ErrorOut(t *testing.T) {
@@ -187,36 +169,18 @@ func TestTraces_RecordIn_ErrorOut(t *testing.T) {
 	require.Error(t, tp.ConsumeTraces(context.Background(), incomingTraces))
 	require.NoError(t, tp.Shutdown(context.Background()))
 
-	testTelemetry.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_processor_incoming_items",
-			Description: "Number of items passed to the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      4,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
-					},
-				},
+	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      4,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
 			},
-		},
-		{
-			Name:        "otelcol_processor_outgoing_items",
-			Description: "Number of items emitted from the processor. [alpha]",
-			Unit:        "{items}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value:      0,
-						Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Value:      0,
+				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp())
+		}, metricdatatest.IgnoreTimestamp())
 }

--- a/scraper/scraperhelper/controller_test.go
+++ b/scraper/scraperhelper/controller_test.go
@@ -30,8 +30,6 @@ import (
 	"go.opentelemetry.io/collector/scraper/scraperhelper/internal/metadatatest"
 )
 
-const transportTag = "transport"
-
 type testInitialize struct {
 	ch  chan bool
 	err error
@@ -460,76 +458,25 @@ func assertLogsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, receiv
 		}
 	}
 
-	tt.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_receiver_accepted_metric_points",
-			Description: "Number of metric points successfully pushed into the pipeline. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(transportTag, "")),
-						Value: int64(logRecordCounts),
-					},
-				},
+	metadatatest.AssertEqualScraperScrapedLogRecords(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String(receiverKey, receiver.String()),
+					attribute.String(scraperKey, scraper.String())),
+				Value: expectedScraped,
 			},
-		},
-		{
-			Name:        "otelcol_receiver_refused_metric_points",
-			Description: "Number of metric points that could not be pushed into the pipeline. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(transportTag, "")),
-						Value: 0,
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+	metadatatest.AssertEqualScraperErroredLogRecords(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String(receiverKey, receiver.String()),
+					attribute.String(scraperKey, scraper.String())),
+				Value: expectedErrored,
 			},
-		},
-		{
-			Name:        "otelcol_scraper_scraped_log_records",
-			Description: "Number of log records successfully scraped. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(scraperKey, scraper.String())),
-						Value: expectedScraped,
-					},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_scraper_errored_log_records",
-			Description: "Number of log records that were unable to be scraped. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(scraperKey, scraper.String())),
-						Value: expectedErrored,
-					},
-				},
-			},
-		},
-	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }
 
 func assertMetricsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, receiver component.ID, scraper component.ID, expectedErr error, sink *consumertest.MetricsSink) {
@@ -550,76 +497,24 @@ func assertMetricsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, rec
 		}
 	}
 
-	tt.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_receiver_accepted_metric_points",
-			Description: "Number of metric points successfully pushed into the pipeline. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(transportTag, "")),
-						Value: int64(dataPointCounts),
-					},
-				},
+	metadatatest.AssertEqualScraperScrapedMetricPoints(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String(receiverKey, receiver.String()),
+					attribute.String(scraperKey, scraper.String())),
+				Value: expectedScraped,
 			},
-		},
-		{
-			Name:        "otelcol_receiver_refused_metric_points",
-			Description: "Number of metric points that could not be pushed into the pipeline. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(transportTag, "")),
-						Value: 0,
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+	metadatatest.AssertEqualScraperErroredMetricPoints(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String(receiverKey, receiver.String()),
+					attribute.String(scraperKey, scraper.String())),
+				Value: expectedErrored,
 			},
-		},
-		{
-			Name:        "otelcol_scraper_scraped_metric_points",
-			Description: "Number of metric points successfully scraped. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(scraperKey, scraper.String())),
-						Value: expectedScraped,
-					},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_scraper_errored_metric_points",
-			Description: "Number of metric points that were unable to be scraped. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(scraperKey, scraper.String())),
-						Value: expectedErrored,
-					},
-				},
-			},
-		},
-	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }
 
 func TestSingleLogsScraperPerInterval(t *testing.T) {

--- a/scraper/scraperhelper/obs_logs_test.go
+++ b/scraper/scraperhelper/obs_logs_test.go
@@ -97,40 +97,23 @@ func TestCheckScraperLogs(t *testing.T) {
 }
 
 func checkScraperLogs(t *testing.T, tt metadatatest.Telemetry, receiver component.ID, scraper component.ID, scrapedLogRecords int64, erroredLogRecords int64) {
-	tt.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_scraper_scraped_log_records",
-			Description: "Number of log records successfully scraped. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(scraperKey, scraper.String())),
-						Value: scrapedLogRecords,
-					},
-				},
+	metadatatest.AssertEqualScraperScrapedLogRecords(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String(receiverKey, receiver.String()),
+					attribute.String(scraperKey, scraper.String())),
+				Value: scrapedLogRecords,
 			},
-		},
-		{
-			Name:        "otelcol_scraper_errored_log_records",
-			Description: "Number of log records that were unable to be scraped. [alpha]",
-			Unit:        "{datapoints}",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Attributes: attribute.NewSet(
-							attribute.String(receiverKey, receiver.String()),
-							attribute.String(scraperKey, scraper.String())),
-						Value: erroredLogRecords,
-					},
-				},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+	metadatatest.AssertEqualScraperErroredLogRecords(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String(receiverKey, receiver.String()),
+					attribute.String(scraperKey, scraper.String())),
+				Value: erroredLogRecords,
 			},
-		},
-	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }

--- a/service/internal/proctelemetry/process_telemetry_linux_test.go
+++ b/service/internal/proctelemetry/process_telemetry_linux_test.go
@@ -20,72 +20,22 @@ func TestProcessTelemetryWithHostProc(t *testing.T) {
 	t.Setenv("HOST_PROC", "foo/bar")
 	tel := metadatatest.SetupTelemetry()
 	require.NoError(t, RegisterProcessMetrics(tel.NewTelemetrySettings(), WithHostProc("/proc")))
-	tel.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_process_uptime",
-			Description: "Uptime of the process [alpha]",
-			Unit:        "s",
-			Data: metricdata.Sum[float64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[float64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_runtime_heap_alloc_bytes",
-			Description: "Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc') [alpha]",
-			Unit:        "By",
-			Data: metricdata.Gauge[int64]{
-				DataPoints: []metricdata.DataPoint[int64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_runtime_total_alloc_bytes",
-			Description: "Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc') [alpha]",
-			Unit:        "By",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_runtime_total_sys_memory_bytes",
-			Description: "Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys') [alpha]",
-			Unit:        "By",
-			Data: metricdata.Gauge[int64]{
-				DataPoints: []metricdata.DataPoint[int64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_cpu_seconds",
-			Description: "Total CPU user and system time in seconds [alpha]",
-			Unit:        "s",
-			Data: metricdata.Sum[float64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[float64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_memory_rss",
-			Description: "Total physical memory (resident set size) [alpha]",
-			Unit:        "By",
-			Data: metricdata.Gauge[int64]{
-				DataPoints: []metricdata.DataPoint[int64]{
-					{},
-				},
-			},
-		},
-	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessUptime(t, tel.Telemetry,
+		[]metricdata.DataPoint[float64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessRuntimeHeapAllocBytes(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessRuntimeTotalAllocBytes(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessRuntimeTotalSysMemoryBytes(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessCPUSeconds(t, tel.Telemetry,
+		[]metricdata.DataPoint[float64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessMemoryRss(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 }

--- a/service/internal/proctelemetry/process_telemetry_test.go
+++ b/service/internal/proctelemetry/process_telemetry_test.go
@@ -16,72 +16,22 @@ import (
 func TestProcessTelemetry(t *testing.T) {
 	tel := metadatatest.SetupTelemetry()
 	require.NoError(t, RegisterProcessMetrics(tel.NewTelemetrySettings()))
-	tel.AssertMetrics(t, []metricdata.Metrics{
-		{
-			Name:        "otelcol_process_uptime",
-			Description: "Uptime of the process [alpha]",
-			Unit:        "s",
-			Data: metricdata.Sum[float64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[float64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_runtime_heap_alloc_bytes",
-			Description: "Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc') [alpha]",
-			Unit:        "By",
-			Data: metricdata.Gauge[int64]{
-				DataPoints: []metricdata.DataPoint[int64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_runtime_total_alloc_bytes",
-			Description: "Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc') [alpha]",
-			Unit:        "By",
-			Data: metricdata.Sum[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_runtime_total_sys_memory_bytes",
-			Description: "Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys') [alpha]",
-			Unit:        "By",
-			Data: metricdata.Gauge[int64]{
-				DataPoints: []metricdata.DataPoint[int64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_cpu_seconds",
-			Description: "Total CPU user and system time in seconds [alpha]",
-			Unit:        "s",
-			Data: metricdata.Sum[float64]{
-				Temporality: metricdata.CumulativeTemporality,
-				IsMonotonic: true,
-				DataPoints: []metricdata.DataPoint[float64]{
-					{},
-				},
-			},
-		},
-		{
-			Name:        "otelcol_process_memory_rss",
-			Description: "Total physical memory (resident set size) [alpha]",
-			Unit:        "By",
-			Data: metricdata.Gauge[int64]{
-				DataPoints: []metricdata.DataPoint[int64]{
-					{},
-				},
-			},
-		},
-	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessUptime(t, tel.Telemetry,
+		[]metricdata.DataPoint[float64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessRuntimeHeapAllocBytes(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessRuntimeTotalAllocBytes(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessRuntimeTotalSysMemoryBytes(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessCPUSeconds(t, tel.Telemetry,
+		[]metricdata.DataPoint[float64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+	metadatatest.AssertEqualProcessMemoryRss(t, tel.Telemetry,
+		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
A follow-up PR of #12179 , cc @bogdandrutu 

Note: This PR also removes those metric assertions which is actually testing metrics that doesn't belong to the package. They might be added due to the limitation of the AssertMetrics function. e.g. changes in `processor/memorylimitprocessor/memorylimiter_test.go`

<!-- Issue number if applicable -->
#### Link to tracking issue
Relevant to #12179 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated

<!--Describe the documentation added.-->
#### Documentation
n/a

<!--Please delete paragraphs that you did not use before submitting.-->
