### PR TITLE
[component/componenttest] Deprecate CheckExporterLogs functions

### DIFF
--- a/.chloggen/deprecate-checkexporterlogs.yaml
+++ b/.chloggen/deprecate-checkexporterlogs.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component/componenttest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate CheckExporterLogs in componenenttest
+
+# One or more tracking issues or pull requests related to the change
+issues: [12185]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use the `metadatatest.AssertEqualMetric` series of functions instead of `obsreporttest.CheckExporterLogs`
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/component/componenttest/obsreporttest.go
+++ b/component/componenttest/obsreporttest.go
@@ -52,6 +52,7 @@ func (tts *TestTelemetry) CheckExporterEnqueueFailedLogs(enqueueFailed int64) er
 	return checkExporterEnqueueFailed(tts.Reader, tts.id, "log_records", enqueueFailed)
 }
 
+// Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 // CheckExporterLogs checks that for the current exported values for logs exporter metrics match given values.
 func (tts *TestTelemetry) CheckExporterLogs(sentLogRecords, sendFailedLogRecords int64) error {
 	return checkExporterLogs(tts.Reader, tts.id, sentLogRecords, sendFailedLogRecords)

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -26,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/metadatatest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/internal/storagetest"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -190,7 +193,7 @@ func TestLogs_WithRecordMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
-	checkRecordedMetricsForLogs(t, tt, le, nil)
+	checkRecordedMetricsForLogs(t, tt, fakeLogsName, le, nil)
 }
 
 func TestLogs_pLogModifiedDownStream_WithRecordMetrics(t *testing.T) {
@@ -205,7 +208,15 @@ func TestLogs_pLogModifiedDownStream_WithRecordMetrics(t *testing.T) {
 
 	require.NoError(t, le.ConsumeLogs(context.Background(), ld))
 	assert.Equal(t, 0, ld.LogRecordCount())
-	require.NoError(t, tt.CheckExporterLogs(int64(2), 0))
+
+	metadatatest.AssertEqualExporterSentLogRecords(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", fakeLogsName.String())),
+				Value: int64(2),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }
 
 func TestLogsRequest_WithRecordMetrics(t *testing.T) {
@@ -219,7 +230,7 @@ func TestLogsRequest_WithRecordMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
-	checkRecordedMetricsForLogs(t, tt, le, nil)
+	checkRecordedMetricsForLogs(t, tt, fakeLogsName, le, nil)
 }
 
 func TestLogs_WithRecordMetrics_ReturnError(t *testing.T) {
@@ -232,7 +243,7 @@ func TestLogs_WithRecordMetrics_ReturnError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
-	checkRecordedMetricsForLogs(t, tt, le, want)
+	checkRecordedMetricsForLogs(t, tt, fakeLogsName, le, want)
 }
 
 func TestLogsRequest_WithRecordMetrics_ExportError(t *testing.T) {
@@ -246,7 +257,7 @@ func TestLogsRequest_WithRecordMetrics_ExportError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
-	checkRecordedMetricsForLogs(t, tt, le, want)
+	checkRecordedMetricsForLogs(t, tt, fakeLogsName, le, want)
 }
 
 func TestLogs_WithRecordEnqueueFailedMetrics(t *testing.T) {
@@ -389,7 +400,7 @@ func newPushLogsData(retError error) consumer.ConsumeLogsFunc {
 	}
 }
 
-func checkRecordedMetricsForLogs(t *testing.T, tt componenttest.TestTelemetry, le exporter.Logs, wantError error) {
+func checkRecordedMetricsForLogs(t *testing.T, tt componenttest.TestTelemetry, id component.ID, le exporter.Logs, wantError error) {
 	ld := testdata.GenerateLogs(2)
 	const numBatches = 7
 	for i := 0; i < numBatches; i++ {
@@ -398,9 +409,23 @@ func checkRecordedMetricsForLogs(t *testing.T, tt componenttest.TestTelemetry, l
 
 	// TODO: When the new metrics correctly count partial dropped fix this.
 	if wantError != nil {
-		require.NoError(t, tt.CheckExporterLogs(0, int64(numBatches*ld.LogRecordCount())))
+		metadatatest.AssertEqualExporterSendFailedLogRecords(t, tt.Telemetry,
+			[]metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("exporter", id.String())),
+					Value: int64(numBatches * ld.LogRecordCount()),
+				},
+			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 	} else {
-		require.NoError(t, tt.CheckExporterLogs(int64(numBatches*ld.LogRecordCount()), 0))
+		metadatatest.AssertEqualExporterSentLogRecords(t, tt.Telemetry,
+			[]metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("exporter", id.String())),
+					Value: int64(numBatches * ld.LogRecordCount()),
+				},
+			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 	}
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Deprecate `CheckExporterLogs` functions, also verified `CheckExporterLogs` function is not being used in the contrib repo as well.

<!-- Issue number if applicable -->
#### Link to tracking issue
Part of #12185 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated

<!--Describe the documentation added.-->
#### Documentation
Added

<!--Please delete paragraphs that you did not use before submitting.-->
