### PR TITLE
[component/componenttest] Deprecate CheckReceiverLogs functions

### DIFF
--- a/.chloggen/deprecate-checkreceiverlogs.yaml
+++ b/.chloggen/deprecate-checkreceiverlogs.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component/componenttest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate CheckReceiverLogs in componenenttest
+
+# One or more tracking issues or pull requests related to the change
+issues: [12185]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use the `metadatatest.AssertEqualMetric` series of functions instead of `obsreporttest.CheckReceiverLogs`
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/component/componenttest/obsreporttest.go
+++ b/component/componenttest/obsreporttest.go
@@ -67,6 +67,7 @@ func (tts *TestTelemetry) CheckReceiverTraces(protocol string, acceptedSpans, dr
 	return checkReceiverTraces(tts.Reader, tts.id, protocol, acceptedSpans, droppedSpans)
 }
 
+// Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 // CheckReceiverLogs checks that for the current exported values for logs receiver metrics match given values.
 func (tts *TestTelemetry) CheckReceiverLogs(protocol string, acceptedLogRecords, droppedLogRecords int64) error {
 	return checkReceiverLogs(tts.Reader, tts.id, protocol, acceptedLogRecords, droppedLogRecords)

--- a/receiver/receiverhelper/obsreport_test.go
+++ b/receiver/receiverhelper/obsreport_test.go
@@ -12,11 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper/internal"
+	"go.opentelemetry.io/collector/receiver/receiverhelper/internal/metadatatest"
 )
 
 const (
@@ -126,7 +129,24 @@ func TestReceiveLogsOp(t *testing.T) {
 				t.Fatalf("unexpected param: %v", params[i])
 			}
 		}
-		require.NoError(t, tt.CheckReceiverLogs(transport, int64(acceptedLogRecords), int64(refusedLogRecords)))
+		metadatatest.AssertEqualReceiverAcceptedLogRecords(t, tt.Telemetry,
+			[]metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("receiver", receiverID.String()),
+						attribute.String("transport", transport)),
+					Value: int64(acceptedLogRecords),
+				},
+			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+		metadatatest.AssertEqualReceiverRefusedLogRecords(t, tt.Telemetry,
+			[]metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("receiver", receiverID.String()),
+						attribute.String("transport", transport)),
+					Value: int64(refusedLogRecords),
+				},
+			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 	})
 }
 
@@ -290,10 +310,24 @@ func TestCheckReceiverLogsViews(t *testing.T) {
 	require.NotNil(t, ctx)
 	rec.EndLogsOp(ctx, format, 7, nil)
 
-	require.NoError(t, tt.CheckReceiverLogs(transport, 7, 0))
-	require.Error(t, tt.CheckReceiverLogs(transport, 7, 7))
-	require.Error(t, tt.CheckReceiverLogs(transport, 0, 0))
-	assert.Error(t, tt.CheckReceiverLogs(transport, 0, 7))
+	metadatatest.AssertEqualReceiverAcceptedLogRecords(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("receiver", receiverID.String()),
+					attribute.String("transport", transport)),
+				Value: int64(7),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+	metadatatest.AssertEqualReceiverRefusedLogRecords(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("receiver", receiverID.String()),
+					attribute.String("transport", transport)),
+				Value: int64(0),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }
 
 func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt componenttest.TestTelemetry)) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Deprecate `CheckReceiverLogs` functions, also verified `CheckReceiverLogs` function is not being used in the contrib repo as well.

<!-- Issue number if applicable -->
#### Link to tracking issue
Part of #12185 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated

<!--Describe the documentation added.-->
#### Documentation
Added

<!--Please delete paragraphs that you did not use before submitting.-->
