### PR TITLE
[component/componenttest] Deprecate `CheckExporterEnqueue*` functions

### DIFF
--- a/.chloggen/deprecate-checkexporterenqueue-functions.yaml
+++ b/.chloggen/deprecate-checkexporterenqueue-functions.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component/componenttest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `CheckExporterEnqueue*` functions in componenenttest
+
+# One or more tracking issues or pull requests related to the change
+issues: [12185]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use the `metadatatest.AssertEqualMetric` series of functions instead of `obsreporttest.CheckExporterEnqueue*` functions.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/component/componenttest/obsreporttest.go
+++ b/component/componenttest/obsreporttest.go
@@ -40,14 +40,17 @@ func (tts *TestTelemetry) CheckExporterMetrics(sentMetricsPoints, sendFailedMetr
 	return checkExporterMetrics(tts.Reader, tts.id, sentMetricsPoints, sendFailedMetricsPoints)
 }
 
+// Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 func (tts *TestTelemetry) CheckExporterEnqueueFailedMetrics(enqueueFailed int64) error {
 	return checkExporterEnqueueFailed(tts.Reader, tts.id, "metric_points", enqueueFailed)
 }
 
+// Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 func (tts *TestTelemetry) CheckExporterEnqueueFailedTraces(enqueueFailed int64) error {
 	return checkExporterEnqueueFailed(tts.Reader, tts.id, "spans", enqueueFailed)
 }
 
+// Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 func (tts *TestTelemetry) CheckExporterEnqueueFailedLogs(enqueueFailed int64) error {
 	return checkExporterEnqueueFailed(tts.Reader, tts.id, "log_records", enqueueFailed)
 }

--- a/exporter/exporterhelper/internal/obs_report_test.go
+++ b/exporter/exporterhelper/internal/obs_report_test.go
@@ -209,7 +209,15 @@ func TestExportEnqueueFailure(t *testing.T) {
 	})
 	require.NoError(t, err)
 	obsrep.RecordEnqueueFailure(context.Background(), int64(7))
-	require.NoError(t, tt.CheckExporterEnqueueFailedLogs(int64(7)))
+
+	metadatatest.AssertEqualExporterEnqueueFailedLogRecords(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", exporterID.String())),
+				Value: int64(7),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
 	obsrep, err = NewObsReport(ObsReportSettings{
 		ExporterSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
@@ -217,7 +225,15 @@ func TestExportEnqueueFailure(t *testing.T) {
 	})
 	require.NoError(t, err)
 	obsrep.RecordEnqueueFailure(context.Background(), int64(12))
-	require.NoError(t, tt.CheckExporterEnqueueFailedTraces(int64(12)))
+
+	metadatatest.AssertEqualExporterEnqueueFailedSpans(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", exporterID.String())),
+				Value: int64(12),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
 	obsrep, err = NewObsReport(ObsReportSettings{
 		ExporterSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
@@ -225,7 +241,15 @@ func TestExportEnqueueFailure(t *testing.T) {
 	})
 	require.NoError(t, err)
 	obsrep.RecordEnqueueFailure(context.Background(), int64(21))
-	require.NoError(t, tt.CheckExporterEnqueueFailedMetrics(int64(21)))
+
+	metadatatest.AssertEqualExporterEnqueueFailedMetricPoints(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", exporterID.String())),
+				Value: int64(21),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }
 
 type testParams struct {

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -282,7 +282,14 @@ func TestLogs_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	}
 
 	// 2 batched must be in queue, and 5 batches (15 log records) rejected due to queue overflow
-	require.NoError(t, tt.CheckExporterEnqueueFailedLogs(int64(15)))
+	metadatatest.AssertEqualExporterEnqueueFailedLogRecords(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", fakeLogsName.String())),
+				Value: int64(15),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }
 
 func TestLogs_WithSpan(t *testing.T) {

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -26,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/metadatatest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/internal/storagetest"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -270,7 +273,14 @@ func TestTraces_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	}
 
 	// 2 batched must be in queue, and 5 batches (10 spans) rejected due to queue overflow
-	require.NoError(t, tt.CheckExporterEnqueueFailedTraces(int64(10)))
+	metadatatest.AssertEqualExporterEnqueueFailedSpans(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", fakeTracesName.String())),
+				Value: int64(10),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }
 
 func TestTraces_WithSpan(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Deprecate `CheckExporterEnqueue*` functions, also verified `CheckExporterEnqueue*` functions are not being used in the contrib repo as well.


<!-- Issue number if applicable -->
#### Link to tracking issue
Part of #12185 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated

<!--Describe the documentation added.-->
#### Documentation
Added

<!--Please delete paragraphs that you did not use before submitting.-->
