### PR TITLE
[component/componenttest] Deprecate `CheckExporterMetrics` functions

### DIFF
--- a/.chloggen/deprecate-checkexportermetrics.yaml
+++ b/.chloggen/deprecate-checkexportermetrics.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component/componenttest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate CheckExporterMetrics in componenenttest
+
+# One or more tracking issues or pull requests related to the change
+issues: [12185]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use the `metadatatest.AssertEqualMetric` series of functions instead of `obsreporttest.CheckExporterMetrics`
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/component/componenttest/obsreporttest.go
+++ b/component/componenttest/obsreporttest.go
@@ -35,6 +35,7 @@ func (tts *TestTelemetry) CheckExporterTraces(sentSpans, sendFailedSpans int64) 
 	return checkExporterTraces(tts.Reader, tts.id, sentSpans, sendFailedSpans)
 }
 
+// Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 // CheckExporterMetrics checks that for the current exported values for metrics exporter metrics match given values.
 func (tts *TestTelemetry) CheckExporterMetrics(sentMetricsPoints, sendFailedMetricsPoints int64) error {
 	return checkExporterMetrics(tts.Reader, tts.id, sentMetricsPoints, sendFailedMetricsPoints)

--- a/exporter/exporterhelper/internal/obs_report_test.go
+++ b/exporter/exporterhelper/internal/obs_report_test.go
@@ -126,7 +126,25 @@ func TestExportMetricsOp(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, tt.CheckExporterMetrics(int64(sentMetricPoints), int64(failedToSendMetricPoints)))
+	metadatatest.AssertEqualExporterSentMetricPoints(t, tt.Telemetry,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", exporterID.String())),
+				Value: int64(sentMetricPoints),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+	if failedToSendMetricPoints > 0 {
+		metadatatest.AssertEqualExporterSendFailedMetricPoints(t, tt.Telemetry,
+			[]metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("exporter", exporterID.String())),
+					Value: int64(failedToSendMetricPoints),
+				},
+			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+	}
 }
 
 func TestExportLogsOp(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Deprecate `CheckExporterMetrics` functions, also verified `CheckExporterMetrics` function is not being used in the contrib repo as well.

<!-- Issue number if applicable -->
#### Link to tracking issue
Part of #12185 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated

<!--Describe the documentation added.-->
#### Documentation
Added

<!--Please delete paragraphs that you did not use before submitting.-->
