### PR TITLE
[chore] [cmd/builder] add caveat for go version in go.mod

### DIFF
--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -96,6 +96,8 @@ go install go.opentelemetry.io/collector/cmd/builder@latest
 
 If installing through this method the binary will be called `builder`.
 
+Please note that the `go.mod` file generated uses `go 1.22` as the version. Versions 1.22.3, 1.21.10, and prior of Go [do not recognize this as a valid go version](https://github.com/golang/go/commit/27ed85d4d1702e868730ab6ea2ad6326988c615c). In order to successfully generate and build a collector using ocb, you must use Go version 1.22.4+, or any version of Go 1.23 and beyond.
+
 ## Running
 
 A build configuration file must be provided with the `--config` flag.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
adds a caveat to ocb cmd/builder documentation about `go.mod` version.
<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #11844 
Replaces #11845 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
none
<!--Describe the documentation added.-->
#### Documentation
README.md
<!--Please delete paragraphs that you did not use before submitting.-->
