### PR TITLE
[extension] Change from interface alias to embedding alias

### DIFF
--- a/.chloggen/mx-psi_extension-interface.yaml
+++ b/.chloggen/mx-psi_extension-interface.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: extension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change `extension.Extension` to be an interface that embeds `component.Component` instead of an alias
+
+# One or more tracking issues or pull requests related to the change
+issues: [11443]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -13,7 +13,9 @@ import (
 // Extension is the interface for objects hosted by the OpenTelemetry Collector that
 // don't participate directly on data pipelines but provide some functionality
 // to the service, examples: health check endpoint, z-pages, etc.
-type Extension = component.Component
+type Extension interface {
+	component.Component
+}
 
 // ModuleInfo describes the go module for each component.
 type ModuleInfo struct {

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -145,7 +145,7 @@ func NewStatusWatcherExtensionFactory(
 		func() component.Config {
 			return &struct{}{}
 		},
-		func(context.Context, extension.Settings, component.Config) (component.Component, error) {
+		func(context.Context, extension.Settings, component.Config) (extension.Extension, error) {
 			return &statusWatcherExtension{onStatusChanged: onStatusChanged}, nil
 		},
 		component.StabilityLevelStable)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Changes `extension.Extension` to a proper interface that embeds `component.Component` instead of being an alias.

#### Link to tracking issue
Fixes the second point mentioned in https://github.com/open-telemetry/opentelemetry-collector/issues/11443#issuecomment-2616396687