### PR TITLE
[component/componenttest] Deprecate `CheckExporterMetricGauge` functions

### DIFF
--- a/.chloggen/deprecate-checkexportermetricgauge.yaml
+++ b/.chloggen/deprecate-checkexportermetricgauge.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component/componenttest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate CheckReceiverMetricGauge in componenenttest
+
+# One or more tracking issues or pull requests related to the change
+issues: [12185]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use the `metadatatest.AssertEqualMetric` series of functions instead of `obsreporttest.CheckReceiverMetricGauge`
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/deprecate-checkexportermetricgauge.yaml
+++ b/.chloggen/deprecate-checkexportermetricgauge.yaml
@@ -7,7 +7,7 @@ change_type: deprecation
 component: component/componenttest
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecate CheckReceiverMetricGauge in componenenttest
+note: Deprecate CheckExporterMetricGauge in componenenttest
 
 # One or more tracking issues or pull requests related to the change
 issues: [12185]

--- a/component/componenttest/obsreporttest.go
+++ b/component/componenttest/obsreporttest.go
@@ -63,6 +63,7 @@ func (tts *TestTelemetry) CheckExporterLogs(sentLogRecords, sendFailedLogRecords
 	return checkExporterLogs(tts.Reader, tts.id, sentLogRecords, sendFailedLogRecords)
 }
 
+// Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 func (tts *TestTelemetry) CheckExporterMetricGauge(metric string, val int64, extraAttrs ...attribute.KeyValue) error {
 	attrs := attributesForExporterMetrics(tts.id, extraAttrs...)
 	return checkIntGauge(tts.Reader, metric, val, attrs)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Deprecate `CheckReceiverMetricGauge` functions, also verified `CheckReceiverMetricGauge` function is not being used in the contrib repo as well.

<!-- Issue number if applicable -->
#### Link to tracking issue
Part of #12185 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated

<!--Describe the documentation added.-->
#### Documentation
Added

<!--Please delete paragraphs that you did not use before submitting.-->
