### PR TITLE
[component] Make component.Kind a struct

### DIFF
--- a/.chloggen/mx-psi_component-kind-structify.yaml
+++ b/.chloggen/mx-psi_component-kind-structify.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change underlying type for `component.Kind` to be a struct.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12214]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/component/component.go
+++ b/component/component.go
@@ -78,31 +78,20 @@ func (f ShutdownFunc) Shutdown(ctx context.Context) error {
 }
 
 // Kind represents component kinds.
-type Kind int
+type Kind struct {
+	name string
+}
 
-const (
-	_ Kind = iota // skip 0, start types from 1.
-	KindReceiver
-	KindProcessor
-	KindExporter
-	KindExtension
-	KindConnector
+var (
+	KindReceiver  = Kind{name: "Receiver"}
+	KindProcessor = Kind{name: "Processor"}
+	KindExporter  = Kind{name: "Exporter"}
+	KindExtension = Kind{name: "Extension"}
+	KindConnector = Kind{name: "Connector"}
 )
 
 func (k Kind) String() string {
-	switch k {
-	case KindReceiver:
-		return "Receiver"
-	case KindProcessor:
-		return "Processor"
-	case KindExporter:
-		return "Exporter"
-	case KindExtension:
-		return "Extension"
-	case KindConnector:
-		return "Connector"
-	}
-	return ""
+	return k.name
 }
 
 // StabilityLevel represents the stability level of the component created by the factory.

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -10,13 +10,12 @@ import (
 )
 
 func TestKindString(t *testing.T) {
-	assert.Equal(t, "", Kind(0).String())
+	assert.Equal(t, "", Kind{}.String())
 	assert.Equal(t, "Receiver", KindReceiver.String())
 	assert.Equal(t, "Processor", KindProcessor.String())
 	assert.Equal(t, "Exporter", KindExporter.String())
 	assert.Equal(t, "Extension", KindExtension.String())
 	assert.Equal(t, "Connector", KindConnector.String())
-	assert.Equal(t, "", Kind(100).String())
 }
 
 func TestStabilityLevelUnmarshal(t *testing.T) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -207,7 +207,7 @@ func TestServiceGetFactory(t *testing.T) {
 	assert.Equal(t, srv.host.Extensions.Factory(nopType), srv.host.GetFactory(component.KindExtension, nopType))
 
 	// Try retrieve non existing component.Kind.
-	assert.Nil(t, srv.host.GetFactory(42, nopType))
+	assert.Nil(t, srv.host.GetFactory(component.Kind{}, nopType))
 }
 
 func TestServiceGetExtensions(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->
Changes the underlying type of `component.Kind` to be closer to [`pipeline.Signal`](https://pkg.go.dev/go.opentelemetry.io/collector/pipeline#Signal). Right now the type is defined within `component`, but it could be moved to an internal module so that we could have a different module exposing other value on this enum.

This is already doable today, the only thing this PR gives us is 
1. slightly more flexibility on things like making the concept of kind more complex (e.g. adding an adjective to a kind).
2. restricting external consumers from implementing their own component kinds without our explicit approval (with some kind of API we design)

I am not convinced this is _necessary_ to do, but we may as well do it.

This is technically a breaking change since `component.Kind(42)` was a valid expression and it no longer is. I think this is extremely rare, so I suggest if we go ahead we do so in one go.

#### Link to tracking issue
Fixes #11443