### PR TITLE
[metadatatest] Generate NewSettings that accepts componenttest.Telemetry

### DIFF
--- a/.chloggen/newsettings.yaml
+++ b/.chloggen/newsettings.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: metadatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Generate NewSettings that accepts componenttest.Telemetry
+
+# One or more tracking issues or pull requests related to the change
+issues: [12216]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Telemetry struct {
-	componenttest.Telemetry
+	*componenttest.Telemetry
 }
 
 func SetupTelemetry(opts ...componenttest.TelemetryOption) Telemetry {
@@ -44,7 +44,14 @@ func (tt *Telemetry) AssertMetrics(t *testing.T, expected []metricdata.Metrics, 
 	require.Equal(t, len(expected), lenMetrics(md))
 }
 
-func AssertEqualBatchSizeTriggerSend(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func NewSettings(tt *componenttest.Telemetry) receiver.Settings {
+	set := receivertest.NewNopSettings()
+	set.ID = component.NewID(component.MustNewType("sample"))
+	set.TelemetrySettings = tt.NewTelemetrySettings()
+	return set
+}
+
+func AssertEqualBatchSizeTriggerSend(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_batch_size_trigger_send",
 		Description: "Number of times the batch was sent due to a size trigger [deprecated since v0.110.0]",
@@ -60,7 +67,7 @@ func AssertEqualBatchSizeTriggerSend(t *testing.T, tt componenttest.Telemetry, d
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessRuntimeTotalAllocBytes(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessRuntimeTotalAllocBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_process_runtime_total_alloc_bytes",
 		Description: "Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')",
@@ -76,7 +83,7 @@ func AssertEqualProcessRuntimeTotalAllocBytes(t *testing.T, tt componenttest.Tel
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualQueueCapacity(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualQueueCapacity(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_queue_capacity",
 		Description: "Queue capacity - sync gauge example.",
@@ -90,7 +97,7 @@ func AssertEqualQueueCapacity(t *testing.T, tt componenttest.Telemetry, dps []me
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualQueueLength(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualQueueLength(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_queue_length",
 		Description: "This metric is optional and therefore not initialized in NewTelemetryBuilder. [alpha]",
@@ -104,7 +111,7 @@ func AssertEqualQueueLength(t *testing.T, tt componenttest.Telemetry, dps []metr
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualRequestDuration(t *testing.T, tt componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
+func AssertEqualRequestDuration(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_request_duration",
 		Description: "Duration of request [alpha]",

--- a/cmd/mdatagen/internal/samplereceiver/metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/metrics_test.go
@@ -26,17 +26,17 @@ func TestGeneratedMetrics(t *testing.T) {
 }
 
 func TestComponentTelemetry(t *testing.T) {
-	tt := metadatatest.SetupTelemetry()
+	tt := componenttest.NewTelemetry()
 	factory := NewFactory()
-	receiver, err := factory.CreateMetrics(context.Background(), tt.NewSettings(), componenttest.NewNopHost(), new(consumertest.MetricsSink))
+	receiver, err := factory.CreateMetrics(context.Background(), metadatatest.NewSettings(tt), componenttest.NewNopHost(), new(consumertest.MetricsSink))
 	require.NoError(t, err)
-	metadatatest.AssertEqualBatchSizeTriggerSend(t, tt.Telemetry,
+	metadatatest.AssertEqualBatchSizeTriggerSend(t, tt,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value: 1,
 			},
 		}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualProcessRuntimeTotalAllocBytes(t, tt.Telemetry,
+	metadatatest.AssertEqualProcessRuntimeTotalAllocBytes(t, tt,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value: 2,
@@ -45,7 +45,7 @@ func TestComponentTelemetry(t *testing.T) {
 	rcv, ok := receiver.(nopReceiver)
 	require.True(t, ok)
 	rcv.initOptionalMetric()
-	metadatatest.AssertEqualQueueLength(t, tt.Telemetry,
+	metadatatest.AssertEqualQueueLength(t, tt,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value: 3,

--- a/cmd/mdatagen/internal/templates/telemetrytest.go.tmpl
+++ b/cmd/mdatagen/internal/templates/telemetrytest.go.tmpl
@@ -21,7 +21,7 @@ import (
 )
 
 type Telemetry struct {
-	componenttest.Telemetry
+	*componenttest.Telemetry
 }
 
 func SetupTelemetry(opts ...componenttest.TelemetryOption) Telemetry {
@@ -50,9 +50,18 @@ func (tt *Telemetry) AssertMetrics(t *testing.T, expected []metricdata.Metrics, 
 	require.Equal(t, len(expected), lenMetrics(md))
 }
 
+{{ if or isConnector isExporter isExtension isProcessor isReceiver isScraper }}
+func NewSettings(tt *componenttest.Telemetry) {{ .Status.Class }}.Settings {
+set := {{ .Status.Class }}test.NewNopSettings()
+set.ID = component.NewID(component.MustNewType("{{ .Type }}"))
+set.TelemetrySettings = tt.NewTelemetrySettings()
+return set
+}
+{{- end }}
+
 {{ range $name, $metric := .Telemetry.Metrics }}
 
-func AssertEqual{{ $name.Render }}(t *testing.T, tt componenttest.Telemetry, dps []metricdata.{{- if eq $metric.Data.Type "Histogram" }} {{$metric.Data.Type}} {{- end }}DataPoint[{{ $metric.Data.BasicType }}], opts ...metricdatatest.Option) {
+func AssertEqual{{ $name.Render }}(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.{{- if eq $metric.Data.Type "Histogram" }} {{$metric.Data.Type}} {{- end }}DataPoint[{{ $metric.Data.BasicType }}], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_{{ $name }}",
 		Description: "{{ $metric.Description }}{{ $metric.Stability }}",

--- a/component/componenttest/obsreporttest.go
+++ b/component/componenttest/obsreporttest.go
@@ -26,62 +26,62 @@ const (
 )
 
 type TestTelemetry struct {
-	Telemetry
+	*Telemetry
 	id component.ID
 }
 
 // Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 // CheckExporterTraces checks that for the current exported values for trace exporter metrics match given values.
 func (tts *TestTelemetry) CheckExporterTraces(sentSpans, sendFailedSpans int64) error {
-	return checkExporterTraces(&tts.Telemetry, tts.id, sentSpans, sendFailedSpans)
+	return checkExporter(tts.Telemetry, tts.id, "spans", sentSpans, sendFailedSpans)
 }
 
 // Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 // CheckExporterMetrics checks that for the current exported values for metrics exporter metrics match given values.
 func (tts *TestTelemetry) CheckExporterMetrics(sentMetricsPoints, sendFailedMetricsPoints int64) error {
-	return checkExporterMetrics(&tts.Telemetry, tts.id, sentMetricsPoints, sendFailedMetricsPoints)
+	return checkExporter(tts.Telemetry, tts.id, "metric_points", sentMetricsPoints, sendFailedMetricsPoints)
 }
 
 // Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 func (tts *TestTelemetry) CheckExporterEnqueueFailedMetrics(enqueueFailed int64) error {
-	return checkExporterEnqueueFailed(&tts.Telemetry, tts.id, "metric_points", enqueueFailed)
+	return checkExporterEnqueueFailed(tts.Telemetry, tts.id, "metric_points", enqueueFailed)
 }
 
 // Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 func (tts *TestTelemetry) CheckExporterEnqueueFailedTraces(enqueueFailed int64) error {
-	return checkExporterEnqueueFailed(&tts.Telemetry, tts.id, "spans", enqueueFailed)
+	return checkExporterEnqueueFailed(tts.Telemetry, tts.id, "spans", enqueueFailed)
 }
 
 // Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 func (tts *TestTelemetry) CheckExporterEnqueueFailedLogs(enqueueFailed int64) error {
-	return checkExporterEnqueueFailed(&tts.Telemetry, tts.id, "log_records", enqueueFailed)
+	return checkExporterEnqueueFailed(tts.Telemetry, tts.id, "log_records", enqueueFailed)
 }
 
 // Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 // CheckExporterLogs checks that for the current exported values for logs exporter metrics match given values.
 func (tts *TestTelemetry) CheckExporterLogs(sentLogRecords, sendFailedLogRecords int64) error {
-	return checkExporterLogs(&tts.Telemetry, tts.id, sentLogRecords, sendFailedLogRecords)
+	return checkExporter(tts.Telemetry, tts.id, "log_records", sentLogRecords, sendFailedLogRecords)
 }
 
 func (tts *TestTelemetry) CheckExporterMetricGauge(metric string, val int64, extraAttrs ...attribute.KeyValue) error {
 	attrs := attributesForExporterMetrics(tts.id, extraAttrs...)
-	return checkIntGauge(&tts.Telemetry, metric, val, attrs)
+	return checkIntGauge(tts.Telemetry, metric, val, attrs)
 }
 
 // CheckReceiverTraces checks that for the current exported values for trace receiver metrics match given values.
 func (tts *TestTelemetry) CheckReceiverTraces(protocol string, acceptedSpans, droppedSpans int64) error {
-	return checkReceiverTraces(&tts.Telemetry, tts.id, protocol, acceptedSpans, droppedSpans)
+	return checkReceiver(tts.Telemetry, tts.id, "spans", protocol, acceptedSpans, droppedSpans)
 }
 
 // Deprecated: [v0.119.0] use the metadatatest.AssertEqualMetric series of functions instead.
 // CheckReceiverLogs checks that for the current exported values for logs receiver metrics match given values.
 func (tts *TestTelemetry) CheckReceiverLogs(protocol string, acceptedLogRecords, droppedLogRecords int64) error {
-	return checkReceiverLogs(&tts.Telemetry, tts.id, protocol, acceptedLogRecords, droppedLogRecords)
+	return checkReceiver(tts.Telemetry, tts.id, "log_records", protocol, acceptedLogRecords, droppedLogRecords)
 }
 
 // CheckReceiverMetrics checks that for the current exported values for metrics receiver metrics match given values.
 func (tts *TestTelemetry) CheckReceiverMetrics(protocol string, acceptedMetricPoints, droppedMetricPoints int64) error {
-	return checkReceiverMetrics(&tts.Telemetry, tts.id, protocol, acceptedMetricPoints, droppedMetricPoints)
+	return checkReceiver(tts.Telemetry, tts.id, "metric_points", protocol, acceptedMetricPoints, droppedMetricPoints)
 }
 
 // TelemetrySettings returns the TestTelemetry's TelemetrySettings

--- a/component/componenttest/otelchecker.go
+++ b/component/componenttest/otelchecker.go
@@ -13,35 +13,11 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-func checkReceiverTraces(tel *Telemetry, receiver component.ID, protocol string, accepted, dropped int64) error {
-	return checkReceiver(tel, receiver, "spans", protocol, accepted, dropped)
-}
-
-func checkReceiverLogs(tel *Telemetry, receiver component.ID, protocol string, accepted, dropped int64) error {
-	return checkReceiver(tel, receiver, "log_records", protocol, accepted, dropped)
-}
-
-func checkReceiverMetrics(tel *Telemetry, receiver component.ID, protocol string, accepted, dropped int64) error {
-	return checkReceiver(tel, receiver, "metric_points", protocol, accepted, dropped)
-}
-
 func checkReceiver(tel *Telemetry, receiver component.ID, datatype, protocol string, acceptedMetricPoints, droppedMetricPoints int64) error {
 	receiverAttrs := attributesForReceiverMetrics(receiver, protocol)
 	return multierr.Combine(
 		checkIntSum(tel, "otelcol_receiver_accepted_"+datatype, acceptedMetricPoints, receiverAttrs),
 		checkIntSum(tel, "otelcol_receiver_refused_"+datatype, droppedMetricPoints, receiverAttrs))
-}
-
-func checkExporterTraces(tel *Telemetry, exporter component.ID, sent, sendFailed int64) error {
-	return checkExporter(tel, exporter, "spans", sent, sendFailed)
-}
-
-func checkExporterLogs(tel *Telemetry, exporter component.ID, sent, sendFailed int64) error {
-	return checkExporter(tel, exporter, "log_records", sent, sendFailed)
-}
-
-func checkExporterMetrics(tel *Telemetry, exporter component.ID, sent, sendFailed int64) error {
-	return checkExporter(tel, exporter, "metric_points", sent, sendFailed)
 }
 
 func checkExporter(tel *Telemetry, exporter component.ID, datatype string, sent, sendFailed int64) error {

--- a/component/componenttest/telemetry.go
+++ b/component/componenttest/telemetry.go
@@ -49,7 +49,7 @@ type Telemetry struct {
 	traceProvider *sdktrace.TracerProvider
 }
 
-func NewTelemetry(opts ...TelemetryOption) Telemetry {
+func NewTelemetry(opts ...TelemetryOption) *Telemetry {
 	reader := sdkmetric.NewManualReader()
 	spanRecorder := new(tracetest.SpanRecorder)
 	tOpts := telemetryOption{
@@ -59,7 +59,7 @@ func NewTelemetry(opts ...TelemetryOption) Telemetry {
 	for _, opt := range opts {
 		opt.apply(&tOpts)
 	}
-	return Telemetry{
+	return &Telemetry{
 		Reader:        reader,
 		SpanRecorder:  spanRecorder,
 		meterProvider: sdkmetric.NewMeterProvider(tOpts.metricOpts...),

--- a/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Telemetry struct {
-	componenttest.Telemetry
+	*componenttest.Telemetry
 }
 
 func SetupTelemetry(opts ...componenttest.TelemetryOption) Telemetry {
@@ -44,7 +44,14 @@ func (tt *Telemetry) AssertMetrics(t *testing.T, expected []metricdata.Metrics, 
 	require.Equal(t, len(expected), lenMetrics(md))
 }
 
-func AssertEqualExporterEnqueueFailedLogRecords(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func NewSettings(tt *componenttest.Telemetry) exporter.Settings {
+	set := exportertest.NewNopSettings()
+	set.ID = component.NewID(component.MustNewType("exporterhelper"))
+	set.TelemetrySettings = tt.NewTelemetrySettings()
+	return set
+}
+
+func AssertEqualExporterEnqueueFailedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_enqueue_failed_log_records",
 		Description: "Number of log records failed to be added to the sending queue. [alpha]",
@@ -60,7 +67,7 @@ func AssertEqualExporterEnqueueFailedLogRecords(t *testing.T, tt componenttest.T
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterEnqueueFailedMetricPoints(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterEnqueueFailedMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_enqueue_failed_metric_points",
 		Description: "Number of metric points failed to be added to the sending queue. [alpha]",
@@ -76,7 +83,7 @@ func AssertEqualExporterEnqueueFailedMetricPoints(t *testing.T, tt componenttest
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterEnqueueFailedSpans(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterEnqueueFailedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_enqueue_failed_spans",
 		Description: "Number of spans failed to be added to the sending queue. [alpha]",
@@ -92,7 +99,7 @@ func AssertEqualExporterEnqueueFailedSpans(t *testing.T, tt componenttest.Teleme
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterQueueCapacity(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterQueueCapacity(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_queue_capacity",
 		Description: "Fixed capacity of the retry queue (in batches) [alpha]",
@@ -106,7 +113,7 @@ func AssertEqualExporterQueueCapacity(t *testing.T, tt componenttest.Telemetry, 
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterQueueSize(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterQueueSize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_queue_size",
 		Description: "Current size of the retry queue (in batches) [alpha]",
@@ -120,7 +127,7 @@ func AssertEqualExporterQueueSize(t *testing.T, tt componenttest.Telemetry, dps 
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterSendFailedLogRecords(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterSendFailedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_send_failed_log_records",
 		Description: "Number of log records in failed attempts to send to destination. [alpha]",
@@ -136,7 +143,7 @@ func AssertEqualExporterSendFailedLogRecords(t *testing.T, tt componenttest.Tele
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterSendFailedMetricPoints(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterSendFailedMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_send_failed_metric_points",
 		Description: "Number of metric points in failed attempts to send to destination. [alpha]",
@@ -152,7 +159,7 @@ func AssertEqualExporterSendFailedMetricPoints(t *testing.T, tt componenttest.Te
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterSendFailedSpans(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterSendFailedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_send_failed_spans",
 		Description: "Number of spans in failed attempts to send to destination. [alpha]",
@@ -168,7 +175,7 @@ func AssertEqualExporterSendFailedSpans(t *testing.T, tt componenttest.Telemetry
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterSentLogRecords(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterSentLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_sent_log_records",
 		Description: "Number of log record successfully sent to destination. [alpha]",
@@ -184,7 +191,7 @@ func AssertEqualExporterSentLogRecords(t *testing.T, tt componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterSentMetricPoints(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterSentMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_sent_metric_points",
 		Description: "Number of metric points successfully sent to destination. [alpha]",
@@ -200,7 +207,7 @@ func AssertEqualExporterSentMetricPoints(t *testing.T, tt componenttest.Telemetr
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterSentSpans(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterSentSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_sent_spans",
 		Description: "Number of spans successfully sent to destination. [alpha]",

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -173,14 +173,14 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 		expectedBatchingFactor = sendBatchSize / spansPerRequest
 	)
 
-	tel := metadatatest.SetupTelemetry()
+	tel := componenttest.NewTelemetry()
 	sizer := &ptrace.ProtoMarshaler{}
 	sink := new(consumertest.TracesSink)
 	cfg := createDefaultConfig().(*Config)
 	cfg.SendBatchSize = sendBatchSize
 	cfg.Timeout = 500 * time.Millisecond
 
-	traces, err := NewFactory().CreateTraces(context.Background(), tel.NewSettings(), cfg, sink)
+	traces, err := NewFactory().CreateTraces(context.Background(), metadatatest.NewSettings(tel), cfg, sink)
 	require.NoError(t, err)
 	require.NoError(t, traces.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -209,7 +209,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 		}
 	}
 
-	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel,
 		[]metricdata.HistogramDataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
@@ -226,7 +226,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel,
 		[]metricdata.HistogramDataPoint[int64]{
 			{
 				Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
@@ -239,7 +239,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      int64(expectedBatchesNum),
@@ -247,7 +247,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      1,
@@ -267,7 +267,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 		totalSpans       = requestCount * spansPerRequest
 	)
 
-	tel := metadatatest.SetupTelemetry()
+	tel := componenttest.NewTelemetry()
 	sizer := &ptrace.ProtoMarshaler{}
 	sink := new(consumertest.TracesSink)
 	cfg := createDefaultConfig().(*Config)
@@ -275,7 +275,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 	cfg.SendBatchMaxSize = uint32(sendBatchMaxSize)
 	cfg.Timeout = 500 * time.Millisecond
 
-	traces, err := NewFactory().CreateTraces(context.Background(), tel.NewSettings(), cfg, sink)
+	traces, err := NewFactory().CreateTraces(context.Background(), metadatatest.NewSettings(tel), cfg, sink)
 	require.NoError(t, err)
 	require.NoError(t, traces.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -308,7 +308,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 		sizeSum += sizer.TracesSize(td)
 	}
 
-	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel,
 		[]metricdata.HistogramDataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
@@ -325,7 +325,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel,
 		[]metricdata.HistogramDataPoint[int64]{
 			{
 				Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
@@ -338,7 +338,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      int64(expectedBatchesNum - 1),
@@ -346,7 +346,7 @@ func TestBatchProcessorSentBySizeWithMaxSize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      1,
@@ -478,7 +478,7 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 }
 
 func TestBatchMetricProcessorBatchSize(t *testing.T) {
-	tel := metadatatest.SetupTelemetry()
+	tel := componenttest.NewTelemetry()
 	sizer := &pmetric.ProtoMarshaler{}
 
 	// Instantiate the batch processor with low config values to test data
@@ -496,7 +496,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 	)
 	sink := new(consumertest.MetricsSink)
 
-	metrics, err := NewFactory().CreateMetrics(context.Background(), tel.NewSettings(), cfg, sink)
+	metrics, err := NewFactory().CreateMetrics(context.Background(), metadatatest.NewSettings(tel), cfg, sink)
 	require.NoError(t, err)
 	require.NoError(t, metrics.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -525,7 +525,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 		}
 	}
 
-	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel,
 		[]metricdata.HistogramDataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
@@ -542,7 +542,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel,
 		[]metricdata.HistogramDataPoint[int64]{
 			{
 				Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
@@ -555,7 +555,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      int64(expectedBatchesNum),
@@ -563,7 +563,7 @@ func TestBatchMetricProcessorBatchSize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      1,
@@ -828,7 +828,7 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 }
 
 func TestBatchLogProcessor_BatchSize(t *testing.T) {
-	tel := metadatatest.SetupTelemetry()
+	tel := componenttest.NewTelemetry()
 	sizer := &plog.ProtoMarshaler{}
 
 	// Instantiate the batch processor with low config values to test data
@@ -844,7 +844,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 	)
 	sink := new(consumertest.LogsSink)
 
-	logs, err := NewFactory().CreateLogs(context.Background(), tel.NewSettings(), cfg, sink)
+	logs, err := NewFactory().CreateLogs(context.Background(), metadatatest.NewSettings(tel), cfg, sink)
 	require.NoError(t, err)
 	require.NoError(t, logs.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -873,7 +873,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 		}
 	}
 
-	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSendSizeBytes(t, tel,
 		[]metricdata.HistogramDataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(attribute.String("processor", "batch")),
@@ -890,7 +890,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSendSize(t, tel,
 		[]metricdata.HistogramDataPoint[int64]{
 			{
 				Attributes:   attribute.NewSet(attribute.String("processor", "batch")),
@@ -903,7 +903,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchBatchSizeTriggerSend(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      int64(expectedBatchesNum),
@@ -911,7 +911,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
-	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorBatchMetadataCardinality(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      1,

--- a/processor/batchprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/batchprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Telemetry struct {
-	componenttest.Telemetry
+	*componenttest.Telemetry
 }
 
 func SetupTelemetry(opts ...componenttest.TelemetryOption) Telemetry {
@@ -44,7 +44,14 @@ func (tt *Telemetry) AssertMetrics(t *testing.T, expected []metricdata.Metrics, 
 	require.Equal(t, len(expected), lenMetrics(md))
 }
 
-func AssertEqualProcessorBatchBatchSendSize(t *testing.T, tt componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+func NewSettings(tt *componenttest.Telemetry) processor.Settings {
+	set := processortest.NewNopSettings()
+	set.ID = component.NewID(component.MustNewType("batch"))
+	set.TelemetrySettings = tt.NewTelemetrySettings()
+	return set
+}
+
+func AssertEqualProcessorBatchBatchSendSize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_batch_batch_send_size",
 		Description: "Number of units in the batch",
@@ -59,7 +66,7 @@ func AssertEqualProcessorBatchBatchSendSize(t *testing.T, tt componenttest.Telem
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorBatchBatchSendSizeBytes(t *testing.T, tt componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorBatchBatchSendSizeBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_batch_batch_send_size_bytes",
 		Description: "Number of bytes in batch that was sent. Only available on detailed level.",
@@ -74,7 +81,7 @@ func AssertEqualProcessorBatchBatchSendSizeBytes(t *testing.T, tt componenttest.
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorBatchBatchSizeTriggerSend(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorBatchBatchSizeTriggerSend(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_batch_batch_size_trigger_send",
 		Description: "Number of times the batch was sent due to a size trigger",
@@ -90,7 +97,7 @@ func AssertEqualProcessorBatchBatchSizeTriggerSend(t *testing.T, tt componenttes
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorBatchMetadataCardinality(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorBatchMetadataCardinality(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_batch_metadata_cardinality",
 		Description: "Number of distinct metadata value combinations being processed",
@@ -106,7 +113,7 @@ func AssertEqualProcessorBatchMetadataCardinality(t *testing.T, tt componenttest
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorBatchTimeoutTriggerSend(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorBatchTimeoutTriggerSend(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_batch_timeout_trigger_send",
 		Description: "Number of times the batch was sent due to a timeout trigger",

--- a/processor/memorylimiterprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/memorylimiterprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Telemetry struct {
-	componenttest.Telemetry
+	*componenttest.Telemetry
 }
 
 func SetupTelemetry(opts ...componenttest.TelemetryOption) Telemetry {
@@ -44,7 +44,14 @@ func (tt *Telemetry) AssertMetrics(t *testing.T, expected []metricdata.Metrics, 
 	require.Equal(t, len(expected), lenMetrics(md))
 }
 
-func AssertEqualProcessorAcceptedLogRecords(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func NewSettings(tt *componenttest.Telemetry) processor.Settings {
+	set := processortest.NewNopSettings()
+	set.ID = component.NewID(component.MustNewType("memory_limiter"))
+	set.TelemetrySettings = tt.NewTelemetrySettings()
+	return set
+}
+
+func AssertEqualProcessorAcceptedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_accepted_log_records",
 		Description: "Number of log records successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]",
@@ -60,7 +67,7 @@ func AssertEqualProcessorAcceptedLogRecords(t *testing.T, tt componenttest.Telem
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorAcceptedMetricPoints(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorAcceptedMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_accepted_metric_points",
 		Description: "Number of metric points successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]",
@@ -76,7 +83,7 @@ func AssertEqualProcessorAcceptedMetricPoints(t *testing.T, tt componenttest.Tel
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorAcceptedSpans(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorAcceptedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_accepted_spans",
 		Description: "Number of spans successfully pushed into the next component in the pipeline. [deprecated since v0.110.0]",
@@ -92,7 +99,7 @@ func AssertEqualProcessorAcceptedSpans(t *testing.T, tt componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorRefusedLogRecords(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorRefusedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_refused_log_records",
 		Description: "Number of log records that were rejected by the next component in the pipeline. [deprecated since v0.110.0]",
@@ -108,7 +115,7 @@ func AssertEqualProcessorRefusedLogRecords(t *testing.T, tt componenttest.Teleme
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorRefusedMetricPoints(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorRefusedMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_refused_metric_points",
 		Description: "Number of metric points that were rejected by the next component in the pipeline. [deprecated since v0.110.0]",
@@ -124,7 +131,7 @@ func AssertEqualProcessorRefusedMetricPoints(t *testing.T, tt componenttest.Tele
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorRefusedSpans(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorRefusedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_refused_spans",
 		Description: "Number of spans that were rejected by the next component in the pipeline. [deprecated since v0.110.0]",

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -210,13 +210,13 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 }
 
 func TestMetricsTelemetry(t *testing.T) {
-	tel := metadatatest.SetupTelemetry()
+	tel := componenttest.NewTelemetry()
 	cfg := &Config{
 		CheckInterval:         time.Second,
 		MemoryLimitPercentage: 50,
 		MemorySpikePercentage: 10,
 	}
-	metrics, err := NewFactory().CreateMetrics(context.Background(), tel.NewSettings(), cfg, consumertest.NewNop())
+	metrics, err := NewFactory().CreateMetrics(context.Background(), metadatatest.NewSettings(tel), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	require.NoError(t, metrics.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -227,7 +227,7 @@ func TestMetricsTelemetry(t *testing.T) {
 	}
 	require.NoError(t, metrics.Shutdown(context.Background()))
 
-	metadatatest.AssertEqualProcessorAcceptedMetricPoints(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessorAcceptedMetricPoints(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      10,

--- a/processor/processorhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/processorhelper/internal/metadatatest/generated_telemetrytest.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Telemetry struct {
-	componenttest.Telemetry
+	*componenttest.Telemetry
 }
 
 func SetupTelemetry(opts ...componenttest.TelemetryOption) Telemetry {
@@ -44,7 +44,14 @@ func (tt *Telemetry) AssertMetrics(t *testing.T, expected []metricdata.Metrics, 
 	require.Equal(t, len(expected), lenMetrics(md))
 }
 
-func AssertEqualProcessorIncomingItems(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func NewSettings(tt *componenttest.Telemetry) processor.Settings {
+	set := processortest.NewNopSettings()
+	set.ID = component.NewID(component.MustNewType("processorhelper"))
+	set.TelemetrySettings = tt.NewTelemetrySettings()
+	return set
+}
+
+func AssertEqualProcessorIncomingItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_incoming_items",
 		Description: "Number of items passed to the processor. [alpha]",
@@ -60,7 +67,7 @@ func AssertEqualProcessorIncomingItems(t *testing.T, tt componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorOutgoingItems(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorOutgoingItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_outgoing_items",
 		Description: "Number of items emitted from the processor. [alpha]",

--- a/processor/processorhelper/logs_test.go
+++ b/processor/processorhelper/logs_test.go
@@ -120,22 +120,22 @@ func TestLogs_RecordInOut(t *testing.T) {
 	incomingLogRecords.AppendEmpty()
 	incomingLogRecords.AppendEmpty()
 
-	testTelemetry := metadatatest.SetupTelemetry()
-	lp, err := NewLogs(context.Background(), testTelemetry.NewSettings(), &testLogsCfg, consumertest.NewNop(), mockAggregate)
+	tel := componenttest.NewTelemetry()
+	lp, err := NewLogs(context.Background(), metadatatest.NewSettings(tel), &testLogsCfg, consumertest.NewNop(), mockAggregate)
 	require.NoError(t, err)
 
 	assert.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, lp.ConsumeLogs(context.Background(), incomingLogs))
 	assert.NoError(t, lp.Shutdown(context.Background()))
 
-	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorIncomingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      3,
 				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
 			},
 		}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorOutgoingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      1,
@@ -158,22 +158,22 @@ func TestLogs_RecordIn_ErrorOut(t *testing.T) {
 	incomingLogRecords.AppendEmpty()
 	incomingLogRecords.AppendEmpty()
 
-	testTelemetry := metadatatest.SetupTelemetry()
-	lp, err := NewLogs(context.Background(), testTelemetry.NewSettings(), &testLogsCfg, consumertest.NewNop(), mockErr)
+	tel := componenttest.NewTelemetry()
+	lp, err := NewLogs(context.Background(), metadatatest.NewSettings(tel), &testLogsCfg, consumertest.NewNop(), mockErr)
 	require.NoError(t, err)
 
 	require.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))
 	require.Error(t, lp.ConsumeLogs(context.Background(), incomingLogs))
 	require.NoError(t, lp.Shutdown(context.Background()))
 
-	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorIncomingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      3,
 				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "logs")),
 			},
 		}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorOutgoingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      0,

--- a/processor/processorhelper/metrics_test.go
+++ b/processor/processorhelper/metrics_test.go
@@ -120,22 +120,22 @@ func TestMetrics_RecordInOut(t *testing.T) {
 	dps.AppendEmpty()
 	dps.AppendEmpty()
 
-	testTelemetry := metadatatest.SetupTelemetry()
-	mp, err := NewMetrics(context.Background(), testTelemetry.NewSettings(), &testMetricsCfg, consumertest.NewNop(), mockAggregate)
+	tel := componenttest.NewTelemetry()
+	mp, err := NewMetrics(context.Background(), metadatatest.NewSettings(tel), &testMetricsCfg, consumertest.NewNop(), mockAggregate)
 	require.NoError(t, err)
 
 	assert.NoError(t, mp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, mp.ConsumeMetrics(context.Background(), incomingMetrics))
 	assert.NoError(t, mp.Shutdown(context.Background()))
 
-	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorIncomingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      2,
 				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
 			},
 		}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorOutgoingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      3,
@@ -157,22 +157,22 @@ func TestMetrics_RecordIn_ErrorOut(t *testing.T) {
 	dps.AppendEmpty()
 	dps.AppendEmpty()
 
-	testTelemetry := metadatatest.SetupTelemetry()
-	mp, err := NewMetrics(context.Background(), testTelemetry.NewSettings(), &testMetricsCfg, consumertest.NewNop(), mockErr)
+	tel := componenttest.NewTelemetry()
+	mp, err := NewMetrics(context.Background(), metadatatest.NewSettings(tel), &testMetricsCfg, consumertest.NewNop(), mockErr)
 	require.NoError(t, err)
 
 	require.NoError(t, mp.Start(context.Background(), componenttest.NewNopHost()))
 	require.Error(t, mp.ConsumeMetrics(context.Background(), incomingMetrics))
 	require.NoError(t, mp.Shutdown(context.Background()))
 
-	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorIncomingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      2,
 				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "metrics")),
 			},
 		}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorOutgoingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      0,

--- a/processor/processorhelper/traces_test.go
+++ b/processor/processorhelper/traces_test.go
@@ -122,22 +122,22 @@ func TestTraces_RecordInOut(t *testing.T) {
 	incomingSpans.AppendEmpty()
 	incomingSpans.AppendEmpty()
 
-	testTelemetry := metadatatest.SetupTelemetry()
-	tp, err := NewTraces(context.Background(), testTelemetry.NewSettings(), &testLogsCfg, consumertest.NewNop(), mockAggregate)
+	tel := componenttest.NewTelemetry()
+	tp, err := NewTraces(context.Background(), metadatatest.NewSettings(tel), &testLogsCfg, consumertest.NewNop(), mockAggregate)
 	require.NoError(t, err)
 
 	assert.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, tp.ConsumeTraces(context.Background(), incomingTraces))
 	assert.NoError(t, tp.Shutdown(context.Background()))
 
-	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorIncomingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      4,
 				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
 			},
 		}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorOutgoingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      1,
@@ -161,22 +161,22 @@ func TestTraces_RecordIn_ErrorOut(t *testing.T) {
 	incomingSpans.AppendEmpty()
 	incomingSpans.AppendEmpty()
 
-	testTelemetry := metadatatest.SetupTelemetry()
-	tp, err := NewTraces(context.Background(), testTelemetry.NewSettings(), &testLogsCfg, consumertest.NewNop(), mockErr)
+	tel := componenttest.NewTelemetry()
+	tp, err := NewTraces(context.Background(), metadatatest.NewSettings(tel), &testLogsCfg, consumertest.NewNop(), mockErr)
 	require.NoError(t, err)
 
 	require.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 	require.Error(t, tp.ConsumeTraces(context.Background(), incomingTraces))
 	require.NoError(t, tp.Shutdown(context.Background()))
 
-	metadatatest.AssertEqualProcessorIncomingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorIncomingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      4,
 				Attributes: attribute.NewSet(attribute.String("processor", "processorhelper"), attribute.String("otel.signal", "traces")),
 			},
 		}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualProcessorOutgoingItems(t, testTelemetry.Telemetry,
+	metadatatest.AssertEqualProcessorOutgoingItems(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Value:      0,

--- a/receiver/receiverhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/receiver/receiverhelper/internal/metadatatest/generated_telemetrytest.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Telemetry struct {
-	componenttest.Telemetry
+	*componenttest.Telemetry
 }
 
 func SetupTelemetry(opts ...componenttest.TelemetryOption) Telemetry {
@@ -44,7 +44,14 @@ func (tt *Telemetry) AssertMetrics(t *testing.T, expected []metricdata.Metrics, 
 	require.Equal(t, len(expected), lenMetrics(md))
 }
 
-func AssertEqualReceiverAcceptedLogRecords(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func NewSettings(tt *componenttest.Telemetry) receiver.Settings {
+	set := receivertest.NewNopSettings()
+	set.ID = component.NewID(component.MustNewType("receiverhelper"))
+	set.TelemetrySettings = tt.NewTelemetrySettings()
+	return set
+}
+
+func AssertEqualReceiverAcceptedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_receiver_accepted_log_records",
 		Description: "Number of log records successfully pushed into the pipeline. [alpha]",
@@ -60,7 +67,7 @@ func AssertEqualReceiverAcceptedLogRecords(t *testing.T, tt componenttest.Teleme
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualReceiverAcceptedMetricPoints(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualReceiverAcceptedMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_receiver_accepted_metric_points",
 		Description: "Number of metric points successfully pushed into the pipeline. [alpha]",
@@ -76,7 +83,7 @@ func AssertEqualReceiverAcceptedMetricPoints(t *testing.T, tt componenttest.Tele
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualReceiverAcceptedSpans(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualReceiverAcceptedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_receiver_accepted_spans",
 		Description: "Number of spans successfully pushed into the pipeline. [alpha]",
@@ -92,7 +99,7 @@ func AssertEqualReceiverAcceptedSpans(t *testing.T, tt componenttest.Telemetry, 
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualReceiverRefusedLogRecords(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualReceiverRefusedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_receiver_refused_log_records",
 		Description: "Number of log records that could not be pushed into the pipeline. [alpha]",
@@ -108,7 +115,7 @@ func AssertEqualReceiverRefusedLogRecords(t *testing.T, tt componenttest.Telemet
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualReceiverRefusedMetricPoints(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualReceiverRefusedMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_receiver_refused_metric_points",
 		Description: "Number of metric points that could not be pushed into the pipeline. [alpha]",
@@ -124,7 +131,7 @@ func AssertEqualReceiverRefusedMetricPoints(t *testing.T, tt componenttest.Telem
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualReceiverRefusedSpans(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualReceiverRefusedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_receiver_refused_spans",
 		Description: "Number of spans that could not be pushed into the pipeline. [alpha]",

--- a/scraper/scraperhelper/controller_test.go
+++ b/scraper/scraperhelper/controller_test.go
@@ -138,12 +138,12 @@ func TestLogsScrapeController(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			receiverID := component.MustNewID("receiver")
-			tt := metadatatest.SetupTelemetry()
-			tel := tt.NewTelemetrySettings()
+			tel := componenttest.NewTelemetry()
+			t.Cleanup(func() { require.NoError(t, tel.Shutdown(context.Background())) })
 
-			_, parentSpan := tel.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+			set := tel.NewTelemetrySettings()
+			_, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 			defer parentSpan.End()
-			t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 			initializeChs := make([]chan bool, test.scrapers)
 			scrapeLogsChs := make([]chan int, test.scrapers)
@@ -159,7 +159,7 @@ func TestLogsScrapeController(t *testing.T) {
 				cfg = test.scraperControllerSettings
 			}
 
-			mr, err := NewLogsController(cfg, receiver.Settings{ID: receiverID, TelemetrySettings: tel, BuildInfo: component.NewDefaultBuildInfo()}, sink, options...)
+			mr, err := NewLogsController(cfg, receiver.Settings{ID: receiverID, TelemetrySettings: set, BuildInfo: component.NewDefaultBuildInfo()}, sink, options...)
 			require.NoError(t, err)
 
 			err = mr.Start(context.Background(), componenttest.NewNopHost())
@@ -197,10 +197,10 @@ func TestLogsScrapeController(t *testing.T) {
 					assert.GreaterOrEqual(t, sink.LogRecordCount(), iterations)
 				}
 
-				spans := tt.SpanRecorder.Ended()
+				spans := tel.SpanRecorder.Ended()
 				assertReceiverSpan(t, spans)
 				assertScraperSpan(t, test.scrapeErr, spans, "scraper/scraper/ScrapeLogs")
-				assertLogsScraperObsMetrics(t, tt, receiverID, component.MustNewID("scraper"), test.scrapeErr, sink)
+				assertLogsScraperObsMetrics(t, tel, receiverID, component.MustNewID("scraper"), test.scrapeErr, sink)
 			}
 
 			err = mr.Shutdown(context.Background())
@@ -249,12 +249,12 @@ func TestMetricsScrapeController(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			receiverID := component.MustNewID("receiver")
-			tt := metadatatest.SetupTelemetry()
-			tel := tt.NewTelemetrySettings()
+			tel := componenttest.NewTelemetry()
+			t.Cleanup(func() { require.NoError(t, tel.Shutdown(context.Background())) })
 
-			_, parentSpan := tel.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+			set := tel.NewTelemetrySettings()
+			_, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 			defer parentSpan.End()
-			t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 			initializeChs := make([]chan bool, test.scrapers)
 			scrapeMetricsChs := make([]chan int, test.scrapers)
@@ -270,7 +270,7 @@ func TestMetricsScrapeController(t *testing.T) {
 				cfg = test.scraperControllerSettings
 			}
 
-			mr, err := NewMetricsController(cfg, receiver.Settings{ID: receiverID, TelemetrySettings: tel, BuildInfo: component.NewDefaultBuildInfo()}, sink, options...)
+			mr, err := NewMetricsController(cfg, receiver.Settings{ID: receiverID, TelemetrySettings: set, BuildInfo: component.NewDefaultBuildInfo()}, sink, options...)
 			require.NoError(t, err)
 
 			err = mr.Start(context.Background(), componenttest.NewNopHost())
@@ -308,10 +308,10 @@ func TestMetricsScrapeController(t *testing.T) {
 					assert.GreaterOrEqual(t, sink.DataPointCount(), iterations)
 				}
 
-				spans := tt.SpanRecorder.Ended()
+				spans := tel.SpanRecorder.Ended()
 				assertReceiverSpan(t, spans)
 				assertScraperSpan(t, test.scrapeErr, spans, "scraper/scraper/ScrapeMetrics")
-				assertMetricsScraperObsMetrics(t, tt, receiverID, component.MustNewID("scraper"), test.scrapeErr, sink)
+				assertMetricsScraperObsMetrics(t, tel, receiverID, component.MustNewID("scraper"), test.scrapeErr, sink)
 			}
 
 			err = mr.Shutdown(context.Background())
@@ -440,7 +440,7 @@ func assertScraperSpan(t *testing.T, expectedErr error, spans []sdktrace.ReadOnl
 	assert.True(t, scraperSpan)
 }
 
-func assertLogsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, receiver component.ID, scraper component.ID, expectedErr error, sink *consumertest.LogsSink) {
+func assertLogsScraperObsMetrics(t *testing.T, tel *componenttest.Telemetry, receiver component.ID, scraper component.ID, expectedErr error, sink *consumertest.LogsSink) {
 	logRecordCounts := 0
 	for _, md := range sink.AllLogs() {
 		logRecordCounts += md.LogRecordCount()
@@ -458,7 +458,7 @@ func assertLogsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, receiv
 		}
 	}
 
-	metadatatest.AssertEqualScraperScrapedLogRecords(t, tt.Telemetry,
+	metadatatest.AssertEqualScraperScrapedLogRecords(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(
@@ -468,7 +468,7 @@ func assertLogsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, receiv
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
-	metadatatest.AssertEqualScraperErroredLogRecords(t, tt.Telemetry,
+	metadatatest.AssertEqualScraperErroredLogRecords(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(
@@ -479,7 +479,7 @@ func assertLogsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, receiv
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }
 
-func assertMetricsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, receiver component.ID, scraper component.ID, expectedErr error, sink *consumertest.MetricsSink) {
+func assertMetricsScraperObsMetrics(t *testing.T, tel *componenttest.Telemetry, receiver component.ID, scraper component.ID, expectedErr error, sink *consumertest.MetricsSink) {
 	dataPointCounts := 0
 	for _, md := range sink.AllMetrics() {
 		dataPointCounts += md.DataPointCount()
@@ -497,7 +497,7 @@ func assertMetricsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, rec
 		}
 	}
 
-	metadatatest.AssertEqualScraperScrapedMetricPoints(t, tt.Telemetry,
+	metadatatest.AssertEqualScraperScrapedMetricPoints(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(
@@ -506,7 +506,7 @@ func assertMetricsScraperObsMetrics(t *testing.T, tt metadatatest.Telemetry, rec
 				Value: expectedScraped,
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
-	metadatatest.AssertEqualScraperErroredMetricPoints(t, tt.Telemetry,
+	metadatatest.AssertEqualScraperErroredMetricPoints(t, tel,
 		[]metricdata.DataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(

--- a/scraper/scraperhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/scraper/scraperhelper/internal/metadatatest/generated_telemetrytest.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Telemetry struct {
-	componenttest.Telemetry
+	*componenttest.Telemetry
 }
 
 func SetupTelemetry(opts ...componenttest.TelemetryOption) Telemetry {
@@ -34,7 +34,7 @@ func (tt *Telemetry) AssertMetrics(t *testing.T, expected []metricdata.Metrics, 
 	require.Equal(t, len(expected), lenMetrics(md))
 }
 
-func AssertEqualScraperErroredLogRecords(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualScraperErroredLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_scraper_errored_log_records",
 		Description: "Number of log records that were unable to be scraped. [alpha]",
@@ -50,7 +50,7 @@ func AssertEqualScraperErroredLogRecords(t *testing.T, tt componenttest.Telemetr
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualScraperErroredMetricPoints(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualScraperErroredMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_scraper_errored_metric_points",
 		Description: "Number of metric points that were unable to be scraped. [alpha]",
@@ -66,7 +66,7 @@ func AssertEqualScraperErroredMetricPoints(t *testing.T, tt componenttest.Teleme
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualScraperScrapedLogRecords(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualScraperScrapedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_scraper_scraped_log_records",
 		Description: "Number of log records successfully scraped. [alpha]",
@@ -82,7 +82,7 @@ func AssertEqualScraperScrapedLogRecords(t *testing.T, tt componenttest.Telemetr
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualScraperScrapedMetricPoints(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualScraperScrapedMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_scraper_scraped_metric_points",
 		Description: "Number of metric points successfully scraped. [alpha]",

--- a/scraper/scraperhelper/obs_metrics_test.go
+++ b/scraper/scraperhelper/obs_metrics_test.go
@@ -14,10 +14,9 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/testdata"
 	"go.opentelemetry.io/collector/scraper"
@@ -39,15 +38,11 @@ type testParams struct {
 }
 
 func TestScrapeMetricsDataOp(t *testing.T) {
-	tt := metadatatest.SetupTelemetry()
-	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+	tel := componenttest.NewTelemetry()
+	t.Cleanup(func() { require.NoError(t, tel.Shutdown(context.Background())) })
 
-	tel := tt.NewTelemetrySettings()
-	// TODO: Add capability for tracing testing in metadatatest.
-	spanRecorder := new(tracetest.SpanRecorder)
-	tel.TracerProvider = sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
-
-	parentCtx, parentSpan := tel.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+	set := tel.NewTelemetrySettings()
+	parentCtx, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	params := []testParams{
@@ -60,13 +55,13 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 			return testdata.GenerateMetrics(params[i].items), params[i].err
 		})
 		require.NoError(t, err)
-		sf, err := wrapObsMetrics(sm, receiverID, scraperID, tel)
+		sf, err := wrapObsMetrics(sm, receiverID, scraperID, set)
 		require.NoError(t, err)
 		_, err = sf.ScrapeMetrics(parentCtx)
 		require.ErrorIs(t, err, params[i].err)
 	}
 
-	spans := spanRecorder.Ended()
+	spans := tel.SpanRecorder.Ended()
 	require.Equal(t, len(params), len(spans))
 
 	var scrapedMetricPoints, erroredMetricPoints int
@@ -96,27 +91,27 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 		}
 	}
 
-	checkScraperMetrics(t, tt, receiverID, scraperID, int64(scrapedMetricPoints), int64(erroredMetricPoints))
+	checkScraperMetrics(t, tel, receiverID, scraperID, int64(scrapedMetricPoints), int64(erroredMetricPoints))
 }
 
 func TestCheckScraperMetrics(t *testing.T) {
-	tt := metadatatest.SetupTelemetry()
-	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+	tel := componenttest.NewTelemetry()
+	t.Cleanup(func() { require.NoError(t, tel.Shutdown(context.Background())) })
 
 	sm, err := scraper.NewMetrics(func(context.Context) (pmetric.Metrics, error) {
 		return testdata.GenerateMetrics(7), nil
 	})
 	require.NoError(t, err)
-	sf, err := wrapObsMetrics(sm, receiverID, scraperID, tt.NewTelemetrySettings())
+	sf, err := wrapObsMetrics(sm, receiverID, scraperID, tel.NewTelemetrySettings())
 	require.NoError(t, err)
 	_, err = sf.ScrapeMetrics(context.Background())
 	require.NoError(t, err)
 
-	checkScraperMetrics(t, tt, receiverID, scraperID, 7, 0)
+	checkScraperMetrics(t, tel, receiverID, scraperID, 7, 0)
 }
 
-func checkScraperMetrics(t *testing.T, tt metadatatest.Telemetry, receiver component.ID, scraper component.ID, scrapedMetricPoints, erroredMetricPoints int64) {
-	metadatatest.AssertEqualScraperScrapedMetricPoints(t, tt.Telemetry,
+func checkScraperMetrics(t *testing.T, tt *componenttest.Telemetry, receiver component.ID, scraper component.ID, scrapedMetricPoints, erroredMetricPoints int64) {
+	metadatatest.AssertEqualScraperScrapedMetricPoints(t, tt,
 		[]metricdata.DataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(
@@ -125,7 +120,7 @@ func checkScraperMetrics(t *testing.T, tt metadatatest.Telemetry, receiver compo
 				Value: scrapedMetricPoints,
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
-	metadatatest.AssertEqualScraperErroredMetricPoints(t, tt.Telemetry,
+	metadatatest.AssertEqualScraperErroredMetricPoints(t, tt,
 		[]metricdata.DataPoint[int64]{
 			{
 				Attributes: attribute.NewSet(

--- a/service/internal/metadatatest/generated_telemetrytest.go
+++ b/service/internal/metadatatest/generated_telemetrytest.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Telemetry struct {
-	componenttest.Telemetry
+	*componenttest.Telemetry
 }
 
 func SetupTelemetry(opts ...componenttest.TelemetryOption) Telemetry {
@@ -34,7 +34,7 @@ func (tt *Telemetry) AssertMetrics(t *testing.T, expected []metricdata.Metrics, 
 	require.Equal(t, len(expected), lenMetrics(md))
 }
 
-func AssertEqualProcessCPUSeconds(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
+func AssertEqualProcessCPUSeconds(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_process_cpu_seconds",
 		Description: "Total CPU user and system time in seconds [alpha]",
@@ -50,7 +50,7 @@ func AssertEqualProcessCPUSeconds(t *testing.T, tt componenttest.Telemetry, dps 
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessMemoryRss(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessMemoryRss(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_process_memory_rss",
 		Description: "Total physical memory (resident set size) [alpha]",
@@ -64,7 +64,7 @@ func AssertEqualProcessMemoryRss(t *testing.T, tt componenttest.Telemetry, dps [
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessRuntimeHeapAllocBytes(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessRuntimeHeapAllocBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_process_runtime_heap_alloc_bytes",
 		Description: "Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc') [alpha]",
@@ -78,7 +78,7 @@ func AssertEqualProcessRuntimeHeapAllocBytes(t *testing.T, tt componenttest.Tele
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessRuntimeTotalAllocBytes(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessRuntimeTotalAllocBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_process_runtime_total_alloc_bytes",
 		Description: "Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc') [alpha]",
@@ -94,7 +94,7 @@ func AssertEqualProcessRuntimeTotalAllocBytes(t *testing.T, tt componenttest.Tel
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessRuntimeTotalSysMemoryBytes(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessRuntimeTotalSysMemoryBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_process_runtime_total_sys_memory_bytes",
 		Description: "Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys') [alpha]",
@@ -108,7 +108,7 @@ func AssertEqualProcessRuntimeTotalSysMemoryBytes(t *testing.T, tt componenttest
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessUptime(t *testing.T, tt componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
+func AssertEqualProcessUptime(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_process_uptime",
 		Description: "Uptime of the process [alpha]",

--- a/service/internal/proctelemetry/process_telemetry_linux_test.go
+++ b/service/internal/proctelemetry/process_telemetry_linux_test.go
@@ -12,30 +12,31 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/service/internal/metadatatest"
 )
 
 func TestProcessTelemetryWithHostProc(t *testing.T) {
 	// Make the sure the environment variable value is not used.
 	t.Setenv("HOST_PROC", "foo/bar")
-	tel := metadatatest.SetupTelemetry()
+	tel := componenttest.NewTelemetry()
 	require.NoError(t, RegisterProcessMetrics(tel.NewTelemetrySettings(), WithHostProc("/proc")))
 
-	metadatatest.AssertEqualProcessUptime(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessUptime(t, tel,
 		[]metricdata.DataPoint[float64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessRuntimeHeapAllocBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessRuntimeHeapAllocBytes(t, tel,
 		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessRuntimeTotalAllocBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessRuntimeTotalAllocBytes(t, tel,
 		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessRuntimeTotalSysMemoryBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessRuntimeTotalSysMemoryBytes(t, tel,
 		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessCPUSeconds(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessCPUSeconds(t, tel,
 		[]metricdata.DataPoint[float64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessMemoryRss(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessMemoryRss(t, tel,
 		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 }

--- a/service/internal/proctelemetry/process_telemetry_test.go
+++ b/service/internal/proctelemetry/process_telemetry_test.go
@@ -10,28 +10,29 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/service/internal/metadatatest"
 )
 
 func TestProcessTelemetry(t *testing.T) {
-	tel := metadatatest.SetupTelemetry()
+	tel := componenttest.NewTelemetry()
 	require.NoError(t, RegisterProcessMetrics(tel.NewTelemetrySettings()))
 
-	metadatatest.AssertEqualProcessUptime(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessUptime(t, tel,
 		[]metricdata.DataPoint[float64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessRuntimeHeapAllocBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessRuntimeHeapAllocBytes(t, tel,
 		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessRuntimeTotalAllocBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessRuntimeTotalAllocBytes(t, tel,
 		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessRuntimeTotalSysMemoryBytes(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessRuntimeTotalSysMemoryBytes(t, tel,
 		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessCPUSeconds(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessCPUSeconds(t, tel,
 		[]metricdata.DataPoint[float64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 
-	metadatatest.AssertEqualProcessMemoryRss(t, tel.Telemetry,
+	metadatatest.AssertEqualProcessMemoryRss(t, tel,
 		[]metricdata.DataPoint[int64]{{}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 }


### PR DESCRIPTION
This is the last functionality needed to replace `metadatatest.Telemetry` with `componenttest.Telemetry`. 

The `metadatatest.Telemetry` will be deprecated next release to give time to change contrib since it is a large change.