### PR TITLE
[chore] Remove manual calls to `Validate`

### DIFF
--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -171,7 +171,7 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	if err = cfg.Validate(); err != nil {
+	if err = component.ValidateConfig(cfg); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
@@ -261,7 +261,7 @@ func (col *Collector) DryRun(ctx context.Context) error {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	return cfg.Validate()
+	return component.ValidateConfig(cfg)
 }
 
 func newFallbackLogger(options []zap.Option) (*zap.Logger, error) {

--- a/otelcol/config.go
+++ b/otelcol/config.go
@@ -54,39 +54,14 @@ func (cfg *Config) Validate() error {
 		return errMissingReceivers
 	}
 
-	// Validate the receiver configuration.
-	for recvID, recvCfg := range cfg.Receivers {
-		if err := component.ValidateConfig(recvCfg); err != nil {
-			return fmt.Errorf("receivers::%s: %w", recvID, err)
-		}
-	}
-
 	// Currently, there is no default exporter enabled.
 	// The configuration must specify at least one exporter to be valid.
 	if len(cfg.Exporters) == 0 {
 		return errMissingExporters
 	}
 
-	// Validate the exporter configuration.
-	for expID, expCfg := range cfg.Exporters {
-		if err := component.ValidateConfig(expCfg); err != nil {
-			return fmt.Errorf("exporters::%s: %w", expID, err)
-		}
-	}
-
-	// Validate the processor configuration.
-	for procID, procCfg := range cfg.Processors {
-		if err := component.ValidateConfig(procCfg); err != nil {
-			return fmt.Errorf("processors::%s: %w", procID, err)
-		}
-	}
-
 	// Validate the connector configuration.
-	for connID, connCfg := range cfg.Connectors {
-		if err := component.ValidateConfig(connCfg); err != nil {
-			return fmt.Errorf("connectors::%s: %w", connID, err)
-		}
-
+	for connID := range cfg.Connectors {
 		if _, ok := cfg.Exporters[connID]; ok {
 			return fmt.Errorf("connectors::%s: ambiguous ID: Found both %q exporter and %q connector. "+
 				"Change one of the components' IDs to eliminate ambiguity (e.g. rename %q connector to %q)",
@@ -97,17 +72,6 @@ func (cfg *Config) Validate() error {
 				"Change one of the components' IDs to eliminate ambiguity (e.g. rename %q connector to %q)",
 				connID, connID, connID, connID, connID.String()+"/connector")
 		}
-	}
-
-	// Validate the extension configuration.
-	for extID, extCfg := range cfg.Extensions {
-		if err := component.ValidateConfig(extCfg); err != nil {
-			return fmt.Errorf("extensions::%s: %w", extID, err)
-		}
-	}
-
-	if err := cfg.Service.Validate(); err != nil {
-		return err
 	}
 
 	// Check that all enabled extensions in the service are configured.

--- a/otelcol/config_test.go
+++ b/otelcol/config_test.go
@@ -234,14 +234,14 @@ func TestConfigValidate(t *testing.T) {
 				cfg.Service.Pipelines = nil
 				return cfg
 			},
-			expected: fmt.Errorf(`service::pipelines config validation failed: %w`, errors.New(`service must have at least one pipeline`)),
+			expected: fmt.Errorf(`service::pipelines: %w`, errors.New(`service must have at least one pipeline`)),
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.cfgFn()
-			err := cfg.Validate()
+			err := component.ValidateConfig(cfg)
 			if tt.expected != nil {
 				assert.EqualError(t, err, tt.expected.Error())
 			} else {

--- a/otelcol/otelcoltest/config.go
+++ b/otelcol/otelcoltest/config.go
@@ -6,6 +6,7 @@ package otelcoltest // import "go.opentelemetry.io/collector/otelcol/otelcoltest
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
@@ -40,5 +41,5 @@ func LoadConfigAndValidate(fileName string, factories otelcol.Factories) (*otelc
 	if err != nil {
 		return nil, err
 	}
-	return cfg, cfg.Validate()
+	return cfg, component.ValidateConfig(cfg)
 }

--- a/service/config.go
+++ b/service/config.go
@@ -4,8 +4,6 @@
 package service // import "go.opentelemetry.io/collector/service"
 
 import (
-	"fmt"
-
 	"go.opentelemetry.io/collector/service/extensions"
 	"go.opentelemetry.io/collector/service/pipelines"
 	"go.opentelemetry.io/collector/service/telemetry"
@@ -21,16 +19,4 @@ type Config struct {
 
 	// Pipelines are the set of data pipelines configured for the service.
 	Pipelines pipelines.Config `mapstructure:"pipelines"`
-}
-
-func (cfg *Config) Validate() error {
-	if err := cfg.Pipelines.Validate(); err != nil {
-		return fmt.Errorf("service::pipelines config validation failed: %w", err)
-	}
-
-	if err := cfg.Telemetry.Validate(); err != nil {
-		return fmt.Errorf("service::telemetry config validation failed: %w", err)
-	}
-
-	return nil
 }

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,7 +47,7 @@ func TestConfigValidate(t *testing.T) {
 				pipe.Processors = append(pipe.Processors, pipe.Processors...)
 				return cfg
 			},
-			expected: fmt.Errorf(`pipeline "traces": %w`, errors.New(`references processor "nop" multiple times`)),
+			expected: errors.New(`references processor "nop" multiple times`),
 		},
 		{
 			name: "invalid-service-pipeline-type",

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -48,7 +48,7 @@ func TestConfigValidate(t *testing.T) {
 				pipe.Processors = append(pipe.Processors, pipe.Processors...)
 				return cfg
 			},
-			expected: fmt.Errorf(`service::pipelines config validation failed: %w`, fmt.Errorf(`pipeline "traces": %w`, errors.New(`references processor "nop" multiple times`))),
+			expected: fmt.Errorf(`pipeline "traces": %w`, errors.New(`references processor "nop" multiple times`)),
 		},
 		{
 			name: "invalid-service-pipeline-type",
@@ -61,7 +61,7 @@ func TestConfigValidate(t *testing.T) {
 				}
 				return cfg
 			},
-			expected: fmt.Errorf(`service::pipelines config validation failed: %w`, errors.New(`pipeline "wrongtype": unknown signal "wrongtype"`)),
+			expected: errors.New(`pipeline "wrongtype": unknown signal "wrongtype"`),
 		},
 		{
 			name: "invalid-telemetry-metric-config",
@@ -71,16 +71,16 @@ func TestConfigValidate(t *testing.T) {
 				cfg.Telemetry.Metrics.Readers = nil
 				return cfg
 			},
-			expected: errors.New("service::telemetry config validation failed: collector telemetry metrics reader should exist when metric level is not none"),
+			expected: errors.New("collector telemetry metrics reader should exist when metric level is not none"),
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.cfgFn()
-			err := cfg.Validate()
+			err := component.ValidateConfig(cfg)
 			if tt.expected != nil {
-				assert.EqualError(t, err, tt.expected.Error())
+				assert.ErrorContains(t, err, tt.expected.Error())
 			} else {
 				assert.NoError(t, err)
 			}

--- a/service/pipelines/config.go
+++ b/service/pipelines/config.go
@@ -38,7 +38,7 @@ func (cfg Config) Validate() error {
 
 	// Check that all pipelines have at least one receiver and one exporter, and they reference
 	// only configured components.
-	for pipelineID, p := range cfg {
+	for pipelineID := range cfg {
 		switch pipelineID.Signal() {
 		case pipeline.SignalTraces, pipeline.SignalMetrics, pipeline.SignalLogs:
 			// Continue
@@ -52,11 +52,6 @@ func (cfg Config) Validate() error {
 			}
 		default:
 			return fmt.Errorf("pipeline %q: unknown signal %q", pipelineID.String(), pipelineID.Signal())
-		}
-
-		// Validate pipeline has at least one receiver.
-		if err := p.Validate(); err != nil {
-			return fmt.Errorf("pipeline %q: %w", pipelineID.String(), err)
 		}
 	}
 

--- a/service/pipelines/config_test.go
+++ b/service/pipelines/config_test.go
@@ -5,7 +5,6 @@ package pipelines
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,7 +35,7 @@ func TestConfigValidate(t *testing.T) {
 				pipe.Processors = append(pipe.Processors, pipe.Processors...)
 				return cfg
 			},
-			expected: fmt.Errorf(`pipeline "traces": %w`, errors.New(`references processor "nop" multiple times`)),
+			expected: errors.New(`references processor "nop" multiple times`),
 		},
 		{
 			name: "missing-pipeline-receivers",
@@ -45,7 +44,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg[pipeline.NewID(pipeline.SignalTraces)].Receivers = nil
 				return cfg
 			},
-			expected: fmt.Errorf(`pipeline "traces": %w`, errMissingServicePipelineReceivers),
+			expected: errMissingServicePipelineReceivers,
 		},
 		{
 			name: "missing-pipeline-exporters",
@@ -54,7 +53,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg[pipeline.NewID(pipeline.SignalTraces)].Exporters = nil
 				return cfg
 			},
-			expected: fmt.Errorf(`pipeline "traces": %w`, errMissingServicePipelineExporters),
+			expected: errMissingServicePipelineExporters,
 		},
 		{
 			name: "missing-pipelines",
@@ -74,7 +73,7 @@ func TestConfigValidate(t *testing.T) {
 				}
 				return cfg
 			},
-			expected: errors.New(`pipeline "wrongtype": unknown signal "wrongtype"`),
+			expected: errors.New(`unknown signal "wrongtype"`),
 		},
 		{
 			name: "disabled-featuregate-profiles",
@@ -87,7 +86,7 @@ func TestConfigValidate(t *testing.T) {
 				}
 				return cfg
 			},
-			expected: errors.New(`pipeline "profiles": profiling signal support is at alpha level, gated under the "service.profilesSupport" feature gate`),
+			expected: errors.New(`profiling signal support is at alpha level, gated under the "service.profilesSupport" feature gate`),
 		},
 		{
 			name: "enabled-featuregate-profiles",
@@ -109,7 +108,11 @@ func TestConfigValidate(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.cfgFn(t)
-			assert.Equal(t, tt.expected, cfg.Validate())
+			if tt.expected != nil {
+				assert.ErrorContains(t, component.ValidateConfig(cfg), tt.expected.Error())
+			} else {
+				assert.NoError(t, component.ValidateConfig(cfg))
+			}
 
 			// Clean up the profiles support gate, which may have been enabled in `cfgFn`.
 			require.NoError(t, featuregate.GlobalRegistry().Set(serviceProfileSupportGateID, false))

--- a/service/pipelines/config_test.go
+++ b/service/pipelines/config_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
@@ -109,9 +108,9 @@ func TestConfigValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.cfgFn(t)
 			if tt.expected != nil {
-				assert.ErrorContains(t, component.ValidateConfig(cfg), tt.expected.Error())
+				require.ErrorContains(t, component.ValidateConfig(cfg), tt.expected.Error())
 			} else {
-				assert.NoError(t, component.ValidateConfig(cfg))
+				require.NoError(t, component.ValidateConfig(cfg))
 			}
 
 			// Clean up the profiles support gate, which may have been enabled in `cfgFn`.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Follow-up to https://github.com/open-telemetry/opentelemetry-collector/pull/12108.

This calls `component.ValidateConfig` on `otelcol.Config`, which causes `Validate` to be recursively called on all eligible structs in the config.

This has the following benefits:
1. `Validate` will now automatically be called instead of config structs needing to call it on member structs.
2. Paths to the exact key that caused a validation error in the config are now consistently printed.
3. If there are multiple errors in the config, they are now all returned to the user instead of just the first error encountered.