### PR TITLE
[exporterhelper] Propagate Context in DisabledBatcher

### DIFF
--- a/exporter/internal/queue/disabled_batcher.go
+++ b/exporter/internal/queue/disabled_batcher.go
@@ -29,13 +29,13 @@ func (qb *DisabledBatcher) Start(_ context.Context, _ component.Host) error {
 	go func() {
 		defer qb.stopWG.Done()
 		for {
-			idx, _, req, ok := qb.queue.Read(context.Background())
+			idx, ctx, req, ok := qb.queue.Read(context.Background())
 			if !ok {
 				return
 			}
 			qb.flush(batch{
 				req:     req,
-				ctx:     context.Background(),
+				ctx:     ctx,
 				idxList: []uint64{idx},
 			})
 		}


### PR DESCRIPTION
#### Description

When the batching functionality of `exporterhelper` is disabled (which is the default), the `DisabledBatcher` [discards the provided Context and creates a new one with context.Background](https://github.com/open-telemetry/opentelemetry-collector/blob/349b84b059e52bd152829ee90422c5f897763a76/exporter/internal/queue/disabled_batcher.go#L32). This breaks traces, even when using the in-memory queue.

#### Link to tracking issue
No tracking issue.

#### Testing
I compared the traces emitted for a simple OTLP receiver -> OTLP exporter pipeline: the `exporterhelper` span is in its own trace before the PR, and in the same trace as the receiver span after.
