### PR TITLE
Change Queue interface to return a callback instead of an index

### DIFF
--- a/.chloggen/done-callback.yaml
+++ b/.chloggen/done-callback.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterqueue
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change Queue interface to return a callback instead of an index
+
+# One or more tracking issues or pull requests related to the change
+issues: [8122]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterqueue/bounded_memory_queue.go
+++ b/exporter/exporterqueue/bounded_memory_queue.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
+var noopDone DoneCallback = func(error) {}
+
 // boundedMemoryQueue implements a producer-consumer exchange similar to a ring buffer queue,
 // where the queue is bounded and if it fills up due to slow consumers, the new items written by
 // the producer are dropped.
@@ -34,11 +36,7 @@ func newBoundedMemoryQueue[T any](set memoryQueueSettings[T]) Queue[T] {
 	}
 }
 
-func (q *boundedMemoryQueue[T]) Read(context.Context) (uint64, context.Context, T, bool) {
+func (q *boundedMemoryQueue[T]) Read(context.Context) (context.Context, T, DoneCallback, bool) {
 	ctx, req, ok := q.sizedQueue.pop()
-	return 0, ctx, req, ok
+	return ctx, req, noopDone, ok
 }
-
-// OnProcessingFinished should be called to remove the item of the given index from the queue once processing is finished.
-// For in memory queue, this function is noop.
-func (q *boundedMemoryQueue[T]) OnProcessingFinished(uint64, error) {}

--- a/exporter/exporterqueue/bounded_memory_queue_test.go
+++ b/exporter/exporterqueue/bounded_memory_queue_test.go
@@ -183,11 +183,11 @@ func TestZeroSizeNoConsumers(t *testing.T) {
 }
 
 func consume[T any](q Queue[T], consumeFunc func(context.Context, T) error) bool {
-	index, ctx, req, ok := q.Read(context.Background())
+	ctx, req, done, ok := q.Read(context.Background())
 	if !ok {
 		return false
 	}
-	q.OnProcessingFinished(index, consumeFunc(ctx, req))
+	done(consumeFunc(ctx, req))
 	return true
 }
 
@@ -203,11 +203,11 @@ func newAsyncConsumer[T any](q Queue[T], numConsumers int, consumeFunc func(cont
 		go func() {
 			defer ac.stopWG.Done()
 			for {
-				index, ctx, req, ok := q.Read(context.Background())
+				ctx, req, done, ok := q.Read(context.Background())
 				if !ok {
 					return
 				}
-				q.OnProcessingFinished(index, consumeFunc(ctx, req))
+				done(consumeFunc(ctx, req))
 			}
 		}()
 	}

--- a/exporter/exporterqueue/persistent_queue.go
+++ b/exporter/exporterqueue/persistent_queue.go
@@ -273,14 +273,14 @@ func (pq *persistentQueue[T]) putInternal(ctx context.Context, req T) error {
 	return nil
 }
 
-func (pq *persistentQueue[T]) Read(ctx context.Context) (uint64, context.Context, T, bool) {
+func (pq *persistentQueue[T]) Read(ctx context.Context) (context.Context, T, DoneCallback, bool) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 
 	for {
 		if pq.stopped {
 			var req T
-			return 0, context.Background(), req, false
+			return context.Background(), req, nil, false
 		}
 
 		// Read until either a successful retrieved element or no more elements in the storage.
@@ -301,7 +301,7 @@ func (pq *persistentQueue[T]) Read(ctx context.Context) (uint64, context.Context
 				}
 				pq.hasMoreSpace.Signal()
 
-				return index, context.Background(), req, true
+				return context.Background(), req, func(processErr error) { pq.onDone(index, processErr) }, true
 			}
 		}
 
@@ -312,7 +312,7 @@ func (pq *persistentQueue[T]) Read(ctx context.Context) (uint64, context.Context
 }
 
 // getNextItem pulls the next available item from the persistent storage along with its index. Once processing is
-// finished, the index should be called with OnProcessingFinished to clean up the storage. If no new item is available,
+// finished, the index should be called with onDone to clean up the storage. If no new item is available,
 // returns false.
 func (pq *persistentQueue[T]) getNextItem(ctx context.Context) (uint64, T, bool) {
 	index := pq.readIndex
@@ -347,8 +347,8 @@ func (pq *persistentQueue[T]) getNextItem(ctx context.Context) (uint64, T, bool)
 	return index, request, true
 }
 
-// OnProcessingFinished should be called to remove the item of the given index from the queue once processing is finished.
-func (pq *persistentQueue[T]) OnProcessingFinished(index uint64, consumeErr error) {
+// onDone should be called to remove the item of the given index from the queue once processing is finished.
+func (pq *persistentQueue[T]) onDone(index uint64, consumeErr error) {
 	// Delete the item from the persistent storage after it was processed.
 	pq.mu.Lock()
 	// Always unref client even if the consumer is shutdown because we always ref it for every valid request.

--- a/exporter/internal/queue/consumers.go
+++ b/exporter/internal/queue/consumers.go
@@ -36,12 +36,11 @@ func (qc *Consumers[T]) Start(_ context.Context, _ component.Host) error {
 			startWG.Done()
 			defer qc.stopWG.Done()
 			for {
-				index, ctx, req, ok := qc.queue.Read(context.Background())
+				ctx, req, done, ok := qc.queue.Read(context.Background())
 				if !ok {
 					return
 				}
-				consumeErr := qc.consumeFunc(ctx, req)
-				qc.queue.OnProcessingFinished(index, consumeErr)
+				done(qc.consumeFunc(ctx, req))
 			}
 		}()
 	}


### PR DESCRIPTION
This change will allow to simplify significantly the implementation for when queue is disabled and caller must block until the batch is constructed and processed downstream

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/8122

It is ok to have this as a breaking change since Queue is still experimental.