### PR TITLE
chore: enable usetesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -218,6 +218,7 @@ linters:
     - unused
     - unparam
     - usestdlibvars
+    - usetesting
     - whitespace
 
 issues:

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -1131,7 +1131,7 @@ func (gts *grpcTraceServer) Export(ctx context.Context, _ ptraceotlp.ExportReque
 
 // tempSocketName provides a temporary Unix socket name for testing.
 func tempSocketName(t *testing.T) string {
-	tmpfile, err := os.CreateTemp("", "sock")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "sock")
 	require.NoError(t, err)
 	require.NoError(t, tmpfile.Close())
 	socket := tmpfile.Name()

--- a/config/configtls/clientcasfilereloader_test.go
+++ b/config/configtls/clientcasfilereloader_test.go
@@ -82,7 +82,7 @@ func createReloader(t *testing.T) (*clientCAsFileReloader, *testLoader, string) 
 }
 
 func createTempFile(t *testing.T) string {
-	tmpCa, err := os.CreateTemp("", "clientCAs.crt")
+	tmpCa, err := os.CreateTemp(t.TempDir(), "clientCAs.crt")
 	require.NoError(t, err)
 	tmpCaPath, err := filepath.Abs(tmpCa.Name())
 	assert.NoError(t, err)

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -456,7 +456,7 @@ func overwriteClientCA(t *testing.T, targetFilePath string, testdataFileName str
 }
 
 func createTempClientCaFile(t *testing.T) string {
-	tmpCa, err := os.CreateTemp("", "ca-tmp.crt")
+	tmpCa, err := os.CreateTemp(t.TempDir(), "ca-tmp.crt")
 	require.NoError(t, err)
 	tmpCaPath, err := filepath.Abs(tmpCa.Name())
 	assert.NoError(t, err)
@@ -533,11 +533,11 @@ func TestCertificateReload(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Copy certs into a temp dir so we can safely modify them
-			certFile, err := os.CreateTemp("", "cert")
+			certFile, err := os.CreateTemp(t.TempDir(), "cert")
 			require.NoError(t, err)
 			defer os.Remove(certFile.Name())
 
-			keyFile, err := os.CreateTemp("", "key")
+			keyFile, err := os.CreateTemp(t.TempDir(), "key")
 			require.NoError(t, err)
 			defer os.Remove(keyFile.Name())
 

--- a/confmap/provider/internal/configurablehttpprovider/provider_test.go
+++ b/confmap/provider/internal/configurablehttpprovider/provider_test.go
@@ -50,7 +50,7 @@ func answerGet(w http.ResponseWriter, _ *http.Request) {
 
 // Generate a self signed certificate specific for the tests. Based on
 // https://go.dev/src/crypto/tls/generate_cert.go
-func generateCertificate(hostname string) (cert string, key string, err error) {
+func generateCertificate(t *testing.T, hostname string) (cert string, key string, err error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to generate private key: %w", err)
@@ -83,7 +83,7 @@ func generateCertificate(hostname string) (cert string, key string, err error) {
 		return "", "", fmt.Errorf("Failed to create certificate: %w", err)
 	}
 
-	certOut, err := os.CreateTemp("", "cert*.pem")
+	certOut, err := os.CreateTemp(t.TempDir(), "cert*.pem")
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to open cert.pem for writing: %w", err)
 	}
@@ -96,7 +96,7 @@ func generateCertificate(hostname string) (cert string, key string, err error) {
 		return "", "", fmt.Errorf("Error closing cert.pem: %w", err)
 	}
 
-	keyOut, err := os.CreateTemp("", "key*.pem")
+	keyOut, err := os.CreateTemp(t.TempDir(), "key*.pem")
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to open key.pem for writing: %w", err)
 	}
@@ -127,10 +127,10 @@ func TestFunctionalityDownloadFileHTTP(t *testing.T) {
 }
 
 func TestFunctionalityDownloadFileHTTPS(t *testing.T) {
-	certPath, keyPath, err := generateCertificate("localhost")
+	certPath, keyPath, err := generateCertificate(t, "localhost")
 	require.NoError(t, err)
 
-	invalidCert, err := os.CreateTemp("", "cert*.crt")
+	invalidCert, err := os.CreateTemp(t.TempDir(), "cert*.crt")
 	require.NoError(t, err)
 	_, err = invalidCert.Write([]byte{0, 1, 2})
 	require.NoError(t, err)


### PR DESCRIPTION
#### Description

Enables and fixes [usetesting](https://golangci-lint.run/usage/linters/#usetesting): Reports uses of functions with replacement inside the testing package.