### PR TITLE
[chore][configgrpc,confighttp] Clarify that config structs are to be used for a single protocol and receiver

### DIFF
--- a/config/configgrpc/doc.go
+++ b/config/configgrpc/doc.go
@@ -5,5 +5,5 @@
 // a gRPC client and server.
 //
 // The configuration structs in this package may be shared across signals, but
-// assume each struct is used for a single protocol and receiver.
+// assume each struct is used for a single protocol and component.
 package configgrpc // import "go.opentelemetry.io/collector/config/configgrpc"

--- a/config/configgrpc/doc.go
+++ b/config/configgrpc/doc.go
@@ -3,4 +3,7 @@
 
 // Package configgrpc defines the  configuration settings to create
 // a gRPC client and server.
+//
+// The configuration structs in this package may be shared across signals, but
+// assume each struct is used for a single protocol and receiver.
 package configgrpc // import "go.opentelemetry.io/collector/config/configgrpc"

--- a/config/confighttp/doc.go
+++ b/config/confighttp/doc.go
@@ -5,5 +5,5 @@
 // for creating an HTTP client and server.
 //
 // The configuration structs in this package may be shared across signals, but
-// assume each struct is used for a single protocol and receiver.
+// assume each struct is used for a single protocol and component.
 package confighttp // import "go.opentelemetry.io/collector/config/confighttp"

--- a/config/confighttp/doc.go
+++ b/config/confighttp/doc.go
@@ -3,4 +3,7 @@
 
 // Package confighttp defines the configuration settings
 // for creating an HTTP client and server.
+//
+// The configuration structs in this package may be shared across signals, but
+// assume each struct is used for a single protocol and receiver.
 package confighttp // import "go.opentelemetry.io/collector/config/confighttp"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds note discussed on 2025-02-03 Collector stability meeting.
