### PR TITLE
Remove `configauth` default, use nil in `configgrpc` default

### DIFF
--- a/.chloggen/configauth-remove-default.yaml
+++ b/.chloggen/configauth-remove-default.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configauth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove NewDefaultAuthentication
+
+# One or more tracking issues or pull requests related to the change
+issues: [12223]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The value returned by this function will always cause an error on startup.
+  In `configgrpc.Client/ServerConfig.Auth`, `nil` should be used instead to disable authentication.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/configgrpc-noauth-default.yaml
+++ b/.chloggen/configgrpc-noauth-default.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Set Auth to nil in NewDefaultClientConfig/NewDefaultServerConfig"
+
+# One or more tracking issues or pull requests related to the change
+issues: [12223]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The value that was used previously would always cause an error on startup.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -27,11 +27,6 @@ type Authentication struct {
 	AuthenticatorID component.ID `mapstructure:"authenticator"`
 }
 
-// NewDefaultAuthentication returns a default authentication configuration.
-func NewDefaultAuthentication() *Authentication {
-	return &Authentication{}
-}
-
 // GetServerAuthenticator attempts to select the appropriate auth.Server from the list of extensions,
 // based on the requested extension name. If an authenticator is not found, an error is returned.
 func (a Authentication) GetServerAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (auth.Server, error) {

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -110,7 +110,6 @@ func NewDefaultClientConfig() *ClientConfig {
 	return &ClientConfig{
 		TLSSetting:   configtls.NewDefaultClientConfig(),
 		Keepalive:    NewDefaultKeepaliveClientConfig(),
-		Auth:         configauth.NewDefaultAuthentication(),
 		BalancerName: BalancerName(),
 	}
 }
@@ -196,7 +195,6 @@ type ServerConfig struct {
 func NewDefaultServerConfig() *ServerConfig {
 	return &ServerConfig{
 		Keepalive: NewDefaultKeepaliveServerConfig(),
-		Auth:      configauth.NewDefaultAuthentication(),
 	}
 }
 


### PR DESCRIPTION
#### Context

(Copypasted from [this comment](https://github.com/open-telemetry/opentelemetry-collector/issues/12223#issuecomment-2634194775))

Across Github, it looks like the `configauth.NewDefaultAuthentication` function is only used in configgrpc.NewDefaultClientConfig ([link](https://github.com/open-telemetry/opentelemetry-collector/blob/477e4d3959932234e71f4e68c9d4e2290015a1df/config/configgrpc/configgrpc.go#L109)) and configgrpc.NewDefaultServerConfig ([link](https://github.com/open-telemetry/opentelemetry-collector/blob/477e4d3959932234e71f4e68c9d4e2290015a1df/config/configgrpc/configgrpc.go#L196)). I haven't found any use of the latter, and the former has [one use in the Elastic OTel components repo](https://github.com/elastic/opentelemetry-collector-components/blob/3cfc4ac3a58e5ac9823bf2ccc966e2f306cff5c9/processor/ratelimitprocessor/config.go#L164), where I suspect the `Auth` field may get overriden anyway. It looks like the gRPC receivers/exporters in Core instead define the default ClientConfig/ServerConfig manually, leaving the Auth field nil.

Moreover, it looks like the nil case is a no-op ([link](https://github.com/open-telemetry/opentelemetry-collector/blob/477e4d3959932234e71f4e68c9d4e2290015a1df/config/configgrpc/configgrpc.go#L310)), but the default Authentication created by this function looks for an authentication extension with a blank name ([link](https://github.com/open-telemetry/opentelemetry-collector/blob/477e4d3959932234e71f4e68c9d4e2290015a1df/config/configauth/configauth.go#L25)), which will always fail and crash the Collector.

#### Description

This PR:
- Removes `configauth.NewDefaultAuthentication`. Because it doesn't seem to be used outside this repo, I decided to skip the deprecation step.
- Replaces its use in `configgrpc.NewDefaultClient/NewDefaultServerConfig` by `nil`. I think this should be considered a bug fix rather than a breaking change, since the current value would cause an error if not overriden.

#### Link to tracking issue
Resolves #12223

#### Testing
Will try to trigger the aforementioned Collector crash to check if my interpretation of the code is correct.
