### PR TITLE
Clarify that data cannot be accessed after Consume* func is called

### DIFF
--- a/.chloggen/consumer-message.yaml
+++ b/.chloggen/consumer-message.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: consumer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Clarify that data cannot be accessed after Consume* func is called.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12284]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/consumer/logs.go
+++ b/consumer/logs.go
@@ -14,7 +14,8 @@ import (
 // as needed, and sends it to the next processing node if any or to the destination.
 type Logs interface {
 	internal.BaseConsumer
-	// ConsumeLogs receives plog.Logs for consumption.
+	// ConsumeLogs processes the logs. After the function returns, the logs are no longer accessible,
+	// and accessing them is considered undefined behavior.
 	ConsumeLogs(ctx context.Context, ld plog.Logs) error
 }
 

--- a/consumer/metrics.go
+++ b/consumer/metrics.go
@@ -14,7 +14,8 @@ import (
 // as needed, and sends it to the next processing node if any or to the destination.
 type Metrics interface {
 	internal.BaseConsumer
-	// ConsumeMetrics receives pmetric.Metrics for consumption.
+	// ConsumeMetrics processes the metrics. After the function returns, the metrics are no longer accessible,
+	// and accessing them is considered undefined behavior.
 	ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error
 }
 

--- a/consumer/traces.go
+++ b/consumer/traces.go
@@ -14,7 +14,8 @@ import (
 // as needed, and sends it to the next processing node if any or to the destination.
 type Traces interface {
 	internal.BaseConsumer
-	// ConsumeTraces receives ptrace.Traces for consumption.
+	// ConsumeTraces processes the traces. After the function returns, the traces are no longer accessible,
+	// and accessing them is considered undefined behavior.
 	ConsumeTraces(ctx context.Context, td ptrace.Traces) error
 }
 

--- a/consumer/xconsumer/profiles.go
+++ b/consumer/xconsumer/profiles.go
@@ -18,7 +18,8 @@ var errNilFunc = errors.New("nil consumer func")
 // as needed, and sends it to the next processing node if any or to the destination.
 type Profiles interface {
 	internal.BaseConsumer
-	// ConsumeProfiles receives pprofile.Profiles for consumption.
+	// ConsumeProfiles processes the profiles. After the function returns, the profiles are no longer accessible,
+	// and accessing them is considered undefined behavior.
 	ConsumeProfiles(ctx context.Context, td pprofile.Profiles) error
 }
 


### PR DESCRIPTION
The problem here is that we have components like batchprocessor or others which are keeping a reference of the data and eventually modifying them without any concurrent access protection. Hence, it is required for the callers to not access any data that were passed downstream.

This is not a backwards incompatible change, since pdata is not thread-safe this is a MUST to have here (consider a bug for not being documented) otherwise things will not work in the processing pipelines.