### PR TITLE
[chore][service/telemetry] Fill out valid level values and match with definition

### DIFF
--- a/service/telemetry/internal/migration/v0.3.0.go
+++ b/service/telemetry/internal/migration/v0.3.0.go
@@ -15,8 +15,10 @@ import (
 
 type TracesConfigV030 struct {
 	// Level configures whether spans are emitted or not, the possible values are:
-	//  - "none" indicates that no tracing data should be collected;
-	//  - "basic" is the recommended and covers the basics of the service telemetry.
+	//  - "None" indicates that no tracing data should be collected.
+	//  - "Basic" is the recommended and covers the basics of the service telemetry.
+	//  - "Normal" adds some other indicators on top of basic.
+	//  - "Detailed" adds dimensions and views to the previous levels.
 	Level configtelemetry.Level `mapstructure:"level"`
 	// Propagators is a list of TextMapPropagators from the supported propagators list. Currently,
 	// tracecontext and  b3 are supported. By default, the value is set to empty list and
@@ -57,10 +59,10 @@ func (c *TracesConfigV030) Unmarshal(conf *confmap.Conf) error {
 
 type MetricsConfigV030 struct {
 	// Level is the level of telemetry metrics, the possible values are:
-	//  - "none" indicates that no telemetry data should be collected;
-	//  - "basic" is the recommended and covers the basics of the service telemetry.
-	//  - "normal" adds some other indicators on top of basic.
-	//  - "detailed" adds dimensions and views to the previous levels.
+	//  - "None" indicates that no telemetry data should be collected.
+	//  - "Basic" is the recommended and covers the basics of the service telemetry.
+	//  - "Normal" adds some other indicators on top of basic.
+	//  - "Detailed" adds dimensions and views to the previous levels.
 	Level configtelemetry.Level `mapstructure:"level"`
 
 	// Deprecated: [v0.111.0] use readers configuration.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This updates the trace and metric configs for service telemetry to have [all config options commented](https://github.com/open-telemetry/opentelemetry-collector/blob/677b87e3ab5c615bc3f93b8f99bb1fa5be951751/config/configtelemetry/configtelemetry.go#L13-L20), along with the exact case of the defined string constants of each level.

Note: The case of `Level` doesn't matter in practice as they're all compared in `strings.ToLower` calls, but I figure exact matching is best here.