### PR TITLE
[exporter][batching] Serialized bytes based batching for logs

### DIFF
--- a/.chloggen/add-byte-size-to-exporter-request-api.yaml
+++ b/.chloggen/add-byte-size-to-exporter-request-api.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added a new API ByteSize() to exporter.request
+
+# One or more tracking issues or pull requests related to the change
+issues: [3265]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -418,6 +418,10 @@ func (mer *mockErrorRequest) ItemsCount() int {
 	return 7
 }
 
+func (mer *mockErrorRequest) ByteSize() int {
+	return 7
+}
+
 func (mer *mockErrorRequest) MergeSplit(context.Context, exporterbatcher.MaxSizeConfig, internal.Request) ([]internal.Request, error) {
 	return nil, nil
 }
@@ -461,6 +465,10 @@ func (m *mockRequest) checkNumRequests(t *testing.T, want int) {
 }
 
 func (m *mockRequest) ItemsCount() int {
+	return m.cnt
+}
+
+func (m *mockRequest) ByteSize() int {
 	return m.cnt
 }
 

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -28,6 +28,7 @@ type logsRequest struct {
 	ld               plog.Logs
 	pusher           consumer.ConsumeLogsFunc
 	cachedItemsCount int
+	cachedByteSize   int
 }
 
 func newLogsRequest(ld plog.Logs, pusher consumer.ConsumeLogsFunc) Request {
@@ -35,6 +36,7 @@ func newLogsRequest(ld plog.Logs, pusher consumer.ConsumeLogsFunc) Request {
 		ld:               ld,
 		pusher:           pusher,
 		cachedItemsCount: ld.LogRecordCount(),
+		cachedByteSize:   -1,
 	}
 }
 
@@ -73,7 +75,14 @@ func (req *logsRequest) setCachedItemsCount(count int) {
 }
 
 func (req *logsRequest) ByteSize() int {
-	return logsMarshaler.LogsSize(req.ld)
+	if req.cachedByteSize == -1 {
+		req.cachedByteSize = logsMarshaler.LogsSize(req.ld)
+	}
+	return req.cachedByteSize
+}
+
+func (req *logsRequest) setCachedByteSize(size int) {
+	req.cachedByteSize = size
 }
 
 type logsExporter struct {

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -72,6 +72,10 @@ func (req *logsRequest) setCachedItemsCount(count int) {
 	req.cachedItemsCount = count
 }
 
+func (req *logsRequest) ByteSize() int {
+	return logsMarshaler.LogsSize(req.ld)
+}
+
 type logsExporter struct {
 	*internal.BaseExporter
 	consumer.Logs

--- a/exporter/exporterhelper/logs_batch.go
+++ b/exporter/exporterhelper/logs_batch.go
@@ -6,6 +6,7 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 import (
 	"context"
 	"errors"
+	math_bits "math/bits"
 
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -30,6 +31,10 @@ func (req *logsRequest) MergeSplit(_ context.Context, cfg exporterbatcher.MaxSiz
 		return []Request{req}, nil
 	}
 
+	return req.mergeSplitBasedOnItemCount(cfg, req2)
+}
+
+func (req *logsRequest) mergeSplitBasedOnItemCount(cfg exporterbatcher.MaxSizeConfig, req2 *logsRequest) ([]Request, error) {
 	var (
 		res          []Request
 		destReq      *logsRequest
@@ -54,7 +59,7 @@ func (req *logsRequest) MergeSplit(_ context.Context, cfg exporterbatcher.MaxSiz
 		}
 
 		for {
-			extractedLogs := extractLogs(srcReq.ld, capacityLeft)
+			extractedLogs := extractLogsBasedOnItemCount(srcReq.ld, capacityLeft)
 			extractedCount := extractedLogs.LogRecordCount()
 			if extractedCount == 0 {
 				break
@@ -85,7 +90,7 @@ func (req *logsRequest) MergeSplit(_ context.Context, cfg exporterbatcher.MaxSiz
 }
 
 // extractLogs extracts logs from the input logs and returns a new logs with the specified number of log records.
-func extractLogs(srcLogs plog.Logs, count int) plog.Logs {
+func extractLogsBasedOnItemCount(srcLogs plog.Logs, count int) plog.Logs {
 	destLogs := plog.NewLogs()
 	srcLogs.ResourceLogs().RemoveIf(func(srcRL plog.ResourceLogs) bool {
 		if count == 0 {
@@ -93,7 +98,7 @@ func extractLogs(srcLogs plog.Logs, count int) plog.Logs {
 		}
 		needToExtract := resourceLogsCount(srcRL) > count
 		if needToExtract {
-			srcRL = extractResourceLogs(srcRL, count)
+			srcRL = extractResourceLogsBasedOnItemCount(srcRL, count)
 		}
 		count -= resourceLogsCount(srcRL)
 		srcRL.MoveTo(destLogs.ResourceLogs().AppendEmpty())
@@ -103,7 +108,7 @@ func extractLogs(srcLogs plog.Logs, count int) plog.Logs {
 }
 
 // extractResourceLogs extracts resource logs and returns a new resource logs with the specified number of log records.
-func extractResourceLogs(srcRL plog.ResourceLogs, count int) plog.ResourceLogs {
+func extractResourceLogsBasedOnItemCount(srcRL plog.ResourceLogs, count int) plog.ResourceLogs {
 	destRL := plog.NewResourceLogs()
 	destRL.SetSchemaUrl(srcRL.SchemaUrl())
 	srcRL.Resource().CopyTo(destRL.Resource())
@@ -113,7 +118,7 @@ func extractResourceLogs(srcRL plog.ResourceLogs, count int) plog.ResourceLogs {
 		}
 		needToExtract := srcSL.LogRecords().Len() > count
 		if needToExtract {
-			srcSL = extractScopeLogs(srcSL, count)
+			srcSL = extractScopeLogsBasedOnItemCount(srcSL, count)
 		}
 		count -= srcSL.LogRecords().Len()
 		srcSL.MoveTo(destRL.ScopeLogs().AppendEmpty())
@@ -123,7 +128,7 @@ func extractResourceLogs(srcRL plog.ResourceLogs, count int) plog.ResourceLogs {
 }
 
 // extractScopeLogs extracts scope logs and returns a new scope logs with the specified number of log records.
-func extractScopeLogs(srcSL plog.ScopeLogs, count int) plog.ScopeLogs {
+func extractScopeLogsBasedOnItemCount(srcSL plog.ScopeLogs, count int) plog.ScopeLogs {
 	destSL := plog.NewScopeLogs()
 	destSL.SetSchemaUrl(srcSL.SchemaUrl())
 	srcSL.Scope().CopyTo(destSL.Scope())
@@ -145,4 +150,147 @@ func resourceLogsCount(rl plog.ResourceLogs) int {
 		count += rl.ScopeLogs().At(k).LogRecords().Len()
 	}
 	return count
+}
+
+func (req *logsRequest) mergeSplitBasedOnByteSize(maxSizeBytes int, req2 *logsRequest) ([]Request, error) {
+	var (
+		res          []Request
+		destReq      *logsRequest
+		capacityLeft = maxSizeBytes
+	)
+	for _, srcReq := range []*logsRequest{req, req2} {
+		if srcReq == nil {
+			continue
+		}
+
+		srcByteSize := srcReq.ByteSize()
+		if srcByteSize <= capacityLeft {
+			if destReq == nil {
+				destReq = srcReq
+			} else {
+				destReq.setCachedByteSize(destReq.ByteSize() + srcByteSize)
+				srcReq.ld.ResourceLogs().MoveAndAppendTo(destReq.ld.ResourceLogs())
+			}
+			capacityLeft -= srcByteSize
+			continue
+		}
+
+		for {
+			extractedLogs, capacityReached := extractLogsBasedOnByteSize(srcReq.ld, capacityLeft)
+			if extractedLogs.LogRecordCount() == 0 {
+				break
+			}
+
+			extractedByteSize := logsMarshaler.LogsSize(extractedLogs)
+			srcReq.setCachedByteSize(srcReq.ByteSize() + extractedByteSize)
+			if destReq == nil {
+				destReq = &logsRequest{
+					ld:             extractedLogs,
+					pusher:         srcReq.pusher,
+					cachedByteSize: extractedByteSize,
+				}
+			} else {
+				destReq.setCachedByteSize(destReq.ByteSize() + extractedByteSize)
+				extractedLogs.ResourceLogs().MoveAndAppendTo(destReq.ld.ResourceLogs())
+			}
+			// Create new batch once capacity is reached.
+			if capacityReached {
+				res = append(res, destReq)
+				destReq = nil
+				capacityLeft = maxSizeBytes
+			} else {
+				capacityLeft = maxSizeBytes - destReq.ByteSize()
+			}
+		}
+	}
+
+	if destReq != nil {
+		res = append(res, destReq)
+	}
+	return res, nil
+}
+
+// extractLogs extracts logs from the input logs and returns a new logs with the specified number of log records.
+func extractLogsBasedOnByteSize(srcLogs plog.Logs, capacity int) (plog.Logs, bool) {
+	capacityReached := false
+	destLogs := plog.NewLogs()
+	capacityLeft := capacity - logsMarshaler.LogsSize(destLogs)
+	srcLogs.ResourceLogs().RemoveIf(func(srcRL plog.ResourceLogs) bool {
+		if capacityReached {
+			return false
+		}
+		needToExtract := logsMarshaler.ResourceLogsSize(srcRL) > capacityLeft
+		if needToExtract {
+			srcRL, capacityReached = extractResourceLogsBasedOnByteSize(srcRL, capacityLeft)
+			if srcRL.ScopeLogs().Len() == 0 {
+				return false
+			}
+		}
+		capacityLeft -= deltaCapacity(logsMarshaler.ResourceLogsSize(srcRL))
+		srcRL.MoveTo(destLogs.ResourceLogs().AppendEmpty())
+		return !needToExtract
+	})
+	return destLogs, capacityReached
+}
+
+// extractResourceLogs extracts resource logs and returns a new resource logs with the specified number of log records.
+func extractResourceLogsBasedOnByteSize(srcRL plog.ResourceLogs, capacity int) (plog.ResourceLogs, bool) {
+	capacityReached := false
+	destRL := plog.NewResourceLogs()
+	destRL.SetSchemaUrl(srcRL.SchemaUrl())
+	srcRL.Resource().CopyTo(destRL.Resource())
+	capacityLeft := capacity - logsMarshaler.ResourceLogsSize(destRL)
+	srcRL.ScopeLogs().RemoveIf(func(srcSL plog.ScopeLogs) bool {
+		if capacityReached {
+			return false
+		}
+		needToExtract := logsMarshaler.ScopeLogsSize(srcSL) > capacityLeft
+		if needToExtract {
+			srcSL, capacityReached = extractScopeLogsBasedOnByteSize(srcSL, capacityLeft)
+			if srcSL.LogRecords().Len() == 0 {
+				return false
+			}
+		}
+
+		capacityLeft -= deltaCapacity(logsMarshaler.ScopeLogsSize(srcSL))
+		srcSL.MoveTo(destRL.ScopeLogs().AppendEmpty())
+		return !needToExtract
+	})
+	return destRL, capacityReached
+}
+
+// extractScopeLogs extracts scope logs and returns a new scope logs with the specified number of log records.
+func extractScopeLogsBasedOnByteSize(srcSL plog.ScopeLogs, capacity int) (plog.ScopeLogs, bool) {
+	capacityReached := false
+	destSL := plog.NewScopeLogs()
+	destSL.SetSchemaUrl(srcSL.SchemaUrl())
+	srcSL.Scope().CopyTo(destSL.Scope())
+	capacityLeft := capacity - logsMarshaler.ScopeLogsSize(destSL)
+
+	srcSL.LogRecords().RemoveIf(func(srcLR plog.LogRecord) bool {
+		if capacityReached || logsMarshaler.LogRecordSize(srcLR) > capacityLeft {
+			capacityReached = true
+			return false
+		}
+		capacityLeft -= deltaCapacity(logsMarshaler.LogRecordSize(srcLR))
+		srcLR.MoveTo(destSL.LogRecords().AppendEmpty())
+		return true
+	})
+	return destSL, capacityReached
+}
+
+// deltaCapacity() returns the delta size of a proto slice when a new item is added.
+// Example:
+//
+//	proto1 = ProtoMessage()
+//	prevSize = proto1.Size()
+//	proto1.SomeRepeatedField().AppendEmpty() = proto2
+//
+// Then, currSize can be calculated as
+//
+//	currSize = prevSize + deltaCapacity(proto2.Size())
+//
+// This is derived from gogo/protobuf 's implementation of Size() functions.
+func deltaCapacity(newItemSize int) int {
+	return 1 + newItemSize + int(math_bits.Len64(uint64(newItemSize|1)+6)/7)
 }

--- a/exporter/exporterhelper/logs_batch_test.go
+++ b/exporter/exporterhelper/logs_batch_test.go
@@ -123,7 +123,108 @@ func TestMergeSplitLogs(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, len(tt.expected), len(res))
 			for i := range res {
-				assert.Equal(t, tt.expected[i], res[i])
+				assert.Equal(t, tt.expected[i].(*logsRequest).ld, res[i].(*logsRequest).ld)
+			}
+		})
+	}
+}
+
+func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
+	// Magic number is the byte size testdata.GenerateLogs(10)
+	tests := []struct {
+		name     string
+		cfg      int
+		lr1      internal.Request
+		lr2      internal.Request
+		expected []*logsRequest
+	}{
+		{
+			name:     "both_requests_empty",
+			cfg:      logsMarshaler.LogsSize(testdata.GenerateLogs(10)),
+			lr1:      &logsRequest{ld: plog.NewLogs()},
+			lr2:      &logsRequest{ld: plog.NewLogs()},
+			expected: []*logsRequest{{ld: plog.NewLogs()}},
+		},
+		{
+			name:     "first_request_empty",
+			cfg:      logsMarshaler.LogsSize(testdata.GenerateLogs(10)),
+			lr1:      &logsRequest{ld: plog.NewLogs()},
+			lr2:      &logsRequest{ld: testdata.GenerateLogs(5)},
+			expected: []*logsRequest{{ld: testdata.GenerateLogs(5)}},
+		},
+		// TODO: add this back once mergeSplitBasedOnByteSize can be triggered from MergeSplit()
+		// {
+		// 	name:     "first_empty_second_nil",
+		// 	cfg:      logsMarshaler.LogsSize(testdata.GenerateLogs(10)),
+		// 	lr1:      &logsRequest{ld: plog.NewLogs()},
+		// 	lr2:      nil,
+		// 	expected: []*logsRequest{{ld: plog.NewLogs()}},
+		// },
+		{
+			name: "merge_only",
+			cfg:  logsMarshaler.LogsSize(testdata.GenerateLogs(11)),
+			lr1:  &logsRequest{ld: testdata.GenerateLogs(4)},
+			lr2:  &logsRequest{ld: testdata.GenerateLogs(6)},
+			expected: []*logsRequest{{ld: func() plog.Logs {
+				logs := testdata.GenerateLogs(4)
+				testdata.GenerateLogs(6).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
+				return logs
+			}()}},
+		},
+		{
+			name: "split_only",
+			cfg:  logsMarshaler.LogsSize(testdata.GenerateLogs(4)),
+			lr1:  &logsRequest{ld: plog.NewLogs()},
+			lr2:  &logsRequest{ld: testdata.GenerateLogs(10)},
+			expected: []*logsRequest{
+				{ld: testdata.GenerateLogs(4)},
+				{ld: testdata.GenerateLogs(4)},
+				{ld: testdata.GenerateLogs(2)},
+			},
+		},
+		{
+			name: "merge_and_split",
+			cfg:  (logsMarshaler.LogsSize(testdata.GenerateLogs(10)) + logsMarshaler.LogsSize(testdata.GenerateLogs(11))) / 2,
+			lr1:  &logsRequest{ld: testdata.GenerateLogs(8)},
+			lr2:  &logsRequest{ld: testdata.GenerateLogs(20)},
+			expected: []*logsRequest{
+				{ld: func() plog.Logs {
+					logs := testdata.GenerateLogs(8)
+					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
+					return logs
+				}()},
+				{ld: testdata.GenerateLogs(10)},
+				{ld: testdata.GenerateLogs(8)},
+			},
+		},
+		{
+			name: "scope_logs_split",
+			cfg:  logsMarshaler.LogsSize(testdata.GenerateLogs(4)),
+			lr1: &logsRequest{ld: func() plog.Logs {
+				ld := testdata.GenerateLogs(4)
+				ld.ResourceLogs().At(0).ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("extra log")
+				return ld
+			}()},
+			lr2: &logsRequest{ld: testdata.GenerateLogs(2)},
+			expected: []*logsRequest{
+				{ld: testdata.GenerateLogs(4)},
+				{ld: func() plog.Logs {
+					ld := testdata.GenerateLogs(0)
+					ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().AppendEmpty().Body().SetStr("extra log")
+					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(ld.ResourceLogs())
+					return ld
+				}()},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.lr1.(*logsRequest).mergeSplitBasedOnByteSize(tt.cfg, tt.lr2.(*logsRequest))
+			require.NoError(t, err)
+			assert.Equal(t, len(tt.expected), len(res))
+			for i, r := range res {
+				assert.Equal(t, tt.expected[i].ld, r.(*logsRequest).ld)
+				assert.Equal(t, r.(*logsRequest).ByteSize(), logsMarshaler.LogsSize(r.(*logsRequest).ld))
 			}
 		})
 	}
@@ -147,9 +248,25 @@ func TestMergeSplitLogsInvalidInput(t *testing.T) {
 func TestExtractLogs(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		ld := testdata.GenerateLogs(10)
-		extractedLogs := extractLogs(ld, i)
+		extractedLogs := extractLogsBasedOnItemCount(ld, i)
 		assert.Equal(t, i, extractedLogs.LogRecordCount())
 		assert.Equal(t, 10-i, ld.LogRecordCount())
+	}
+}
+
+func TestExtractLogsBasedOnByteSize(t *testing.T) {
+	for i := 0; i < 11; i++ {
+		ld := testdata.GenerateLogs(10)
+		byteSize := logsMarshaler.LogsSize(testdata.GenerateLogs(i))
+		extractedLogs, capacityReached := extractLogsBasedOnByteSize(ld, byteSize)
+		assert.Equal(t, i, extractedLogs.LogRecordCount())
+		assert.Equal(t, 10-i, ld.LogRecordCount())
+		if i < 10 {
+			assert.True(t, capacityReached)
+		} else {
+			assert.False(t, capacityReached)
+		}
+		assert.GreaterOrEqual(t, byteSize, logsMarshaler.LogsSize(extractedLogs))
 	}
 }
 
@@ -167,6 +284,17 @@ func BenchmarkSplittingBasedOnItemCountManySmallLogs(b *testing.B) {
 	}
 }
 
+func BenchmarkSplittingBasedOnByteSizeManySmallLogs(b *testing.B) {
+	maxSizeBytes := logsMarshaler.LogsSize(testdata.GenerateLogs(1010000))
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(10)}
+		for j := 0; j < 1000; j++ {
+			lr2 := &logsRequest{ld: testdata.GenerateLogs(10)}
+			lr1.mergeSplitBasedOnByteSize(maxSizeBytes, lr2)
+		}
+	}
+}
+
 func BenchmarkSplittingBasedOnItemCountManyLogsSlightlyAboveLimit(b *testing.B) {
 	// Every incoming request results in a split.
 	cfg := exporterbatcher.MaxSizeConfig{MaxSizeItems: 10000}
@@ -180,7 +308,16 @@ func BenchmarkSplittingBasedOnItemCountManyLogsSlightlyAboveLimit(b *testing.B) 
 		assert.Len(b, merged, 11)
 	}
 }
-
+func BenchmarkSplittingBasedOnByteSizeManyLogsSlightlyAboveLimit(b *testing.B) {
+	maxSizeBytes := logsMarshaler.LogsSize(testdata.GenerateLogs(10000))
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(10001)}
+		for j := 0; j < 10; j++ {
+			lr2 := &logsRequest{ld: testdata.GenerateLogs(10001)}
+			lr1.mergeSplitBasedOnByteSize(maxSizeBytes, lr2)
+		}
+	}
+}
 func BenchmarkSplittingBasedOnItemCountHugeLogs(b *testing.B) {
 	// One request splits into many batches.
 	cfg := exporterbatcher.MaxSizeConfig{MaxSizeItems: 10000}
@@ -190,5 +327,14 @@ func BenchmarkSplittingBasedOnItemCountHugeLogs(b *testing.B) {
 		res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 		merged = append(merged[0:len(merged)-1], res...)
 		assert.Len(b, merged, 10)
+	}
+}
+
+func BenchmarkSplittingBasedOnByteSizeHugeLog(b *testing.B) {
+	maxSizeBytes := logsMarshaler.LogsSize(testdata.GenerateLogs(10000))
+	for i := 0; i < b.N; i++ {
+		lr1 := &logsRequest{ld: testdata.GenerateLogs(1)}
+		lr2 := &logsRequest{ld: testdata.GenerateLogs(100000)}
+		lr1.mergeSplitBasedOnByteSize(maxSizeBytes, lr2)
 	}
 }

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -43,6 +43,8 @@ var (
 
 func TestLogsRequest(t *testing.T) {
 	lr := newLogsRequest(testdata.GenerateLogs(1), nil)
+	assert.Equal(t, 1, lr.ItemsCount())
+	assert.Equal(t, logsMarshaler.LogsSize(testdata.GenerateLogs(1)), lr.ByteSize())
 
 	logErr := consumererror.NewLogs(errors.New("some error"), plog.NewLogs())
 	assert.EqualValues(

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -44,7 +44,7 @@ var (
 func TestLogsRequest(t *testing.T) {
 	lr := newLogsRequest(testdata.GenerateLogs(1), nil)
 	assert.Equal(t, 1, lr.ItemsCount())
-	assert.Equal(t, logsMarshaler.LogsSize(testdata.GenerateLogs(1)), lr.ByteSize())
+	assert.Equal(t, 160, lr.ByteSize())
 
 	logErr := consumererror.NewLogs(errors.New("some error"), plog.NewLogs())
 	assert.EqualValues(

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -72,6 +72,10 @@ func (req *metricsRequest) setCachedItemsCount(count int) {
 	req.cachedItemsCount = count
 }
 
+func (req *metricsRequest) ByteSize() int {
+	return metricsMarshaler.MetricsSize(req.md)
+}
+
 type metricsExporter struct {
 	*internal.BaseExporter
 	consumer.Metrics

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -43,6 +43,8 @@ var (
 
 func TestMetricsRequest(t *testing.T) {
 	mr := newMetricsRequest(testdata.GenerateMetrics(1), nil)
+	assert.Equal(t, 2, mr.ItemsCount())
+	assert.Equal(t, metricsMarshaler.MetricsSize(testdata.GenerateMetrics(1)), mr.ByteSize())
 
 	metricsErr := consumererror.NewMetrics(errors.New("some error"), pmetric.NewMetrics())
 	assert.EqualValues(

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -44,7 +44,7 @@ var (
 func TestMetricsRequest(t *testing.T) {
 	mr := newMetricsRequest(testdata.GenerateMetrics(1), nil)
 	assert.Equal(t, 2, mr.ItemsCount())
-	assert.Equal(t, metricsMarshaler.MetricsSize(testdata.GenerateMetrics(1)), mr.ByteSize())
+	assert.Equal(t, 183, mr.ByteSize())
 
 	metricsErr := consumererror.NewMetrics(errors.New("some error"), pmetric.NewMetrics())
 	assert.EqualValues(

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -72,6 +72,10 @@ func (req *tracesRequest) setCachedItemsCount(count int) {
 	req.cachedItemsCount = count
 }
 
+func (req *tracesRequest) ByteSize() int {
+	return tracesMarshaler.TracesSize(req.td)
+}
+
 type tracesExporter struct {
 	*internal.BaseExporter
 	consumer.Traces

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -42,10 +42,12 @@ var (
 )
 
 func TestTracesRequest(t *testing.T) {
-	mr := newTracesRequest(testdata.GenerateTraces(1), nil)
+	tr := newTracesRequest(testdata.GenerateTraces(1), nil)
+	assert.Equal(t, 1, tr.ItemsCount())
+	assert.Equal(t, tracesMarshaler.TracesSize(testdata.GenerateTraces(1)), tr.ByteSize())
 
 	traceErr := consumererror.NewTraces(errors.New("some error"), ptrace.NewTraces())
-	assert.EqualValues(t, newTracesRequest(ptrace.NewTraces(), nil), mr.(RequestErrorHandler).OnError(traceErr))
+	assert.EqualValues(t, newTracesRequest(ptrace.NewTraces(), nil), tr.(RequestErrorHandler).OnError(traceErr))
 }
 
 func TestTraces_InvalidName(t *testing.T) {

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -44,7 +44,7 @@ var (
 func TestTracesRequest(t *testing.T) {
 	tr := newTracesRequest(testdata.GenerateTraces(1), nil)
 	assert.Equal(t, 1, tr.ItemsCount())
-	assert.Equal(t, tracesMarshaler.TracesSize(testdata.GenerateTraces(1)), tr.ByteSize())
+	assert.Equal(t, 240, tr.ByteSize())
 
 	traceErr := consumererror.NewTraces(errors.New("some error"), ptrace.NewTraces())
 	assert.EqualValues(t, newTracesRequest(ptrace.NewTraces(), nil), tr.(RequestErrorHandler).OnError(traceErr))

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -75,6 +75,10 @@ func (req *profilesRequest) setCachedItemsCount(count int) {
 	req.cachedItemsCount = count
 }
 
+func (req *profilesRequest) ByteSize() int {
+	return profilesMarshaler.ProfilesSize(req.pd)
+}
+
 type profileExporter struct {
 	*internal.BaseExporter
 	xconsumer.Profiles

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
@@ -152,6 +152,10 @@ func (req *dummyRequest) ItemsCount() int {
 	return 1
 }
 
+func (req *dummyRequest) ByteSize() int {
+	return 1
+}
+
 func (req *dummyRequest) MergeSplit(_ context.Context, _ exporterbatcher.MaxSizeConfig, _ exporterhelper.Request) (
 	[]exporterhelper.Request, error,
 ) {

--- a/exporter/exporterhelper/xexporterhelper/profiles_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_test.go
@@ -46,7 +46,7 @@ var fakeProfilesExporterConfig = struct{}{}
 func TestProfilesRequest(t *testing.T) {
 	pr := newProfilesRequest(testdata.GenerateProfiles(1), nil)
 	assert.Equal(t, 1, pr.ItemsCount())
-	assert.Equal(t, profilesMarshaler.ProfilesSize(testdata.GenerateProfiles(1)), pr.ByteSize())
+	assert.Equal(t, 122, pr.ByteSize())
 
 	profileErr := xconsumererror.NewProfiles(errors.New("some error"), pprofile.NewProfiles())
 	assert.EqualValues(

--- a/exporter/exporterhelper/xexporterhelper/profiles_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_test.go
@@ -44,13 +44,15 @@ const (
 var fakeProfilesExporterConfig = struct{}{}
 
 func TestProfilesRequest(t *testing.T) {
-	lr := newProfilesRequest(testdata.GenerateProfiles(1), nil)
+	pr := newProfilesRequest(testdata.GenerateProfiles(1), nil)
+	assert.Equal(t, 1, pr.ItemsCount())
+	assert.Equal(t, profilesMarshaler.ProfilesSize(testdata.GenerateProfiles(1)), pr.ByteSize())
 
 	profileErr := xconsumererror.NewProfiles(errors.New("some error"), pprofile.NewProfiles())
 	assert.EqualValues(
 		t,
 		newProfilesRequest(pprofile.NewProfiles(), nil),
-		lr.(exporterhelper.RequestErrorHandler).OnError(profileErr),
+		pr.(exporterhelper.RequestErrorHandler).OnError(profileErr),
 	)
 }
 

--- a/exporter/internal/request.go
+++ b/exporter/internal/request.go
@@ -16,9 +16,10 @@ type Request interface {
 	// Export exports the request to an external endpoint.
 	Export(ctx context.Context) error
 	// ItemsCount returns a number of basic items in the request where item is the smallest piece of data that can be
-	// sent. For example, for OTLP exporter, this value represents the number of spans,
-	// metric data points or log records.
+	// sent. For example, for OTLP exporter, this value represents the number of spans, metric data points or log records.
 	ItemsCount() int
+	// ByteSize returns the serialized byte size of of the request.
+	ByteSize() int
 	// MergeSplit is a function that merge and/or splits this request with another one into multiple requests based on the
 	// configured limit provided in MaxSizeConfig.
 	// MergeSplit does not split if all fields in MaxSizeConfig are not initialized (zero).

--- a/exporter/internal/request.go
+++ b/exporter/internal/request.go
@@ -16,7 +16,8 @@ type Request interface {
 	// Export exports the request to an external endpoint.
 	Export(ctx context.Context) error
 	// ItemsCount returns a number of basic items in the request where item is the smallest piece of data that can be
-	// sent. For example, for OTLP exporter, this value represents the number of spans, metric data points or log records.
+	// sent. For example, for OTLP exporter, this value represents the number of spans,
+	// metric data points or log records.
 	ItemsCount() int
 	// ByteSize returns the serialized byte size of of the request.
 	ByteSize() int

--- a/exporter/internal/requesttest/fake_request.go
+++ b/exporter/internal/requesttest/fake_request.go
@@ -25,6 +25,10 @@ func (s *Sink) ItemsCount() int64 {
 	return s.itemsCount.Load()
 }
 
+func (s *Sink) ByteSize() int64 {
+	return s.itemsCount.Load()
+}
+
 func NewSink() *Sink {
 	return &Sink{
 		requestsCount: new(atomic.Int64),
@@ -57,6 +61,10 @@ func (r *FakeRequest) Export(ctx context.Context) error {
 }
 
 func (r *FakeRequest) ItemsCount() int {
+	return r.Items
+}
+
+func (r *FakeRequest) ByteSize() int {
 	return r.Items
 }
 

--- a/pdata/plog/pb.go
+++ b/pdata/plog/pb.go
@@ -22,6 +22,18 @@ func (e *ProtoMarshaler) LogsSize(ld Logs) int {
 	return pb.Size()
 }
 
+func (e *ProtoMarshaler) ResourceLogsSize(rl ResourceLogs) int {
+	return rl.orig.Size()
+}
+
+func (e *ProtoMarshaler) ScopeLogsSize(sl ScopeLogs) int {
+	return sl.orig.Size()
+}
+
+func (e *ProtoMarshaler) LogRecordSize(lr LogRecord) int {
+	return lr.orig.Size()
+}
+
 var _ Unmarshaler = (*ProtoUnmarshaler)(nil)
 
 type ProtoUnmarshaler struct{}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR implements serialized bytes based batching.

Right now, the feature is exposed to test only via a private interface `mergeSplitBasedByteSize()`. We will support configuring this feature after https://github.com/open-telemetry/opentelemetry-collector/pull/12154 is merged.

<!-- Issue number if applicable -->
#### Link to tracking issue

https://github.com/open-telemetry/opentelemetry-collector/issues/3262

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
