### PR TITLE
[chore] Merge batch_sander into the queue_sander

### DIFF
--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -21,15 +21,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterqueue" // BaseExporter contains common fields between different exporter types.
 	"go.opentelemetry.io/collector/exporter/internal"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pipeline"
-)
-
-var usePullingBasedExporterQueueBatcher = featuregate.GlobalRegistry().MustRegister(
-	"exporter.UsePullingBasedExporterQueueBatcher",
-	featuregate.StageAlpha,
-	featuregate.WithRegisterFromVersion("v0.115.0"),
-	featuregate.WithRegisterDescription("if set to true, turns on the pulling-based exporter queue bathcer"),
 )
 
 type ObsrepSenderFactory = func(obsrep *ObsReport, next Sender[internal.Request]) Sender[internal.Request]
@@ -52,7 +44,6 @@ type BaseExporter struct {
 	// Chain of senders that the exporter helper applies before passing the data to the actual exporter.
 	// The data is handled by each sender in the respective order starting from the queueSender.
 	// Most of the senders are optional, and initialized with a no-op path-through sender.
-	BatchSender  Sender[internal.Request]
 	QueueSender  Sender[internal.Request]
 	ObsrepSender Sender[internal.Request]
 	RetrySender  Sender[internal.Request]
@@ -101,16 +92,7 @@ func NewBaseExporter(set exporter.Settings, signal pipeline.Signal, osf ObsrepSe
 		be.ConsumerOptions = append(be.ConsumerOptions, consumer.WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	}
 
-	if !usePullingBasedExporterQueueBatcher.IsEnabled() && be.batcherCfg.Enabled {
-		concurrencyLimit := int64(0)
-		if be.queueCfg.Enabled {
-			concurrencyLimit = int64(be.queueCfg.NumConsumers)
-		}
-		be.BatchSender = NewBatchSender(be.batcherCfg, set, concurrencyLimit, be.firstSender)
-		be.firstSender = be.BatchSender
-	}
-
-	if be.queueCfg.Enabled || usePullingBasedExporterQueueBatcher.IsEnabled() && be.batcherCfg.Enabled {
+	if be.queueCfg.Enabled || be.batcherCfg.Enabled {
 		qSet := exporterqueue.Settings{
 			Signal:           signal,
 			ExporterSettings: set,
@@ -144,13 +126,6 @@ func (be *BaseExporter) Start(ctx context.Context, host component.Host) error {
 		return err
 	}
 
-	if be.BatchSender != nil {
-		// If no error then start the BatchSender.
-		if err := be.BatchSender.Start(ctx, host); err != nil {
-			return err
-		}
-	}
-
 	// Last start the queueSender.
 	if be.QueueSender != nil {
 		return be.QueueSender.Start(ctx, host)
@@ -165,11 +140,6 @@ func (be *BaseExporter) Shutdown(ctx context.Context) error {
 	// First shutdown the retry sender, so the queue sender can flush the queue without retries.
 	if be.RetrySender != nil {
 		err = multierr.Append(err, be.RetrySender.Shutdown(ctx))
-	}
-
-	// Then shutdown the batch sender
-	if be.BatchSender != nil {
-		err = multierr.Append(err, be.BatchSender.Shutdown(ctx))
 	}
 
 	// Then shutdown the queue sender.

--- a/exporter/exporterhelper/internal/queue_sender.go
+++ b/exporter/exporterhelper/internal/queue_sender.go
@@ -14,6 +14,14 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterqueue"
 	"go.opentelemetry.io/collector/exporter/internal"
 	"go.opentelemetry.io/collector/exporter/internal/queue"
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+var usePullingBasedExporterQueueBatcher = featuregate.GlobalRegistry().MustRegister(
+	"exporter.UsePullingBasedExporterQueueBatcher",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterFromVersion("v0.115.0"),
+	featuregate.WithRegisterDescription("if set to true, turns on the pulling-based exporter queue bathcer"),
 )
 
 // QueueConfig defines configuration for queueing batches before sending to the consumerSender.
@@ -67,6 +75,7 @@ func (qCfg *QueueConfig) Validate() error {
 type QueueSender struct {
 	queue   exporterqueue.Queue[internal.Request]
 	batcher component.Component
+	bs      *BatchSender
 }
 
 func NewQueueSender(
@@ -77,6 +86,39 @@ func NewQueueSender(
 	exportFailureMessage string,
 	next Sender[internal.Request],
 ) (*QueueSender, error) {
+	if !usePullingBasedExporterQueueBatcher.IsEnabled() {
+		concurrencyLimit := int64(0)
+		if qCfg.Enabled {
+			concurrencyLimit = int64(qCfg.NumConsumers)
+		}
+
+		var bs *BatchSender
+		if bCfg.Enabled {
+			bs = NewBatchSender(bCfg, qSet.ExporterSettings, concurrencyLimit, next)
+			next = bs
+		}
+
+		exportFunc := func(ctx context.Context, req internal.Request) error {
+			// Have to read the number of items before sending the request since the request can
+			// be modified by the downstream components like the batcher.
+			itemsCount := req.ItemsCount()
+			err := next.Send(ctx, req)
+			if err != nil {
+				qSet.ExporterSettings.Logger.Error("Exporting failed. Dropping data."+exportFailureMessage,
+					zap.Error(err), zap.Int("dropped_items", itemsCount))
+			}
+			return err
+		}
+
+		q, err := newObsQueue(qSet, qf(context.Background(), qSet, qCfg, func(ctx context.Context, req internal.Request, done exporterqueue.Done) {
+			done.OnDone(exportFunc(ctx, req))
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return &QueueSender{queue: q, bs: bs}, nil
+	}
+
 	exportFunc := func(ctx context.Context, req internal.Request) error {
 		// Have to read the number of items before sending the request since the request can
 		// be modified by the downstream components like the batcher.
@@ -87,15 +129,6 @@ func NewQueueSender(
 				zap.Error(err), zap.Int("dropped_items", itemsCount))
 		}
 		return err
-	}
-	if !usePullingBasedExporterQueueBatcher.IsEnabled() {
-		q, err := newObsQueue(qSet, qf(context.Background(), qSet, qCfg, func(ctx context.Context, req internal.Request, done exporterqueue.Done) {
-			done.OnDone(exportFunc(ctx, req))
-		}))
-		if err != nil {
-			return nil, err
-		}
-		return &QueueSender{queue: q}, nil
 	}
 
 	b, err := queue.NewBatcher(bCfg, exportFunc, qCfg.NumConsumers)
@@ -116,6 +149,13 @@ func NewQueueSender(
 
 // Start is invoked during service startup.
 func (qs *QueueSender) Start(ctx context.Context, host component.Host) error {
+	if qs.bs != nil {
+		// If no error then start the BatchSender.
+		if err := qs.bs.Start(ctx, host); err != nil {
+			return err
+		}
+	}
+
 	if err := qs.queue.Start(ctx, host); err != nil {
 		return err
 	}
@@ -129,9 +169,15 @@ func (qs *QueueSender) Start(ctx context.Context, host component.Host) error {
 
 // Shutdown is invoked during service shutdown.
 func (qs *QueueSender) Shutdown(ctx context.Context) error {
+	var err error
+	// Then shutdown the batch sender
+	if qs.bs != nil {
+		err = errors.Join(err, qs.bs.Shutdown(ctx))
+	}
+
 	// Stop the queue and batcher, this will drain the queue and will call the retry (which is stopped) that will only
 	// try once every request.
-	err := qs.queue.Shutdown(ctx)
+	err = errors.Join(err, qs.queue.Shutdown(ctx))
 	if usePullingBasedExporterQueueBatcher.IsEnabled() {
 		return errors.Join(err, qs.batcher.Shutdown(ctx))
 	}


### PR DESCRIPTION
This change will allow to change current separate queue and batch unit tests to be merged and only use the "queue_batch" part of the exporter.