### PR TITLE
[extension] Remove Settings.ModuleInfo and move to service.Host hidden method

### DIFF
--- a/.chloggen/mx-psi_move-moduleinfo-to-method.yaml
+++ b/.chloggen/mx-psi_move-moduleinfo-to-method.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: extension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `extension.Settings.ModuleInfo`
+
+# One or more tracking issues or pull requests related to the change
+issues: [12296]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  - The functionality is now available as an optional, hidden interface on `service`'s implementation of the `Host`
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -17,15 +17,6 @@ type Extension interface {
 	component.Component
 }
 
-// ModuleInfo describes the go module for each component.
-type ModuleInfo struct {
-	Receiver  map[component.Type]string
-	Processor map[component.Type]string
-	Exporter  map[component.Type]string
-	Extension map[component.Type]string
-	Connector map[component.Type]string
-}
-
 // Settings is passed to Factory.Create(...) function.
 type Settings struct {
 	// ID returns the ID of the component that will be created.
@@ -35,9 +26,6 @@ type Settings struct {
 
 	// BuildInfo can be used by components for informational purposes
 	BuildInfo component.BuildInfo
-
-	// ModuleInfo describes the go module for each component.
-	ModuleInfo ModuleInfo
 }
 
 // CreateFunc is the equivalent of Factory.Create(...) function.

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
-	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/otelcol/internal/grpclog"
 	"go.opentelemetry.io/collector/service"
 )
@@ -199,7 +198,7 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		ExtensionsConfigs:   cfg.Extensions,
 		ExtensionsFactories: factories.Extensions,
 
-		ModuleInfo: extension.ModuleInfo{
+		ModuleInfo: service.ModuleInfo{
 			Receiver:  factories.ReceiverModules,
 			Processor: factories.ProcessorModules,
 			Exporter:  factories.ExporterModules,

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -157,6 +157,14 @@ func (col *Collector) Shutdown() {
 	}
 }
 
+func buildModuleInfo(m map[component.Type]string) map[component.Type]service.ModuleInfo {
+	moduleInfo := make(map[component.Type]service.ModuleInfo)
+	for k, v := range m {
+		moduleInfo[k] = service.ModuleInfo{BuilderRef: v}
+	}
+	return moduleInfo
+}
+
 // setupConfigurationComponents loads the config, creates the graph, and starts the components. If all the steps succeeds it
 // sets the col.service with the service currently running.
 func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
@@ -198,12 +206,12 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		ExtensionsConfigs:   cfg.Extensions,
 		ExtensionsFactories: factories.Extensions,
 
-		ModuleInfo: service.ModuleInfo{
-			Receiver:  factories.ReceiverModules,
-			Processor: factories.ProcessorModules,
-			Exporter:  factories.ExporterModules,
-			Extension: factories.ExtensionModules,
-			Connector: factories.ConnectorModules,
+		ModuleInfos: service.ModuleInfos{
+			Receiver:  buildModuleInfo(factories.ReceiverModules),
+			Processor: buildModuleInfo(factories.ProcessorModules),
+			Exporter:  buildModuleInfo(factories.ExporterModules),
+			Extension: buildModuleInfo(factories.ExtensionModules),
+			Connector: buildModuleInfo(factories.ConnectorModules),
 		},
 		AsyncErrorChannel: col.asyncErrorChannel,
 		LoggingOptions:    col.set.LoggingOptions,

--- a/service/extensions/extensions.go
+++ b/service/extensions/extensions.go
@@ -170,9 +170,8 @@ func (bes *Extensions) HandleZPages(w http.ResponseWriter, r *http.Request) {
 
 // Settings holds configuration for building Extensions.
 type Settings struct {
-	Telemetry  component.TelemetrySettings
-	BuildInfo  component.BuildInfo
-	ModuleInfo extension.ModuleInfo
+	Telemetry component.TelemetrySettings
+	BuildInfo component.BuildInfo
 
 	// Extensions builder for extensions.
 	Extensions builders.Extension
@@ -214,7 +213,6 @@ func New(ctx context.Context, set Settings, cfg Config, options ...Option) (*Ext
 			ID:                extID,
 			TelemetrySettings: set.Telemetry,
 			BuildInfo:         set.BuildInfo,
-			ModuleInfo:        set.ModuleInfo,
 		}
 		extSet.TelemetrySettings.Logger = components.ExtensionLogger(set.Telemetry.Logger, extID)
 

--- a/service/internal/graph/host.go
+++ b/service/internal/graph/host.go
@@ -11,11 +11,11 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
-	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/service/extensions"
 	"go.opentelemetry.io/collector/service/internal/builders"
+	"go.opentelemetry.io/collector/service/internal/moduleinfo"
 	"go.opentelemetry.io/collector/service/internal/status"
 	"go.opentelemetry.io/collector/service/internal/zpages"
 )
@@ -25,9 +25,16 @@ type getExporters interface {
 	GetExporters() map[pipeline.Signal]map[component.ID]component.Component
 }
 
+// TODO: expose GetModuleInfo as part of a service/hostcapabilities package.
+type getModuleInfo interface {
+	// GetModuleInfo returns the module information for the host.
+	GetModuleInfo() moduleinfo.ModuleInfo
+}
+
 var (
 	_ getExporters   = (*Host)(nil)
 	_ component.Host = (*Host)(nil)
+	_ getModuleInfo  = (*Host)(nil)
 )
 
 type Host struct {
@@ -38,7 +45,7 @@ type Host struct {
 	Connectors        *builders.ConnectorBuilder
 	Extensions        *builders.ExtensionBuilder
 
-	ModuleInfo extension.ModuleInfo
+	ModuleInfo moduleinfo.ModuleInfo
 	BuildInfo  component.BuildInfo
 
 	Pipelines         *Graph
@@ -65,6 +72,10 @@ func (host *Host) GetFactory(kind component.Kind, componentType component.Type) 
 
 func (host *Host) GetExtensions() map[component.ID]component.Component {
 	return host.ServiceExtensions.GetExtensions()
+}
+
+func (host *Host) GetModuleInfo() moduleinfo.ModuleInfo {
+	return host.ModuleInfo
 }
 
 // Deprecated: [0.79.0] This function will be removed in the future.

--- a/service/internal/graph/host.go
+++ b/service/internal/graph/host.go
@@ -26,15 +26,15 @@ type getExporters interface {
 }
 
 // TODO: expose GetModuleInfo as part of a service/hostcapabilities package.
-type getModuleInfo interface {
+type getModuleInfos interface {
 	// GetModuleInfo returns the module information for the host.
-	GetModuleInfo() moduleinfo.ModuleInfo
+	GetModuleInfos() moduleinfo.ModuleInfos
 }
 
 var (
 	_ getExporters   = (*Host)(nil)
 	_ component.Host = (*Host)(nil)
-	_ getModuleInfo  = (*Host)(nil)
+	_ getModuleInfos = (*Host)(nil)
 )
 
 type Host struct {
@@ -45,8 +45,8 @@ type Host struct {
 	Connectors        *builders.ConnectorBuilder
 	Extensions        *builders.ExtensionBuilder
 
-	ModuleInfo moduleinfo.ModuleInfo
-	BuildInfo  component.BuildInfo
+	ModuleInfos moduleinfo.ModuleInfos
+	BuildInfo   component.BuildInfo
 
 	Pipelines         *Graph
 	ServiceExtensions *extensions.Extensions
@@ -74,8 +74,8 @@ func (host *Host) GetExtensions() map[component.ID]component.Component {
 	return host.ServiceExtensions.GetExtensions()
 }
 
-func (host *Host) GetModuleInfo() moduleinfo.ModuleInfo {
-	return host.ModuleInfo
+func (host *Host) GetModuleInfos() moduleinfo.ModuleInfos {
+	return host.ModuleInfos
 }
 
 // Deprecated: [0.79.0] This function will be removed in the future.

--- a/service/internal/moduleinfo/moduleinfo.go
+++ b/service/internal/moduleinfo/moduleinfo.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package moduleinfo // import "go.opentelemetry.io/collector/service/internal/moduleinfo"
+
+import "go.opentelemetry.io/collector/component"
+
+// ModuleInfo describes the go module for each component.
+type ModuleInfo struct {
+	Receiver  map[component.Type]string
+	Processor map[component.Type]string
+	Exporter  map[component.Type]string
+	Extension map[component.Type]string
+	Connector map[component.Type]string
+}

--- a/service/internal/moduleinfo/moduleinfo.go
+++ b/service/internal/moduleinfo/moduleinfo.go
@@ -5,11 +5,16 @@ package moduleinfo // import "go.opentelemetry.io/collector/service/internal/mod
 
 import "go.opentelemetry.io/collector/component"
 
-// ModuleInfo describes the go module for each component.
 type ModuleInfo struct {
-	Receiver  map[component.Type]string
-	Processor map[component.Type]string
-	Exporter  map[component.Type]string
-	Extension map[component.Type]string
-	Connector map[component.Type]string
+	// BuilderRef is the raw string passed in the builder configuration used to build this service.
+	BuilderRef string
+}
+
+// ModuleInfos describes the go module for each component.
+type ModuleInfos struct {
+	Receiver  map[component.Type]ModuleInfo
+	Processor map[component.Type]ModuleInfo
+	Exporter  map[component.Type]ModuleInfo
+	Extension map[component.Type]ModuleInfo
+	Connector map[component.Type]ModuleInfo
 }

--- a/service/service.go
+++ b/service/service.go
@@ -57,8 +57,11 @@ var disableHighCardinalityMetricsFeatureGate = featuregate.GlobalRegistry().Must
 	featuregate.WithRegisterDescription("controls whether the collector should enable potentially high"+
 		"cardinality metrics. The gate will be removed when the collector allows for view configuration."))
 
-// ModuleInfo describes the go module for each component.
+// ModuleInfo describes the Go module for a particular component.
 type ModuleInfo = moduleinfo.ModuleInfo
+
+// ModuleInfo describes the go module for all components.
+type ModuleInfos = moduleinfo.ModuleInfos
 
 // Settings holds configuration for building a new Service.
 type Settings struct {
@@ -92,7 +95,7 @@ type Settings struct {
 	ExtensionsFactories map[component.Type]extension.Factory
 
 	// ModuleInfo describes the go module for each component.
-	ModuleInfo ModuleInfo
+	ModuleInfos ModuleInfos
 
 	// AsyncErrorChannel is the channel that is used to report fatal errors.
 	AsyncErrorChannel chan error
@@ -121,7 +124,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 			Connectors: builders.NewConnector(set.ConnectorsConfigs, set.ConnectorsFactories),
 			Extensions: builders.NewExtension(set.ExtensionsConfigs, set.ExtensionsFactories),
 
-			ModuleInfo:        set.ModuleInfo,
+			ModuleInfos:       set.ModuleInfos,
 			BuildInfo:         set.BuildInfo,
 			AsyncErrorChannel: set.AsyncErrorChannel,
 		},

--- a/service/service.go
+++ b/service/service.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/collector/service/extensions"
 	"go.opentelemetry.io/collector/service/internal/builders"
 	"go.opentelemetry.io/collector/service/internal/graph"
+	"go.opentelemetry.io/collector/service/internal/moduleinfo"
 	"go.opentelemetry.io/collector/service/internal/proctelemetry"
 	"go.opentelemetry.io/collector/service/internal/resource"
 	"go.opentelemetry.io/collector/service/internal/status"
@@ -55,6 +56,9 @@ var disableHighCardinalityMetricsFeatureGate = featuregate.GlobalRegistry().Must
 	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("controls whether the collector should enable potentially high"+
 		"cardinality metrics. The gate will be removed when the collector allows for view configuration."))
+
+// ModuleInfo describes the go module for each component.
+type ModuleInfo = moduleinfo.ModuleInfo
 
 // Settings holds configuration for building a new Service.
 type Settings struct {
@@ -88,7 +92,7 @@ type Settings struct {
 	ExtensionsFactories map[component.Type]extension.Factory
 
 	// ModuleInfo describes the go module for each component.
-	ModuleInfo extension.ModuleInfo
+	ModuleInfo ModuleInfo
 
 	// AsyncErrorChannel is the channel that is used to report fatal errors.
 	AsyncErrorChannel chan error
@@ -341,7 +345,6 @@ func (srv *Service) initExtensions(ctx context.Context, cfg extensions.Config) e
 		Telemetry:  srv.telemetrySettings,
 		BuildInfo:  srv.buildInfo,
 		Extensions: srv.host.Extensions,
-		ModuleInfo: srv.host.ModuleInfo,
 	}
 	if srv.host.ServiceExtensions, err = extensions.New(ctx, extensionsSettings, cfg, extensions.WithReporter(srv.host.Reporter)); err != nil {
 		return fmt.Errorf("failed to build extensions: %w", err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Moves `extension.Settings.ModuleInfo` to a `service.Host.GetModuleInfo` method.

This field probably fits better on `extension.Settings` or even in `component.BuildInfo`, but since its contents are a bit in flux per discussions like #12283, I would like to move it here to not stabilize it alongside the rest of `extension`.

The field is not used in any public code on Github, so I think it won't have a huge impact to remove it in one go, happy to do this in two steps if preferred.

One relevant difference is that this information is no longer available at extension build time, but rather after the `Start` method is called. Another relevant difference is that this is now available for all component kinds, not just extensions. This could be worked around (we could pass a different host depending on the component kind) but I don't see the use right now.

#### Link to tracking issue
Updates #12283