### PR TITLE
[otelcol] Make the `ConfigProvider` interface a struct

### DIFF
--- a/.chloggen/convert-configprovider-struct.yaml
+++ b/.chloggen/convert-configprovider-struct.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otelcol
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make the `ConfigProvider` interface a struct
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Calls to `NewConfigProvider` will now return `*ConfigProvider`,
+  but will otherwise work the same as before.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/convert-configprovider-struct.yaml
+++ b/.chloggen/convert-configprovider-struct.yaml
@@ -10,7 +10,7 @@ component: otelcol
 note: Make the `ConfigProvider` interface a struct
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [12297]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -95,7 +95,7 @@ type CollectorSettings struct {
 type Collector struct {
 	set CollectorSettings
 
-	configProvider ConfigProvider
+	configProvider *ConfigProvider
 
 	serviceConfig *service.Config
 	service       *service.Service

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -76,27 +76,27 @@ func TestCollectorCancelContext(t *testing.T) {
 	assert.Equal(t, StateClosed, col.GetState())
 }
 
-type mockCfgProvider struct {
-	ConfigProvider
-	watcher chan error
-}
-
-func (p mockCfgProvider) Watch() <-chan error {
-	return p.watcher
-}
-
 func TestCollectorStateAfterConfigChange(t *testing.T) {
-	watcher := make(chan error, 1)
-	col, err := NewCollector(CollectorSettings{
-		BuildInfo: component.NewDefaultBuildInfo(),
-		Factories: nopFactories,
-		// this will be overwritten, but we need something to get past validation
-		ConfigProviderSettings: newDefaultConfigProviderSettings(t, []string{filepath.Join("testdata", "otelcol-nop.yaml")}),
+	var watcher confmap.WatcherFunc
+	fileProvider := newFakeProvider("file", func(_ context.Context, uri string, w confmap.WatcherFunc) (*confmap.Retrieved, error) {
+		watcher = w
+		return confmap.NewRetrieved(newConfFromFile(t, uri[5:]))
 	})
+	set := ConfigProviderSettings{
+		ResolverSettings: confmap.ResolverSettings{
+			URIs: []string{filepath.Join("testdata", "otelcol-nop.yaml")},
+			ProviderFactories: []confmap.ProviderFactory{
+				fileProvider,
+			},
+		},
+	}
+	col, err := NewCollector(CollectorSettings{
+		BuildInfo:              component.NewDefaultBuildInfo(),
+		Factories:              nopFactories,
+		ConfigProviderSettings: set,
+	})
+
 	require.NoError(t, err)
-	provider, err := NewConfigProvider(newDefaultConfigProviderSettings(t, []string{filepath.Join("testdata", "otelcol-nop.yaml")}))
-	require.NoError(t, err)
-	col.configProvider = &mockCfgProvider{ConfigProvider: provider, watcher: watcher}
 
 	wg := startCollector(context.Background(), t, col)
 
@@ -104,7 +104,7 @@ func TestCollectorStateAfterConfigChange(t *testing.T) {
 		return StateRunning == col.GetState()
 	}, 2*time.Second, 200*time.Millisecond)
 
-	watcher <- nil
+	watcher(&confmap.ChangeEvent{})
 
 	assert.Eventually(t, func() bool {
 		return StateRunning == col.GetState()

--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -20,35 +20,9 @@ import (
 //	cfgProvider.Watch() // wait for an event.
 //	// repeat Get/Watch cycle until it is time to shut down the Collector process.
 //	cfgProvider.Shutdown()
-type ConfigProvider interface {
-	// Get returns the service configuration, or error otherwise.
-	//
-	// Should never be called concurrently with itself, Watch or Shutdown.
-	Get(ctx context.Context, factories Factories) (*Config, error)
-
-	// Watch blocks until any configuration change was detected or an unrecoverable error
-	// happened during monitoring the configuration changes.
-	//
-	// Error is nil if the configuration is changed and needs to be re-fetched. Any non-nil
-	// error indicates that there was a problem with watching the config changes.
-	//
-	// Should never be called concurrently with itself or Get.
-	Watch() <-chan error
-
-	// Shutdown signals that the provider is no longer in use and the that should close
-	// and release any resources that it may have created.
-	//
-	// This function must terminate the Watch channel.
-	//
-	// Should never be called concurrently with itself or Get.
-	Shutdown(ctx context.Context) error
-}
-
-type configProvider struct {
+type ConfigProvider struct {
 	mapResolver *confmap.Resolver
 }
-
-var _ ConfigProvider = (*configProvider)(nil)
 
 // ConfigProviderSettings are the settings to configure the behavior of the ConfigProvider.
 type ConfigProviderSettings struct {
@@ -62,18 +36,21 @@ type ConfigProviderSettings struct {
 //   - Then applies all the confmap.Converter in the given order.
 //
 // * Then unmarshalls the confmap.Conf into the service Config.
-func NewConfigProvider(set ConfigProviderSettings) (ConfigProvider, error) {
+func NewConfigProvider(set ConfigProviderSettings) (*ConfigProvider, error) {
 	mr, err := confmap.NewResolver(set.ResolverSettings)
 	if err != nil {
 		return nil, err
 	}
 
-	return &configProvider{
+	return &ConfigProvider{
 		mapResolver: mr,
 	}, nil
 }
 
-func (cm *configProvider) Get(ctx context.Context, factories Factories) (*Config, error) {
+// Get returns the service configuration, or error otherwise.
+//
+// Should never be called concurrently with itself, Watch or Shutdown.
+func (cm *ConfigProvider) Get(ctx context.Context, factories Factories) (*Config, error) {
 	conf, err := cm.mapResolver.Resolve(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot resolve the configuration: %w", err)
@@ -94,10 +71,23 @@ func (cm *configProvider) Get(ctx context.Context, factories Factories) (*Config
 	}, nil
 }
 
-func (cm *configProvider) Watch() <-chan error {
+// Watch blocks until any configuration change was detected or an unrecoverable error
+// happened during monitoring the configuration changes.
+//
+// Error is nil if the configuration is changed and needs to be re-fetched. Any non-nil
+// error indicates that there was a problem with watching the config changes.
+//
+// Should never be called concurrently with itself or Get.
+func (cm *ConfigProvider) Watch() <-chan error {
 	return cm.mapResolver.Watch()
 }
 
-func (cm *configProvider) Shutdown(ctx context.Context) error {
+// Shutdown signals that the provider is no longer in use and the that should close
+// and release any resources that it may have created.
+//
+// This function must terminate the Watch channel.
+//
+// Should never be called concurrently with itself or Get.
+func (cm *ConfigProvider) Shutdown(ctx context.Context) error {
 	return cm.mapResolver.Shutdown(ctx)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `ConfigProvider` interface is not very useful since it isn't used by `otelcol.Collector` anymore since we moved to creating it through `ConfigProviderSettings` inside `otelcol.Collector`. Therefore, we should just make `configProvider` the concrete implementation and remove the interface. We could consider entirely removing `ConfigProvider` from the API, but it is used by some downstream distributions, and there is no other way to marshal YAML into `otelcol.Config`, so we would need to make additional changes to provide an adequate replacement.

We could also follow our deprecation process for this change, but in my opinion that will only cause more churn for downstream consumers since they will need to update their code multiple times throughout the process instead of just once.
