### PR TITLE
[confignet] Add `omitempty` tags to fields

### DIFF
--- a/.chloggen/confignet-omitempty.yaml
+++ b/.chloggen/confignet-omitempty.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confignet
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the `omitempty` mapstructure tag to struct fields
+
+# One or more tracking issues or pull requests related to the change
+issues: [12191]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This results in unset fields not being rendered when marshaling.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -59,7 +59,7 @@ func (tt *TransportType) UnmarshalText(in []byte) error {
 type DialerConfig struct {
 	// Timeout is the maximum amount of time a dial will wait for
 	// a connect to complete. The default is no timeout.
-	Timeout time.Duration `mapstructure:"timeout"`
+	Timeout time.Duration `mapstructure:"timeout,omitempty"`
 }
 
 // NewDefaultDialerConfig creates a new DialerConfig with any default values set
@@ -74,14 +74,14 @@ type AddrConfig struct {
 	// or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name.
 	// If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or
 	// "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
-	Endpoint string `mapstructure:"endpoint"`
+	Endpoint string `mapstructure:"endpoint,omitempty"`
 
 	// Transport to use. Allowed protocols are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only),
 	// "udp6" (IPv6-only), "ip", "ip4" (IPv4-only), "ip6" (IPv6-only), "unix", "unixgram" and "unixpacket".
-	Transport TransportType `mapstructure:"transport"`
+	Transport TransportType `mapstructure:"transport,omitempty"`
 
 	// DialerConfig contains options for connecting to an address.
-	DialerConfig DialerConfig `mapstructure:"dialer"`
+	DialerConfig DialerConfig `mapstructure:"dialer,omitempty"`
 }
 
 // NewDefaultAddrConfig creates a new AddrConfig with any default values set
@@ -130,10 +130,10 @@ type TCPAddrConfig struct {
 	// resolved to IP addresses. The port must be a literal port number or a service name.
 	// If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or
 	// "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
-	Endpoint string `mapstructure:"endpoint"`
+	Endpoint string `mapstructure:"endpoint,omitempty"`
 
 	// DialerConfig contains options for connecting to an address.
-	DialerConfig DialerConfig `mapstructure:"dialer"`
+	DialerConfig DialerConfig `mapstructure:"dialer,omitempty"`
 }
 
 // NewDefaultTCPAddrConfig creates a new TCPAddrConfig with any default values set

--- a/internal/e2e/confignet_test.go
+++ b/internal/e2e/confignet_test.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func TestConfmapMarshalConfigNet(t *testing.T) {
+	conf := confmap.New()
+	require.NoError(t, conf.Marshal(confignet.NewDefaultDialerConfig()))
+	assert.Equal(t, map[string]any{}, conf.ToStringMap())
+
+	conf = confmap.New()
+	require.NoError(t, conf.Marshal(confignet.NewDefaultAddrConfig()))
+	assert.Equal(t, map[string]any{}, conf.ToStringMap())
+
+	conf = confmap.New()
+	require.NoError(t, conf.Marshal(confignet.NewDefaultTCPAddrConfig()))
+	assert.Equal(t, map[string]any{}, conf.ToStringMap())
+}

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -10,6 +10,7 @@ require (
 	go.opentelemetry.io/collector/component/componenttest v0.119.0
 	go.opentelemetry.io/collector/config/configgrpc v0.119.0
 	go.opentelemetry.io/collector/config/confighttp v0.119.0
+	go.opentelemetry.io/collector/config/confignet v1.25.0
 	go.opentelemetry.io/collector/config/configopaque v1.25.0
 	go.opentelemetry.io/collector/config/configretry v1.25.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.119.0
@@ -81,7 +82,6 @@ require (
 	go.opentelemetry.io/collector/client v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.119.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.25.0 // indirect
-	go.opentelemetry.io/collector/config/confignet v1.25.0 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.119.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.119.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.119.0 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds `omitempty` to all struct fields that are not set with any of the `NewDefault[...]` functions. If we like the approach here, I'll open PRs for other config modules.

<!-- Issue number if applicable -->
#### Link to tracking issue

Works toward https://github.com/open-telemetry/opentelemetry-collector/issues/12191

<!--Describe what testing was performed and which tests were added.-->
#### Testing

I added tests to check that this works when structs are marshaled with confmap in a separate module so as not to create a direct dependency on confmap within confignet.