### PR TITLE
[exporter][batcher] MergedContext implemented with SpanLink

### DIFF
--- a/.chloggen/merged_context.yaml
+++ b/.chloggen/merged_context.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Link batcher context to all batched request's span contexts.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12212, 8122]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/batcher/batch_context.go
+++ b/exporter/exporterhelper/internal/batcher/batch_context.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package batcher // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/batcher"
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+type traceContextKeyType int
+
+const batchSpanLinksKey traceContextKeyType = iota
+
+// LinksFromContext returns a list of trace links registered in the context.
+func LinksFromContext(ctx context.Context) []trace.Link {
+	if ctx == nil {
+		return []trace.Link{}
+	}
+	if links, ok := ctx.Value(batchSpanLinksKey).([]trace.Link); ok {
+		return links
+	}
+	return []trace.Link{trace.LinkFromContext(ctx)}
+}
+
+func contextWithMergedLinks(ctx1 context.Context, ctx2 context.Context) context.Context {
+	return context.WithValue(
+		context.Background(),
+		batchSpanLinksKey,
+		append(LinksFromContext(ctx1), LinksFromContext(ctx2)...))
+}

--- a/exporter/exporterhelper/internal/batcher/batch_context_test.go
+++ b/exporter/exporterhelper/internal/batcher/batch_context_test.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package batcher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+)
+
+func TestBatchContextLink(t *testing.T) {
+	tracerProvider := componenttest.NewTelemetry().NewTelemetrySettings().TracerProvider
+	tracer := tracerProvider.Tracer("go.opentelemetry.io/collector/exporter/exporterhelper")
+
+	ctx1 := context.Background()
+
+	ctx2, span2 := tracer.Start(ctx1, "span2")
+	defer span2.End()
+
+	ctx3, span3 := tracer.Start(ctx1, "span3")
+	defer span3.End()
+
+	ctx4, span4 := tracer.Start(ctx1, "span4")
+	defer span4.End()
+
+	batchContext := contextWithMergedLinks(ctx2, ctx3)
+	batchContext = contextWithMergedLinks(batchContext, ctx4)
+
+	actualLinks := LinksFromContext(batchContext)
+	require.Len(t, actualLinks, 3)
+	require.Equal(t, trace.SpanContextFromContext(ctx2), actualLinks[0].SpanContext)
+	require.Equal(t, trace.SpanContextFromContext(ctx3), actualLinks[1].SpanContext)
+	require.Equal(t, trace.SpanContextFromContext(ctx4), actualLinks[2].SpanContext)
+}

--- a/exporter/exporterhelper/internal/batcher/default_batcher.go
+++ b/exporter/exporterhelper/internal/batcher/default_batcher.go
@@ -120,9 +120,10 @@ func (qb *defaultBatcher) Consume(ctx context.Context, req request.Request, done
 	// - Last result may not have enough data to be flushed.
 
 	// Logic on how to deal with the current batch:
-	// TODO: Deal with merging Context.
 	qb.currentBatch.req = reqList[0]
 	qb.currentBatch.done = append(qb.currentBatch.done, done)
+	qb.currentBatch.ctx = contextWithMergedLinks(qb.currentBatch.ctx, ctx)
+
 	// Save the "currentBatch" if we need to flush it, because we want to execute flush without holding the lock, and
 	// cannot unlock and re-lock because we are not done processing all the responses.
 	var firstBatch *batch

--- a/exporter/exporterhelper/internal/obs_queue.go
+++ b/exporter/exporterhelper/internal/obs_queue.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/metadata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
@@ -21,6 +22,7 @@ type obsQueue[T request.Request] struct {
 	tb                *metadata.TelemetryBuilder
 	metricAttr        metric.MeasurementOption
 	enqueueFailedInst metric.Int64Counter
+	tracer            trace.Tracer
 }
 
 func newObsQueue[T request.Request](set exporterqueue.Settings[T], delegate exporterqueue.Queue[T]) (exporterqueue.Queue[T], error) {
@@ -47,10 +49,13 @@ func newObsQueue[T request.Request](set exporterqueue.Settings[T], delegate expo
 		return nil, err
 	}
 
+	tracer := metadata.Tracer(set.ExporterSettings.TelemetrySettings)
+
 	or := &obsQueue[T]{
 		Queue:      delegate,
 		tb:         tb,
 		metricAttr: metric.WithAttributeSet(attribute.NewSet(exporterAttr)),
+		tracer:     tracer,
 	}
 
 	switch set.Signal {
@@ -74,7 +79,11 @@ func (or *obsQueue[T]) Offer(ctx context.Context, req T) error {
 	// Have to read the number of items before sending the request since the request can
 	// be modified by the downstream components like the batcher.
 	numItems := req.ItemsCount()
+
+	ctx, _ = or.tracer.Start(ctx, "exporter/enqueue")
 	err := or.Queue.Offer(ctx, req)
+	trace.SpanFromContext(ctx).End()
+
 	// No metrics recorded for profiles, remove enqueueFailedInst check with nil when profiles metrics available.
 	if err != nil && or.enqueueFailedInst != nil {
 		or.enqueueFailedInst.Add(ctx, int64(numItems), or.metricAttr)

--- a/exporter/exporterhelper/internal/obs_report_sender.go
+++ b/exporter/exporterhelper/internal/obs_report_sender.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/batcher"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/metadata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/pipeline"
@@ -95,7 +96,10 @@ func (ors *obsReportSender[K]) Send(ctx context.Context, req K) error {
 // StartOp creates the span used to trace the operation. Returning
 // the updated context and the created span.
 func (ors *obsReportSender[K]) startOp(ctx context.Context) context.Context {
-	ctx, _ = ors.tracer.Start(ctx, ors.spanName, ors.spanAttrs)
+	ctx, _ = ors.tracer.Start(ctx,
+		ors.spanName,
+		ors.spanAttrs,
+		trace.WithLinks(batcher.LinksFromContext(ctx)...))
 	return ctx
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR implements a component called mergedContext that is linked to all incoming context via a spanLink.

For example: let's say req1, req2, req3 are batched in the same request, then

* `batch = { requests: [req1, req2, req3], mergedContext: ctx1}`
* `ctx1.span` is linked to `ctx2.span` and `ctx3.span` via a `SpanLink`

<!-- Issue number if applicable -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector/issues/12212
https://github.com/open-telemetry/opentelemetry-collector/issues/8122
