### PR TITLE
[configgrpc] Add `omitempty` tag to fields

### DIFF
--- a/.chloggen/configgrpc-omitempty.yaml
+++ b/.chloggen/configgrpc-omitempty.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the `omitempty` mapstructure tag to struct fields
+
+# One or more tracking issues or pull requests related to the change
+issues: [12191]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This results in unset fields not being rendered when marshaling.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -45,7 +45,7 @@ var errMetadataNotFound = errors.New("no request metadata found")
 type KeepaliveClientConfig struct {
 	Time                time.Duration `mapstructure:"time"`
 	Timeout             time.Duration `mapstructure:"timeout"`
-	PermitWithoutStream bool          `mapstructure:"permit_without_stream"`
+	PermitWithoutStream bool          `mapstructure:"permit_without_stream,omitempty"`
 }
 
 // NewDefaultKeepaliveClientConfig returns a new instance of KeepaliveClientConfig with default values.
@@ -66,32 +66,32 @@ type ClientConfig struct {
 	// The target to which the exporter is going to send traces or metrics,
 	// using the gRPC protocol. The valid syntax is described at
 	// https://github.com/grpc/grpc/blob/master/doc/naming.md.
-	Endpoint string `mapstructure:"endpoint"`
+	Endpoint string `mapstructure:"endpoint,omitempty"`
 
 	// The compression key for supported compression types within collector.
-	Compression configcompression.Type `mapstructure:"compression"`
+	Compression configcompression.Type `mapstructure:"compression,omitempty"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.ClientConfig `mapstructure:"tls"`
+	TLSSetting configtls.ClientConfig `mapstructure:"tls,omitempty"`
 
 	// The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams.
 	// (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
-	Keepalive *KeepaliveClientConfig `mapstructure:"keepalive"`
+	Keepalive *KeepaliveClientConfig `mapstructure:"keepalive,omitempty"`
 
 	// ReadBufferSize for gRPC client. See grpc.WithReadBufferSize.
 	// (https://godoc.org/google.golang.org/grpc#WithReadBufferSize).
-	ReadBufferSize int `mapstructure:"read_buffer_size"`
+	ReadBufferSize int `mapstructure:"read_buffer_size,omitempty"`
 
 	// WriteBufferSize for gRPC gRPC. See grpc.WithWriteBufferSize.
 	// (https://godoc.org/google.golang.org/grpc#WithWriteBufferSize).
-	WriteBufferSize int `mapstructure:"write_buffer_size"`
+	WriteBufferSize int `mapstructure:"write_buffer_size,omitempty"`
 
 	// WaitForReady parameter configures client to wait for ready state before sending data.
 	// (https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md)
-	WaitForReady bool `mapstructure:"wait_for_ready"`
+	WaitForReady bool `mapstructure:"wait_for_ready,omitempty"`
 
 	// The headers associated with gRPC requests.
-	Headers map[string]configopaque.String `mapstructure:"headers"`
+	Headers map[string]configopaque.String `mapstructure:"headers,omitempty"`
 
 	// Sets the balancer in grpclb_policy to discover the servers. Default is pick_first.
 	// https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md
@@ -99,10 +99,10 @@ type ClientConfig struct {
 
 	// WithAuthority parameter configures client to rewrite ":authority" header
 	// (godoc.org/google.golang.org/grpc#WithAuthority)
-	Authority string `mapstructure:"authority"`
+	Authority string `mapstructure:"authority,omitempty"`
 
 	// Auth configuration for outgoing RPCs.
-	Auth *configauth.Authentication `mapstructure:"auth"`
+	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
 }
 
 // NewDefaultClientConfig returns a new instance of ClientConfig with default values.
@@ -116,8 +116,8 @@ func NewDefaultClientConfig() *ClientConfig {
 
 // KeepaliveServerConfig is the configuration for keepalive.
 type KeepaliveServerConfig struct {
-	ServerParameters  *KeepaliveServerParameters  `mapstructure:"server_parameters"`
-	EnforcementPolicy *KeepaliveEnforcementPolicy `mapstructure:"enforcement_policy"`
+	ServerParameters  *KeepaliveServerParameters  `mapstructure:"server_parameters,omitempty"`
+	EnforcementPolicy *KeepaliveEnforcementPolicy `mapstructure:"enforcement_policy,omitempty"`
 }
 
 // NewDefaultKeepaliveServerConfig returns a new instance of KeepaliveServerConfig with default values.
@@ -132,11 +132,11 @@ func NewDefaultKeepaliveServerConfig() *KeepaliveServerConfig {
 // The same default values as keepalive.ServerParameters are applicable and get applied by the server.
 // See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for details.
 type KeepaliveServerParameters struct {
-	MaxConnectionIdle     time.Duration `mapstructure:"max_connection_idle"`
-	MaxConnectionAge      time.Duration `mapstructure:"max_connection_age"`
-	MaxConnectionAgeGrace time.Duration `mapstructure:"max_connection_age_grace"`
-	Time                  time.Duration `mapstructure:"time"`
-	Timeout               time.Duration `mapstructure:"timeout"`
+	MaxConnectionIdle     time.Duration `mapstructure:"max_connection_idle,omitempty"`
+	MaxConnectionAge      time.Duration `mapstructure:"max_connection_age,omitempty"`
+	MaxConnectionAgeGrace time.Duration `mapstructure:"max_connection_age_grace,omitempty"`
+	Time                  time.Duration `mapstructure:"time,omitempty"`
+	Timeout               time.Duration `mapstructure:"timeout,omitempty"`
 }
 
 // NewDefaultKeepaliveServerParameters creates and returns a new instance of KeepaliveServerParameters with default settings.
@@ -148,8 +148,8 @@ func NewDefaultKeepaliveServerParameters() *KeepaliveServerParameters {
 // The same default values as keepalive.EnforcementPolicy are applicable and get applied by the server.
 // See https://godoc.org/google.golang.org/grpc/keepalive#EnforcementPolicy for details.
 type KeepaliveEnforcementPolicy struct {
-	MinTime             time.Duration `mapstructure:"min_time"`
-	PermitWithoutStream bool          `mapstructure:"permit_without_stream"`
+	MinTime             time.Duration `mapstructure:"min_time,omitempty"`
+	PermitWithoutStream bool          `mapstructure:"permit_without_stream,omitempty"`
 }
 
 // NewDefaultKeepaliveEnforcementPolicy creates and returns a new instance of KeepaliveEnforcementPolicy with default settings.
@@ -164,31 +164,31 @@ type ServerConfig struct {
 
 	// Configures the protocol to use TLS.
 	// The default value is nil, which will cause the protocol to not use TLS.
-	TLSSetting *configtls.ServerConfig `mapstructure:"tls"`
+	TLSSetting *configtls.ServerConfig `mapstructure:"tls,omitempty"`
 
 	// MaxRecvMsgSizeMiB sets the maximum size (in MiB) of messages accepted by the server.
-	MaxRecvMsgSizeMiB int `mapstructure:"max_recv_msg_size_mib"`
+	MaxRecvMsgSizeMiB int `mapstructure:"max_recv_msg_size_mib,omitempty"`
 
 	// MaxConcurrentStreams sets the limit on the number of concurrent streams to each ServerTransport.
 	// It has effect only for streaming RPCs.
-	MaxConcurrentStreams uint32 `mapstructure:"max_concurrent_streams"`
+	MaxConcurrentStreams uint32 `mapstructure:"max_concurrent_streams,omitempty,omitempty"`
 
 	// ReadBufferSize for gRPC server. See grpc.ReadBufferSize.
 	// (https://godoc.org/google.golang.org/grpc#ReadBufferSize).
-	ReadBufferSize int `mapstructure:"read_buffer_size"`
+	ReadBufferSize int `mapstructure:"read_buffer_size,omitempty"`
 
 	// WriteBufferSize for gRPC server. See grpc.WriteBufferSize.
 	// (https://godoc.org/google.golang.org/grpc#WriteBufferSize).
-	WriteBufferSize int `mapstructure:"write_buffer_size"`
+	WriteBufferSize int `mapstructure:"write_buffer_size,omitempty"`
 
 	// Keepalive anchor for all the settings related to keepalive.
-	Keepalive *KeepaliveServerConfig `mapstructure:"keepalive"`
+	Keepalive *KeepaliveServerConfig `mapstructure:"keepalive,omitempty"`
 
 	// Auth for this receiver
-	Auth *configauth.Authentication `mapstructure:"auth"`
+	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
 
 	// Include propagates the incoming connection's metadata to downstream consumers.
-	IncludeMetadata bool `mapstructure:"include_metadata"`
+	IncludeMetadata bool `mapstructure:"include_metadata,omitempty"`
 }
 
 // NewDefaultServerConfig returns a new instance of ServerConfig with default values.

--- a/internal/e2e/configgrpc_test.go
+++ b/internal/e2e/configgrpc_test.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func TestConfmapMarshalConfigGRPC(t *testing.T) {
+	keepaliveClientConfig := map[string]any{
+		"time":    time.Second * 10,
+		"timeout": time.Second * 10,
+	}
+	keepaliveServerConfig := map[string]any{
+		"server_parameters":  map[string]any{},
+		"enforcement_policy": map[string]any{},
+	}
+
+	conf := confmap.New()
+	require.NoError(t, conf.Marshal(configgrpc.NewDefaultClientConfig()))
+	assert.Equal(t, map[string]any{
+		"keepalive":     keepaliveClientConfig,
+		"balancer_name": "round_robin",
+	}, conf.ToStringMap())
+
+	conf = confmap.New()
+	require.NoError(t, conf.Marshal(configgrpc.NewDefaultKeepaliveClientConfig()))
+	assert.Equal(t, keepaliveClientConfig, conf.ToStringMap())
+
+	conf = confmap.New()
+	require.NoError(t, conf.Marshal(configgrpc.NewDefaultKeepaliveEnforcementPolicy()))
+	assert.Equal(t, map[string]any{}, conf.ToStringMap())
+
+	conf = confmap.New()
+	require.NoError(t, conf.Marshal(configgrpc.NewDefaultKeepaliveServerConfig()))
+	assert.Equal(t, keepaliveServerConfig, conf.ToStringMap())
+
+	conf = confmap.New()
+	require.NoError(t, conf.Marshal(configgrpc.NewDefaultKeepaliveServerParameters()))
+	assert.Equal(t, map[string]any{}, conf.ToStringMap())
+
+	conf = confmap.New()
+	require.NoError(t, conf.Marshal(configgrpc.NewDefaultServerConfig()))
+	assert.Equal(t, map[string]any{
+		"keepalive": keepaliveServerConfig,
+	}, conf.ToStringMap())
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

I didn't add the tag to any fields that have defaults set, since setting these values to Go's zero value for that type would be a meaningful configuration option that should appear in the config.

I think we could consider updates to the marshaler in the future to make it possible to omit fields that have values matching the ones produced by the `NewDefault[...]` functions, but that will be a more involved effort we can tackle later.

<!-- Issue number if applicable -->
#### Link to tracking issue

Works toward https://github.com/open-telemetry/opentelemetry-collector/issues/12191
