### PR TITLE
[chore] Update codeowners according to releases-approvers RFC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,11 @@
 
 * @open-telemetry/collector-approvers
 
+# Files owned by collector-releases-approvers
+.github/workflows/prepare-release.yml    @open-telemetry/collector-releases-approvers
+.github/workflows/sourcecode-release.yml @open-telemetry/collector-releases-approvers
+.github/workflows/scripts/release-*.sh   @open-telemetry/collector-releases-approvers
+
 # Start components list
 
 cmd/mdatagen/                            @open-telemetry/collector-approvers @dmitryax

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,9 +12,9 @@
 * @open-telemetry/collector-approvers
 
 # Files owned by collector-releases-approvers
-.github/workflows/prepare-release.yml    @open-telemetry/collector-releases-approvers
-.github/workflows/sourcecode-release.yml @open-telemetry/collector-releases-approvers
-.github/workflows/scripts/release-*.sh   @open-telemetry/collector-releases-approvers
+.github/workflows/prepare-release.yml    @open-telemetry/collector-approvers @open-telemetry/collector-releases-approvers
+.github/workflows/sourcecode-release.yml @open-telemetry/collector-approvers @open-telemetry/collector-releases-approvers
+.github/workflows/scripts/release-*.sh   @open-telemetry/collector-approvers @open-telemetry/collector-releases-approvers
 
 # Start components list
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds the releases-approvers user group as codeowners for all files related to the release.

<!-- Issue number if applicable -->
#### Link to tracking issue
Parf of https://github.com/open-telemetry/opentelemetry-collector/pull/11577



<!--Describe the documentation added.-->
#### Documentation
https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/release-approvers.md

<!--Please delete paragraphs that you did not use before submitting.-->
