### PR TITLE
[chore] Remove dead code from mdatagen.

### DIFF
--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -30,11 +30,9 @@ type TelemetryBuilder struct {
 	registrations                 []metric.Registration
 	BatchSizeTriggerSend          metric.Int64Counter
 	ProcessRuntimeTotalAllocBytes metric.Int64ObservableCounter
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeProcessRuntimeTotalAllocBytes func(context.Context, metric.Observer) error
-	QueueCapacity                        metric.Int64Gauge
-	QueueLength                          metric.Int64ObservableGauge
-	RequestDuration                      metric.Float64Histogram
+	QueueCapacity                 metric.Int64Gauge
+	QueueLength                   metric.Int64ObservableGauge
+	RequestDuration               metric.Float64Histogram
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -118,13 +116,6 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeProcessRuntimeTotalAllocBytes != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeProcessRuntimeTotalAllocBytes, builder.ProcessRuntimeTotalAllocBytes)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	builder.QueueCapacity, err = builder.meter.Int64Gauge(
 		"otelcol_queue_capacity",
 		metric.WithDescription("Queue capacity - sync gauge example."),

--- a/cmd/mdatagen/internal/templates/telemetry.go.tmpl
+++ b/cmd/mdatagen/internal/templates/telemetry.go.tmpl
@@ -40,8 +40,6 @@ type TelemetryBuilder struct {
 	{{- range $name, $metric := .Telemetry.Metrics }}
 	{{ $name.Render }} metric.{{ $metric.Data.Instrument }}
     {{- if and ($metric.Data.Async) (not $metric.Optional) }}
-    // TODO: Remove in v0.119.0 when remove deprecated funcs.
-    observe{{ $name.Render }} func(context.Context, metric.Observer) error
     {{- end }}
 	{{- end }}
 }
@@ -140,15 +138,6 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
         {{- end }}
     )
     errs = errors.Join(errs, err)
-    {{- if and ($metric.Data.Async) (not $metric.Optional) }}
-	if builder.observe{{ $name.Render }} != nil {
-        reg, err := builder.meter.RegisterCallback(builder.observe{{ $name.Render }}, builder.{{ $name.Render }})
-        errs = errors.Join(errs, err)
-		if err == nil {
-            builder.registrations = append(builder.registrations, reg)
-        }
-	}
-    {{- end }}
     {{- end }}
     return &builder, errs
 }

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -32,17 +32,13 @@ type TelemetryBuilder struct {
 	ExporterEnqueueFailedMetricPoints metric.Int64Counter
 	ExporterEnqueueFailedSpans        metric.Int64Counter
 	ExporterQueueCapacity             metric.Int64ObservableGauge
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeExporterQueueCapacity func(context.Context, metric.Observer) error
-	ExporterQueueSize            metric.Int64ObservableGauge
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeExporterQueueSize       func(context.Context, metric.Observer) error
-	ExporterSendFailedLogRecords   metric.Int64Counter
-	ExporterSendFailedMetricPoints metric.Int64Counter
-	ExporterSendFailedSpans        metric.Int64Counter
-	ExporterSentLogRecords         metric.Int64Counter
-	ExporterSentMetricPoints       metric.Int64Counter
-	ExporterSentSpans              metric.Int64Counter
+	ExporterQueueSize                 metric.Int64ObservableGauge
+	ExporterSendFailedLogRecords      metric.Int64Counter
+	ExporterSendFailedMetricPoints    metric.Int64Counter
+	ExporterSendFailedSpans           metric.Int64Counter
+	ExporterSentLogRecords            metric.Int64Counter
+	ExporterSentMetricPoints          metric.Int64Counter
+	ExporterSentSpans                 metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -138,26 +134,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{batches}"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeExporterQueueCapacity != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeExporterQueueCapacity, builder.ExporterQueueCapacity)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	builder.ExporterQueueSize, err = builder.meter.Int64ObservableGauge(
 		"otelcol_exporter_queue_size",
 		metric.WithDescription("Current size of the retry queue (in batches) [alpha]"),
 		metric.WithUnit("{batches}"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeExporterQueueSize != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeExporterQueueSize, builder.ExporterQueueSize)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	builder.ExporterSendFailedLogRecords, err = builder.meter.Int64Counter(
 		"otelcol_exporter_send_failed_log_records",
 		metric.WithDescription("Number of log records in failed attempts to send to destination. [alpha]"),

--- a/processor/batchprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/batchprocessor/internal/metadata/generated_telemetry.go
@@ -32,9 +32,7 @@ type TelemetryBuilder struct {
 	ProcessorBatchBatchSendSizeBytes   metric.Int64Histogram
 	ProcessorBatchBatchSizeTriggerSend metric.Int64Counter
 	ProcessorBatchMetadataCardinality  metric.Int64ObservableUpDownCounter
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeProcessorBatchMetadataCardinality func(context.Context, metric.Observer) error
-	ProcessorBatchTimeoutTriggerSend         metric.Int64Counter
+	ProcessorBatchTimeoutTriggerSend   metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -117,13 +115,6 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{combinations}"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeProcessorBatchMetadataCardinality != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeProcessorBatchMetadataCardinality, builder.ProcessorBatchMetadataCardinality)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	builder.ProcessorBatchTimeoutTriggerSend, err = builder.meter.Int64Counter(
 		"otelcol_processor_batch_timeout_trigger_send",
 		metric.WithDescription("Number of times the batch was sent due to a timeout trigger"),

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -25,27 +25,15 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter             metric.Meter
-	mu                sync.Mutex
-	registrations     []metric.Registration
-	ProcessCPUSeconds metric.Float64ObservableCounter
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeProcessCPUSeconds func(context.Context, metric.Observer) error
-	ProcessMemoryRss         metric.Int64ObservableGauge
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeProcessMemoryRss      func(context.Context, metric.Observer) error
-	ProcessRuntimeHeapAllocBytes metric.Int64ObservableGauge
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeProcessRuntimeHeapAllocBytes func(context.Context, metric.Observer) error
-	ProcessRuntimeTotalAllocBytes       metric.Int64ObservableCounter
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeProcessRuntimeTotalAllocBytes func(context.Context, metric.Observer) error
-	ProcessRuntimeTotalSysMemoryBytes    metric.Int64ObservableGauge
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeProcessRuntimeTotalSysMemoryBytes func(context.Context, metric.Observer) error
-	ProcessUptime                            metric.Float64ObservableCounter
-	// TODO: Remove in v0.119.0 when remove deprecated funcs.
-	observeProcessUptime func(context.Context, metric.Observer) error
+	meter                             metric.Meter
+	mu                                sync.Mutex
+	registrations                     []metric.Registration
+	ProcessCPUSeconds                 metric.Float64ObservableCounter
+	ProcessMemoryRss                  metric.Int64ObservableGauge
+	ProcessRuntimeHeapAllocBytes      metric.Int64ObservableGauge
+	ProcessRuntimeTotalAllocBytes     metric.Int64ObservableCounter
+	ProcessRuntimeTotalSysMemoryBytes metric.Int64ObservableGauge
+	ProcessUptime                     metric.Float64ObservableCounter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -193,77 +181,35 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("s"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeProcessCPUSeconds != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeProcessCPUSeconds, builder.ProcessCPUSeconds)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	builder.ProcessMemoryRss, err = builder.meter.Int64ObservableGauge(
 		"otelcol_process_memory_rss",
 		metric.WithDescription("Total physical memory (resident set size) [alpha]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeProcessMemoryRss != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeProcessMemoryRss, builder.ProcessMemoryRss)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	builder.ProcessRuntimeHeapAllocBytes, err = builder.meter.Int64ObservableGauge(
 		"otelcol_process_runtime_heap_alloc_bytes",
 		metric.WithDescription("Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc') [alpha]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeProcessRuntimeHeapAllocBytes != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeProcessRuntimeHeapAllocBytes, builder.ProcessRuntimeHeapAllocBytes)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	builder.ProcessRuntimeTotalAllocBytes, err = builder.meter.Int64ObservableCounter(
 		"otelcol_process_runtime_total_alloc_bytes",
 		metric.WithDescription("Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc') [alpha]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeProcessRuntimeTotalAllocBytes != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeProcessRuntimeTotalAllocBytes, builder.ProcessRuntimeTotalAllocBytes)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	builder.ProcessRuntimeTotalSysMemoryBytes, err = builder.meter.Int64ObservableGauge(
 		"otelcol_process_runtime_total_sys_memory_bytes",
 		metric.WithDescription("Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys') [alpha]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeProcessRuntimeTotalSysMemoryBytes != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeProcessRuntimeTotalSysMemoryBytes, builder.ProcessRuntimeTotalSysMemoryBytes)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	builder.ProcessUptime, err = builder.meter.Float64ObservableCounter(
 		"otelcol_process_uptime",
 		metric.WithDescription("Uptime of the process [alpha]"),
 		metric.WithUnit("s"),
 	)
 	errs = errors.Join(errs, err)
-	if builder.observeProcessUptime != nil {
-		reg, err := builder.meter.RegisterCallback(builder.observeProcessUptime, builder.ProcessUptime)
-		errs = errors.Join(errs, err)
-		if err == nil {
-			builder.registrations = append(builder.registrations, reg)
-		}
-	}
 	return &builder, errs
 }


### PR DESCRIPTION
Missed by https://github.com/open-telemetry/opentelemetry-collector/pull/12304, this variables can no longer be initialized so this becomes dead code.