### PR TITLE
[otlpreceiver] Add component ID as HTTP span name prefix

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -89,6 +89,7 @@ require (
 	go.opentelemetry.io/collector/config/configcompression v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.119.0 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.119.0 // indirect
+	go.opentelemetry.io/collector/config/confighttp/xconfighttp v0.119.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.25.0 // indirect
@@ -181,6 +182,8 @@ replace go.opentelemetry.io/collector/config/configcompression => ../../config/c
 replace go.opentelemetry.io/collector/config/configgrpc => ../../config/configgrpc
 
 replace go.opentelemetry.io/collector/config/confighttp => ../../config/confighttp
+
+replace go.opentelemetry.io/collector/config/confighttp/xconfighttp => ../../config/confighttp/xconfighttp
 
 replace go.opentelemetry.io/collector/config/confignet => ../../config/confignet
 

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -83,6 +83,7 @@ require (
 	go.opentelemetry.io/collector/component/componentattribute v0.0.0-20250207221750-83d93cd7cf86 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.119.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.25.0 // indirect
+	go.opentelemetry.io/collector/config/confighttp/xconfighttp v0.119.0 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.119.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.119.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.119.0 // indirect
@@ -147,6 +148,8 @@ replace go.opentelemetry.io/collector/config/configgrpc => ../../config/configgr
 replace go.opentelemetry.io/collector/config/confignet => ../../config/confignet
 
 replace go.opentelemetry.io/collector/config/confighttp => ../../config/confighttp
+
+replace go.opentelemetry.io/collector/config/confighttp/xconfighttp => ../../config/confighttp/xconfighttp
 
 replace go.opentelemetry.io/collector/config/configauth => ../../config/configauth
 

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -14,6 +14,7 @@ require (
 	go.opentelemetry.io/collector/config/configauth v0.119.0
 	go.opentelemetry.io/collector/config/configgrpc v0.119.0
 	go.opentelemetry.io/collector/config/confighttp v0.119.0
+	go.opentelemetry.io/collector/config/confighttp/xconfighttp v0.119.0
 	go.opentelemetry.io/collector/config/confignet v1.25.0
 	go.opentelemetry.io/collector/config/configtls v1.25.0
 	go.opentelemetry.io/collector/confmap v1.25.0
@@ -29,6 +30,7 @@ require (
 	go.opentelemetry.io/collector/receiver v0.119.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.119.0
 	go.opentelemetry.io/collector/receiver/xreceiver v0.119.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.uber.org/goleak v1.3.0
@@ -67,7 +69,6 @@ require (
 	go.opentelemetry.io/collector/extension/auth v0.119.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.119.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
@@ -89,6 +90,8 @@ replace go.opentelemetry.io/collector/config/configauth => ../../config/configau
 replace go.opentelemetry.io/collector/config/configcompression => ../../config/configcompression
 
 replace go.opentelemetry.io/collector/config/confighttp => ../../config/confighttp
+
+replace go.opentelemetry.io/collector/config/confighttp/xconfighttp => ../../config/confighttp/xconfighttp
 
 replace go.opentelemetry.io/collector/config/configgrpc => ../../config/configgrpc
 


### PR DESCRIPTION
#### Description

In the spirit of #9382, this PR adds the component ID as a prefix to the name of spans generated by otelhttp instrumentation on the OTLP endpoint. Instead of, for instance, `/v1/traces`, that span will now be called `otlp/foo:/v1/traces`, to easily differentiate between spans from unrelated HTTP endpoints.

I believe this is not a breaking change, as traces are not stable in self-telemetry.

#### Testing
I manually checked that the span name changed. Not sure if a test would be necessary?
