### PR TITLE
[confighttp] Add ToClientOption

### DIFF
--- a/.chloggen/mx-psi_toclient-option.yaml
+++ b/.chloggen/mx-psi_toclient-option.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `ToClientOption` type and add it to signature of `ToClient` method.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12353]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  - This has no use for now, it may be used in the future.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -148,8 +148,15 @@ func (hcs *ClientConfig) Validate() error {
 	return nil
 }
 
+// ToClientOption is an option to change the behavior of the HTTP client
+// returned by ClientConfig.ToClient().
+// There are currently no available options.
+type ToClientOption interface {
+	sealed()
+}
+
 // ToClient creates an HTTP client.
-func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
+func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, settings component.TelemetrySettings, _ ...ToClientOption) (*http.Client, error) {
 	tlsCfg, err := hcs.TLSSetting.LoadTLSConfig(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Adds `ToClientOption` option type to future-proof `ToClient` method. It has no current uses.

Skipping the deprecation process per [this exception](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/coding-guidelines.md#exceptions).

#### Link to tracking issue
Fixes #12353
