### PR TITLE
[receiver/otlp, exporter/otlp] Use NewDefaultConfig

### DIFF
--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -135,6 +136,7 @@ func TestUnmarshalConfig(t *testing.T) {
 							AllowedOrigins: []string{"https://*.test.com", "https://test.com"},
 							MaxAge:         7200,
 						},
+						ResponseHeaders: map[string]configopaque.String{},
 					},
 					TracesURLPath:  "/traces",
 					MetricsURLPath: "/v2/metrics",
@@ -159,10 +161,13 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 						Transport: confignet.TransportTypeUnix,
 					},
 					ReadBufferSize: 512 * 1024,
+					Keepalive:      configgrpc.NewDefaultKeepaliveServerConfig(),
 				},
 				HTTP: &HTTPConfig{
 					ServerConfig: &confighttp.ServerConfig{
-						Endpoint: "/tmp/http_otlp.sock",
+						Endpoint:        "/tmp/http_otlp.sock",
+						CORS:            confighttp.NewDefaultCORSConfig(),
+						ResponseHeaders: map[string]configopaque.String{},
 					},
 					TracesURLPath:  defaultTracesURLPath,
 					MetricsURLPath: defaultMetricsURLPath,

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -39,20 +39,26 @@ func NewFactory() receiver.Factory {
 
 // createDefaultConfig creates the default configuration for receiver.
 func createDefaultConfig() component.Config {
+	grpcCfg := configgrpc.NewDefaultServerConfig()
+	grpcCfg.NetAddr = confignet.NewDefaultAddrConfig()
+	grpcCfg.NetAddr.Endpoint = "localhost:4317"
+	grpcCfg.NetAddr.Transport = confignet.TransportTypeTCP
+	// We almost write 0 bytes, so no need to tune WriteBufferSize.
+	grpcCfg.ReadBufferSize = 512 * 1024
+
+	httpCfg := confighttp.NewDefaultServerConfig()
+	httpCfg.Endpoint = "localhost:4318"
+	// For backward compatibility:
+	httpCfg.TLSSetting = nil
+	httpCfg.WriteTimeout = 0
+	httpCfg.ReadHeaderTimeout = 0
+	httpCfg.IdleTimeout = 0
+
 	return &Config{
 		Protocols: Protocols{
-			GRPC: &configgrpc.ServerConfig{
-				NetAddr: confignet.AddrConfig{
-					Endpoint:  "localhost:4317",
-					Transport: confignet.TransportTypeTCP,
-				},
-				// We almost write 0 bytes, so no need to tune WriteBufferSize.
-				ReadBufferSize: 512 * 1024,
-			},
+			GRPC: grpcCfg,
 			HTTP: &HTTPConfig{
-				ServerConfig: &confighttp.ServerConfig{
-					Endpoint: "localhost:4318",
-				},
+				ServerConfig:   &httpCfg,
 				TracesURLPath:  defaultTracesURLPath,
 				MetricsURLPath: defaultMetricsURLPath,
 				LogsURLPath:    defaultLogsURLPath,

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/collector/config/configgrpc v0.119.0
 	go.opentelemetry.io/collector/config/confighttp v0.119.0
 	go.opentelemetry.io/collector/config/confignet v1.25.0
+	go.opentelemetry.io/collector/config/configopaque v1.25.0
 	go.opentelemetry.io/collector/config/configtls v1.25.0
 	go.opentelemetry.io/collector/confmap v1.25.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.0.0-20250205001856-68ff067415c1
@@ -62,7 +63,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.25.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.25.0 // indirect
 	go.opentelemetry.io/collector/extension v0.119.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.119.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.119.0 // indirect


### PR DESCRIPTION
#### Description

According to [the coding guidelines](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/coding-guidelines.md#default-configuration), config structs should be initialized using the corresponding `NewDefaultX` function, and fields overwritten as necessary. This PR makes sure that the OTLP receiver and gRPC OTLP exporter follow this guideline.

Implemented naively, this would be a breaking change, as there are multiple default values provided by these functions that behave differently from the zero value. Notably, `confighttp.NewDefaultServerConfig` creates an HTTPS server which rejects insecure connections, whereas the current default (`ServerConfig.TLSSetting: nil`) accepts them.

I think deciding whether `confighttp` and `configgrpc`'s defaults are appropriate for these two components' defaults is out of the scope of this PR, so for now, I overwrote the updated fields back to their previous defaults. (The default CORS, Keepalive, and ResponseHeaders values behave the same as setting them to nil.)
