### PR TITLE
Fix otlphttpexporter parsing logic for Retry-After

### DIFF
--- a/.chloggen/fix-otlp-http-exp.yaml
+++ b/.chloggen/fix-otlp-http-exp.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlphttpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix parsing logic for Retry-After in OTLP http protocol.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12366]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The value of Retry-After field can be either an HTTP-date or delay-seconds and the current logic only parsed delay-seconds.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -222,24 +222,34 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 	}
 	formattedErr = httphelper.NewStatusFromMsgAndHTTPCode(errString, resp.StatusCode).Err()
 
-	if isRetryableStatusCode(resp.StatusCode) {
-		// A retry duration of 0 seconds will trigger the default backoff policy
-		// of our caller (retry handler).
-		retryAfter := 0
-
-		// Check if the server is overwhelmed.
-		// See spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp-throttling
-		isThrottleError := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable
-		if val := resp.Header.Get(headerRetryAfter); isThrottleError && val != "" {
-			if seconds, err2 := strconv.Atoi(val); err2 == nil {
-				retryAfter = seconds
-			}
-		}
-
-		return exporterhelper.NewThrottleRetry(formattedErr, time.Duration(retryAfter)*time.Second)
+	if !isRetryableStatusCode(resp.StatusCode) {
+		return consumererror.NewPermanent(formattedErr)
 	}
 
-	return consumererror.NewPermanent(formattedErr)
+	// Check if the server is overwhelmed.
+	// See spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp-throttling
+	isThrottleError := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable
+	if isThrottleError {
+		// Use Values to check if the header is present, and if present even if it is empty return ThrottleRetry.
+		values := resp.Header.Values(headerRetryAfter)
+		if len(values) == 0 {
+			return formattedErr
+		}
+		// The value of Retry-After field can be either an HTTP-date or a number of
+		// seconds to delay after the response is received. See https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3
+		//
+		// Retry-After = HTTP-date / delay-seconds
+		//
+		// First try to parse delay-seconds, since that is what the receiver will send.
+		if seconds, err := strconv.Atoi(values[0]); err == nil {
+			return exporterhelper.NewThrottleRetry(formattedErr, time.Duration(seconds)*time.Second)
+		}
+		if date, err := time.Parse(time.RFC1123, values[0]); err == nil {
+			return exporterhelper.NewThrottleRetry(formattedErr, time.Until(date))
+		}
+		return formattedErr
+	}
+	return formattedErr
 }
 
 // Determine if the status code is retryable according to the specification.


### PR DESCRIPTION
Small improvement to not create a throttled error when delay is 0, same behavior.