### PR TITLE
bump minimum supported go version to 1.23

### DIFF
--- a/.chloggen/codeboten_1.24.yaml
+++ b/.chloggen/codeboten_1.24.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: all
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Added support for go.14, bumped minimum version to 1.23
+note: Added support for go1.24, bumped minimum version to 1.23
 
 # One or more tracking issues or pull requests related to the change
 issues: [12370]

--- a/.chloggen/codeboten_1.24.yaml
+++ b/.chloggen/codeboten_1.24.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added support for go.14, bumped minimum version to 1.23
+
+# One or more tracking issues or pull requests related to the change
+issues: [12370]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
 
       # Generate apidiff states of Main
       - name: Generate-States

--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         id: go-cache
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         id: go-cache
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         id: go-cache
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         id: go-cache
@@ -142,7 +142,7 @@ jobs:
     strategy:
       matrix:
         runner: [ubuntu-latest]
-        go-version: ["~1.23", "~1.22"] # 1.20 needs quotes otherwise it's interpreted as 1.2
+        go-version: ["~1.24", "~1.23"] # 1.20 needs quotes otherwise it's interpreted as 1.2
     runs-on: ${{ matrix.runner }}
     needs: [setup-environment]
     steps:
@@ -200,7 +200,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         id: go-cache
@@ -264,7 +264,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -35,6 +35,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
       - name: Test
         run: make builder-integration-test

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
       - name: Cache Go
         id: go-cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Run Contrib Tests
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
 
       - name: Run benchmark
         run: make gobenchmark

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
       # Prepare Core for release.
       #   - Update CHANGELOG.md file, this is done via chloggen
       #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.22.12
+          go-version: ~1.23.6
           cache: false
       - name: Cache Go
         id: go-cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ section of the general project contributing guide.
 Working with the project sources requires the following tools:
 
 1. [git](https://git-scm.com/)
-2. [go](https://golang.org/) (version 1.22 and up)
+2. [go](https://golang.org/) (version 1.23 and up)
 3. [make](https://www.gnu.org/software/make/)
 4. [docker](https://www.docker.com/)
 
@@ -249,7 +249,7 @@ before merging (but see the above paragraph about writing good commit messages i
 
 ## General Notes
 
-This project uses Go 1.22.* and [Github Actions.](https://github.com/features/actions)
+This project uses Go 1.23.* and [Github Actions.](https://github.com/features/actions)
 
 It is recommended to run `make gofmt all` before submitting your PR.
 

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/client
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -96,7 +96,7 @@ go install go.opentelemetry.io/collector/cmd/builder@latest
 
 If installing through this method the binary will be called `builder`.
 
-Please note that the `go.mod` file generated uses `go 1.22` as the version. Versions 1.22.3, 1.21.10, and prior of Go [do not recognize this as a valid go version](https://github.com/golang/go/commit/27ed85d4d1702e868730ab6ea2ad6326988c615c). In order to successfully generate and build a collector using ocb, you must use Go version 1.22.4+, or any version of Go 1.23 and beyond.
+In order to successfully generate and build a collector using ocb, you must use [compatible Go version](../../README.md#compatibility).
 
 ## Running
 

--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -3,7 +3,7 @@
 
 module go.opentelemetry.io/collector/cmd/builder
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/knadh/koanf/parsers/yaml v0.1.0

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/cmd/mdatagen
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -2,7 +2,7 @@
 
 module go.opentelemetry.io/collector/cmd/otelcorecol
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.23.6
 

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -4,7 +4,7 @@ module go.opentelemetry.io/collector/cmd/otelcorecol
 
 go 1.22.0
 
-toolchain go1.22.12
+toolchain go1.23.6
 
 require (
 	go.opentelemetry.io/collector/component v0.119.0

--- a/component/componentstatus/go.mod
+++ b/component/componentstatus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component/componentstatus
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/component/componenttest/go.mod
+++ b/component/componenttest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component/componenttest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/component/go.mod
+++ b/component/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configauth/go.mod
+++ b/config/configauth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configauth
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configcompression/go.mod
+++ b/config/configcompression/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configcompression
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configgrpc
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/mostynb/go-grpc-compression v1.2.3

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confighttp
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/golang/snappy v0.0.4

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confighttp/xconfighttp
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/confignet/go.mod
+++ b/config/confignet/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confignet
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configopaque/go.mod
+++ b/config/configopaque/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configopaque
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configretry/go.mod
+++ b/config/configretry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configretry
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/config/configtelemetry/go.mod
+++ b/config/configtelemetry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtelemetry
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configtls/go.mod
+++ b/config/configtls/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtls
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/fsnotify/fsnotify v1.8.0

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.2.1

--- a/confmap/internal/e2e/go.mod
+++ b/confmap/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/internal/e2e
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/envprovider/go.mod
+++ b/confmap/provider/envprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/envprovider
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/fileprovider/go.mod
+++ b/confmap/provider/fileprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/fileprovider
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/httpprovider/go.mod
+++ b/confmap/provider/httpprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpprovider
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/httpsprovider/go.mod
+++ b/confmap/provider/httpsprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpsprovider
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/yamlprovider/go.mod
+++ b/confmap/provider/yamlprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/yamlprovider
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/xconfmap/go.mod
+++ b/confmap/xconfmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/xconfmap
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/connectortest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/forwardconnector
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/connector/xconnector/go.mod
+++ b/connector/xconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/xconnector
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/consumererror/go.mod
+++ b/consumer/consumererror/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumererror
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/consumererror/xconsumererror/go.mod
+++ b/consumer/consumererror/xconsumererror/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumererror/xconsumererror
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/consumertest/go.mod
+++ b/consumer/consumertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumertest
 
-go 1.22.0
+go 1.23.0
 
 replace go.opentelemetry.io/collector/consumer => ../
 

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/xconsumer/go.mod
+++ b/consumer/xconsumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/xconsumer
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/debugexporter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/exportertest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/nopexporter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlpexporter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlphttpexporter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/xexporter/go.mod
+++ b/exporter/xexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/xexporter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/auth/authtest/go.mod
+++ b/extension/auth/authtest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/auth/authtest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/auth/go.mod
+++ b/extension/auth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/auth
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensioncapabilities/go.mod
+++ b/extension/extensioncapabilities/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensioncapabilities
 
-go 1.22.0
+go 1.23.0
 
 require (
 	go.opentelemetry.io/collector/component v0.119.0

--- a/extension/extensiontest/go.mod
+++ b/extension/extensiontest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensiontest
 
-go 1.22.0
+go 1.23.0
 
 replace go.opentelemetry.io/collector/extension => ..
 

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/memorylimiterextension
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/xextension/go.mod
+++ b/extension/xextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/xextension
 
-go 1.22.0
+go 1.23.0
 
 require (
 	go.opentelemetry.io/collector/component v0.119.0

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/zpagesextension
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/featuregate/go.mod
+++ b/featuregate/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/featuregate
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/hashicorp/go-version v1.7.0

--- a/filter/go.mod
+++ b/filter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/filter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module go.opentelemetry.io/collector
 // For the OpenTelemetry Collector Core distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/e2e
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/fanoutconsumer/go.mod
+++ b/internal/fanoutconsumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/fanoutconsumer
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/memorylimiter/go.mod
+++ b/internal/memorylimiter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/memorylimiter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/shirou/gopsutil/v4 v4.25.1

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/sharedcomponent
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/telemetry/go.mod
+++ b/internal/telemetry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/telemetry
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/otelcol
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/spf13/cobra v1.8.1

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/otelcol/otelcoltest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pdata/go.mod
+++ b/pdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pdata/pprofile/go.mod
+++ b/pdata/pprofile/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/pprofile
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/json-iterator/go v1.1.12

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/testdata
 
-go 1.22.0
+go 1.23.0
 
 require (
 	go.opentelemetry.io/collector/pdata v1.25.0

--- a/pipeline/go.mod
+++ b/pipeline/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pipeline
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pipeline/xpipeline/go.mod
+++ b/pipeline/xpipeline/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pipeline/xpipeline
 
-go 1.22.0
+go 1.23.0
 
 require go.opentelemetry.io/collector/pipeline v0.119.0
 

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/batchprocessor
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/memorylimiterprocessor
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/processorhelper/xprocessorhelper/go.mod
+++ b/processor/processorhelper/xprocessorhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processortest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/xprocessor/go.mod
+++ b/processor/xprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/xprocessor
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/nopreceiver
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/otlpreceiver
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/receivertest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/receiver/xreceiver/go.mod
+++ b/receiver/xreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/xreceiver
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     "dependencies"
   ],
   "constraints": {
-    "go": "1.22"
+    "go": "1.23"
   },
   "extends": [
     "config:recommended"

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/scraper/scraperhelper/go.mod
+++ b/scraper/scraperhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/scraperhelper
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/scraper/scrapertest/go.mod
+++ b/scraper/scrapertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/scrapertest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/semconv/go.mod
+++ b/semconv/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/semconv
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/hashicorp/go-version v1.7.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/service
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
With the release of 1.24, we need to bump the tested versions.
