### PR TITLE
[chore] Enable `generate-contrib` step in `check-contrib`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ generate-contrib:
 	@echo -e "\nGenerating files in contrib"
 	$(MAKE) -C $(CONTRIB_PATH) -B install-tools
 	$(MAKE) -C $(CONTRIB_PATH) generate
-	$(MAKE) -C $(CONTRIB_PATH) gofmt
+	$(MAKE) -C $(CONTRIB_PATH) gofmt GROUP=all
 
 # Restores contrib to its original state after running check-contrib.
 .PHONY: restore-contrib

--- a/Makefile
+++ b/Makefile
@@ -283,8 +283,7 @@ check-contrib:
 generate-contrib:
 	@echo -e "\nGenerating files in contrib"
 	$(MAKE) -C $(CONTRIB_PATH) -B install-tools
-	$(MAKE) -C $(CONTRIB_PATH) generate
-	$(MAKE) -C $(CONTRIB_PATH) gofmt GROUP=all
+	$(MAKE) -C $(CONTRIB_PATH) generate GROUP=all
 
 # Restores contrib to its original state after running check-contrib.
 .PHONY: restore-contrib

--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,8 @@ check-contrib:
 		$(addprefix -replace ,$(join $(ALL_MOD_PATHS:%=go.opentelemetry.io/collector%=),$(ALL_MOD_PATHS:%=$(CURDIR)%)))"
 	@$(MAKE) -j2 -C $(CONTRIB_PATH) gotidy
 
+	@$(MAKE) generate-contrib
+
 	@echo -e "\nRunning tests"
 	@$(MAKE) -C $(CONTRIB_PATH) gotest
 
@@ -281,7 +283,7 @@ check-contrib:
 generate-contrib:
 	@echo -e "\nGenerating files in contrib"
 	$(MAKE) -C $(CONTRIB_PATH) -B install-tools
-	$(MAKE) -C $(CONTRIB_PATH) generate GROUP=all
+	$(MAKE) -C $(CONTRIB_PATH) generate
 
 # Restores contrib to its original state after running check-contrib.
 .PHONY: restore-contrib

--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,7 @@ generate-contrib:
 	@echo -e "\nGenerating files in contrib"
 	$(MAKE) -C $(CONTRIB_PATH) -B install-tools
 	$(MAKE) -C $(CONTRIB_PATH) generate
+	$(MAKE) -C $(CONTRIB_PATH) gofmt
 
 # Restores contrib to its original state after running check-contrib.
 .PHONY: restore-contrib


### PR DESCRIPTION
#### Description

This PR enables the `make generate-contrib` step in `make check-contrib` originally introduced in #11670, which allows testing the latest version of the mdatagen against contrib. It had been disabled as initial remediation against #11795, which has since been resolved by making `make gotidy` on contrib tidy modules in topological order.

#### Link to tracking issue
Fixes #11167

#### Testing
Modifying `mdatagen` locally to crash on startup causes `make check-contrib` to fail.