### PR TITLE
[chore] Add fmt step to mdatagen-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,6 +444,7 @@ builder-integration-test: $(ENVSUBST)
 mdatagen-test:
 	cd cmd/mdatagen && $(GOCMD) install .
 	cd cmd/mdatagen && $(GOCMD) generate ./...
+	cd cmd/mdatagen && $(MAKE) fmt
 	cd cmd/mdatagen && $(GOCMD) test ./...
 
 .PHONY: generate-gh-issue-templates


### PR DESCRIPTION
#### Description

Not sure if anyone is actually using `make mdatagen-test`, but it is failing on main because of missing imports. This is because `mdatagen` does not work without a subsequent `goimports` pass. This PR adds a `make fmt` step to make it pass again.
