### PR TITLE
[chore] Use public Linux ARM64 runners

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -24,7 +24,7 @@ jobs:
   arm-unittest-matrix:
     strategy:
       matrix:
-        os: [otel-linux-arm64, macos-14]
+        os: [ubuntu-22.04-arm, macos-14]
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
#### Description

Switches Linux ARM64 runners to the public version.

#### Link to tracking issue
Handles https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/


<!--Describe what testing was performed and which tests were added.-->
#### Testing

CI

## Notes

Already done in .NET, .NET Auto and rust. It will allow to remove private runners from otel org and execute whole pipeline on public forks.