### PR TITLE
[service] fix v0.2.0 to v0.3.0 conversion bug

### DIFF
--- a/.chloggen/codeboten_bump-config-pkg.yaml
+++ b/.chloggen/codeboten_bump-config-pkg.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix crash at startup when converting from v0.2.0 to v0.3.0
+
+# One or more tracking issues or pull requests related to the change
+issues: [12438]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -391,6 +391,7 @@ func TestCollectorRun(t *testing.T) {
 	}{
 		{file: "otelcol-noreaders.yaml"},
 		{file: "otelcol-emptyreaders.yaml"},
+		{file: "otelcol-multipleheaders.yaml"},
 	}
 
 	for _, tt := range tests {

--- a/otelcol/testdata/otelcol-multipleheaders.yaml
+++ b/otelcol/testdata/otelcol-multipleheaders.yaml
@@ -1,0 +1,24 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  telemetry:
+    metrics:
+      level: none
+    logs:
+      processors:
+      - batch:
+          exporter:
+            otlp:
+              endpoint: localhost:4318
+              headers:
+                first: val1
+                second: val2
+              protocol: http/protobuf
+  pipelines:
+    metrics:
+      receivers: [nop]
+      exporters: [nop]

--- a/otelcol/testdata/otelcol-multipleheaders.yaml
+++ b/otelcol/testdata/otelcol-multipleheaders.yaml
@@ -8,7 +8,7 @@ service:
   telemetry:
     metrics:
       level: none
-    logs:
+    traces:
       processors:
       - batch:
           exporter:

--- a/service/telemetry/internal/migration/testdata/v0.2.0_metrics.yaml
+++ b/service/telemetry/internal/migration/testdata/v0.2.0_metrics.yaml
@@ -7,6 +7,7 @@ readers:
           endpoint: 127.0.0.1:4317
           headers:
             "key1": "value1"
+            "key2": "value2"
   - pull:
       exporter:
         prometheus:

--- a/service/telemetry/internal/migration/v0.2.0.go
+++ b/service/telemetry/internal/migration/v0.2.0.go
@@ -37,7 +37,7 @@ type logsConfigV020 struct {
 }
 
 func headersV02ToV03(in configv02.Headers) []config.NameStringValuePair {
-	var headers []config.NameStringValuePair
+	headers := make([]config.NameStringValuePair, 0, len(in))
 	for k, v := range in {
 		headers = append(headers, config.NameStringValuePair{
 			Name:  k,

--- a/service/telemetry/internal/migration/v0.2.0.go
+++ b/service/telemetry/internal/migration/v0.2.0.go
@@ -37,13 +37,12 @@ type logsConfigV020 struct {
 }
 
 func headersV02ToV03(in configv02.Headers) []config.NameStringValuePair {
-	headers := make([]config.NameStringValuePair, len(in))
-	idx := 0
+	var headers []config.NameStringValuePair
 	for k, v := range in {
-		headers[idx] = config.NameStringValuePair{
+		headers = append(headers, config.NameStringValuePair{
 			Name:  k,
 			Value: &v,
-		}
+		})
 	}
 	return headers
 }

--- a/service/telemetry/internal/migration/v0.2.0_test.go
+++ b/service/telemetry/internal/migration/v0.2.0_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/confmap/confmaptest"
 	config "go.opentelemetry.io/contrib/config/v0.3.0"
+
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 
 func TestUnmarshalLogsConfigV020(t *testing.T) {

--- a/service/telemetry/internal/migration/v0.2.0_test.go
+++ b/service/telemetry/internal/migration/v0.2.0_test.go
@@ -66,3 +66,4 @@ func TestUnmarshalMetricsConfigV020(t *testing.T) {
 
 func ptr[T any](v T) *T {
 	return &v
+}

--- a/service/telemetry/internal/migration/v0.2.0_test.go
+++ b/service/telemetry/internal/migration/v0.2.0_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	config "go.opentelemetry.io/contrib/config/v0.3.0"
 
 	"go.opentelemetry.io/collector/confmap/confmaptest"

--- a/service/telemetry/internal/migration/v0.2.0_test.go
+++ b/service/telemetry/internal/migration/v0.2.0_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+	config "go.opentelemetry.io/contrib/config/v0.3.0"
 )
 
 func TestUnmarshalLogsConfigV020(t *testing.T) {
@@ -47,4 +48,9 @@ func TestUnmarshalMetricsConfigV020(t *testing.T) {
 	require.Len(t, cfg.Readers, 2)
 	// check the endpoint is prefixed w/ http
 	require.Equal(t, "http://127.0.0.1:4317", *cfg.Readers[0].Periodic.Exporter.OTLP.Endpoint)
+	require.ElementsMatch(t, []config.NameStringValuePair{{Name: "key1", Value: ptr("value1")}, {Name: "key2", Value: ptr("value2")}}, cfg.Readers[0].Periodic.Exporter.OTLP.Headers)
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }


### PR DESCRIPTION
Converting headers from config schema v0.2.0 to v0.3.0 was causing a nil dereferencing issue by incorrectly setting the name/value pair to a nil pointer. Added a test in both the loading of the config in otelcol, as well as the migration code unit test.

Fixes #12439 