### PR TITLE
[chore] Update release schedule

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -236,8 +236,6 @@ Once a module is ready to be released under the `1.x` version scheme, file a PR 
 
 | Date       | Version  | Release manager                                   |
 |------------|----------|---------------------------------------------------|
-| 2025-02-03 | v0.119.0 | [@bogdandrutu](https://github.com/bogdandrutu)    |
-| 2025-02-17 | v0.120.0 | [@jpkrohling](https://github.com/jpkrohling)      |
 | 2025-03-03 | v0.121.0 | [@mx-psi](https://github.com/mx-psi)              |
 | 2025-03-17 | v0.122.0 | [@evan-bradley](https://github.com/evan-bradley)  |
 | 2025-03-31 | v0.123.0 | [@TylerHelmuth](https://github.com/TylerHelmuth)  |
@@ -245,3 +243,5 @@ Once a module is ready to be released under the `1.x` version scheme, file a PR 
 | 2025-04-28 | v0.125.0 | [@songy23](https://github.com/songy23)            |
 | 2025-05-12 | v0.126.0 | [@dmitryax](https://github.com/dmitryax)          |
 | 2025-05-26 | v0.127.0 | [@codeboten](https://github.com/codeboten)        |
+| 2025-06-09 | v0.128.0 | [@bogdandrutu](https://github.com/bogdandrutu)    |
+| 2025-06-30 | v0.129.0 | [@jpkrohling](https://github.com/jpkrohling)      |


### PR DESCRIPTION
Note the 3-week window between .128 and .129, as we'll likely have OTel Community Day on the week of June 23. An alternative to that is to have the release on June 23 and assign to someone who knows already that they won't be there anyway.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
