### PR TITLE
Remove deprecated NewNopSettings functions

### DIFF
--- a/.chloggen/removing-deprecated-newnopsettings.yaml
+++ b/.chloggen/removing-deprecated-newnopsettings.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: connector, exporter, extension, processor, receiver, scraper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `NewNopSettings` functions
+
+# One or more tracking issues or pull requests related to the change
+issues: [12305]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/connector/connectortest/connector.go
+++ b/connector/connectortest/connector.go
@@ -19,12 +19,6 @@ import (
 
 var NopType = component.MustNewType("nop")
 
-// NewNopSettings returns a new nop settings for Create* functions.
-// Deprecated: [v0.120.0] Use NewNopSettingsWithType instead.
-func NewNopSettings() connector.Settings {
-	return NewNopSettingsWithType(NopType)
-}
-
 // NewNopSettingsWithType returns a new nop settings for Create* functions with the given type.
 func NewNopSettingsWithType(typ component.Type) connector.Settings {
 	return connector.Settings{

--- a/exporter/exportertest/nop_exporter.go
+++ b/exporter/exportertest/nop_exporter.go
@@ -17,12 +17,6 @@ import (
 
 var NopType = component.MustNewType("nop")
 
-// NewNopSettings returns a new nop settings for Create* functions.
-// Deprecated: [v0.120.0] Use NewNopSettingsWithType instead.
-func NewNopSettings() exporter.Settings {
-	return NewNopSettingsWithType(NopType)
-}
-
 // NewNopSettingsWithType returns a new nop settings for Create* functions with the given type.
 func NewNopSettingsWithType(typ component.Type) exporter.Settings {
 	return exporter.Settings{

--- a/extension/extensiontest/nop_extension.go
+++ b/extension/extensiontest/nop_extension.go
@@ -16,12 +16,6 @@ import (
 // NopType is the type of the nop extension.
 var NopType = component.MustNewType("nop")
 
-// NewNopSettings returns a new nop settings for extension.Factory Create* functions.
-// Deprecated: [v0.120.0] Use NewNopSettingsWithType(NopType) instead.
-func NewNopSettings() extension.Settings {
-	return NewNopSettingsWithType(NopType)
-}
-
 // NewNopSettings returns a new nop settings for extension.Factory Create* functions with the given type.
 func NewNopSettingsWithType(ty component.Type) extension.Settings {
 	return extension.Settings{

--- a/processor/processortest/nop_processor.go
+++ b/processor/processortest/nop_processor.go
@@ -17,12 +17,6 @@ import (
 
 var NopType = component.MustNewType("nop")
 
-// NewNopSettings returns a new nop settings for Create* functions.
-// Deprecated: [v0.120.0] Use NewNopSettingsWithType instead.
-func NewNopSettings() processor.Settings {
-	return NewNopSettingsWithType(NopType)
-}
-
 // NewNopSettingsWithType returns a new nop settings for Create* functions with the given type.
 func NewNopSettingsWithType(typ component.Type) processor.Settings {
 	return processor.Settings{

--- a/receiver/receivertest/nop_receiver.go
+++ b/receiver/receivertest/nop_receiver.go
@@ -18,12 +18,6 @@ import (
 
 var NopType = component.MustNewType("nop")
 
-// NewNopSettings returns a new nop settings for Create*Receiver functions.
-// Deprecated: [v0.120.0] Use NewNopSettingsWithType instead.
-func NewNopSettings() receiver.Settings {
-	return NewNopSettingsWithType(NopType)
-}
-
 // NewNopSettingsWithType returns a new nop settings for Create*Receiver functions with the given type.
 func NewNopSettingsWithType(typ component.Type) receiver.Settings {
 	return receiver.Settings{

--- a/scraper/scrapertest/settings.go
+++ b/scraper/scrapertest/settings.go
@@ -13,12 +13,6 @@ import (
 
 var NopType = component.MustNewType("nop")
 
-// NewNopSettings returns a new nop scraper.Settings.
-// Deprecated: [v0.120.0] Use NewNopSettingsWithType(NopType) instead.
-func NewNopSettings() scraper.Settings {
-	return NewNopSettingsWithType(NopType)
-}
-
 // NewNopSettings returns a new nop scraper.Settings with the given type.
 func NewNopSettingsWithType(typ component.Type) scraper.Settings {
 	return scraper.Settings{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR removes deprecated `NewNopSettings` functions which are missing in #12421 

cc @mx-psi 
<!-- Issue number if applicable -->
#### Link to tracking issue
Relevant to #12305 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
n/a

<!--Describe the documentation added.-->
#### Documentation
n/a

<!--Please delete paragraphs that you did not use before submitting.-->
