### PR TITLE
[mdatagen] fix missing resource attributes import in metrics template

### DIFF
--- a/.chloggen/mdatagen-fix.yaml
+++ b/.chloggen/mdatagen-fix.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds back missing import for filter when emitting resource attributes
+
+# One or more tracking issues or pull requests related to the change
+issues: [12455]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -18,6 +18,9 @@ import (
 	{{- if .SemConvVersion }}
 	conventions "go.opentelemetry.io/collector/semconv/v{{ .SemConvVersion }}"
 	{{- end }}
+	{{ if .ResourceAttributes -}}
+	"go.opentelemetry.io/collector/filter"
+	{{- end }}
 )
 
 {{ range $name, $info := .Attributes }}


### PR DESCRIPTION
#### Description

Re-adds the missing import for the `ResourceAttributes` for metrics generation. This impacts receivers that emit resource attributes. Filter is still within the template code for resource attributes, but not imported.

#### Link to tracking issue
Fixes #12455

