### PR TITLE
POC for how to avoid duplicating WithStart and WithShutdown

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -77,6 +77,41 @@ func (f ShutdownFunc) Shutdown(ctx context.Context) error {
 	return f(ctx)
 }
 
+type baseComponent struct {
+	StartFunc
+	ShutdownFunc
+}
+
+type Option interface {
+	apply(bc *baseComponent)
+}
+
+type optionFunc func(*baseComponent)
+
+func (of optionFunc) apply(bc *baseComponent) {
+	of(bc)
+}
+
+func WithStartFunc(start StartFunc) Option {
+	return optionFunc(func(o *baseComponent) {
+		o.StartFunc = start
+	})
+}
+
+func WithShutdownFunc(shutdown ShutdownFunc) Option {
+	return optionFunc(func(o *baseComponent) {
+		o.ShutdownFunc = shutdown
+	})
+}
+
+func NewComponent(opts ...Option) Component {
+	bc := baseComponent{}
+	for _, opt := range opts {
+		opt.apply(&bc)
+	}
+	return bc
+}
+
 // Kind represents component kinds.
 type Kind struct {
 	name string

--- a/processor/processorhelper/logs.go
+++ b/processor/processorhelper/logs.go
@@ -21,8 +21,7 @@ import (
 type ProcessLogsFunc func(context.Context, plog.Logs) (plog.Logs, error)
 
 type logs struct {
-	component.StartFunc
-	component.ShutdownFunc
+	component.Component
 	consumer.Logs
 }
 
@@ -70,8 +69,7 @@ func NewLogs(
 	}
 
 	return &logs{
-		StartFunc:    bs.StartFunc,
-		ShutdownFunc: bs.ShutdownFunc,
-		Logs:         logsConsumer,
+		Component: component.NewComponent(bs.componentOptions...),
+		Logs:      logsConsumer,
 	}, nil
 }

--- a/processor/processorhelper/metrics.go
+++ b/processor/processorhelper/metrics.go
@@ -21,8 +21,7 @@ import (
 type ProcessMetricsFunc func(context.Context, pmetric.Metrics) (pmetric.Metrics, error)
 
 type metrics struct {
-	component.StartFunc
-	component.ShutdownFunc
+	component.Component
 	consumer.Metrics
 }
 
@@ -70,8 +69,7 @@ func NewMetrics(
 	}
 
 	return &metrics{
-		StartFunc:    bs.StartFunc,
-		ShutdownFunc: bs.ShutdownFunc,
-		Metrics:      metricsConsumer,
+		Component: component.NewComponent(bs.componentOptions...),
+		Metrics:   metricsConsumer,
 	}, nil
 }

--- a/processor/processorhelper/processor.go
+++ b/processor/processorhelper/processor.go
@@ -32,20 +32,22 @@ func (of optionFunc) apply(e *baseSettings) {
 	of(e)
 }
 
-// WithStart overrides the default Start function for an processor.
-// The default shutdown function does nothing and always returns nil.
-func WithStart(start component.StartFunc) Option {
-	return optionFunc(func(o *baseSettings) {
-		o.StartFunc = start
+// WithComponentOptions overrides the default component (start/shutdown) functions for a processor.
+// The default functions do nothing and always returns nil.
+func WithComponentOptions(option ...component.Option) Option {
+	return optionFunc(func(e *baseSettings) {
+		e.componentOptions = append(e.componentOptions, option...)
 	})
 }
 
-// WithShutdown overrides the default Shutdown function for an processor.
-// The default shutdown function does nothing and always returns nil.
+// Deprecated: [v0.121.0] use WithComponentOptions.
+func WithStart(start component.StartFunc) Option {
+	return WithComponentOptions(component.WithStartFunc(start))
+}
+
+// Deprecated: [v0.121.0] use WithComponentOptions.
 func WithShutdown(shutdown component.ShutdownFunc) Option {
-	return optionFunc(func(o *baseSettings) {
-		o.ShutdownFunc = shutdown
-	})
+	return WithComponentOptions(component.WithShutdownFunc(shutdown))
 }
 
 // WithCapabilities overrides the default GetCapabilities function for an processor.
@@ -57,9 +59,8 @@ func WithCapabilities(capabilities consumer.Capabilities) Option {
 }
 
 type baseSettings struct {
-	component.StartFunc
-	component.ShutdownFunc
-	consumerOptions []consumer.Option
+	componentOptions []component.Option
+	consumerOptions  []consumer.Option
 }
 
 // fromOptions returns the internal settings starting from the default and applying all options.

--- a/processor/processorhelper/traces.go
+++ b/processor/processorhelper/traces.go
@@ -21,8 +21,7 @@ import (
 type ProcessTracesFunc func(context.Context, ptrace.Traces) (ptrace.Traces, error)
 
 type traces struct {
-	component.StartFunc
-	component.ShutdownFunc
+	component.Component
 	consumer.Traces
 }
 
@@ -70,8 +69,7 @@ func NewTraces(
 	}
 
 	return &traces{
-		StartFunc:    bs.StartFunc,
-		ShutdownFunc: bs.ShutdownFunc,
-		Traces:       traceConsumer,
+		Component: component.NewComponent(bs.componentOptions...),
+		Traces:    traceConsumer,
 	}, nil
 }


### PR DESCRIPTION
This way, we allow in the future to add more options in the component that will automatically be picked by every component implementation, as well as we remove duplicate definition.