### PR TITLE
Enhance config validation by Instantiating `service` during dryrun.

### DIFF
--- a/.chloggen/enhance_config-validation.yaml
+++ b/.chloggen/enhance_config-validation.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otelcol
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enhance config validation using <validate> command to capture all validation errors that prevents the collector from starting."
+
+# One or more tracking issues or pull requests related to the change
+issues: [8721]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -175,9 +175,7 @@ func (col *Collector) createService(ctx context.Context, cfg *Config, factories 
 
 	conf := confmap.New()
 
-	if err := conf.Marshal(cfg); err != nil {
-		return nil, fmt.Errorf("could not marshal configuration: %w", err)
-	}
+	_ = conf.Marshal(cfg)
 
 	return service.New(ctx, service.Settings{
 		BuildInfo:     col.set.BuildInfo,

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -511,6 +511,14 @@ func TestCollectorDryRun(t *testing.T) {
 			},
 			expectedErr: `failed to build pipelines: connector "nop/connector1" used as exporter in [logs/in2] pipeline but not used in any supported receiver pipeline`,
 		},
+		"cyclic_connector": {
+			settings: CollectorSettings{
+				BuildInfo:              component.NewDefaultBuildInfo(),
+				Factories:              nopFactories,
+				ConfigProviderSettings: newDefaultConfigProviderSettings(t, []string{filepath.Join("testdata", "otelcol-cyclic-connector.yaml")}),
+			},
+			expectedErr: `failed to build pipelines: cycle detected: connector "nop/forward" (traces to traces) -> connector "nop/forward" (traces to traces)`,
+		},
 	}
 
 	for name, test := range tests {

--- a/otelcol/testdata/otelcol-cyclic-connector.yaml
+++ b/otelcol/testdata/otelcol-cyclic-connector.yaml
@@ -1,0 +1,19 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+connectors:
+  nop/forward:
+
+service:
+  pipelines:
+    traces/in:
+      receivers: [nop/forward]
+      processors: [ ]
+      exporters: [nop/forward]
+    traces/out:
+      receivers: [nop/forward]
+      processors: [ ]
+      exporters: [nop/forward]

--- a/otelcol/testdata/otelcol-invalid-connector-use.yaml
+++ b/otelcol/testdata/otelcol-invalid-connector-use.yaml
@@ -1,0 +1,23 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+connectors:
+  nop/connector1:
+
+service:
+  pipelines:
+    logs/in1:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop]
+    logs/in2:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop/connector1]
+    logs/out:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop]

--- a/otelcol/testdata/otelcol-valid-connector-use.yaml
+++ b/otelcol/testdata/otelcol-valid-connector-use.yaml
@@ -1,0 +1,23 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+connectors:
+  nop/connector1:
+
+service:
+  pipelines:
+    logs/in1:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop]
+    logs/in2:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop/connector1]
+    logs/out:
+      receivers: [nop/connector1]
+      processors: [ ]
+      exporters: [nop]

--- a/otelcol/unmarshal_dry_run_test.go
+++ b/otelcol/unmarshal_dry_run_test.go
@@ -71,6 +71,7 @@ func TestDryRunWithExpandedValues(t *testing.T) {
 			mockMap: map[string]string{
 				"number": "123",
 			},
+			expectErr: true,
 		},
 		{
 			name:       "string that looks like a bool",

--- a/service/service.go
+++ b/service/service.go
@@ -190,8 +190,6 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		return nil, fmt.Errorf("failed to create tracer provider: %w", err)
 	}
 
-	logger.Info("Setting up own telemetry...")
-
 	mp, err := telFactory.CreateMeterProvider(ctx, telset, &cfg.Telemetry)
 	if err != nil {
 		err = multierr.Append(err, sdk.Shutdown(ctx))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
As mentioned in https://github.com/open-telemetry/opentelemetry-collector/issues/8721#issuecomment-1775393905, we can surface configuration errors by instantiating the service during a dry run.

Expanding on this idea, this PR enhances configuration validation. The validate command will now capture all validation errors that would prevent the collector from starting.

<!-- Issue number if applicable -->
#### Link to the tracking issue
Fixes #8721

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit tests. Also, a few scenarios and example output are given below. I will add more unit tests if necessary.

**1. Improper Connector Use**
<details>
  <summary><strong>invalid_config.yaml</strong></summary>

```yaml
receivers:
  otlp:
    protocols:
      grpc:
exporters:
  debug:
connectors:
  forward:
service:
  pipelines:
    logs/in:
      receivers: [otlp]
      processors: []
      exporters: [forward]
    logs/in2:
      receivers: [ otlp ]
      processors: [ ]
      exporters: [ forward ]
    logs/out:
      receivers: [otlp]
      processors: []
      exporters: [debug]
    traces:
      receivers: [ otlp ]
      processors: [ ]
      exporters: [ forward ]
    metrics:
      receivers: [ forward ]
      processors: [ ]
      exporters: [ debug ]
```
</details>

**Before:** No error detected

**Proposed Change:**
```bash
Error: failed to build pipelines: connector "forward" used as exporter in [logs/in2 logs/in] pipeline but not used in any supported receiver pipeline
2025/02/25 16:58:09 collector server run finished with error: failed to build pipelines: connector "forward" used as exporter in [logs/in2 logs/in] pipeline but not used in any supported receiver pipeline

```

**2. Unused Connector**
<details>
  <summary><strong>invalid_config.yaml</strong></summary>

```yaml
receivers:
  otlp:
    protocols:
      grpc:
      http:
exporters:
  debug:
connectors:
  forward:
service:
  pipelines:
    logs/out:
      receivers: [forward]
      processors: []
      exporters: [debug]
```
</details>

**Before:** No error detected

**Proposed Change:**
```bash
Error: failed to build pipelines: connector "forward" used as receiver in [logs/out] pipeline but not used in any supported exporter pipeline
2025/02/26 10:40:53 collector server run finished with error: failed to build pipelines: connector "forward" used as receiver in [logs/out] pipeline but not used in any supported exporter pipeline

```

**2. Cycle in the Pipeline**
<details>
  <summary><strong>invalid_config.yaml</strong></summary>

```yaml
receivers:
  otlp:
    protocols:
      grpc:

exporters:
  debug:

connectors:
  forward:

service:
  pipelines:
    traces/in:
      receivers: [forward]
      processors: [ ]
      exporters: [forward]
    traces/out:
      receivers: [forward]
      processors: [ ]
      exporters: [forward]
```
</details>

**Before:** No error detected

**Proposed Change:**
```bash
Error: failed to build pipelines: cycle detected: connector "forward" (traces to traces) -> connector "forward" (traces to traces)
2025/02/26 11:12:53 collector server run finished with error: failed to build pipelines: cycle detected: connector "forward" (traces to traces) -> connector "forward" (traces to traces)

```

<!--Describe the documentation added.-->
#### Note
I removed the following log as it seemed redundant to me and it is also surfaced during validation. Let me know if we absolutely need to keep it
https://github.com/open-telemetry/opentelemetry-collector/blob/5812712eddc3c64f469c5e061872ab17d3dc4124/service/service.go#L193

<!--Please delete paragraphs that you did not use before submitting.-->
