### PR TITLE
[chore] remove cmd-1 contrib test group

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -36,7 +36,6 @@ jobs:
           - internal
           - pkg
           - cmd-0
-          - cmd-1
           - other
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Fix the build as cmd-1 is no longer used as a group for contrib tests.