### PR TITLE
[chore] Do not introduce pointers in the deprecated batcher fields

### DIFF
--- a/exporter/exporterbatcher/config.go
+++ b/exporter/exporterbatcher/config.go
@@ -42,13 +42,13 @@ type SizeConfig struct {
 // Deprecated: [v0.121.0] use SizeConfig.
 type MinSizeConfig struct {
 	// Deprecated: [v0.121.0] use SizeConfig.MinSize.
-	MinSizeItems *int `mapstructure:"min_size_items"`
+	MinSizeItems int `mapstructure:"min_size_items"`
 }
 
 // Deprecated: [v0.121.0] use SizeConfig.
 type MaxSizeConfig struct {
 	// Deprecated: [v0.121.0] use SizeConfig.MaxSize.
-	MaxSizeItems *int `mapstructure:"max_size_items"`
+	MaxSizeItems int `mapstructure:"max_size_items"`
 }
 
 func (c *Config) Unmarshal(conf *confmap.Conf) error {
@@ -56,12 +56,12 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 		return err
 	}
 
-	if c.MinSizeItems != nil {
-		c.SizeConfig.MinSize = *c.MinSizeItems
+	if conf.IsSet("min_size_items") {
+		c.SizeConfig.MinSize = c.MinSizeItems
 	}
 
-	if c.MaxSizeItems != nil {
-		c.SizeConfig.MaxSize = *c.MaxSizeItems
+	if conf.IsSet("max_size_items") {
+		c.SizeConfig.MaxSize = c.MaxSizeItems
 	}
 
 	return nil

--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -70,7 +70,7 @@ func NewBaseExporter(set exporter.Settings, signal pipeline.Signal, options ...O
 	}
 
 	//nolint: staticcheck
-	if be.batcherCfg.MinSizeItems != nil || be.batcherCfg.MaxSizeItems != nil {
+	if be.batcherCfg.MinSizeItems != 0 || be.batcherCfg.MaxSizeItems != 0 {
 		set.Logger.Warn("Using of deprecated fields `min_size_items` and `max_size_items`")
 	}
 


### PR DESCRIPTION
Do not introduce an unnecessary Go API breaking change.

Fixes contrib tests.

A follow-up to https://github.com/open-telemetry/opentelemetry-collector/pull/12486.