### PR TITLE
[chore][mdatagen] Remove telemetry::level from schema file

### DIFF
--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -133,8 +133,6 @@ tests:
 # Optional: map of metric names with the key being the metric name and value
 # being described below.
 telemetry:
-  # Optional: level allows components to specify the minimum telemetry level for metrics to be produced. defaults to basic if not set.
-  level: string
   metrics:
     <metric.name>:
       # Required: whether the metric is collected by default.


### PR DESCRIPTION
#### Description

The `telemetry::level` key in `metadata.yaml` wasn't used for anything, and support for it was dropped in #12144. However, it was never removed from the schema file. This PR fixes that.
