### PR TITLE
[service] Add `omitempty` tag to config fields

### DIFF
--- a/.chloggen/service-omitempty.yaml
+++ b/.chloggen/service-omitempty.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the `omitempty` mapstructure tag to struct fields
+
+# One or more tracking issues or pull requests related to the change
+issues: [12191]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This results in unset fields not being rendered when marshaling.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/service/config.go
+++ b/service/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	Telemetry telemetry.Config `mapstructure:"telemetry"`
 
 	// Extensions are the ordered list of extensions configured for the service.
-	Extensions extensions.Config `mapstructure:"extensions"`
+	Extensions extensions.Config `mapstructure:"extensions,omitempty"`
 
 	// Pipelines are the set of data pipelines configured for the service.
 	Pipelines pipelines.Config `mapstructure:"pipelines"`

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -6,13 +6,16 @@ package service
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	config "go.opentelemetry.io/contrib/config/v0.3.0"
 	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/service/extensions"
@@ -86,6 +89,54 @@ func TestConfigValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfmapMarshalConfig(t *testing.T) {
+	telFactory := telemetry.NewFactory()
+	defaultTelConfig := *telFactory.CreateDefaultConfig().(*telemetry.Config)
+	conf := confmap.New()
+
+	require.NoError(t, conf.Marshal(Config{
+		Telemetry: defaultTelConfig,
+	}))
+	assert.Equal(t, map[string]any{
+		"pipelines": map[string]any{},
+		"telemetry": map[string]any{
+			"logs": map[string]any{
+				"encoding":           "console",
+				"level":              "info",
+				"error_output_paths": []any{"stderr"},
+				"output_paths":       []any{"stderr"},
+				"sampling": map[string]any{
+					"enabled":    true,
+					"initial":    10,
+					"thereafter": 100,
+					"tick":       10 * time.Second,
+				},
+			},
+			"metrics": map[string]any{
+				"level": "Normal",
+				"readers": []any{
+					map[string]any{
+						"pull": map[string]any{
+							"exporter": map[string]any{
+								"prometheus": map[string]any{
+									"host": "localhost",
+									"port": 8888,
+									"with_resource_constant_labels": map[string]any{
+										"included": []any(nil),
+									},
+									"without_scope_info":  true,
+									"without_type_suffix": true,
+									"without_units":       true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, conf.ToStringMap())
 }
 
 func generateConfig() *Config {

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -30,13 +30,13 @@ var disableAddressFieldForInternalTelemetryFeatureGate = featuregate.GlobalRegis
 type Config struct {
 	Logs    LogsConfig    `mapstructure:"logs"`
 	Metrics MetricsConfig `mapstructure:"metrics"`
-	Traces  TracesConfig  `mapstructure:"traces"`
+	Traces  TracesConfig  `mapstructure:"traces,omitempty"`
 
 	// Resource specifies user-defined attributes to include with all emitted telemetry.
 	// Note that some attributes are added automatically (e.g. service.version) even
 	// if they are not specified here. In order to suppress such attributes the
 	// attribute must be specified in this map with null YAML value (nil string pointer).
-	Resource map[string]*string `mapstructure:"resource"`
+	Resource map[string]*string `mapstructure:"resource,omitempty"`
 }
 
 // LogsConfig defines the configurable settings for service telemetry logs.

--- a/service/telemetry/internal/migration/v0.3.0.go
+++ b/service/telemetry/internal/migration/v0.3.0.go
@@ -68,7 +68,7 @@ type MetricsConfigV030 struct {
 	Level configtelemetry.Level `mapstructure:"level"`
 
 	// Deprecated: [v0.111.0] use readers configuration.
-	Address string `mapstructure:"address"`
+	Address string `mapstructure:"address,omitempty"`
 
 	// Readers allow configuration of metric readers to emit metrics to
 	// any number of supported backends.
@@ -110,7 +110,7 @@ type LogsConfigV030 struct {
 	// Development puts the logger in development mode, which changes the
 	// behavior of DPanicLevel and takes stacktraces more liberally.
 	// (default = false)
-	Development bool `mapstructure:"development"`
+	Development bool `mapstructure:"development,omitempty"`
 
 	// Encoding sets the logger's encoding.
 	// Example values are "json", "console".
@@ -119,13 +119,13 @@ type LogsConfigV030 struct {
 	// DisableCaller stops annotating logs with the calling function's file
 	// name and line number. By default, all logs are annotated.
 	// (default = false)
-	DisableCaller bool `mapstructure:"disable_caller"`
+	DisableCaller bool `mapstructure:"disable_caller,omitempty"`
 
 	// DisableStacktrace completely disables automatic stacktrace capturing. By
 	// default, stacktraces are captured for WarnLevel and above logs in
 	// development and ErrorLevel and above in production.
 	// (default = false)
-	DisableStacktrace bool `mapstructure:"disable_stacktrace"`
+	DisableStacktrace bool `mapstructure:"disable_stacktrace,omitempty"`
 
 	// Sampling sets a sampling policy.
 	// Default:
@@ -164,11 +164,11 @@ type LogsConfigV030 struct {
 	//	   		foo: "bar"
 	//
 	// By default, there is no initial field.
-	InitialFields map[string]any `mapstructure:"initial_fields"`
+	InitialFields map[string]any `mapstructure:"initial_fields,omitempty"`
 
 	// Processors allow configuration of log record processors to emit logs to
-	// any number of suported backends.
-	Processors []config.LogRecordProcessor `mapstructure:"processors"`
+	// any number of supported backends.
+	Processors []config.LogRecordProcessor `mapstructure:"processors,omitempty"`
 }
 
 // LogsSamplingConfig sets a sampling strategy for the logger. Sampling caps the


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Update config structs in the service module to include `omitempty` tags.

<!-- Issue number if applicable -->
#### Link to tracking issue
Works toward https://github.com/open-telemetry/opentelemetry-collector/issues/12191