### PR TITLE
[chore] [exporterhelper/batcher] Ignore deprecated fields if new set

### DIFF
--- a/exporter/exporterbatcher/config.go
+++ b/exporter/exporterbatcher/config.go
@@ -56,11 +56,11 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 		return err
 	}
 
-	if c.MinSizeItems != nil {
+	if c.MinSizeItems != nil && !conf.IsSet("min_size") {
 		c.SizeConfig.MinSize = *c.MinSizeItems
 	}
 
-	if c.MaxSizeItems != nil {
+	if c.MaxSizeItems != nil && !conf.IsSet("max_size") {
 		c.SizeConfig.MaxSize = *c.MaxSizeItems
 	}
 

--- a/exporter/exporterbatcher/config_test.go
+++ b/exporter/exporterbatcher/config_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/confmap"
 )
 
 func TestValidateConfig(t *testing.T) {
@@ -39,4 +41,73 @@ func TestValidateSizeConfig(t *testing.T) {
 		MinSize: 200,
 	}
 	require.EqualError(t, cfg.Validate(), "`max_size` must be greater than or equal to mix_size")
+}
+
+func TestUnmarshalDeprecatedFields(t *testing.T) {
+	p111 := 111
+	p222 := 222
+	tests := []struct {
+		name     string
+		input    map[string]any
+		expected Config
+	}{
+		{
+			name: "only_deprecated_fields_used",
+			input: map[string]any{
+				"enabled":        true,
+				"flush_timeout":  200,
+				"min_size_items": 111,
+				"max_size_items": 222,
+			},
+			expected: Config{
+				Enabled:      true,
+				FlushTimeout: 200,
+				SizeConfig: SizeConfig{
+					Sizer:   SizerTypeItems,
+					MinSize: 111,
+					MaxSize: 222,
+				},
+				MinSizeConfig: MinSizeConfig{
+					MinSizeItems: &p111,
+				},
+				MaxSizeConfig: MaxSizeConfig{
+					MaxSizeItems: &p222,
+				},
+			},
+		},
+		{
+			name: "both_new_and_deprecated_fields_used",
+			input: map[string]any{
+				"enabled":        true,
+				"flush_timeout":  200,
+				"min_size_items": 111,
+				"max_size_items": 222,
+				"min_size":       11,
+				"max_size":       22,
+			},
+			expected: Config{
+				Enabled:      true,
+				FlushTimeout: 200,
+				SizeConfig: SizeConfig{
+					Sizer:   SizerTypeItems,
+					MinSize: 11,
+					MaxSize: 22,
+				},
+				MinSizeConfig: MinSizeConfig{
+					MinSizeItems: &p111,
+				},
+				MaxSizeConfig: MaxSizeConfig{
+					MaxSizeItems: &p222,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := NewDefaultConfig()
+			require.NoError(t, cfg.Unmarshal(confmap.NewFromStringMap(test.input)))
+			require.Equal(t, test.expected, cfg)
+			require.NoError(t, cfg.Validate())
+		})
+	}
 }


### PR DESCRIPTION
In the batcher config, ignore deprecated `min_size_items` and `max_size_items` fields if new `min_size` and `max_size` are set.

A follow-up to https://github.com/open-telemetry/opentelemetry-collector/pull/12486.
