### PR TITLE
[chore][cmd/builder] Improve main.go template formatting

### DIFF
--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -45,16 +45,17 @@ func main() {
 				DefaultScheme: "{{ .ConfResolver.DefaultURIScheme }}",
 				{{- end }}
 			},
-		}, ProviderModules: map[string]string{
+		},
+		ProviderModules: map[string]string{
 			{{- range .ConfmapProviders}}
 			{{.Name}}.NewFactory().Create(confmap.ProviderSettings{}).Scheme(): "{{.GoMod}}",
 			{{- end}}
-    }, ConverterModules: []string{
-		  {{- range .ConfmapConverters}}
+    	},
+		ConverterModules: []string{
+			{{- range .ConfmapConverters}}
 			"{{.GoMod}}",
 			{{- end}}
 		},
-
 	}
 
 	if err := run(set); err != nil {

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -36,13 +36,15 @@ func main() {
 					yamlprovider.NewFactory(),
 				},
 			},
-		}, ProviderModules: map[string]string{
+		},
+		ProviderModules: map[string]string{
 			envprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():   "go.opentelemetry.io/collector/confmap/provider/envprovider v1.26.0",
 			fileprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/fileprovider v1.26.0",
 			httpprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/httpprovider v1.26.0",
 			httpsprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme(): "go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.26.0",
 			yamlprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.26.0",
-		}, ConverterModules: []string{},
+		},
+		ConverterModules: []string{},
 	}
 
 	if err := run(set); err != nil {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Puts the keys in `ConfigProviderSettings` to all be on their own lines like the other keys in the struct.