### PR TITLE
[component] Add namespace parameter to component.BuildInfo

### DIFF
--- a/.chloggen/dakotapaasman_bpop-2116-configurable-servicenamespace-value-in-ocb.yaml
+++ b/.chloggen/dakotapaasman_bpop-2116-configurable-servicenamespace-value-in-ocb.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add namespace field to component.BuildInfo to support service.namespace semantic convention
+
+# One or more tracking issues or pull requests related to the change
+issues: [12505]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -9,6 +9,7 @@ $ go install go.opentelemetry.io/collector/cmd/builder@v0.109.0
 $ cat > otelcol-builder.yaml <<EOF
 dist:
   name: otelcol-custom
+  namespace: opentelemetry-custom
   description: Local OpenTelemetry Collector binary
   output_path: /tmp/dist
 exporters:
@@ -58,13 +59,14 @@ $ /tmp/dist/otelcol-custom --config=/tmp/otelcol.yaml
 ## Installation
 
 There are three supported ways to install the builder:
+
 1. Via official release Docker images (recommended)
 2. Via official release binaries (recommended)
 3. Through `go install` (not recommended)
 
 ### Official release Docker image
 
-You will find the official docker images at [DockerHub](https://hub.docker.com/r/otel/opentelemetry-collector-builder). 
+You will find the official docker images at [DockerHub](https://hub.docker.com/r/otel/opentelemetry-collector-builder).
 
 Pull the image via tagged version number (e.g. v0.110.0) or 'latest'. You may also specify platform, although Docker will handle this automatically as it is a multi-platform build.
 
@@ -80,9 +82,9 @@ Assuming you are running this image in your working directory, have a `builder-c
 docker run -v "$(pwd)/builder-config.yaml:/build/builder-config.yaml" -v "$(pwd)/output:/build/otelcol-dev" otel/opentelemetry-collector-builder:latest
 ```
 
-Additional arguments may be passed to ocb on the command line as specified below, but if you wish to do this, you must make sure to pass the `--config` argument, as this is specified as an additional `CMD`, not an entrypoint. 
+Additional arguments may be passed to ocb on the command line as specified below, but if you wish to do this, you must make sure to pass the `--config` argument, as this is specified as an additional `CMD`, not an entrypoint.
 
-### Official release binaries 
+### Official release binaries
 
 This is the recommended installation method for the binary. Download the binary for your respective platform from the ["Releases"](https://github.com/open-telemetry/opentelemetry-collector-releases/releases?q=cmd/builder) page.
 
@@ -116,7 +118,7 @@ Use `ocb --help` to learn about which flags are available.
 
 By default, the LDflags are set to `-s -w`, which strips debugging symbols to produce a smaller OpenTelemetry Collector binary. To retain debugging symbols and DWARF debugging data in the binary, override the LDflags as shown:
 
-```console 
+```console
 ocb --ldflags="" --config=builder-config.yaml.
 ```
 
@@ -154,13 +156,14 @@ Optionally, a list of `go mod` replace entries can be provided, in case custom o
 
 ```yaml
 dist:
-    module: github.com/open-telemetry/opentelemetry-collector # the module name for the new distribution, following Go mod conventions. Optional, but recommended.
-    name: otelcol-custom # the binary name. Optional.
-    description: "Custom OpenTelemetry Collector distribution" # a long name for the application. Optional.
-    output_path: /tmp/otelcol-distributionNNN # the path to write the output (sources and binary). Optional.
-    version: "1.0.0" # the version for your custom OpenTelemetry Collector. Optional.
-    go: "/usr/bin/go" # which Go binary to use to compile the generated sources. Optional.
-    debug_compilation: false # enabling this causes the builder to keep the debug symbols in the resulting binary. Optional.
+  module: github.com/open-telemetry/opentelemetry-collector # the module name for the new distribution, following Go mod conventions. Optional, but recommended.
+  name: otelcol-custom # the binary name. Optional.
+  namespace: opentelemetry-custom # the "service.namespace" semantic convention value. Optional.
+  description: "Custom OpenTelemetry Collector distribution" # a long name for the application. Optional.
+  output_path: /tmp/otelcol-distributionNNN # the path to write the output (sources and binary). Optional.
+  version: "1.0.0" # the version for your custom OpenTelemetry Collector. Optional.
+  go: "/usr/bin/go" # which Go binary to use to compile the generated sources. Optional.
+  debug_compilation: false # enabling this causes the builder to keep the debug symbols in the resulting binary. Optional.
 exporters:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.40.0" # the Go module for the component. Required.
     import: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter" # the import path for the component. Optional.
@@ -175,7 +178,7 @@ The builder also allows setting the scheme to use as the default URI scheme via 
 
 ```yaml
 conf_resolver:
-   default_uri_scheme: "env"
+  default_uri_scheme: "env"
 ```
 
 This tells the builder to produce a Collector that uses the `env` scheme when expanding configuration that does not
@@ -185,9 +188,9 @@ provide a scheme, such as `${HOST}` (instead of doing `${env:HOST}`).
 
 The builder has 3 steps:
 
-* Generate: generates the golang source code
-* Get modules: generates the go.mod file based on the imported modules in the generated golang source code
-* Compilation: builds the OpenTelemetry Collector executable
+- Generate: generates the golang source code
+- Get modules: generates the go.mod file based on the imported modules in the generated golang source code
+- Compilation: builds the OpenTelemetry Collector executable
 
 Each step can be skipped independently: `--skip-generate`, `--skip-get-modules` and `--skip-compilation`.
 
@@ -213,12 +216,12 @@ file for the following things after `go get`ing all components and calling
 
 1. The `dist::otelcol_version` field in the build configuration must have
    matching major and minor versions as the core library version calculated by
-   the Go toolchain, considering all components.  A mismatch could happen, for
+   the Go toolchain, considering all components. A mismatch could happen, for
    example, when the builder or one of the components depends on a newer release
    of the core collector library.
 2. For each component in the build configuration, the major and minor versions
    included in the `gomod` module specifier must match the one calculated by
-   the Go toolchain, considering all components.  A mismatch could
+   the Go toolchain, considering all components. A mismatch could
    happen, for example, when the enclosing Go module uses a newer
    release of the core collector library.
 

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -67,6 +67,7 @@ type ConfResolver struct {
 type Distribution struct {
 	Module      string `mapstructure:"module"`
 	Name        string `mapstructure:"name"`
+	Namespace   string `mapstructure:"namespace"`
 	Go          string `mapstructure:"go"`
 	Description string `mapstructure:"description"`
 	// Deprecated: [v0.113.0] only here to return a detailed error and not failing during unmarshalling.

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -291,6 +291,7 @@ func TestNewDefaultConfig(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 	assert.False(t, cfg.Distribution.DebugCompilation)
 	assert.Empty(t, cfg.Distribution.BuildTags)
+	assert.Empty(t, cfg.Distribution.Namespace)
 	assert.False(t, cfg.LDSet)
 	assert.Empty(t, cfg.LDFlags)
 	assert.False(t, cfg.GCSet)
@@ -362,6 +363,16 @@ func TestDebugOptionSetConfig(t *testing.T) {
 	}
 	require.NoError(t, cfg.Validate())
 	assert.True(t, cfg.Distribution.DebugCompilation)
+}
+
+func TestNamespaceConfig(t *testing.T) {
+	cfg := Config{
+		Distribution: Distribution{
+			Namespace: "customNamespace",
+		},
+	}
+	require.NoError(t, cfg.Validate())
+	assert.Equal(t, "customNamespace", cfg.Distribution.Namespace)
 }
 
 func TestAddsDefaultProviders(t *testing.T) {

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -20,6 +20,7 @@ import (
 func main() {
 	info := component.BuildInfo{
 		Command:     "{{ .Distribution.Name }}",
+		Namespace:   "{{ .Distribution.Namespace }}",
 		Description: "{{ .Distribution.Description }}",
 		Version:     "{{ .Distribution.Version }}",
 	}

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -9,6 +9,7 @@
 dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
+  namespace: opentelemetry-core
   description: Local OpenTelemetry Collector binary, testing only.
   version: 0.121.0-dev
 
@@ -35,4 +36,3 @@ providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.27.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.27.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.27.0
-

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -9,6 +9,7 @@
 dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
+  namespace: opentelemetry-core
   description: Local OpenTelemetry Collector binary, testing only.
   version: 0.121.0-dev
 

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -19,6 +19,7 @@ import (
 func main() {
 	info := component.BuildInfo{
 		Command:     "otelcorecol",
+		Namespace:   "opentelemetry-core",
 		Description: "Local OpenTelemetry Collector binary, testing only.",
 		Version:     "0.121.0-dev",
 	}

--- a/component/build_info.go
+++ b/component/build_info.go
@@ -9,6 +9,9 @@ type BuildInfo struct {
 	// Command is the executable file name, e.g. "otelcol".
 	Command string
 
+	// Namespace is the namespace of the collector, e.g. "opentelemetry".
+	Namespace string
+
 	// Description is the full name of the collector, e.g. "OpenTelemetry Collector".
 	Description string
 
@@ -20,6 +23,7 @@ type BuildInfo struct {
 func NewDefaultBuildInfo() BuildInfo {
 	return BuildInfo{
 		Command:     "otelcol",
+		Namespace:   "opentelemetry",
 		Description: "OpenTelemetry Collector",
 		Version:     "latest",
 	}

--- a/component/build_info_test.go
+++ b/component/build_info_test.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDefaultBuildInfo(t *testing.T) {
+	buildInfo := NewDefaultBuildInfo()
+	assert.Equal(t, "otelcol", buildInfo.Command)
+	assert.Equal(t, "opentelemetry", buildInfo.Namespace)
+	assert.Equal(t, "OpenTelemetry Collector", buildInfo.Description)
+	assert.Equal(t, "latest", buildInfo.Version)
+}

--- a/internal/e2e/status_test.go
+++ b/internal/e2e/status_test.go
@@ -75,7 +75,7 @@ func Test_ComponentStatusReporting_SharedInstance(t *testing.T) {
 			component.MustNewType("watcher"): newExtensionFactory(),
 		},
 	}
-	set.BuildInfo = component.BuildInfo{Version: "test version", Command: "otelcoltest"}
+	set.BuildInfo = component.BuildInfo{Version: "test version", Command: "otelcoltest", Namespace: "opentelemetry"}
 
 	cfg := service.Config{
 		Telemetry: telemetry.Config{

--- a/otelcol/testdata/components-output.yaml
+++ b/otelcol/testdata/components-output.yaml
@@ -1,5 +1,6 @@
 buildinfo:
     command: otelcol
+    namespace: opentelemetry
     description: OpenTelemetry Collector
     version: latest
 receivers:

--- a/service/attributes_test.go
+++ b/service/attributes_test.go
@@ -24,29 +24,29 @@ func TestAttributes(t *testing.T) {
 		{
 			name:           "no build info and no resource config",
 			cfg:            telemetry.Config{},
-			wantAttributes: []config.AttributeNameValue{{Name: "service.name", Value: ""}, {Name: "service.version", Value: ""}, {Name: "service.instance.id", Value: ""}},
+			wantAttributes: []config.AttributeNameValue{{Name: "service.name", Value: ""}, {Name: "service.version", Value: ""}, {Name: "service.namespace", Value: ""}, {Name: "service.instance.id", Value: ""}},
 		},
 		{
 			name:           "build info and no resource config",
 			cfg:            telemetry.Config{},
-			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
-			wantAttributes: []config.AttributeNameValue{{Name: "service.name", Value: "otelcoltest"}, {Name: "service.version", Value: "0.0.0-test"}, {Name: "service.instance.id", Value: ""}},
+			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test", Namespace: "opentelemetry"},
+			wantAttributes: []config.AttributeNameValue{{Name: "service.name", Value: "otelcoltest"}, {Name: "service.version", Value: "0.0.0-test"}, {Name: "service.namespace", Value: "opentelemetry"}, {Name: "service.instance.id", Value: ""}},
 		},
 		{
 			name:           "no build info and resource config",
-			cfg:            telemetry.Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "test": ptr("test")}},
-			wantAttributes: []config.AttributeNameValue{{Name: "service.name", Value: "resource.name"}, {Name: "service.version", Value: "resource.version"}, {Name: "test", Value: "test"}, {Name: "service.instance.id", Value: ""}},
+			cfg:            telemetry.Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "service.namespace": ptr("resource.namespace"), "test": ptr("test")}},
+			wantAttributes: []config.AttributeNameValue{{Name: "service.name", Value: "resource.name"}, {Name: "service.version", Value: "resource.version"}, {Name: "service.namespace", Value: "resource.namespace"}, {Name: "test", Value: "test"}, {Name: "service.instance.id", Value: ""}},
 		},
 		{
 			name:           "build info and resource config",
 			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
-			cfg:            telemetry.Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "test": ptr("test")}},
-			wantAttributes: []config.AttributeNameValue{{Name: "service.name", Value: "resource.name"}, {Name: "service.version", Value: "resource.version"}, {Name: "test", Value: "test"}, {Name: "service.instance.id", Value: ""}},
+			cfg:            telemetry.Config{Resource: map[string]*string{"service.name": ptr("resource.name"), "service.version": ptr("resource.version"), "service.namespace": ptr("resource.namespace"), "test": ptr("test")}},
+			wantAttributes: []config.AttributeNameValue{{Name: "service.name", Value: "resource.name"}, {Name: "service.version", Value: "resource.version"}, {Name: "service.namespace", Value: "resource.namespace"}, {Name: "test", Value: "test"}, {Name: "service.instance.id", Value: ""}},
 		},
 		{
 			name:           "deleting a nil value",
-			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test"},
-			cfg:            telemetry.Config{Resource: map[string]*string{"service.name": nil, "service.version": ptr("resource.version"), "test": ptr("test")}},
+			buildInfo:      component.BuildInfo{Command: "otelcoltest", Version: "0.0.0-test", Namespace: "opentelemetry"},
+			cfg:            telemetry.Config{Resource: map[string]*string{"service.name": nil, "service.version": ptr("resource.version"), "service.namespace": nil, "test": ptr("test")}},
 			wantAttributes: []config.AttributeNameValue{{Name: "service.version", Value: "resource.version"}, {Name: "test", Value: "test"}, {Name: "service.instance.id", Value: ""}},
 		},
 	}

--- a/service/internal/resource/config.go
+++ b/service/internal/resource/config.go
@@ -28,6 +28,11 @@ func New(buildInfo component.BuildInfo, resourceCfg map[string]*string) *resourc
 		telAttrs = append(telAttrs, attribute.String(semconv.AttributeServiceName, buildInfo.Command))
 	}
 
+	if _, ok := resourceCfg[semconv.AttributeServiceNamespace]; !ok {
+		// AttributeServiceNamespace is not specified in the config. Use the default namespace.
+		telAttrs = append(telAttrs, attribute.String(semconv.AttributeServiceNamespace, buildInfo.Namespace))
+	}
+
 	if _, ok := resourceCfg[semconv.AttributeServiceInstanceID]; !ok {
 		// AttributeServiceInstanceID is not specified in the config. Auto-generate one.
 		instanceUUID, _ := uuid.NewRandom()

--- a/service/internal/resource/config.go
+++ b/service/internal/resource/config.go
@@ -29,7 +29,7 @@ func New(buildInfo component.BuildInfo, resourceCfg map[string]*string) *resourc
 	}
 
 	if _, ok := resourceCfg[semconv.AttributeServiceNamespace]; !ok {
-		// AttributeServiceNamespace is not specified in the config. Use the default namespace.
+		// AttributeServiceNamespace is not specified in the config. Use the default namespace built into the binary.
 		telAttrs = append(telAttrs, attribute.String(semconv.AttributeServiceNamespace, buildInfo.Namespace))
 	}
 

--- a/service/internal/resource/config_test.go
+++ b/service/internal/resource/config_test.go
@@ -21,8 +21,9 @@ const (
 )
 
 var buildInfo = component.BuildInfo{
-	Command: "otelcol",
-	Version: "1.0.0",
+	Command:   "otelcol",
+	Version:   "1.0.0",
+	Namespace: "opentelemetry",
 }
 
 func ptr[T any](v T) *T {
@@ -41,6 +42,7 @@ func TestNew(t *testing.T) {
 			want: map[string]string{
 				"service.name":        "otelcol",
 				"service.version":     "1.0.0",
+				"service.namespace":   "opentelemetry",
 				"service.instance.id": randomUUIDSpecialValue,
 			},
 		},
@@ -49,11 +51,13 @@ func TestNew(t *testing.T) {
 			resourceCfg: map[string]*string{
 				"service.name":        ptr("my-service"),
 				"service.version":     ptr("1.2.3"),
+				"service.namespace":   ptr("my-namespace"),
 				"service.instance.id": ptr("123"),
 			},
 			want: map[string]string{
 				"service.name":        "my-service",
 				"service.version":     "1.2.3",
+				"service.namespace":   "my-namespace",
 				"service.instance.id": "123",
 			},
 		},
@@ -62,6 +66,7 @@ func TestNew(t *testing.T) {
 			resourceCfg: map[string]*string{
 				"service.name":        nil,
 				"service.version":     nil,
+				"service.namespace":   nil,
 				"service.instance.id": nil,
 			},
 			want: map[string]string{},
@@ -74,6 +79,7 @@ func TestNew(t *testing.T) {
 			want: map[string]string{
 				"service.name":        "otelcol",
 				"service.version":     "1.0.0",
+				"service.namespace":   "opentelemetry",
 				"service.instance.id": randomUUIDSpecialValue,
 				"host.name":           "my-host",
 			},
@@ -124,7 +130,7 @@ func TestBuildResource(t *testing.T) {
 	otelRes := New(buildInfo, resMap)
 	res := pdataFromSdk(otelRes)
 
-	assert.Equal(t, 3, res.Attributes().Len())
+	assert.Equal(t, 4, res.Attributes().Len())
 	value, ok := res.Attributes().Get(semconv.AttributeServiceName)
 	assert.True(t, ok)
 	assert.Equal(t, buildInfo.Command, value.AsString())
@@ -140,6 +146,7 @@ func TestBuildResource(t *testing.T) {
 		semconv.AttributeServiceName:       nil,
 		semconv.AttributeServiceVersion:    nil,
 		semconv.AttributeServiceInstanceID: nil,
+		semconv.AttributeServiceNamespace:  nil,
 	}
 	otelRes = New(buildInfo, resMap)
 	res = pdataFromSdk(otelRes)
@@ -153,11 +160,12 @@ func TestBuildResource(t *testing.T) {
 		semconv.AttributeServiceName:       strPtr("a"),
 		semconv.AttributeServiceVersion:    strPtr("b"),
 		semconv.AttributeServiceInstanceID: strPtr("c"),
+		semconv.AttributeServiceNamespace:  strPtr("d"),
 	}
 	otelRes = New(buildInfo, resMap)
 	res = pdataFromSdk(otelRes)
 
-	assert.Equal(t, 3, res.Attributes().Len())
+	assert.Equal(t, 4, res.Attributes().Len())
 	value, ok = res.Attributes().Get(semconv.AttributeServiceName)
 	assert.True(t, ok)
 	assert.Equal(t, "a", value.AsString())
@@ -167,4 +175,7 @@ func TestBuildResource(t *testing.T) {
 	value, ok = res.Attributes().Get(semconv.AttributeServiceInstanceID)
 	assert.True(t, ok)
 	assert.Equal(t, "c", value.AsString())
+	value, ok = res.Attributes().Get(semconv.AttributeServiceNamespace)
+	assert.True(t, ok)
+	assert.Equal(t, "d", value.AsString())
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -63,6 +63,7 @@ var (
 	testInstanceID        = "test_instance_id"
 	testServiceVersion    = "2022-05-20"
 	testServiceName       = "test name"
+	testServiceNamespace  = "test namespace"
 )
 
 // prometheusToOtelConv is used to check that the expected resource labels exist as
@@ -76,6 +77,7 @@ var prometheusToOtelConv = map[string]string{
 const (
 	metricsVersion = "test version"
 	otelCommand    = "otelcoltest"
+	otelNamespace  = "opentelemetry"
 )
 
 func ownMetricsTestCases() []ownMetricsTestCase {
@@ -93,6 +95,7 @@ func ownMetricsTestCases() []ownMetricsTestCase {
 				"service_instance_id": {state: labelAnyValue},
 				"service_name":        {label: otelCommand, state: labelSpecificValue},
 				"service_version":     {label: metricsVersion, state: labelSpecificValue},
+				"service_namespace":   {label: otelNamespace, state: labelSpecificValue},
 			},
 		},
 		{
@@ -104,6 +107,7 @@ func ownMetricsTestCases() []ownMetricsTestCase {
 				"service_instance_id":  {state: labelAnyValue},
 				"service_name":         {label: otelCommand, state: labelSpecificValue},
 				"service_version":      {label: metricsVersion, state: labelSpecificValue},
+				"service_namespace":    {label: otelNamespace, state: labelSpecificValue},
 				"custom_resource_attr": {label: "resource_attr_test_value", state: labelSpecificValue},
 			},
 		},
@@ -116,6 +120,7 @@ func ownMetricsTestCases() []ownMetricsTestCase {
 				"service_instance_id": {state: labelAnyValue},
 				"service_name":        {label: testServiceName, state: labelSpecificValue},
 				"service_version":     {label: metricsVersion, state: labelSpecificValue},
+				"service_namespace":   {label: otelNamespace, state: labelSpecificValue},
 			},
 		},
 		{
@@ -127,6 +132,7 @@ func ownMetricsTestCases() []ownMetricsTestCase {
 				"service_instance_id": {state: labelAnyValue},
 				"service_name":        {state: labelNotPresent},
 				"service_version":     {label: metricsVersion, state: labelSpecificValue},
+				"service_namespace":   {label: otelNamespace, state: labelSpecificValue},
 			},
 		},
 		{
@@ -138,6 +144,7 @@ func ownMetricsTestCases() []ownMetricsTestCase {
 				"service_instance_id": {label: "test_instance_id", state: labelSpecificValue},
 				"service_name":        {label: otelCommand, state: labelSpecificValue},
 				"service_version":     {label: metricsVersion, state: labelSpecificValue},
+				"service_namespace":   {label: otelNamespace, state: labelSpecificValue},
 			},
 		},
 		{
@@ -149,6 +156,7 @@ func ownMetricsTestCases() []ownMetricsTestCase {
 				"service_instance_id": {state: labelNotPresent},
 				"service_name":        {label: otelCommand, state: labelSpecificValue},
 				"service_version":     {label: metricsVersion, state: labelSpecificValue},
+				"service_namespace":   {label: otelNamespace, state: labelSpecificValue},
 			},
 		},
 		{
@@ -160,6 +168,7 @@ func ownMetricsTestCases() []ownMetricsTestCase {
 				"service_instance_id": {state: labelAnyValue},
 				"service_name":        {label: otelCommand, state: labelSpecificValue},
 				"service_version":     {label: "2022-05-20", state: labelSpecificValue},
+				"service_namespace":   {label: otelNamespace, state: labelSpecificValue},
 			},
 		},
 		{
@@ -171,6 +180,31 @@ func ownMetricsTestCases() []ownMetricsTestCase {
 				"service_instance_id": {state: labelAnyValue},
 				"service_name":        {label: otelCommand, state: labelSpecificValue},
 				"service_version":     {state: labelNotPresent},
+				"service_namespace":   {label: otelNamespace, state: labelSpecificValue},
+			},
+		},
+		{
+			name: "override service.namespace",
+			userDefinedResource: map[string]*string{
+				"service.namespace": &testServiceNamespace,
+			},
+			expectedLabels: map[string]labelValue{
+				"service_instance_id": {state: labelAnyValue},
+				"service_name":        {label: otelCommand, state: labelSpecificValue},
+				"service_version":     {label: metricsVersion, state: labelSpecificValue},
+				"service_namespace":   {label: "test namespace", state: labelSpecificValue},
+			},
+		},
+		{
+			name: "suppress service.namespace",
+			userDefinedResource: map[string]*string{
+				"service.namespace": nil,
+			},
+			expectedLabels: map[string]labelValue{
+				"service_instance_id": {state: labelAnyValue},
+				"service_name":        {label: otelCommand, state: labelSpecificValue},
+				"service_version":     {label: metricsVersion, state: labelSpecificValue},
+				"service_namespace":   {state: labelNotPresent},
 			},
 		},
 	}
@@ -304,7 +338,7 @@ func testCollectorStartHelperWithReaders(t *testing.T, tc ownMetricsTestCase, ne
 	require.NotZero(t, zpagesAddr, "network must be either of tcp, tcp4 or tcp6")
 
 	set := newNopSettings()
-	set.BuildInfo = component.BuildInfo{Version: "test version", Command: otelCommand}
+	set.BuildInfo = component.BuildInfo{Version: "test version", Command: otelCommand, Namespace: otelNamespace}
 	set.ExtensionsConfigs = map[component.ID]component.Config{
 		component.MustNewID("zpages"): &zpagesextension.Config{
 			ServerConfig: confighttp.ServerConfig{Endpoint: zpagesAddr},

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -72,6 +72,7 @@ var prometheusToOtelConv = map[string]string{
 	"service_instance_id": "service.instance.id",
 	"service_name":        "service.name",
 	"service_version":     "service.version",
+	"service_namespace":   "service.namespace",
 }
 
 const (


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds a new field to `component.BuildInfo` to facilitate support for reporting the `service.namespace` semantic convention in OpAMP. Includes corresponding updates to resource attributes reported by the collector. Also adds a new parameter to the builder configuration to facilitate setting this via the OCB.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #12505 

Need follow up PR to OpAMP extension making use of this value.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Relevant unit tests updated. 

Running the updated otelcorecol with logging enabled in `service.telemetry` and the new resource attribute for `service.namespace` shows up. This was done sending to another collector running the otlp receiver and logging via the debug exporter.

[02-26-25_monitoring-output.txt](https://github.com/user-attachments/files/18993755/02-26-25_monitoring-output.txt)


<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
