### PR TITLE
[chore][extensionauth] Return error on NewClient and NewServer constructors

### DIFF
--- a/config/configauth/configauth_test.go
+++ b/config/configauth/configauth_test.go
@@ -17,6 +17,13 @@ import (
 
 var mockID = component.MustNewID("mock")
 
+func must[T any](t *testing.T, builder func() (T, error)) T {
+	t.Helper()
+	thing, err := builder()
+	require.NoError(t, err)
+	return thing
+}
+
 func TestGetServer(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -24,14 +31,18 @@ func TestGetServer(t *testing.T) {
 		expected      error
 	}{
 		{
-			name:          "obtain server authenticator",
-			authenticator: extensionauth.NewServer(),
-			expected:      nil,
+			name: "obtain server authenticator",
+			authenticator: must(t, func() (extension.Extension, error) {
+				return extensionauth.NewServer()
+			}),
+			expected: nil,
 		},
 		{
-			name:          "not a server authenticator",
-			authenticator: extensionauth.NewClient(),
-			expected:      errNotServer,
+			name: "not a server authenticator",
+			authenticator: must(t, func() (extension.Extension, error) {
+				return extensionauth.NewClient()
+			}),
+			expected: errNotServer,
 		},
 	}
 	for _, tt := range testCases {
@@ -75,14 +86,18 @@ func TestGetClient(t *testing.T) {
 		expected      error
 	}{
 		{
-			name:          "obtain client authenticator",
-			authenticator: extensionauth.NewClient(),
-			expected:      nil,
+			name: "obtain client authenticator",
+			authenticator: must(t, func() (extension.Extension, error) {
+				return extensionauth.NewClient()
+			}),
+			expected: nil,
 		},
 		{
-			name:          "not a client authenticator",
-			authenticator: extensionauth.NewServer(),
-			expected:      errNotClient,
+			name: "not a client authenticator",
+			authenticator: must(t, func() (extension.Extension, error) {
+				return extensionauth.NewServer()
+			}),
+			expected: errNotClient,
 		},
 	}
 	for _, tt := range testCases {

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -42,6 +42,13 @@ func (c *customRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, nil
 }
 
+func mustNewServerAuth(t *testing.T, opts ...extensionauth.ServerOption) extensionauth.Server {
+	t.Helper()
+	srv, err := extensionauth.NewServer(opts...)
+	require.NoError(t, err)
+	return srv
+}
+
 var (
 	testAuthID    = component.MustNewID("testauth")
 	mockID        = component.MustNewID("mock")
@@ -825,7 +832,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 
 	host := &mockHost{
 		ext: map[component.ID]component.Component{
-			mockID: extensionauth.NewServer(
+			mockID: mustNewServerAuth(t,
 				extensionauth.WithServerAuthenticate(func(ctx context.Context, _ map[string][]string) (context.Context, error) {
 					return ctx, errors.New("Settings failed")
 				}),
@@ -1137,7 +1144,7 @@ func TestServerAuth(t *testing.T) {
 
 	host := &mockHost{
 		ext: map[component.ID]component.Component{
-			mockID: extensionauth.NewServer(
+			mockID: mustNewServerAuth(t,
 				extensionauth.WithServerAuthenticate(func(ctx context.Context, _ map[string][]string) (context.Context, error) {
 					authCalled = true
 					return ctx, nil
@@ -1188,7 +1195,7 @@ func TestFailedServerAuth(t *testing.T) {
 	}
 	host := &mockHost{
 		ext: map[component.ID]component.Component{
-			mockID: extensionauth.NewServer(
+			mockID: mustNewServerAuth(t,
 				extensionauth.WithServerAuthenticate(func(ctx context.Context, _ map[string][]string) (context.Context, error) {
 					return ctx, errors.New("Settings failed")
 				}),
@@ -1369,7 +1376,7 @@ func TestAuthWithQueryParams(t *testing.T) {
 
 	host := &mockHost{
 		ext: map[component.ID]component.Component{
-			mockID: extensionauth.NewServer(
+			mockID: mustNewServerAuth(t,
 				extensionauth.WithServerAuthenticate(func(ctx context.Context, sources map[string][]string) (context.Context, error) {
 					require.Len(t, sources, 1)
 					assert.Equal(t, "1", sources["auth"][0])

--- a/extension/auth/client.go
+++ b/extension/auth/client.go
@@ -57,5 +57,9 @@ func WithClientPerRPCCredentials(perRPCCredentialsFunc ClientPerRPCCredentialsFu
 // NewClient returns a Client configured with the provided options.
 // Deprecated: [v0.121.0] Use extensionauth.NewClient instead.
 func NewClient(options ...ClientOption) Client {
-	return extensionauth.NewClient(options...)
+	client, err := extensionauth.NewClient(options...)
+	if err != nil {
+		panic("unexpected error when calling extensionauth.NewClient: " + err.Error())
+	}
+	return client
 }

--- a/extension/auth/server.go
+++ b/extension/auth/server.go
@@ -48,5 +48,9 @@ func WithServerShutdown(shutdownFunc component.ShutdownFunc) ServerOption {
 // NewServer returns a Server configured with the provided options.
 // Deprecated: [v0.121.0] Use extensionauth.NewServer instead.
 func NewServer(options ...ServerOption) Server {
-	return extensionauth.NewServer(options...)
+	srv, err := extensionauth.NewServer(options...)
+	if err != nil {
+		panic("unexpected error when calling extensionauth.NewServer: " + err.Error())
+	}
+	return srv
 }

--- a/extension/extensionauth/client.go
+++ b/extension/extensionauth/client.go
@@ -96,12 +96,12 @@ func WithClientPerRPCCredentials(perRPCCredentialsFunc ClientPerRPCCredentialsFu
 }
 
 // NewClient returns a Client configured with the provided options.
-func NewClient(options ...ClientOption) Client {
+func NewClient(options ...ClientOption) (Client, error) {
 	bc := &defaultClient{}
 
 	for _, op := range options {
 		op.apply(bc)
 	}
 
-	return bc
+	return bc, nil
 }

--- a/extension/extensionauth/client_test.go
+++ b/extension/extensionauth/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/collector/component"
@@ -17,7 +18,8 @@ import (
 
 func TestClientDefaultValues(t *testing.T) {
 	// prepare
-	e := NewClient()
+	e, err := NewClient()
+	require.NoError(t, err)
 
 	// test
 	t.Run("start", func(t *testing.T) {
@@ -45,13 +47,14 @@ func TestClientDefaultValues(t *testing.T) {
 
 func TestWithClientStart(t *testing.T) {
 	called := false
-	e := NewClient(WithClientStart(func(context.Context, component.Host) error {
+	e, err := NewClient(WithClientStart(func(context.Context, component.Host) error {
 		called = true
 		return nil
 	}))
+	require.NoError(t, err)
 
 	// test
-	err := e.Start(context.Background(), componenttest.NewNopHost())
+	err = e.Start(context.Background(), componenttest.NewNopHost())
 
 	// verify
 	assert.True(t, called)
@@ -60,13 +63,14 @@ func TestWithClientStart(t *testing.T) {
 
 func TestWithClientShutdown(t *testing.T) {
 	called := false
-	e := NewClient(WithClientShutdown(func(context.Context) error {
+	e, err := NewClient(WithClientShutdown(func(context.Context) error {
 		called = true
 		return nil
 	}))
+	require.NoError(t, err)
 
 	// test
-	err := e.Shutdown(context.Background())
+	err = e.Shutdown(context.Background())
 
 	// verify
 	assert.True(t, called)
@@ -75,10 +79,11 @@ func TestWithClientShutdown(t *testing.T) {
 
 func TestWithClientRoundTripper(t *testing.T) {
 	called := false
-	e := NewClient(WithClientRoundTripper(func(base http.RoundTripper) (http.RoundTripper, error) {
+	e, err := NewClient(WithClientRoundTripper(func(base http.RoundTripper) (http.RoundTripper, error) {
 		called = true
 		return base, nil
 	}))
+	require.NoError(t, err)
 
 	// test
 	rt, err := e.RoundTripper(http.DefaultTransport)
@@ -103,10 +108,11 @@ func (c *customPerRPCCredentials) RequireTransportSecurity() bool {
 
 func TestWithPerRPCCredentials(t *testing.T) {
 	called := false
-	e := NewClient(WithClientPerRPCCredentials(func() (credentials.PerRPCCredentials, error) {
+	e, err := NewClient(WithClientPerRPCCredentials(func() (credentials.PerRPCCredentials, error) {
 		called = true
 		return &customPerRPCCredentials{}, nil
 	}))
+	require.NoError(t, err)
 
 	// test
 	p, err := e.PerRPCCredentials()

--- a/extension/extensionauth/server.go
+++ b/extension/extensionauth/server.go
@@ -81,12 +81,12 @@ func WithServerShutdown(shutdownFunc component.ShutdownFunc) ServerOption {
 }
 
 // NewServer returns a Server configured with the provided options.
-func NewServer(options ...ServerOption) Server {
+func NewServer(options ...ServerOption) (Server, error) {
 	bc := &defaultServer{}
 
 	for _, op := range options {
 		op.apply(bc)
 	}
 
-	return bc
+	return bc, nil
 }

--- a/extension/extensionauth/server_test.go
+++ b/extension/extensionauth/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -15,7 +16,8 @@ import (
 
 func TestDefaultValues(t *testing.T) {
 	// prepare
-	e := NewServer()
+	e, err := NewServer()
+	require.NoError(t, err)
 
 	// test
 	t.Run("start", func(t *testing.T) {
@@ -38,15 +40,16 @@ func TestDefaultValues(t *testing.T) {
 func TestWithServerAuthenticateFunc(t *testing.T) {
 	// prepare
 	authCalled := false
-	e := NewServer(
+	e, err := NewServer(
 		WithServerAuthenticate(func(ctx context.Context, _ map[string][]string) (context.Context, error) {
 			authCalled = true
 			return ctx, nil
 		}),
 	)
+	require.NoError(t, err)
 
 	// test
-	_, err := e.Authenticate(context.Background(), make(map[string][]string))
+	_, err = e.Authenticate(context.Background(), make(map[string][]string))
 
 	// verify
 	assert.True(t, authCalled)
@@ -55,13 +58,14 @@ func TestWithServerAuthenticateFunc(t *testing.T) {
 
 func TestWithServerStart(t *testing.T) {
 	called := false
-	e := NewServer(WithServerStart(func(context.Context, component.Host) error {
+	e, err := NewServer(WithServerStart(func(context.Context, component.Host) error {
 		called = true
 		return nil
 	}))
+	require.NoError(t, err)
 
 	// test
-	err := e.Start(context.Background(), componenttest.NewNopHost())
+	err = e.Start(context.Background(), componenttest.NewNopHost())
 
 	// verify
 	assert.True(t, called)
@@ -70,13 +74,14 @@ func TestWithServerStart(t *testing.T) {
 
 func TestWithServerShutdown(t *testing.T) {
 	called := false
-	e := NewServer(WithServerShutdown(func(context.Context) error {
+	e, err := NewServer(WithServerShutdown(func(context.Context) error {
 		called = true
 		return nil
 	}))
+	require.NoError(t, err)
 
 	// test
-	err := e.Shutdown(context.Background())
+	err = e.Shutdown(context.Background())
 
 	// verify
 	assert.True(t, called)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds errors in return type to `extensionauth.New*` functions. This is not a breaking change since `extensionauth` is an unreleased module.