### PR TITLE
[receiver] Mark module as stable

### DIFF
--- a/.chloggen/mx-psi_receiver-1.0.yaml
+++ b/.chloggen/mx-psi_receiver-1.0.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: receiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark module as stable
+
+# One or more tracking issues or pull requests related to the change
+issues: [12513]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/versions.yaml
+++ b/versions.yaml
@@ -22,6 +22,7 @@ module-sets:
       - go.opentelemetry.io/collector/config/confignet
       - go.opentelemetry.io/collector/consumer
       - go.opentelemetry.io/collector/extension
+      - go.opentelemetry.io/collector/receiver
   beta:
     version: v0.121.0
     modules:
@@ -75,7 +76,6 @@ module-sets:
       - go.opentelemetry.io/collector/processor/memorylimiterprocessor
       - go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper
       - go.opentelemetry.io/collector/processor/xprocessor
-      - go.opentelemetry.io/collector/receiver
       - go.opentelemetry.io/collector/receiver/receiverhelper
       - go.opentelemetry.io/collector/receiver/nopreceiver
       - go.opentelemetry.io/collector/receiver/otlpreceiver


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Marks receiver as 1.0. I believe we can do this since this is basically extension+consumer. `receiverhelper` is not ready yet

#### Link to tracking issue
Fixes #12513
