### PR TITLE
Introduce `Equal` comparison in pcommon types

### DIFF
--- a/.chloggen/pcommon-equal.yaml
+++ b/.chloggen/pcommon-equal.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata/pcommon
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Introduce `Equal()` method for comparison equality to `Value`, `ByteSlice`, `Float64Slice`, `Int32Slice`, `Int64Slice`, `StringSlice`, `Uint64Slice`, `Map` and `Slice`
+
+# One or more tracking issues or pull requests related to the change
+issues: [12568]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice.go.tmpl
@@ -104,6 +104,11 @@ func (ms {{ .structName }}) CopyTo(dest {{ .structName }}) {
 	*dest.getOrig() = copy{{ .structName }}(*dest.getOrig(), *ms.getOrig())
 }
 
+// Equal checks equality with a raw []{{ .itemType }}
+func (ms {{ .structName }}) Equal(val []{{ .itemType }}) bool {
+	return slices.Equal(*ms.getOrig(), val)
+}
+
 func copy{{ .structName }}(dst, src []{{ .itemType }}) []{{ .itemType }} {
 	dst = dst[:0]
 	return append(dst, src...)

--- a/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice_test.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice_test.go.tmpl
@@ -111,3 +111,25 @@ func Test{{ .structName }}EnsureCapacity(t *testing.T) {
 	ms.EnsureCapacity(2)
 	assert.Equal(t, 4, cap(*ms.getOrig()))
 }
+
+func Test{{ .structName }}Equal(t *testing.T) {
+	ms := New{{ .structName }}()
+	assert.True(t, ms.Equal([]{{ .itemType }}{}))
+
+	ms.Append({{ .testOrigVal }})
+	assert.False(t, ms.Equal([]{{ .itemType }}{}))
+	assert.True(t, ms.Equal([]{{ .itemType }}{ {{ .testOrigVal }} }))
+}
+
+func Benchmark{{ .structName }}Equal(b *testing.B) {
+	ms := New{{ .structName }}()
+	ms.Append({{ .testOrigVal }})
+	cmp := []{{ .itemType }}{ {{ .testOrigVal }} }
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = ms.Equal(cmp)
+	}
+}

--- a/pdata/pcommon/generated_byteslice.go
+++ b/pdata/pcommon/generated_byteslice.go
@@ -7,6 +7,8 @@
 package pcommon
 
 import (
+	"slices"
+
 	"go.opentelemetry.io/collector/pdata/internal"
 )
 
@@ -100,6 +102,11 @@ func (ms ByteSlice) MoveTo(dest ByteSlice) {
 func (ms ByteSlice) CopyTo(dest ByteSlice) {
 	dest.getState().AssertMutable()
 	*dest.getOrig() = copyByteSlice(*dest.getOrig(), *ms.getOrig())
+}
+
+// Equal checks equality with a raw []byte
+func (ms ByteSlice) Equal(val []byte) bool {
+	return slices.Equal(*ms.getOrig(), val)
 }
 
 func copyByteSlice(dst, src []byte) []byte {

--- a/pdata/pcommon/generated_byteslice_test.go
+++ b/pdata/pcommon/generated_byteslice_test.go
@@ -81,3 +81,25 @@ func TestByteSliceEnsureCapacity(t *testing.T) {
 	ms.EnsureCapacity(2)
 	assert.Equal(t, 4, cap(*ms.getOrig()))
 }
+
+func TestByteSliceEqual(t *testing.T) {
+	ms := NewByteSlice()
+	assert.True(t, ms.Equal([]byte{}))
+
+	ms.Append(1, 2, 3)
+	assert.False(t, ms.Equal([]byte{}))
+	assert.True(t, ms.Equal([]byte{1, 2, 3}))
+}
+
+func BenchmarkByteSliceEqual(b *testing.B) {
+	ms := NewByteSlice()
+	ms.Append(1, 2, 3)
+	cmp := []byte{1, 2, 3}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = ms.Equal(cmp)
+	}
+}

--- a/pdata/pcommon/generated_float64slice.go
+++ b/pdata/pcommon/generated_float64slice.go
@@ -7,6 +7,8 @@
 package pcommon
 
 import (
+	"slices"
+
 	"go.opentelemetry.io/collector/pdata/internal"
 )
 
@@ -100,6 +102,11 @@ func (ms Float64Slice) MoveTo(dest Float64Slice) {
 func (ms Float64Slice) CopyTo(dest Float64Slice) {
 	dest.getState().AssertMutable()
 	*dest.getOrig() = copyFloat64Slice(*dest.getOrig(), *ms.getOrig())
+}
+
+// Equal checks equality with a raw []float64
+func (ms Float64Slice) Equal(val []float64) bool {
+	return slices.Equal(*ms.getOrig(), val)
 }
 
 func copyFloat64Slice(dst, src []float64) []float64 {

--- a/pdata/pcommon/generated_float64slice_test.go
+++ b/pdata/pcommon/generated_float64slice_test.go
@@ -81,3 +81,25 @@ func TestFloat64SliceEnsureCapacity(t *testing.T) {
 	ms.EnsureCapacity(2)
 	assert.Equal(t, 4, cap(*ms.getOrig()))
 }
+
+func TestFloat64SliceEqual(t *testing.T) {
+	ms := NewFloat64Slice()
+	assert.True(t, ms.Equal([]float64{}))
+
+	ms.Append(1, 2, 3)
+	assert.False(t, ms.Equal([]float64{}))
+	assert.True(t, ms.Equal([]float64{1, 2, 3}))
+}
+
+func BenchmarkFloat64SliceEqual(b *testing.B) {
+	ms := NewFloat64Slice()
+	ms.Append(1, 2, 3)
+	cmp := []float64{1, 2, 3}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = ms.Equal(cmp)
+	}
+}

--- a/pdata/pcommon/generated_int32slice.go
+++ b/pdata/pcommon/generated_int32slice.go
@@ -7,6 +7,8 @@
 package pcommon
 
 import (
+	"slices"
+
 	"go.opentelemetry.io/collector/pdata/internal"
 )
 
@@ -100,6 +102,11 @@ func (ms Int32Slice) MoveTo(dest Int32Slice) {
 func (ms Int32Slice) CopyTo(dest Int32Slice) {
 	dest.getState().AssertMutable()
 	*dest.getOrig() = copyInt32Slice(*dest.getOrig(), *ms.getOrig())
+}
+
+// Equal checks equality with a raw []int32
+func (ms Int32Slice) Equal(val []int32) bool {
+	return slices.Equal(*ms.getOrig(), val)
 }
 
 func copyInt32Slice(dst, src []int32) []int32 {

--- a/pdata/pcommon/generated_int32slice_test.go
+++ b/pdata/pcommon/generated_int32slice_test.go
@@ -81,3 +81,25 @@ func TestInt32SliceEnsureCapacity(t *testing.T) {
 	ms.EnsureCapacity(2)
 	assert.Equal(t, 4, cap(*ms.getOrig()))
 }
+
+func TestInt32SliceEqual(t *testing.T) {
+	ms := NewInt32Slice()
+	assert.True(t, ms.Equal([]int32{}))
+
+	ms.Append(1, 2, 3)
+	assert.False(t, ms.Equal([]int32{}))
+	assert.True(t, ms.Equal([]int32{1, 2, 3}))
+}
+
+func BenchmarkInt32SliceEqual(b *testing.B) {
+	ms := NewInt32Slice()
+	ms.Append(1, 2, 3)
+	cmp := []int32{1, 2, 3}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = ms.Equal(cmp)
+	}
+}

--- a/pdata/pcommon/generated_int64slice.go
+++ b/pdata/pcommon/generated_int64slice.go
@@ -7,6 +7,8 @@
 package pcommon
 
 import (
+	"slices"
+
 	"go.opentelemetry.io/collector/pdata/internal"
 )
 
@@ -100,6 +102,11 @@ func (ms Int64Slice) MoveTo(dest Int64Slice) {
 func (ms Int64Slice) CopyTo(dest Int64Slice) {
 	dest.getState().AssertMutable()
 	*dest.getOrig() = copyInt64Slice(*dest.getOrig(), *ms.getOrig())
+}
+
+// Equal checks equality with a raw []int64
+func (ms Int64Slice) Equal(val []int64) bool {
+	return slices.Equal(*ms.getOrig(), val)
 }
 
 func copyInt64Slice(dst, src []int64) []int64 {

--- a/pdata/pcommon/generated_int64slice_test.go
+++ b/pdata/pcommon/generated_int64slice_test.go
@@ -81,3 +81,25 @@ func TestInt64SliceEnsureCapacity(t *testing.T) {
 	ms.EnsureCapacity(2)
 	assert.Equal(t, 4, cap(*ms.getOrig()))
 }
+
+func TestInt64SliceEqual(t *testing.T) {
+	ms := NewInt64Slice()
+	assert.True(t, ms.Equal([]int64{}))
+
+	ms.Append(1, 2, 3)
+	assert.False(t, ms.Equal([]int64{}))
+	assert.True(t, ms.Equal([]int64{1, 2, 3}))
+}
+
+func BenchmarkInt64SliceEqual(b *testing.B) {
+	ms := NewInt64Slice()
+	ms.Append(1, 2, 3)
+	cmp := []int64{1, 2, 3}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = ms.Equal(cmp)
+	}
+}

--- a/pdata/pcommon/generated_stringslice.go
+++ b/pdata/pcommon/generated_stringslice.go
@@ -7,6 +7,8 @@
 package pcommon
 
 import (
+	"slices"
+
 	"go.opentelemetry.io/collector/pdata/internal"
 )
 
@@ -100,6 +102,11 @@ func (ms StringSlice) MoveTo(dest StringSlice) {
 func (ms StringSlice) CopyTo(dest StringSlice) {
 	dest.getState().AssertMutable()
 	*dest.getOrig() = copyStringSlice(*dest.getOrig(), *ms.getOrig())
+}
+
+// Equal checks equality with a raw []string
+func (ms StringSlice) Equal(val []string) bool {
+	return slices.Equal(*ms.getOrig(), val)
 }
 
 func copyStringSlice(dst, src []string) []string {

--- a/pdata/pcommon/generated_stringslice_test.go
+++ b/pdata/pcommon/generated_stringslice_test.go
@@ -81,3 +81,25 @@ func TestStringSliceEnsureCapacity(t *testing.T) {
 	ms.EnsureCapacity(2)
 	assert.Equal(t, 4, cap(*ms.getOrig()))
 }
+
+func TestStringSliceEqual(t *testing.T) {
+	ms := NewStringSlice()
+	assert.True(t, ms.Equal([]string{}))
+
+	ms.Append("a", "b", "c")
+	assert.False(t, ms.Equal([]string{}))
+	assert.True(t, ms.Equal([]string{"a", "b", "c"}))
+}
+
+func BenchmarkStringSliceEqual(b *testing.B) {
+	ms := NewStringSlice()
+	ms.Append("a", "b", "c")
+	cmp := []string{"a", "b", "c"}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = ms.Equal(cmp)
+	}
+}

--- a/pdata/pcommon/generated_uint64slice.go
+++ b/pdata/pcommon/generated_uint64slice.go
@@ -7,6 +7,8 @@
 package pcommon
 
 import (
+	"slices"
+
 	"go.opentelemetry.io/collector/pdata/internal"
 )
 
@@ -100,6 +102,11 @@ func (ms UInt64Slice) MoveTo(dest UInt64Slice) {
 func (ms UInt64Slice) CopyTo(dest UInt64Slice) {
 	dest.getState().AssertMutable()
 	*dest.getOrig() = copyUInt64Slice(*dest.getOrig(), *ms.getOrig())
+}
+
+// Equal checks equality with a raw []uint64
+func (ms UInt64Slice) Equal(val []uint64) bool {
+	return slices.Equal(*ms.getOrig(), val)
 }
 
 func copyUInt64Slice(dst, src []uint64) []uint64 {

--- a/pdata/pcommon/generated_uint64slice_test.go
+++ b/pdata/pcommon/generated_uint64slice_test.go
@@ -81,3 +81,25 @@ func TestUInt64SliceEnsureCapacity(t *testing.T) {
 	ms.EnsureCapacity(2)
 	assert.Equal(t, 4, cap(*ms.getOrig()))
 }
+
+func TestUInt64SliceEqual(t *testing.T) {
+	ms := NewUInt64Slice()
+	assert.True(t, ms.Equal([]uint64{}))
+
+	ms.Append(1, 2, 3)
+	assert.False(t, ms.Equal([]uint64{}))
+	assert.True(t, ms.Equal([]uint64{1, 2, 3}))
+}
+
+func BenchmarkUInt64SliceEqual(b *testing.B) {
+	ms := NewUInt64Slice()
+	ms.Append(1, 2, 3)
+	cmp := []uint64{1, 2, 3}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = ms.Equal(cmp)
+	}
+}

--- a/pdata/pcommon/map.go
+++ b/pdata/pcommon/map.go
@@ -290,3 +290,20 @@ func (m Map) FromRaw(rawMap map[string]any) error {
 	*m.getOrig() = origs
 	return errs
 }
+
+// Equal checks equality with a raw map
+func (m Map) Equal(val map[string]any) bool {
+	if m.Len() != len(val) {
+		return false
+	}
+
+	fullEqual := true
+
+	m.Range(func(k string, v Value) bool {
+		if !v.Equal(val[k]) {
+			fullEqual = false
+		}
+		return fullEqual
+	})
+	return fullEqual
+}

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -564,3 +564,25 @@ func TestInvalidMap(t *testing.T) {
 	assert.Panics(t, func() { v.AsRaw() })
 	assert.Panics(t, func() { _ = v.FromRaw(map[string]any{"foo": "bar"}) })
 }
+
+func TestMapEqual(t *testing.T) {
+	m := NewMap()
+	assert.True(t, m.Equal(map[string]any{}))
+
+	m.PutStr("hello", "world")
+	assert.False(t, m.Equal(map[string]any{}))
+	assert.True(t, m.Equal(map[string]any{"hello": "world"}))
+}
+
+func BenchmarkMapEqual(b *testing.B) {
+	m := NewMap()
+	m.PutStr("hello", "world")
+	cmp := map[string]any{"hello": "world"}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = m.Equal(cmp)
+	}
+}

--- a/pdata/pcommon/slice.go
+++ b/pdata/pcommon/slice.go
@@ -164,3 +164,17 @@ func (es Slice) FromRaw(rawSlice []any) error {
 	*es.getOrig() = origs
 	return errs
 }
+
+// Equal checks equality with a raw []any
+func (es Slice) Equal(val []any) bool {
+	if es.Len() != len(val) {
+		return false
+	}
+
+	for i := 0; i < es.Len(); i++ {
+		if !es.At(i).Equal(val[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pcommon/slice_test.go
+++ b/pdata/pcommon/slice_test.go
@@ -150,3 +150,27 @@ func TestInvalidSlice(t *testing.T) {
 	assert.Panics(t, func() { es.AsRaw() })
 	assert.Panics(t, func() { _ = es.FromRaw([]any{3}) })
 }
+
+func TestSliceEqual(t *testing.T) {
+	es := NewSlice()
+	assert.True(t, es.Equal([]any{}))
+
+	v := es.AppendEmpty()
+	v.SetStr("test")
+	assert.False(t, es.Equal([]any{}))
+	assert.True(t, es.Equal([]any{"test"}))
+}
+
+func BenchmarkSliceEqual(b *testing.B) {
+	es := NewSlice()
+	v := es.AppendEmpty()
+	v.SetStr("test")
+	cmp := []any{"test"}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = es.Equal(cmp)
+	}
+}

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -507,6 +507,9 @@ func (v Value) Equal(c any) bool {
 	case []any:
 		return v.Type() == ValueTypeSlice &&
 			v.Slice().Equal(t)
+	case map[string]any:
+		return v.Type() == ValueTypeMap &&
+			v.Map().Equal(t)
 	}
 
 	return false

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -501,6 +501,12 @@ func (v Value) Equal(c any) bool {
 	case float64:
 		return v.Type() == ValueTypeDouble &&
 			v.Double() == t
+	case []byte:
+		return v.Type() == ValueTypeBytes &&
+			v.Bytes().Equal(t)
+	case []any:
+		return v.Type() == ValueTypeSlice &&
+			v.Slice().Equal(t)
 	}
 
 	return false

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -452,6 +452,60 @@ func (v Value) AsRaw() any {
 	return fmt.Sprintf("<Unknown OpenTelemetry value type %q>", v.Type())
 }
 
+func (v Value) Equal(c any) bool {
+	switch t := c.(type) {
+	case string:
+		if v.Type() == ValueTypeEmpty {
+			return t == ""
+		}
+		return v.Type() == ValueTypeStr &&
+			v.Str() == t
+	case bool:
+		return v.Type() == ValueTypeBool &&
+			v.Bool() == t
+	case int:
+		return v.Type() == ValueTypeInt &&
+			v.Int() == int64(t)
+	case int8:
+		return v.Type() == ValueTypeInt &&
+			v.Int() == int64(t)
+	case int16:
+		return v.Type() == ValueTypeInt &&
+			v.Int() == int64(t)
+	case int32:
+		return v.Type() == ValueTypeInt &&
+			v.Int() == int64(t)
+	case int64:
+		return v.Type() == ValueTypeInt &&
+			v.Int() == t
+	case uint:
+		//nolint:gosec
+		return v.Type() == ValueTypeInt &&
+			v.Int() == int64(t)
+	case uint8:
+		return v.Type() == ValueTypeInt &&
+			v.Int() == int64(t)
+	case uint16:
+		return v.Type() == ValueTypeInt &&
+			v.Int() == int64(t)
+	case uint32:
+		return v.Type() == ValueTypeInt &&
+			v.Int() == int64(t)
+	case uint64:
+		//nolint:gosec
+		return v.Type() == ValueTypeInt &&
+			v.Int() == int64(t)
+	case float32:
+		return v.Type() == ValueTypeDouble &&
+			float32(v.Double()) == t
+	case float64:
+		return v.Type() == ValueTypeDouble &&
+			v.Double() == t
+	}
+
+	return false
+}
+
 func newKeyValueString(k string, v string) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	state := internal.StateMutable

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -454,6 +454,8 @@ func (v Value) AsRaw() any {
 
 func (v Value) Equal(c any) bool {
 	switch t := c.(type) {
+	case nil:
+		return v.Type() == ValueTypeEmpty
 	case string:
 		if v.Type() == ValueTypeEmpty {
 			return t == ""

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -765,6 +765,46 @@ func TestValueEqual(t *testing.T) {
 			comparison: float64(17.01),
 			expected:   false,
 		},
+		{
+			name: "same byte slice",
+			value: func() Value {
+				m := NewValueBytes()
+				m.Bytes().FromRaw([]byte{1, 3, 3, 7})
+				return m
+			}(),
+			comparison: []byte{1, 3, 3, 7},
+			expected:   true,
+		},
+		{
+			name: "different byte slice",
+			value: func() Value {
+				m := NewValueBytes()
+				m.Bytes().FromRaw([]byte{1, 3, 3, 7})
+				return m
+			}(),
+			comparison: []byte{1, 7, 0, 1},
+			expected:   false,
+		},
+		{
+			name: "same slice",
+			value: func() Value {
+				m := NewValueSlice()
+				require.NoError(t, m.Slice().FromRaw([]any{1337}))
+				return m
+			}(),
+			comparison: []any{1337},
+			expected:   true,
+		},
+		{
+			name: "different slice",
+			value: func() Value {
+				m := NewValueSlice()
+				require.NoError(t, m.Slice().FromRaw([]any{1337}))
+				return m
+			}(),
+			comparison: []any{1701},
+			expected:   false,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.value.Equal(tt.comparison))

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -816,7 +816,7 @@ func TestValueEqual(t *testing.T) {
 			expected:   true,
 		},
 		{
-			name: "different slice",
+			name: "different maps",
 			value: func() Value {
 				m := NewValueMap()
 				m.Map().PutStr("hello", "world")
@@ -828,6 +828,121 @@ func TestValueEqual(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.value.Equal(tt.comparison))
+		})
+	}
+}
+
+func BenchmarkValueEqual(b *testing.B) {
+	for _, bb := range []struct {
+		name       string
+		value      Value
+		comparison any
+	}{
+		{
+			name:       "strings",
+			value:      NewValueStr("test"),
+			comparison: "test",
+		},
+		{
+			name:       "booleans",
+			value:      NewValueBool(true),
+			comparison: true,
+		},
+		{
+			name:       "ints",
+			value:      NewValueInt(42),
+			comparison: int(42),
+		},
+		{
+			name:       "ints8",
+			value:      NewValueInt(42),
+			comparison: int8(42),
+		},
+		{
+			name:       "ints16",
+			value:      NewValueInt(42),
+			comparison: int16(42),
+		},
+		{
+			name:       "ints32",
+			value:      NewValueInt(42),
+			comparison: int32(42),
+		},
+		{
+			name:       "ints64",
+			value:      NewValueInt(42),
+			comparison: int(42),
+		},
+		{
+			name:       "uints",
+			value:      NewValueInt(42),
+			comparison: uint(42),
+		},
+		{
+			name:       "uints8",
+			value:      NewValueInt(42),
+			comparison: uint8(42),
+		},
+		{
+			name:       "uints16",
+			value:      NewValueInt(42),
+			comparison: uint16(42),
+		},
+		{
+			name:       "uints32",
+			value:      NewValueInt(42),
+			comparison: uint32(42),
+		},
+		{
+			name:       "uints64",
+			value:      NewValueInt(42),
+			comparison: uint(42),
+		},
+		{
+			name:       "floats32",
+			value:      NewValueDouble(13.37),
+			comparison: float32(13.37),
+		},
+		{
+			name:       "floats64",
+			value:      NewValueDouble(13.37),
+			comparison: float64(13.37),
+		},
+		{
+			name: "byte slices",
+			value: func() Value {
+				m := NewValueBytes()
+				m.Bytes().FromRaw([]byte{1, 3, 3, 7})
+				return m
+			}(),
+			comparison: []byte{1, 3, 3, 7},
+		},
+		{
+			name: "slices",
+			value: func() Value {
+				m := NewValueSlice()
+				require.NoError(b, m.Slice().FromRaw([]any{1337}))
+				return m
+			}(),
+			comparison: []any{1337},
+		},
+		{
+			name: "maps",
+			value: func() Value {
+				m := NewValueMap()
+				m.Map().PutStr("hello", "world")
+				return m
+			}(),
+			comparison: map[string]any{"hello": "world"},
+		},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for n := 0; n < b.N; n++ {
+				_ = bb.value.Equal(bb.comparison)
+			}
 		})
 	}
 }

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -586,6 +586,12 @@ func TestValueEqual(t *testing.T) {
 		expected   bool
 	}{
 		{
+			name:       "same empty",
+			value:      NewValueEmpty(),
+			comparison: nil,
+			expected:   true,
+		},
+		{
 			name:       "same strings",
 			value:      NewValueStr("test"),
 			comparison: "test",
@@ -838,6 +844,11 @@ func BenchmarkValueEqual(b *testing.B) {
 		value      Value
 		comparison any
 	}{
+		{
+			name:       "nil",
+			value:      NewValueEmpty(),
+			comparison: nil,
+		},
 		{
 			name:       "strings",
 			value:      NewValueStr("test"),

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -805,6 +805,26 @@ func TestValueEqual(t *testing.T) {
 			comparison: []any{1701},
 			expected:   false,
 		},
+		{
+			name: "same map",
+			value: func() Value {
+				m := NewValueMap()
+				m.Map().PutStr("hello", "world")
+				return m
+			}(),
+			comparison: map[string]any{"hello": "world"},
+			expected:   true,
+		},
+		{
+			name: "different slice",
+			value: func() Value {
+				m := NewValueMap()
+				m.Map().PutStr("hello", "world")
+				return m
+			}(),
+			comparison: map[string]any{"bonjour": "monde"},
+			expected:   false,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.value.Equal(tt.comparison))

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -578,6 +578,200 @@ func TestInvalidValue(t *testing.T) {
 	assert.Panics(t, func() { v.CopyTo(NewValueEmpty()) })
 }
 
+func TestValueEqual(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		value      Value
+		comparison any
+		expected   bool
+	}{
+		{
+			name:       "same strings",
+			value:      NewValueStr("test"),
+			comparison: "test",
+			expected:   true,
+		},
+		{
+			name:       "different strings",
+			value:      NewValueStr("test"),
+			comparison: "non-test",
+			expected:   false,
+		},
+		{
+			name:       "an empty value and an empty string",
+			value:      NewValueEmpty(),
+			comparison: "",
+			expected:   true,
+		},
+		{
+			name:       "an empty value and a non-empty string",
+			value:      NewValueEmpty(),
+			comparison: "test",
+			expected:   false,
+		},
+		{
+			name:       "same booleans",
+			value:      NewValueBool(true),
+			comparison: true,
+			expected:   true,
+		},
+		{
+			name:       "different booleans",
+			value:      NewValueBool(true),
+			comparison: false,
+			expected:   false,
+		},
+		{
+			name:       "same int",
+			value:      NewValueInt(42),
+			comparison: int(42),
+			expected:   true,
+		},
+		{
+			name:       "different ints",
+			value:      NewValueInt(42),
+			comparison: int(1701),
+			expected:   false,
+		},
+		{
+			name:       "same int8",
+			value:      NewValueInt(42),
+			comparison: int8(42),
+			expected:   true,
+		},
+		{
+			name:       "different ints8",
+			value:      NewValueInt(42),
+			comparison: int8(127),
+			expected:   false,
+		},
+		{
+			name:       "same int16",
+			value:      NewValueInt(42),
+			comparison: int16(42),
+			expected:   true,
+		},
+		{
+			name:       "different ints16",
+			value:      NewValueInt(42),
+			comparison: int16(1701),
+			expected:   false,
+		},
+		{
+			name:       "same int32",
+			value:      NewValueInt(42),
+			comparison: int32(42),
+			expected:   true,
+		},
+		{
+			name:       "different ints32",
+			value:      NewValueInt(42),
+			comparison: int32(1701),
+			expected:   false,
+		},
+		{
+			name:       "same int64",
+			value:      NewValueInt(42),
+			comparison: int(42),
+			expected:   true,
+		},
+		{
+			name:       "different ints64",
+			value:      NewValueInt(42),
+			comparison: int64(1701),
+			expected:   false,
+		},
+		{
+			name:       "same uint",
+			value:      NewValueInt(42),
+			comparison: uint(42),
+			expected:   true,
+		},
+		{
+			name:       "different uints",
+			value:      NewValueInt(42),
+			comparison: uint(1701),
+			expected:   false,
+		},
+		{
+			name:       "same uint8",
+			value:      NewValueInt(42),
+			comparison: uint8(42),
+			expected:   true,
+		},
+		{
+			name:       "different uints8",
+			value:      NewValueInt(42),
+			comparison: uint8(255),
+			expected:   false,
+		},
+		{
+			name:       "same uint16",
+			value:      NewValueInt(42),
+			comparison: uint16(42),
+			expected:   true,
+		},
+		{
+			name:       "different uints16",
+			value:      NewValueInt(42),
+			comparison: uint16(1701),
+			expected:   false,
+		},
+		{
+			name:       "same uint32",
+			value:      NewValueInt(42),
+			comparison: uint32(42),
+			expected:   true,
+		},
+		{
+			name:       "different uints32",
+			value:      NewValueInt(42),
+			comparison: uint32(1701),
+			expected:   false,
+		},
+		{
+			name:       "same uint64",
+			value:      NewValueInt(42),
+			comparison: uint(42),
+			expected:   true,
+		},
+		{
+			name:       "different uints64",
+			value:      NewValueInt(42),
+			comparison: uint64(1701),
+			expected:   false,
+		},
+		{
+			name:       "same float32",
+			value:      NewValueDouble(13.37),
+			comparison: float32(13.37),
+			expected:   true,
+		},
+		{
+			name:       "different floats32",
+			value:      NewValueDouble(13.37),
+			comparison: float32(17.01),
+			expected:   false,
+		},
+		{
+			name:       "same float64",
+			value:      NewValueDouble(13.37),
+			comparison: float64(13.37),
+			expected:   true,
+		},
+		{
+			name:       "different floats64",
+			value:      NewValueDouble(13.37),
+			comparison: float64(17.01),
+			expected:   false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.value.Equal(tt.comparison))
+		})
+	}
+}
+
 func generateTestValueMap() Value {
 	ret := NewValueMap()
 	attrMap := ret.Map()


### PR DESCRIPTION
#### Description

This introduces `.Equal()` methods to most pcommon types, so equality comparison can be performed with no allocations.

The types `Equal` is added to are:

* `Value`
* `ByteSlice`
* `Float64Slice`
* `Int32Slice`
* `Int64Slice`
* `StringSlice`
* `Uint64Slice`
* `Map`
* `Slice`

The original intent was to add it to `Value`. However, to be able to handle every type in there, I had to also add it to the other types, some of which are coming too because they are auto-generated.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #12561

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Here are the results from the new benchmarks.

```
go test -bench=. ./...
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/collector/pdata/pcommon
cpu: Apple M1 Max
BenchmarkByteSliceEqual-10              518354892                2.216 ns/op           0 B/op          0 allocs/op
BenchmarkFloat64SliceEqual-10           536303960                2.213 ns/op           0 B/op          0 allocs/op
BenchmarkInt32SliceEqual-10             544727418                2.208 ns/op           0 B/op          0 allocs/op
BenchmarkInt64SliceEqual-10             544786770                2.218 ns/op           0 B/op          0 allocs/op
BenchmarkStringSliceEqual-10            161984316                7.491 ns/op           0 B/op          0 allocs/op
BenchmarkUInt64SliceEqual-10            543405762                2.211 ns/op           0 B/op          0 allocs/op
BenchmarkMapEqual-10                    95199063                12.37 ns/op            0 B/op          0 allocs/op
BenchmarkSliceEqual-10                  180702288                6.640 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/nil-10              583397124                2.065 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/strings-10          252571316                4.735 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/booleans-10         421377843                2.865 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/ints-10             420362413                2.861 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/ints8-10            420972375                2.867 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/ints16-10           420432676                2.865 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/ints32-10           418548438                2.871 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/ints64-10           419564282                2.868 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/uints-10            420894673                2.874 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/uints8-10           419992580                2.864 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/uints16-10          419492168                2.869 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/uints32-10          418700623                2.862 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/uints64-10          419113983                2.870 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/floats32-10         419409087                2.866 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/floats64-10         418236566                2.872 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/byte_slices-10              223578720                5.368 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/slices-10                   140243206                8.587 ns/op           0 B/op          0 allocs/op
BenchmarkValueEqual/maps-10                     72963666                16.25 ns/op            0 B/op          0 allocs/op
PASS
ok      go.opentelemetry.io/collector/pdata/pcommon     40.049s
```