### PR TITLE
[chore] fix receiverhelper version

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -121,7 +121,7 @@ require (
 	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.121.0 // indirect
 	go.opentelemetry.io/collector/processor/processortest v0.121.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.121.0 // indirect
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.121.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.121.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.121.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.121.0 // indirect

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -100,7 +100,7 @@ require (
 	go.opentelemetry.io/collector/processor v0.121.0 // indirect
 	go.opentelemetry.io/collector/processor/processortest v0.121.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.121.0 // indirect
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.121.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.121.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.121.0 // indirect
 	go.opentelemetry.io/collector/service/hostcapabilities v0.121.0 // indirect

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/collector/pdata/pprofile v0.121.0
 	go.opentelemetry.io/collector/pdata/testdata v0.121.0
 	go.opentelemetry.io/collector/receiver v0.121.0
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.121.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.121.0
 	go.opentelemetry.io/collector/receiver/xreceiver v0.121.0
 	go.opentelemetry.io/otel v1.35.0


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
I changed the version of receiverhelper from 0.0.0-00010101000000-000000000000 to 0.121.0. I noticed this while trying to fix another issue, and I am not sure if this change matters, but I haven't seen other packages having that version in the collector, so I felt it was worth adjusting.

<!-- Issue number if applicable -->
#### Link to tracking issue
none

<!--Describe what testing was performed and which tests were added.-->
#### Testing
`make all golint gotest` all pass without dirtying the index