### PR TITLE
Propagate telemetry.resource to the internal logs

### DIFF
--- a/.chloggen/fix-resource-attributes-internal-console-logger.yaml
+++ b/.chloggen/fix-resource-attributes-internal-console-logger.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+ # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+ change_type: bug_fix
+
+ # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+ component: "internal telemetry"
+
+ # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+ note: "Add resource attributes from telemetry.resource to the logger"
+
+ # One or more tracking issues or pull requests related to the change
+ issues: [12582]
+
+ # (Optional) One or more lines of additional information to render under the primary note.
+ # These lines will be padded with 2 spaces and then inserted directly into the document.
+ # Use pipe (|) for multiline entries.
+ subtext: |
+   Resource attributes from telemetry.resource were not added to the internal
+   console logs.
+
+   Now, they are added to the logger as part of the "resource" field.
+
+ # Optional: The change log or logs in which this entry should be included.
+ # e.g. '[user]' or '[user, api]'
+ # Include 'user' if the change is relevant to end users.
+ # Include 'api' if there is a change to a library API.
+ # Default: '[user]'
+ change_logs: []

--- a/service/telemetry/logger.go
+++ b/service/telemetry/logger.go
@@ -39,6 +39,22 @@ func newLogger(set Settings, cfg Config) (*zap.Logger, log.LoggerProvider, error
 		return nil, nil, err
 	}
 
+	// The attributes in cfg.Resource are added as resource attributes for logs exported through the LoggerProvider instantiated below.
+	// To make sure they are also exposed in logs written to stdout, we add them as fields to the Zap core created above using WrapCore.
+	// We do NOT add them to the logger using With, because that would apply to all logs, even ones exported through the core that wraps
+	// the LoggerProvider, meaning that the attributes would be exported twice.
+	logger = logger.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+		fields := []zap.Field{}
+		for k, v := range cfg.Resource {
+			if v != nil {
+				f := zap.Stringp(k, v)
+				fields = append(fields, f)
+			}
+		}
+		r := zap.Dict("resource", fields...)
+		return c.With([]zapcore.Field{r})
+	}))
+
 	var lp log.LoggerProvider
 
 	logger = logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {


### PR DESCRIPTION
#### Description
Propagate `telemetry.resource` to the internal logs.

#### Link to tracking issue
Fixes #12582
