### PR TITLE
[chore] update min version in tidy

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -76,7 +76,7 @@ fmt: common/gofmt common/goimports common/gofumpt
 .PHONY: tidy
 tidy:
 	rm -fr go.sum
-	$(GOCMD) mod tidy -compat=1.22.0
+	$(GOCMD) mod tidy -compat=1.23.0
 
 .PHONY: lint
 lint: $(LINT)

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -149,7 +149,7 @@ func GetModules(cfg *Config) error {
 		return nil
 	}
 
-	if _, err := runGoCommand(cfg, "mod", "tidy", "-compat=1.22"); err != nil {
+	if _, err := runGoCommand(cfg, "mod", "tidy", "-compat=1.23"); err != nil {
 		return fmt.Errorf("failed to update go.mod: %w", err)
 	}
 


### PR DESCRIPTION
This was missed in the upgrade of go1.24
