### PR TITLE
[builder] Add --go-build-flags cli flag

### DIFF
--- a/.chloggen/braydonk_ocb-build-flags.yaml
+++ b/.chloggen/braydonk_ocb-build-flags.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `--go-build-flags` CLI flag that allows the user to supply arguments to the `go build` command used to build the collector.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12588]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -225,3 +225,22 @@ file for the following things after `go get`ing all components and calling
 The `--skip-strict-versioning` flag disables these versioning checks.
 This flag is available temporarily and
 **will be removed in a future minor version**.
+
+## Customize Go Build
+
+By default, the builder will set a number of default arguments for the `go build` command it runs to build the collector. This includes: 
+
+* `-o` matching `dist::name`
+* `-trimpath` 
+* Default or provided `-ldflags`
+* Provided `-gcflags`
+* `-tags` configured from `dist::build_tags`
+
+You can provide additional flags to `go build` with the builder flag `--go-build-flags`:
+```console
+ocb --config=config.yaml --go-build-flags="-p 32 -buildvcs=false"
+```
+If you provide any flags in `--go-build-flags` that are already configured by the builder automatically, **they will be overridden**:
+```console
+ocb --config=config.yaml --go-build-flags="-o alt-bin-name" # The binary will be called "alt-bin-name" instead of dist::name
+```

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -36,9 +36,9 @@ type Config struct {
 	SkipGetModules       bool   `mapstructure:"-"`
 	SkipStrictVersioning bool   `mapstructure:"-"`
 	LDFlags              string `mapstructure:"-"`
-	LDSet                bool   `mapstructure:"-"`
+	LDSet                bool   `mapstructure:"-"` // true if ldflags is set from cli flag
 	GCFlags              string `mapstructure:"-"`
-	GCSet                bool   `mapstructure:"-"`
+	GCSet                bool   `mapstructure:"-"` // true if gcflags is set from cli flag
 	GoBuildFlags         string `mapstructure:"-"`
 	Verbose              bool   `mapstructure:"-"`
 

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -242,7 +242,8 @@ func (c *Config) getGoBuildArgs() []string {
 	// Typically the -ldflags values are quoted i.e. -ldflags="<flags>".
 	// However since these args are used as exec.Cmd args, adding quotes
 	// will break the exec.Cmd argument parser. So they are instead provided
-	// as -ldflags=<flags>.
+	// as -ldflags=<flags>, and when it is applied to the go build command
+	// it will effectively be `go build "-ldflags=<flags>"`.
 	args = append(args, "-ldflags="+ldflags)
 	args = append(args, "-gcflags="+gcflags)
 

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -36,7 +36,9 @@ type Config struct {
 	SkipGetModules       bool   `mapstructure:"-"`
 	SkipStrictVersioning bool   `mapstructure:"-"`
 	LDFlags              string `mapstructure:"-"`
+	LDSet                bool   `mapstructure:"-"`
 	GCFlags              string `mapstructure:"-"`
+	GCSet                bool   `mapstructure:"-"`
 	GoBuildFlags         string `mapstructure:"-"`
 	Verbose              bool   `mapstructure:"-"`
 
@@ -227,11 +229,11 @@ func (c *Config) getGoBuildArgs() []string {
 		ldflags = c.LDFlags
 		gcflags = "all=-N -l"
 	} else {
-		if c.LDFlags != "" {
+		if c.LDSet {
 			c.Logger.Info("Using custom ldflags", zap.String("ldflags", c.LDFlags))
 			ldflags = c.LDFlags
 		}
-		if c.GCFlags != "" {
+		if c.GCSet {
 			c.Logger.Info("Using custom gcflags", zap.String("gcflags", c.GCFlags))
 			gcflags = c.GCFlags
 		}

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -291,7 +291,9 @@ func TestNewDefaultConfig(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 	assert.False(t, cfg.Distribution.DebugCompilation)
 	assert.Empty(t, cfg.Distribution.BuildTags)
+	assert.False(t, cfg.LDSet)
 	assert.Empty(t, cfg.LDFlags)
+	assert.False(t, cfg.GCSet)
 	assert.Empty(t, cfg.GCFlags)
 }
 

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -5,6 +5,7 @@ package builder
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -388,6 +389,10 @@ func TestValidateDeprecatedOtelColVersion(t *testing.T) {
 
 func TestGetGoBuildArgs(t *testing.T) {
 	distribution := Distribution{Name: "default", BuildTags: "default"}
+	oFlagValue := distribution.Name
+	if runtime.GOOS == "windows" {
+		oFlagValue += ".exe"
+	}
 	testCases := []struct {
 		name         string
 		cfg          *Config
@@ -399,7 +404,7 @@ func TestGetGoBuildArgs(t *testing.T) {
 				Distribution: distribution,
 			},
 			expectedArgs: []string{
-				"build", "-trimpath", "-o", distribution.Name,
+				"build", "-trimpath", "-o", oFlagValue,
 				"-ldflags=-s -w", "-gcflags=", "-tags", distribution.BuildTags,
 			},
 		},
@@ -411,7 +416,7 @@ func TestGetGoBuildArgs(t *testing.T) {
 				LDFlags:      "-msan -f",
 			},
 			expectedArgs: []string{
-				"build", "-trimpath", "-o", distribution.Name,
+				"build", "-trimpath", "-o", oFlagValue,
 				"-ldflags=-msan -f", "-gcflags=", "-tags", distribution.BuildTags,
 			},
 		},
@@ -423,7 +428,7 @@ func TestGetGoBuildArgs(t *testing.T) {
 				GCFlags:      "-asan",
 			},
 			expectedArgs: []string{
-				"build", "-trimpath", "-o", distribution.Name,
+				"build", "-trimpath", "-o", oFlagValue,
 				"-ldflags=-s -w", "-gcflags=-asan", "-tags", distribution.BuildTags,
 			},
 		},
@@ -434,7 +439,7 @@ func TestGetGoBuildArgs(t *testing.T) {
 				GoBuildFlags: "-buildvcs=false -p 32",
 			},
 			expectedArgs: []string{
-				"build", "-trimpath", "-o", distribution.Name,
+				"build", "-trimpath", "-o", oFlagValue,
 				"-ldflags=-s -w", "-gcflags=", "-tags", distribution.BuildTags,
 				"-buildvcs=false", "-p", "32",
 			},
@@ -449,7 +454,7 @@ func TestGetGoBuildArgs(t *testing.T) {
 				}(),
 			},
 			expectedArgs: []string{
-				"build", "-trimpath", "-o", distribution.Name,
+				"build", "-trimpath", "-o", oFlagValue,
 				"-ldflags=-s -w", "-gcflags=",
 			},
 		},
@@ -460,7 +465,7 @@ func TestGetGoBuildArgs(t *testing.T) {
 				GoBuildFlags: "-tags alternate,tags",
 			},
 			expectedArgs: []string{
-				"build", "-trimpath", "-o", distribution.Name,
+				"build", "-trimpath", "-o", oFlagValue,
 				"-ldflags=-s -w", "-gcflags=", "-tags", distribution.BuildTags,
 				"-tags", "alternate,tags",
 			},

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -407,6 +407,7 @@ func TestGetGoBuildArgs(t *testing.T) {
 			name: "override ldflags",
 			cfg: &Config{
 				Distribution: distribution,
+				LDSet:        true,
 				LDFlags:      "-B test",
 			},
 			expectedArgs: []string{
@@ -418,6 +419,7 @@ func TestGetGoBuildArgs(t *testing.T) {
 			name: "override gcflags",
 			cfg: &Config{
 				Distribution: distribution,
+				GCSet:        true,
 				GCFlags:      "-asan",
 			},
 			expectedArgs: []string{

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -408,11 +408,11 @@ func TestGetGoBuildArgs(t *testing.T) {
 			cfg: &Config{
 				Distribution: distribution,
 				LDSet:        true,
-				LDFlags:      "-B test",
+				LDFlags:      "-msan -f",
 			},
 			expectedArgs: []string{
 				"build", "-trimpath", "-o", distribution.Name,
-				"-ldflags=-B test", "-gcflags=", "-tags", distribution.BuildTags,
+				"-ldflags=-msan -f", "-gcflags=", "-tags", distribution.BuildTags,
 			},
 		},
 		{

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -473,7 +473,6 @@ func TestGetGoBuildArgs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tc.cfg.Logger = zap.NewNop()

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -108,33 +108,7 @@ func Compile(cfg *Config) error {
 	}
 
 	cfg.Logger.Info("Compiling")
-
-	ldflags := "-s -w" // we strip the symbols by default for smaller binaries
-	gcflags := ""
-
-	args := []string{"build", "-trimpath", "-o", cfg.Distribution.Name}
-	if cfg.Distribution.DebugCompilation {
-		cfg.Logger.Info("Debug compilation is enabled, the debug symbols will be left on the resulting binary")
-		ldflags = cfg.LDFlags
-		gcflags = "all=-N -l"
-	} else {
-		if cfg.LDSet {
-			cfg.Logger.Info("Using custom ldflags", zap.String("ldflags", cfg.LDFlags))
-			ldflags = cfg.LDFlags
-		}
-		if cfg.GCSet {
-			cfg.Logger.Info("Using custom gcflags", zap.String("gcflags", cfg.GCFlags))
-			gcflags = cfg.GCFlags
-		}
-	}
-
-	args = append(args, "-ldflags="+ldflags)
-	args = append(args, "-gcflags="+gcflags)
-
-	if cfg.Distribution.BuildTags != "" {
-		args = append(args, "-tags", cfg.Distribution.BuildTags)
-	}
-	if _, err := runGoCommand(cfg, args...); err != nil {
+	if _, err := runGoCommand(cfg, cfg.getGoBuildArgs()...); err != nil {
 		return fmt.Errorf("%w: %s", errCompileFailed, err.Error())
 	}
 	cfg.Logger.Info("Compiled", zap.String("binary", fmt.Sprintf("%s/%s", cfg.Distribution.OutputPath, cfg.Distribution.Name)))

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -113,6 +113,7 @@ var replaceModules = []string{
 func newTestConfig(tb testing.TB) *Config {
 	cfg, err := NewDefaultConfig()
 	require.NoError(tb, err)
+	cfg.Distribution.Name = "test_distribution"
 	cfg.downloadModules.wait = 0
 	cfg.downloadModules.numRetries = 1
 	return cfg
@@ -251,7 +252,6 @@ func TestGenerateAndCompile(t *testing.T) {
 				cfg := newTestConfig(t)
 				cfg.Distribution.OutputPath = t.TempDir()
 				cfg.Replaces = append(cfg.Replaces, replaces...)
-				cfg.LDSet = true
 				cfg.LDFlags = `-X "test.gitVersion=0743dc6c6411272b98494a9b32a63378e84c34da" -X "test.gitTag=local-testing" -X "test.goVersion=go version go1.20.7 darwin/amd64"`
 				return cfg
 			},
@@ -262,7 +262,6 @@ func TestGenerateAndCompile(t *testing.T) {
 				cfg := newTestConfig(t)
 				cfg.Distribution.OutputPath = t.TempDir()
 				cfg.Replaces = append(cfg.Replaces, replaces...)
-				cfg.GCSet = true
 				cfg.GCFlags = `all=-N -l`
 				return cfg
 			},
@@ -358,8 +357,7 @@ func TestReplaceStatementsAreComplete(t *testing.T) {
 
 	var err error
 	dir := t.TempDir()
-	cfg, err := NewDefaultConfig()
-	require.NoError(t, err)
+	cfg := newTestConfig(t)
 	cfg.Distribution.Go = "go"
 	cfg.Distribution.OutputPath = dir
 	cfg.Replaces = append(cfg.Replaces, generateReplaces()...)

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -348,6 +348,25 @@ func TestGenerateAndCompile(t *testing.T) {
 	}
 }
 
+func TestGenerateAndCompile_CompileError(t *testing.T) {
+	// This test forces a compile failure by providing
+	// purposely malformed ldflag.
+	cfg := newTestConfig(t)
+	cfg.ConfResolver = ConfResolver{
+		DefaultURIScheme: "env",
+	}
+	cfg.Distribution.OutputPath = t.TempDir()
+	cfg.Replaces = append(cfg.Replaces, generateReplaces()...)
+	if testing.Verbose() {
+		cfg.Verbose = true
+	}
+	cfg.LDSet = true
+	cfg.LDFlags = "-B otelrocks"
+	assert.NoError(t, cfg.SetGoPath())
+	assert.NoError(t, cfg.ParseModules())
+	require.ErrorIs(t, GenerateAndCompile(cfg), errCompileFailed)
+}
+
 // Test that the go.mod files that other tests in this file
 // may generate have all their modules covered by our
 // "replace" statements created in `generateReplaces`.

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -319,6 +319,19 @@ func TestGenerateAndCompile(t *testing.T) {
 				return cfg
 			},
 		},
+		{
+			name: "Go Build Flags compilation",
+			cfgBuilder: func(t *testing.T) *Config {
+				cfg := newTestConfig(t)
+				cfg.ConfResolver = ConfResolver{
+					DefaultURIScheme: "env",
+				}
+				cfg.GoBuildFlags = "-p 16"
+				cfg.Distribution.OutputPath = t.TempDir()
+				cfg.Replaces = append(cfg.Replaces, replaces...)
+				return cfg
+			},
+		},
 	}
 
 	for _, tt := range testCases {
@@ -327,6 +340,9 @@ func TestGenerateAndCompile(t *testing.T) {
 			assert.NoError(t, cfg.Validate())
 			assert.NoError(t, cfg.SetGoPath())
 			assert.NoError(t, cfg.ParseModules())
+			if testing.Verbose() {
+				cfg.Verbose = true
+			}
 			require.NoError(t, GenerateAndCompile(cfg))
 		})
 	}

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -150,10 +150,12 @@ func applyFlags(flags *flag.FlagSet, cfg *builder.Config) error {
 	errs = multierr.Append(errs, err)
 
 	if flags.Changed(ldflagsFlag) {
+		cfg.LDSet = true
 		cfg.LDFlags, err = flags.GetString(ldflagsFlag)
 		errs = multierr.Append(errs, err)
 	}
 	if flags.Changed(gcflagsFlag) {
+		cfg.GCSet = true
 		cfg.GCFlags, err = flags.GetString(gcflagsFlag)
 		errs = multierr.Append(errs, err)
 	}

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -28,6 +28,7 @@ const (
 	skipStrictVersioningFlag   = "skip-strict-versioning"
 	ldflagsFlag                = "ldflags"
 	gcflagsFlag                = "gcflags"
+	goBuildFlagsFlag           = "go-build-flags"
 	distributionOutputPathFlag = "output-path"
 	verboseFlag                = "verbose"
 )
@@ -86,6 +87,7 @@ func initFlags(flags *flag.FlagSet) error {
 	flags.Bool(verboseFlag, false, "Whether builder should print verbose output (default false)")
 	flags.String(ldflagsFlag, "", `ldflags to include in the "go build" command`)
 	flags.String(gcflagsFlag, "", `gcflags to include in the "go build" command`)
+	flags.String(goBuildFlagsFlag, "", `Addition args for the "go build" command`)
 	flags.String(distributionOutputPathFlag, "", "Where to write the resulting files")
 	return flags.MarkDeprecated(distributionOutputPathFlag, "use config distribution::output_path")
 }
@@ -148,13 +150,15 @@ func applyFlags(flags *flag.FlagSet, cfg *builder.Config) error {
 	errs = multierr.Append(errs, err)
 
 	if flags.Changed(ldflagsFlag) {
-		cfg.LDSet = true
 		cfg.LDFlags, err = flags.GetString(ldflagsFlag)
 		errs = multierr.Append(errs, err)
 	}
 	if flags.Changed(gcflagsFlag) {
-		cfg.GCSet = true
 		cfg.GCFlags, err = flags.GetString(gcflagsFlag)
+		errs = multierr.Append(errs, err)
+	}
+	if flags.Changed(goBuildFlagsFlag) {
+		cfg.GoBuildFlags, err = flags.GetString(goBuildFlagsFlag)
 		errs = multierr.Append(errs, err)
 	}
 

--- a/cmd/builder/internal/command_test.go
+++ b/cmd/builder/internal/command_test.go
@@ -68,15 +68,21 @@ func TestApplyFlags(t *testing.T) {
 			},
 		},
 		{
-			name:  "All flag values",
-			flags: []string{"--skip-generate=true", "--skip-compilation=true", "--skip-get-modules=true", "--skip-strict-versioning=true", "--ldflags=test", "--gcflags=test", "--verbose=true"},
+			name: "All flag values",
+			flags: []string{
+				"--skip-generate=true", "--skip-compilation=true", "--skip-get-modules=true", "--skip-strict-versioning=true",
+				"--ldflags=-s -w", "--gcflags=-asan", "--verbose=true", "--go-build-flags='-buildvcs=false'",
+			},
 			want: &builder.Config{
 				SkipGenerate:         true,
 				SkipCompilation:      true,
 				SkipGetModules:       true,
 				SkipStrictVersioning: true,
-				LDFlags:              "test",
-				GCFlags:              "test",
+				LDFlags:              "-s -w",
+				LDSet:                true,
+				GCFlags:              "-all",
+				GCSet:                true,
+				GoBuildFlags:         "-buildvcs=false",
 				Verbose:              true,
 			},
 		},
@@ -93,7 +99,10 @@ func TestApplyFlags(t *testing.T) {
 			assert.Equal(t, tt.want.SkipCompilation, cfg.SkipCompilation)
 			assert.Equal(t, tt.want.SkipGetModules, cfg.SkipGetModules)
 			assert.Equal(t, tt.want.SkipStrictVersioning, cfg.SkipStrictVersioning)
+			assert.Equal(t, tt.want.LDSet, cfg.LDSet)
 			assert.Equal(t, tt.want.LDFlags, cfg.LDFlags)
+			assert.Equal(t, tt.want.GCSet, cfg.GCSet)
+			assert.Equal(t, tt.want.GCFlags, cfg.GCFlags)
 			assert.Equal(t, tt.want.Verbose, cfg.Verbose)
 		})
 	}

--- a/cmd/builder/internal/command_test.go
+++ b/cmd/builder/internal/command_test.go
@@ -80,7 +80,7 @@ func TestApplyFlags(t *testing.T) {
 				SkipStrictVersioning: true,
 				LDFlags:              "-s -w",
 				LDSet:                true,
-				GCFlags:              "-all",
+				GCFlags:              "-asan",
 				GCSet:                true,
 				GoBuildFlags:         "-buildvcs=false",
 				Verbose:              true,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds the `--go-build-flags` cli flag which will allow the user to pass additional flags for the `go build` command used to compile the collector.

While doing the refactor, I also made it so that the default binary name now adds the `.exe` extension when building for Windows.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #12588 
Fixes #12591 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
New unit tests were added to verify the build command args based on the config. A new CompileAndGenerate test case was added as well.

<!--Describe the documentation added.-->
#### Documentation
A section has been added to the README.

<!--Please delete paragraphs that you did not use before submitting.-->
