### PR TITLE
confighttp: route-based span naming for ServeMux

### DIFF
--- a/.chloggen/confighttp-server-spanname.yaml
+++ b/.chloggen/confighttp-server-spanname.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use low-cardinality route pattern for confighttp server span names
+
+# One or more tracking issues or pull requests related to the change
+issues: [12468]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  For components that route HTTP requests using a net/http.ServeMux, such as otlpreceiver,
+  server spans will now be given low-cardinality span names based on the route pattern.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api, user]

--- a/.chloggen/confighttp-server-spanname.yaml
+++ b/.chloggen/confighttp-server-spanname.yaml
@@ -24,4 +24,4 @@ subtext: |
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [api, user]
+change_logs: [user]

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.121.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0
 	go.opentelemetry.io/otel v1.35.0
+	go.opentelemetry.io/otel/sdk v1.35.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/net v0.36.0
@@ -37,7 +38,6 @@ require (
 	go.opentelemetry.io/collector/extension v1.27.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.27.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect


### PR DESCRIPTION
#### Description

Update confighttp.ServerConfig.ToServer to handle ServeMux specially: if the handler supplied to ToServer is an http.ServeMux, we use its [Handler method](https://pkg.go.dev/net/http#ServeMux.Handler) to determine the matching pattern and use that to name the span as described at https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name. If there is no matching pattern then we fall back to "unknown route".

This approach means that everything will magically just work for components that supply a ServeMux, but there are a couple of downsides:
 - this is a little bit magical, and won't help for components that _don't_ happen to use a ServeMux
 - route pattern matching needs to be done twice: once for the instrumentation, and once for routing to the correct handler

The alternative that I started working on before I came to this solution was to introduce a new method, ServerConfig.ToServeMux, which would not accept an `http.Handler`, and would instead return a type that wraps `*http.ServeMux`, and would instrument handlers as they are registered. With that approach the instrumentation would come after the routing, and we would install a default `/` NotFoundHandler that is also instrumented. This approach is a bit less magical, and a bit more efficient, but would require all the components to be updated.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/12468 (for any receiver that uses a ServeMux, like otlpreceiver)

#### Testing

- Added a unit test to confighttp for the instrumentation added by ServerConfig.ToServer.
- Tested with a otlpreceiver:
   - ran `make run` with trace telemetry enabled, exporting to console
   - used `telemetrygen logs --otlp-http`, confirmed that a span named "POST /v1/logs" is produced
   - used `curl http://localhost:4318`, confirmed that a span named "GET unknown route" is produced

#### Documentation

Added doc comment to confighttp.ServerConfig.ToServer explaining the new behaviour.