### PR TITLE
[chore] bump go version

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
 
       # Generate apidiff states of Main
       - name: Generate-States

--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         id: go-cache
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         id: go-cache
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         id: go-cache
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         id: go-cache
@@ -200,7 +200,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         id: go-cache
@@ -264,7 +264,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -35,6 +35,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
       - name: Test
         run: make builder-integration-test

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
       - name: Cache Go
         id: go-cache
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Run tests
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
 
       - name: Run benchmark
         run: make gobenchmark

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
       # Prepare Core for release.
       #   - Update CHANGELOG.md file, this is done via chloggen
       #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ~1.23.6
+          go-version: ~1.23.7
           cache: false
       - name: Cache Go
         id: go-cache

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -4,7 +4,7 @@ module go.opentelemetry.io/collector/cmd/otelcorecol
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.7
 
 require (
 	go.opentelemetry.io/collector/component v1.27.0


### PR DESCRIPTION
Latest version of go is causing toolchain change which breaks "Checks"
