### PR TITLE
Switch the pprofile.AddAttribute to use pcommon.Value rather than raw data

### DIFF
--- a/pdata/pprofile/attributes.go
+++ b/pdata/pprofile/attributes.go
@@ -34,11 +34,11 @@ func FromAttributeIndices(table AttributeTableSlice, record attributable) pcommo
 // AddAttribute updates an AttributeTable and a record's AttributeIndices to
 // add a new attribute.
 // The record can by any struct that implements an `AttributeIndices` method.
-func AddAttribute(table AttributeTableSlice, record attributable, key string, value any) error {
+func AddAttribute(table AttributeTableSlice, record attributable, key string, value pcommon.Value) error {
 	for i := range table.Len() {
 		a := table.At(i)
 
-		if a.Key() == key && value == a.Value().AsRaw() {
+		if a.Key() == key && a.Value().Equal(value) {
 			if i >= math.MaxInt32 {
 				return fmt.Errorf("Attribute %s=%#v has too high an index to be added to AttributeIndices", key, value)
 			}
@@ -61,9 +61,7 @@ func AddAttribute(table AttributeTableSlice, record attributable, key string, va
 	table.EnsureCapacity(table.Len() + 1)
 	entry := table.AppendEmpty()
 	entry.SetKey(key)
-	if err := entry.Value().FromRaw(value); err != nil {
-		return err
-	}
+	value.CopyTo(entry.Value())
 	record.AttributeIndices().Append(int32(table.Len()) - 1) //nolint:gosec // overflow checked
 
 	return nil

--- a/pdata/pprofile/attributes_test.go
+++ b/pdata/pprofile/attributes_test.go
@@ -52,7 +52,7 @@ func TestAddAttribute(t *testing.T) {
 
 	// Add a brand new attribute
 	loc := NewLocation()
-	err := AddAttribute(table, loc, "bonjour", "monde")
+	err := AddAttribute(table, loc, "bonjour", pcommon.NewValueStr("monde"))
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, table.Len())
@@ -60,14 +60,14 @@ func TestAddAttribute(t *testing.T) {
 
 	// Add an already existing attribute
 	mapp := NewMapping()
-	err = AddAttribute(table, mapp, "hello", "world")
+	err = AddAttribute(table, mapp, "hello", pcommon.NewValueStr("world"))
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, table.Len())
 	assert.Equal(t, []int32{0}, mapp.AttributeIndices().AsRaw())
 
 	// Add a duplicate attribute
-	err = AddAttribute(table, mapp, "hello", "world")
+	err = AddAttribute(table, mapp, "hello", pcommon.NewValueStr("world"))
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, table.Len())
@@ -98,19 +98,19 @@ func BenchmarkAddAttribute(b *testing.B) {
 	for _, bb := range []struct {
 		name  string
 		key   string
-		value any
+		value pcommon.Value
 
 		runBefore func(*testing.B, AttributeTableSlice, attributable)
 	}{
 		{
 			name:  "with a new string attribute",
 			key:   "attribute",
-			value: "test",
+			value: pcommon.NewValueStr("test"),
 		},
 		{
 			name:  "with an existing attribute",
 			key:   "attribute",
-			value: "test",
+			value: pcommon.NewValueStr("test"),
 
 			runBefore: func(_ *testing.B, table AttributeTableSlice, _ attributable) {
 				entry := table.AppendEmpty()
@@ -121,16 +121,16 @@ func BenchmarkAddAttribute(b *testing.B) {
 		{
 			name:  "with a duplicate attribute",
 			key:   "attribute",
-			value: "test",
+			value: pcommon.NewValueStr("test"),
 
 			runBefore: func(_ *testing.B, table AttributeTableSlice, obj attributable) {
-				require.NoError(b, AddAttribute(table, obj, "attribute", "test"))
+				require.NoError(b, AddAttribute(table, obj, "attribute", pcommon.NewValueStr("test")))
 			},
 		},
 		{
 			name:  "with a hundred attributes to loop through",
 			key:   "attribute",
-			value: "test",
+			value: pcommon.NewValueStr("test"),
 
 			runBefore: func(_ *testing.B, table AttributeTableSlice, _ attributable) {
 				for i := range 100 {


### PR DESCRIPTION
#### Description

As discussed in https://github.com/open-telemetry/opentelemetry-collector/issues/12561, this switches the `pprofile.AddAttribute` method to use `pcommon.Value` rather than raw data.

I didn't add a changelog entry, because this method has not been released yet. So the [introduction changelog entry](https://github.com/open-telemetry/opentelemetry-collector/blob/main/.chloggen/pprofile-add-attribute.yaml) should be enough.


#### Testing

Benchmark tests:

```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/collector/pdata/pprofile
cpu: Apple M1 Max
BenchmarkAddAttribute/with_a_new_string_attribute-10            47255384                25.08 ns/op           16 B/op          1 allocs/op
BenchmarkAddAttribute/with_an_existing_attribute-10             46872556                25.16 ns/op           16 B/op          1 allocs/op
BenchmarkAddAttribute/with_a_duplicate_attribute-10             47020178                25.18 ns/op           16 B/op          1 allocs/op
BenchmarkAddAttribute/with_a_hundred_attributes_to_loop_through-10               9166004               131.2 ns/op            16 B/op          1 allocs/op
PASS
ok      go.opentelemetry.io/collector/pdata/pprofile    6.246s
```
