### PR TITLE
Fix process metrics disable

### DIFF
--- a/.chloggen/fix_process_metrics_disable.yaml
+++ b/.chloggen/fix_process_metrics_disable.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: do not attempt to register process metrics if they are disabled
+
+# One or more tracking issues or pull requests related to the change
+issues: [12098]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/service/service.go
+++ b/service/service.go
@@ -224,8 +224,10 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		return nil, err
 	}
 
-	if err = proctelemetry.RegisterProcessMetrics(srv.telemetrySettings); err != nil {
-		return nil, fmt.Errorf("failed to register process metrics: %w", err)
+	if cfg.Level == configtelemetry.LevelNone || (cfg.Address == "" && len(cfg.Readers) == 0) {
+		if err = proctelemetry.RegisterProcessMetrics(srv.telemetrySettings); err != nil {
+			return nil, fmt.Errorf("failed to register process metrics: %w", err)
+		}
 	}
 
 	return srv, nil

--- a/service/service.go
+++ b/service/service.go
@@ -197,8 +197,6 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		err = multierr.Append(err, sdk.Shutdown(ctx))
 		return nil, fmt.Errorf("failed to create meter provider: %w", err)
 	}
-
-	logsAboutMeterProvider(logger, cfg.Telemetry.Metrics, mp)
 	srv.telemetrySettings = component.TelemetrySettings{
 		Logger:         logger,
 		MeterProvider:  mp,
@@ -229,6 +227,8 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 			return nil, fmt.Errorf("failed to register process metrics: %w", err)
 		}
 	}
+
+	logsAboutMeterProvider(logger, cfg.Telemetry.Metrics, mp)
 
 	return srv, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -224,7 +224,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		return nil, err
 	}
 
-	if cfg.Telemetry.Metrics.Level == configtelemetry.LevelNone || len(cfg.Telemetry.Metrics.Readers) == 0 {
+	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone || len(readers) != 0 {
 		if err = proctelemetry.RegisterProcessMetrics(srv.telemetrySettings); err != nil {
 			return nil, fmt.Errorf("failed to register process metrics: %w", err)
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -224,7 +224,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		return nil, err
 	}
 
-	if cfg.Level == configtelemetry.LevelNone || (cfg.Address == "" && len(cfg.Readers) == 0) {
+	if cfg.Telemetry.Metrics.Level == configtelemetry.LevelNone || len(cfg.Telemetry.Metrics.Readers) == 0 {
 		if err = proctelemetry.RegisterProcessMetrics(srv.telemetrySettings); err != nil {
 			return nil, fmt.Errorf("failed to register process metrics: %w", err)
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -222,7 +222,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		return nil, err
 	}
 
-	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone || len(readers) != 0 {
+	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && (len(readers) != 0 || cfg.Telemetry.Metrics.Address != "") {
 		if err = proctelemetry.RegisterProcessMetrics(srv.telemetrySettings); err != nil {
 			return nil, fmt.Errorf("failed to register process metrics: %w", err)
 		}


### PR DESCRIPTION
#### Description
Process registration protection for telemetry level being set to "None"

#### Link to tracking issue
Fixes #12098

#### Testing
Manual testing on an AIX 7.3 system rented from SiteOx:

```
-bash-5.2# ./otelcorecol_aix_ppc64 --config ./example.yaml 
2025-03-11T16:52:04.318-0500    info    service@v0.121.0/service.go:193 Setting up own telemetry...
2025-03-11T16:52:04.318-0500    info    service@v0.121.0/service.go:238 Skipped telemetry setup.
2025-03-11T16:52:04.318-0500    info    service@v0.121.0/service.go:260 Starting otelcorecol... {"Version": "0.121.0-dev", "NumCPU": 8}
2025-03-11T16:52:04.319-0500    info    extensions/extensions.go:40     Starting extensions...
2025-03-11T16:52:04.319-0500    info    service@v0.121.0/service.go:283 Everything is ready. Begin running and processing data.
2025-03-11T16:52:13.786-0500  info    otelcol@v0.121.0/collector.go:342       Received signal from OS {"signal": "interrupt"}
2025-03-11T16:52:13.786-0500    info    service@v0.121.0/service.go:325 Starting shutdown...
2025-03-11T16:52:13.786-0500    info    extensions/extensions.go:68     Stopping extensions...
2025-03-11T16:52:13.786-0500    info    service@v0.121.0/service.go:339 Shutdown complete.
```