### PR TITLE
[chore] Reduce port contention in service tests

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -349,12 +349,23 @@ func testCollectorStartHelperWithReaders(t *testing.T, tc ownMetricsTestCase, ne
 
 // TestServiceTelemetryRestart tests that the service correctly restarts the telemetry server.
 func TestServiceTelemetryRestart(t *testing.T) {
+	metricsAddr := promtest.GetAvailableLocalAddressPrometheus(t)
+	cfg := newNopConfig()
+	cfg.Telemetry.Metrics.Readers = []config.MetricReader{
+		{
+			Pull: &config.PullMetricReader{
+				Exporter: config.PullMetricExporter{
+					Prometheus: metricsAddr,
+				},
+			},
+		},
+	}
 	// Create a service
-	srvOne, err := New(context.Background(), newNopSettings(), newNopConfig())
+	srvOne, err := New(context.Background(), newNopSettings(), cfg)
 	require.NoError(t, err)
 
 	// URL of the telemetry service metrics endpoint
-	telemetryURL := "http://localhost:8888/metrics"
+	telemetryURL := fmt.Sprintf("http://%s:%d/metrics", *metricsAddr.Host, *metricsAddr.Port)
 
 	// Start the service
 	require.NoError(t, srvOne.Start(context.Background()))
@@ -375,7 +386,7 @@ func TestServiceTelemetryRestart(t *testing.T) {
 	require.NoError(t, srvOne.Shutdown(context.Background()))
 
 	// Create a new service with the same telemetry
-	srvTwo, err := New(context.Background(), newNopSettings(), newNopConfig())
+	srvTwo, err := New(context.Background(), newNopSettings(), cfg)
 	require.NoError(t, err)
 
 	// Start the new service
@@ -693,14 +704,6 @@ func newNopConfigPipelineConfigs(pipelineCfgs pipelines.Config) Config {
 			},
 			Metrics: telemetry.MetricsConfig{
 				Level: configtelemetry.LevelBasic,
-				Readers: []config.MetricReader{
-					{
-						Pull: &config.PullMetricReader{Exporter: config.PullMetricExporter{Prometheus: &config.Prometheus{
-							Host: newPtr("localhost"),
-							Port: newPtr(8888),
-						}}},
-					},
-				},
 			},
 		},
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -373,6 +373,7 @@ func TestServiceTelemetryRestart(t *testing.T) {
 	// check telemetry server to ensure we get a response
 	var resp *http.Response
 
+	//nolint:gosec
 	resp, err = http.Get(telemetryURL)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
@@ -395,6 +396,7 @@ func TestServiceTelemetryRestart(t *testing.T) {
 	// check telemetry server to ensure we get a response
 	require.Eventually(t,
 		func() bool {
+			//nolint:gosec
 			resp, err = http.Get(telemetryURL)
 			assert.NoError(t, resp.Body.Close())
 			return err == nil


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

I noticed the service tests were a little flaky due to using the default Prometheus port. This should at least reduce the frequency where this happens if not eliminate it.

I did two things to help elimination contention for the port:
1. Disable the Prometheus server in tests where it isn't needed.
2. Ensure the port is randomized in tests where it is needed.
