### PR TITLE
Replace exporterhelper Request.Export with passing a ConsumeRequest func

### DIFF
--- a/.chloggen/rm-request-export.yaml
+++ b/.chloggen/rm-request-export.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the Request.Export function in favor of an equivalent request consume func in the New[Traces|Metrics|Logs|Profiles]Request
+
+# One or more tracking issues or pull requests related to the change
+issues: [12637]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -12,12 +12,14 @@ var (
 	errNilConfig = errors.New("nil config")
 	// errNilLogger is returned when a logger is nil
 	errNilLogger = errors.New("nil logger")
-	// errNilPushTraceData is returned when a nil PushTraces is given.
-	errNilPushTraceData = errors.New("nil PushTraces")
-	// errNilPushMetricsData is returned when a nil PushMetrics is given.
-	errNilPushMetricsData = errors.New("nil PushMetrics")
-	// errNilPushLogsData is returned when a nil PushLogs is given.
-	errNilPushLogsData = errors.New("nil PushLogs")
+	// errNilConsumeRequest is returned when a nil PushTraces is given.
+	errNilConsumeRequest = errors.New("nil RequestConsumeFunc")
+	// errNilPushTraces is returned when a nil PushTraces is given.
+	errNilPushTraces = errors.New("nil PushTraces")
+	// errNilPushMetrics is returned when a nil PushMetrics is given.
+	errNilPushMetrics = errors.New("nil PushMetrics")
+	// errNilPushLogs is returned when a nil PushLogs is given.
+	errNilPushLogs = errors.New("nil PushLogs")
 	// errNilTracesConverter is returned when a nil RequestFromTracesFunc is given.
 	errNilTracesConverter = errors.New("nil RequestFromTracesFunc")
 	// errNilMetricsConverter is returned when a nil RequestFromMetricsFunc is given.

--- a/exporter/exporterhelper/internal/queue_sender_test.go
+++ b/exporter/exporterhelper/internal/queue_sender_test.go
@@ -23,9 +23,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/requesttest"
 	"go.opentelemetry.io/collector/exporter/exporterqueue"
-	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/internal/storagetest"
-	"go.opentelemetry.io/collector/pipeline"
 )
 
 type fakeEncoding struct {
@@ -44,17 +42,23 @@ func newFakeEncoding(mr request.Request) exporterqueue.Encoding[request.Request]
 	return &fakeEncoding{mr: mr}
 }
 
+var defaultQueueSettings = exporterqueue.Settings[request.Request]{
+	Signal:           defaultSignal,
+	ExporterSettings: defaultSettings,
+}
+
 func TestQueueBatcherStopWhileWaiting(t *testing.T) {
+	sink := requesttest.NewSink()
 	qCfg := exporterqueue.NewDefaultConfig()
 	qCfg.NumConsumers = 1
-	be, err := newQueueBatcherExporter(qCfg, exporterbatcher.Config{})
+	be, err := NewQueueSender(
+		defaultQueueSettings, qCfg, exporterbatcher.Config{}, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
-
-	sink := requesttest.NewSink()
-	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4, Sink: sink, ExportErr: errors.New("transient error")}))
+	sink.SetExportErr(errors.New("transient error"))
+	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4}))
 	// Enqueue another request to ensure when calling shutdown we drain the queue.
-	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 3, Sink: sink, Delay: 100 * time.Millisecond}))
+	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 3, Delay: 100 * time.Millisecond}))
 	require.LessOrEqual(t, int64(1), be.queue.Size())
 
 	require.NoError(t, be.Shutdown(context.Background()))
@@ -64,17 +68,17 @@ func TestQueueBatcherStopWhileWaiting(t *testing.T) {
 }
 
 func TestQueueBatcherDoNotPreserveCancellation(t *testing.T) {
+	sink := requesttest.NewSink()
 	qCfg := exporterqueue.NewDefaultConfig()
 	qCfg.NumConsumers = 1
-	be, err := newQueueBatcherExporter(qCfg, exporterbatcher.Config{})
+	be, err := NewQueueSender(defaultQueueSettings, qCfg, exporterbatcher.Config{}, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	cancelFunc()
 
-	sink := requesttest.NewSink()
-	require.NoError(t, be.Send(ctx, &requesttest.FakeRequest{Items: 4, Sink: sink}))
+	require.NoError(t, be.Send(ctx, &requesttest.FakeRequest{Items: 4}))
 	require.NoError(t, be.Shutdown(context.Background()))
 
 	assert.EqualValues(t, 1, sink.RequestsCount())
@@ -88,16 +92,16 @@ func TestQueueBatcherHappyPath(t *testing.T) {
 		QueueSize:    10,
 		NumConsumers: 1,
 	}
-	be, err := newQueueBatcherExporter(qCfg, exporterbatcher.Config{})
+	sink := requesttest.NewSink()
+	be, err := NewQueueSender(defaultQueueSettings, qCfg, exporterbatcher.Config{}, "", newSender(sink.Export))
 	require.NoError(t, err)
 
-	sink := requesttest.NewSink()
 	for i := 0; i < 10; i++ {
-		require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: i, Sink: sink}))
+		require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: i}))
 	}
 
 	// expect queue to be full
-	require.Error(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 2, Sink: sink}))
+	require.Error(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 2}))
 
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Eventually(t, func() bool {
@@ -107,18 +111,15 @@ func TestQueueBatcherHappyPath(t *testing.T) {
 }
 
 func TestQueueFailedRequestDropped(t *testing.T) {
-	qSet := exporterqueue.Settings[request.Request]{
-		Signal:           defaultSignal,
-		ExporterSettings: defaultSettings,
-	}
+	qSet := defaultQueueSettings
 	logger, observed := observer.New(zap.ErrorLevel)
 	qSet.ExporterSettings.Logger = zap.New(logger)
 	be, err := NewQueueSender(
-		qSet, exporterqueue.NewDefaultConfig(), exporterbatcher.Config{}, "", newNoopExportSender())
+		qSet, exporterqueue.NewDefaultConfig(), exporterbatcher.Config{}, "", newSender(func(context.Context, request.Request) error { return errors.New("some error") }))
 
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
-	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 2, ExportErr: errors.New("some error")}))
+	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 2}))
 	require.NoError(t, be.Shutdown(context.Background()))
 	assert.Len(t, observed.All(), 1)
 	assert.Equal(t, "Exporting failed. Dropping data.", observed.All()[0].Message)
@@ -178,10 +179,10 @@ func TestQueueBatcherPersistentEnabled_NoDataLossOnShutdown(t *testing.T) {
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 0 // retry infinitely so shutdown can be triggered
-	rs := newRetrySender(rCfg, defaultSettings, newNoopExportSender())
+	rs := newRetrySender(rCfg, defaultSettings, newSender(func(context.Context, request.Request) error { return errors.New("transient error") }))
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 
-	mockReq := newErrorRequest(errors.New("transient error"))
+	mockReq := &requesttest.FakeRequest{Items: 2}
 	qSet := exporterqueue.Settings[request.Request]{
 		Signal:           defaultSignal,
 		ExporterSettings: defaultSettings,
@@ -211,9 +212,9 @@ func TestQueueBatcherPersistentEnabled_NoDataLossOnShutdown(t *testing.T) {
 
 	// start the exporter again replacing the preserved mockRequest in the unmarshaler with a new one that doesn't fail.
 	sink := requesttest.NewSink()
-	replacedReq := &requesttest.FakeRequest{Items: 7, Sink: sink}
+	replacedReq := &requesttest.FakeRequest{Items: 7}
 	qSet.Encoding = newFakeEncoding(replacedReq)
-	be, err = NewQueueSender(qSet, qCfg, exporterbatcher.Config{}, "", newNoopExportSender())
+	be, err = NewQueueSender(qSet, qCfg, exporterbatcher.Config{}, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), host))
 
@@ -224,13 +225,7 @@ func TestQueueBatcherPersistentEnabled_NoDataLossOnShutdown(t *testing.T) {
 }
 
 func TestQueueBatcherNoStartShutdown(t *testing.T) {
-	set := exportertest.NewNopSettings(exportertest.NopType)
-	set.ID = exporterID
-	qSet := exporterqueue.Settings[request.Request]{
-		Signal:           pipeline.SignalTraces,
-		ExporterSettings: set,
-	}
-	qs, err := NewQueueSender(qSet, exporterqueue.NewDefaultConfig(), exporterbatcher.NewDefaultConfig(), "", newNoopExportSender())
+	qs, err := NewQueueSender(defaultQueueSettings, exporterqueue.NewDefaultConfig(), exporterbatcher.NewDefaultConfig(), "", newNoopExportSender())
 	require.NoError(t, err)
 	assert.NoError(t, qs.Shutdown(context.Background()))
 }
@@ -267,25 +262,24 @@ func TestQueueBatcher_Merge(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			be, err := newQueueBatcherExporter(exporterqueue.NewDefaultConfig(), tt.batchCfg)
+			sink := requesttest.NewSink()
+			be, err := NewQueueSender(defaultQueueSettings, exporterqueue.NewDefaultConfig(), tt.batchCfg, "", newSender(sink.Export))
 			require.NoError(t, err)
 			require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 			t.Cleanup(func() {
 				require.NoError(t, be.Shutdown(context.Background()))
 			})
 
-			sink := requesttest.NewSink()
-
-			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 8, Sink: sink}))
-			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 3, Sink: sink}))
+			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 8}))
+			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 3}))
 
 			// the first two requests should be merged into one and sent by reaching the minimum items size
 			assert.Eventually(t, func() bool {
 				return sink.RequestsCount() == 1 && sink.ItemsCount() == 11
 			}, 50*time.Millisecond, 10*time.Millisecond)
 
-			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 3, Sink: sink}))
-			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Sink: sink}))
+			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 3}))
+			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1}))
 
 			// the third and fifth requests should be sent by reaching the timeout
 			// the fourth request should be ignored because of the merge error.
@@ -293,11 +287,11 @@ func TestQueueBatcher_Merge(t *testing.T) {
 
 			// should be ignored because of the merge error.
 			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{
-				Items: 3, Sink: sink,
+				Items:    3,
 				MergeErr: errors.New("merge error"),
 			}))
 
-			assert.Equal(t, int64(1), sink.RequestsCount())
+			assert.Equal(t, 1, sink.RequestsCount())
 			assert.Eventually(t, func() bool {
 				return sink.RequestsCount() == 2 && sink.ItemsCount() == 15
 			}, 1*time.Second, 10*time.Millisecond)
@@ -309,8 +303,8 @@ func TestQueueBatcher_BatchExportError(t *testing.T) {
 	tests := []struct {
 		name             string
 		batchCfg         exporterbatcher.Config
-		expectedRequests int64
-		expectedItems    int64
+		expectedRequests int
+		expectedItems    int
 	}{
 		{
 			name: "merge_only",
@@ -338,25 +332,30 @@ func TestQueueBatcher_BatchExportError(t *testing.T) {
 				return cfg
 			}(),
 			expectedRequests: 1,
-			expectedItems:    20,
+			expectedItems:    8,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			be, err := newQueueBatcherExporter(exporterqueue.NewDefaultConfig(), tt.batchCfg)
+			sink := requesttest.NewSink()
+			qSet := exporterqueue.Settings[request.Request]{
+				Signal:           defaultSignal,
+				ExporterSettings: defaultSettings,
+			}
+			be, err := NewQueueSender(qSet, exporterqueue.NewDefaultConfig(), tt.batchCfg, "", newSender(sink.Export))
 			require.NoError(t, err)
 			require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-			sink := requesttest.NewSink()
-			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4, Sink: sink}))
-			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4, Sink: sink}))
+			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4}))
+			require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4}))
 
 			// the first two requests should be blocked by the batchSender.
 			time.Sleep(50 * time.Millisecond)
-			assert.Equal(t, int64(0), sink.RequestsCount())
+			assert.Equal(t, 0, sink.RequestsCount())
 
 			// the third request should trigger the export and cause an error.
-			errReq := &requesttest.FakeRequest{Items: 20, ExportErr: errors.New("transient error"), Sink: sink}
+			sink.SetExportErr(errors.New("transient error"))
+			errReq := &requesttest.FakeRequest{Items: 20}
 			require.NoError(t, be.Send(context.Background(), errReq))
 
 			// the batch should be dropped since the queue doesn't have re-queuing enabled.
@@ -372,35 +371,35 @@ func TestQueueBatcher_BatchExportError(t *testing.T) {
 }
 
 func TestQueueBatcher_MergeOrSplit(t *testing.T) {
+	sink := requesttest.NewSink()
 	batchCfg := exporterbatcher.NewDefaultConfig()
 	batchCfg.MinSize = 5
 	batchCfg.MaxSize = 10
 	batchCfg.FlushTimeout = 100 * time.Millisecond
-	be, err := newQueueBatcherExporter(exporterqueue.NewDefaultConfig(), batchCfg)
+	be, err := NewQueueSender(defaultQueueSettings, exporterqueue.NewDefaultConfig(), batchCfg, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	sink := requesttest.NewSink()
 	// should be sent right away by reaching the minimum items size.
-	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 8, Sink: sink}))
+	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 8}))
 	assert.Eventually(t, func() bool {
 		return sink.RequestsCount() == 1 && sink.ItemsCount() == 8
 	}, 1*time.Second, 10*time.Millisecond)
 
 	// big request should be broken down into two requests, both are sent right away.
-	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 17, Sink: sink}))
+	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 17}))
 	assert.Eventually(t, func() bool {
 		return sink.RequestsCount() == 3 && sink.ItemsCount() == 25
 	}, 1*time.Second, 10*time.Millisecond)
 
 	// request that cannot be split should be dropped.
 	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{
-		Items: 11, Sink: sink,
+		Items:    11,
 		MergeErr: errors.New("split error"),
 	}))
 
 	// big request should be broken down into two requests, both are sent right away.
-	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 13, Sink: sink}))
+	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 13}))
 	assert.Eventually(t, func() bool {
 		return sink.RequestsCount() == 5 && sink.ItemsCount() == 38
 	}, 1*time.Second, 10*time.Millisecond)
@@ -408,14 +407,14 @@ func TestQueueBatcher_MergeOrSplit(t *testing.T) {
 }
 
 func TestQueueBatcher_Shutdown(t *testing.T) {
+	sink := requesttest.NewSink()
 	batchCfg := exporterbatcher.NewDefaultConfig()
 	batchCfg.MinSize = 10
-	be, err := newQueueBatcherExporter(exporterqueue.NewDefaultConfig(), batchCfg)
+	be, err := NewQueueSender(defaultQueueSettings, exporterqueue.NewDefaultConfig(), batchCfg, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	sink := requesttest.NewSink()
-	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 3, Sink: sink}))
+	require.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 3}))
 
 	// To make the request reached the batchSender before shutdown.
 	time.Sleep(50 * time.Millisecond)
@@ -423,88 +422,87 @@ func TestQueueBatcher_Shutdown(t *testing.T) {
 	require.NoError(t, be.Shutdown(context.Background()))
 
 	// shutdown should force sending the batch
-	assert.Equal(t, int64(1), sink.RequestsCount())
-	assert.Equal(t, int64(3), sink.ItemsCount())
+	assert.Equal(t, 1, sink.RequestsCount())
+	assert.Equal(t, 3, sink.ItemsCount())
 }
 
 func TestQueueBatcher_BatchBlocking(t *testing.T) {
+	sink := requesttest.NewSink()
 	bCfg := exporterbatcher.NewDefaultConfig()
 	bCfg.MinSize = 3
-	be, err := newQueueBatcherExporter(exporterqueue.Config{}, bCfg)
+	be, err := NewQueueSender(defaultQueueSettings, exporterqueue.Config{}, bCfg, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	sink := requesttest.NewSink()
 	// send 6 blocking requests
 	wg := sync.WaitGroup{}
 	for i := 0; i < 6; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Sink: sink, Delay: 10 * time.Millisecond}))
+			assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Delay: 10 * time.Millisecond}))
 		}()
 	}
 	wg.Wait()
 
 	// should be sent in two batches since the batch size is 3
-	assert.Equal(t, int64(2), sink.RequestsCount())
-	assert.Equal(t, int64(6), sink.ItemsCount())
+	assert.Equal(t, 2, sink.RequestsCount())
+	assert.Equal(t, 6, sink.ItemsCount())
 
 	require.NoError(t, be.Shutdown(context.Background()))
 }
 
 // Validate that the batch is cancelled once the first request in the request is cancelled
 func TestQueueBatcher_BatchCancelled(t *testing.T) {
+	sink := requesttest.NewSink()
 	bCfg := exporterbatcher.NewDefaultConfig()
 	bCfg.MinSize = 2
-	be, err := newQueueBatcherExporter(exporterqueue.Config{}, bCfg)
+	be, err := NewQueueSender(defaultQueueSettings, exporterqueue.Config{}, bCfg, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	sink := requesttest.NewSink()
 	// send 2 blocking requests
 	wg := sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert.ErrorIs(t, be.Send(ctx, &requesttest.FakeRequest{Items: 1, Sink: sink, Delay: 100 * time.Millisecond}), context.Canceled)
+		assert.ErrorIs(t, be.Send(ctx, &requesttest.FakeRequest{Items: 1, Delay: 100 * time.Millisecond}), context.Canceled)
 	}()
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		time.Sleep(100 * time.Millisecond) // ensure this call is the second
-		assert.ErrorIs(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Sink: sink, Delay: 100 * time.Millisecond}), context.Canceled)
+		assert.ErrorIs(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Delay: 100 * time.Millisecond}), context.Canceled)
 	}()
 	cancel() // canceling the first request should cancel the whole batch
 	wg.Wait()
 
 	// nothing should be delivered
-	assert.Equal(t, int64(0), sink.RequestsCount())
-	assert.Equal(t, int64(0), sink.ItemsCount())
+	assert.Equal(t, 0, sink.RequestsCount())
+	assert.Equal(t, 0, sink.ItemsCount())
 
 	require.NoError(t, be.Shutdown(context.Background()))
 }
 
 func TestQueueBatcher_DrainActiveRequests(t *testing.T) {
+	sink := requesttest.NewSink()
 	bCfg := exporterbatcher.NewDefaultConfig()
 	bCfg.MinSize = 2
 
-	be, err := newQueueBatcherExporter(exporterqueue.Config{}, bCfg)
+	be, err := NewQueueSender(defaultQueueSettings, exporterqueue.Config{}, bCfg, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	sink := requesttest.NewSink()
-
 	// send 3 blocking requests with a timeout
 	go func() {
-		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Sink: sink, Delay: 40 * time.Millisecond}))
+		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Delay: 40 * time.Millisecond}))
 	}()
 	go func() {
-		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Sink: sink, Delay: 40 * time.Millisecond}))
+		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Delay: 40 * time.Millisecond}))
 	}()
 	go func() {
-		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Sink: sink, Delay: 40 * time.Millisecond}))
+		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 1, Delay: 40 * time.Millisecond}))
 	}()
 
 	// give time for the first two requests to be batched
@@ -514,34 +512,34 @@ func TestQueueBatcher_DrainActiveRequests(t *testing.T) {
 	// It should take 120 milliseconds to complete.
 	require.NoError(t, be.Shutdown(context.Background()))
 
-	assert.Equal(t, int64(2), sink.RequestsCount())
-	assert.Equal(t, int64(3), sink.ItemsCount())
+	assert.Equal(t, 2, sink.RequestsCount())
+	assert.Equal(t, 3, sink.ItemsCount())
 }
 
 func TestQueueBatcherUnstartedShutdown(t *testing.T) {
-	be, err := newQueueBatcherExporter(exporterqueue.NewDefaultConfig(), exporterbatcher.NewDefaultConfig())
+	be, err := NewQueueSender(defaultQueueSettings, exporterqueue.NewDefaultConfig(), exporterbatcher.NewDefaultConfig(), "", newNoopExportSender())
 	require.NoError(t, err)
 	err = be.Shutdown(context.Background())
 	require.NoError(t, err)
 }
 
 func TestQueueBatcherWithTimeout(t *testing.T) {
+	sink := requesttest.NewSink()
 	bCfg := exporterbatcher.NewDefaultConfig()
 	bCfg.MinSize = 10
 
-	be, err := newQueueBatcherExporter(exporterqueue.Config{}, bCfg)
+	be, err := NewQueueSender(defaultQueueSettings, exporterqueue.Config{}, bCfg, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	sink := requesttest.NewSink()
 	// Send 3 concurrent requests that should be merged in one batch
 	wg := sync.WaitGroup{}
 	for i := 0; i < 3; i++ {
 		wg.Add(1)
 		go func() {
-			assert.NoError(t, be.Send(ctx, &requesttest.FakeRequest{Items: 4, Sink: sink}))
+			assert.NoError(t, be.Send(ctx, &requesttest.FakeRequest{Items: 4}))
 			wg.Done()
 		}()
 	}
@@ -553,7 +551,7 @@ func TestQueueBatcherWithTimeout(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		wg.Add(1)
 		go func() {
-			assert.Error(t, be.Send(ctx, &requesttest.FakeRequest{Items: 4, Sink: sink, Delay: 30 * time.Millisecond}))
+			assert.Error(t, be.Send(ctx, &requesttest.FakeRequest{Items: 4, Delay: 30 * time.Millisecond}))
 			wg.Done()
 		}()
 	}
@@ -567,27 +565,27 @@ func TestQueueBatcherWithTimeout(t *testing.T) {
 }
 
 func TestQueueBatcherTimerResetNoConflict(t *testing.T) {
+	sink := requesttest.NewSink()
 	bCfg := exporterbatcher.NewDefaultConfig()
 	bCfg.MinSize = 8
 	bCfg.FlushTimeout = 100 * time.Millisecond
-	be, err := newQueueBatcherExporter(exporterqueue.Config{}, bCfg)
+	be, err := NewQueueSender(defaultQueueSettings, exporterqueue.Config{}, bCfg, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	sink := requesttest.NewSink()
 	// Send 2 concurrent requests that should be merged in one batch in the same interval as the flush timer
 	go func() {
-		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4, Sink: sink}))
+		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4}))
 	}()
 	time.Sleep(30 * time.Millisecond)
 	go func() {
-		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4, Sink: sink}))
+		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4}))
 	}()
 
 	// The batch should be sent either with the flush interval or by reaching the minimum items size with no conflict
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.LessOrEqual(c, int64(1), sink.RequestsCount())
-		assert.EqualValues(c, 8, sink.ItemsCount())
+		assert.LessOrEqual(c, 1, sink.RequestsCount())
+		assert.Equal(c, 8, sink.ItemsCount())
 	}, 1*time.Second, 10*time.Millisecond)
 
 	require.NoError(t, be.Shutdown(context.Background()))
@@ -597,48 +595,40 @@ func TestQueueBatcherTimerFlush(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping flaky test on Windows, see https://github.com/open-telemetry/opentelemetry-collector/issues/10802")
 	}
+	sink := requesttest.NewSink()
 	bCfg := exporterbatcher.NewDefaultConfig()
 	bCfg.MinSize = 8
 	bCfg.FlushTimeout = 100 * time.Millisecond
-	be, err := newQueueBatcherExporter(exporterqueue.Config{}, bCfg)
+	be, err := NewQueueSender(defaultQueueSettings, exporterqueue.Config{}, bCfg, "", newSender(sink.Export))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
-	sink := requesttest.NewSink()
 	time.Sleep(50 * time.Millisecond)
 
 	// Send 2 concurrent requests that should be merged in one batch and sent immediately
 	go func() {
-		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4, Sink: sink}))
+		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4}))
 	}()
 	go func() {
-		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4, Sink: sink}))
+		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4}))
 	}()
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.LessOrEqual(c, int64(1), sink.RequestsCount())
-		assert.EqualValues(c, 8, sink.ItemsCount())
+		assert.LessOrEqual(c, 1, sink.RequestsCount())
+		assert.Equal(c, 8, sink.ItemsCount())
 	}, 30*time.Millisecond, 5*time.Millisecond)
 
 	// Send another request that should be flushed after 100ms instead of 50ms since last flush
 	go func() {
-		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4, Sink: sink}))
+		assert.NoError(t, be.Send(context.Background(), &requesttest.FakeRequest{Items: 4}))
 	}()
 
 	// Confirm that it is not flushed in 50ms
 	time.Sleep(60 * time.Millisecond)
-	assert.LessOrEqual(t, int64(1), sink.RequestsCount())
-	assert.EqualValues(t, 8, sink.ItemsCount())
+	assert.LessOrEqual(t, 1, sink.RequestsCount())
+	assert.Equal(t, 8, sink.ItemsCount())
 
 	// Confirm that it is flushed after 100ms (using 60+50=110 here to be safe)
 	time.Sleep(50 * time.Millisecond)
-	assert.LessOrEqual(t, int64(2), sink.RequestsCount())
-	assert.EqualValues(t, 12, sink.ItemsCount())
+	assert.LessOrEqual(t, 2, sink.RequestsCount())
+	assert.Equal(t, 12, sink.ItemsCount())
 	require.NoError(t, be.Shutdown(context.Background()))
-}
-
-func newQueueBatcherExporter(qCfg exporterqueue.Config, bCfg exporterbatcher.Config) (*QueueSender, error) {
-	qSet := exporterqueue.Settings[request.Request]{
-		Signal:           defaultSignal,
-		ExporterSettings: defaultSettings,
-	}
-	return NewQueueSender(qSet, qCfg, bCfg, "", newNoopExportSender())
 }

--- a/exporter/exporterhelper/internal/request/request.go
+++ b/exporter/exporterhelper/internal/request/request.go
@@ -13,8 +13,6 @@ import (
 // Experimental: This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
 type Request interface {
-	// Export exports the request to an external endpoint.
-	Export(ctx context.Context) error
 	// ItemsCount returns a number of basic items in the request where item is the smallest piece of data that can be
 	// sent. For example, for OTLP exporter, this value represents the number of spans,
 	// metric data points or log records.

--- a/exporter/exporterhelper/internal/requesttest/request.go
+++ b/exporter/exporterhelper/internal/requesttest/request.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
@@ -16,26 +15,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
-
-type Sink struct {
-	requestsCount *atomic.Int64
-	itemsCount    *atomic.Int64
-}
-
-func (s *Sink) RequestsCount() int64 {
-	return s.requestsCount.Load()
-}
-
-func (s *Sink) ItemsCount() int64 {
-	return s.itemsCount.Load()
-}
-
-func NewSink() *Sink {
-	return &Sink{
-		requestsCount: new(atomic.Int64),
-		itemsCount:    new(atomic.Int64),
-	}
-}
 
 type errorPartial struct {
 	fr *FakeRequest
@@ -46,44 +25,10 @@ func (e errorPartial) Error() string {
 }
 
 type FakeRequest struct {
-	Items     int
-	Sink      *Sink
-	ExportErr error
-	Partial   int
-	MergeErr  error
-	Delay     time.Duration
-}
-
-func (r *FakeRequest) Export(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(r.Delay):
-	}
-	if r.ExportErr != nil {
-		err := r.ExportErr
-		r.ExportErr = nil
-		return err
-	}
-	if r.Partial > 0 {
-		if r.Sink != nil {
-			r.Sink.requestsCount.Add(1)
-			r.Sink.itemsCount.Add(int64(r.Items - r.Partial))
-		}
-		return errorPartial{fr: &FakeRequest{
-			Items:     r.Partial,
-			Sink:      r.Sink,
-			ExportErr: r.ExportErr,
-			Partial:   0,
-			MergeErr:  r.MergeErr,
-			Delay:     r.Delay,
-		}}
-	}
-	if r.Sink != nil {
-		r.Sink.requestsCount.Add(1)
-		r.Sink.itemsCount.Add(int64(r.Items))
-	}
-	return nil
+	Items    int
+	Partial  int
+	MergeErr error
+	Delay    time.Duration
 }
 
 func (r *FakeRequest) OnError(err error) request.Request {
@@ -117,7 +62,7 @@ func (r *FakeRequest) MergeSplit(_ context.Context, cfg exporterbatcher.SizeConf
 
 	var fr2 *FakeRequest
 	if r2 == nil {
-		fr2 = &FakeRequest{Sink: r.Sink, ExportErr: r.ExportErr, Delay: r.Delay}
+		fr2 = &FakeRequest{Delay: r.Delay}
 	} else {
 		if r2.(*FakeRequest).MergeErr != nil {
 			return nil, r2.(*FakeRequest).MergeErr
@@ -140,10 +85,10 @@ func (r *FakeRequest) MergeSplit(_ context.Context, cfg exporterbatcher.SizeConf
 	// split fr2 to maxItems
 	for {
 		if fr2.Items <= maxItems {
-			res = append(res, &FakeRequest{Items: fr2.Items, Sink: fr2.Sink, ExportErr: fr2.ExportErr, Delay: fr2.Delay})
+			res = append(res, &FakeRequest{Items: fr2.Items, Delay: fr2.Delay})
 			break
 		}
-		res = append(res, &FakeRequest{Items: maxItems, Sink: fr2.Sink, ExportErr: fr2.ExportErr, Delay: fr2.Delay})
+		res = append(res, &FakeRequest{Items: maxItems, Delay: fr2.Delay})
 		fr2.Items -= maxItems
 	}
 
@@ -152,24 +97,33 @@ func (r *FakeRequest) MergeSplit(_ context.Context, cfg exporterbatcher.SizeConf
 
 func (r *FakeRequest) mergeTo(dst *FakeRequest) {
 	dst.Items += r.Items
-	dst.ExportErr = errors.Join(dst.ExportErr, r.ExportErr)
 	dst.Delay += r.Delay
 }
 
-func RequestFromMetricsFunc(reqErr error) func(context.Context, pmetric.Metrics) (request.Request, error) {
+func NoopPusherFunc(context.Context, request.Request) error {
+	return nil
+}
+
+func NewErrPusherFunc(err error) func(context.Context, request.Request) error {
+	return func(context.Context, request.Request) error {
+		return err
+	}
+}
+
+func RequestFromMetricsFunc(err error) func(context.Context, pmetric.Metrics) (request.Request, error) {
 	return func(_ context.Context, md pmetric.Metrics) (request.Request, error) {
-		return &FakeRequest{Items: md.DataPointCount(), ExportErr: reqErr}, nil
+		return &FakeRequest{Items: md.DataPointCount()}, err
 	}
 }
 
-func RequestFromTracesFunc(reqErr error) func(context.Context, ptrace.Traces) (request.Request, error) {
+func RequestFromTracesFunc(err error) func(context.Context, ptrace.Traces) (request.Request, error) {
 	return func(_ context.Context, td ptrace.Traces) (request.Request, error) {
-		return &FakeRequest{Items: td.SpanCount(), ExportErr: reqErr}, nil
+		return &FakeRequest{Items: td.SpanCount()}, err
 	}
 }
 
-func RequestFromLogsFunc(reqErr error) func(context.Context, plog.Logs) (request.Request, error) {
+func RequestFromLogsFunc(err error) func(context.Context, plog.Logs) (request.Request, error) {
 	return func(_ context.Context, ld plog.Logs) (request.Request, error) {
-		return &FakeRequest{Items: ld.LogRecordCount(), ExportErr: reqErr}, nil
+		return &FakeRequest{Items: ld.LogRecordCount()}, err
 	}
 }

--- a/exporter/exporterhelper/internal/requesttest/sink.go
+++ b/exporter/exporterhelper/internal/requesttest/sink.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package requesttest // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/requesttest"
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+)
+
+func NewSink() *Sink {
+	return &Sink{}
+}
+
+type Sink struct {
+	requestsCount int
+	itemsCount    int
+	mu            sync.Mutex
+	exportErr     error
+}
+
+func (s *Sink) Export(ctx context.Context, req request.Request) error {
+	r := req.(*FakeRequest)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(r.Delay):
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.exportErr != nil {
+		err := s.exportErr
+		s.exportErr = nil
+		return err
+	}
+	if r.Partial > 0 {
+		s.requestsCount++
+		s.itemsCount += r.Items - r.Partial
+		return errorPartial{fr: &FakeRequest{
+			Items:    r.Partial,
+			Partial:  0,
+			MergeErr: r.MergeErr,
+			Delay:    r.Delay,
+		}}
+	}
+	s.requestsCount++
+	s.itemsCount += r.Items
+	return nil
+}
+
+func (s *Sink) SetExportErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.exportErr = err
+}
+
+func (s *Sink) RequestsCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requestsCount
+}
+
+func (s *Sink) ItemsCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.itemsCount
+}

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -18,7 +18,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer/consumererror"
-	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/requesttest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -28,12 +27,14 @@ func TestRetrySenderDropOnPermanentError(t *testing.T) {
 	rCfg := configretry.NewDefaultBackOffConfig()
 	sink := requesttest.NewSink()
 	expErr := consumererror.NewPermanent(errors.New("bad data"))
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newNoopExportSender())
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newSender(sink.Export))
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
-	require.ErrorIs(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2, Sink: sink, ExportErr: expErr}), expErr)
-	require.ErrorIs(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 3, Sink: sink, ExportErr: expErr}), expErr)
-	assert.Equal(t, int64(0), sink.ItemsCount())
-	assert.Equal(t, int64(0), sink.RequestsCount())
+	sink.SetExportErr(expErr)
+	require.ErrorIs(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2}), expErr)
+	sink.SetExportErr(expErr)
+	require.ErrorIs(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 3}), expErr)
+	assert.Equal(t, 0, sink.ItemsCount())
+	assert.Equal(t, 0, sink.RequestsCount())
 	require.NoError(t, rs.Shutdown(context.Background()))
 }
 
@@ -42,11 +43,12 @@ func TestRetrySenderSimpleRetry(t *testing.T) {
 	rCfg.InitialInterval = 0
 	sink := requesttest.NewSink()
 	expErr := errors.New("transient error")
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newNoopExportSender())
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newSender(sink.Export))
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
-	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2, Sink: sink, ExportErr: expErr}))
-	assert.Equal(t, int64(2), sink.ItemsCount())
-	assert.Equal(t, int64(1), sink.RequestsCount())
+	sink.SetExportErr(expErr)
+	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2}))
+	assert.Equal(t, 2, sink.ItemsCount())
+	assert.Equal(t, 1, sink.RequestsCount())
 	require.NoError(t, rs.Shutdown(context.Background()))
 }
 
@@ -54,11 +56,11 @@ func TestRetrySenderRetryPartial(t *testing.T) {
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = 0
 	sink := requesttest.NewSink()
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newNoopExportSender())
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newSender(sink.Export))
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
-	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 5, Sink: sink, Partial: 3}))
-	assert.Equal(t, int64(5), sink.ItemsCount())
-	assert.Equal(t, int64(2), sink.RequestsCount())
+	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 5, Partial: 3}))
+	assert.Equal(t, 5, sink.ItemsCount())
+	assert.Equal(t, 2, sink.RequestsCount())
 	require.NoError(t, rs.Shutdown(context.Background()))
 }
 
@@ -66,13 +68,10 @@ func TestRetrySenderMaxElapsedTime(t *testing.T) {
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 100 * time.Millisecond
-	sink := requesttest.NewSink()
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newNoopExportSender())
-	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	expErr := errors.New("transient error")
-	require.ErrorIs(t, rs.Send(context.Background(), newErrorRequest(expErr)), expErr)
-	assert.Equal(t, int64(0), sink.ItemsCount())
-	assert.Equal(t, int64(0), sink.RequestsCount())
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newSender(func(context.Context, request.Request) error { return expErr }))
+	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
+	require.ErrorIs(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2}), expErr)
 	require.NoError(t, rs.Shutdown(context.Background()))
 }
 
@@ -80,15 +79,16 @@ func TestRetrySenderThrottleError(t *testing.T) {
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = 10 * time.Millisecond
 	sink := requesttest.NewSink()
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newNoopExportSender())
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newSender(sink.Export))
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	retry := fmt.Errorf("wrappe error: %w", NewThrottleRetry(errors.New("throttle error"), 100*time.Millisecond))
 	start := time.Now()
-	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 5, Sink: sink, ExportErr: retry}))
+	sink.SetExportErr(retry)
+	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 5}))
 	// The initial backoff is 10ms, but because of the throttle this should wait at least 100ms.
 	assert.Less(t, 100*time.Millisecond, time.Since(start))
-	assert.Equal(t, int64(5), sink.ItemsCount())
-	assert.Equal(t, int64(1), sink.RequestsCount())
+	assert.Equal(t, 5, sink.ItemsCount())
+	assert.Equal(t, 1, sink.RequestsCount())
 	require.NoError(t, rs.Shutdown(context.Background()))
 }
 
@@ -104,13 +104,13 @@ func TestRetrySenderWithContextTimeout(t *testing.T) {
 	set := exportertest.NewNopSettings(exportertest.NopType)
 	logger, observed := observer.New(zap.InfoLevel)
 	set.Logger = zap.New(logger)
-	rs := newRetrySender(rCfg, set, newNoopExportSender())
+	rs := newRetrySender(rCfg, set, newSender(func(context.Context, request.Request) error { return errors.New("transient error") }))
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 	require.ErrorContains(t,
-		rs.Send(ctx, newErrorRequest(errors.New("transient error"))),
+		rs.Send(ctx, &requesttest.FakeRequest{Items: 2}),
 		"request will be cancelled before next retry: transient error")
 	assert.Len(t, observed.All(), 1)
 	assert.Equal(t, "Exporting failed. Will retry the request after interval.", observed.All()[0].Message)
@@ -123,7 +123,7 @@ func TestRetrySenderWithCancelledContext(t *testing.T) {
 	rCfg.Enabled = true
 	// First attempt after 1s is attempted
 	rCfg.InitialInterval = 1 * time.Second
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newNoopExportSender())
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), newSender(func(context.Context, request.Request) error { return errors.New("transient error") }))
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	start := time.Now()
 	ctx, cancel := context.WithCancelCause(context.Background())
@@ -132,32 +132,8 @@ func TestRetrySenderWithCancelledContext(t *testing.T) {
 		cancel(errors.New("my reason"))
 	}()
 	require.ErrorContains(t,
-		rs.Send(ctx, newErrorRequest(errors.New("transient error"))),
+		rs.Send(ctx, &requesttest.FakeRequest{Items: 2}),
 		"request is cancelled or timed out: transient error")
 	require.Less(t, time.Since(start), 1*time.Second)
 	require.NoError(t, rs.Shutdown(context.Background()))
-}
-
-type mockErrorRequest struct {
-	err error
-}
-
-func (mer *mockErrorRequest) Export(context.Context) error {
-	return mer.err
-}
-
-func (mer *mockErrorRequest) OnError(error) request.Request {
-	return mer
-}
-
-func (mer *mockErrorRequest) ItemsCount() int {
-	return 7
-}
-
-func (mer *mockErrorRequest) MergeSplit(context.Context, exporterbatcher.SizeConfig, request.Request) ([]request.Request, error) {
-	return nil, nil
-}
-
-func newErrorRequest(err error) request.Request {
-	return &mockErrorRequest{err: err}
 }

--- a/exporter/exporterhelper/logs_batch.go
+++ b/exporter/exporterhelper/logs_batch.go
@@ -53,7 +53,7 @@ func (req *logsRequest) split(maxSize int, sz sizer.LogsSizer) []Request {
 	for req.size(sz) > maxSize {
 		ld, rmSize := extractLogs(req.ld, maxSize, sz)
 		req.setCachedSize(req.size(sz) - rmSize)
-		res = append(res, newLogsRequest(ld, req.pusher))
+		res = append(res, newLogsRequest(ld))
 	}
 	res = append(res, req)
 	return res

--- a/exporter/exporterhelper/logs_batch_test.go
+++ b/exporter/exporterhelper/logs_batch_test.go
@@ -17,18 +17,11 @@ import (
 )
 
 func TestMergeLogs(t *testing.T) {
-	lr1 := newLogsRequest(testdata.GenerateLogs(2), nil)
-	lr2 := newLogsRequest(testdata.GenerateLogs(3), nil)
+	lr1 := newLogsRequest(testdata.GenerateLogs(2))
+	lr2 := newLogsRequest(testdata.GenerateLogs(3))
 	res, err := lr1.MergeSplit(context.Background(), exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems}, lr2)
 	require.NoError(t, err)
 	require.Equal(t, 5, res[0].ItemsCount())
-}
-
-func TestMergeLogsInvalidInput(t *testing.T) {
-	lr1 := newTracesRequest(testdata.GenerateTraces(2), nil)
-	lr2 := newLogsRequest(testdata.GenerateLogs(3), nil)
-	_, err := lr1.MergeSplit(context.Background(), exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems}, lr2)
-	require.Error(t, err)
 }
 
 func TestMergeSplitLogs(t *testing.T) {
@@ -42,59 +35,59 @@ func TestMergeSplitLogs(t *testing.T) {
 		{
 			name:     "both_requests_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			lr1:      newLogsRequest(plog.NewLogs(), nil),
-			lr2:      newLogsRequest(plog.NewLogs(), nil),
-			expected: []Request{newLogsRequest(plog.NewLogs(), nil)},
+			lr1:      newLogsRequest(plog.NewLogs()),
+			lr2:      newLogsRequest(plog.NewLogs()),
+			expected: []Request{newLogsRequest(plog.NewLogs())},
 		},
 		{
 			name:     "first_request_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			lr1:      newLogsRequest(plog.NewLogs(), nil),
-			lr2:      newLogsRequest(testdata.GenerateLogs(5), nil),
-			expected: []Request{newLogsRequest(testdata.GenerateLogs(5), nil)},
+			lr1:      newLogsRequest(plog.NewLogs()),
+			lr2:      newLogsRequest(testdata.GenerateLogs(5)),
+			expected: []Request{newLogsRequest(testdata.GenerateLogs(5))},
 		},
 		{
 			name:     "first_empty_second_nil",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			lr1:      newLogsRequest(plog.NewLogs(), nil),
+			lr1:      newLogsRequest(plog.NewLogs()),
 			lr2:      nil,
-			expected: []Request{newLogsRequest(plog.NewLogs(), nil)},
+			expected: []Request{newLogsRequest(plog.NewLogs())},
 		},
 		{
 			name: "merge_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			lr1:  newLogsRequest(testdata.GenerateLogs(4), nil),
-			lr2:  newLogsRequest(testdata.GenerateLogs(6), nil),
+			lr1:  newLogsRequest(testdata.GenerateLogs(4)),
+			lr2:  newLogsRequest(testdata.GenerateLogs(6)),
 			expected: []Request{newLogsRequest(func() plog.Logs {
 				logs := testdata.GenerateLogs(4)
 				testdata.GenerateLogs(6).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
 				return logs
-			}(), nil)},
+			}())},
 		},
 		{
 			name: "split_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 4},
-			lr1:  newLogsRequest(plog.NewLogs(), nil),
-			lr2:  newLogsRequest(testdata.GenerateLogs(10), nil),
+			lr1:  newLogsRequest(plog.NewLogs()),
+			lr2:  newLogsRequest(testdata.GenerateLogs(10)),
 			expected: []Request{
-				newLogsRequest(testdata.GenerateLogs(4), nil),
-				newLogsRequest(testdata.GenerateLogs(4), nil),
-				newLogsRequest(testdata.GenerateLogs(2), nil),
+				newLogsRequest(testdata.GenerateLogs(4)),
+				newLogsRequest(testdata.GenerateLogs(4)),
+				newLogsRequest(testdata.GenerateLogs(2)),
 			},
 		},
 		{
 			name: "merge_and_split",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			lr1:  newLogsRequest(testdata.GenerateLogs(8), nil),
-			lr2:  newLogsRequest(testdata.GenerateLogs(20), nil),
+			lr1:  newLogsRequest(testdata.GenerateLogs(8)),
+			lr2:  newLogsRequest(testdata.GenerateLogs(20)),
 			expected: []Request{
 				newLogsRequest(func() plog.Logs {
 					logs := testdata.GenerateLogs(8)
 					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
 					return logs
-				}(), nil),
-				newLogsRequest(testdata.GenerateLogs(10), nil),
-				newLogsRequest(testdata.GenerateLogs(8), nil),
+				}()),
+				newLogsRequest(testdata.GenerateLogs(10)),
+				newLogsRequest(testdata.GenerateLogs(8)),
 			},
 		},
 		{
@@ -104,16 +97,16 @@ func TestMergeSplitLogs(t *testing.T) {
 				ld := testdata.GenerateLogs(4)
 				ld.ResourceLogs().At(0).ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("extra log")
 				return ld
-			}(), nil),
-			lr2: newLogsRequest(testdata.GenerateLogs(2), nil),
+			}()),
+			lr2: newLogsRequest(testdata.GenerateLogs(2)),
 			expected: []Request{
-				newLogsRequest(testdata.GenerateLogs(4), nil),
+				newLogsRequest(testdata.GenerateLogs(4)),
 				newLogsRequest(func() plog.Logs {
 					ld := testdata.GenerateLogs(0)
 					ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().AppendEmpty().Body().SetStr("extra log")
 					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(ld.ResourceLogs())
 					return ld
-				}(), nil),
+				}()),
 			},
 		},
 	}
@@ -140,44 +133,44 @@ func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
 		{
 			name:     "both_requests_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: logsMarshaler.LogsSize(testdata.GenerateLogs(10))},
-			lr1:      newLogsRequest(plog.NewLogs(), nil),
-			lr2:      newLogsRequest(plog.NewLogs(), nil),
-			expected: []Request{newLogsRequest(plog.NewLogs(), nil)},
+			lr1:      newLogsRequest(plog.NewLogs()),
+			lr2:      newLogsRequest(plog.NewLogs()),
+			expected: []Request{newLogsRequest(plog.NewLogs())},
 		},
 		{
 			name:     "first_request_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: logsMarshaler.LogsSize(testdata.GenerateLogs(10))},
-			lr1:      newLogsRequest(plog.NewLogs(), nil),
-			lr2:      newLogsRequest(testdata.GenerateLogs(5), nil),
-			expected: []Request{newLogsRequest(testdata.GenerateLogs(5), nil)},
+			lr1:      newLogsRequest(plog.NewLogs()),
+			lr2:      newLogsRequest(testdata.GenerateLogs(5)),
+			expected: []Request{newLogsRequest(testdata.GenerateLogs(5))},
 		},
 		{
 			name:     "first_empty_second_nil",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: logsMarshaler.LogsSize(testdata.GenerateLogs(10))},
-			lr1:      newLogsRequest(plog.NewLogs(), nil),
+			lr1:      newLogsRequest(plog.NewLogs()),
 			lr2:      nil,
-			expected: []Request{newLogsRequest(plog.NewLogs(), nil)},
+			expected: []Request{newLogsRequest(plog.NewLogs())},
 		},
 		{
 			name: "merge_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: logsMarshaler.LogsSize(testdata.GenerateLogs(11))},
-			lr1:  newLogsRequest(testdata.GenerateLogs(4), nil),
-			lr2:  newLogsRequest(testdata.GenerateLogs(6), nil),
+			lr1:  newLogsRequest(testdata.GenerateLogs(4)),
+			lr2:  newLogsRequest(testdata.GenerateLogs(6)),
 			expected: []Request{newLogsRequest(func() plog.Logs {
 				logs := testdata.GenerateLogs(4)
 				testdata.GenerateLogs(6).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
 				return logs
-			}(), nil)},
+			}())},
 		},
 		{
 			name: "split_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: logsMarshaler.LogsSize(testdata.GenerateLogs(4))},
-			lr1:  newLogsRequest(plog.NewLogs(), nil),
-			lr2:  newLogsRequest(testdata.GenerateLogs(10), nil),
+			lr1:  newLogsRequest(plog.NewLogs()),
+			lr2:  newLogsRequest(testdata.GenerateLogs(10)),
 			expected: []Request{
-				newLogsRequest(testdata.GenerateLogs(4), nil),
-				newLogsRequest(testdata.GenerateLogs(4), nil),
-				newLogsRequest(testdata.GenerateLogs(2), nil),
+				newLogsRequest(testdata.GenerateLogs(4)),
+				newLogsRequest(testdata.GenerateLogs(4)),
+				newLogsRequest(testdata.GenerateLogs(2)),
 			},
 		},
 		{
@@ -186,16 +179,16 @@ func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
 				Sizer:   exporterbatcher.SizerTypeBytes,
 				MaxSize: logsMarshaler.LogsSize(testdata.GenerateLogs(10))/2 + logsMarshaler.LogsSize(testdata.GenerateLogs(11))/2,
 			},
-			lr1: newLogsRequest(testdata.GenerateLogs(8), nil),
-			lr2: newLogsRequest(testdata.GenerateLogs(20), nil),
+			lr1: newLogsRequest(testdata.GenerateLogs(8)),
+			lr2: newLogsRequest(testdata.GenerateLogs(20)),
 			expected: []Request{
 				newLogsRequest(func() plog.Logs {
 					logs := testdata.GenerateLogs(8)
 					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
 					return logs
-				}(), nil),
-				newLogsRequest(testdata.GenerateLogs(10), nil),
-				newLogsRequest(testdata.GenerateLogs(8), nil),
+				}()),
+				newLogsRequest(testdata.GenerateLogs(10)),
+				newLogsRequest(testdata.GenerateLogs(8)),
 			},
 		},
 		{
@@ -205,16 +198,16 @@ func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
 				ld := testdata.GenerateLogs(4)
 				ld.ResourceLogs().At(0).ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("extra log")
 				return ld
-			}(), nil),
-			lr2: newLogsRequest(testdata.GenerateLogs(2), nil),
+			}()),
+			lr2: newLogsRequest(testdata.GenerateLogs(2)),
 			expected: []Request{
-				newLogsRequest(testdata.GenerateLogs(4), nil),
+				newLogsRequest(testdata.GenerateLogs(4)),
 				newLogsRequest(func() plog.Logs {
 					ld := testdata.GenerateLogs(0)
 					ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().AppendEmpty().Body().SetStr("extra log")
 					testdata.GenerateLogs(2).ResourceLogs().MoveAndAppendTo(ld.ResourceLogs())
 					return ld
-				}(), nil),
+				}()),
 			},
 		},
 	}
@@ -231,18 +224,11 @@ func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
 }
 
 func TestMergeSplitLogsInputNotModifiedIfErrorReturned(t *testing.T) {
-	r1 := newLogsRequest(testdata.GenerateLogs(18), nil)
-	r2 := newTracesRequest(testdata.GenerateTraces(3), nil)
+	r1 := newLogsRequest(testdata.GenerateLogs(18))
+	r2 := newTracesRequest(testdata.GenerateTraces(3))
 	_, err := r1.MergeSplit(context.Background(), exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10}, r2)
 	require.Error(t, err)
 	assert.Equal(t, 18, r1.ItemsCount())
-}
-
-func TestMergeSplitLogsInvalidInput(t *testing.T) {
-	r1 := newTracesRequest(testdata.GenerateTraces(2), nil)
-	r2 := newLogsRequest(testdata.GenerateLogs(3), nil)
-	_, err := r1.MergeSplit(context.Background(), exporterbatcher.SizeConfig{}, r2)
-	require.Error(t, err)
 }
 
 func TestExtractLogs(t *testing.T) {
@@ -257,9 +243,9 @@ func TestExtractLogs(t *testing.T) {
 func TestMergeSplitManySmallLogs(t *testing.T) {
 	// All requests merge into a single batch.
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10000}
-	merged := []Request{newLogsRequest(testdata.GenerateLogs(1), nil)}
+	merged := []Request{newLogsRequest(testdata.GenerateLogs(1))}
 	for j := 0; j < 1000; j++ {
-		lr2 := newLogsRequest(testdata.GenerateLogs(10), nil)
+		lr2 := newLogsRequest(testdata.GenerateLogs(10))
 		res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 		merged = append(merged[0:len(merged)-1], res...)
 	}
@@ -270,7 +256,7 @@ func TestLogsMergeSplitExactBytes(t *testing.T) {
 	pb := plog.ProtoMarshaler{}
 	// Set max size off by 1, so forces every log to be it's own batch.
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: pb.LogsSize(testdata.GenerateLogs(2)) - 1}
-	lr := newLogsRequest(testdata.GenerateLogs(4), nil)
+	lr := newLogsRequest(testdata.GenerateLogs(4))
 	merged, err := lr.MergeSplit(context.Background(), cfg, nil)
 	require.NoError(t, err)
 	assert.Len(t, merged, 4)
@@ -279,7 +265,7 @@ func TestLogsMergeSplitExactBytes(t *testing.T) {
 func TestLogsMergeSplitExactItems(t *testing.T) {
 	// Set max size off by 1, so forces every log to be it's own batch.
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 1}
-	lr := newLogsRequest(testdata.GenerateLogs(4), nil)
+	lr := newLogsRequest(testdata.GenerateLogs(4))
 	merged, err := lr.MergeSplit(context.Background(), cfg, nil)
 	require.NoError(t, err)
 	assert.Len(t, merged, 4)
@@ -290,9 +276,9 @@ func BenchmarkSplittingBasedOnItemCountManySmallLogs(b *testing.B) {
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10010}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		merged := []Request{newLogsRequest(testdata.GenerateLogs(10), nil)}
+		merged := []Request{newLogsRequest(testdata.GenerateLogs(10))}
 		for j := 0; j < 1000; j++ {
-			lr2 := newLogsRequest(testdata.GenerateLogs(10), nil)
+			lr2 := newLogsRequest(testdata.GenerateLogs(10))
 			res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 			merged = append(merged[0:len(merged)-1], res...)
 		}
@@ -305,9 +291,9 @@ func BenchmarkSplittingBasedOnByteSizeManySmallLogs(b *testing.B) {
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: logsMarshaler.LogsSize(testdata.GenerateLogs(11000))}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		merged := []Request{newLogsRequest(testdata.GenerateLogs(10), nil)}
+		merged := []Request{newLogsRequest(testdata.GenerateLogs(10))}
 		for j := 0; j < 1000; j++ {
-			lr2 := newLogsRequest(testdata.GenerateLogs(10), nil)
+			lr2 := newLogsRequest(testdata.GenerateLogs(10))
 			res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 			merged = append(merged[0:len(merged)-1], res...)
 		}
@@ -320,9 +306,9 @@ func BenchmarkSplittingBasedOnItemCountManyLogsSlightlyAboveLimit(b *testing.B) 
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10000}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		merged := []Request{newLogsRequest(testdata.GenerateLogs(0), nil)}
+		merged := []Request{newLogsRequest(testdata.GenerateLogs(0))}
 		for j := 0; j < 10; j++ {
-			lr2 := newLogsRequest(testdata.GenerateLogs(10001), nil)
+			lr2 := newLogsRequest(testdata.GenerateLogs(10001))
 			res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 			merged = append(merged[0:len(merged)-1], res...)
 		}
@@ -335,9 +321,9 @@ func BenchmarkSplittingBasedOnByteSizeManyLogsSlightlyAboveLimit(b *testing.B) {
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: logsMarshaler.LogsSize(testdata.GenerateLogs(10000))}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		merged := []Request{newLogsRequest(testdata.GenerateLogs(0), nil)}
+		merged := []Request{newLogsRequest(testdata.GenerateLogs(0))}
 		for j := 0; j < 10; j++ {
-			lr2 := newLogsRequest(testdata.GenerateLogs(10001), nil)
+			lr2 := newLogsRequest(testdata.GenerateLogs(10001))
 			res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 			assert.Len(b, res, 2)
 			merged = append(merged[0:len(merged)-1], res...)
@@ -351,8 +337,8 @@ func BenchmarkSplittingBasedOnItemCountHugeLogs(b *testing.B) {
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10000}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		merged := []Request{newLogsRequest(testdata.GenerateLogs(0), nil)}
-		lr2 := newLogsRequest(testdata.GenerateLogs(100000), nil)
+		merged := []Request{newLogsRequest(testdata.GenerateLogs(0))}
+		lr2 := newLogsRequest(testdata.GenerateLogs(100000))
 		res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 		merged = append(merged[0:len(merged)-1], res...)
 		assert.Len(b, merged, 10)
@@ -364,8 +350,8 @@ func BenchmarkSplittingBasedOnByteSizeHugeLogs(b *testing.B) {
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: logsMarshaler.LogsSize(testdata.GenerateLogs(10010))}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		merged := []Request{newLogsRequest(testdata.GenerateLogs(0), nil)}
-		lr2 := newLogsRequest(testdata.GenerateLogs(100000), nil)
+		merged := []Request{newLogsRequest(testdata.GenerateLogs(0))}
+		lr2 := newLogsRequest(testdata.GenerateLogs(100000))
 		res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 		merged = append(merged[0:len(merged)-1], res...)
 		assert.Len(b, merged, 10)
@@ -374,7 +360,7 @@ func BenchmarkSplittingBasedOnByteSizeHugeLogs(b *testing.B) {
 
 func TestLogsRequest_MergeSplit_UnknownSizerType(t *testing.T) {
 	// Create a logs request
-	req := newLogsRequest(plog.NewLogs(), nil)
+	req := newLogsRequest(plog.NewLogs())
 
 	// Create config with invalid sizer type by using zero value
 	cfg := exporterbatcher.SizeConfig{

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -26,44 +26,36 @@ var (
 
 type metricsRequest struct {
 	md         pmetric.Metrics
-	pusher     consumer.ConsumeMetricsFunc
 	cachedSize int
 }
 
-func newMetricsRequest(md pmetric.Metrics, pusher consumer.ConsumeMetricsFunc) Request {
+func newMetricsRequest(md pmetric.Metrics) Request {
 	return &metricsRequest{
 		md:         md,
-		pusher:     pusher,
 		cachedSize: -1,
 	}
 }
 
-type metricsEncoding struct {
-	pusher consumer.ConsumeMetricsFunc
-}
+type metricsEncoding struct{}
 
-func (me *metricsEncoding) Unmarshal(bytes []byte) (Request, error) {
+func (metricsEncoding) Unmarshal(bytes []byte) (Request, error) {
 	metrics, err := metricsUnmarshaler.UnmarshalMetrics(bytes)
 	if err != nil {
 		return nil, err
 	}
-	return newMetricsRequest(metrics, me.pusher), nil
+	return newMetricsRequest(metrics), nil
 }
 
-func (me *metricsEncoding) Marshal(req Request) ([]byte, error) {
+func (metricsEncoding) Marshal(req Request) ([]byte, error) {
 	return metricsMarshaler.MarshalMetrics(req.(*metricsRequest).md)
 }
 
 func (req *metricsRequest) OnError(err error) Request {
 	var metricsError consumererror.Metrics
 	if errors.As(err, &metricsError) {
-		return newMetricsRequest(metricsError.Data(), req.pusher)
+		return newMetricsRequest(metricsError.Data())
 	}
 	return req
-}
-
-func (req *metricsRequest) Export(ctx context.Context) error {
-	return req.pusher(ctx, req.md)
 }
 
 func (req *metricsRequest) ItemsCount() int {
@@ -98,18 +90,25 @@ func NewMetrics(
 		return nil, errNilConfig
 	}
 	if pusher == nil {
-		return nil, errNilPushMetricsData
+		return nil, errNilPushMetrics
 	}
-	return NewMetricsRequest(ctx, set, requestFromMetrics(pusher), append([]Option{internal.WithEncoding(&metricsEncoding{pusher: pusher})}, options...)...)
+	return NewMetricsRequest(ctx, set, requestFromMetrics(), requestConsumeFromMetrics(pusher), append([]Option{internal.WithEncoding(metricsEncoding{})}, options...)...)
 }
 
 // Deprecated: [v0.122.0] use RequestConverterFunc[pmetric.Metrics].
 type RequestFromMetricsFunc = RequestConverterFunc[pmetric.Metrics]
 
+// requestConsumeFromMetrics returns a RequestConsumeFunc that consumes pmetric.Metrics.
+func requestConsumeFromMetrics(pusher consumer.ConsumeMetricsFunc) RequestConsumeFunc {
+	return func(ctx context.Context, request Request) error {
+		return pusher.ConsumeMetrics(ctx, request.(*metricsRequest).md)
+	}
+}
+
 // requestFromMetrics returns a RequestFromMetricsFunc that converts pdata.Metrics into a Request.
-func requestFromMetrics(pusher consumer.ConsumeMetricsFunc) RequestConverterFunc[pmetric.Metrics] {
+func requestFromMetrics() RequestConverterFunc[pmetric.Metrics] {
 	return func(_ context.Context, md pmetric.Metrics) (Request, error) {
-		return newMetricsRequest(md, pusher), nil
+		return newMetricsRequest(md), nil
 	}
 }
 
@@ -120,6 +119,7 @@ func NewMetricsRequest(
 	_ context.Context,
 	set exporter.Settings,
 	converter RequestConverterFunc[pmetric.Metrics],
+	pusher RequestConsumeFunc,
 	options ...Option,
 ) (exporter.Metrics, error) {
 	if set.Logger == nil {
@@ -130,7 +130,11 @@ func NewMetricsRequest(
 		return nil, errNilMetricsConverter
 	}
 
-	be, err := internal.NewBaseExporter(set, pipeline.SignalMetrics, options...)
+	if pusher == nil {
+		return nil, errNilConsumeRequest
+	}
+
+	be, err := internal.NewBaseExporter(set, pipeline.SignalMetrics, pusher, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/exporterhelper/metrics_batch.go
+++ b/exporter/exporterhelper/metrics_batch.go
@@ -53,7 +53,7 @@ func (req *metricsRequest) split(maxSize int, sz sizer.MetricsSizer) []Request {
 	for req.size(sz) > maxSize {
 		md, rmSize := extractMetrics(req.md, maxSize, sz)
 		req.setCachedSize(req.size(sz) - rmSize)
-		res = append(res, newMetricsRequest(md, req.pusher))
+		res = append(res, newMetricsRequest(md))
 	}
 	res = append(res, req)
 	return res

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -26,3 +26,7 @@ type RequestErrorHandler = request.ErrorHandler
 // Experimental: This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
 type RequestConverterFunc[K any] func(context.Context, K) (Request, error)
+
+// RequestConsumeFunc processes the request. After the function returns, the request is no longer accessible,
+// and accessing it is considered undefined behavior.
+type RequestConsumeFunc = func(context.Context, Request) error

--- a/exporter/exporterhelper/traces_batch.go
+++ b/exporter/exporterhelper/traces_batch.go
@@ -53,7 +53,7 @@ func (req *tracesRequest) split(maxSize int, sz sizer.TracesSizer) []Request {
 	for req.size(sz) > maxSize {
 		td, rmSize := extractTraces(req.td, maxSize, sz)
 		req.setCachedSize(req.size(sz) - rmSize)
-		res = append(res, newTracesRequest(td, req.pusher))
+		res = append(res, newTracesRequest(td))
 	}
 	res = append(res, req)
 	return res

--- a/exporter/exporterhelper/traces_batch_test.go
+++ b/exporter/exporterhelper/traces_batch_test.go
@@ -17,18 +17,11 @@ import (
 )
 
 func TestMergeTraces(t *testing.T) {
-	tr1 := newTracesRequest(testdata.GenerateTraces(2), nil)
-	tr2 := newTracesRequest(testdata.GenerateTraces(3), nil)
+	tr1 := newTracesRequest(testdata.GenerateTraces(2))
+	tr2 := newTracesRequest(testdata.GenerateTraces(3))
 	res, err := tr1.MergeSplit(context.Background(), exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems}, tr2)
 	require.NoError(t, err)
 	assert.Equal(t, 5, res[0].ItemsCount())
-}
-
-func TestMergeTracesInvalidInput(t *testing.T) {
-	tr1 := newLogsRequest(testdata.GenerateLogs(2), nil)
-	tr2 := newTracesRequest(testdata.GenerateTraces(3), nil)
-	_, err := tr1.MergeSplit(context.Background(), exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems}, tr2)
-	require.Error(t, err)
 }
 
 func TestMergeSplitTraces(t *testing.T) {
@@ -42,66 +35,66 @@ func TestMergeSplitTraces(t *testing.T) {
 		{
 			name:     "both_requests_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			tr1:      newTracesRequest(ptrace.NewTraces(), nil),
-			tr2:      newTracesRequest(ptrace.NewTraces(), nil),
-			expected: []Request{newTracesRequest(ptrace.NewTraces(), nil)},
+			tr1:      newTracesRequest(ptrace.NewTraces()),
+			tr2:      newTracesRequest(ptrace.NewTraces()),
+			expected: []Request{newTracesRequest(ptrace.NewTraces())},
 		},
 		{
 			name:     "first_request_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			tr1:      newTracesRequest(ptrace.NewTraces(), nil),
-			tr2:      newTracesRequest(testdata.GenerateTraces(5), nil),
-			expected: []Request{newTracesRequest(testdata.GenerateTraces(5), nil)},
+			tr1:      newTracesRequest(ptrace.NewTraces()),
+			tr2:      newTracesRequest(testdata.GenerateTraces(5)),
+			expected: []Request{newTracesRequest(testdata.GenerateTraces(5))},
 		},
 		{
 			name:     "second_request_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			tr1:      newTracesRequest(testdata.GenerateTraces(5), nil),
-			tr2:      newTracesRequest(ptrace.NewTraces(), nil),
-			expected: []Request{newTracesRequest(testdata.GenerateTraces(5), nil)},
+			tr1:      newTracesRequest(testdata.GenerateTraces(5)),
+			tr2:      newTracesRequest(ptrace.NewTraces()),
+			expected: []Request{newTracesRequest(testdata.GenerateTraces(5))},
 		},
 		{
 			name:     "first_empty_second_nil",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			tr1:      newTracesRequest(ptrace.NewTraces(), nil),
+			tr1:      newTracesRequest(ptrace.NewTraces()),
 			tr2:      nil,
-			expected: []Request{newTracesRequest(ptrace.NewTraces(), nil)},
+			expected: []Request{newTracesRequest(ptrace.NewTraces())},
 		},
 		{
 			name: "merge_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			tr1:  newTracesRequest(testdata.GenerateTraces(5), nil),
-			tr2:  newTracesRequest(testdata.GenerateTraces(5), nil),
+			tr1:  newTracesRequest(testdata.GenerateTraces(5)),
+			tr2:  newTracesRequest(testdata.GenerateTraces(5)),
 			expected: []Request{newTracesRequest(func() ptrace.Traces {
 				td := testdata.GenerateTraces(5)
 				testdata.GenerateTraces(5).ResourceSpans().MoveAndAppendTo(td.ResourceSpans())
 				return td
-			}(), nil)},
+			}())},
 		},
 		{
 			name: "split_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 4},
-			tr1:  newTracesRequest(ptrace.NewTraces(), nil),
-			tr2:  newTracesRequest(testdata.GenerateTraces(10), nil),
+			tr1:  newTracesRequest(ptrace.NewTraces()),
+			tr2:  newTracesRequest(testdata.GenerateTraces(10)),
 			expected: []Request{
-				newTracesRequest(testdata.GenerateTraces(4), nil),
-				newTracesRequest(testdata.GenerateTraces(4), nil),
-				newTracesRequest(testdata.GenerateTraces(2), nil),
+				newTracesRequest(testdata.GenerateTraces(4)),
+				newTracesRequest(testdata.GenerateTraces(4)),
+				newTracesRequest(testdata.GenerateTraces(2)),
 			},
 		},
 		{
 			name: "split_and_merge",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			tr1:  newTracesRequest(testdata.GenerateTraces(4), nil),
-			tr2:  newTracesRequest(testdata.GenerateTraces(20), nil),
+			tr1:  newTracesRequest(testdata.GenerateTraces(4)),
+			tr2:  newTracesRequest(testdata.GenerateTraces(20)),
 			expected: []Request{
 				newTracesRequest(func() ptrace.Traces {
 					td := testdata.GenerateTraces(4)
 					testdata.GenerateTraces(6).ResourceSpans().MoveAndAppendTo(td.ResourceSpans())
 					return td
-				}(), nil),
-				newTracesRequest(testdata.GenerateTraces(10), nil),
-				newTracesRequest(testdata.GenerateTraces(4), nil),
+				}()),
+				newTracesRequest(testdata.GenerateTraces(10)),
+				newTracesRequest(testdata.GenerateTraces(4)),
 			},
 		},
 		{
@@ -113,15 +106,15 @@ func TestMergeSplitTraces(t *testing.T) {
 				extraScopeTraces.ResourceSpans().At(0).ScopeSpans().At(0).Scope().SetName("extra scope")
 				extraScopeTraces.ResourceSpans().MoveAndAppendTo(td.ResourceSpans())
 				return td
-			}(), nil),
+			}()),
 			tr2: nil,
 			expected: []Request{
-				newTracesRequest(testdata.GenerateTraces(10), nil),
+				newTracesRequest(testdata.GenerateTraces(10)),
 				newTracesRequest(func() ptrace.Traces {
 					td := testdata.GenerateTraces(5)
 					td.ResourceSpans().At(0).ScopeSpans().At(0).Scope().SetName("extra scope")
 					return td
-				}(), nil),
+				}()),
 			},
 		},
 	}
@@ -148,44 +141,44 @@ func TestMergeSplitTracesBasedOnByteSize(t *testing.T) {
 		{
 			name:     "both_requests_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: tracesMarshaler.TracesSize(testdata.GenerateTraces(10))},
-			lr1:      newTracesRequest(ptrace.NewTraces(), nil),
-			lr2:      newTracesRequest(ptrace.NewTraces(), nil),
-			expected: []Request{newTracesRequest(ptrace.NewTraces(), nil)},
+			lr1:      newTracesRequest(ptrace.NewTraces()),
+			lr2:      newTracesRequest(ptrace.NewTraces()),
+			expected: []Request{newTracesRequest(ptrace.NewTraces())},
 		},
 		{
 			name:     "first_request_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: tracesMarshaler.TracesSize(testdata.GenerateTraces(10))},
-			lr1:      newTracesRequest(ptrace.NewTraces(), nil),
-			lr2:      newTracesRequest(testdata.GenerateTraces(5), nil),
-			expected: []Request{newTracesRequest(testdata.GenerateTraces(5), nil)},
+			lr1:      newTracesRequest(ptrace.NewTraces()),
+			lr2:      newTracesRequest(testdata.GenerateTraces(5)),
+			expected: []Request{newTracesRequest(testdata.GenerateTraces(5))},
 		},
 		{
 			name:     "first_empty_second_nil",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: tracesMarshaler.TracesSize(testdata.GenerateTraces(10))},
-			lr1:      newTracesRequest(ptrace.NewTraces(), nil),
+			lr1:      newTracesRequest(ptrace.NewTraces()),
 			lr2:      nil,
-			expected: []Request{newTracesRequest(ptrace.NewTraces(), nil)},
+			expected: []Request{newTracesRequest(ptrace.NewTraces())},
 		},
 		{
 			name: "merge_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: tracesMarshaler.TracesSize(testdata.GenerateTraces(10))},
-			lr1:  newTracesRequest(testdata.GenerateTraces(1), nil),
-			lr2:  newTracesRequest(testdata.GenerateTraces(6), nil),
+			lr1:  newTracesRequest(testdata.GenerateTraces(1)),
+			lr2:  newTracesRequest(testdata.GenerateTraces(6)),
 			expected: []Request{newTracesRequest(func() ptrace.Traces {
 				traces := testdata.GenerateTraces(1)
 				testdata.GenerateTraces(6).ResourceSpans().MoveAndAppendTo(traces.ResourceSpans())
 				return traces
-			}(), nil)},
+			}())},
 		},
 		{
 			name: "split_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: tracesMarshaler.TracesSize(testdata.GenerateTraces(4))},
-			lr1:  newTracesRequest(ptrace.NewTraces(), nil),
-			lr2:  newTracesRequest(testdata.GenerateTraces(10), nil),
+			lr1:  newTracesRequest(ptrace.NewTraces()),
+			lr2:  newTracesRequest(testdata.GenerateTraces(10)),
 			expected: []Request{
-				newTracesRequest(testdata.GenerateTraces(4), nil),
-				newTracesRequest(testdata.GenerateTraces(4), nil),
-				newTracesRequest(testdata.GenerateTraces(2), nil),
+				newTracesRequest(testdata.GenerateTraces(4)),
+				newTracesRequest(testdata.GenerateTraces(4)),
+				newTracesRequest(testdata.GenerateTraces(2)),
 			},
 		},
 		{
@@ -194,16 +187,16 @@ func TestMergeSplitTracesBasedOnByteSize(t *testing.T) {
 				Sizer:   exporterbatcher.SizerTypeBytes,
 				MaxSize: tracesMarshaler.TracesSize(testdata.GenerateTraces(10))/2 + tracesMarshaler.TracesSize(testdata.GenerateTraces(11))/2,
 			},
-			lr1: newTracesRequest(testdata.GenerateTraces(8), nil),
-			lr2: newTracesRequest(testdata.GenerateTraces(20), nil),
+			lr1: newTracesRequest(testdata.GenerateTraces(8)),
+			lr2: newTracesRequest(testdata.GenerateTraces(20)),
 			expected: []Request{
 				newTracesRequest(func() ptrace.Traces {
 					traces := testdata.GenerateTraces(8)
 					testdata.GenerateTraces(2).ResourceSpans().MoveAndAppendTo(traces.ResourceSpans())
 					return traces
-				}(), nil),
-				newTracesRequest(testdata.GenerateTraces(10), nil),
-				newTracesRequest(testdata.GenerateTraces(8), nil),
+				}()),
+				newTracesRequest(testdata.GenerateTraces(10)),
+				newTracesRequest(testdata.GenerateTraces(8)),
 			},
 		},
 		{
@@ -213,16 +206,16 @@ func TestMergeSplitTracesBasedOnByteSize(t *testing.T) {
 				ld := testdata.GenerateTraces(4)
 				ld.ResourceSpans().At(0).ScopeSpans().AppendEmpty().Spans().AppendEmpty().Attributes().PutStr("attr", "attrvalue")
 				return ld
-			}(), nil),
-			lr2: newTracesRequest(testdata.GenerateTraces(2), nil),
+			}()),
+			lr2: newTracesRequest(testdata.GenerateTraces(2)),
 			expected: []Request{
-				newTracesRequest(testdata.GenerateTraces(4), nil),
+				newTracesRequest(testdata.GenerateTraces(4)),
 				newTracesRequest(func() ptrace.Traces {
 					ld := testdata.GenerateTraces(0)
 					ld.ResourceSpans().At(0).ScopeSpans().At(0).Spans().AppendEmpty().Attributes().PutStr("attr", "attrvalue")
 					testdata.GenerateTraces(2).ResourceSpans().MoveAndAppendTo(ld.ResourceSpans())
 					return ld
-				}(), nil),
+				}()),
 			},
 		},
 	}
@@ -239,18 +232,11 @@ func TestMergeSplitTracesBasedOnByteSize(t *testing.T) {
 }
 
 func TestMergeSplitTracesInputNotModifiedIfErrorReturned(t *testing.T) {
-	r1 := newTracesRequest(testdata.GenerateTraces(18), nil)
-	r2 := newLogsRequest(testdata.GenerateLogs(3), nil)
+	r1 := newTracesRequest(testdata.GenerateTraces(18))
+	r2 := newLogsRequest(testdata.GenerateLogs(3))
 	_, err := r1.MergeSplit(context.Background(), exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10}, r2)
 	require.Error(t, err)
 	assert.Equal(t, 18, r1.ItemsCount())
-}
-
-func TestMergeSplitTracesInvalidInput(t *testing.T) {
-	r1 := newTracesRequest(testdata.GenerateTraces(2), nil)
-	r2 := newMetricsRequest(testdata.GenerateMetrics(3), nil)
-	_, err := r1.MergeSplit(context.Background(), exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10}, r2)
-	require.Error(t, err)
 }
 
 func TestExtractTraces(t *testing.T) {
@@ -265,9 +251,9 @@ func TestExtractTraces(t *testing.T) {
 
 func TestMergeSplitManySmallTraces(t *testing.T) {
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10000}
-	merged := []Request{newTracesRequest(testdata.GenerateTraces(1), nil)}
+	merged := []Request{newTracesRequest(testdata.GenerateTraces(1))}
 	for j := 0; j < 1000; j++ {
-		lr2 := newTracesRequest(testdata.GenerateTraces(10), nil)
+		lr2 := newTracesRequest(testdata.GenerateTraces(10))
 		res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 		merged = append(merged[0:len(merged)-1], res...)
 	}
@@ -278,7 +264,7 @@ func TestTracesMergeSplitExactBytes(t *testing.T) {
 	pb := ptrace.ProtoMarshaler{}
 	// Set max size off by 1, so forces every log to be it's own batch.
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeBytes, MaxSize: pb.TracesSize(testdata.GenerateTraces(2)) - 1}
-	lr := newTracesRequest(testdata.GenerateTraces(4), nil)
+	lr := newTracesRequest(testdata.GenerateTraces(4))
 	merged, err := lr.MergeSplit(context.Background(), cfg, nil)
 	require.NoError(t, err)
 	assert.Len(t, merged, 4)
@@ -287,7 +273,7 @@ func TestTracesMergeSplitExactBytes(t *testing.T) {
 func TestTracesMergeSplitExactItems(t *testing.T) {
 	// Set max size off by 1, so forces every log to be it's own batch.
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 1}
-	lr := newLogsRequest(testdata.GenerateLogs(4), nil)
+	lr := newTracesRequest(testdata.GenerateTraces(4))
 	merged, err := lr.MergeSplit(context.Background(), cfg, nil)
 	require.NoError(t, err)
 	assert.Len(t, merged, 4)
@@ -298,9 +284,9 @@ func BenchmarkSplittingBasedOnItemCountManySmallTraces(b *testing.B) {
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10010}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		merged := []Request{newTracesRequest(testdata.GenerateTraces(10), nil)}
+		merged := []Request{newTracesRequest(testdata.GenerateTraces(10))}
 		for j := 0; j < 1000; j++ {
-			lr2 := newTracesRequest(testdata.GenerateTraces(10), nil)
+			lr2 := newTracesRequest(testdata.GenerateTraces(10))
 			res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 			merged = append(merged[0:len(merged)-1], res...)
 		}
@@ -313,9 +299,9 @@ func BenchmarkSplittingBasedOnItemCountManyTracesSlightlyAboveLimit(b *testing.B
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10000}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		merged := []Request{newTracesRequest(testdata.GenerateTraces(0), nil)}
+		merged := []Request{newTracesRequest(testdata.GenerateTraces(0))}
 		for j := 0; j < 10; j++ {
-			lr2 := newTracesRequest(testdata.GenerateTraces(10001), nil)
+			lr2 := newTracesRequest(testdata.GenerateTraces(10001))
 			res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 			merged = append(merged[0:len(merged)-1], res...)
 		}
@@ -328,8 +314,8 @@ func BenchmarkSplittingBasedOnItemCountHugeTraces(b *testing.B) {
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10000}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		merged := []Request{newTracesRequest(testdata.GenerateTraces(0), nil)}
-		lr2 := newTracesRequest(testdata.GenerateTraces(100000), nil)
+		merged := []Request{newTracesRequest(testdata.GenerateTraces(0))}
+		lr2 := newTracesRequest(testdata.GenerateTraces(100000))
 		res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 		merged = append(merged[0:len(merged)-1], res...)
 		assert.Len(b, merged, 10)

--- a/exporter/exporterhelper/xexporterhelper/constants.go
+++ b/exporter/exporterhelper/xexporterhelper/constants.go
@@ -12,6 +12,8 @@ var (
 	errNilConfig = errors.New("nil config")
 	// errNilLogger is returned when a logger is nil
 	errNilLogger = errors.New("nil logger")
+	// errNilConsumeRequest is returned when a nil PushTraces is given.
+	errNilConsumeRequest = errors.New("nil RequestConsumeFunc")
 	// errNilPushProfileData is returned when a nil PushProfiles is given.
 	errNilPushProfileData = errors.New("nil PushProfiles")
 	// errNilProfilesConverter is returned when a nil RequestFromProfilesFunc is given.

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -28,44 +28,36 @@ var (
 
 type profilesRequest struct {
 	pd               pprofile.Profiles
-	pusher           xconsumer.ConsumeProfilesFunc
 	cachedItemsCount int
 }
 
-func newProfilesRequest(pd pprofile.Profiles, pusher xconsumer.ConsumeProfilesFunc) exporterhelper.Request {
+func newProfilesRequest(pd pprofile.Profiles) exporterhelper.Request {
 	return &profilesRequest{
 		pd:               pd,
-		pusher:           pusher,
 		cachedItemsCount: pd.SampleCount(),
 	}
 }
 
-type profilesEncoding struct {
-	pusher xconsumer.ConsumeProfilesFunc
-}
+type profilesEncoding struct{}
 
-func (le *profilesEncoding) Unmarshal(bytes []byte) (exporterhelper.Request, error) {
+func (profilesEncoding) Unmarshal(bytes []byte) (exporterhelper.Request, error) {
 	profiles, err := profilesUnmarshaler.UnmarshalProfiles(bytes)
 	if err != nil {
 		return nil, err
 	}
-	return newProfilesRequest(profiles, le.pusher), nil
+	return newProfilesRequest(profiles), nil
 }
 
-func (le *profilesEncoding) Marshal(req exporterhelper.Request) ([]byte, error) {
+func (profilesEncoding) Marshal(req exporterhelper.Request) ([]byte, error) {
 	return profilesMarshaler.MarshalProfiles(req.(*profilesRequest).pd)
 }
 
 func (req *profilesRequest) OnError(err error) exporterhelper.Request {
 	var profileError xconsumererror.Profiles
 	if errors.As(err, &profileError) {
-		return newProfilesRequest(profileError.Data(), req.pusher)
+		return newProfilesRequest(profileError.Data())
 	}
 	return req
-}
-
-func (req *profilesRequest) Export(ctx context.Context) error {
-	return req.pusher(ctx, req.pd)
 }
 
 func (req *profilesRequest) ItemsCount() int {
@@ -95,17 +87,24 @@ func NewProfilesExporter(
 	if pusher == nil {
 		return nil, errNilPushProfileData
 	}
-	opts := []exporterhelper.Option{internal.WithEncoding(&profilesEncoding{pusher: pusher})}
-	return NewProfilesRequestExporter(ctx, set, requestFromProfiles(pusher), append(opts, options...)...)
+	opts := []exporterhelper.Option{internal.WithEncoding(profilesEncoding{})}
+	return NewProfilesRequestExporter(ctx, set, requestFromProfiles(), requestConsumeFromProfiles(pusher), append(opts, options...)...)
 }
 
 // Deprecated: [v0.122.0] use exporterhelper.RequestConverterFunc[pprofile.Profiles].
 type RequestFromProfilesFunc = exporterhelper.RequestConverterFunc[pprofile.Profiles]
 
+// requestConsumeFromProfiles returns a RequestConsumeFunc that consumes pprofile.Profiles.
+func requestConsumeFromProfiles(pusher xconsumer.ConsumeProfilesFunc) exporterhelper.RequestConsumeFunc {
+	return func(ctx context.Context, request exporterhelper.Request) error {
+		return pusher.ConsumeProfiles(ctx, request.(*profilesRequest).pd)
+	}
+}
+
 // requestFromProfiles returns a RequestFromProfilesFunc that converts pprofile.Profiles into a Request.
-func requestFromProfiles(pusher xconsumer.ConsumeProfilesFunc) exporterhelper.RequestConverterFunc[pprofile.Profiles] {
+func requestFromProfiles() exporterhelper.RequestConverterFunc[pprofile.Profiles] {
 	return func(_ context.Context, profiles pprofile.Profiles) (exporterhelper.Request, error) {
-		return newProfilesRequest(profiles, pusher), nil
+		return newProfilesRequest(profiles), nil
 	}
 }
 
@@ -116,6 +115,7 @@ func NewProfilesRequestExporter(
 	_ context.Context,
 	set exporter.Settings,
 	converter exporterhelper.RequestConverterFunc[pprofile.Profiles],
+	pusher exporterhelper.RequestConsumeFunc,
 	options ...exporterhelper.Option,
 ) (xexporter.Profiles, error) {
 	if set.Logger == nil {
@@ -126,7 +126,11 @@ func NewProfilesRequestExporter(
 		return nil, errNilProfilesConverter
 	}
 
-	be, err := internal.NewBaseExporter(set, xpipeline.SignalProfiles, options...)
+	if pusher == nil {
+		return nil, errNilConsumeRequest
+	}
+
+	be, err := internal.NewBaseExporter(set, xpipeline.SignalProfiles, pusher, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch.go
@@ -41,7 +41,7 @@ func (req *profilesRequest) split(cfg exporterbatcher.SizeConfig) ([]exporterhel
 		pd := extractProfiles(req.pd, cfg.MaxSize)
 		size := pd.SampleCount()
 		req.setCachedItemsCount(req.ItemsCount() - size)
-		res = append(res, &profilesRequest{pd: pd, pusher: req.pusher, cachedItemsCount: size})
+		res = append(res, &profilesRequest{pd: pd, cachedItemsCount: size})
 	}
 	res = append(res, req)
 	return res, nil

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 func TestMergeProfiles(t *testing.T) {
-	pr1 := newProfilesRequest(testdata.GenerateProfiles(2), nil)
-	pr2 := newProfilesRequest(testdata.GenerateProfiles(3), nil)
+	pr1 := newProfilesRequest(testdata.GenerateProfiles(2))
+	pr2 := newProfilesRequest(testdata.GenerateProfiles(3))
 	res, err := pr1.MergeSplit(context.Background(), exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems}, pr2)
 	require.NoError(t, err)
 	assert.Len(t, res, 1)
@@ -27,7 +27,7 @@ func TestMergeProfiles(t *testing.T) {
 }
 
 func TestMergeProfilesInvalidInput(t *testing.T) {
-	pr2 := newProfilesRequest(testdata.GenerateProfiles(3), nil)
+	pr2 := newProfilesRequest(testdata.GenerateProfiles(3))
 	_, err := pr2.MergeSplit(context.Background(), exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems}, &requesttest.FakeRequest{Items: 1})
 	assert.Error(t, err)
 }
@@ -43,59 +43,59 @@ func TestMergeSplitProfiles(t *testing.T) {
 		{
 			name:     "both_requests_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			pr1:      newProfilesRequest(pprofile.NewProfiles(), nil),
-			pr2:      newProfilesRequest(pprofile.NewProfiles(), nil),
-			expected: []exporterhelper.Request{newProfilesRequest(pprofile.NewProfiles(), nil)},
+			pr1:      newProfilesRequest(pprofile.NewProfiles()),
+			pr2:      newProfilesRequest(pprofile.NewProfiles()),
+			expected: []exporterhelper.Request{newProfilesRequest(pprofile.NewProfiles())},
 		},
 		{
 			name:     "first_request_empty",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			pr1:      newProfilesRequest(pprofile.NewProfiles(), nil),
-			pr2:      newProfilesRequest(testdata.GenerateProfiles(5), nil),
-			expected: []exporterhelper.Request{newProfilesRequest(testdata.GenerateProfiles(5), nil)},
+			pr1:      newProfilesRequest(pprofile.NewProfiles()),
+			pr2:      newProfilesRequest(testdata.GenerateProfiles(5)),
+			expected: []exporterhelper.Request{newProfilesRequest(testdata.GenerateProfiles(5))},
 		},
 		{
 			name:     "first_empty_second_nil",
 			cfg:      exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			pr1:      newProfilesRequest(pprofile.NewProfiles(), nil),
+			pr1:      newProfilesRequest(pprofile.NewProfiles()),
 			pr2:      nil,
-			expected: []exporterhelper.Request{newProfilesRequest(pprofile.NewProfiles(), nil)},
+			expected: []exporterhelper.Request{newProfilesRequest(pprofile.NewProfiles())},
 		},
 		{
 			name: "merge_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			pr1:  newProfilesRequest(testdata.GenerateProfiles(4), nil),
-			pr2:  newProfilesRequest(testdata.GenerateProfiles(6), nil),
+			pr1:  newProfilesRequest(testdata.GenerateProfiles(4)),
+			pr2:  newProfilesRequest(testdata.GenerateProfiles(6)),
 			expected: []exporterhelper.Request{newProfilesRequest(func() pprofile.Profiles {
 				profiles := testdata.GenerateProfiles(4)
 				testdata.GenerateProfiles(6).ResourceProfiles().MoveAndAppendTo(profiles.ResourceProfiles())
 				return profiles
-			}(), nil)},
+			}())},
 		},
 		{
 			name: "split_only",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 4},
-			pr1:  newProfilesRequest(testdata.GenerateProfiles(10), nil),
+			pr1:  newProfilesRequest(testdata.GenerateProfiles(10)),
 			pr2:  nil,
 			expected: []exporterhelper.Request{
-				newProfilesRequest(testdata.GenerateProfiles(4), nil),
-				newProfilesRequest(testdata.GenerateProfiles(4), nil),
-				newProfilesRequest(testdata.GenerateProfiles(2), nil),
+				newProfilesRequest(testdata.GenerateProfiles(4)),
+				newProfilesRequest(testdata.GenerateProfiles(4)),
+				newProfilesRequest(testdata.GenerateProfiles(2)),
 			},
 		},
 		{
 			name: "merge_and_split",
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10},
-			pr1:  newProfilesRequest(testdata.GenerateProfiles(8), nil),
-			pr2:  newProfilesRequest(testdata.GenerateProfiles(20), nil),
+			pr1:  newProfilesRequest(testdata.GenerateProfiles(8)),
+			pr2:  newProfilesRequest(testdata.GenerateProfiles(20)),
 			expected: []exporterhelper.Request{
 				newProfilesRequest(func() pprofile.Profiles {
 					profiles := testdata.GenerateProfiles(8)
 					testdata.GenerateProfiles(2).ResourceProfiles().MoveAndAppendTo(profiles.ResourceProfiles())
 					return profiles
-				}(), nil),
-				newProfilesRequest(testdata.GenerateProfiles(10), nil),
-				newProfilesRequest(testdata.GenerateProfiles(8), nil),
+				}()),
+				newProfilesRequest(testdata.GenerateProfiles(10)),
+				newProfilesRequest(testdata.GenerateProfiles(8)),
 			},
 		},
 		{
@@ -103,13 +103,13 @@ func TestMergeSplitProfiles(t *testing.T) {
 			cfg:  exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 4},
 			pr1: newProfilesRequest(func() pprofile.Profiles {
 				return testdata.GenerateProfiles(6)
-			}(), nil),
+			}()),
 			pr2: nil,
 			expected: []exporterhelper.Request{
-				newProfilesRequest(testdata.GenerateProfiles(4), nil),
+				newProfilesRequest(testdata.GenerateProfiles(4)),
 				newProfilesRequest(func() pprofile.Profiles {
 					return testdata.GenerateProfiles(2)
-				}(), nil),
+				}()),
 			},
 		},
 	}
@@ -137,9 +137,9 @@ func TestExtractProfiles(t *testing.T) {
 func TestMergeSplitManySmallLogs(t *testing.T) {
 	// All requests merge into a single batch.
 	cfg := exporterbatcher.SizeConfig{Sizer: exporterbatcher.SizerTypeItems, MaxSize: 10000}
-	merged := []exporterhelper.Request{newProfilesRequest(testdata.GenerateProfiles(1), nil)}
+	merged := []exporterhelper.Request{newProfilesRequest(testdata.GenerateProfiles(1))}
 	for j := 0; j < 1000; j++ {
-		lr2 := newProfilesRequest(testdata.GenerateProfiles(10), nil)
+		lr2 := newProfilesRequest(testdata.GenerateProfiles(10))
 		res, _ := merged[len(merged)-1].MergeSplit(context.Background(), cfg, lr2)
 		merged = append(merged[0:len(merged)-1], res...)
 	}


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/8950

The logic behind this, is that during merging and splitting we should not care about the export func (see complicated logic removed in FakeRequest of in the pdata requests implementations).

Also, this simplify what user should carry with the request.