### PR TITLE
[exporterbatcher] Update batcher to support serialized bytes based batching.

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/default_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/default_batcher.go
@@ -68,6 +68,17 @@ func (qb *defaultBatcher) resetTimer() {
 	}
 }
 
+// batchReachedFlushingThreshold returns whether the request has reached the flushing threshold based on the sizer.
+func batchReachedFlushingThreshold(req request.Request, batchConfig BatchConfig, sizerType request.SizerType) bool {
+	switch sizerType {
+	case request.SizerTypeItems:
+		return req.ItemsCount() >= batchConfig.MinSize
+	case request.SizerTypeBytes:
+		return req.ByteSize() >= batchConfig.MinSize
+	}
+	return true
+}
+
 func (qb *defaultBatcher) Consume(ctx context.Context, req request.Request, done Done) {
 	qb.currentBatchMu.Lock()
 

--- a/exporter/exporterhelper/internal/request/request.go
+++ b/exporter/exporterhelper/internal/request/request.go
@@ -15,6 +15,8 @@ type Request interface {
 	// sent. For example, for OTLP exporter, this value represents the number of spans,
 	// metric data points or log records.
 	ItemsCount() int
+	// ByteSize returns the size of the request in bytes.
+	ByteSize() int
 	// MergeSplit is a function that merge and/or splits this request with another one into multiple requests based on the
 	// configured limit provided in MaxSizeConfig.
 	// MergeSplit does not split if all fields in MaxSizeConfig are not initialized (zero).

--- a/exporter/exporterhelper/internal/requesttest/request.go
+++ b/exporter/exporterhelper/internal/requesttest/request.go
@@ -42,6 +42,10 @@ func (r *FakeRequest) ItemsCount() int {
 	return r.Items
 }
 
+func (r *FakeRequest) ByteSize() int {
+	return r.Items
+}
+
 func (r *FakeRequest) MergeSplit(_ context.Context, maxSize int, _ request.SizerType, r2 request.Request) ([]request.Request, error) {
 	if r.MergeErr != nil {
 		return nil, r.MergeErr

--- a/exporter/exporterhelper/logs_batch.go
+++ b/exporter/exporterhelper/logs_batch.go
@@ -41,17 +41,17 @@ func (req *logsRequest) MergeSplit(_ context.Context, maxSize int, szt RequestSi
 
 func (req *logsRequest) mergeTo(dst *logsRequest, sz sizer.LogsSizer) {
 	if sz != nil {
-		dst.setCachedSize(dst.size(sz) + req.size(sz))
-		req.setCachedSize(0)
+		dst.setCachedSize(sz, dst.sizeFromSizer(sz)+req.sizeFromSizer(sz))
+		req.setCachedSize(sz, 0)
 	}
 	req.ld.ResourceLogs().MoveAndAppendTo(dst.ld.ResourceLogs())
 }
 
 func (req *logsRequest) split(maxSize int, sz sizer.LogsSizer) []Request {
 	var res []Request
-	for req.size(sz) > maxSize {
+	for req.sizeFromSizer(sz) > maxSize {
 		ld, rmSize := extractLogs(req.ld, maxSize, sz)
-		req.setCachedSize(req.size(sz) - rmSize)
+		req.setCachedSize(sz, req.sizeFromSizer(sz)-rmSize)
 		res = append(res, newLogsRequest(ld))
 	}
 	res = append(res, req)

--- a/exporter/exporterhelper/metrics_batch.go
+++ b/exporter/exporterhelper/metrics_batch.go
@@ -41,17 +41,17 @@ func (req *metricsRequest) MergeSplit(_ context.Context, maxSize int, szt Reques
 
 func (req *metricsRequest) mergeTo(dst *metricsRequest, sz sizer.MetricsSizer) {
 	if sz != nil {
-		dst.setCachedSize(dst.size(sz) + req.size(sz))
-		req.setCachedSize(0)
+		dst.setCachedSize(sz, dst.sizeFromSizer(sz)+req.sizeFromSizer(sz))
+		req.setCachedSize(sz, 0)
 	}
 	req.md.ResourceMetrics().MoveAndAppendTo(dst.md.ResourceMetrics())
 }
 
 func (req *metricsRequest) split(maxSize int, sz sizer.MetricsSizer) []Request {
 	var res []Request
-	for req.size(sz) > maxSize {
+	for req.sizeFromSizer(sz) > maxSize {
 		md, rmSize := extractMetrics(req.md, maxSize, sz)
-		req.setCachedSize(req.size(sz) - rmSize)
+		req.setCachedSize(sz, req.sizeFromSizer(sz)-rmSize)
 		res = append(res, newMetricsRequest(md))
 	}
 	res = append(res, req)

--- a/exporter/exporterhelper/metrics_batch_test.go
+++ b/exporter/exporterhelper/metrics_batch_test.go
@@ -27,7 +27,6 @@ func TestMergeMetrics(t *testing.T) {
 }
 
 func TestMergeSplitMetrics(t *testing.T) {
-	s := sizer.MetricsCountSizer{}
 	tests := []struct {
 		name     string
 		szt      RequestSizerType
@@ -130,7 +129,7 @@ func TestMergeSplitMetrics(t *testing.T) {
 			for i := range res {
 				expected := tt.expected[i].(*metricsRequest)
 				actual := res[i].(*metricsRequest)
-				assert.Equal(t, expected.size(&s), actual.size(&s))
+				assert.Equal(t, expected.ItemsCount(), actual.ItemsCount())
 			}
 		})
 	}
@@ -290,7 +289,7 @@ func TestMergeSplitMetricsBasedOnByteSize(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, len(tt.expectedSizes), len(res))
 			for i := range res {
-				assert.Equal(t, tt.expectedSizes[i], res[i].(*metricsRequest).size(&s))
+				assert.Equal(t, tt.expectedSizes[i], res[i].(*metricsRequest).ByteSize())
 			}
 		})
 	}

--- a/exporter/exporterhelper/traces_batch.go
+++ b/exporter/exporterhelper/traces_batch.go
@@ -41,17 +41,17 @@ func (req *tracesRequest) MergeSplit(_ context.Context, maxSize int, szt Request
 
 func (req *tracesRequest) mergeTo(dst *tracesRequest, sz sizer.TracesSizer) {
 	if sz != nil {
-		dst.setCachedSize(dst.size(sz) + req.size(sz))
-		req.setCachedSize(0)
+		dst.setCachedSize(sz, dst.sizeFromSizer(sz)+req.sizeFromSizer(sz))
+		req.setCachedSize(sz, 0)
 	}
 	req.td.ResourceSpans().MoveAndAppendTo(dst.td.ResourceSpans())
 }
 
 func (req *tracesRequest) split(maxSize int, sz sizer.TracesSizer) []Request {
 	var res []Request
-	for req.size(sz) > maxSize {
+	for req.sizeFromSizer(sz) > maxSize {
 		td, rmSize := extractTraces(req.td, maxSize, sz)
-		req.setCachedSize(req.size(sz) - rmSize)
+		req.setCachedSize(sz, req.sizeFromSizer(sz)-rmSize)
 		res = append(res, newTracesRequest(td))
 	}
 	res = append(res, req)

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -46,14 +46,14 @@ func NewProfilesQueueBatchSettings() exporterhelper.QueueBatchSettings {
 }
 
 type profilesRequest struct {
-	pd               pprofile.Profiles
-	cachedItemsCount int
+	pd          pprofile.Profiles
+	cachedItems int
 }
 
 func newProfilesRequest(pd pprofile.Profiles) exporterhelper.Request {
 	return &profilesRequest{
-		pd:               pd,
-		cachedItemsCount: pd.SampleCount(),
+		pd:          pd,
+		cachedItems: pd.SampleCount(),
 	}
 }
 
@@ -80,11 +80,16 @@ func (req *profilesRequest) OnError(err error) exporterhelper.Request {
 }
 
 func (req *profilesRequest) ItemsCount() int {
-	return req.cachedItemsCount
+	return req.cachedItems
+}
+
+func (req *profilesRequest) ByteSize() int {
+	// TODO: Not implemented
+	return 0
 }
 
 func (req *profilesRequest) setCachedItemsCount(count int) {
-	req.cachedItemsCount = count
+	req.cachedItems = count
 }
 
 type profileExporter struct {

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch.go
@@ -40,7 +40,7 @@ func (req *profilesRequest) split(maxSize int) ([]exporterhelper.Request, error)
 		pd := extractProfiles(req.pd, maxSize)
 		size := pd.SampleCount()
 		req.setCachedItemsCount(req.ItemsCount() - size)
-		res = append(res, &profilesRequest{pd: pd, cachedItemsCount: size})
+		res = append(res, &profilesRequest{pd: pd, cachedItems: size})
 	}
 	res = append(res, req)
 	return res, nil


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR
1. Updates batcher to use Size(sizerType) instead of itemsCount()
2. For logs, traces, and metrics, it also makes sure that the `cachedSize` is associated with the `sizerType`.

This will be followed by https://github.com/open-telemetry/opentelemetry-collector/pull/12635/files which enables turning on this feature from configuration.

<!-- Issue number if applicable -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector/issues/3262

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
