### PR TITLE
[chore] Auto-populate release notes

### DIFF
--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -12,6 +12,8 @@ entries_dir: .chloggen
 # (Optional) Default: .chloggen/TEMPLATE.yaml
 template_yaml: .chloggen/TEMPLATE.yaml
 
+summary_template: .chloggen/summary.tmpl
+
 # The CHANGELOG file or files to which 'chloggen update' will write new entries
 # (Optional) Default filename: CHANGELOG.md
 change_logs:

--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -1,0 +1,70 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+#{{ $issue }}
+{{- end -}}
+)
+
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+## {{ .Version }}
+
+{{- if .BreakingChanges }}
+
+### 🛑 Breaking changes 🛑
+
+{{- range $i, $change := .BreakingChanges }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Deprecations }}
+
+### 🚩 Deprecations 🚩
+
+{{- range $i, $change := .Deprecations }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .NewComponents }}
+
+### 🚀 New components 🚀
+
+{{- range $i, $change := .NewComponents }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Enhancements }}
+
+### 💡 Enhancements 💡
+
+{{- range $i, $change := .Enhancements }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .BugFixes }}
+
+### 🧰 Bug fixes 🧰
+
+{{- range $i, $change := .BugFixes }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+<!-- previous-version -->

--- a/.github/workflows/sourcecode-release.yaml
+++ b/.github/workflows/sourcecode-release.yaml
@@ -13,9 +13,18 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+
+      - name: Prepare release notes
+        run: |
+          touch release-notes.md
+          echo "### Images and binaries here: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/${{ github.ref_name }}" >> release-notes.md
+
+          awk '/<!-- next version -->/,/<!-- previous-version -->/' CHANGELOG.md >> release-notes.md
+          awk '/<!-- next version -->/,/<!-- previous-version -->/' CHANGELOG-API.md >> release-notes.md
+
       - name: Create Github Release
         run: |
-          gh release create ${{ github.ref_name }} -t ${{ github.ref_name }} -n "### Images and binaries here: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/${{ github.ref_name }}"
+          gh release create ${{ github.ref_name }} -t ${{ github.ref_name }} -F release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR changes the release workflow to autofill the release notes from `CHANGELOG.md` and `CHANGELOG-API.md` into the generated GH release.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10191

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
