### PR TITLE
[mdatagen] better errors when can't get package name

### DIFF
--- a/.chloggen/mdatagen-better-errors.yaml
+++ b/.chloggen/mdatagen-better-errors.yaml
@@ -10,7 +10,7 @@ component: mdatagen
 note: "Better error messages when metadata can't get package name"
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [12682]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/mdatagen-better-errors.yaml
+++ b/.chloggen/mdatagen-better-errors.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Better error messages when metadata can't get package name"
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -4,7 +4,9 @@
 package internal // import "go.opentelemetry.io/collector/cmd/mdatagen/internal"
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -81,10 +83,13 @@ func shortFolderName(filePath string) string {
 }
 
 func packageName() (string, error) {
-	cmd := exec.Command("go", "list", "-f", "{{.ImportPath}}")
+	cmdArgs := []string{"go", "list", "-f", "{{.ImportPath}}"}
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	output, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to run %s command: %w: %s", strings.Join(cmdArgs, " "), err, stderr.String())
 	}
 	return strings.TrimSpace(string(output)), nil
 }

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -84,7 +84,7 @@ func shortFolderName(filePath string) string {
 
 func packageName() (string, error) {
 	cmdArgs := []string{"go", "list", "-f", "{{.ImportPath}}"}
-	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) //nolint: gosec
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	output, err := cmd.Output()

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -390,3 +390,20 @@ func TestLoadMetadata(t *testing.T) {
 func strPtr(s string) *string {
 	return &s
 }
+
+func Test_packageName(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		result, err := packageName()
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		// Temporarily set PATH to empty to make 'go' command fail
+		t.Setenv("PATH", "")
+		result, err := packageName()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to run go list")
+		require.Empty(t, result)
+	})
+}


### PR DESCRIPTION
#### Description
Make errors more detailed if mdatagen can't get go package name

errors before
```
Error: failed loading metadata.yaml: exit status 1
```

after 
```
Error: failed loading metadata.yaml: failed to run go list -f {{.ImportPath}} command: exit status 1: main module (...) does not contain package ...
```
