### PR TITLE
[chore] Allow to configure available sizers in the queuebatch Settings

### DIFF
--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -92,9 +92,10 @@ func NewBaseExporter(set exporter.Settings, signal pipeline.Signal, pusher sende
 
 	if be.queueCfg.Enabled || be.batcherCfg.Enabled {
 		qSet := queuebatch.QueueSettings[request.Request]{
-			Signal:           signal,
-			ExporterSettings: set,
-			Encoding:         be.queueBatchSettings.Encoding,
+			Signal:    signal,
+			ID:        set.ID,
+			Telemetry: set.TelemetrySettings,
+			Settings:  be.queueBatchSettings,
 		}
 		be.QueueSender, err = NewQueueSender(qSet, be.queueCfg, be.batcherCfg, be.ExportFailureMessage, be.firstSender)
 		if err != nil {

--- a/exporter/exporterhelper/internal/obs_queue.go
+++ b/exporter/exporterhelper/internal/obs_queue.go
@@ -24,12 +24,12 @@ type obsQueue[T request.Request] struct {
 }
 
 func newObsQueue[T request.Request](set queuebatch.QueueSettings[T], delegate queuebatch.Queue[T]) (queuebatch.Queue[T], error) {
-	tb, err := metadata.NewTelemetryBuilder(set.ExporterSettings.TelemetrySettings)
+	tb, err := metadata.NewTelemetryBuilder(set.Telemetry)
 	if err != nil {
 		return nil, err
 	}
 
-	exporterAttr := attribute.String(ExporterKey, set.ExporterSettings.ID.String())
+	exporterAttr := attribute.String(ExporterKey, set.ID.String())
 	asyncAttr := metric.WithAttributeSet(attribute.NewSet(exporterAttr, attribute.String(DataTypeKey, set.Signal.String())))
 	err = tb.RegisterExporterQueueSizeCallback(func(_ context.Context, o metric.Int64Observer) error {
 		o.Observe(delegate.Size(), asyncAttr)

--- a/exporter/exporterhelper/internal/obs_queue_test.go
+++ b/exporter/exporterhelper/internal/obs_queue_test.go
@@ -13,9 +13,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/metadatatest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
@@ -51,8 +49,9 @@ func TestObsQueueLogsSizeCapacity(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	te, err := newObsQueue[request.Request](queuebatch.QueueSettings[request.Request]{
-		Signal:           pipeline.SignalLogs,
-		ExporterSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+		Signal:    pipeline.SignalLogs,
+		ID:        exporterID,
+		Telemetry: tt.NewTelemetrySettings(),
 	}, newFakeQueue[request.Request](nil, 7, 9))
 	require.NoError(t, err)
 	require.NoError(t, te.Offer(context.Background(), &requesttest.FakeRequest{Items: 2}))
@@ -81,8 +80,9 @@ func TestObsQueueLogsFailure(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	te, err := newObsQueue[request.Request](queuebatch.QueueSettings[request.Request]{
-		Signal:           pipeline.SignalLogs,
-		ExporterSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+		Signal:    pipeline.SignalLogs,
+		ID:        exporterID,
+		Telemetry: tt.NewTelemetrySettings(),
 	}, newFakeQueue[request.Request](errors.New("my error"), 7, 9))
 	require.NoError(t, err)
 	require.Error(t, te.Offer(context.Background(), &requesttest.FakeRequest{Items: 2}))
@@ -101,8 +101,9 @@ func TestObsQueueTracesSizeCapacity(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	te, err := newObsQueue[request.Request](queuebatch.QueueSettings[request.Request]{
-		Signal:           pipeline.SignalTraces,
-		ExporterSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+		Signal:    pipeline.SignalTraces,
+		ID:        exporterID,
+		Telemetry: tt.NewTelemetrySettings(),
 	}, newFakeQueue[request.Request](nil, 17, 19))
 	require.NoError(t, err)
 	require.NoError(t, te.Offer(context.Background(), &requesttest.FakeRequest{Items: 12}))
@@ -131,8 +132,9 @@ func TestObsQueueTracesFailure(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	te, err := newObsQueue[request.Request](queuebatch.QueueSettings[request.Request]{
-		Signal:           pipeline.SignalTraces,
-		ExporterSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+		Signal:    pipeline.SignalTraces,
+		ID:        exporterID,
+		Telemetry: tt.NewTelemetrySettings(),
 	}, newFakeQueue[request.Request](errors.New("my error"), 0, 0))
 	require.NoError(t, err)
 	require.Error(t, te.Offer(context.Background(), &requesttest.FakeRequest{Items: 12}))
@@ -151,8 +153,9 @@ func TestObsQueueMetrics(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	te, err := newObsQueue[request.Request](queuebatch.QueueSettings[request.Request]{
-		Signal:           pipeline.SignalMetrics,
-		ExporterSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+		Signal:    pipeline.SignalMetrics,
+		ID:        exporterID,
+		Telemetry: tt.NewTelemetrySettings(),
 	}, newFakeQueue[request.Request](nil, 27, 29))
 	require.NoError(t, err)
 	require.NoError(t, te.Offer(context.Background(), &requesttest.FakeRequest{Items: 22}))
@@ -181,8 +184,9 @@ func TestObsQueueMetricsFailure(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	te, err := newObsQueue[request.Request](queuebatch.QueueSettings[request.Request]{
-		Signal:           pipeline.SignalMetrics,
-		ExporterSettings: exporter.Settings{ID: exporterID, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+		Signal:    pipeline.SignalMetrics,
+		ID:        exporterID,
+		Telemetry: tt.NewTelemetrySettings(),
 	}, newFakeQueue[request.Request](errors.New("my error"), 0, 0))
 	require.NoError(t, err)
 	require.Error(t, te.Offer(context.Background(), &requesttest.FakeRequest{Items: 22}))

--- a/exporter/exporterhelper/internal/queuebatch/disabled_batcher_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/disabled_batcher_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
@@ -44,14 +45,21 @@ func TestDisabledBatcher_Basic(t *testing.T) {
 			ba, err := NewBatcher(cfg, sink.Export, tt.maxWorkers)
 			require.NoError(t, err)
 
-			q := NewQueue[request.Request](
+			q, err := NewQueue[request.Request](
 				context.Background(),
 				QueueSettings[request.Request]{
-					Signal:           pipeline.SignalTraces,
-					ExporterSettings: exportertest.NewNopSettings(exportertest.NopType),
+					Signal:    pipeline.SignalTraces,
+					ID:        component.NewID(exportertest.NopType),
+					Telemetry: componenttest.NewNopTelemetrySettings(),
+					Settings: Settings[request.Request]{
+						Sizers: map[exporterbatcher.SizerType]Sizer[request.Request]{
+							exporterbatcher.SizerTypeRequests: RequestsSizer[request.Request]{},
+						},
+					},
 				},
 				exporterqueue.NewDefaultConfig(),
 				ba.Consume)
+			require.NoError(t, err)
 
 			require.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
 			require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))

--- a/exporter/exporterhelper/internal/queuebatch/disabled_queue.go
+++ b/exporter/exporterhelper/internal/queuebatch/disabled_queue.go
@@ -19,7 +19,7 @@ var donePool = sync.Pool{
 
 func newDisabledQueue[T any](consumeFunc ConsumeFunc[T]) Queue[T] {
 	return &disabledQueue[T]{
-		sizer:       &requestSizer[T]{},
+		sizer:       RequestsSizer[T]{},
 		consumeFunc: consumeFunc,
 		size:        &atomic.Int64{},
 	}
@@ -29,7 +29,7 @@ type disabledQueue[T any] struct {
 	component.StartFunc
 	component.ShutdownFunc
 	consumeFunc ConsumeFunc[T]
-	sizer       sizer[T]
+	sizer       Sizer[T]
 	size        *atomic.Int64
 }
 

--- a/exporter/exporterhelper/internal/queuebatch/memory_queue.go
+++ b/exporter/exporterhelper/internal/queuebatch/memory_queue.go
@@ -21,7 +21,7 @@ var errInvalidSize = errors.New("invalid element size")
 
 // memoryQueueSettings defines internal parameters for boundedMemoryQueue creation.
 type memoryQueueSettings[T any] struct {
-	sizer    sizer[T]
+	sizer    Sizer[T]
 	capacity int64
 	blocking bool
 }
@@ -29,7 +29,7 @@ type memoryQueueSettings[T any] struct {
 // memoryQueue is an in-memory implementation of a Queue.
 type memoryQueue[T any] struct {
 	component.StartFunc
-	sizer sizer[T]
+	sizer Sizer[T]
 	cap   int64
 
 	mu              sync.Mutex

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch.go
@@ -4,9 +4,11 @@
 package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 
 import (
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterqueue"
 )
 
 type Settings[K any] struct {
 	Encoding exporterqueue.Encoding[K]
+	Sizers   map[exporterbatcher.SizerType]Sizer[K]
 }

--- a/exporter/exporterhelper/internal/queuebatch/sizer.go
+++ b/exporter/exporterhelper/internal/queuebatch/sizer.go
@@ -3,14 +3,36 @@
 
 package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 
-// sizer is an interface that returns the size of the given element.
-type sizer[T any] interface {
+import (
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+)
+
+// Sizer is an interface that returns the size of the given element.
+type Sizer[T any] interface {
 	Sizeof(T) int64
 }
 
-// requestSizer is a sizer implementation that returns the size of a queue element as one request.
-type requestSizer[T any] struct{}
+type SizeofFunc[T any] func(T) int64
 
-func (rs *requestSizer[T]) Sizeof(T) int64 {
+func (f SizeofFunc[T]) Sizeof(t T) int64 {
+	return f(t)
+}
+
+// RequestsSizer is a Sizer implementation that returns the size of a queue element as one request.
+type RequestsSizer[T any] struct{}
+
+func (rs RequestsSizer[T]) Sizeof(T) int64 {
 	return 1
+}
+
+type BaseSizer struct {
+	SizeofFunc[request.Request]
+}
+
+func NewItemsSizer() Sizer[request.Request] {
+	return BaseSizer{
+		SizeofFunc: func(req request.Request) int64 {
+			return int64(req.ItemsCount())
+		},
+	}
 }

--- a/exporter/exporterhelper/internal/queuebatch/sizer_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/sizer_test.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/requesttest"
+)
+
+func TestItemsSizer(t *testing.T) {
+	sz := NewItemsSizer()
+	assert.EqualValues(t, 3, sz.Sizeof(&requesttest.FakeRequest{Items: 3}))
+}

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -6,6 +6,7 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
 )
@@ -31,3 +32,11 @@ type RequestConverterFunc[K any] func(context.Context, K) (Request, error)
 // RequestConsumeFunc processes the request. After the function returns, the request is no longer accessible,
 // and accessing it is considered undefined behavior.
 type RequestConsumeFunc = sender.SendFunc[request.Request]
+
+// RequestSizer is an interface that returns the size of the given request.
+type RequestSizer = queuebatch.Sizer[request.Request]
+
+// NewRequestsSizer returns a RequestSizer that counts the requests by the number of requests, always returning 1.
+func NewRequestsSizer() RequestSizer {
+	return queuebatch.RequestsSizer[request.Request]{}
+}

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -13,8 +13,10 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pipeline"
@@ -24,6 +26,24 @@ var (
 	tracesMarshaler   = &ptrace.ProtoMarshaler{}
 	tracesUnmarshaler = &ptrace.ProtoUnmarshaler{}
 )
+
+// NewTracesQueueBatchSettings returns a new QueueBatchSettings to configure to WithQueueBatch when using ptrace.Traces.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewTracesQueueBatchSettings() QueueBatchSettings {
+	return QueueBatchSettings{
+		Encoding: tracesEncoding{},
+		Sizers: map[exporterbatcher.SizerType]queuebatch.Sizer[Request]{
+			exporterbatcher.SizerTypeRequests: NewRequestsSizer(),
+			exporterbatcher.SizerTypeItems:    queuebatch.NewItemsSizer(),
+			exporterbatcher.SizerTypeBytes: queuebatch.BaseSizer{
+				SizeofFunc: func(req request.Request) int64 {
+					return int64(tracesMarshaler.TracesSize(req.(*tracesRequest).td))
+				},
+			},
+		},
+	}
+}
 
 type tracesRequest struct {
 	td         ptrace.Traces
@@ -94,7 +114,7 @@ func NewTraces(
 		return nil, errNilPushTraces
 	}
 	return NewTracesRequest(ctx, set, requestFromTraces(), requestConsumeFromTraces(pusher),
-		append([]Option{internal.WithQueueBatchSettings(queuebatch.Settings[Request]{Encoding: tracesEncoding{}})}, options...)...)
+		append([]Option{internal.WithQueueBatchSettings(NewTracesQueueBatchSettings())}, options...)...)
 }
 
 // requestConsumeFromTraces returns a RequestConsumeFunc that consumes ptrace.Traces.


### PR DESCRIPTION
Users cannot yet configure which sizer to use, so not yet a changelog entry for this.