### PR TITLE
Statically validate connector config during dry-run.

### DIFF
--- a/.chloggen/enhance_config-validation.yaml
+++ b/.chloggen/enhance_config-validation.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otelcol
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enhance config validation using <validate> command to capture all validation errors that prevents the collector from starting."
+
+# One or more tracking issues or pull requests related to the change
+issues: [8721]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -272,7 +272,25 @@ func (col *Collector) DryRun(ctx context.Context) error {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	return xconfmap.Validate(cfg)
+	if err = xconfmap.Validate(cfg); err != nil {
+		return err
+	}
+
+	return service.ValidateGraph(ctx, service.Settings{
+		BuildInfo:           col.set.BuildInfo,
+		ReceiversConfigs:    cfg.Receivers,
+		ReceiversFactories:  factories.Receivers,
+		ProcessorsConfigs:   cfg.Processors,
+		ProcessorsFactories: factories.Processors,
+		ExportersConfigs:    cfg.Exporters,
+		ExportersFactories:  factories.Exporters,
+		ConnectorsConfigs:   cfg.Connectors,
+		ConnectorsFactories: factories.Connectors,
+		ExtensionsConfigs:   cfg.Extensions,
+		ExtensionsFactories: factories.Extensions,
+	}, service.Config{
+		Pipelines: cfg.Service.Pipelines,
+	})
 }
 
 func newFallbackLogger(options []zap.Option) (*zap.Logger, error) {

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -286,8 +286,6 @@ func (col *Collector) DryRun(ctx context.Context) error {
 		ExportersFactories:  factories.Exporters,
 		ConnectorsConfigs:   cfg.Connectors,
 		ConnectorsFactories: factories.Connectors,
-		ExtensionsConfigs:   cfg.Extensions,
-		ExtensionsFactories: factories.Extensions,
 	}, service.Config{
 		Pipelines: cfg.Service.Pipelines,
 	})

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -276,7 +276,7 @@ func (col *Collector) DryRun(ctx context.Context) error {
 		return err
 	}
 
-	return service.ValidateGraph(ctx, service.Settings{
+	return service.Validate(ctx, service.Settings{
 		BuildInfo:           col.set.BuildInfo,
 		ReceiversConfigs:    cfg.Receivers,
 		ReceiversFactories:  factories.Receivers,

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -462,6 +462,30 @@ func TestCollectorDryRun(t *testing.T) {
 			},
 			expectedErr: `service::pipelines::traces: references processor "invalid" which is not configured`,
 		},
+		"invalid_connector_use_unused_exp": {
+			settings: CollectorSettings{
+				BuildInfo:              component.NewDefaultBuildInfo(),
+				Factories:              nopFactories,
+				ConfigProviderSettings: newDefaultConfigProviderSettings(t, []string{filepath.Join("testdata", "otelcol-invalid-connector-unused-exp.yaml")}),
+			},
+			expectedErr: `failed to build pipelines: connector "nop/connector1" used as receiver in [logs/in2] pipeline but not used in any supported exporter pipeline`,
+		},
+		"invalid_connector_use_unused_rec": {
+			settings: CollectorSettings{
+				BuildInfo:              component.NewDefaultBuildInfo(),
+				Factories:              nopFactories,
+				ConfigProviderSettings: newDefaultConfigProviderSettings(t, []string{filepath.Join("testdata", "otelcol-invalid-connector-unused-rec.yaml")}),
+			},
+			expectedErr: `failed to build pipelines: connector "nop/connector1" used as exporter in [logs/in2] pipeline but not used in any supported receiver pipeline`,
+		},
+		"cyclic_connector": {
+			settings: CollectorSettings{
+				BuildInfo:              component.NewDefaultBuildInfo(),
+				Factories:              nopFactories,
+				ConfigProviderSettings: newDefaultConfigProviderSettings(t, []string{filepath.Join("testdata", "otelcol-cyclic-connector.yaml")}),
+			},
+			expectedErr: `failed to build pipelines: cycle detected: connector "nop/forward" (traces to traces) -> connector "nop/forward" (traces to traces)`,
+		},
 	}
 
 	for name, test := range tests {

--- a/otelcol/testdata/otelcol-cyclic-connector.yaml
+++ b/otelcol/testdata/otelcol-cyclic-connector.yaml
@@ -1,0 +1,19 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+connectors:
+  nop/forward:
+
+service:
+  pipelines:
+    traces/in:
+      receivers: [nop/forward]
+      processors: [ ]
+      exporters: [nop/forward]
+    traces/out:
+      receivers: [nop/forward]
+      processors: [ ]
+      exporters: [nop/forward]

--- a/otelcol/testdata/otelcol-invalid-connector-unused-exp.yaml
+++ b/otelcol/testdata/otelcol-invalid-connector-unused-exp.yaml
@@ -1,0 +1,23 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+connectors:
+  nop/connector1:
+
+service:
+  pipelines:
+    logs/in1:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop]
+    logs/in2:
+      receivers: [nop/connector1]
+      processors: [ ]
+      exporters: [nop]
+    logs/out:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop]

--- a/otelcol/testdata/otelcol-invalid-connector-unused-rec.yaml
+++ b/otelcol/testdata/otelcol-invalid-connector-unused-rec.yaml
@@ -1,0 +1,23 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+connectors:
+  nop/connector1:
+
+service:
+  pipelines:
+    logs/in1:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop]
+    logs/in2:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop/connector1]
+    logs/out:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop]

--- a/otelcol/testdata/otelcol-valid-connector-use.yaml
+++ b/otelcol/testdata/otelcol-valid-connector-use.yaml
@@ -1,0 +1,23 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+connectors:
+  nop/connector1:
+
+service:
+  pipelines:
+    logs/in1:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop]
+    logs/in2:
+      receivers: [nop]
+      processors: [ ]
+      exporters: [nop/connector1]
+    logs/out:
+      receivers: [nop/connector1]
+      processors: [ ]
+      exporters: [nop]

--- a/otelcol/unmarshal_dry_run_test.go
+++ b/otelcol/unmarshal_dry_run_test.go
@@ -71,6 +71,7 @@ func TestDryRunWithExpandedValues(t *testing.T) {
 			mockMap: map[string]string{
 				"number": "123",
 			},
+			expectErr: true,
 		},
 		{
 			name:       "string that looks like a bool",

--- a/service/service.go
+++ b/service/service.go
@@ -14,7 +14,9 @@ import (
 	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/metric"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+	nooptrace "go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
@@ -538,7 +540,14 @@ func ptr[T any](v T) *T {
 
 // ValidateGraph verifies the graph by calling the internal graph.Build.
 func ValidateGraph(ctx context.Context, set Settings, cfg Config) error {
+	tel := component.TelemetrySettings{
+		Logger:         zap.NewNop(),
+		TracerProvider: nooptrace.NewTracerProvider(),
+		MeterProvider:  noopmetric.NewMeterProvider(),
+		Resource:       pcommon.NewResource(),
+	}
 	_, err := graph.Build(ctx, graph.Settings{
+		Telemetry:        tel,
 		BuildInfo:        set.BuildInfo,
 		ReceiverBuilder:  builders.NewReceiver(set.ReceiversConfigs, set.ReceiversFactories),
 		ProcessorBuilder: builders.NewProcessor(set.ProcessorsConfigs, set.ProcessorsFactories),

--- a/service/service.go
+++ b/service/service.go
@@ -535,3 +535,19 @@ func configureViews(level configtelemetry.Level) []config.View {
 func ptr[T any](v T) *T {
 	return &v
 }
+
+// ValidateGraph verifies the graph by calling the internal graph.Build.
+func ValidateGraph(ctx context.Context, set Settings, cfg Config) error {
+	_, err := graph.Build(ctx, graph.Settings{
+		BuildInfo:        set.BuildInfo,
+		ReceiverBuilder:  builders.NewReceiver(set.ReceiversConfigs, set.ReceiversFactories),
+		ProcessorBuilder: builders.NewProcessor(set.ProcessorsConfigs, set.ProcessorsFactories),
+		ExporterBuilder:  builders.NewExporter(set.ExportersConfigs, set.ExportersFactories),
+		ConnectorBuilder: builders.NewConnector(set.ConnectorsConfigs, set.ConnectorsFactories),
+		PipelineConfigs:  cfg.Pipelines,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build pipelines: %w", err)
+	}
+	return nil
+}

--- a/service/service.go
+++ b/service/service.go
@@ -538,8 +538,8 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-// ValidateGraph verifies the graph by calling the internal graph.Build.
-func ValidateGraph(ctx context.Context, set Settings, cfg Config) error {
+// Validate verifies the graph by calling the internal graph.Build.
+func Validate(ctx context.Context, set Settings, cfg Config) error {
 	tel := component.TelemetrySettings{
 		Logger:         zap.NewNop(),
 		TracerProvider: nooptrace.NewTracerProvider(),

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -897,7 +897,7 @@ func TestValidateGraph(t *testing.T) {
 				Pipelines: tc.pipelinesCfg,
 			}
 
-			err := ValidateGraph(context.Background(), settings, cfg)
+			err := Validate(context.Background(), settings, cfg)
 			if tc.expectedError == "" {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
As described in [#8721](https://github.com/open-telemetry/opentelemetry-collector/issues/8721), the current `validate` command cannot capture improper connector usage errors during a dry run. 

One proposed solution _(as mentioned in [this comment](https://github.com/open-telemetry/opentelemetry-collector/issues/8721#issuecomment-1775393905))_ is to surface configuration errors by instantiating the service during the dry run. However, reviewers preferred statically verifying the errors over instantiating the service (see the [PR #12488 comments](https://github.com/open-telemetry/opentelemetry-collector/pull/12488)).

The validation logic for connectors is located in the [`service/internal/graph`](https://github.com/open-telemetry/opentelemetry-collector/blob/1daa315455d02bac90185027878d858ba08a0f07/service/internal/graph) package. In the discussion of [PR #12681](https://github.com/open-telemetry/opentelemetry-collector/pull/12681), it was concluded that instantiating the graph is the better approach (see [this comment](https://github.com/open-telemetry/opentelemetry-collector/pull/12681#issuecomment-2746258749)).

Finally, this PR uses the `graph.Build()` method to surface configuration errors during the dry run.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #8721 #12535

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
