### PR TITLE
[chore][ping-codeowners-on-new-issue] Ping even if owner filed

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
+++ b/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
@@ -48,7 +48,7 @@ for COMPONENT in ${BODY_COMPONENTS}; do
 
   CODEOWNERS=$(COMPONENT="${COMPONENT}" "${CUR_DIRECTORY}/get-codeowners.sh" || true)
 
-  if [[ -n "${CODEOWNERS}" && ! ("${CODEOWNERS}" =~ ${OPENER}) ]]; then
+  if [[ -n "${CODEOWNERS}" ]]; then
     if [[ -v PINGED_COMPONENTS["${COMPONENT}"] ]]; then
       continue
     fi


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Code owners should be pinged even if a code owner filed an issue. This helps other code owners, in the case of more than one for a single component, be notified of relevant issues being filed.

This is the same change as https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38841, as [requested](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38841#issuecomment-2747326094).