### PR TITLE
[chore] Added a workflow to lint YAML files using actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,17 @@
+self-hosted-runner:
+  labels: []
+
+config-variables: null
+
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - '.*shellcheck reported issue in this script: SC1070:.+'
+      - '.*shellcheck reported issue in this script: SC1133:.+'
+      - '.*shellcheck reported issue in this script: SC2086:.+'
+      - '.*shellcheck reported issue in this script: SC2046:.+'
+      - '.*shellcheck reported issue in this script: SC2059:.+'
+      - '.*shellcheck reported issue in this script: SC2236:.+'
+      - '.*shellcheck reported issue in this script: SC1001:.+'
+      - '.*shellcheck reported issue in this script: SC2129:.+'
+      - '.*the runner of ".+" action is too old to run on GitHub Actions.+'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,12 +6,39 @@ config-variables: null
 paths:
   .github/workflows/**/*.{yml,yaml}:
     ignore:
+      # SC1070: Suppressing because scripts intentionally contain valid but unusual characters,
+      # Escape characters like `\o` used purposefully, and tested for clarity
       - '.*shellcheck reported issue in this script: SC1070:.+'
+
+      # SC1133: ShellCheck suggests optimizing conditional expressions, but these scripts
+      # operate correctly and readability is prioritized in real-world use. This ensures familiarity for contributors.
       - '.*shellcheck reported issue in this script: SC1133:.+'
+
+      # SC2086: Ignored because word splitting is intentional in commands like `git diff`,
+      # where simple, predictable paths are passed as arguments. No unintended globbing occurs in this context.
       - '.*shellcheck reported issue in this script: SC2086:.+'
+
+      # SC2046: Suppressed because word splitting is desired and necessary in certain scenarios,
+      # PR_HEAD is set by GitHub Actions and paths are fixed/controlled.
       - '.*shellcheck reported issue in this script: SC2046:.+'
+
+      # SC2059: Format strings in `printf` are deliberately designed and controlled for specific outputs.
+      # ShellCheck’s safeguard warning is appreciated but not critical in these cases.
       - '.*shellcheck reported issue in this script: SC2059:.+'
+
+      # SC2236: Both `! -z` and `-n` achieve the same result, and while `-n` is idiomatic. (Just a style suggestion)
+      # suppressing this warning allows scripts to remain consistent with existing standards.
       - '.*shellcheck reported issue in this script: SC2236:.+'
+
+      # SC1001: Escaped characters (like `\o`) are deliberate in certain scripts for expected functionality.
+      # ShellCheck’s flagging of these characters as potential issues isn’t applicable to this use case.
       - '.*shellcheck reported issue in this script: SC1001:.+'
+
+      # SC2129: Individual redirections are chosen for simplicity and clarity in the workflows.
+      # combining them is technically efficient, the current approach ensures more readable scripts.
       - '.*shellcheck reported issue in this script: SC2129:.+'
+
+      # Runner warnings ignored because scripts are validated against specific configurations
+      # and tested on GitHub Actions, ensuring compatibility. These warnings do not affect functionality.
       - '.*the runner of ".+" action is too old to run on GitHub Actions.+'
+

--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -106,7 +106,7 @@ jobs:
           url=$(gh pr create --title "$message" \
                              --body "$body" \
                              --base main)
+          # The SC2034 warning is disabled because 'pull_request_number' is assigned but not used directly.
+          # ShellCheck flags this as unused, but it's stored for potential external usage.
           # shellcheck disable=SC2034
           pull_request_number=${url//*\//} 
-        # The SC2034 warning is disabled here because 'pull_request_number' is assigned but not used directly in this script.
-        # ShellCheck flags this as unused, but it's stored for potential external usage.

--- a/.github/workflows/generate-semantic-conventions-pr.yaml
+++ b/.github/workflows/generate-semantic-conventions-pr.yaml
@@ -82,6 +82,7 @@ jobs:
           VERSION: ${{ needs.check-versions.outputs.latest-version }}
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          
         run: |
           message="Add semantic conventions version $VERSION"
           body="Add semantic conventions version \`$VERSION\`. Related to #10842"
@@ -105,5 +106,7 @@ jobs:
           url=$(gh pr create --title "$message" \
                              --body "$body" \
                              --base main)
-
-          pull_request_number=${url//*\//}
+          # shellcheck disable=SC2034
+          pull_request_number=${url//*\//} 
+        # The SC2034 warning is disabled here because 'pull_request_number' is assigned but not used directly in this script.
+        # ShellCheck flags this as unused, but it's stored for potential external usage.

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -1,0 +1,38 @@
+name: Lint GitHub Workflow YAML Files
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+
+      - name: Build Actionlint binary
+        run: |
+          mkdir -p .tools
+          go build -o .tools/actionlint github.com/rhysd/actionlint/cmd/actionlint
+          chmod +x .tools/actionlint
+
+      - name: Lint GitHub Workflow YAML Files
+        run: |
+          ./.tools/actionlint -config-file .github/actionlint.yaml -color .github/workflows/*.yml .github/workflows/*.yaml
+
+      - name: Reminder to Address Linting Errors
+        if: failure()
+        run: echo "⚠️ Please address all linting errors before merging this pull request."
+
+      - name: All linting checks passed
+        if: success()
+        run: echo "✅ All linting checks passed."

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -19,15 +19,16 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Build Actionlint binary
+      - name: Install Actionlint
         run: |
           mkdir -p .tools
-          go build -o .tools/actionlint github.com/rhysd/actionlint/cmd/actionlint
-          chmod +x .tools/actionlint
+          cd internal/tools
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+          mv $(go env GOPATH)/bin/actionlint ../../.tools/actionlint
 
-      - name: Lint GitHub Workflow YAML Files
+      - name: Run Actionlint
         run: |
-          ./.tools/actionlint -config-file .github/actionlint.yaml -color .github/workflows/*.yml .github/workflows/*.yaml
+          make actionlint
 
       - name: Reminder to Address Linting Errors
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,11 @@ otelcorecol:
 genotelcorecol: install-tools
 	pushd cmd/builder/ && $(GOCMD) run ./ --skip-compilation --config ../otelcorecol/builder-config.yaml --output-path ../otelcorecol && popd
 	$(MAKE) -C cmd/otelcorecol fmt
+	cd internal/tools && $(GOCMD) install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
+.PHONY: actionlint
+actionlint:
+	./.tools/actionlint -config-file .github/actionlint.yaml -color .github/workflows/*.yml .github/workflows/*.yaml
 
 .PHONY: ocb
 ocb:

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/addlicense v1.1.1
 	github.com/jcchavezs/porto v0.7.0
 	github.com/pavius/impi v0.0.3
+	github.com/rhysd/actionlint v1.7.7
 	go.opentelemetry.io/build-tools/checkfile v0.21.0
 	go.opentelemetry.io/build-tools/chloggen v0.21.0
 	go.opentelemetry.io/build-tools/crosslink v0.21.0
@@ -151,6 +152,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mgechev/revive v1.7.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/moricho/tparallel v0.3.2 // indirect
@@ -175,6 +177,7 @@ require (
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	github.com/raeperd/recvcheck v0.2.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ryancurrah/gomodguard v1.4.1 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.5.1 // indirect

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -325,6 +325,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mgechev/revive v1.7.0 h1:JyeQ4yO5K8aZhIKf5rec56u0376h8AlKNQEmjfkjKlY=
 github.com/mgechev/revive v1.7.0/go.mod h1:qZnwcNhoguE58dfi96IJeSTPeZQejNeoMQLUZGi4SW4=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -391,9 +393,13 @@ github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 h1:M8mH9eK4OUR4l
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567/go.mod h1:DWNGW8A4Y+GyBgPuaQJuWiy0XYftx4Xm/y5Jqk9I6VQ=
 github.com/raeperd/recvcheck v0.2.0 h1:GnU+NsbiCqdC2XX5+vMZzP+jAJC5fht7rcVTAhX74UI=
 github.com/raeperd/recvcheck v0.2.0/go.mod h1:n04eYkwIR0JbgD73wT8wL4JjPC3wm0nFtzBnWNocnYU=
+github.com/rhysd/actionlint v1.7.7 h1:0KgkoNTrYY7vmOCs9BW2AHxLvvpoY9nEUzgBHiPUr0k=
+github.com/rhysd/actionlint v1.7.7/go.mod h1:AE6I6vJEkNaIfWqC2GNE5spIJNhxf8NCtLEKU4NnUXg=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/google/addlicense"
 	_ "github.com/jcchavezs/porto/cmd/porto"
 	_ "github.com/pavius/impi/cmd/impi"
+	_ "github.com/rhysd/actionlint/cmd/actionlint"
 	_ "go.opentelemetry.io/build-tools/checkfile"
 	_ "go.opentelemetry.io/build-tools/chloggen"
 	_ "go.opentelemetry.io/build-tools/crosslink"


### PR DESCRIPTION
#### Description

This pull request builds on the work done in #11493 
This PR introduces Actionlint as part of the project to enable linting of GitHub Workflow files. The changes ensure that Actionlint is installed locally within the project and is automatically run during pull requests to enforce consistency and best practices for workflow files.

- Added a `actionlint` target to the Makefile for running Actionlint on workflow files.
- Added actionlint configuration to `.github/actionlint.yaml`
- update `internal/tools/go.mod` and `internal/tools/go.sum`
- Ignored some shellcheck errors (with comments) since shellcheck isn't always right.
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector/issues/9676

#### Fixes
- Addresses potential linting errors in workflow files after changes are made.

#### Testing
- The workflow has been tested to ensure the changes resolve identified issues and maintain functionality.
- Verified that `make actionlint` runs correctly using the local binary.
- Confirmed that the GitHub Actions workflow triggers automatically when relevant files are changed in a pull request.
- Tested for proper error handling and feedback during linting failures.

#### Documentation
No new documentation added, as this change is self-explanatory within the context of CI.
