### PR TITLE
[chore] prefer accessing metric struct function by value

### DIFF
--- a/cmd/mdatagen/internal/metric.go
+++ b/cmd/mdatagen/internal/metric.go
@@ -76,7 +76,7 @@ func (s Stability) String() string {
 	return fmt.Sprintf(" [%s]", s.Level)
 }
 
-func (m *Metric) validate() error {
+func (m Metric) validate() error {
 	var errs error
 	if m.Sum == nil && m.Gauge == nil && m.Histogram == nil {
 		errs = errors.Join(errs, errors.New("missing metric type key, "+
@@ -101,7 +101,7 @@ func (m *Metric) validate() error {
 	return errs
 }
 
-func (m *Metric) Unmarshal(parser *confmap.Conf) error {
+func (m Metric) Unmarshal(parser *confmap.Conf) error {
 	if !parser.IsSet("enabled") {
 		return errors.New("missing required field: `enabled`")
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
A nit reported by Intellij: the struct functions are defined with a mix of pointer and value receiver. Use the value receiver as none of the functions change the metric.
