### PR TITLE
[chore] use pointer receiver for Data function

### DIFF
--- a/cmd/mdatagen/internal/metric.go
+++ b/cmd/mdatagen/internal/metric.go
@@ -108,7 +108,7 @@ func (m *Metric) Unmarshal(parser *confmap.Conf) error {
 	return parser.Unmarshal(m)
 }
 
-func (m Metric) Data() MetricData {
+func (m *Metric) Data() MetricData {
 	if m.Sum != nil {
 		return m.Sum
 	}


### PR DESCRIPTION
Access this function by pointer to be consistent in how we define functions on the Metric struct.
