### PR TITLE
[exporter/otlp] mark BatcherConfig as deprecated

### DIFF
--- a/.chloggen/codeboten_deprecate-batcher-config.yaml
+++ b/.chloggen/codeboten_deprecate-batcher-config.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark BatcherConfig as deprecated
+
+# One or more tracking issues or pull requests related to the change
+issues: [12726]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
@@ -29,6 +30,20 @@ type Config struct {
 	//
 	// Deprecated: [v0.123.0] batch configuration moving to queue configuration.
 	BatcherConfig exporterhelper.BatcherConfig `mapstructure:"batcher"`
+	// remove at the same time as BatcherConfig
+	hasBatcher bool
+}
+
+func (c *Config) Unmarshal(conf *confmap.Conf) error {
+	if err := conf.Unmarshal(c); err != nil {
+		return err
+	}
+
+	if conf.IsSet("batcher") {
+		fmt.Println("in here for sure")
+		c.hasBatcher = true
+	}
+	return nil
 }
 
 func (c *Config) Validate() error {

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -26,6 +26,8 @@ type Config struct {
 
 	// Experimental: This configuration is at the early stage of development and may change without backward compatibility
 	// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved
+	//
+	// Deprecated: [v0.123.0] batch configuration moving to queue configuration.
 	BatcherConfig exporterhelper.BatcherConfig `mapstructure:"batcher"`
 }
 

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -53,6 +53,10 @@ type baseExporter struct {
 func newExporter(cfg component.Config, set exporter.Settings) *baseExporter {
 	oCfg := cfg.(*Config)
 
+	if oCfg.hasBatcher {
+		set.TelemetrySettings.Logger.Warn("using deprecated field: batcher")
+	}
+
 	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
 		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
 


### PR DESCRIPTION
The config for batcher is moving to queue configuration.
