### PR TITLE
[chore] Auto-populate versions during release preparation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -96,11 +96,6 @@ jobs:
             exit 1
           fi
 
-      - name: Debugging
-        run: |
-          echo "next_beta_core: ${{ steps.next-versions.outputs.next_beta }}"
-          echo "next_stable_core: ${{ steps.next-versions.outputs.next_stable }}"
-
   check-blockers:
     needs:
       - extract-versions
@@ -113,13 +108,13 @@ jobs:
       - name: Check blockers in core
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: mowies/opentelemetry-collector
+          REPO: open-telemetry/opentelemetry-collector
         run: ./.github/workflows/scripts/release-check-blockers.sh
       # Make sure that there are no open issues with release:blocker label in Contrib. The release has to be delayed until they are resolved.
       - name: Check blockers in contrib
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: mowies/opentelemetry-collector-contrib
+          REPO: open-telemetry/opentelemetry-collector-contrib
         run: ./.github/workflows/scripts/release-check-blockers.sh
       # Make sure the current main branch build successfully passes (Core).
       - name: Check build status in core
@@ -155,7 +150,7 @@ jobs:
           CANDIDATE_STABLE: ${{ needs.extract-versions.outputs.next-stable }}
           CURRENT_BETA: ${{ needs.extract-versions.outputs.current-beta }}
           CURRENT_STABLE: ${{ needs.extract-versions.outputs.current-stable }}
-          REPO: mowies/opentelemetry-collector
+          REPO: open-telemetry/opentelemetry-collector
         run: ./.github/workflows/scripts/release-create-tracking-issue.sh
 
   # Releasing opentelemetry-collector
@@ -181,7 +176,7 @@ jobs:
       - name: Prepare release for core
         env:
           GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
-          REPO: mowies/opentelemetry-collector
+          REPO: open-telemetry/opentelemetry-collector
           CANDIDATE_BETA: ${{ needs.extract-versions.outputs.next-beta }}
           CANDIDATE_STABLE: ${{ needs.extract-versions.outputs.next-stable }}
           CURRENT_BETA: ${{ needs.extract-versions.outputs.current-beta }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -77,6 +77,8 @@ jobs:
             echo "next_beta=${{ steps.semvers-beta.outputs.minor }}" >> $GITHUB_OUTPUT
           elif [[ '${{ inputs.candidate-beta }}' == 'patch' ]]; then
             echo "next_beta=${{ steps.semvers-beta.outputs.patch }}" >> $GITHUB_OUTPUT
+          elif [[ '${{ inputs.candidate-beta }}' == 'no bump' ]]; then
+            echo "next_beta=" >> $GITHUB_OUTPUT
           else
             echo "Error: unsupported semver type for Candidate Beta"
             exit 1
@@ -87,6 +89,8 @@ jobs:
             echo "next_stable=${{ steps.semvers-stable.outputs.minor }}" >> $GITHUB_OUTPUT
           elif [[ '${{ inputs.candidate-stable }}' == 'patch' ]]; then
             echo "next_stable=${{ steps.semvers-stable.outputs.patch }}" >> $GITHUB_OUTPUT
+          elif [[ '${{ inputs.candidate-stable }}' == 'no bump' ]]; then
+            echo "next_stable=" >> $GITHUB_OUTPUT
           else
             echo "Error: unsupported semver type Candidate Stable"
             exit 1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -97,8 +97,6 @@ jobs:
           fi
 
   check-blockers:
-    needs:
-      - extract-versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -95,87 +95,87 @@ jobs:
           echo "next_beta_core: ${{ steps.next-versions.outputs.next_beta }}"
           echo "next_stable_core: ${{ steps.next-versions.outputs.next_stable }}"
 
-  check-blockers:
-    needs:
-      - extract-versions
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      # Make sure that there are no open issues with release:blocker label in Core. The release has to be delayed until they are resolved.
-      - name: Check blockers in core
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector
-        run: ./.github/workflows/scripts/release-check-blockers.sh
-      # Make sure that there are no open issues with release:blocker label in Contrib. The release has to be delayed until they are resolved.
-      - name: Check blockers in contrib
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector-contrib
-        run: ./.github/workflows/scripts/release-check-blockers.sh
-      # Make sure the current main branch build successfully passes (Core).
-      - name: Check build status in core
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector
-        run: ./.github/workflows/scripts/release-check-build-status.sh
-      # Make sure the current main branch build successfully passes (Contrib).
-      - name: Check build status in contrib
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector-contrib
-        run: ./.github/workflows/scripts/release-check-build-status.sh
-
-  create-release-issue:
-    needs:
-      - check-blockers
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      # To keep track of the progress, it might be helpful to create a tracking issue similar to #6067. You are responsible
-      # for all of the steps under the "Performed by collector release manager" heading. Once the issue is created, you can
-      # create the individual ones by hovering them and clicking the "Convert to issue" button on the right hand side.
-      - name: Create issue for tracking release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CANDIDATE_BETA: ${{ inputs.candidate-beta }}
-          CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
-          CURRENT_BETA: ${{ inputs.current-beta }}
-          CURRENT_STABLE: ${{ inputs.current-stable }}
-          REPO: open-telemetry/opentelemetry-collector
-        run: ./.github/workflows/scripts/release-create-tracking-issue.sh
-
-  # Releasing opentelemetry-collector
-  prepare-release:
-    needs:
-      - check-blockers
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ~1.23.7
-      # Prepare Core for release.
-      #   - Update CHANGELOG.md file, this is done via chloggen
-      #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable
-      #   - Run make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0 MODSET=beta
-      - name: Prepare release for core
-        env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector
-          CANDIDATE_BETA: ${{ inputs.candidate-beta }}
-          CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
-          CURRENT_BETA: ${{ inputs.current-beta }}
-          CURRENT_STABLE: ${{ inputs.current-stable }}
-        run: ./.github/workflows/scripts/release-prepare-release.sh
+#  check-blockers:
+#    needs:
+#      - extract-versions
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+#        with:
+#          fetch-depth: 0
+#      # Make sure that there are no open issues with release:blocker label in Core. The release has to be delayed until they are resolved.
+#      - name: Check blockers in core
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          REPO: open-telemetry/opentelemetry-collector
+#        run: ./.github/workflows/scripts/release-check-blockers.sh
+#      # Make sure that there are no open issues with release:blocker label in Contrib. The release has to be delayed until they are resolved.
+#      - name: Check blockers in contrib
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          REPO: open-telemetry/opentelemetry-collector-contrib
+#        run: ./.github/workflows/scripts/release-check-blockers.sh
+#      # Make sure the current main branch build successfully passes (Core).
+#      - name: Check build status in core
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          REPO: open-telemetry/opentelemetry-collector
+#        run: ./.github/workflows/scripts/release-check-build-status.sh
+#      # Make sure the current main branch build successfully passes (Contrib).
+#      - name: Check build status in contrib
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          REPO: open-telemetry/opentelemetry-collector-contrib
+#        run: ./.github/workflows/scripts/release-check-build-status.sh
+#
+#  create-release-issue:
+#    needs:
+#      - check-blockers
+#    runs-on: ubuntu-latest
+#    permissions:
+#      issues: write
+#    steps:
+#      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+#        with:
+#          fetch-depth: 0
+#      # To keep track of the progress, it might be helpful to create a tracking issue similar to #6067. You are responsible
+#      # for all of the steps under the "Performed by collector release manager" heading. Once the issue is created, you can
+#      # create the individual ones by hovering them and clicking the "Convert to issue" button on the right hand side.
+#      - name: Create issue for tracking release
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          CANDIDATE_BETA: ${{ inputs.candidate-beta }}
+#          CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
+#          CURRENT_BETA: ${{ inputs.current-beta }}
+#          CURRENT_STABLE: ${{ inputs.current-stable }}
+#          REPO: open-telemetry/opentelemetry-collector
+#        run: ./.github/workflows/scripts/release-create-tracking-issue.sh
+#
+#  # Releasing opentelemetry-collector
+#  prepare-release:
+#    needs:
+#      - check-blockers
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write
+#    steps:
+#      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+#        with:
+#          fetch-depth: 0
+#      - name: Setup Go
+#        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+#        with:
+#          go-version: ~1.23.7
+#      # Prepare Core for release.
+#      #   - Update CHANGELOG.md file, this is done via chloggen
+#      #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable
+#      #   - Run make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0 MODSET=beta
+#      - name: Prepare release for core
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+#          REPO: open-telemetry/opentelemetry-collector
+#          CANDIDATE_BETA: ${{ inputs.candidate-beta }}
+#          CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
+#          CURRENT_BETA: ${{ inputs.current-beta }}
+#          CURRENT_STABLE: ${{ inputs.current-stable }}
+#        run: ./.github/workflows/scripts/release-prepare-release.sh

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -108,25 +108,25 @@ jobs:
       - name: Check blockers in core
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector
+          REPO: mowies/opentelemetry-collector
         run: ./.github/workflows/scripts/release-check-blockers.sh
       # Make sure that there are no open issues with release:blocker label in Contrib. The release has to be delayed until they are resolved.
       - name: Check blockers in contrib
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector-contrib
+          REPO: mowies/opentelemetry-collector-contrib
         run: ./.github/workflows/scripts/release-check-blockers.sh
       # Make sure the current main branch build successfully passes (Core).
       - name: Check build status in core
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector
+          REPO: mowies/opentelemetry-collector
         run: ./.github/workflows/scripts/release-check-build-status.sh
       # Make sure the current main branch build successfully passes (Contrib).
       - name: Check build status in contrib
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector-contrib
+          REPO: mowies/opentelemetry-collector-contrib
         run: ./.github/workflows/scripts/release-check-build-status.sh
 
   create-release-issue:
@@ -150,7 +150,7 @@ jobs:
           CANDIDATE_STABLE: ${{ needs.extract-versions.outputs.next-stable }}
           CURRENT_BETA: ${{ needs.extract-versions.outputs.current-beta }}
           CURRENT_STABLE: ${{ needs.extract-versions.outputs.current-stable }}
-          REPO: open-telemetry/opentelemetry-collector
+          REPO: mowies/opentelemetry-collector
         run: ./.github/workflows/scripts/release-create-tracking-issue.sh
 
   # Releasing opentelemetry-collector
@@ -176,7 +176,7 @@ jobs:
       - name: Prepare release for core
         env:
           GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector
+          REPO: mowies/opentelemetry-collector
           CANDIDATE_BETA: ${{ needs.extract-versions.outputs.next-beta }}
           CANDIDATE_STABLE: ${{ needs.extract-versions.outputs.next-stable }}
           CURRENT_BETA: ${{ needs.extract-versions.outputs.current-beta }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,7 +11,7 @@ on:
         options:
           - minor
           - patch
-          - ""
+          - "no bump"
         default: minor
 
       candidate-beta:
@@ -20,6 +20,7 @@ on:
         options:
           - minor
           - patch
+          - "no bump"
         default: minor
 
 permissions: read-all
@@ -120,13 +121,13 @@ jobs:
       - name: Check build status in core
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: mowies/opentelemetry-collector
+          REPO: open-telemetry/opentelemetry-collector
         run: ./.github/workflows/scripts/release-check-build-status.sh
       # Make sure the current main branch build successfully passes (Contrib).
       - name: Check build status in contrib
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: mowies/opentelemetry-collector-contrib
+          REPO: open-telemetry/opentelemetry-collector-contrib
         run: ./.github/workflows/scripts/release-check-build-status.sh
 
   create-release-issue:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -7,62 +7,97 @@ on:
     inputs:
       candidate-stable:
         description: Release candidate version (stable, like 1.3.0). Don't include a leading `v`.
-
-      current-stable:
-        required: true
-        description: Current version (stable, like 1.2.0). Don't include a leading `v`.
+        type: choice
+        options:
+          - minor
+          - patch
+        default: minor
 
       candidate-beta:
         description: Release candidate version (beta, like 0.96.0). Don't include `v`.
-
-      current-beta:
-        required: true
-        description: Current version (beta, like 0.95.1). Don't include `v`.
+        type: choice
+        options:
+          - minor
+          - patch
+        default: minor
 
 permissions: read-all
 
 jobs:
-  validate-versions-format:
+  extract-versions:
+    outputs:
+      current-beta: ${{ steps.current-version-core-beta.outputs.tags }}
+      current-stable: ${{ steps.current-version-core-stable-trimmed.outputs.tag }}
+      next-beta: ${{ steps.next-versions.outputs.next_beta }}
+      next-stable: ${{ steps.next-versions.outputs.next_stable }}
     runs-on: ubuntu-latest
 
     steps:
-      - name: Validate version format
-        shell: bash
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Get current tag for core beta
+        id: current-version-core-beta
+        uses: WyriHaximus/github-action-get-previous-tag@04e8485ecb6487243907e330d522ff60f02283ce # v1.4.0
+        with:
+          prefix: v0
+
+      - name: Get current tag for core stable
+        id: current-version-core-stable
+        uses: WyriHaximus/github-action-get-previous-tag@04e8485ecb6487243907e330d522ff60f02283ce # v1.4.0
+        with:
+          prefix: component/v1 # needs to be a tag of a stable component because major tags are not published
+
+      - name: Clean up core tag
+        id: current-version-core-stable-trimmed
         run: |
-          validate_beta_version() {
-            local regex_pattern_beta='^[0-9]+\.[0-9]+\.[0-9]+$'
-            if [[ ! "$1" =~ $regex_pattern_beta ]]; then
-              echo "Invalid $2 version format. For beta, it can be 0.1.0 or higher"
-              exit 1
-            fi
-          }
+          monorepo_tag=${{ steps.current-version-core-stable.outputs.tag }}
+          echo "tag=${monorepo_tag#component/}" >> $GITHUB_OUTPUT
 
-          validate_stable_version() {
-            local regex_pattern_stable='^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
-            if [[ ! "$1" =~ $regex_pattern_stable ]]; then
-              echo "Invalid stable version format for $2. Major version must be greater than 1."
-              exit 1
-            fi
-          }
+      - name: Get next versions - beta
+        id: semvers-beta
+        uses: WyriHaximus/github-action-next-semvers@18aa9ed4152808ab99b88d71f5481e41f8d89930 # v1.2.1
+        with:
+          version: ${{ steps.current-version-core-beta.outputs.tag }}
 
-          if [[ ! -z "${{ inputs.candidate-beta }}" ]]; then
-            validate_beta_version "${{ inputs.candidate-beta }}" "candidate-beta"
-          fi
-          validate_beta_version "${{ inputs.current-beta }}" "current-beta"
+      - name: Get next versions - stable
+        id: semvers-stable
+        uses: WyriHaximus/github-action-next-semvers@18aa9ed4152808ab99b88d71f5481e41f8d89930 # v1.2.1
+        with:
+          version: ${{ steps.current-version-core-stable-trimmed.outputs.tag }}
 
-          if [[ ! -z "${{ inputs.candidate-stable }}" ]]; then
-            validate_stable_version "${{ inputs.candidate-stable }}" "candidate-stable"
-          fi
-          validate_stable_version "${{ inputs.current-stable }}" "current-stable"
-
-          if [[ -z "${{ inputs.candidate-beta }}" && -z "${{ inputs.candidate-stable }}" ]]; then
-            echo "Candidate version is not set for beta or stable. Please set a version to proceed."
+      - name: Select next versions
+        id: next-versions
+        run: |
+          # Candidate Beta
+          if [[ '${{ inputs.candidate-beta }}' == 'minor' ]]; then
+            echo "next_beta=${{ steps.semvers-beta.outputs.minor }}" >> $GITHUB_OUTPUT
+          elif [[ '${{ inputs.candidate-beta }}' == 'patch' ]]; then
+            echo "next_beta=${{ steps.semvers-beta.outputs.patch }}" >> $GITHUB_OUTPUT
+          else
+            echo "Error: unsupported semver type for Candidate Beta"
             exit 1
           fi
 
+          # Candidate Stable
+          if [[ '${{ inputs.candidate-stable }}' == 'minor' ]]; then
+            echo "next_stable=${{ steps.semvers-stable.outputs.minor }}" >> $GITHUB_OUTPUT
+          elif [[ '${{ inputs.candidate-stable }}' == 'patch' ]]; then
+            echo "next_stable=${{ steps.semvers-stable.outputs.patch }}" >> $GITHUB_OUTPUT
+          else
+            echo "Error: unsupported semver type Candidate Stable"
+            exit 1
+          fi
+
+      - name: Debugging
+        run: |
+          echo "next_beta_core: ${{ steps.next-versions.outputs.next_beta }}"
+          echo "next_stable_core: ${{ steps.next-versions.outputs.next_stable }}"
+
   check-blockers:
     needs:
-      - validate-versions-format
+      - extract-versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -6,15 +6,16 @@ on:
     # the minor version number and set the patch number to 0.
     inputs:
       candidate-stable:
-        description: Release candidate version (stable, like 1.3.0). Don't include a leading `v`.
+        description: Release candidate version bump (stable).
         type: choice
         options:
           - minor
           - patch
+          - ""
         default: minor
 
       candidate-beta:
-        description: Release candidate version (beta, like 0.96.0). Don't include `v`.
+        description: Release candidate version bump (beta).
         type: choice
         options:
           - minor
@@ -95,87 +96,89 @@ jobs:
           echo "next_beta_core: ${{ steps.next-versions.outputs.next_beta }}"
           echo "next_stable_core: ${{ steps.next-versions.outputs.next_stable }}"
 
-#  check-blockers:
-#    needs:
-#      - extract-versions
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-#        with:
-#          fetch-depth: 0
-#      # Make sure that there are no open issues with release:blocker label in Core. The release has to be delayed until they are resolved.
-#      - name: Check blockers in core
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          REPO: open-telemetry/opentelemetry-collector
-#        run: ./.github/workflows/scripts/release-check-blockers.sh
-#      # Make sure that there are no open issues with release:blocker label in Contrib. The release has to be delayed until they are resolved.
-#      - name: Check blockers in contrib
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          REPO: open-telemetry/opentelemetry-collector-contrib
-#        run: ./.github/workflows/scripts/release-check-blockers.sh
-#      # Make sure the current main branch build successfully passes (Core).
-#      - name: Check build status in core
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          REPO: open-telemetry/opentelemetry-collector
-#        run: ./.github/workflows/scripts/release-check-build-status.sh
-#      # Make sure the current main branch build successfully passes (Contrib).
-#      - name: Check build status in contrib
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          REPO: open-telemetry/opentelemetry-collector-contrib
-#        run: ./.github/workflows/scripts/release-check-build-status.sh
-#
-#  create-release-issue:
-#    needs:
-#      - check-blockers
-#    runs-on: ubuntu-latest
-#    permissions:
-#      issues: write
-#    steps:
-#      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-#        with:
-#          fetch-depth: 0
-#      # To keep track of the progress, it might be helpful to create a tracking issue similar to #6067. You are responsible
-#      # for all of the steps under the "Performed by collector release manager" heading. Once the issue is created, you can
-#      # create the individual ones by hovering them and clicking the "Convert to issue" button on the right hand side.
-#      - name: Create issue for tracking release
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          CANDIDATE_BETA: ${{ inputs.candidate-beta }}
-#          CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
-#          CURRENT_BETA: ${{ inputs.current-beta }}
-#          CURRENT_STABLE: ${{ inputs.current-stable }}
-#          REPO: open-telemetry/opentelemetry-collector
-#        run: ./.github/workflows/scripts/release-create-tracking-issue.sh
-#
-#  # Releasing opentelemetry-collector
-#  prepare-release:
-#    needs:
-#      - check-blockers
-#    runs-on: ubuntu-latest
-#    permissions:
-#      contents: write
-#    steps:
-#      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-#        with:
-#          fetch-depth: 0
-#      - name: Setup Go
-#        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-#        with:
-#          go-version: ~1.23.7
-#      # Prepare Core for release.
-#      #   - Update CHANGELOG.md file, this is done via chloggen
-#      #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable
-#      #   - Run make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0 MODSET=beta
-#      - name: Prepare release for core
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
-#          REPO: open-telemetry/opentelemetry-collector
-#          CANDIDATE_BETA: ${{ inputs.candidate-beta }}
-#          CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
-#          CURRENT_BETA: ${{ inputs.current-beta }}
-#          CURRENT_STABLE: ${{ inputs.current-stable }}
-#        run: ./.github/workflows/scripts/release-prepare-release.sh
+  check-blockers:
+    needs:
+      - extract-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      # Make sure that there are no open issues with release:blocker label in Core. The release has to be delayed until they are resolved.
+      - name: Check blockers in core
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector
+        run: ./.github/workflows/scripts/release-check-blockers.sh
+      # Make sure that there are no open issues with release:blocker label in Contrib. The release has to be delayed until they are resolved.
+      - name: Check blockers in contrib
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector-contrib
+        run: ./.github/workflows/scripts/release-check-blockers.sh
+      # Make sure the current main branch build successfully passes (Core).
+      - name: Check build status in core
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector
+        run: ./.github/workflows/scripts/release-check-build-status.sh
+      # Make sure the current main branch build successfully passes (Contrib).
+      - name: Check build status in contrib
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector-contrib
+        run: ./.github/workflows/scripts/release-check-build-status.sh
+
+  create-release-issue:
+    needs:
+      - check-blockers
+      - extract-versions
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      # To keep track of the progress, it might be helpful to create a tracking issue similar to #6067. You are responsible
+      # for all of the steps under the "Performed by collector release manager" heading. Once the issue is created, you can
+      # create the individual ones by hovering them and clicking the "Convert to issue" button on the right hand side.
+      - name: Create issue for tracking release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CANDIDATE_BETA: ${{ needs.extract-versions.outputs.next-beta }}
+          CANDIDATE_STABLE: ${{ needs.extract-versions.outputs.next-stable }}
+          CURRENT_BETA: ${{ needs.extract-versions.outputs.current-beta }}
+          CURRENT_STABLE: ${{ needs.extract-versions.outputs.current-stable }}
+          REPO: open-telemetry/opentelemetry-collector
+        run: ./.github/workflows/scripts/release-create-tracking-issue.sh
+
+  # Releasing opentelemetry-collector
+  prepare-release:
+    needs:
+      - check-blockers
+      - extract-versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: ~1.23.7
+      # Prepare Core for release.
+      #   - Update CHANGELOG.md file, this is done via chloggen
+      #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable
+      #   - Run make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0 MODSET=beta
+      - name: Prepare release for core
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector
+          CANDIDATE_BETA: ${{ needs.extract-versions.outputs.next-beta }}
+          CANDIDATE_STABLE: ${{ needs.extract-versions.outputs.next-stable }}
+          CURRENT_BETA: ${{ needs.extract-versions.outputs.current-beta }}
+          CURRENT_STABLE: ${{ needs.extract-versions.outputs.current-stable }}
+        run: ./.github/workflows/scripts/release-prepare-release.sh

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -20,7 +20,6 @@ on:
         options:
           - minor
           - patch
-          - "no bump"
         default: minor
 
 permissions: read-all

--- a/docs/release.md
+++ b/docs/release.md
@@ -38,8 +38,8 @@ Before the release, make sure there are no open release blockers in [core](https
    insignificant, consider not releasing a new version for stable modules.
 
 3. Manually run the action [Automation - Prepare Release](https://github.com/open-telemetry/opentelemetry-collector/actions/workflows/prepare-release.yml). This action will create an issue to track the progress of the release and a pull request to update the changelog and version numbers in the repo.
-   - When prompted, enter the version numbers determined in Step 2, but do not include a leading `v`.
-   - If not intending to release stable modules, do not specify a version for `Release candidate version stable`.
+   - When prompted, enter the version bumps that are needed.
+   - If not intending to release stable modules, do not specify a version for `Release candidate version bump (stable)`.
    - While this PR is open all merging in Core is automatically halted via the `Merge freeze / Check` CI check.
    - If the PR needs updated in any way you can make the changes in a fork and PR those changes into the `prepare-release-prs/x` branch. You do not need to wait for the CI to pass in this prep-to-prep PR.
    -  🛑 **Do not move forward until this PR is merged.** 🛑


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR updated the prepare-release workflow so that the version bump just needs to be selected in a dropdown menu instead of putting in the version numbers by hand. Additionally, "no bump" can be selected to not bump specific component sets (beta or stable).

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #12565

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Only bumping beta to next minor: [workflow run](https://github.com/mowies/opentelemetry-collector/actions/runs/14059792536) - [release tracker issue](https://github.com/mowies/opentelemetry-collector/issues/17)
Bumping beta and stable to next minor: [workflow run](https://github.com/mowies/opentelemetry-collector/actions/runs/14058979304/job/39364990356) - [release tracker issue](https://github.com/mowies/opentelemetry-collector/issues/16)
Bumping beta and stable to next patch: [workflow run](https://github.com/mowies/opentelemetry-collector/actions/runs/14059861157)

<!--Please delete paragraphs that you did not use before submitting.-->
