### PR TITLE
[cmd/mdatagen] Support `attributes.<name>.enabled`

### DIFF
--- a/.chloggen/support_enabled_on_metric_attributes.yaml
+++ b/.chloggen/support_enabled_on_metric_attributes.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support `attributes.<name>.enabled`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12722]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This configuration field was present but not used by mdatagen when generating code this far.
+  This enhancement enables the field.
+  
+  Please be aware that this field will change the default behavior of your attributes:
+  If they were not explicitly enabled previously, they will not be recorded.
+  To address this, please make sure to set `enabled: true` for all attributes.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/generated_package_test.go
+++ b/cmd/mdatagen/generated_package_test.go
@@ -3,9 +3,8 @@
 package main
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/mdatagen/internal/samplereceiver/documentation.md
+++ b/cmd/mdatagen/internal/samplereceiver/documentation.md
@@ -31,6 +31,7 @@ The metric will be become optional soon.
 | enum_attr | Attribute with a known set of string values. | Str: ``red``, ``green``, ``blue`` |
 | slice_attr | Attribute with a slice value. | Any Slice |
 | map_attr | Attribute with a map value. | Any Map |
+| disabled_attr | Attribute which is not enabled. | Any Str |
 
 ### default.metric.to_be_removed
 

--- a/cmd/mdatagen/internal/samplereceiver/generated_package_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package samplereceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
@@ -122,15 +122,77 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 	}
 }
 
+// AttributeConfig provides common config for a particular attribute.
+type AttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+
+	enabledSetByUser bool
+}
+
+func (rac *AttributeConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+	err := parser.Unmarshal(rac)
+	if err != nil {
+		return err
+	}
+	rac.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// AttributesConfig provides config for sample attributes.
+type AttributesConfig struct {
+	BooleanAttr       AttributeConfig `mapstructure:"boolean_attr"`
+	BooleanAttr2      AttributeConfig `mapstructure:"boolean_attr2"`
+	DisabledAttr      AttributeConfig `mapstructure:"disabled_attr"`
+	EnumAttr          AttributeConfig `mapstructure:"enum_attr"`
+	MapAttr           AttributeConfig `mapstructure:"map_attr"`
+	OverriddenIntAttr AttributeConfig `mapstructure:"overridden_int_attr"`
+	SliceAttr         AttributeConfig `mapstructure:"slice_attr"`
+	StringAttr        AttributeConfig `mapstructure:"string_attr"`
+}
+
+func DefaultAttributesConfig() AttributesConfig {
+	return AttributesConfig{
+		BooleanAttr: AttributeConfig{
+			Enabled: false,
+		},
+		BooleanAttr2: AttributeConfig{
+			Enabled: false,
+		},
+		DisabledAttr: AttributeConfig{
+			Enabled: false,
+		},
+		EnumAttr: AttributeConfig{
+			Enabled: false,
+		},
+		MapAttr: AttributeConfig{
+			Enabled: false,
+		},
+		OverriddenIntAttr: AttributeConfig{
+			Enabled: false,
+		},
+		SliceAttr: AttributeConfig{
+			Enabled: false,
+		},
+		StringAttr: AttributeConfig{
+			Enabled: false,
+		},
+	}
+}
+
 // MetricsBuilderConfig is a configuration for sample metrics builder.
 type MetricsBuilderConfig struct {
 	Metrics            MetricsConfig            `mapstructure:"metrics"`
 	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
+	Attributes         AttributesConfig         `mapstructure:"attributes"`
 }
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
 		Metrics:            DefaultMetricsConfig(),
 		ResourceAttributes: DefaultResourceAttributesConfig(),
+		Attributes:         DefaultAttributesConfig(),
 	}
 }

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
@@ -46,9 +46,10 @@ var MapAttributeEnumAttr = map[string]AttributeEnumAttr{
 }
 
 type metricDefaultMetric struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data             pmetric.Metric   // data buffer for generated metric.
+	config           MetricConfig     // metric config provided by user.
+	capacity         int              // max observed number of data points added to the metric.
+	attributesConfig AttributesConfig // attributes configuration
 }
 
 // init fills default.metric metric with initial data.
@@ -62,7 +63,7 @@ func (m *metricDefaultMetric) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue string, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any) {
+func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue string, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any, disabledAttrAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -70,11 +71,24 @@ func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
-	dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
-	dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
-	dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
-	dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
+	if m.attributesConfig.StringAttr.Enabled {
+		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
+	}
+	if m.attributesConfig.OverriddenIntAttr.Enabled {
+		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
+	}
+	if m.attributesConfig.EnumAttr.Enabled {
+		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
+	}
+	if m.attributesConfig.SliceAttr.Enabled {
+		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
+	}
+	if m.attributesConfig.MapAttr.Enabled {
+		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
+	}
+	if m.attributesConfig.DisabledAttr.Enabled {
+		dp.Attributes().PutStr("disabled_attr", disabledAttrAttributeValue)
+	}
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -103,9 +117,10 @@ func newMetricDefaultMetric(cfg MetricConfig) metricDefaultMetric {
 }
 
 type metricDefaultMetricToBeRemoved struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data             pmetric.Metric   // data buffer for generated metric.
+	config           MetricConfig     // metric config provided by user.
+	capacity         int              // max observed number of data points added to the metric.
+	attributesConfig AttributesConfig // attributes configuration
 }
 
 // init fills default.metric.to_be_removed metric with initial data.
@@ -154,9 +169,10 @@ func newMetricDefaultMetricToBeRemoved(cfg MetricConfig) metricDefaultMetricToBe
 }
 
 type metricMetricInputType struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data             pmetric.Metric   // data buffer for generated metric.
+	config           MetricConfig     // metric config provided by user.
+	capacity         int              // max observed number of data points added to the metric.
+	attributesConfig AttributesConfig // attributes configuration
 }
 
 // init fills metric.input_type metric with initial data.
@@ -178,11 +194,21 @@ func (m *metricMetricInputType) recordDataPoint(start pcommon.Timestamp, ts pcom
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
-	dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
-	dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
-	dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
-	dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
+	if m.attributesConfig.StringAttr.Enabled {
+		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
+	}
+	if m.attributesConfig.OverriddenIntAttr.Enabled {
+		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
+	}
+	if m.attributesConfig.EnumAttr.Enabled {
+		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
+	}
+	if m.attributesConfig.SliceAttr.Enabled {
+		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
+	}
+	if m.attributesConfig.MapAttr.Enabled {
+		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
+	}
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -211,9 +237,10 @@ func newMetricMetricInputType(cfg MetricConfig) metricMetricInputType {
 }
 
 type metricOptionalMetric struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data             pmetric.Metric   // data buffer for generated metric.
+	config           MetricConfig     // metric config provided by user.
+	capacity         int              // max observed number of data points added to the metric.
+	attributesConfig AttributesConfig // attributes configuration
 }
 
 // init fills optional.metric metric with initial data.
@@ -233,9 +260,15 @@ func (m *metricOptionalMetric) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
-	dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
-	dp.Attributes().PutBool("boolean_attr2", booleanAttr2AttributeValue)
+	if m.attributesConfig.StringAttr.Enabled {
+		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
+	}
+	if m.attributesConfig.BooleanAttr.Enabled {
+		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
+	}
+	if m.attributesConfig.BooleanAttr2.Enabled {
+		dp.Attributes().PutBool("boolean_attr2", booleanAttr2AttributeValue)
+	}
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -264,9 +297,10 @@ func newMetricOptionalMetric(cfg MetricConfig) metricOptionalMetric {
 }
 
 type metricOptionalMetricEmptyUnit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data             pmetric.Metric   // data buffer for generated metric.
+	config           MetricConfig     // metric config provided by user.
+	capacity         int              // max observed number of data points added to the metric.
+	attributesConfig AttributesConfig // attributes configuration
 }
 
 // init fills optional.metric.empty_unit metric with initial data.
@@ -286,8 +320,12 @@ func (m *metricOptionalMetricEmptyUnit) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
-	dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
+	if m.attributesConfig.StringAttr.Enabled {
+		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
+	}
+	if m.attributesConfig.BooleanAttr.Enabled {
+		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
+	}
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -539,8 +577,8 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 }
 
 // RecordDefaultMetricDataPoint adds a data point to default.metric metric.
-func (mb *MetricsBuilder) RecordDefaultMetricDataPoint(ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue AttributeEnumAttr, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any) {
-	mb.metricDefaultMetric.recordDataPoint(mb.startTime, ts, val, stringAttrAttributeValue, overriddenIntAttrAttributeValue, enumAttrAttributeValue.String(), sliceAttrAttributeValue, mapAttrAttributeValue)
+func (mb *MetricsBuilder) RecordDefaultMetricDataPoint(ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue AttributeEnumAttr, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any, disabledAttrAttributeValue string) {
+	mb.metricDefaultMetric.recordDataPoint(mb.startTime, ts, val, stringAttrAttributeValue, overriddenIntAttrAttributeValue, enumAttrAttributeValue.String(), sliceAttrAttributeValue, mapAttrAttributeValue, disabledAttrAttributeValue)
 }
 
 // RecordDefaultMetricToBeRemovedDataPoint adds a data point to default.metric.to_be_removed metric.

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics_test.go
@@ -6,12 +6,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
-
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type testDataSet int
@@ -99,7 +98,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordDefaultMetricDataPoint(ts, 1, "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"})
+			mb.RecordDefaultMetricDataPoint(ts, 1, "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"}, "disabled_attr-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -175,6 +174,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("map_attr")
 					assert.True(t, ok)
 					assert.EqualValues(t, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"}, attrVal.Map().AsRaw())
+					attrVal, ok = dp.Attributes().Get("disabled_attr")
+					assert.True(t, ok)
+					assert.EqualValues(t, "disabled_attr-val", attrVal.Str())
 				case "default.metric.to_be_removed":
 					assert.False(t, validatedMetrics["default.metric.to_be_removed"], "Found a duplicate in the metrics slice: default.metric.to_be_removed")
 					validatedMetrics["default.metric.to_be_removed"] = true

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 )
 
 func NewSettings(tt *componenttest.Telemetry) receiver.Settings {

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest_test.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
-	"go.opentelemetry.io/collector/cmd/mdatagen/internal/samplereceiver/internal/metadata"
 	"go.opentelemetry.io/collector/component/componenttest"
 )
 

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -105,6 +105,11 @@ attributes:
     description: Attribute with a map value.
     type: map
 
+  disabled_attr:
+    description: Attribute which is not enabled.
+    type: string
+    enabled: false
+
 metrics:
   default.metric:
     enabled: true
@@ -115,7 +120,7 @@ metrics:
       value_type: int
       monotonic: true
       aggregation_temporality: cumulative
-    attributes: [string_attr, overridden_int_attr, enum_attr, slice_attr, map_attr]
+    attributes: [string_attr, overridden_int_attr, enum_attr, slice_attr, map_attr, disabled_attr]
     warnings:
       if_enabled_not_set: This metric will be disabled by default soon.
 

--- a/cmd/mdatagen/internal/templates/config.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config.go.tmpl
@@ -94,6 +94,44 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 }
 {{- end }}
 
+{{ if .Attributes -}}
+// AttributeConfig provides common config for a particular attribute.
+type AttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+
+	enabledSetByUser bool
+}
+
+func (rac *AttributeConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+	err := parser.Unmarshal(rac)
+	if err != nil {
+		return err
+	}
+	rac.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// AttributesConfig provides config for {{ .Type }} attributes.
+type AttributesConfig struct {
+	{{- range $name, $attr := .Attributes }}
+	{{ $name.Render }} AttributeConfig `mapstructure:"{{ $name }}"`
+	{{- end }}
+}
+
+func DefaultAttributesConfig() AttributesConfig {
+	return AttributesConfig{
+		{{- range $name, $attr := .Attributes }}
+		{{ $name.Render }}: AttributeConfig {
+			Enabled: {{ $attr.Enabled }},
+		},
+		{{- end }}
+	}
+}
+{{- end }}
+
 {{ if .Metrics -}}
 // MetricsBuilderConfig is a configuration for {{ .Type }} metrics builder.
 type MetricsBuilderConfig struct {
@@ -101,6 +139,9 @@ type MetricsBuilderConfig struct {
 	{{- if .ResourceAttributes }}
 	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 	{{- end }}
+	{{- if .Attributes }}
+  Attributes AttributesConfig `mapstructure:"attributes"`
+  {{- end }}
 }
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
@@ -108,6 +149,9 @@ func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 		Metrics: DefaultMetricsConfig(),
 		{{- if .ResourceAttributes }}
 		ResourceAttributes: DefaultResourceAttributesConfig(),
+		{{- end }}
+		{{- if .Attributes }}
+		Attributes: DefaultAttributesConfig(),
 		{{- end }}
 	}
 }

--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -58,9 +58,10 @@ var MapAttribute{{ $name.Render }} = map[string]Attribute{{ $name.Render }}{
 
 {{ range $name, $metric := .Metrics -}}
 type metric{{ $name.Render }} struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data             pmetric.Metric   // data buffer for generated metric.
+	config           MetricConfig     // metric config provided by user.
+	capacity         int              // max observed number of data points added to the metric.
+	attributesConfig AttributesConfig // attributes configuration
 }
 
 // init fills {{ $name }} metric with initial data.
@@ -90,15 +91,17 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetTimestamp(ts)
 	dp.Set{{ $metric.Data.MetricValueType }}Value(val)
 	{{- range $metric.Attributes }}
-	{{- if eq (attributeInfo .).Type.Primitive "[]byte" }}
-	dp.Attributes().PutEmptyBytes("{{ (attributeInfo .).Name }}").FromRaw({{ .RenderUnexported }}AttributeValue)
-	{{- else if eq (attributeInfo .).Type.Primitive "[]any" }}
-	dp.Attributes().PutEmptySlice("{{ (attributeInfo .).Name }}").FromRaw({{ .RenderUnexported }}AttributeValue)
-	{{- else if eq (attributeInfo .).Type.Primitive "map[string]any" }}
-	dp.Attributes().PutEmptyMap("{{ (attributeInfo .).Name }}").FromRaw({{ .RenderUnexported }}AttributeValue)
-	{{- else }}
-	dp.Attributes().Put{{ (attributeInfo .).Type }}("{{ (attributeInfo .).Name }}", {{ .RenderUnexported }}AttributeValue)
-	{{- end }}
+	if m.attributesConfig.{{ .Render }}.Enabled {
+		{{- if eq (attributeInfo .).Type.Primitive "[]byte" }}
+		dp.Attributes().PutEmptyBytes("{{ (attributeInfo .).Name }}").FromRaw({{ .RenderUnexported }}AttributeValue)
+		{{- else if eq (attributeInfo .).Type.Primitive "[]any" }}
+		dp.Attributes().PutEmptySlice("{{ (attributeInfo .).Name }}").FromRaw({{ .RenderUnexported }}AttributeValue)
+		{{- else if eq (attributeInfo .).Type.Primitive "map[string]any" }}
+		dp.Attributes().PutEmptyMap("{{ (attributeInfo .).Name }}").FromRaw({{ .RenderUnexported }}AttributeValue)
+		{{- else }}
+		dp.Attributes().Put{{ (attributeInfo .).Type }}("{{ (attributeInfo .).Name }}", {{ .RenderUnexported }}AttributeValue)
+		{{- end }}
+	}
 	{{- end }}
 }
 

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -69,6 +69,8 @@ resource_attributes:
 # being described below.
 attributes:
   <attribute.name>:
+    # Required: whether the attribute is added to the emitted metrics by default.
+    enabled: bool
     # Optional: this field can be used to override the actual attribute name defined by the key.
     # It should be used if multiple metrics have different attributes with the same name.
     name_override:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
A cut of supporting the enabled field on metric attributes.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #12722

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Generated the code

<!--Describe the documentation added.-->
#### Documentation
Added to schema.