### PR TITLE
chore: Add local test steps to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,8 @@ Alternatively, copy `./.chloggen/TEMPLATE.yaml`, or just create your file from s
 
 ## Local Testing
 
-To manually test your changes, follow these steps to build and run the Collector locally:
+To manually test your changes, follow these steps to build and run the Collector
+locally. Ensure that you execute these commands from the root of the repository:
 
 1. Build the Collector:
 
@@ -317,9 +318,13 @@ To manually test your changes, follow these steps to build and run the Collector
   ./bin/otelcorecol --config ./examples/local/otel-config.yaml
   ```
 
+  The actual name of the binary may be different depending on your platform, so
+  adjust accordingly (e.g., `./bin/otelcorecol_darwin_arm64`).
+  
   Replace `otel-config.yaml` with the appropriate configuration file as needed.
 
-3. Verify that your changes are reflected in the Collector's behavior by testing it against the provided configuration.
+3. Verify that your changes are reflected in the Collector's behavior by testing
+   it against the provided configuration.
 
 ## Membership, Roles, and Responsibilities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,6 +301,26 @@ During the collector release process, all `./chloggen/*.yaml` files are transcri
 
 Alternatively, copy `./.chloggen/TEMPLATE.yaml`, or just create your file from scratch.
 
+## Local Testing
+
+To manually test your changes, follow these steps to build and run the Collector locally:
+
+1. Build the Collector:
+
+  ```shell
+  make otelcorecol
+  ```
+
+2. Run the Collector with a local configuration file:
+
+  ```shell
+  ./bin/otelcorecol --config ./examples/local/otel-config.yaml
+  ```
+
+  Replace `otel-config.yaml` with the appropriate configuration file as needed.
+
+3. Verify that your changes are reflected in the Collector's behavior by testing it against the provided configuration.
+
 ## Membership, Roles, and Responsibilities
 
 ### Membership levels


### PR DESCRIPTION
#### Documentation

Contributing doc updated to show steps required to build & run the collector locally. I am unsure if this is too obvious to be stated? I personally had to ask around how to do this when making some contribution in the past!
