### PR TITLE
[chore]: Fix cspell

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4 
+      - uses: actions/checkout@v4
 
       - name: Run cSpell
         uses: streetsidesoftware/cspell-action@8485bb4b688c68384c2f6db7ad931f5e3e63f21c #v6.10.1

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 
 
       - name: Run cSpell
         uses: streetsidesoftware/cspell-action@8485bb4b688c68384c2f6db7ad931f5e3e63f21c #v6.10.1

--- a/.github/workflows/utils/cspell.json
+++ b/.github/workflows/utils/cspell.json
@@ -369,6 +369,7 @@
       "protogen",
       "protos",
       "ptraceotlp",
+      "queuebatch",
       "receiverhelper",
       "receiverprofiles",
       "receivertest",


### PR DESCRIPTION
Attempting to fix the following failure in CI due to cspell.

> Warning: Unknown word (queuebatch)
> exporter/exporterhelper/internal/queuebatch/metadata.yaml:1:7 Unknown word (queuebatch)
> Files checked: 289, Issues found: 1 in 1 files.
> Error: 1 spelling issue found in 1 of the 289 files checked.