### PR TITLE
[chore]: Add benchmark.txt to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ coverage/*
 coverage.txt
 
 # Benchmarks
+**/benchmark.txt
 benchmarks.txt
 
 # Wix


### PR DESCRIPTION
Running `make gobenchmark` locally creates individual benchmarks files. This PR adds them to git-ignore list. The combined benchmarks.txt was already ignored.