### PR TITLE
[chore] update tests to use Empty

### DIFF
--- a/component/component_test.go
+++ b/component/component_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestKindString(t *testing.T) {
-	assert.Equal(t, "", Kind{}.String())
+	assert.Empty(t, Kind{}.String())
 	assert.Equal(t, "Receiver", KindReceiver.String())
 	assert.Equal(t, "Processor", KindProcessor.String())
 	assert.Equal(t, "Exporter", KindExporter.String())
@@ -78,7 +78,7 @@ func TestStabilityLevelString(t *testing.T) {
 	assert.Equal(t, "Alpha", StabilityLevelAlpha.String())
 	assert.Equal(t, "Beta", StabilityLevelBeta.String())
 	assert.Equal(t, "Stable", StabilityLevelStable.String())
-	assert.Equal(t, "", StabilityLevel(100).String())
+	assert.Empty(t, StabilityLevel(100).String())
 }
 
 func TestStabilityLevelLogMessage(t *testing.T) {

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -29,7 +29,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	require.NoError(t, componenttest.CheckConfigStruct(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
-	assert.Equal(t, "", ocfg.ClientConfig.Endpoint)
+	assert.Empty(t, ocfg.ClientConfig.Endpoint)
 	assert.Equal(t, 30*time.Second, ocfg.ClientConfig.Timeout, "default timeout is 30 second")
 	assert.True(t, ocfg.RetryConfig.Enabled, "default retry is enabled")
 	assert.Equal(t, 300*time.Second, ocfg.RetryConfig.MaxElapsedTime, "default retry MaxElapsedTime")

--- a/internal/memorylimiter/cgroups/mountpoint_test.go
+++ b/internal/memorylimiter/cgroups/mountpoint_test.go
@@ -170,7 +170,7 @@ func TestMountPointTranslateError(t *testing.T) {
 			path:       path,
 		}
 
-		assert.Equal(t, "", translated, "inaccessiblePaths[%d] == %q", i, path)
+		assert.Empty(t, translated, "inaccessiblePaths[%d] == %q", i, path)
 		assert.Equal(t, errExpected, err, "inaccessiblePaths[%d] == %q", i, path)
 	}
 
@@ -183,7 +183,7 @@ func TestMountPointTranslateError(t *testing.T) {
 	for i, path := range relPaths {
 		translated, err := cgroupMountPoint.Translate(path)
 
-		assert.Equal(t, "", translated, "relPaths[%d] == %q", i, path)
+		assert.Empty(t, translated, "relPaths[%d] == %q", i, path)
 		assert.Error(t, err, path)
 	}
 }

--- a/pdata/pcommon/spanid_test.go
+++ b/pdata/pcommon/spanid_test.go
@@ -23,7 +23,7 @@ func TestNewSpanIDEmpty(t *testing.T) {
 
 func TestSpanIDString(t *testing.T) {
 	sid := SpanID([8]byte{})
-	assert.Equal(t, "", sid.String())
+	assert.Empty(t, sid.String())
 
 	sid = SpanID([8]byte{0x12, 0x23, 0xAD, 0x12, 0x23, 0xAD, 0x12, 0x23})
 	assert.Equal(t, "1223ad1223ad1223", sid.String())

--- a/pdata/pcommon/trace_state_test.go
+++ b/pdata/pcommon/trace_state_test.go
@@ -31,7 +31,7 @@ func TestTraceState_CopyTo(t *testing.T) {
 
 func TestTraceState_FromRaw_AsRaw(t *testing.T) {
 	ms := NewTraceState()
-	assert.Equal(t, "", ms.AsRaw())
+	assert.Empty(t, ms.AsRaw())
 	ms.FromRaw("congo=t61rcWkgMzE")
 	assert.Equal(t, "congo=t61rcWkgMzE", ms.AsRaw())
 }

--- a/pdata/pcommon/traceid_test.go
+++ b/pdata/pcommon/traceid_test.go
@@ -23,7 +23,7 @@ func TestNewTraceIDEmpty(t *testing.T) {
 
 func TestTraceIDString(t *testing.T) {
 	tid := TraceID([16]byte{})
-	assert.Equal(t, "", tid.String())
+	assert.Empty(t, tid.String())
 
 	tid = [16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}
 	assert.Equal(t, "12345678123456781234567812345678", tid.String())

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -560,7 +560,7 @@ func TestInvalidValue(t *testing.T) {
 	assert.False(t, v.Bool())
 	assert.Equal(t, int64(0), v.Int())
 	assert.InDelta(t, float64(0), v.Double(), 0.01)
-	assert.Equal(t, "", v.Str())
+	assert.Empty(t, v.Str())
 	assert.Equal(t, ByteSlice{}, v.Bytes())
 	assert.Equal(t, Map{}, v.Map())
 	assert.Equal(t, Slice{}, v.Slice())

--- a/pdata/pmetric/aggregation_temporality_test.go
+++ b/pdata/pmetric/aggregation_temporality_test.go
@@ -13,5 +13,5 @@ func TestAggregationTemporalityString(t *testing.T) {
 	assert.Equal(t, "Unspecified", AggregationTemporalityUnspecified.String())
 	assert.Equal(t, "Delta", AggregationTemporalityDelta.String())
 	assert.Equal(t, "Cumulative", AggregationTemporalityCumulative.String())
-	assert.Equal(t, "", (AggregationTemporalityCumulative + 1).String())
+	assert.Empty(t, (AggregationTemporalityCumulative + 1).String())
 }

--- a/pdata/pmetric/exemplar_value_type_test.go
+++ b/pdata/pmetric/exemplar_value_type_test.go
@@ -13,5 +13,5 @@ func TestExemplarValueTypeString(t *testing.T) {
 	assert.Equal(t, "Empty", ExemplarValueTypeEmpty.String())
 	assert.Equal(t, "Int", ExemplarValueTypeInt.String())
 	assert.Equal(t, "Double", ExemplarValueTypeDouble.String())
-	assert.Equal(t, "", (ExemplarValueTypeDouble + 1).String())
+	assert.Empty(t, (ExemplarValueTypeDouble + 1).String())
 }

--- a/pdata/pmetric/metric_type_test.go
+++ b/pdata/pmetric/metric_type_test.go
@@ -16,5 +16,5 @@ func TestMetricTypeString(t *testing.T) {
 	assert.Equal(t, "Histogram", MetricTypeHistogram.String())
 	assert.Equal(t, "ExponentialHistogram", MetricTypeExponentialHistogram.String())
 	assert.Equal(t, "Summary", MetricTypeSummary.String())
-	assert.Equal(t, "", (MetricTypeSummary + 1).String())
+	assert.Empty(t, (MetricTypeSummary + 1).String())
 }

--- a/pdata/pmetric/number_data_point_value_type_test.go
+++ b/pdata/pmetric/number_data_point_value_type_test.go
@@ -13,5 +13,5 @@ func TestNumberDataPointValueTypeString(t *testing.T) {
 	assert.Equal(t, "Empty", NumberDataPointValueTypeEmpty.String())
 	assert.Equal(t, "Int", NumberDataPointValueTypeInt.String())
 	assert.Equal(t, "Double", NumberDataPointValueTypeDouble.String())
-	assert.Equal(t, "", (NumberDataPointValueTypeDouble + 1).String())
+	assert.Empty(t, (NumberDataPointValueTypeDouble + 1).String())
 }

--- a/pdata/pprofile/aggregation_temporality_test.go
+++ b/pdata/pprofile/aggregation_temporality_test.go
@@ -13,5 +13,5 @@ func TestAggregationTemporalityString(t *testing.T) {
 	assert.Equal(t, "Unspecified", AggregationTemporalityUnspecified.String())
 	assert.Equal(t, "Delta", AggregationTemporalityDelta.String())
 	assert.Equal(t, "Cumulative", AggregationTemporalityCumulative.String())
-	assert.Equal(t, "", (AggregationTemporalityCumulative + 1).String())
+	assert.Empty(t, (AggregationTemporalityCumulative + 1).String())
 }

--- a/pdata/pprofile/profileid_test.go
+++ b/pdata/pprofile/profileid_test.go
@@ -23,7 +23,7 @@ func TestNewProfileIDEmpty(t *testing.T) {
 
 func TestProfileIDString(t *testing.T) {
 	pid := ProfileID([16]byte{})
-	assert.Equal(t, "", pid.String())
+	assert.Empty(t, pid.String())
 
 	pid = [16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}
 	assert.Equal(t, "12345678123456781234567812345678", pid.String())


### PR DESCRIPTION
This change was caught by the linter in the update of golangci-lint to v2 (see https://github.com/open-telemetry/opentelemetry-collector/pull/12731)
