### PR TITLE
[builder] Remove deprecated OtelColVersion, already an error if used

### DIFF
--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -65,12 +65,10 @@ type ConfResolver struct {
 
 // Distribution holds the parameters for the final binary
 type Distribution struct {
-	Module      string `mapstructure:"module"`
-	Name        string `mapstructure:"name"`
-	Go          string `mapstructure:"go"`
-	Description string `mapstructure:"description"`
-	// Deprecated: [v0.113.0] only here to return a detailed error and not failing during unmarshalling.
-	OtelColVersion   string `mapstructure:"otelcol_version"`
+	Module           string `mapstructure:"module"`
+	Name             string `mapstructure:"name"`
+	Go               string `mapstructure:"go"`
+	Description      string `mapstructure:"description"`
 	OutputPath       string `mapstructure:"output_path"`
 	Version          string `mapstructure:"version"`
 	BuildTags        string `mapstructure:"build_tags"`
@@ -137,9 +135,6 @@ func NewDefaultConfig() (*Config, error) {
 
 // Validate checks whether the current configuration is valid
 func (c *Config) Validate() error {
-	if c.Distribution.OtelColVersion != "" {
-		return errors.New("`otelcol_version` has been removed. To build with an older Collector API, use an older (aligned) builder version instead")
-	}
 	return multierr.Combine(
 		validateModules("extension", c.Extensions),
 		validateModules("receiver", c.Receivers),

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -378,10 +378,3 @@ func TestSkipsNilFieldValidation(t *testing.T) {
 	cfg.ConfmapConverters = nil
 	assert.NoError(t, cfg.Validate())
 }
-
-func TestValidateDeprecatedOtelColVersion(t *testing.T) {
-	cfg, err := NewDefaultConfig()
-	require.NoError(t, err)
-	cfg.Distribution.OtelColVersion = "test"
-	assert.Error(t, cfg.Validate())
-}


### PR DESCRIPTION
As titled said, this is not a breaking change, since we only are going to return a different error.