### PR TITLE
[mdatagen] do not allow `attributes.<attribute name>.enabled`.

### DIFF
--- a/.chloggen/mdatagen_enabled_attributes.yaml
+++ b/.chloggen/mdatagen_enabled_attributes.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: do not allow attributes.<attribute name>.enabled.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12722]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This field is reserved to resource attributes.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 )
 
-func setAttributesFullName(attrs map[AttributeName]Attribute) {
+func setAttributesFullName(attrs map[AttributeName]ResourceAttribute) {
 	for k, v := range attrs {
 		v.FullName = k
 		attrs[k] = v
@@ -58,7 +58,10 @@ func LoadMetadata(filePath string) (Metadata, error) {
 		return md, err
 	}
 
-	setAttributesFullName(md.Attributes)
+	for k, v := range md.Attributes {
+		v.FullName = k
+		md.Attributes[k] = v
+	}
 	setAttributesFullName(md.ResourceAttributes)
 
 	return md, nil

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -68,78 +68,94 @@ func TestLoadMetadata(t *testing.T) {
 				},
 				ResourceAttributes: map[AttributeName]ResourceAttribute{
 					"string.resource.attr": {
-						Description: "Resource attribute with any string value.",
-						Enabled:     true,
-						Type: ValueType{
-							ValueType: pcommon.ValueTypeStr,
+						Enabled: true,
+						Attribute: Attribute{
+							Description: "Resource attribute with any string value.",
+							Type: ValueType{
+								ValueType: pcommon.ValueTypeStr,
+							},
+							FullName: "string.resource.attr",
 						},
-						FullName: "string.resource.attr",
 					},
 					"string.enum.resource.attr": {
-						Description: "Resource attribute with a known set of string values.",
-						Enabled:     true,
-						Enum:        []string{"one", "two"},
-						Type: ValueType{
-							ValueType: pcommon.ValueTypeStr,
+						Enabled: true,
+						Attribute: Attribute{
+							Description: "Resource attribute with a known set of string values.",
+							Enum:        []string{"one", "two"},
+							Type: ValueType{
+								ValueType: pcommon.ValueTypeStr,
+							},
+							FullName: "string.enum.resource.attr",
 						},
-						FullName: "string.enum.resource.attr",
 					},
 					"optional.resource.attr": {
-						Description: "Explicitly disabled ResourceAttribute.",
-						Enabled:     false,
-						Type: ValueType{
-							ValueType: pcommon.ValueTypeStr,
+						Enabled: false,
+						Attribute: Attribute{
+							Description: "Explicitly disabled ResourceAttribute.",
+							Type: ValueType{
+								ValueType: pcommon.ValueTypeStr,
+							},
+							FullName: "optional.resource.attr",
 						},
-						FullName: "optional.resource.attr",
 					},
 					"slice.resource.attr": {
-						Description: "Resource attribute with a slice value.",
-						Enabled:     true,
-						Type: ValueType{
-							ValueType: pcommon.ValueTypeSlice,
+						Enabled: true,
+						Attribute: Attribute{
+							Description: "Resource attribute with a slice value.",
+							Type: ValueType{
+								ValueType: pcommon.ValueTypeSlice,
+							},
+							FullName: "slice.resource.attr",
 						},
-						FullName: "slice.resource.attr",
 					},
 					"map.resource.attr": {
-						Description: "Resource attribute with a map value.",
-						Enabled:     true,
-						Type: ValueType{
-							ValueType: pcommon.ValueTypeMap,
+						Enabled: true,
+						Attribute: Attribute{
+							Description: "Resource attribute with a map value.",
+							Type: ValueType{
+								ValueType: pcommon.ValueTypeMap,
+							},
+							FullName: "map.resource.attr",
 						},
-						FullName: "map.resource.attr",
 					},
 					"string.resource.attr_disable_warning": {
-						Description: "Resource attribute with any string value.",
 						Warnings: Warnings{
 							IfEnabledNotSet: "This resource_attribute will be disabled by default soon.",
 						},
 						Enabled: true,
-						Type: ValueType{
-							ValueType: pcommon.ValueTypeStr,
+						Attribute: Attribute{
+							Description: "Resource attribute with any string value.",
+							Type: ValueType{
+								ValueType: pcommon.ValueTypeStr,
+							},
+							FullName: "string.resource.attr_disable_warning",
 						},
-						FullName: "string.resource.attr_disable_warning",
 					},
 					"string.resource.attr_remove_warning": {
-						Description: "Resource attribute with any string value.",
 						Warnings: Warnings{
 							IfConfigured: "This resource_attribute is deprecated and will be removed soon.",
 						},
 						Enabled: false,
-						Type: ValueType{
-							ValueType: pcommon.ValueTypeStr,
+						Attribute: Attribute{
+							Description: "Resource attribute with any string value.",
+							Type: ValueType{
+								ValueType: pcommon.ValueTypeStr,
+							},
+							FullName: "string.resource.attr_remove_warning",
 						},
-						FullName: "string.resource.attr_remove_warning",
 					},
 					"string.resource.attr_to_be_removed": {
-						Description: "Resource attribute with any string value.",
 						Warnings: Warnings{
 							IfEnabled: "This resource_attribute is deprecated and will be removed soon.",
 						},
 						Enabled: true,
-						Type: ValueType{
-							ValueType: pcommon.ValueTypeStr,
+						Attribute: Attribute{
+							Description: "Resource attribute with any string value.",
+							Type: ValueType{
+								ValueType: pcommon.ValueTypeStr,
+							},
+							FullName: "string.resource.attr_to_be_removed",
 						},
-						FullName: "string.resource.attr_to_be_removed",
 					},
 				},
 

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -66,7 +66,7 @@ func TestLoadMetadata(t *testing.T) {
 					Warnings:             []string{"Any additional information that should be brought to the consumer's attention"},
 					UnsupportedPlatforms: []string{"freebsd", "illumos"},
 				},
-				ResourceAttributes: map[AttributeName]Attribute{
+				ResourceAttributes: map[AttributeName]ResourceAttribute{
 					"string.resource.attr": {
 						Description: "Resource attribute with any string value.",
 						Enabled:     true,

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -286,59 +286,13 @@ type Warnings struct {
 }
 
 type ResourceAttribute struct {
-	// Description describes the purpose of the attribute.
-	Description string `mapstructure:"description"`
-	// NameOverride can be used to override the attribute name.
-	NameOverride string `mapstructure:"name_override"`
+	Attribute `mapstructure:",squash"`
 	// Enabled defines whether the attribute is enabled by default.
 	Enabled bool `mapstructure:"enabled"`
-	// Include can be used to filter attributes.
-	Include []filter.Config `mapstructure:"include"`
-	// Include can be used to filter attributes.
-	Exclude []filter.Config `mapstructure:"exclude"`
-	// Enum can optionally describe the set of values to which the attribute can belong.
-	Enum []string `mapstructure:"enum"`
-	// Type is an attribute type.
-	Type ValueType `mapstructure:"type"`
-	// FullName is the attribute name populated from the map key.
-	FullName AttributeName `mapstructure:"-"`
 	// Warnings that will be shown to user under specified conditions.
 	Warnings Warnings `mapstructure:"warnings"`
 	// Optional defines whether the attribute is required.
 	Optional bool `mapstructure:"optional"`
-}
-
-// Name returns actual name of the attribute that is set on the metric after applying NameOverride.
-func (a ResourceAttribute) Name() AttributeName {
-	if a.NameOverride != "" {
-		return AttributeName(a.NameOverride)
-	}
-	return a.FullName
-}
-
-func (a ResourceAttribute) TestValue() string {
-	if a.Enum != nil {
-		return fmt.Sprintf(`"%s"`, a.Enum[0])
-	}
-	switch a.Type.ValueType {
-	case pcommon.ValueTypeEmpty:
-		return ""
-	case pcommon.ValueTypeStr:
-		return fmt.Sprintf(`"%s-val"`, a.FullName)
-	case pcommon.ValueTypeInt:
-		return strconv.Itoa(len(a.FullName))
-	case pcommon.ValueTypeDouble:
-		return fmt.Sprintf("%f", 0.1+float64(len(a.FullName)))
-	case pcommon.ValueTypeBool:
-		return strconv.FormatBool(len(a.FullName)%2 == 0)
-	case pcommon.ValueTypeMap:
-		return fmt.Sprintf(`map[string]any{"key1": "%s-val1", "key2": "%s-val2"}`, a.FullName, a.FullName)
-	case pcommon.ValueTypeSlice:
-		return fmt.Sprintf(`[]any{"%s-item1", "%s-item2"}`, a.FullName, a.FullName)
-	case pcommon.ValueTypeBytes:
-		return fmt.Sprintf(`[]byte("%s-val")`, a.FullName)
-	}
-	return ""
 }
 
 type Attribute struct {
@@ -356,8 +310,6 @@ type Attribute struct {
 	Type ValueType `mapstructure:"type"`
 	// FullName is the attribute name populated from the map key.
 	FullName AttributeName `mapstructure:"-"`
-	// Warnings that will be shown to user under specified conditions.
-	Warnings Warnings `mapstructure:"warnings"`
 }
 
 // Name returns actual name of the attribute that is set on the metric after applying NameOverride.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Do not allow `attributes.<attribute name>.enabled`. This field is reserved to resource attributes.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #12722
