### PR TITLE
[chore] add missing multiplier option to exporterhelper readme

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -13,6 +13,7 @@ The following configuration options can be modified:
   - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`
   - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
   - `max_elapsed_time` (default = 300s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`. If set to 0, the retries are never stopped.
+  - `multiplier` (default = 1.5): Factor by which the retry interval is multiplied on each attempt; ignored if `enabled` is `false`
 - `sending_queue`
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`


### PR DESCRIPTION
#### Description
This PR adds the already existing/supported `multiplier` config option to the exporterhelper's readme.