### PR TITLE
add GetFactory interface to hostcapabilities package

### DIFF
--- a/.chloggen/document_get_factory_interface.yaml
+++ b/.chloggen/document_get_factory_interface.yaml
@@ -22,4 +22,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [api]

--- a/.chloggen/document_get_factory_interface.yaml
+++ b/.chloggen/document_get_factory_interface.yaml
@@ -10,7 +10,7 @@ component: service
 note: Adds the GetFactory interface to the hostcapabilities package
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [12789]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/document_get_factory_interface.yaml
+++ b/.chloggen/document_get_factory_interface.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds the GetFactory interface to the hostcapabilities package
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/service/hostcapabilities/interfaces.go
+++ b/service/hostcapabilities/interfaces.go
@@ -26,3 +26,11 @@ type ModuleInfo interface {
 type ExposeExporters interface {
 	GetExporters() map[pipeline.Signal]map[component.ID]component.Component
 }
+
+// ComponentFactory is an interface that may be implemented by the host to
+// provide a component's factory
+type ComponentFactory interface {
+	// GetFactory returns the component factory for the given
+	// component type
+	GetFactory(kind component.Kind, componentType component.Type) component.Factory
+}

--- a/service/internal/graph/host.go
+++ b/service/internal/graph/host.go
@@ -22,9 +22,10 @@ import (
 )
 
 var (
-	_ component.Host                   = (*Host)(nil)
-	_ hostcapabilities.ModuleInfo      = (*Host)(nil)
-	_ hostcapabilities.ExposeExporters = (*Host)(nil)
+	_ component.Host                    = (*Host)(nil)
+	_ hostcapabilities.ModuleInfo       = (*Host)(nil)
+	_ hostcapabilities.ExposeExporters  = (*Host)(nil)
+	_ hostcapabilities.ComponentFactory = (*Host)(nil)
 )
 
 type Host struct {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The GetFactory method is used by a few receivers in the contrib package (e.g. receiver_creator). This PR adds a new interface to the hostcapabilities package so it can be cast correctly from other packages/components.  

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
