### PR TITLE
[chore] enable github action pin digest helper in renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
     "go": "1.23"
   },
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "schedule": [
     "on tuesday"


### PR DESCRIPTION
#### Description

As part of the security slam, we've been working to pin digests in GitHub actions. There's some tools that can run through and pin everything, but without the notes and comments of every versioned, it can be difficult to understand what is actually being pinned. Thus, I'm opting to add the [renovate helper](https://docs.renovatebot.com/modules/manager/github-actions/#digest-pinning-and-updating) for this in GitHub actions which should automatically manage version pinning.

#### Link to tracking issue
Related to [#86](https://github.com/open-telemetry/sig-security/issues/87#issuecomment-2776660785)

#### Testing

Ran `npx --yes --package renovate -- renovate-config-validator renovate.json` after updating the config.
