### PR TITLE
client: add Metadata.Keys method

### DIFF
--- a/.chloggen/client-metadata-keys.yaml
+++ b/.chloggen/client-metadata-keys.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: client
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for iterating over client metadata keys
+
+# One or more tracking issues or pull requests related to the change
+issues: [12804]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/client/client.go
+++ b/client/client.go
@@ -79,6 +79,8 @@ package client // import "go.opentelemetry.io/collector/client"
 
 import (
 	"context"
+	"iter"
+	"maps"
 	"net"
 	"strings"
 )
@@ -146,6 +148,11 @@ func NewMetadata(md map[string][]string) Metadata {
 	return Metadata{
 		data: c,
 	}
+}
+
+// Keys returns an iterator for the metadata keys.
+func (m Metadata) Keys() iter.Seq[string] {
+	return maps.Keys(m.data)
 }
 
 // Get gets the value of the key from metadata, returning a copy.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -8,6 +8,7 @@ package client
 import (
 	"context"
 	"net"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,6 +80,7 @@ func TestFromContext(t *testing.T) {
 func TestMetadata(t *testing.T) {
 	source := map[string][]string{"test-key": {"test-val"}, "TEST-KEY-2": {"test-val"}}
 	md := NewMetadata(source)
+	assert.Equal(t, []string{"test-key", "test-key-2"}, slices.Sorted(md.Keys()))
 	assert.Equal(t, []string{"test-val"}, md.Get("test-key"))
 	assert.Equal(t, []string{"test-val"}, md.Get("test-KEY"))   // case insensitive lookup
 	assert.Equal(t, []string{"test-val"}, md.Get("test-key-2")) // case insensitive lookup
@@ -93,5 +95,6 @@ func TestMetadata(t *testing.T) {
 
 func TestUninstantiatedMetadata(t *testing.T) {
 	i := Info{}
+	assert.Empty(t, slices.Collect(i.Metadata.Keys()))
 	assert.Empty(t, i.Metadata.Get("test"))
 }


### PR DESCRIPTION
#### Description

Add support for iterating over the client metadata keys.

At the moment it is only possible to get the values for a known key, which makes it impossible to inspect metadata keys without prior knowledge of all possible keys, e.g. as described in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39157.

#### Link to tracking issue

Closes https://github.com/open-telemetry/opentelemetry-collector/issues/12804

#### Testing

Trivial addition, added unit tests.

#### Documentation

N/A