### PR TITLE
Fix confmap to preserve original type when a slice of a map is unmarshalled

### DIFF
--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -211,6 +211,33 @@ func (l *Conf) ToStringMap() map[string]any {
 	return sanitize(l.toStringMapWithExpand()).(map[string]any)
 }
 
+// sliceOfMapsHookFunc provides a hook that processes maps within slices,
+// ensuring proper type conversion (especially for numeric values to strings).
+func sliceOfMapsHookFunc() mapstructure.DecodeHookFuncType {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		// Process slices - recursively handle maps within slices
+		if f.Kind() == reflect.Slice && data != nil {
+			if slice, ok := data.([]interface{}); ok {
+				for i, item := range slice {
+					if itemMap, ok := item.(map[string]interface{}); ok {
+						// Process each map within the slice - convert numeric values to strings
+						for k, v := range itemMap {
+							switch val := v.(type) {
+							case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
+								itemMap[k] = fmt.Sprintf("%v", val)
+							}
+						}
+						slice[i] = itemMap
+					}
+				}
+				return slice, nil
+			}
+		}
+		
+		return data, nil
+	}
+}
+
 // decodeConfig decodes the contents of the Conf into the result argument, using a
 // mapstructure decoder with the following notable behaviors. Ensures that maps whose
 // values are nil pointer structs resolved to the zero value of the target struct (see
@@ -232,6 +259,7 @@ func decodeConfig(m *Conf, result any, errorUnused bool, skipTopLevelUnmarshaler
 			mapKeyStringToMapKeyTextUnmarshalerHookFunc(),
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.TextUnmarshallerHookFunc(),
+                        sliceOfMapsHookFunc(),
 			unmarshalerHookFunc(result, skipTopLevelUnmarshaler),
 			// after the main unmarshaler hook is called,
 			// we unmarshal the embedded structs if present to merge with the result:

--- a/confmap/confmap_slice_of_maps_test.go
+++ b/confmap/confmap_slice_of_maps_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package confmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSliceOfMapsUnmarshal(t *testing.T) {
+	// Config struct with a slice of maps
+	type Header struct {
+		Action       string `mapstructure:"action"`
+		Key          string `mapstructure:"key"`
+		FromContext  string `mapstructure:"from_context"`
+		DefaultValue string `mapstructure:"default_value"`
+	}
+
+	type HeadersSetterConfig struct {
+		Headers []Header `mapstructure:"headers"`
+	}
+
+	// Create a confmap with a numeric value in a map within a slice
+	conf := NewFromStringMap(map[string]interface{}{
+		"headers": []interface{}{
+			map[string]interface{}{
+				"action":        "upsert",
+				"key":           "X-TOKEN",
+				"from_context":  "X-TOKEN",
+				"default_value": 12345, // Numeric value that should be converted to string
+			},
+		},
+	})
+
+	// Unmarshal into the config struct
+	var config HeadersSetterConfig
+	err := conf.Unmarshal(&config)
+	require.NoError(t, err)
+
+	// Verify the numeric value was correctly converted to a string
+	assert.Len(t, config.Headers, 1)
+	assert.Equal(t, "12345", config.Headers[0].DefaultValue)
+}


### PR DESCRIPTION
#### Description

This PR fixes an issue where the confmap package fails to preserve the original type when a slice of a map is unmarshalled. This occurs specifically when using environment variables with numeric values (e.g., SPLUNK_ACCESS_TOKEN=12345) in configurations with slices of maps.
The error manifests as:
`'headers[0].default_value' expected type 'string', got unconvertible type 'int', value: '12345'`

The root cause is that while the confmap package correctly handles type conversion for regular maps, it doesn't process maps within slices. I've added a new hook function (sliceOfMapsHookFunc) that specifically converts numeric values to strings within maps that are nested in slices during the unmarshalling process.

#### Link to tracking issue
Fixes #12793

#### Testing

I've added a unit test TestSliceOfMapsUnmarshal which verifies that numeric values in maps within slices are correctly converted to strings during unmarshalling. The test creates a configuration that mimics the scenario described in the issue and confirms that the unmarshalling process works as expected.


#### Documentation 

No documentation changes were needed as this is a bug fix for existing functionality.