### PR TITLE
Proposed "snappy" vs "x-snappy-framed" content-type confusion

### DIFF
--- a/.chloggen/snappy-done-right.yaml
+++ b/.chloggen/snappy-done-right.yaml
@@ -1,0 +1,37 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix handling of `snappy` content-encoding in a backwards-compatible way"
+
+# One or more tracking issues or pull requests related to the change
+issues: [10584, 12825]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The collector used the Snappy compression type of "framed" to handle the HTTP
+  content-encoding "snappy".  However, this encoding is typically used to indicate
+  the "block" compression variant of "snappy".  This change allows the collector to:
+  - The server endpoints will now accept "x-snappy-framed" as a valid
+    content-encoding.
+  - Client compression type "snappy" will now compress to the "block" variant of snappy
+    instead of "framed".  If you want the old behavior, you can set the
+    compression type to "x-snappy-framed".
+  - When a server endpoint receives a content-encoding of "snappy", it will
+    look at the first bytes of the payload to determine if it is "framed" or "block" snappy,
+    and will decompress accordingly.  This is a backwards-compatible change.
+  - In a future release, this checking behavior may be removed.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/config/configcompression/compressiontype.go
+++ b/config/configcompression/compressiontype.go
@@ -22,6 +22,7 @@ const (
 	TypeZlib                Type = "zlib"
 	TypeDeflate             Type = "deflate"
 	TypeSnappy              Type = "snappy"
+	TypeSnappyFramed        Type = "x-snappy-framed"
 	TypeZstd                Type = "zstd"
 	TypeLz4                 Type = "lz4"
 	typeNone                Type = "none"
@@ -41,6 +42,7 @@ func (ct *Type) UnmarshalText(in []byte) error {
 		typ == TypeZlib ||
 		typ == TypeDeflate ||
 		typ == TypeSnappy ||
+		typ == TypeSnappyFramed ||
 		typ == TypeZstd ||
 		typ == TypeLz4 ||
 		typ == typeNone ||

--- a/config/configcompression/compressiontype_test.go
+++ b/config/configcompression/compressiontype_test.go
@@ -43,6 +43,12 @@ func TestUnmarshalText(t *testing.T) {
 			isCompressed:    true,
 		},
 		{
+			name:            "ValidSnappyFramed",
+			compressionName: []byte("x-snappy-framed"),
+			shouldError:     false,
+			isCompressed:    true,
+		},
+		{
 			name:            "ValidZstd",
 			compressionName: []byte("zstd"),
 			shouldError:     false,
@@ -125,6 +131,17 @@ func TestValidateParams(t *testing.T) {
 		{
 			name:             "InvalidSnappy",
 			compressionName:  []byte("snappy"),
+			compressionLevel: 1,
+			shouldError:      true,
+		},
+		{
+			name:            "ValidSnappyFramed",
+			compressionName: []byte("x-snappy-framed"),
+			shouldError:     false,
+		},
+		{
+			name:             "InvalidSnappyFramed",
+			compressionName:  []byte("x-snappy-framed"),
 			compressionLevel: 1,
 			shouldError:      true,
 		},

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,7 +45,7 @@ func snappyHandler(body io.ReadCloser) (io.ReadCloser, error) {
 	br := bufio.NewReader(body)
 
 	peekBytes, err := br.Peek(len(snappyFramingHeader))
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -55,17 +55,16 @@ func snappyHandler(body io.ReadCloser) (io.ReadCloser, error) {
 			Reader: snappy.NewReader(br),
 			orig:   body,
 		}, nil
-	} else {
-		compressed, err := io.ReadAll(br)
-		if err != nil {
-			return nil, err
-		}
-		decoded, err := snappy.Decode(nil, compressed)
-		if err != nil {
-			return nil, err
-		}
-		return io.NopCloser(bytes.NewReader(decoded)), nil
 	}
+	compressed, err := io.ReadAll(br)
+	if err != nil {
+		return nil, err
+	}
+	decoded, err := snappy.Decode(nil, compressed)
+	if err != nil {
+		return nil, err
+	}
+	return io.NopCloser(bytes.NewReader(decoded)), nil
 }
 
 var availableDecoders = map[string]func(body io.ReadCloser) (io.ReadCloser, error){

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -277,6 +277,12 @@ func TestHTTPContentDecompressionHandler(t *testing.T) {
 			respCode: http.StatusOK,
 		},
 		{
+			name:     "ValidSnappyFramedAsSnappy",
+			encoding: "snappy",
+			reqBody:  compressSnappyFramed(t, testBody),
+			respCode: http.StatusOK,
+		},
+		{
 			name:     "ValidLz4",
 			encoding: "lz4",
 			reqBody:  compressLz4(t, testBody),

--- a/config/confighttp/compressor.go
+++ b/config/confighttp/compressor.go
@@ -66,9 +66,13 @@ func newWriteCloserResetFunc(compressionType configcompression.Type, compression
 			w, _ := gzip.NewWriterLevel(nil, int(compressionParams.Level))
 			return w
 		}, nil
-	case configcompression.TypeSnappy:
+	case configcompression.TypeSnappyFramed:
 		return func() writeCloserReset {
 			return snappy.NewBufferedWriter(nil)
+		}, nil
+	case configcompression.TypeSnappy:
+		return func() writeCloserReset {
+			return &rawSnappyWriter{}
 		}, nil
 	case configcompression.TypeZstd:
 		level := zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(int(compressionParams.Level)))
@@ -110,4 +114,38 @@ func (p *compressor) compress(buf *bytes.Buffer, body io.ReadCloser) error {
 	}
 
 	return writer.Close()
+}
+
+// rawSnappyWriter buffers all writes and, on Close,
+// compresses the data as a raw snappy block (non-framed)
+// and writes the compressed bytes to the underlying writer.
+type rawSnappyWriter struct {
+	buffer bytes.Buffer
+	w      io.Writer
+	closed bool
+}
+
+// Write buffers the data.
+func (w *rawSnappyWriter) Write(p []byte) (int, error) {
+	return w.buffer.Write(p)
+}
+
+// Close compresses the buffered data in one shot using snappy.Encode,
+// writes the compressed block to the underlying writer, and marks the writer as closed.
+func (w *rawSnappyWriter) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	// Compress the buffered uncompressed bytes.
+	compressed := snappy.Encode(nil, w.buffer.Bytes())
+	_, err := w.w.Write(compressed)
+	return err
+}
+
+// Reset sets a new underlying writer, resets the buffer and the closed flag.
+func (w *rawSnappyWriter) Reset(newWriter io.Writer) {
+	w.buffer.Reset()
+	w.w = newWriter
+	w.closed = false
 }

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -37,7 +37,7 @@ const (
 	defaultMaxRequestBodySize = 20 * 1024 * 1024 // 20MiB
 )
 
-var defaultCompressionAlgorithms = []string{"", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"}
+var defaultCompressionAlgorithms = []string{"", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4", "x-snappy-framed"}
 
 // ClientConfig defines settings for creating an HTTP client.
 type ClientConfig struct {


### PR DESCRIPTION
#### Description

The collector http compression and decompression logic uses "snappy" incorrectly.  The content-type "snappy" should be the block ("non-framed") version, while "x-snappy-framed" should be the framed one.  Unfortunately, the collector code used framed compression and decompression and called it "snappy."

This corrects this in two ways:

* Add `x-snappy-framed` as a content-type for both incoming and outgoing compression.
* Add a (hopefully temporary) hack that will, when decompressing content-type "snappy", peek into the data, and see if the 10 byte snappy-framed header is present.  If it is, uncompress it using framed, otherwise use the block decompression.

In contrast to other proposals in the linked issue, this feels like a clean path forward as warnings about using "snappy" in the docs can be added, and people can either not change (in which case it will just start working using the block format) or change, in which case it will use framed.

#### Link to tracking issue
Fixes #10584 by providing a way forward

#### Testing
* Test correct and incorrect configuration of both "snappy" and "x-snappy-framed" content-types.
* Add a test for content-type "snappy" but framed data.

