### PR TITLE
[chore]: remove testifylint-fix target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,6 @@ gotest-with-cover:
 gotest-with-junit:
 	@$(MAKE) for-all-target TARGET="test-with-junit"
 
-.PHONY: gotestifylint-fix
-gotestifylint-fix:
-	$(MAKE) for-all-target TARGET="testifylint-fix"
-
 .PHONY: goporto
 goporto: $(PORTO)
 	$(PORTO) -w --include-internal --skip-dirs "^cmd/mdatagen/third_party$$" ./


### PR DESCRIPTION
#### Description

golangci-lint is now able to apply suggested fixes from testifylint with golangci-lint --fix .
This PR removes testifylint-fix target from Makefile.