### PR TITLE
[chore]: clean up golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,6 +90,12 @@ linters:
         # See https://github.com/open-telemetry/opentelemetry-collector/issues/2789
         - fieldalignment
       enable-all: true
+      printf: # analyzer name, run `go tool vet help` to see all analyzers 
+        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
+          - Infof
+          - Warnf
+          - Errorf
+          - Fatalf
 
     misspell:
       # Correct spellings using locale preferences for US or UK.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,8 +90,9 @@ linters:
         # See https://github.com/open-telemetry/opentelemetry-collector/issues/2789
         - fieldalignment
       enable-all: true
+      # settings per analyzer
       settings:
-        printf: # analyzer name, run `go tool vet help` to see all analyzers 
+        printf: # analyzer name, run `go tool vet help` to see all analyzers
           funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
             - Infof
             - Warnf

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,12 +90,13 @@ linters:
         # See https://github.com/open-telemetry/opentelemetry-collector/issues/2789
         - fieldalignment
       enable-all: true
-      printf: # analyzer name, run `go tool vet help` to see all analyzers 
-        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
-          - Infof
-          - Warnf
-          - Errorf
-          - Fatalf
+      settings:
+        printf: # analyzer name, run `go tool vet help` to see all analyzers 
+          funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
+            - Infof
+            - Warnf
+            - Errorf
+            - Fatalf
 
     misspell:
       # Correct spellings using locale preferences for US or UK.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,14 +90,6 @@ linters:
         # See https://github.com/open-telemetry/opentelemetry-collector/issues/2789
         - fieldalignment
       enable-all: true
-      # settings per analyzer
-      settings:
-        printf: # analyzer name, run `go tool vet help` to see all analyzers
-          funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
-            - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Infof
-            - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Warnf
-            - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Errorf
-            - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Fatalf
 
     misspell:
       # Correct spellings using locale preferences for US or UK.
@@ -185,8 +177,6 @@ linters:
         - -ST1022
 
     testifylint:
-      disable:
-        - useless-assert # FIXME when golangci-lint > 2.0.2
       enable-all: true
 
     thelper:


### PR DESCRIPTION
#### Description

Remove exclusion of useless-assert rule from testifylint. 
Also removes golangci-lint config that does not apply