### PR TITLE
Implement a merge freeze when an "[chore] Update core dependencies" PR on opentelemetry-collector-contrib is present

### DIFF
--- a/.github/workflows/scripts/check-merge-freeze.sh
+++ b/.github/workflows/scripts/check-merge-freeze.sh
@@ -3,9 +3,18 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# Check for [chore] Prepare release PRs in core repo
 BLOCKERS=$( gh pr list -A opentelemetrybot -S "[chore] Prepare release" --json url -q '.[].url' -R "${REPO}" )
+
+# Check for [chore] Update core dependencies PRs in opentelemetry-collector-contrib
+CONTRIB_REPO="open-telemetry/opentelemetry-collector-contrib"
+CONTRIB_BLOCKERS=$( gh pr list -A opentelemetrybot -S "[chore] Update core dependencies" --json url -q '.[].url' -R "${CONTRIB_REPO}" )
+
+# Combine both blockers
+BLOCKERS="${BLOCKERS}${BLOCKERS:+ }${CONTRIB_BLOCKERS}"
+
 if [ "${BLOCKERS}" != "" ]; then
-    echo "Merging in main is frozen, as there are open \"Prepare release\" PRs: ${BLOCKERS}"
+    echo "Merging in main is frozen, as there are open release/update PRs: ${BLOCKERS}"
     echo "If you believe this is no longer true, re-run this job to unblock your PR."
     exit 1
 fi


### PR DESCRIPTION

#### Description
Extend the merge freeze logic in `.github/workflows/scripts/check-merge-freeze.sh` to include open PRs titled "[chore] Update core dependencies" in the `opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib` repository, in addition to the existing check for "[chore] Prepare release" PRs in the core repo.

This ensures that no PRs can be merged into `main` while a core update PR is pending in contrib, helping us avoid version drift and keep dependencies aligned between core and contrib.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/12830

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tested locally by:

- Opening a dummy "[chore] Update core dependencies" PR on `opentelemetry-collector-contrib`
- Running the updated `check-merge-freeze.sh` script to confirm it correctly blocks merges
- Verified output message includes the contrib PR URL when such a PR is open
<!--Describe the documentation added.-->
#### Documentation
No user-facing documentation changes needed. This change only affects internal CI logic.
<!--Please delete paragraphs that you did not use before submitting.-->
