### PR TITLE
[confmap] **Discussion** Identify string field type and set the expanded value accordingly

### DIFF
--- a/.chloggen/ExpandedValueType.yaml
+++ b/.chloggen/ExpandedValueType.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Identify string field type and set the expanded value accordingly. Also handle fields of type pointer to a string. This addresses an issue where an expanded config contains a map or slice of type struct.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12793]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]


### PR DESCRIPTION
#### Description
##### Note: This PR is for discussion as I might be missing something obvious in how the type identification works in confmap. If code owner agreed with the Issue identified and the PR is accepted, I will need to push more changes to cleanup unused code.

Issue:
If you have a config that contains a slice/map of type struct and one of the fields in that struct is an env variable which is set to a numerical value, the collector will fail to start with 

````
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
error decoding 'extensions': error reading configuration for "headers_setter": decoding failed due to the following error(s):
'headers[0].default_value' expected type 'string', got unconvertible type 'int', value: '12345'
````
The existing  `isStringyStructure` does not handle structs which causes the first call made to `useExpandValue` to sanitize "ALL" data input and use the parsed value. 

After looking into mapstructure code, I have noticed that the `useExpandValue` is called on every sub config with the associated data https://github.com/go-viper/mapstructure/blame/main/mapstructure.go#L514-L546 
This made me wonder why the extra logic to check the whole structure is needed and that the first block of `useExpandValue` `if exp, ok := data.(expandedValue); ok {` should do the job.

#### Link to tracking issue
I have removed the extra structure type check and some and fixed the string pointer edge case.
Added an extra unit test that exposes the issue at hand.

#### Testing
Added a unit test and ran a bunch of manual tests 

