### PR TITLE
Fix 'otelcol.component.kind' value capitalization

### DIFF
--- a/.chloggen/fix-attribute-cap.yaml
+++ b/.chloggen/fix-attribute-cap.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Lowercase values for 'otelcol.component.kind' attributes.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12865]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/service/internal/attribute/attribute.go
+++ b/service/internal/attribute/attribute.go
@@ -5,6 +5,7 @@ package attribute // import "go.opentelemetry.io/collector/service/internal/attr
 
 import (
 	"hash/fnv"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -44,7 +45,7 @@ func (a Attributes) ID() int64 {
 
 func Receiver(pipelineType pipeline.Signal, id component.ID) Attributes {
 	return newAttributes(
-		attribute.String(componentattribute.ComponentKindKey, component.KindReceiver.String()),
+		attribute.String(componentattribute.ComponentKindKey, strings.ToLower(component.KindReceiver.String())),
 		attribute.String(componentattribute.SignalKey, pipelineType.String()),
 		attribute.String(componentattribute.ComponentIDKey, id.String()),
 	)
@@ -52,7 +53,7 @@ func Receiver(pipelineType pipeline.Signal, id component.ID) Attributes {
 
 func Processor(pipelineID pipeline.ID, id component.ID) Attributes {
 	return newAttributes(
-		attribute.String(componentattribute.ComponentKindKey, component.KindProcessor.String()),
+		attribute.String(componentattribute.ComponentKindKey, strings.ToLower(component.KindProcessor.String())),
 		attribute.String(componentattribute.SignalKey, pipelineID.Signal().String()),
 		attribute.String(componentattribute.PipelineIDKey, pipelineID.String()),
 		attribute.String(componentattribute.ComponentIDKey, id.String()),
@@ -61,7 +62,7 @@ func Processor(pipelineID pipeline.ID, id component.ID) Attributes {
 
 func Exporter(pipelineType pipeline.Signal, id component.ID) Attributes {
 	return newAttributes(
-		attribute.String(componentattribute.ComponentKindKey, component.KindExporter.String()),
+		attribute.String(componentattribute.ComponentKindKey, strings.ToLower(component.KindExporter.String())),
 		attribute.String(componentattribute.SignalKey, pipelineType.String()),
 		attribute.String(componentattribute.ComponentIDKey, id.String()),
 	)
@@ -69,7 +70,7 @@ func Exporter(pipelineType pipeline.Signal, id component.ID) Attributes {
 
 func Connector(exprPipelineType, rcvrPipelineType pipeline.Signal, id component.ID) Attributes {
 	return newAttributes(
-		attribute.String(componentattribute.ComponentKindKey, component.KindConnector.String()),
+		attribute.String(componentattribute.ComponentKindKey, strings.ToLower(component.KindConnector.String())),
 		attribute.String(componentattribute.SignalKey, exprPipelineType.String()),
 		attribute.String(componentattribute.SignalOutputKey, rcvrPipelineType.String()),
 		attribute.String(componentattribute.ComponentIDKey, id.String()),
@@ -78,7 +79,7 @@ func Connector(exprPipelineType, rcvrPipelineType pipeline.Signal, id component.
 
 func Extension(id component.ID) Attributes {
 	return newAttributes(
-		attribute.String(componentattribute.ComponentKindKey, component.KindExtension.String()),
+		attribute.String(componentattribute.ComponentKindKey, strings.ToLower(component.KindExtension.String())),
 		attribute.String(componentattribute.ComponentIDKey, id.String()),
 	)
 }

--- a/service/internal/attribute/attribute_test.go
+++ b/service/internal/attribute/attribute_test.go
@@ -47,7 +47,7 @@ func TestReceiver(t *testing.T) {
 			r := attribute.Receiver(sig, id)
 			componentKind, ok := r.Set().Value(componentattribute.ComponentKindKey)
 			require.True(t, ok)
-			require.Equal(t, component.KindReceiver.String(), componentKind.AsString())
+			require.Equal(t, "receiver", componentKind.AsString())
 
 			signal, ok := r.Set().Value(componentattribute.SignalKey)
 			require.True(t, ok)
@@ -66,7 +66,7 @@ func TestProcessor(t *testing.T) {
 			p := attribute.Processor(pID, id)
 			componentKind, ok := p.Set().Value(componentattribute.ComponentKindKey)
 			require.True(t, ok)
-			require.Equal(t, component.KindProcessor.String(), componentKind.AsString())
+			require.Equal(t, "processor", componentKind.AsString())
 
 			pipelineID, ok := p.Set().Value(componentattribute.PipelineIDKey)
 			require.True(t, ok)
@@ -85,7 +85,7 @@ func TestExporter(t *testing.T) {
 			e := attribute.Exporter(sig, id)
 			componentKind, ok := e.Set().Value(componentattribute.ComponentKindKey)
 			require.True(t, ok)
-			require.Equal(t, component.KindExporter.String(), componentKind.AsString())
+			require.Equal(t, "exporter", componentKind.AsString())
 
 			signal, ok := e.Set().Value(componentattribute.SignalKey)
 			require.True(t, ok)
@@ -105,7 +105,7 @@ func TestConnector(t *testing.T) {
 				c := attribute.Connector(exprSig, rcvrSig, id)
 				componentKind, ok := c.Set().Value(componentattribute.ComponentKindKey)
 				require.True(t, ok)
-				require.Equal(t, component.KindConnector.String(), componentKind.AsString())
+				require.Equal(t, "connector", componentKind.AsString())
 
 				signal, ok := c.Set().Value(componentattribute.SignalKey)
 				require.True(t, ok)
@@ -127,7 +127,7 @@ func TestExtension(t *testing.T) {
 	e := attribute.Extension(component.MustNewID("foo"))
 	componentKind, ok := e.Set().Value(componentattribute.ComponentKindKey)
 	require.True(t, ok)
-	require.Equal(t, component.KindExtension.String(), componentKind.AsString())
+	require.Equal(t, "extension", componentKind.AsString())
 }
 
 func TestSetEquality(t *testing.T) {

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -2231,11 +2231,11 @@ func TestGraphBuildErrors(t *testing.T) {
 				},
 			},
 			expected: `cycle detected: ` +
-				`connector "nop/conn" (traces to traces) -> ` +
-				`processor "nop" in pipeline "traces/1" -> ` +
 				`connector "nop/conn1" (traces to traces) -> ` +
 				`processor "nop" in pipeline "traces/2" -> ` +
-				`connector "nop/conn" (traces to traces)`,
+				`connector "nop/conn" (traces to traces) -> ` +
+				`processor "nop" in pipeline "traces/1" -> ` +
+				`connector "nop/conn1" (traces to traces)`,
 		},
 		{
 			name: "not_allowed_deep_cycle_metrics.yaml",
@@ -2321,11 +2321,11 @@ func TestGraphBuildErrors(t *testing.T) {
 				},
 			},
 			expected: `cycle detected: ` +
-				`connector "nop/conn1" (logs to logs) -> ` +
-				`processor "nop" in pipeline "logs/2" -> ` +
 				`connector "nop/conn" (logs to logs) -> ` +
 				`processor "nop" in pipeline "logs/1" -> ` +
-				`connector "nop/conn1" (logs to logs)`,
+				`connector "nop/conn1" (logs to logs) -> ` +
+				`processor "nop" in pipeline "logs/2" -> ` +
+				`connector "nop/conn" (logs to logs)`,
 		},
 		{
 			name: "not_allowed_deep_cycle_profiles.yaml",


### PR DESCRIPTION
This brings capitalization in line with the attributes defined in the [Pipeline Component Telemetry](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md#attributes) RFC.