### PR TITLE
[chore][confmap] Add tests for handling of slices

### DIFF
--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -689,6 +689,59 @@ func TestZeroSliceHookFunc(t *testing.T) {
 	}
 }
 
+// Tests for issue that happened in https://github.com/open-telemetry/opentelemetry-collector/issues/12661.
+func TestStructValuesReplaced(t *testing.T) {
+	type S struct {
+		A string `mapstructure:"A,omitempty"`
+		B string `mapstructure:"B,omitempty"`
+	}
+
+	type structWithSlices struct {
+		Structs []S `mapstructure:"structs"`
+	}
+
+	slicesStruct := structWithSlices{
+		Structs: []S{
+			{A: "A"},
+		},
+	}
+
+	bCfg := map[string]any{
+		"structs": []any{
+			map[string]any{
+				"B": "B",
+			},
+		},
+	}
+	bConf := NewFromStringMap(bCfg)
+	err := bConf.Unmarshal(&slicesStruct)
+	require.NoError(t, err)
+
+	assert.Equal(t, []S{{B: "B"}}, slicesStruct.Structs)
+}
+
+func TestNilValuesUnchanged(t *testing.T) {
+	type structWithSlices struct {
+		Strings []string `mapstructure:"strings"`
+	}
+
+	slicesStruct := &structWithSlices{}
+
+	nilCfg := map[string]any{
+		"strings": []any(nil),
+	}
+	nilConf := NewFromStringMap(nilCfg)
+	err := nilConf.Unmarshal(slicesStruct)
+	require.NoError(t, err)
+
+	confFromStruct := New()
+	err = confFromStruct.Marshal(slicesStruct)
+	require.NoError(t, err)
+
+	require.Equal(t, nilCfg, nilConf.ToStringMap())
+	require.Equal(t, confFromStruct.ToStringMap(), nilConf.ToStringMap())
+}
+
 type c struct {
 	Modifiers []string `mapstructure:"modifiers"`
 }

--- a/faulty_config.yaml
+++ b/faulty_config.yaml
@@ -1,0 +1,18 @@
+receivers:
+  nop:
+exporters:
+  nop:
+service:
+  pipelines:
+    logs:
+      receivers: [nop]
+      processors: []
+      exporters: [nop]
+  telemetry:
+    metrics:
+      readers:
+        - periodic:
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: https://backend:4318


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Adds a test for #12661 and another test present on #11882.

I verified that the first test fails in v0.123.0: on this version the slice has `[]S{A: "A", B: "B"}` instead.
