### PR TITLE
[confmap] Correctly distinguish between empty and nil slices

### DIFF
--- a/.chloggen/mx-psi_nil-empty-slices.yaml
+++ b/.chloggen/mx-psi_nil-empty-slices.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Maintain nil values when marshaling or unmarshaling nil slices
+
+# One or more tracking issues or pull requests related to the change
+issues: [11882]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, nil slices were converted to empty lists, which are semantically different
+  than a nil slice. This change makes this conversion more consistent when encoding
+  or decoding config, and these values are now maintained.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -140,7 +140,12 @@ func sanitizeExpanded(a any, useOriginal bool) any {
 		}
 		return c
 	case []any:
+		// If the value is nil, return nil.
 		var newSlice []any
+		if m == nil {
+			return newSlice
+		}
+		newSlice = make([]any, 0, len(m))
 		for _, e := range m {
 			newSlice = append(newSlice, sanitizeExpanded(e, useOriginal))
 		}
@@ -555,7 +560,13 @@ type Marshaler interface {
 func zeroSliceHookFunc() mapstructure.DecodeHookFuncValue {
 	return func(from reflect.Value, to reflect.Value) (any, error) {
 		if to.CanSet() && to.Kind() == reflect.Slice && from.Kind() == reflect.Slice {
-			to.Set(reflect.MakeSlice(to.Type(), from.Len(), from.Cap()))
+			if from.IsNil() {
+				// input slice is nil, set output slice to nil.
+				to.Set(reflect.Zero(to.Type()))
+			} else {
+				// input slice is not nil, set the output slice to a new slice of the same type.
+				to.Set(reflect.MakeSlice(to.Type(), from.Len(), from.Cap()))
+			}
 		}
 
 		return from.Interface(), nil

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -731,6 +731,28 @@ func TestNilValuesUnchanged(t *testing.T) {
 		"strings": []any(nil),
 	}
 	nilConf := NewFromStringMap(nilCfg)
+	require.Equal(t, nilCfg, nilConf.ToStringMap())
+	err := nilConf.Unmarshal(slicesStruct)
+	require.NoError(t, err)
+
+	confFromStruct := New()
+	err = confFromStruct.Marshal(slicesStruct)
+	require.NoError(t, err)
+
+	require.Equal(t, confFromStruct.ToStringMap(), nilConf.ToStringMap())
+}
+
+func TestEmptySliceUnchanged(t *testing.T) {
+	type structWithSlices struct {
+		Strings []string `mapstructure:"strings"`
+	}
+
+	slicesStruct := &structWithSlices{}
+
+	nilCfg := map[string]any{
+		"strings": []any{},
+	}
+	nilConf := NewFromStringMap(nilCfg)
 	err := nilConf.Unmarshal(slicesStruct)
 	require.NoError(t, err)
 
@@ -739,7 +761,7 @@ func TestNilValuesUnchanged(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, nilCfg, nilConf.ToStringMap())
-	require.Equal(t, confFromStruct.ToStringMap(), nilConf.ToStringMap())
+	require.EqualValues(t, nilConf.ToStringMap(), confFromStruct.ToStringMap())
 }
 
 type c struct {

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -761,7 +761,7 @@ func TestEmptySliceUnchanged(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, nilCfg, nilConf.ToStringMap())
-	require.EqualValues(t, nilConf.ToStringMap(), confFromStruct.ToStringMap())
+	require.Equal(t, nilConf.ToStringMap(), confFromStruct.ToStringMap())
 }
 
 type c struct {

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -731,7 +731,6 @@ func TestNilValuesUnchanged(t *testing.T) {
 		"strings": []any(nil),
 	}
 	nilConf := NewFromStringMap(nilCfg)
-	require.Equal(t, nilCfg, nilConf.ToStringMap())
 	err := nilConf.Unmarshal(slicesStruct)
 	require.NoError(t, err)
 
@@ -739,6 +738,7 @@ func TestNilValuesUnchanged(t *testing.T) {
 	err = confFromStruct.Marshal(slicesStruct)
 	require.NoError(t, err)
 
+	require.Equal(t, nilCfg, nilConf.ToStringMap())
 	require.Equal(t, confFromStruct.ToStringMap(), nilConf.ToStringMap())
 }
 

--- a/confmap/confmaptest/configtest_test.go
+++ b/confmap/confmaptest/configtest_test.go
@@ -33,8 +33,7 @@ func TestLoadConf(t *testing.T) {
 func TestToStringMapSanitizeEmptySlice(t *testing.T) {
 	cfg, err := LoadConf(filepath.Join("testdata", "empty-slice.yaml"))
 	require.NoError(t, err)
-	var nilSlice []any
-	assert.Equal(t, map[string]any{"slice": nilSlice}, cfg.ToStringMap())
+	assert.Equal(t, map[string]any{"slice": []any{}}, cfg.ToStringMap())
 }
 
 func TestValidateProviderScheme(t *testing.T) {

--- a/confmap/internal/mapstructure/encoder.go
+++ b/confmap/internal/mapstructure/encoder.go
@@ -141,6 +141,11 @@ func (e *Encoder) encodeSlice(value reflect.Value) (any, error) {
 			Kind:   value.Kind(),
 		}
 	}
+
+	if value.IsNil() {
+		return []any(nil), nil
+	}
+
 	result := make([]any, value.Len())
 	for i := 0; i < value.Len(); i++ {
 		var err error

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -124,7 +124,7 @@ func TestConfmapMarshalConfig(t *testing.T) {
 									"host": "localhost",
 									"port": 8888,
 									"with_resource_constant_labels": map[string]any{
-										"included": []any(nil),
+										"included": []any{},
 									},
 									"without_scope_info":  true,
 									"without_type_suffix": true,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

A second attempt at #11882.

Note that I added some tests in #12871 to prevent something like #12661 from happening again.

#### Link to tracking issue
Fixes #11749

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->

See tests from #12871 as well as the new tests added here.
