### PR TITLE
Use Err prefix for always return error implementation

### DIFF
--- a/.chloggen/use-err.yaml
+++ b/.chloggen/use-err.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: extensionauthtest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate NewErrorClient in favor of NewErrClient.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12874]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -455,7 +455,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			shouldErr: true,
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
-					mockID: extensionauthtest.NewErrorClient(errors.New("error")),
+					mockID: extensionauthtest.NewErr(errors.New("error")),
 				},
 			},
 		},

--- a/extension/extensionauth/extensionauthtest/err_test.go
+++ b/extension/extensionauth/extensionauthtest/err_test.go
@@ -4,6 +4,7 @@
 package extensionauthtest
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -13,7 +14,7 @@ import (
 )
 
 func TestErrorClient(t *testing.T) {
-	client := NewErrorClient(errors.New("error"))
+	client := NewErr(errors.New("error"))
 
 	httpClient, ok := client.(extensionauth.HTTPClient)
 	require.True(t, ok)
@@ -23,5 +24,10 @@ func TestErrorClient(t *testing.T) {
 	grpcClient, ok := client.(extensionauth.GRPCClient)
 	require.True(t, ok)
 	_, err = grpcClient.PerRPCCredentials()
+	require.Error(t, err)
+
+	server, ok := client.(extensionauth.Server)
+	require.True(t, ok)
+	_, err = server.Authenticate(context.Background(), map[string][]string{})
 	require.Error(t, err)
 }


### PR DESCRIPTION
Make this package consistent with a way more used package https://github.com/open-telemetry/opentelemetry-collector/blob/main/consumer/consumertest/err.go#L15