### PR TITLE
Fix MoveTo when moving to the same destination

### DIFF
--- a/.chloggen/fix-moveto.yaml
+++ b/.chloggen/fix-moveto.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix MoveTo when moving to the same destination
+
+# One or more tracking issues or pull requests related to the change
+issues: [12887]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pdata/internal/cmd/pdatagen/internal/templates/message.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/message.go.tmpl
@@ -50,6 +50,10 @@ func New{{ .structName }}() {{ .structName }} {
 func (ms {{ .structName }}) MoveTo(dest {{ .structName }}) {
 	ms.{{ .stateAccessor }}.AssertMutable()
 	dest.{{ .stateAccessor }}.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.{{ .origAccessor }} == dest.{{ .origAccessor }} {
+		return
+	}
 	*dest.{{ .origAccessor }} = *ms.{{ .origAccessor }}
 	*ms.{{ .origAccessor }} = {{ .originName }}{}
 }

--- a/pdata/internal/cmd/pdatagen/internal/templates/message_test.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/message_test.go.tmpl
@@ -18,6 +18,8 @@ func Test{{ .structName }}_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, New{{ .structName }}(), ms)
 	assert.Equal(t, generateTest{{ .structName }}(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTest{{ .structName }}(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(new{{ .structName }}(&{{ .originName }}{}, &sharedState)) })
 	assert.Panics(t, func() { new{{ .structName }}(&{{ .originName }}{}, &sharedState).MoveTo(dest) })

--- a/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice.go.tmpl
@@ -105,6 +105,10 @@ func (ms {{ .structName }}) Append(elms ...{{ .itemType }}) {
 func (ms {{ .structName }}) MoveTo(dest {{ .structName }}) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = nil
 }

--- a/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice_test.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice_test.go.tmpl
@@ -65,6 +65,13 @@ func TestNew{{ .structName }}(t *testing.T) {
 	{{- else }}
 	assert.Equal(t, {{ .itemType }}({{index .testInterfaceOrigVal 0 }}), mv.At(0))
 	{{- end }}
+	mv.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	{{- if eq .itemType "float64" }}
+	assert.InDelta(t, {{ .itemType }}({{index .testInterfaceOrigVal 0 }}), mv.At(0), 0.01)
+	{{- else }}
+	assert.Equal(t, {{ .itemType }}({{index .testInterfaceOrigVal 0 }}), mv.At(0))
+	{{- end }}
 }
 
 func Test{{ .structName }}ReadOnly(t *testing.T) {

--- a/pdata/internal/cmd/pdatagen/internal/templates/slice.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/slice.go.tmpl
@@ -113,6 +113,10 @@ func (es {{ .structName }}) AppendEmpty() {{ .elementName }} {
 func (es {{ .structName }}) MoveAndAppendTo(dest {{ .structName }}) {
 	es.{{ .stateAccessor }}.AssertMutable()
 	dest.{{ .stateAccessor }}.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.{{ .origAccessor }} == dest.{{ .origAccessor }} {
+		return
+	}
 	if *dest.{{ .origAccessor }} == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.{{ .origAccessor }} = *es.{{ .origAccessor }}

--- a/pdata/internal/cmd/pdatagen/internal/templates/slice_test.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/slice_test.go.tmpl
@@ -107,6 +107,13 @@ func Test{{ .structName }}_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func Test{{ .structName }}_RemoveIf(t *testing.T) {

--- a/pdata/pcommon/generated_byteslice.go
+++ b/pdata/pcommon/generated_byteslice.go
@@ -106,6 +106,10 @@ func (ms ByteSlice) Append(elms ...byte) {
 func (ms ByteSlice) MoveTo(dest ByteSlice) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = nil
 }

--- a/pdata/pcommon/generated_byteslice_test.go
+++ b/pdata/pcommon/generated_byteslice_test.go
@@ -43,6 +43,9 @@ func TestNewByteSlice(t *testing.T) {
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
 	assert.Equal(t, byte(1), mv.At(0))
+	mv.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.Equal(t, byte(1), mv.At(0))
 }
 
 func TestByteSliceReadOnly(t *testing.T) {

--- a/pdata/pcommon/generated_float64slice.go
+++ b/pdata/pcommon/generated_float64slice.go
@@ -106,6 +106,10 @@ func (ms Float64Slice) Append(elms ...float64) {
 func (ms Float64Slice) MoveTo(dest Float64Slice) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = nil
 }

--- a/pdata/pcommon/generated_float64slice_test.go
+++ b/pdata/pcommon/generated_float64slice_test.go
@@ -43,6 +43,9 @@ func TestNewFloat64Slice(t *testing.T) {
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
 	assert.InDelta(t, float64(1), mv.At(0), 0.01)
+	mv.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.InDelta(t, float64(1), mv.At(0), 0.01)
 }
 
 func TestFloat64SliceReadOnly(t *testing.T) {

--- a/pdata/pcommon/generated_instrumentationscope.go
+++ b/pdata/pcommon/generated_instrumentationscope.go
@@ -38,6 +38,10 @@ func NewInstrumentationScope() InstrumentationScope {
 func (ms InstrumentationScope) MoveTo(dest InstrumentationScope) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = otlpcommon.InstrumentationScope{}
 }

--- a/pdata/pcommon/generated_instrumentationscope_test.go
+++ b/pdata/pcommon/generated_instrumentationscope_test.go
@@ -21,6 +21,8 @@ func TestInstrumentationScope_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewInstrumentationScope(), ms)
 	assert.Equal(t, generateTestInstrumentationScope(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestInstrumentationScope(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newInstrumentationScope(&otlpcommon.InstrumentationScope{}, &sharedState)) })
 	assert.Panics(t, func() { newInstrumentationScope(&otlpcommon.InstrumentationScope{}, &sharedState).MoveTo(dest) })

--- a/pdata/pcommon/generated_int32slice.go
+++ b/pdata/pcommon/generated_int32slice.go
@@ -106,6 +106,10 @@ func (ms Int32Slice) Append(elms ...int32) {
 func (ms Int32Slice) MoveTo(dest Int32Slice) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = nil
 }

--- a/pdata/pcommon/generated_int32slice_test.go
+++ b/pdata/pcommon/generated_int32slice_test.go
@@ -43,6 +43,9 @@ func TestNewInt32Slice(t *testing.T) {
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
 	assert.Equal(t, int32(1), mv.At(0))
+	mv.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.Equal(t, int32(1), mv.At(0))
 }
 
 func TestInt32SliceReadOnly(t *testing.T) {

--- a/pdata/pcommon/generated_int64slice.go
+++ b/pdata/pcommon/generated_int64slice.go
@@ -106,6 +106,10 @@ func (ms Int64Slice) Append(elms ...int64) {
 func (ms Int64Slice) MoveTo(dest Int64Slice) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = nil
 }

--- a/pdata/pcommon/generated_int64slice_test.go
+++ b/pdata/pcommon/generated_int64slice_test.go
@@ -43,6 +43,9 @@ func TestNewInt64Slice(t *testing.T) {
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
 	assert.Equal(t, int64(1), mv.At(0))
+	mv.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.Equal(t, int64(1), mv.At(0))
 }
 
 func TestInt64SliceReadOnly(t *testing.T) {

--- a/pdata/pcommon/generated_resource.go
+++ b/pdata/pcommon/generated_resource.go
@@ -38,6 +38,10 @@ func NewResource() Resource {
 func (ms Resource) MoveTo(dest Resource) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = otlpresource.Resource{}
 }

--- a/pdata/pcommon/generated_resource_test.go
+++ b/pdata/pcommon/generated_resource_test.go
@@ -21,6 +21,8 @@ func TestResource_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewResource(), ms)
 	assert.Equal(t, generateTestResource(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestResource(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newResource(&otlpresource.Resource{}, &sharedState)) })
 	assert.Panics(t, func() { newResource(&otlpresource.Resource{}, &sharedState).MoveTo(dest) })

--- a/pdata/pcommon/generated_stringslice.go
+++ b/pdata/pcommon/generated_stringslice.go
@@ -106,6 +106,10 @@ func (ms StringSlice) Append(elms ...string) {
 func (ms StringSlice) MoveTo(dest StringSlice) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = nil
 }

--- a/pdata/pcommon/generated_stringslice_test.go
+++ b/pdata/pcommon/generated_stringslice_test.go
@@ -43,6 +43,9 @@ func TestNewStringSlice(t *testing.T) {
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
 	assert.Equal(t, string("a"), mv.At(0))
+	mv.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.Equal(t, string("a"), mv.At(0))
 }
 
 func TestStringSliceReadOnly(t *testing.T) {

--- a/pdata/pcommon/generated_uint64slice.go
+++ b/pdata/pcommon/generated_uint64slice.go
@@ -106,6 +106,10 @@ func (ms UInt64Slice) Append(elms ...uint64) {
 func (ms UInt64Slice) MoveTo(dest UInt64Slice) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = nil
 }

--- a/pdata/pcommon/generated_uint64slice_test.go
+++ b/pdata/pcommon/generated_uint64slice_test.go
@@ -43,6 +43,9 @@ func TestNewUInt64Slice(t *testing.T) {
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
 	assert.Equal(t, uint64(1), mv.At(0))
+	mv.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.Equal(t, uint64(1), mv.At(0))
 }
 
 func TestUInt64SliceReadOnly(t *testing.T) {

--- a/pdata/pcommon/map.go
+++ b/pdata/pcommon/map.go
@@ -248,6 +248,10 @@ func (m Map) All() iter.Seq2[string, Value] {
 func (m Map) MoveTo(dest Map) {
 	m.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if m.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *m.getOrig()
 	*m.getOrig() = nil
 }

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -416,6 +416,11 @@ func TestMap_MoveTo(t *testing.T) {
 	// Test MoveTo from empty to non-empty
 	NewMap().MoveTo(dest)
 	assert.Equal(t, 0, dest.Len())
+
+	dest.PutStr("k", "v")
+	dest.MoveTo(dest)
+	assert.Equal(t, 1, dest.Len())
+	assert.Equal(t, map[string]any{"k": "v"}, dest.AsRaw())
 }
 
 func TestMap_CopyTo(t *testing.T) {

--- a/pdata/pcommon/trace_state.go
+++ b/pdata/pcommon/trace_state.go
@@ -42,6 +42,10 @@ func (ms TraceState) FromRaw(v string) {
 func (ms TraceState) MoveTo(dest TraceState) {
 	ms.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = ""
 }

--- a/pdata/pcommon/trace_state_test.go
+++ b/pdata/pcommon/trace_state_test.go
@@ -17,6 +17,9 @@ func TestTraceState_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewTraceState(), ms)
 	assert.Equal(t, TraceState(internal.GenerateTestTraceState()), dest)
+
+	dest.MoveTo(dest)
+	assert.Equal(t, TraceState(internal.GenerateTestTraceState()), dest)
 }
 
 func TestTraceState_CopyTo(t *testing.T) {

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -324,6 +324,10 @@ func (v Value) SetEmptySlice() Slice {
 func (v Value) MoveTo(dest Value) {
 	v.getState().AssertMutable()
 	dest.getState().AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if v.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = *v.getOrig()
 	v.getOrig().Value = nil
 }

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -244,6 +244,9 @@ func TestValue_MoveTo(t *testing.T) {
 	expected := NewValueMap()
 	expected.Map().PutStr("key", "value")
 	assert.True(t, dest.Equal(expected))
+
+	dest.MoveTo(dest)
+	assert.True(t, dest.Equal(expected))
 }
 
 func TestValue_CopyTo(t *testing.T) {

--- a/pdata/plog/generated_logrecord.go
+++ b/pdata/plog/generated_logrecord.go
@@ -43,6 +43,10 @@ func NewLogRecord() LogRecord {
 func (ms LogRecord) MoveTo(dest LogRecord) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlplogs.LogRecord{}
 }

--- a/pdata/plog/generated_logrecord_test.go
+++ b/pdata/plog/generated_logrecord_test.go
@@ -23,6 +23,8 @@ func TestLogRecord_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewLogRecord(), ms)
 	assert.Equal(t, generateTestLogRecord(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestLogRecord(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newLogRecord(&otlplogs.LogRecord{}, &sharedState)) })
 	assert.Panics(t, func() { newLogRecord(&otlplogs.LogRecord{}, &sharedState).MoveTo(dest) })

--- a/pdata/plog/generated_logrecordslice.go
+++ b/pdata/plog/generated_logrecordslice.go
@@ -109,6 +109,10 @@ func (es LogRecordSlice) AppendEmpty() LogRecord {
 func (es LogRecordSlice) MoveAndAppendTo(dest LogRecordSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/plog/generated_logrecordslice_test.go
+++ b/pdata/plog/generated_logrecordslice_test.go
@@ -103,6 +103,13 @@ func TestLogRecordSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestLogRecordSlice_RemoveIf(t *testing.T) {

--- a/pdata/plog/generated_resourcelogs.go
+++ b/pdata/plog/generated_resourcelogs.go
@@ -42,6 +42,10 @@ func NewResourceLogs() ResourceLogs {
 func (ms ResourceLogs) MoveTo(dest ResourceLogs) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlplogs.ResourceLogs{}
 }

--- a/pdata/plog/generated_resourcelogs_test.go
+++ b/pdata/plog/generated_resourcelogs_test.go
@@ -22,6 +22,8 @@ func TestResourceLogs_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewResourceLogs(), ms)
 	assert.Equal(t, generateTestResourceLogs(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestResourceLogs(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newResourceLogs(&otlplogs.ResourceLogs{}, &sharedState)) })
 	assert.Panics(t, func() { newResourceLogs(&otlplogs.ResourceLogs{}, &sharedState).MoveTo(dest) })

--- a/pdata/plog/generated_resourcelogsslice.go
+++ b/pdata/plog/generated_resourcelogsslice.go
@@ -109,6 +109,10 @@ func (es ResourceLogsSlice) AppendEmpty() ResourceLogs {
 func (es ResourceLogsSlice) MoveAndAppendTo(dest ResourceLogsSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/plog/generated_resourcelogsslice_test.go
+++ b/pdata/plog/generated_resourcelogsslice_test.go
@@ -103,6 +103,13 @@ func TestResourceLogsSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestResourceLogsSlice_RemoveIf(t *testing.T) {

--- a/pdata/plog/generated_scopelogs.go
+++ b/pdata/plog/generated_scopelogs.go
@@ -42,6 +42,10 @@ func NewScopeLogs() ScopeLogs {
 func (ms ScopeLogs) MoveTo(dest ScopeLogs) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlplogs.ScopeLogs{}
 }

--- a/pdata/plog/generated_scopelogs_test.go
+++ b/pdata/plog/generated_scopelogs_test.go
@@ -22,6 +22,8 @@ func TestScopeLogs_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewScopeLogs(), ms)
 	assert.Equal(t, generateTestScopeLogs(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestScopeLogs(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newScopeLogs(&otlplogs.ScopeLogs{}, &sharedState)) })
 	assert.Panics(t, func() { newScopeLogs(&otlplogs.ScopeLogs{}, &sharedState).MoveTo(dest) })

--- a/pdata/plog/generated_scopelogsslice.go
+++ b/pdata/plog/generated_scopelogsslice.go
@@ -109,6 +109,10 @@ func (es ScopeLogsSlice) AppendEmpty() ScopeLogs {
 func (es ScopeLogsSlice) MoveAndAppendTo(dest ScopeLogsSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/plog/generated_scopelogsslice_test.go
+++ b/pdata/plog/generated_scopelogsslice_test.go
@@ -103,6 +103,13 @@ func TestScopeLogsSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestScopeLogsSlice_RemoveIf(t *testing.T) {

--- a/pdata/plog/plogotlp/generated_exportpartialsuccess.go
+++ b/pdata/plog/plogotlp/generated_exportpartialsuccess.go
@@ -41,6 +41,10 @@ func NewExportPartialSuccess() ExportPartialSuccess {
 func (ms ExportPartialSuccess) MoveTo(dest ExportPartialSuccess) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpcollectorlog.ExportLogsPartialSuccess{}
 }

--- a/pdata/plog/plogotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/plog/plogotlp/generated_exportpartialsuccess_test.go
@@ -21,6 +21,8 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewExportPartialSuccess(), ms)
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newExportPartialSuccess(&otlpcollectorlog.ExportLogsPartialSuccess{}, &sharedState)) })
 	assert.Panics(t, func() {

--- a/pdata/pmetric/generated_exemplar.go
+++ b/pdata/pmetric/generated_exemplar.go
@@ -46,6 +46,10 @@ func NewExemplar() Exemplar {
 func (ms Exemplar) MoveTo(dest Exemplar) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.Exemplar{}
 }

--- a/pdata/pmetric/generated_exemplar_test.go
+++ b/pdata/pmetric/generated_exemplar_test.go
@@ -23,6 +23,8 @@ func TestExemplar_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewExemplar(), ms)
 	assert.Equal(t, generateTestExemplar(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestExemplar(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newExemplar(&otlpmetrics.Exemplar{}, &sharedState)) })
 	assert.Panics(t, func() { newExemplar(&otlpmetrics.Exemplar{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_exemplarslice.go
+++ b/pdata/pmetric/generated_exemplarslice.go
@@ -108,6 +108,10 @@ func (es ExemplarSlice) AppendEmpty() Exemplar {
 func (es ExemplarSlice) MoveAndAppendTo(dest ExemplarSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pmetric/generated_exemplarslice_test.go
+++ b/pdata/pmetric/generated_exemplarslice_test.go
@@ -102,6 +102,13 @@ func TestExemplarSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestExemplarSlice_RemoveIf(t *testing.T) {

--- a/pdata/pmetric/generated_exponentialhistogram.go
+++ b/pdata/pmetric/generated_exponentialhistogram.go
@@ -42,6 +42,10 @@ func NewExponentialHistogram() ExponentialHistogram {
 func (ms ExponentialHistogram) MoveTo(dest ExponentialHistogram) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.ExponentialHistogram{}
 }

--- a/pdata/pmetric/generated_exponentialhistogram_test.go
+++ b/pdata/pmetric/generated_exponentialhistogram_test.go
@@ -21,6 +21,8 @@ func TestExponentialHistogram_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewExponentialHistogram(), ms)
 	assert.Equal(t, generateTestExponentialHistogram(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestExponentialHistogram(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, &sharedState)) })
 	assert.Panics(t, func() { newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint.go
@@ -45,6 +45,10 @@ func NewExponentialHistogramDataPoint() ExponentialHistogramDataPoint {
 func (ms ExponentialHistogramDataPoint) MoveTo(dest ExponentialHistogramDataPoint) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.ExponentialHistogramDataPoint{}
 }

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
@@ -22,6 +22,8 @@ func TestExponentialHistogramDataPoint_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewExponentialHistogramDataPoint(), ms)
 	assert.Equal(t, generateTestExponentialHistogramDataPoint(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestExponentialHistogramDataPoint(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {
 		ms.MoveTo(newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState))

--- a/pdata/pmetric/generated_exponentialhistogramdatapointbuckets.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointbuckets.go
@@ -42,6 +42,10 @@ func NewExponentialHistogramDataPointBuckets() ExponentialHistogramDataPointBuck
 func (ms ExponentialHistogramDataPointBuckets) MoveTo(dest ExponentialHistogramDataPointBuckets) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.ExponentialHistogramDataPoint_Buckets{}
 }

--- a/pdata/pmetric/generated_exponentialhistogramdatapointbuckets_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointbuckets_test.go
@@ -21,6 +21,8 @@ func TestExponentialHistogramDataPointBuckets_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewExponentialHistogramDataPointBuckets(), ms)
 	assert.Equal(t, generateTestExponentialHistogramDataPointBuckets(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestExponentialHistogramDataPointBuckets(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {
 		ms.MoveTo(newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, &sharedState))

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
@@ -109,6 +109,10 @@ func (es ExponentialHistogramDataPointSlice) AppendEmpty() ExponentialHistogramD
 func (es ExponentialHistogramDataPointSlice) MoveAndAppendTo(dest ExponentialHistogramDataPointSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
@@ -103,6 +103,13 @@ func TestExponentialHistogramDataPointSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestExponentialHistogramDataPointSlice_RemoveIf(t *testing.T) {

--- a/pdata/pmetric/generated_gauge.go
+++ b/pdata/pmetric/generated_gauge.go
@@ -41,6 +41,10 @@ func NewGauge() Gauge {
 func (ms Gauge) MoveTo(dest Gauge) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.Gauge{}
 }

--- a/pdata/pmetric/generated_gauge_test.go
+++ b/pdata/pmetric/generated_gauge_test.go
@@ -21,6 +21,8 @@ func TestGauge_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewGauge(), ms)
 	assert.Equal(t, generateTestGauge(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestGauge(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newGauge(&otlpmetrics.Gauge{}, &sharedState)) })
 	assert.Panics(t, func() { newGauge(&otlpmetrics.Gauge{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_histogram.go
+++ b/pdata/pmetric/generated_histogram.go
@@ -41,6 +41,10 @@ func NewHistogram() Histogram {
 func (ms Histogram) MoveTo(dest Histogram) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.Histogram{}
 }

--- a/pdata/pmetric/generated_histogram_test.go
+++ b/pdata/pmetric/generated_histogram_test.go
@@ -21,6 +21,8 @@ func TestHistogram_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewHistogram(), ms)
 	assert.Equal(t, generateTestHistogram(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestHistogram(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newHistogram(&otlpmetrics.Histogram{}, &sharedState)) })
 	assert.Panics(t, func() { newHistogram(&otlpmetrics.Histogram{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_histogramdatapoint.go
+++ b/pdata/pmetric/generated_histogramdatapoint.go
@@ -42,6 +42,10 @@ func NewHistogramDataPoint() HistogramDataPoint {
 func (ms HistogramDataPoint) MoveTo(dest HistogramDataPoint) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.HistogramDataPoint{}
 }

--- a/pdata/pmetric/generated_histogramdatapoint_test.go
+++ b/pdata/pmetric/generated_histogramdatapoint_test.go
@@ -22,6 +22,8 @@ func TestHistogramDataPoint_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewHistogramDataPoint(), ms)
 	assert.Equal(t, generateTestHistogramDataPoint(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestHistogramDataPoint(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, &sharedState)) })
 	assert.Panics(t, func() { newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_histogramdatapointslice.go
+++ b/pdata/pmetric/generated_histogramdatapointslice.go
@@ -109,6 +109,10 @@ func (es HistogramDataPointSlice) AppendEmpty() HistogramDataPoint {
 func (es HistogramDataPointSlice) MoveAndAppendTo(dest HistogramDataPointSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pmetric/generated_histogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_histogramdatapointslice_test.go
@@ -103,6 +103,13 @@ func TestHistogramDataPointSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestHistogramDataPointSlice_RemoveIf(t *testing.T) {

--- a/pdata/pmetric/generated_metric.go
+++ b/pdata/pmetric/generated_metric.go
@@ -43,6 +43,10 @@ func NewMetric() Metric {
 func (ms Metric) MoveTo(dest Metric) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.Metric{}
 }

--- a/pdata/pmetric/generated_metric_test.go
+++ b/pdata/pmetric/generated_metric_test.go
@@ -22,6 +22,8 @@ func TestMetric_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewMetric(), ms)
 	assert.Equal(t, generateTestMetric(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestMetric(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newMetric(&otlpmetrics.Metric{}, &sharedState)) })
 	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_metricslice.go
+++ b/pdata/pmetric/generated_metricslice.go
@@ -109,6 +109,10 @@ func (es MetricSlice) AppendEmpty() Metric {
 func (es MetricSlice) MoveAndAppendTo(dest MetricSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pmetric/generated_metricslice_test.go
+++ b/pdata/pmetric/generated_metricslice_test.go
@@ -103,6 +103,13 @@ func TestMetricSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestMetricSlice_RemoveIf(t *testing.T) {

--- a/pdata/pmetric/generated_numberdatapoint.go
+++ b/pdata/pmetric/generated_numberdatapoint.go
@@ -42,6 +42,10 @@ func NewNumberDataPoint() NumberDataPoint {
 func (ms NumberDataPoint) MoveTo(dest NumberDataPoint) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.NumberDataPoint{}
 }

--- a/pdata/pmetric/generated_numberdatapoint_test.go
+++ b/pdata/pmetric/generated_numberdatapoint_test.go
@@ -22,6 +22,8 @@ func TestNumberDataPoint_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewNumberDataPoint(), ms)
 	assert.Equal(t, generateTestNumberDataPoint(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestNumberDataPoint(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, &sharedState)) })
 	assert.Panics(t, func() { newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_numberdatapointslice.go
+++ b/pdata/pmetric/generated_numberdatapointslice.go
@@ -109,6 +109,10 @@ func (es NumberDataPointSlice) AppendEmpty() NumberDataPoint {
 func (es NumberDataPointSlice) MoveAndAppendTo(dest NumberDataPointSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pmetric/generated_numberdatapointslice_test.go
+++ b/pdata/pmetric/generated_numberdatapointslice_test.go
@@ -103,6 +103,13 @@ func TestNumberDataPointSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestNumberDataPointSlice_RemoveIf(t *testing.T) {

--- a/pdata/pmetric/generated_resourcemetrics.go
+++ b/pdata/pmetric/generated_resourcemetrics.go
@@ -42,6 +42,10 @@ func NewResourceMetrics() ResourceMetrics {
 func (ms ResourceMetrics) MoveTo(dest ResourceMetrics) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.ResourceMetrics{}
 }

--- a/pdata/pmetric/generated_resourcemetrics_test.go
+++ b/pdata/pmetric/generated_resourcemetrics_test.go
@@ -22,6 +22,8 @@ func TestResourceMetrics_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewResourceMetrics(), ms)
 	assert.Equal(t, generateTestResourceMetrics(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestResourceMetrics(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newResourceMetrics(&otlpmetrics.ResourceMetrics{}, &sharedState)) })
 	assert.Panics(t, func() { newResourceMetrics(&otlpmetrics.ResourceMetrics{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_resourcemetricsslice.go
+++ b/pdata/pmetric/generated_resourcemetricsslice.go
@@ -109,6 +109,10 @@ func (es ResourceMetricsSlice) AppendEmpty() ResourceMetrics {
 func (es ResourceMetricsSlice) MoveAndAppendTo(dest ResourceMetricsSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pmetric/generated_resourcemetricsslice_test.go
+++ b/pdata/pmetric/generated_resourcemetricsslice_test.go
@@ -103,6 +103,13 @@ func TestResourceMetricsSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestResourceMetricsSlice_RemoveIf(t *testing.T) {

--- a/pdata/pmetric/generated_scopemetrics.go
+++ b/pdata/pmetric/generated_scopemetrics.go
@@ -42,6 +42,10 @@ func NewScopeMetrics() ScopeMetrics {
 func (ms ScopeMetrics) MoveTo(dest ScopeMetrics) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.ScopeMetrics{}
 }

--- a/pdata/pmetric/generated_scopemetrics_test.go
+++ b/pdata/pmetric/generated_scopemetrics_test.go
@@ -22,6 +22,8 @@ func TestScopeMetrics_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewScopeMetrics(), ms)
 	assert.Equal(t, generateTestScopeMetrics(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestScopeMetrics(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newScopeMetrics(&otlpmetrics.ScopeMetrics{}, &sharedState)) })
 	assert.Panics(t, func() { newScopeMetrics(&otlpmetrics.ScopeMetrics{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_scopemetricsslice.go
+++ b/pdata/pmetric/generated_scopemetricsslice.go
@@ -109,6 +109,10 @@ func (es ScopeMetricsSlice) AppendEmpty() ScopeMetrics {
 func (es ScopeMetricsSlice) MoveAndAppendTo(dest ScopeMetricsSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pmetric/generated_scopemetricsslice_test.go
+++ b/pdata/pmetric/generated_scopemetricsslice_test.go
@@ -103,6 +103,13 @@ func TestScopeMetricsSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestScopeMetricsSlice_RemoveIf(t *testing.T) {

--- a/pdata/pmetric/generated_sum.go
+++ b/pdata/pmetric/generated_sum.go
@@ -41,6 +41,10 @@ func NewSum() Sum {
 func (ms Sum) MoveTo(dest Sum) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.Sum{}
 }

--- a/pdata/pmetric/generated_sum_test.go
+++ b/pdata/pmetric/generated_sum_test.go
@@ -21,6 +21,8 @@ func TestSum_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewSum(), ms)
 	assert.Equal(t, generateTestSum(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestSum(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newSum(&otlpmetrics.Sum{}, &sharedState)) })
 	assert.Panics(t, func() { newSum(&otlpmetrics.Sum{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_summary.go
+++ b/pdata/pmetric/generated_summary.go
@@ -41,6 +41,10 @@ func NewSummary() Summary {
 func (ms Summary) MoveTo(dest Summary) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.Summary{}
 }

--- a/pdata/pmetric/generated_summary_test.go
+++ b/pdata/pmetric/generated_summary_test.go
@@ -21,6 +21,8 @@ func TestSummary_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewSummary(), ms)
 	assert.Equal(t, generateTestSummary(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestSummary(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newSummary(&otlpmetrics.Summary{}, &sharedState)) })
 	assert.Panics(t, func() { newSummary(&otlpmetrics.Summary{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_summarydatapoint.go
+++ b/pdata/pmetric/generated_summarydatapoint.go
@@ -42,6 +42,10 @@ func NewSummaryDataPoint() SummaryDataPoint {
 func (ms SummaryDataPoint) MoveTo(dest SummaryDataPoint) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.SummaryDataPoint{}
 }

--- a/pdata/pmetric/generated_summarydatapoint_test.go
+++ b/pdata/pmetric/generated_summarydatapoint_test.go
@@ -22,6 +22,8 @@ func TestSummaryDataPoint_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewSummaryDataPoint(), ms)
 	assert.Equal(t, generateTestSummaryDataPoint(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestSummaryDataPoint(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, &sharedState)) })
 	assert.Panics(t, func() { newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, &sharedState).MoveTo(dest) })

--- a/pdata/pmetric/generated_summarydatapointslice.go
+++ b/pdata/pmetric/generated_summarydatapointslice.go
@@ -109,6 +109,10 @@ func (es SummaryDataPointSlice) AppendEmpty() SummaryDataPoint {
 func (es SummaryDataPointSlice) MoveAndAppendTo(dest SummaryDataPointSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pmetric/generated_summarydatapointslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointslice_test.go
@@ -103,6 +103,13 @@ func TestSummaryDataPointSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestSummaryDataPointSlice_RemoveIf(t *testing.T) {

--- a/pdata/pmetric/generated_summarydatapointvalueatquantile.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantile.go
@@ -41,6 +41,10 @@ func NewSummaryDataPointValueAtQuantile() SummaryDataPointValueAtQuantile {
 func (ms SummaryDataPointValueAtQuantile) MoveTo(dest SummaryDataPointValueAtQuantile) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpmetrics.SummaryDataPoint_ValueAtQuantile{}
 }

--- a/pdata/pmetric/generated_summarydatapointvalueatquantile_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantile_test.go
@@ -21,6 +21,8 @@ func TestSummaryDataPointValueAtQuantile_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewSummaryDataPointValueAtQuantile(), ms)
 	assert.Equal(t, generateTestSummaryDataPointValueAtQuantile(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestSummaryDataPointValueAtQuantile(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {
 		ms.MoveTo(newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &sharedState))

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
@@ -109,6 +109,10 @@ func (es SummaryDataPointValueAtQuantileSlice) AppendEmpty() SummaryDataPointVal
 func (es SummaryDataPointValueAtQuantileSlice) MoveAndAppendTo(dest SummaryDataPointValueAtQuantileSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
@@ -103,6 +103,13 @@ func TestSummaryDataPointValueAtQuantileSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestSummaryDataPointValueAtQuantileSlice_RemoveIf(t *testing.T) {

--- a/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess.go
@@ -41,6 +41,10 @@ func NewExportPartialSuccess() ExportPartialSuccess {
 func (ms ExportPartialSuccess) MoveTo(dest ExportPartialSuccess) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpcollectormetrics.ExportMetricsPartialSuccess{}
 }

--- a/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess_test.go
@@ -21,6 +21,8 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewExportPartialSuccess(), ms)
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {
 		ms.MoveTo(newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, &sharedState))

--- a/pdata/pprofile/generated_attribute.go
+++ b/pdata/pprofile/generated_attribute.go
@@ -42,6 +42,10 @@ func NewAttribute() Attribute {
 func (ms Attribute) MoveTo(dest Attribute) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = v1.KeyValue{}
 }

--- a/pdata/pprofile/generated_attribute_test.go
+++ b/pdata/pprofile/generated_attribute_test.go
@@ -22,6 +22,8 @@ func TestAttribute_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewAttribute(), ms)
 	assert.Equal(t, generateTestAttribute(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestAttribute(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newAttribute(&v1.KeyValue{}, &sharedState)) })
 	assert.Panics(t, func() { newAttribute(&v1.KeyValue{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_attributetableslice.go
+++ b/pdata/pprofile/generated_attributetableslice.go
@@ -108,6 +108,10 @@ func (es AttributeTableSlice) AppendEmpty() Attribute {
 func (es AttributeTableSlice) MoveAndAppendTo(dest AttributeTableSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_attributetableslice_test.go
+++ b/pdata/pprofile/generated_attributetableslice_test.go
@@ -102,6 +102,13 @@ func TestAttributeTableSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestAttributeTableSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_attributeunit.go
+++ b/pdata/pprofile/generated_attributeunit.go
@@ -41,6 +41,10 @@ func NewAttributeUnit() AttributeUnit {
 func (ms AttributeUnit) MoveTo(dest AttributeUnit) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.AttributeUnit{}
 }

--- a/pdata/pprofile/generated_attributeunit_test.go
+++ b/pdata/pprofile/generated_attributeunit_test.go
@@ -21,6 +21,8 @@ func TestAttributeUnit_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewAttributeUnit(), ms)
 	assert.Equal(t, generateTestAttributeUnit(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestAttributeUnit(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newAttributeUnit(&otlpprofiles.AttributeUnit{}, &sharedState)) })
 	assert.Panics(t, func() { newAttributeUnit(&otlpprofiles.AttributeUnit{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_attributeunitslice.go
+++ b/pdata/pprofile/generated_attributeunitslice.go
@@ -109,6 +109,10 @@ func (es AttributeUnitSlice) AppendEmpty() AttributeUnit {
 func (es AttributeUnitSlice) MoveAndAppendTo(dest AttributeUnitSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_attributeunitslice_test.go
+++ b/pdata/pprofile/generated_attributeunitslice_test.go
@@ -103,6 +103,13 @@ func TestAttributeUnitSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestAttributeUnitSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_function.go
+++ b/pdata/pprofile/generated_function.go
@@ -41,6 +41,10 @@ func NewFunction() Function {
 func (ms Function) MoveTo(dest Function) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.Function{}
 }

--- a/pdata/pprofile/generated_function_test.go
+++ b/pdata/pprofile/generated_function_test.go
@@ -21,6 +21,8 @@ func TestFunction_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewFunction(), ms)
 	assert.Equal(t, generateTestFunction(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestFunction(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newFunction(&otlpprofiles.Function{}, &sharedState)) })
 	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_functionslice.go
+++ b/pdata/pprofile/generated_functionslice.go
@@ -109,6 +109,10 @@ func (es FunctionSlice) AppendEmpty() Function {
 func (es FunctionSlice) MoveAndAppendTo(dest FunctionSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_functionslice_test.go
+++ b/pdata/pprofile/generated_functionslice_test.go
@@ -103,6 +103,13 @@ func TestFunctionSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestFunctionSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_line.go
+++ b/pdata/pprofile/generated_line.go
@@ -41,6 +41,10 @@ func NewLine() Line {
 func (ms Line) MoveTo(dest Line) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.Line{}
 }

--- a/pdata/pprofile/generated_line_test.go
+++ b/pdata/pprofile/generated_line_test.go
@@ -21,6 +21,8 @@ func TestLine_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewLine(), ms)
 	assert.Equal(t, generateTestLine(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestLine(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newLine(&otlpprofiles.Line{}, &sharedState)) })
 	assert.Panics(t, func() { newLine(&otlpprofiles.Line{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_lineslice.go
+++ b/pdata/pprofile/generated_lineslice.go
@@ -109,6 +109,10 @@ func (es LineSlice) AppendEmpty() Line {
 func (es LineSlice) MoveAndAppendTo(dest LineSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_lineslice_test.go
+++ b/pdata/pprofile/generated_lineslice_test.go
@@ -103,6 +103,13 @@ func TestLineSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestLineSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_link.go
+++ b/pdata/pprofile/generated_link.go
@@ -43,6 +43,10 @@ func NewLink() Link {
 func (ms Link) MoveTo(dest Link) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.Link{}
 }

--- a/pdata/pprofile/generated_link_test.go
+++ b/pdata/pprofile/generated_link_test.go
@@ -23,6 +23,8 @@ func TestLink_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewLink(), ms)
 	assert.Equal(t, generateTestLink(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestLink(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newLink(&otlpprofiles.Link{}, &sharedState)) })
 	assert.Panics(t, func() { newLink(&otlpprofiles.Link{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_linkslice.go
+++ b/pdata/pprofile/generated_linkslice.go
@@ -109,6 +109,10 @@ func (es LinkSlice) AppendEmpty() Link {
 func (es LinkSlice) MoveAndAppendTo(dest LinkSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_linkslice_test.go
+++ b/pdata/pprofile/generated_linkslice_test.go
@@ -103,6 +103,13 @@ func TestLinkSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestLinkSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_location.go
+++ b/pdata/pprofile/generated_location.go
@@ -42,6 +42,10 @@ func NewLocation() Location {
 func (ms Location) MoveTo(dest Location) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.Location{}
 }

--- a/pdata/pprofile/generated_location_test.go
+++ b/pdata/pprofile/generated_location_test.go
@@ -22,6 +22,8 @@ func TestLocation_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewLocation(), ms)
 	assert.Equal(t, generateTestLocation(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestLocation(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newLocation(&otlpprofiles.Location{}, &sharedState)) })
 	assert.Panics(t, func() { newLocation(&otlpprofiles.Location{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_locationslice.go
+++ b/pdata/pprofile/generated_locationslice.go
@@ -109,6 +109,10 @@ func (es LocationSlice) AppendEmpty() Location {
 func (es LocationSlice) MoveAndAppendTo(dest LocationSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_locationslice_test.go
+++ b/pdata/pprofile/generated_locationslice_test.go
@@ -103,6 +103,13 @@ func TestLocationSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestLocationSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_mapping.go
+++ b/pdata/pprofile/generated_mapping.go
@@ -42,6 +42,10 @@ func NewMapping() Mapping {
 func (ms Mapping) MoveTo(dest Mapping) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.Mapping{}
 }

--- a/pdata/pprofile/generated_mapping_test.go
+++ b/pdata/pprofile/generated_mapping_test.go
@@ -22,6 +22,8 @@ func TestMapping_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewMapping(), ms)
 	assert.Equal(t, generateTestMapping(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestMapping(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newMapping(&otlpprofiles.Mapping{}, &sharedState)) })
 	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_mappingslice.go
+++ b/pdata/pprofile/generated_mappingslice.go
@@ -109,6 +109,10 @@ func (es MappingSlice) AppendEmpty() Mapping {
 func (es MappingSlice) MoveAndAppendTo(dest MappingSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_mappingslice_test.go
+++ b/pdata/pprofile/generated_mappingslice_test.go
@@ -103,6 +103,13 @@ func TestMappingSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestMappingSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_profile.go
+++ b/pdata/pprofile/generated_profile.go
@@ -43,6 +43,10 @@ func NewProfile() Profile {
 func (ms Profile) MoveTo(dest Profile) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.Profile{}
 }

--- a/pdata/pprofile/generated_profile_test.go
+++ b/pdata/pprofile/generated_profile_test.go
@@ -23,6 +23,8 @@ func TestProfile_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewProfile(), ms)
 	assert.Equal(t, generateTestProfile(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestProfile(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newProfile(&otlpprofiles.Profile{}, &sharedState)) })
 	assert.Panics(t, func() { newProfile(&otlpprofiles.Profile{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_profilesslice.go
+++ b/pdata/pprofile/generated_profilesslice.go
@@ -109,6 +109,10 @@ func (es ProfilesSlice) AppendEmpty() Profile {
 func (es ProfilesSlice) MoveAndAppendTo(dest ProfilesSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_profilesslice_test.go
+++ b/pdata/pprofile/generated_profilesslice_test.go
@@ -103,6 +103,13 @@ func TestProfilesSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestProfilesSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_resourceprofiles.go
+++ b/pdata/pprofile/generated_resourceprofiles.go
@@ -42,6 +42,10 @@ func NewResourceProfiles() ResourceProfiles {
 func (ms ResourceProfiles) MoveTo(dest ResourceProfiles) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.ResourceProfiles{}
 }

--- a/pdata/pprofile/generated_resourceprofiles_test.go
+++ b/pdata/pprofile/generated_resourceprofiles_test.go
@@ -22,6 +22,8 @@ func TestResourceProfiles_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewResourceProfiles(), ms)
 	assert.Equal(t, generateTestResourceProfiles(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestResourceProfiles(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newResourceProfiles(&otlpprofiles.ResourceProfiles{}, &sharedState)) })
 	assert.Panics(t, func() { newResourceProfiles(&otlpprofiles.ResourceProfiles{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_resourceprofilesslice.go
+++ b/pdata/pprofile/generated_resourceprofilesslice.go
@@ -109,6 +109,10 @@ func (es ResourceProfilesSlice) AppendEmpty() ResourceProfiles {
 func (es ResourceProfilesSlice) MoveAndAppendTo(dest ResourceProfilesSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_resourceprofilesslice_test.go
+++ b/pdata/pprofile/generated_resourceprofilesslice_test.go
@@ -103,6 +103,13 @@ func TestResourceProfilesSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestResourceProfilesSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_sample.go
+++ b/pdata/pprofile/generated_sample.go
@@ -42,6 +42,10 @@ func NewSample() Sample {
 func (ms Sample) MoveTo(dest Sample) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.Sample{}
 }

--- a/pdata/pprofile/generated_sample_test.go
+++ b/pdata/pprofile/generated_sample_test.go
@@ -22,6 +22,8 @@ func TestSample_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewSample(), ms)
 	assert.Equal(t, generateTestSample(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestSample(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newSample(&otlpprofiles.Sample{}, &sharedState)) })
 	assert.Panics(t, func() { newSample(&otlpprofiles.Sample{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_sampleslice.go
+++ b/pdata/pprofile/generated_sampleslice.go
@@ -109,6 +109,10 @@ func (es SampleSlice) AppendEmpty() Sample {
 func (es SampleSlice) MoveAndAppendTo(dest SampleSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_sampleslice_test.go
+++ b/pdata/pprofile/generated_sampleslice_test.go
@@ -103,6 +103,13 @@ func TestSampleSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestSampleSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_scopeprofiles.go
+++ b/pdata/pprofile/generated_scopeprofiles.go
@@ -42,6 +42,10 @@ func NewScopeProfiles() ScopeProfiles {
 func (ms ScopeProfiles) MoveTo(dest ScopeProfiles) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.ScopeProfiles{}
 }

--- a/pdata/pprofile/generated_scopeprofiles_test.go
+++ b/pdata/pprofile/generated_scopeprofiles_test.go
@@ -22,6 +22,8 @@ func TestScopeProfiles_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewScopeProfiles(), ms)
 	assert.Equal(t, generateTestScopeProfiles(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestScopeProfiles(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newScopeProfiles(&otlpprofiles.ScopeProfiles{}, &sharedState)) })
 	assert.Panics(t, func() { newScopeProfiles(&otlpprofiles.ScopeProfiles{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_scopeprofilesslice.go
+++ b/pdata/pprofile/generated_scopeprofilesslice.go
@@ -109,6 +109,10 @@ func (es ScopeProfilesSlice) AppendEmpty() ScopeProfiles {
 func (es ScopeProfilesSlice) MoveAndAppendTo(dest ScopeProfilesSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_scopeprofilesslice_test.go
+++ b/pdata/pprofile/generated_scopeprofilesslice_test.go
@@ -103,6 +103,13 @@ func TestScopeProfilesSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestScopeProfilesSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/generated_valuetype.go
+++ b/pdata/pprofile/generated_valuetype.go
@@ -41,6 +41,10 @@ func NewValueType() ValueType {
 func (ms ValueType) MoveTo(dest ValueType) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpprofiles.ValueType{}
 }

--- a/pdata/pprofile/generated_valuetype_test.go
+++ b/pdata/pprofile/generated_valuetype_test.go
@@ -21,6 +21,8 @@ func TestValueType_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewValueType(), ms)
 	assert.Equal(t, generateTestValueType(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestValueType(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newValueType(&otlpprofiles.ValueType{}, &sharedState)) })
 	assert.Panics(t, func() { newValueType(&otlpprofiles.ValueType{}, &sharedState).MoveTo(dest) })

--- a/pdata/pprofile/generated_valuetypeslice.go
+++ b/pdata/pprofile/generated_valuetypeslice.go
@@ -109,6 +109,10 @@ func (es ValueTypeSlice) AppendEmpty() ValueType {
 func (es ValueTypeSlice) MoveAndAppendTo(dest ValueTypeSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/pprofile/generated_valuetypeslice_test.go
+++ b/pdata/pprofile/generated_valuetypeslice_test.go
@@ -103,6 +103,13 @@ func TestValueTypeSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestValueTypeSlice_RemoveIf(t *testing.T) {

--- a/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess.go
@@ -41,6 +41,10 @@ func NewExportPartialSuccess() ExportPartialSuccess {
 func (ms ExportPartialSuccess) MoveTo(dest ExportPartialSuccess) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpcollectorprofile.ExportProfilesPartialSuccess{}
 }

--- a/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess_test.go
@@ -21,6 +21,8 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewExportPartialSuccess(), ms)
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {
 		ms.MoveTo(newExportPartialSuccess(&otlpcollectorprofile.ExportProfilesPartialSuccess{}, &sharedState))

--- a/pdata/ptrace/generated_resourcespans.go
+++ b/pdata/ptrace/generated_resourcespans.go
@@ -42,6 +42,10 @@ func NewResourceSpans() ResourceSpans {
 func (ms ResourceSpans) MoveTo(dest ResourceSpans) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlptrace.ResourceSpans{}
 }

--- a/pdata/ptrace/generated_resourcespans_test.go
+++ b/pdata/ptrace/generated_resourcespans_test.go
@@ -22,6 +22,8 @@ func TestResourceSpans_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewResourceSpans(), ms)
 	assert.Equal(t, generateTestResourceSpans(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestResourceSpans(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newResourceSpans(&otlptrace.ResourceSpans{}, &sharedState)) })
 	assert.Panics(t, func() { newResourceSpans(&otlptrace.ResourceSpans{}, &sharedState).MoveTo(dest) })

--- a/pdata/ptrace/generated_resourcespansslice.go
+++ b/pdata/ptrace/generated_resourcespansslice.go
@@ -109,6 +109,10 @@ func (es ResourceSpansSlice) AppendEmpty() ResourceSpans {
 func (es ResourceSpansSlice) MoveAndAppendTo(dest ResourceSpansSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/ptrace/generated_resourcespansslice_test.go
+++ b/pdata/ptrace/generated_resourcespansslice_test.go
@@ -103,6 +103,13 @@ func TestResourceSpansSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestResourceSpansSlice_RemoveIf(t *testing.T) {

--- a/pdata/ptrace/generated_scopespans.go
+++ b/pdata/ptrace/generated_scopespans.go
@@ -42,6 +42,10 @@ func NewScopeSpans() ScopeSpans {
 func (ms ScopeSpans) MoveTo(dest ScopeSpans) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlptrace.ScopeSpans{}
 }

--- a/pdata/ptrace/generated_scopespans_test.go
+++ b/pdata/ptrace/generated_scopespans_test.go
@@ -22,6 +22,8 @@ func TestScopeSpans_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewScopeSpans(), ms)
 	assert.Equal(t, generateTestScopeSpans(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestScopeSpans(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newScopeSpans(&otlptrace.ScopeSpans{}, &sharedState)) })
 	assert.Panics(t, func() { newScopeSpans(&otlptrace.ScopeSpans{}, &sharedState).MoveTo(dest) })

--- a/pdata/ptrace/generated_scopespansslice.go
+++ b/pdata/ptrace/generated_scopespansslice.go
@@ -109,6 +109,10 @@ func (es ScopeSpansSlice) AppendEmpty() ScopeSpans {
 func (es ScopeSpansSlice) MoveAndAppendTo(dest ScopeSpansSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/ptrace/generated_scopespansslice_test.go
+++ b/pdata/ptrace/generated_scopespansslice_test.go
@@ -103,6 +103,13 @@ func TestScopeSpansSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestScopeSpansSlice_RemoveIf(t *testing.T) {

--- a/pdata/ptrace/generated_span.go
+++ b/pdata/ptrace/generated_span.go
@@ -44,6 +44,10 @@ func NewSpan() Span {
 func (ms Span) MoveTo(dest Span) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlptrace.Span{}
 }

--- a/pdata/ptrace/generated_span_test.go
+++ b/pdata/ptrace/generated_span_test.go
@@ -23,6 +23,8 @@ func TestSpan_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewSpan(), ms)
 	assert.Equal(t, generateTestSpan(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestSpan(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newSpan(&otlptrace.Span{}, &sharedState)) })
 	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, &sharedState).MoveTo(dest) })

--- a/pdata/ptrace/generated_spanevent.go
+++ b/pdata/ptrace/generated_spanevent.go
@@ -43,6 +43,10 @@ func NewSpanEvent() SpanEvent {
 func (ms SpanEvent) MoveTo(dest SpanEvent) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlptrace.Span_Event{}
 }

--- a/pdata/ptrace/generated_spanevent_test.go
+++ b/pdata/ptrace/generated_spanevent_test.go
@@ -22,6 +22,8 @@ func TestSpanEvent_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewSpanEvent(), ms)
 	assert.Equal(t, generateTestSpanEvent(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestSpanEvent(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newSpanEvent(&otlptrace.Span_Event{}, &sharedState)) })
 	assert.Panics(t, func() { newSpanEvent(&otlptrace.Span_Event{}, &sharedState).MoveTo(dest) })

--- a/pdata/ptrace/generated_spaneventslice.go
+++ b/pdata/ptrace/generated_spaneventslice.go
@@ -109,6 +109,10 @@ func (es SpanEventSlice) AppendEmpty() SpanEvent {
 func (es SpanEventSlice) MoveAndAppendTo(dest SpanEventSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/ptrace/generated_spaneventslice_test.go
+++ b/pdata/ptrace/generated_spaneventslice_test.go
@@ -103,6 +103,13 @@ func TestSpanEventSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestSpanEventSlice_RemoveIf(t *testing.T) {

--- a/pdata/ptrace/generated_spanlink.go
+++ b/pdata/ptrace/generated_spanlink.go
@@ -45,6 +45,10 @@ func NewSpanLink() SpanLink {
 func (ms SpanLink) MoveTo(dest SpanLink) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlptrace.Span_Link{}
 }

--- a/pdata/ptrace/generated_spanlink_test.go
+++ b/pdata/ptrace/generated_spanlink_test.go
@@ -23,6 +23,8 @@ func TestSpanLink_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewSpanLink(), ms)
 	assert.Equal(t, generateTestSpanLink(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestSpanLink(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newSpanLink(&otlptrace.Span_Link{}, &sharedState)) })
 	assert.Panics(t, func() { newSpanLink(&otlptrace.Span_Link{}, &sharedState).MoveTo(dest) })

--- a/pdata/ptrace/generated_spanlinkslice.go
+++ b/pdata/ptrace/generated_spanlinkslice.go
@@ -109,6 +109,10 @@ func (es SpanLinkSlice) AppendEmpty() SpanLink {
 func (es SpanLinkSlice) MoveAndAppendTo(dest SpanLinkSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/ptrace/generated_spanlinkslice_test.go
+++ b/pdata/ptrace/generated_spanlinkslice_test.go
@@ -103,6 +103,13 @@ func TestSpanLinkSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestSpanLinkSlice_RemoveIf(t *testing.T) {

--- a/pdata/ptrace/generated_spanslice.go
+++ b/pdata/ptrace/generated_spanslice.go
@@ -109,6 +109,10 @@ func (es SpanSlice) AppendEmpty() Span {
 func (es SpanSlice) MoveAndAppendTo(dest SpanSlice) {
 	es.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if es.orig == dest.orig {
+		return
+	}
 	if *dest.orig == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.orig = *es.orig

--- a/pdata/ptrace/generated_spanslice_test.go
+++ b/pdata/ptrace/generated_spanslice_test.go
@@ -103,6 +103,13 @@ func TestSpanSlice_MoveAndAppendTo(t *testing.T) {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
 		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
 	}
+
+	dest.MoveAndAppendTo(dest)
+	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.Equal(t, expectedSlice.At(i), dest.At(i))
+		assert.Equal(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
 }
 
 func TestSpanSlice_RemoveIf(t *testing.T) {

--- a/pdata/ptrace/generated_status.go
+++ b/pdata/ptrace/generated_status.go
@@ -42,6 +42,10 @@ func NewStatus() Status {
 func (ms Status) MoveTo(dest Status) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlptrace.Status{}
 }

--- a/pdata/ptrace/generated_status_test.go
+++ b/pdata/ptrace/generated_status_test.go
@@ -21,6 +21,8 @@ func TestStatus_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewStatus(), ms)
 	assert.Equal(t, generateTestStatus(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestStatus(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() { ms.MoveTo(newStatus(&otlptrace.Status{}, &sharedState)) })
 	assert.Panics(t, func() { newStatus(&otlptrace.Status{}, &sharedState).MoveTo(dest) })

--- a/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess.go
@@ -41,6 +41,10 @@ func NewExportPartialSuccess() ExportPartialSuccess {
 func (ms ExportPartialSuccess) MoveTo(dest ExportPartialSuccess) {
 	ms.state.AssertMutable()
 	dest.state.AssertMutable()
+	// If they point to the same data, they are the same, nothing to do.
+	if ms.orig == dest.orig {
+		return
+	}
 	*dest.orig = *ms.orig
 	*ms.orig = otlpcollectortrace.ExportTracePartialSuccess{}
 }

--- a/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess_test.go
@@ -21,6 +21,8 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	ms.MoveTo(dest)
 	assert.Equal(t, NewExportPartialSuccess(), ms)
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
+	dest.MoveTo(dest)
+	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	sharedState := internal.StateReadOnly
 	assert.Panics(t, func() {
 		ms.MoveTo(newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, &sharedState))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Moving the data between same source and destination causes the destination to be cleared.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #12887
