### PR TITLE
[configauth] Deprecate Authentication in favor of authentication.Config

### DIFF
--- a/.chloggen/mx-psi_naming-configauth.yaml
+++ b/.chloggen/mx-psi_naming-configauth.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configauth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `configauth.Authentication` in favor of `configauth.AuthenticationConfig`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12875]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/mx-psi_naming-configauth.yaml
+++ b/.chloggen/mx-psi_naming-configauth.yaml
@@ -7,7 +7,7 @@ change_type: deprecation
 component: configauth
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecate `configauth.Authentication` in favor of `configauth.AuthenticationConfig`.
+note: Deprecate `configauth.Authentication` in favor of `configauth.Config`.
 
 # One or more tracking issues or pull requests related to the change
 issues: [12875]

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -22,8 +22,11 @@ var (
 	errNotServer             = errors.New("requested authenticator is not a server authenticator")
 )
 
-// Authentication defines the auth settings for the receiver.
-type Authentication struct {
+// Deprecated: [v0.125.0] Use AuthenticationConfig instead.
+type Authentication = AuthenticationConfig
+
+// AuthenticationConfig defines the auth settings for the receiver.
+type AuthenticationConfig struct {
 	// AuthenticatorID specifies the name of the extension to use in order to authenticate the incoming data point.
 	AuthenticatorID component.ID `mapstructure:"authenticator,omitempty"`
 	// prevent unkeyed literal initialization
@@ -32,7 +35,7 @@ type Authentication struct {
 
 // GetServerAuthenticator attempts to select the appropriate extensionauth.Server from the list of extensions,
 // based on the requested extension name. If an authenticator is not found, an error is returned.
-func (a Authentication) GetServerAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.Server, error) {
+func (a AuthenticationConfig) GetServerAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.Server, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if server, ok := ext.(extensionauth.Server); ok {
 			return server, nil
@@ -46,7 +49,7 @@ func (a Authentication) GetServerAuthenticator(_ context.Context, extensions map
 // GetHTTPClientAuthenticator attempts to select the appropriate extensionauth.Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by HTTP clients.
-func (a Authentication) GetHTTPClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.HTTPClient, error) {
+func (a AuthenticationConfig) GetHTTPClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.HTTPClient, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if client, ok := ext.(extensionauth.HTTPClient); ok {
 			return client, nil
@@ -59,7 +62,7 @@ func (a Authentication) GetHTTPClientAuthenticator(_ context.Context, extensions
 // GetGRPCClientAuthenticator attempts to select the appropriate extensionauth.Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by gRPC clients.
-func (a Authentication) GetGRPCClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.GRPCClient, error) {
+func (a AuthenticationConfig) GetGRPCClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.GRPCClient, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if client, ok := ext.(extensionauth.GRPCClient); ok {
 			return client, nil

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -22,11 +22,11 @@ var (
 	errNotServer             = errors.New("requested authenticator is not a server authenticator")
 )
 
-// Deprecated: [v0.125.0] Use AuthenticationConfig instead.
-type Authentication = AuthenticationConfig
+// Deprecated: [v0.125.0] Use Config instead.
+type Authentication = Config
 
-// AuthenticationConfig defines the auth settings for the receiver.
-type AuthenticationConfig struct {
+// Config defines the auth settings for the receiver.
+type Config struct {
 	// AuthenticatorID specifies the name of the extension to use in order to authenticate the incoming data point.
 	AuthenticatorID component.ID `mapstructure:"authenticator,omitempty"`
 	// prevent unkeyed literal initialization
@@ -35,7 +35,7 @@ type AuthenticationConfig struct {
 
 // GetServerAuthenticator attempts to select the appropriate extensionauth.Server from the list of extensions,
 // based on the requested extension name. If an authenticator is not found, an error is returned.
-func (a AuthenticationConfig) GetServerAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.Server, error) {
+func (a Config) GetServerAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.Server, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if server, ok := ext.(extensionauth.Server); ok {
 			return server, nil
@@ -49,7 +49,7 @@ func (a AuthenticationConfig) GetServerAuthenticator(_ context.Context, extensio
 // GetHTTPClientAuthenticator attempts to select the appropriate extensionauth.Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by HTTP clients.
-func (a AuthenticationConfig) GetHTTPClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.HTTPClient, error) {
+func (a Config) GetHTTPClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.HTTPClient, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if client, ok := ext.(extensionauth.HTTPClient); ok {
 			return client, nil
@@ -62,7 +62,7 @@ func (a AuthenticationConfig) GetHTTPClientAuthenticator(_ context.Context, exte
 // GetGRPCClientAuthenticator attempts to select the appropriate extensionauth.Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by gRPC clients.
-func (a AuthenticationConfig) GetGRPCClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.GRPCClient, error) {
+func (a Config) GetGRPCClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.GRPCClient, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if client, ok := ext.(extensionauth.GRPCClient); ok {
 			return client, nil

--- a/config/configauth/configauth_test.go
+++ b/config/configauth/configauth_test.go
@@ -37,7 +37,7 @@ func TestGetServer(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			// prepare
-			cfg := &Authentication{
+			cfg := &Config{
 				AuthenticatorID: mockID,
 			}
 			ext := map[component.ID]component.Component{
@@ -59,7 +59,7 @@ func TestGetServer(t *testing.T) {
 }
 
 func TestGetServerFails(t *testing.T) {
-	cfg := &Authentication{
+	cfg := &Config{
 		AuthenticatorID: component.MustNewID("does_not_exist"),
 	}
 
@@ -88,7 +88,7 @@ func TestGetHTTPClient(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			// prepare
-			cfg := &Authentication{
+			cfg := &Config{
 				AuthenticatorID: mockID,
 			}
 			ext := map[component.ID]component.Component{
@@ -110,7 +110,7 @@ func TestGetHTTPClient(t *testing.T) {
 }
 
 func TestGetGRPCClientFails(t *testing.T) {
-	cfg := &Authentication{
+	cfg := &Config{
 		AuthenticatorID: component.MustNewID("does_not_exist"),
 	}
 	authenticator, err := cfg.GetGRPCClientAuthenticator(context.Background(), map[component.ID]component.Component{})

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -105,7 +105,7 @@ type ClientConfig struct {
 	Authority string `mapstructure:"authority,omitempty"`
 
 	// Auth configuration for outgoing RPCs.
-	Auth *configauth.AuthenticationConfig `mapstructure:"auth,omitempty"`
+	Auth *configauth.Config `mapstructure:"auth,omitempty"`
 
 	// Middlewares for the gRPC client.
 	Middlewares []configmiddleware.Config `mapstructure:"middlewares,omitempty"`
@@ -197,7 +197,7 @@ type ServerConfig struct {
 	Keepalive *KeepaliveServerConfig `mapstructure:"keepalive,omitempty"`
 
 	// Auth for this receiver
-	Auth *configauth.AuthenticationConfig `mapstructure:"auth,omitempty"`
+	Auth *configauth.Config `mapstructure:"auth,omitempty"`
 
 	// Include propagates the incoming connection's metadata to downstream consumers.
 	IncludeMetadata bool `mapstructure:"include_metadata,omitempty"`

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -105,7 +105,7 @@ type ClientConfig struct {
 	Authority string `mapstructure:"authority,omitempty"`
 
 	// Auth configuration for outgoing RPCs.
-	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
+	Auth *configauth.AuthenticationConfig `mapstructure:"auth,omitempty"`
 
 	// Middlewares for the gRPC client.
 	Middlewares []configmiddleware.Config `mapstructure:"middlewares,omitempty"`
@@ -197,7 +197,7 @@ type ServerConfig struct {
 	Keepalive *KeepaliveServerConfig `mapstructure:"keepalive,omitempty"`
 
 	// Auth for this receiver
-	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
+	Auth *configauth.AuthenticationConfig `mapstructure:"auth,omitempty"`
 
 	// Include propagates the incoming connection's metadata to downstream consumers.
 	IncludeMetadata bool `mapstructure:"include_metadata,omitempty"`

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -176,7 +176,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
 				Authority:       "pseudo-authority",
-				Auth:            &configauth.Authentication{AuthenticatorID: testAuthID},
+				Auth:            &configauth.AuthenticationConfig{AuthenticatorID: testAuthID},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
@@ -205,7 +205,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
 				Authority:       "pseudo-authority",
-				Auth:            &configauth.Authentication{AuthenticatorID: testAuthID},
+				Auth:            &configauth.AuthenticationConfig{AuthenticatorID: testAuthID},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
@@ -234,7 +234,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
 				Authority:       "pseudo-authority",
-				Auth:            &configauth.Authentication{AuthenticatorID: testAuthID},
+				Auth:            &configauth.AuthenticationConfig{AuthenticatorID: testAuthID},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
@@ -413,7 +413,7 @@ func TestGrpcServerAuthSettings(t *testing.T) {
 			Endpoint: "0.0.0.0:1234",
 		},
 	}
-	gss.Auth = &configauth.Authentication{
+	gss.Auth = &configauth.AuthenticationConfig{
 		AuthenticatorID: mockID,
 	}
 
@@ -492,7 +492,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "failed to resolve authenticator \"doesntexist\": authenticator not found",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Authentication{AuthenticatorID: doesntExistID},
+				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: doesntExistID},
 			},
 			host: &mockHost{ext: map[component.ID]component.Component{}},
 		},
@@ -500,7 +500,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "no extensions configuration available",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Authentication{AuthenticatorID: doesntExistID},
+				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: doesntExistID},
 			},
 			host: &mockHost{},
 		},

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -176,7 +176,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
 				Authority:       "pseudo-authority",
-				Auth:            &configauth.AuthenticationConfig{AuthenticatorID: testAuthID},
+				Auth:            &configauth.Config{AuthenticatorID: testAuthID},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
@@ -205,7 +205,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
 				Authority:       "pseudo-authority",
-				Auth:            &configauth.AuthenticationConfig{AuthenticatorID: testAuthID},
+				Auth:            &configauth.Config{AuthenticatorID: testAuthID},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
@@ -234,7 +234,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
 				Authority:       "pseudo-authority",
-				Auth:            &configauth.AuthenticationConfig{AuthenticatorID: testAuthID},
+				Auth:            &configauth.Config{AuthenticatorID: testAuthID},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
@@ -413,7 +413,7 @@ func TestGrpcServerAuthSettings(t *testing.T) {
 			Endpoint: "0.0.0.0:1234",
 		},
 	}
-	gss.Auth = &configauth.AuthenticationConfig{
+	gss.Auth = &configauth.Config{
 		AuthenticatorID: mockID,
 	}
 
@@ -492,7 +492,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "failed to resolve authenticator \"doesntexist\": authenticator not found",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: doesntExistID},
+				Auth:     &configauth.Config{AuthenticatorID: doesntExistID},
 			},
 			host: &mockHost{ext: map[component.ID]component.Component{}},
 		},
@@ -500,7 +500,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "no extensions configuration available",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: doesntExistID},
+				Auth:     &configauth.Config{AuthenticatorID: doesntExistID},
 			},
 			host: &mockHost{},
 		},

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -69,7 +69,7 @@ type ClientConfig struct {
 	Headers map[string]configopaque.String `mapstructure:"headers,omitempty"`
 
 	// Auth configuration for outgoing HTTP calls.
-	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
+	Auth *configauth.AuthenticationConfig `mapstructure:"auth,omitempty"`
 
 	// The compression key for supported compression types within collector.
 	Compression configcompression.Type `mapstructure:"compression,omitempty"`
@@ -384,7 +384,7 @@ func NewDefaultServerConfig() ServerConfig {
 
 type AuthConfig struct {
 	// Auth for this receiver.
-	configauth.Authentication `mapstructure:",squash"`
+	configauth.AuthenticationConfig `mapstructure:",squash"`
 
 	// RequestParameters is a list of parameters that should be extracted from the request and added to the context.
 	// When a parameter is found in both the query string and the header, the value from the query string will be used.

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -69,7 +69,7 @@ type ClientConfig struct {
 	Headers map[string]configopaque.String `mapstructure:"headers,omitempty"`
 
 	// Auth configuration for outgoing HTTP calls.
-	Auth *configauth.AuthenticationConfig `mapstructure:"auth,omitempty"`
+	Auth *configauth.Config `mapstructure:"auth,omitempty"`
 
 	// The compression key for supported compression types within collector.
 	Compression configcompression.Type `mapstructure:"compression,omitempty"`
@@ -384,7 +384,7 @@ func NewDefaultServerConfig() ServerConfig {
 
 type AuthConfig struct {
 	// Auth for this receiver.
-	configauth.AuthenticationConfig `mapstructure:",squash"`
+	configauth.Config `mapstructure:",squash"`
 
 	// RequestParameters is a list of parameters that should be extracted from the request and added to the context.
 	// When a parameter is found in both the query string and the header, the value from the query string will be used.

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -328,7 +328,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			err: "failed to resolve authenticator \"dummy\": authenticator not found",
 			settings: ClientConfig{
 				Endpoint: "https://localhost:1234/v1/traces",
-				Auth:     &configauth.Authentication{AuthenticatorID: dummyID},
+				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: dummyID},
 			},
 		},
 	}
@@ -387,7 +387,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_and_no_extension",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Authentication{AuthenticatorID: dummyID},
+				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: dummyID},
 			},
 			shouldErr: true,
 			host: &mockHost{
@@ -400,7 +400,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_and_no_extension_map",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Authentication{AuthenticatorID: dummyID},
+				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: dummyID},
 			},
 			shouldErr: true,
 			host:      componenttest.NewNopHost(),
@@ -409,7 +409,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_extension",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Authentication{AuthenticatorID: mockID},
+				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: mockID},
 			},
 			shouldErr: false,
 			host: &mockHost{
@@ -422,7 +422,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_extension_and_headers",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Authentication{AuthenticatorID: mockID},
+				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: mockID},
 				Headers:  map[string]configopaque.String{"foo": "bar"},
 			},
 			shouldErr: false,
@@ -436,7 +436,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_extension_and_compression",
 			settings: ClientConfig{
 				Endpoint:    "localhost:1234",
-				Auth:        &configauth.Authentication{AuthenticatorID: component.MustNewID("mock")},
+				Auth:        &configauth.AuthenticationConfig{AuthenticatorID: component.MustNewID("mock")},
 				Compression: configcompression.TypeGzip,
 			},
 			shouldErr: false,
@@ -450,7 +450,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_err_extension",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Authentication{AuthenticatorID: mockID},
+				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: mockID},
 			},
 			shouldErr: true,
 			host: &mockHost{
@@ -844,7 +844,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 			AllowedOrigins: []string{"*"},
 		},
 		Auth: &AuthConfig{
-			Authentication: configauth.Authentication{
+			Authentication: configauth.AuthenticationConfig{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1154,7 +1154,7 @@ func TestServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: configauth.Authentication{
+			Authentication: configauth.AuthenticationConfig{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1188,7 +1188,7 @@ func TestServerAuth(t *testing.T) {
 func TestInvalidServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Auth: &AuthConfig{
-			Authentication: configauth.Authentication{
+			Authentication: configauth.AuthenticationConfig{
 				AuthenticatorID: nonExistingID,
 			},
 		},
@@ -1204,7 +1204,7 @@ func TestFailedServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: configauth.Authentication{
+			Authentication: configauth.AuthenticationConfig{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1234,7 +1234,7 @@ func TestFailedServerAuthWithErrorHandler(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: configauth.Authentication{
+			Authentication: configauth.AuthenticationConfig{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1420,7 +1420,7 @@ func TestAuthWithQueryParams(t *testing.T) {
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
 			RequestParameters: []string{"auth"},
-			Authentication: configauth.Authentication{
+			Authentication: configauth.AuthenticationConfig{
 				AuthenticatorID: mockID,
 			},
 		},

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -328,7 +328,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			err: "failed to resolve authenticator \"dummy\": authenticator not found",
 			settings: ClientConfig{
 				Endpoint: "https://localhost:1234/v1/traces",
-				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: dummyID},
+				Auth:     &configauth.Config{AuthenticatorID: dummyID},
 			},
 		},
 	}
@@ -387,7 +387,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_and_no_extension",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: dummyID},
+				Auth:     &configauth.Config{AuthenticatorID: dummyID},
 			},
 			shouldErr: true,
 			host: &mockHost{
@@ -400,7 +400,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_and_no_extension_map",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: dummyID},
+				Auth:     &configauth.Config{AuthenticatorID: dummyID},
 			},
 			shouldErr: true,
 			host:      componenttest.NewNopHost(),
@@ -409,7 +409,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_extension",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: mockID},
+				Auth:     &configauth.Config{AuthenticatorID: mockID},
 			},
 			shouldErr: false,
 			host: &mockHost{
@@ -422,7 +422,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_extension_and_headers",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: mockID},
+				Auth:     &configauth.Config{AuthenticatorID: mockID},
 				Headers:  map[string]configopaque.String{"foo": "bar"},
 			},
 			shouldErr: false,
@@ -436,7 +436,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_extension_and_compression",
 			settings: ClientConfig{
 				Endpoint:    "localhost:1234",
-				Auth:        &configauth.AuthenticationConfig{AuthenticatorID: component.MustNewID("mock")},
+				Auth:        &configauth.Config{AuthenticatorID: component.MustNewID("mock")},
 				Compression: configcompression.TypeGzip,
 			},
 			shouldErr: false,
@@ -450,7 +450,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_err_extension",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.AuthenticationConfig{AuthenticatorID: mockID},
+				Auth:     &configauth.Config{AuthenticatorID: mockID},
 			},
 			shouldErr: true,
 			host: &mockHost{
@@ -844,7 +844,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 			AllowedOrigins: []string{"*"},
 		},
 		Auth: &AuthConfig{
-			Authentication: configauth.AuthenticationConfig{
+			Authentication: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1154,7 +1154,7 @@ func TestServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: configauth.AuthenticationConfig{
+			Authentication: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1188,7 +1188,7 @@ func TestServerAuth(t *testing.T) {
 func TestInvalidServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Auth: &AuthConfig{
-			Authentication: configauth.AuthenticationConfig{
+			Authentication: configauth.Config{
 				AuthenticatorID: nonExistingID,
 			},
 		},
@@ -1204,7 +1204,7 @@ func TestFailedServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: configauth.AuthenticationConfig{
+			Authentication: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1234,7 +1234,7 @@ func TestFailedServerAuthWithErrorHandler(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: configauth.AuthenticationConfig{
+			Authentication: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1420,7 +1420,7 @@ func TestAuthWithQueryParams(t *testing.T) {
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
 			RequestParameters: []string{"auth"},
-			Authentication: configauth.AuthenticationConfig{
+			Authentication: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -844,7 +844,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 			AllowedOrigins: []string{"*"},
 		},
 		Auth: &AuthConfig{
-			Authentication: configauth.Config{
+			Config: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1154,7 +1154,7 @@ func TestServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: configauth.Config{
+			Config: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1188,7 +1188,7 @@ func TestServerAuth(t *testing.T) {
 func TestInvalidServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Auth: &AuthConfig{
-			Authentication: configauth.Config{
+			Config: configauth.Config{
 				AuthenticatorID: nonExistingID,
 			},
 		},
@@ -1204,7 +1204,7 @@ func TestFailedServerAuth(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: configauth.Config{
+			Config: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1234,7 +1234,7 @@ func TestFailedServerAuthWithErrorHandler(t *testing.T) {
 	hss := ServerConfig{
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
-			Authentication: configauth.Config{
+			Config: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},
@@ -1420,7 +1420,7 @@ func TestAuthWithQueryParams(t *testing.T) {
 		Endpoint: "localhost:0",
 		Auth: &AuthConfig{
 			RequestParameters: []string{"auth"},
-			Authentication: configauth.Config{
+			Config: configauth.Config{
 				AuthenticatorID: mockID,
 			},
 		},

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -82,7 +82,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				},
 				WriteBufferSize: 512 * 1024,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.Authentication{AuthenticatorID: component.MustNewID("nop")},
+				Auth:            &configauth.AuthenticationConfig{AuthenticatorID: component.MustNewID("nop")},
 			},
 		}, cfg)
 }

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -82,7 +82,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				},
 				WriteBufferSize: 512 * 1024,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.AuthenticationConfig{AuthenticatorID: component.MustNewID("nop")},
+				Auth:            &configauth.Config{AuthenticatorID: component.MustNewID("nop")},
 			},
 		}, cfg)
 }

--- a/extension/extensionauth/client.go
+++ b/extension/extensionauth/client.go
@@ -11,7 +11,7 @@ import (
 
 // HTTPClient is an optional Extension interface that can be used as an HTTP authenticator for the configauth.Config option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
-// names from the Authentication configuration.
+// names from the [configauth.Config] configuration.
 type HTTPClient interface {
 	// RoundTripper returns a RoundTripper that can be used to authenticate HTTP requests.
 	RoundTripper(base http.RoundTripper) (http.RoundTripper, error)
@@ -19,7 +19,7 @@ type HTTPClient interface {
 
 // GRPCClient is an optional Extension interface that can be used as a gRPC authenticator for the configauth.Config option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
-// names from the Authentication configuration.
+// names from the [configauth.Config] configuration.
 type GRPCClient interface {
 	// PerRPCCredentials returns a PerRPCCredentials that can be used to authenticate gRPC requests.
 	PerRPCCredentials() (credentials.PerRPCCredentials, error)

--- a/extension/extensionauth/client.go
+++ b/extension/extensionauth/client.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// HTTPClient is an optional Extension interface that can be used as an HTTP authenticator for the configauth.AuthenticationConfig option.
+// HTTPClient is an optional Extension interface that can be used as an HTTP authenticator for the configauth.Config option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
 // names from the Authentication configuration.
 type HTTPClient interface {
@@ -17,7 +17,7 @@ type HTTPClient interface {
 	RoundTripper(base http.RoundTripper) (http.RoundTripper, error)
 }
 
-// GRPCClient is an optional Extension interface that can be used as a gRPC authenticator for the configauth.AuthenticationConfig option.
+// GRPCClient is an optional Extension interface that can be used as a gRPC authenticator for the configauth.Config option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
 // names from the Authentication configuration.
 type GRPCClient interface {

--- a/extension/extensionauth/client.go
+++ b/extension/extensionauth/client.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// HTTPClient is an optional Extension interface that can be used as an HTTP authenticator for the configauth.Authentication option.
+// HTTPClient is an optional Extension interface that can be used as an HTTP authenticator for the configauth.AuthenticationConfig option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
 // names from the Authentication configuration.
 type HTTPClient interface {
@@ -17,7 +17,7 @@ type HTTPClient interface {
 	RoundTripper(base http.RoundTripper) (http.RoundTripper, error)
 }
 
-// GRPCClient is an optional Extension interface that can be used as a gRPC authenticator for the configauth.Authentication option.
+// GRPCClient is an optional Extension interface that can be used as a gRPC authenticator for the configauth.AuthenticationConfig option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
 // names from the Authentication configuration.
 type GRPCClient interface {

--- a/extension/extensionauth/server.go
+++ b/extension/extensionauth/server.go
@@ -9,7 +9,7 @@ import (
 
 // Server is an optional Extension interface that can be used as an authenticator for the configauth.Config option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
-// names from the Authentication configuration. Each Server is free to define its own behavior and configuration options,
+// names from the [configauth.Config] configuration. Each Server is free to define its own behavior and configuration options,
 // but note that the expectations that come as part of Extensions exist here as well. For instance, multiple instances of the same
 // authenticator should be possible to exist under different names.
 type Server interface {

--- a/extension/extensionauth/server.go
+++ b/extension/extensionauth/server.go
@@ -7,7 +7,7 @@ import (
 	"context"
 )
 
-// Server is an optional Extension interface that can be used as an authenticator for the configauth.Authentication option.
+// Server is an optional Extension interface that can be used as an authenticator for the configauth.AuthenticationConfig option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
 // names from the Authentication configuration. Each Server is free to define its own behavior and configuration options,
 // but note that the expectations that come as part of Extensions exist here as well. For instance, multiple instances of the same

--- a/extension/extensionauth/server.go
+++ b/extension/extensionauth/server.go
@@ -7,7 +7,7 @@ import (
 	"context"
 )
 
-// Server is an optional Extension interface that can be used as an authenticator for the configauth.AuthenticationConfig option.
+// Server is an optional Extension interface that can be used as an authenticator for the configauth.Config option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
 // names from the Authentication configuration. Each Server is free to define its own behavior and configuration options,
 // but note that the expectations that come as part of Extensions exist here as well. For instance, multiple instances of the same

--- a/extension/zpagesextension/zpagesextension_test.go
+++ b/extension/zpagesextension/zpagesextension_test.go
@@ -81,7 +81,7 @@ func TestZPagesExtensionBadAuthExtension(t *testing.T) {
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: "localhost:0",
 			Auth: &confighttp.AuthConfig{
-				Authentication: configauth.Config{
+				Config: configauth.Config{
 					AuthenticatorID: component.MustNewIDWithName("foo", "bar"),
 				},
 			},

--- a/extension/zpagesextension/zpagesextension_test.go
+++ b/extension/zpagesextension/zpagesextension_test.go
@@ -81,7 +81,7 @@ func TestZPagesExtensionBadAuthExtension(t *testing.T) {
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: "localhost:0",
 			Auth: &confighttp.AuthConfig{
-				Authentication: configauth.Authentication{
+				Authentication: configauth.AuthenticationConfig{
 					AuthenticatorID: component.MustNewIDWithName("foo", "bar"),
 				},
 			},

--- a/extension/zpagesextension/zpagesextension_test.go
+++ b/extension/zpagesextension/zpagesextension_test.go
@@ -81,7 +81,7 @@ func TestZPagesExtensionBadAuthExtension(t *testing.T) {
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: "localhost:0",
 			Auth: &confighttp.AuthConfig{
-				Authentication: configauth.AuthenticationConfig{
+				Authentication: configauth.Config{
 					AuthenticatorID: component.MustNewIDWithName("foo", "bar"),
 				},
 			},

--- a/internal/e2e/configauth_test.go
+++ b/internal/e2e/configauth_test.go
@@ -15,6 +15,6 @@ import (
 
 func TestConfmapMarshalConfigAuth(t *testing.T) {
 	conf := confmap.New()
-	require.NoError(t, conf.Marshal(configauth.Authentication{}))
+	require.NoError(t, conf.Marshal(configauth.AuthenticationConfig{}))
 	assert.Equal(t, map[string]any{}, conf.ToStringMap())
 }

--- a/internal/e2e/configauth_test.go
+++ b/internal/e2e/configauth_test.go
@@ -15,6 +15,6 @@ import (
 
 func TestConfmapMarshalConfigAuth(t *testing.T) {
 	conf := confmap.New()
-	require.NoError(t, conf.Marshal(configauth.AuthenticationConfig{}))
+	require.NoError(t, conf.Marshal(configauth.Config{}))
 	assert.Equal(t, map[string]any{}, conf.ToStringMap())
 }

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -121,7 +121,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				HTTP: &HTTPConfig{
 					ServerConfig: confighttp.ServerConfig{
 						Auth: &confighttp.AuthConfig{
-							Authentication: configauth.Config{
+							Config: configauth.Config{
 								AuthenticatorID: component.MustNewID("test"),
 							},
 						},

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -121,7 +121,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				HTTP: &HTTPConfig{
 					ServerConfig: confighttp.ServerConfig{
 						Auth: &confighttp.AuthConfig{
-							Authentication: configauth.Authentication{
+							Authentication: configauth.AuthenticationConfig{
 								AuthenticatorID: component.MustNewID("test"),
 							},
 						},

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -121,7 +121,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				HTTP: &HTTPConfig{
 					ServerConfig: confighttp.ServerConfig{
 						Auth: &confighttp.AuthConfig{
-							Authentication: configauth.AuthenticationConfig{
+							Authentication: configauth.Config{
 								AuthenticatorID: component.MustNewID("test"),
 							},
 						},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Deprecates `configauth.Authentication` in favor of `configauth.AuthenticationConfig`.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #12875 