### PR TITLE
fix: wrap url parse error 

### DIFF
--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -63,7 +63,7 @@ func newExporter(cfg component.Config, set exporter.Settings) (*baseExporter, er
 	if oCfg.ClientConfig.Endpoint != "" {
 		_, err := url.Parse(oCfg.ClientConfig.Endpoint)
 		if err != nil {
-			return nil, errors.New("endpoint must be a valid URL")
+			return nil, fmt.Errorf("endpoint must be a valid URL: %w", err)
 		}
 	}
 


### PR DESCRIPTION
#### Description
When passing a invalid url to `otlphttpexporter` the error message was `endpoint must be a valid URL`. To make it more obvious what was wrong the error returned from `url.Parse` should be wrapped

Fixes #

#### Testing

#### Documentation

