### PR TITLE
Fix typo in README.md

### DIFF
--- a/exporter/otlphttpexporter/README.md
+++ b/exporter/otlphttpexporter/README.md
@@ -34,7 +34,7 @@ The following settings can be optionally configured:
 - `metrics_endpoint` (no default): The target URL to send metric data to (e.g.: https://example.com:4318/v1/metrics).
    If this setting is present the `endpoint` setting is ignored for metrics.
 - `logs_endpoint` (no default): The target URL to send log data to (e.g.: https://example.com:4318/v1/logs).
-   If this setting is present the `endpoint` setting is ignored logs.
+   If this setting is present the `endpoint` setting is ignored for logs.
 - `tls`: see [TLS Configuration Settings](../../config/configtls/README.md) for the full set of available options.
 - `timeout` (default = 30s): HTTP request time limit. For details see https://golang.org/pkg/net/http/#Client
 - `read_buffer_size` (default = 0): ReadBufferSize for HTTP client.


### PR DESCRIPTION
Corrected a missing "for" in the extended description to improve readability and grammar.
