### PR TITLE
[exporter][queuebatch] Reproduce issues/12244 deadlock

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/queue_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch.go
@@ -64,7 +64,7 @@ func newQueueBatch(
 	var b Batcher[request.Request]
 	if cfg.Batch != nil {
 		// TODO: https://github.com/open-telemetry/opentelemetry-collector/issues/12244
-		cfg.NumConsumers = 1
+		fmt.Println("Number of consumer is ", cfg.NumConsumers)
 		if oldBatcher {
 			// If user configures the old batcher we only can support "items" sizer.
 			b = newDefaultBatcher(*cfg.Batch, batcherSettings[request.Request]{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

An attempt to reproduce deadlock mentioned in https://github.com/open-telemetry/opentelemetry-collector/issues/12244

Setup:
* `waitForSetup` is true
* `numConsumer = 2`
* time-based flushing disabled
* 5 requests needed to trigger the flush (min is set to 19, per request size is 4)

Result:
* No deadlock detected

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
