### PR TITLE
[exporterhelper] Do not ignore the `num_consumers` setting when batching is enabled

### DIFF
--- a/.chloggen/exporterhelper-remove-hardcoded-one-worker.yaml
+++ b/.chloggen/exporterhelper-remove-hardcoded-one-worker.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not ignore the `num_consumers` setting when batching is enabled.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12244]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch.go
@@ -63,8 +63,6 @@ func newQueueBatch(
 
 	var b Batcher[request.Request]
 	if cfg.Batch != nil {
-		// TODO: https://github.com/open-telemetry/opentelemetry-collector/issues/12244
-		cfg.NumConsumers = 1
 		if oldBatcher {
 			// If user configures the old batcher we only can support "items" sizer.
 			b = newDefaultBatcher(*cfg.Batch, batcherSettings[request.Request]{
@@ -81,6 +79,9 @@ func newQueueBatch(
 				maxWorkers: cfg.NumConsumers,
 			})
 		}
+		// Keep the number of queue consumers to 1 if batching is enabled until we support sharding as described in
+		// https://github.com/open-telemetry/opentelemetry-collector/issues/12473
+		cfg.NumConsumers = 1
 	} else {
 		b = newDisabledBatcher[request.Request](next)
 	}


### PR DESCRIPTION
Remove hardcoding the number of queue workers to one if batching is enabled. The bug described in https://github.com/open-telemetry/opentelemetry-collector/issues/12244 isn't relevant anymore.
