### PR TITLE
add storage full error to xextension/storage

### DIFF
--- a/.chloggen/storage-full-error.yaml
+++ b/.chloggen/storage-full-error.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: xextension/storage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: ErrStorageFull error added to xextension/storage contract
+
+# One or more tracking issues or pull requests related to the change
+issues: [12925]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/extension/xextension/storage/storage.go
+++ b/extension/xextension/storage/storage.go
@@ -5,6 +5,7 @@ package storage // import "go.opentelemetry.io/collector/extension/xextension/st
 
 import (
 	"context"
+	"errors"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
@@ -91,3 +92,5 @@ func DeleteOperation(key string) *Operation {
 		Type: Delete,
 	}
 }
+
+var ErrStorageFull = errors.New("the storage extension has run out of available space")


### PR DESCRIPTION
#### Description
This adds an error for when the storage extension runs out of space. Extensions can return this error when it's not possible to store data because the maximum allowable/possible space has been reached.

#### Link to tracking issue
Fixes #12634

#### Testing
I have been working on the filestorage extension and have a draft PR that uses this error: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39667