### PR TITLE
[chore] exporter/exporterhelper: remove outdated warning

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -1,8 +1,7 @@
 # Exporter Helper
 
-This is a helper exporter that other exporters can depend on. Today, it primarily offers queued retry capabilities.
-
-> :warning: This exporter should not be added to a service pipeline.
+This package provides reusable implementations of common capabilities for exporters.
+Currently, this includes queuing, batching, timeouts, and retries.
 
 ## Configuration
 


### PR DESCRIPTION
#### Description

The warning does not appear to be relevant any more. It comes from a time when the package provided a factory, and I assume it was warning against using that factory directly within the service pipeline, as opposed to indirectly from another exporter.

#### Link to tracking issue

N/A

#### Testing

N/A

#### Documentation

N/A