### PR TITLE
[chore] apply no literal unkeyed initialization

### DIFF
--- a/component/build_info.go
+++ b/component/build_info.go
@@ -14,6 +14,9 @@ type BuildInfo struct {
 
 	// Version string.
 	Version string
+
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // NewDefaultBuildInfo returns a default BuildInfo.

--- a/config/configmiddleware/configmiddleware.go
+++ b/config/configmiddleware/configmiddleware.go
@@ -29,6 +29,8 @@ var (
 type Config struct {
 	// ID specifies the name of the extension to use.
 	ID component.ID `mapstructure:"id,omitempty"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // GetHTTPClientRoundTripper attempts to select the appropriate

--- a/config/configtls/tpm.go
+++ b/config/configtls/tpm.go
@@ -21,6 +21,8 @@ type TPMConfig struct {
 	Path      string `mapstructure:"path"`
 	OwnerAuth string `mapstructure:"owner_auth"`
 	Auth      string `mapstructure:"auth"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (c TPMConfig) tpmCertificate(keyPem []byte, certPem []byte, openTPM func() (transport.TPMCloser, error)) (tls.Certificate, error) {

--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -28,6 +28,8 @@ type ConfigProvider struct {
 type ConfigProviderSettings struct {
 	// ResolverSettings are the settings to configure the behavior of the confmap.Resolver.
 	ResolverSettings confmap.ResolverSettings
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // NewConfigProvider returns a new ConfigProvider that provides the service configuration:

--- a/receiver/receivertest/contract_checker.go
+++ b/receiver/receivertest/contract_checker.go
@@ -63,6 +63,8 @@ type CheckConsumeContractParams struct {
 	// GenerateCount specifies the number of times to call the generator.Generate()
 	// for each test scenario.
 	GenerateCount int
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // CheckConsumeContract checks the contract between the receiver and its next consumer. For the contract

--- a/service/config.go
+++ b/service/config.go
@@ -19,4 +19,7 @@ type Config struct {
 
 	// Pipelines are the set of data pipelines configured for the service.
 	Pipelines pipelines.Config `mapstructure:"pipelines"`
+
+	// prevent unkeyed literal initialization
+	_ struct{}
 }


### PR DESCRIPTION
Add a few `_ struct{}` to block unkeyed literal initialization. See #12360 
