### PR TITLE
[chore] Update obsconsumer to use new attribute name

### DIFF
--- a/service/internal/obsconsumer/logs_test.go
+++ b/service/internal/obsconsumer/logs_test.go
@@ -67,7 +67,7 @@ func TestLogsConsumeSuccess(t *testing.T) {
 
 	attrs := data.DataPoints[0].Attributes
 	require.Equal(t, 1, attrs.Len())
-	val, ok := attrs.Value(attribute.Key("outcome"))
+	val, ok := attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 }
@@ -108,7 +108,7 @@ func TestLogsConsumeFailure(t *testing.T) {
 
 	attrs := data.DataPoints[0].Attributes
 	require.Equal(t, 1, attrs.Len())
-	val, ok := attrs.Value(attribute.Key("outcome"))
+	val, ok := attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "failure", val.Emit())
 }
@@ -152,7 +152,7 @@ func TestLogsWithStaticAttributes(t *testing.T) {
 	val, ok := attrs.Value(attribute.Key("test"))
 	require.True(t, ok)
 	require.Equal(t, "value", val.Emit())
-	val, ok = attrs.Value(attribute.Key("outcome"))
+	val, ok = attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 }
@@ -224,7 +224,7 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 	// Find success and failure data points
 	var successDP, failureDP metricdata.DataPoint[int64]
 	for _, dp := range data.DataPoints {
-		val, ok := dp.Attributes.Value(attribute.Key("outcome"))
+		val, ok := dp.Attributes.Value(attribute.Key(obsconsumer.ComponentOutcome))
 		if ok && val.Emit() == "success" {
 			successDP = dp
 		} else {

--- a/service/internal/obsconsumer/metrics_test.go
+++ b/service/internal/obsconsumer/metrics_test.go
@@ -68,7 +68,7 @@ func TestMetricsConsumeSuccess(t *testing.T) {
 
 	attrs := data.DataPoints[0].Attributes
 	require.Equal(t, 1, attrs.Len())
-	val, ok := attrs.Value(attribute.Key("outcome"))
+	val, ok := attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 }
@@ -110,7 +110,7 @@ func TestMetricsConsumeFailure(t *testing.T) {
 
 	attrs := data.DataPoints[0].Attributes
 	require.Equal(t, 1, attrs.Len())
-	val, ok := attrs.Value(attribute.Key("outcome"))
+	val, ok := attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "failure", val.Emit())
 }
@@ -156,7 +156,7 @@ func TestMetricsWithStaticAttributes(t *testing.T) {
 	val, ok := attrs.Value(attribute.Key("test"))
 	require.True(t, ok)
 	require.Equal(t, "value", val.Emit())
-	val, ok = attrs.Value(attribute.Key("outcome"))
+	val, ok = attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 }
@@ -232,7 +232,7 @@ func TestMetricsMultipleItemsMixedOutcomes(t *testing.T) {
 	// Find success and failure data points
 	var successDP, failureDP metricdata.DataPoint[int64]
 	for _, dp := range data.DataPoints {
-		val, ok := dp.Attributes.Value(attribute.Key("outcome"))
+		val, ok := dp.Attributes.Value(attribute.Key(obsconsumer.ComponentOutcome))
 		if ok && val.Emit() == "success" {
 			successDP = dp
 		} else {

--- a/service/internal/obsconsumer/option.go
+++ b/service/internal/obsconsumer/option.go
@@ -8,6 +8,10 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+const (
+	ComponentOutcome = "otelcol.component.outcome"
+)
+
 // Option modifies the consumer behavior.
 type Option interface {
 	apply(*options)
@@ -35,11 +39,11 @@ type compiledOptions struct {
 
 func (o *options) compile() compiledOptions {
 	successAttrs := make([]attribute.KeyValue, 0, 1+len(o.staticDataPointAttributes))
-	successAttrs = append(successAttrs, attribute.String("outcome", "success"))
+	successAttrs = append(successAttrs, attribute.String(ComponentOutcome, "success"))
 	successAttrs = append(successAttrs, o.staticDataPointAttributes...)
 
 	failureAttrs := make([]attribute.KeyValue, 0, 1+len(o.staticDataPointAttributes))
-	failureAttrs = append(failureAttrs, attribute.String("outcome", "failure"))
+	failureAttrs = append(failureAttrs, attribute.String(ComponentOutcome, "failure"))
 	failureAttrs = append(failureAttrs, o.staticDataPointAttributes...)
 
 	return compiledOptions{

--- a/service/internal/obsconsumer/profiles_test.go
+++ b/service/internal/obsconsumer/profiles_test.go
@@ -67,7 +67,7 @@ func TestProfilesConsumeSuccess(t *testing.T) {
 
 	attrs := data.DataPoints[0].Attributes
 	require.Equal(t, 1, attrs.Len())
-	val, ok := attrs.Value(attribute.Key("outcome"))
+	val, ok := attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 }
@@ -108,7 +108,7 @@ func TestProfilesConsumeFailure(t *testing.T) {
 
 	attrs := data.DataPoints[0].Attributes
 	require.Equal(t, 1, attrs.Len())
-	val, ok := attrs.Value(attribute.Key("outcome"))
+	val, ok := attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "failure", val.Emit())
 }
@@ -152,7 +152,7 @@ func TestProfilesWithStaticAttributes(t *testing.T) {
 	val, ok := attrs.Value(attribute.Key("test"))
 	require.True(t, ok)
 	require.Equal(t, "value", val.Emit())
-	val, ok = attrs.Value(attribute.Key("outcome"))
+	val, ok = attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 }
@@ -224,7 +224,7 @@ func TestProfilesMultipleItemsMixedOutcomes(t *testing.T) {
 	// Find success and failure data points
 	var successDP, failureDP metricdata.DataPoint[int64]
 	for _, dp := range data.DataPoints {
-		val, ok := dp.Attributes.Value(attribute.Key("outcome"))
+		val, ok := dp.Attributes.Value(attribute.Key(obsconsumer.ComponentOutcome))
 		if ok && val.Emit() == "success" {
 			successDP = dp
 		} else {

--- a/service/internal/obsconsumer/traces_test.go
+++ b/service/internal/obsconsumer/traces_test.go
@@ -67,7 +67,7 @@ func TestTracesConsumeSuccess(t *testing.T) {
 
 	attrs := data.DataPoints[0].Attributes
 	require.Equal(t, 1, attrs.Len())
-	val, ok := attrs.Value(attribute.Key("outcome"))
+	val, ok := attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 }
@@ -108,7 +108,7 @@ func TestTracesConsumeFailure(t *testing.T) {
 
 	attrs := data.DataPoints[0].Attributes
 	require.Equal(t, 1, attrs.Len())
-	val, ok := attrs.Value(attribute.Key("outcome"))
+	val, ok := attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "failure", val.Emit())
 }
@@ -152,7 +152,7 @@ func TestTracesWithStaticAttributes(t *testing.T) {
 	val, ok := attrs.Value(attribute.Key("test"))
 	require.True(t, ok)
 	require.Equal(t, "value", val.Emit())
-	val, ok = attrs.Value(attribute.Key("outcome"))
+	val, ok = attrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 }
@@ -224,7 +224,7 @@ func TestTracesMultipleItemsMixedOutcomes(t *testing.T) {
 	// Find success and failure data points
 	var successDP, failureDP metricdata.DataPoint[int64]
 	for _, dp := range data.DataPoints {
-		val, ok := dp.Attributes.Value(attribute.Key("outcome"))
+		val, ok := dp.Attributes.Value(attribute.Key(obsconsumer.ComponentOutcome))
 		if ok && val.Emit() == "success" {
 			successDP = dp
 		} else {


### PR DESCRIPTION
Implements new name for attribute as documented in #12951.

Note: The obsconsumer package is unused until #12812 is merged so this is not a breaking change.