### PR TITLE
[chore] Add testing requirements for stable components

### DIFF
--- a/docs/component-stability.md
+++ b/docs/component-stability.md
@@ -87,6 +87,16 @@ Stable components MUST be compatible between minor versions unless critical secu
 component owner MUST provide a migration path and a reasonable time frame for users to upgrade. The same rules from beta
 components apply to stable when it comes to configuration changes.
 
+#### Testing requirements
+
+Stable components MUST have a test coverage that exceeds the highest between 80% coverage and the
+repository-wide minimum. The unit test suite SHOULD cover all configuration options. The coverage
+MUST be shown as part of the component documentation.
+
+Stable components SHOULD provide at least one example configuration that works for each stable
+signal, and have at least one lifecycle test that tests the component's initialization with a valid
+configuration. Said configuration should also be shown in the component documentation.
+
 #### Documentation requirements
 
 Stable components should have a complete set of documentation, including:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Adds wording regarding testing requirements for stable components. The intent is for the lifecycle tests to be handled via mdatagen.

This follows the work done on open-telemetry/opentelemetry-collector-contrib/issues/39543, with which now we have component coverage per component.

#### Link to tracking issue
Fixes #11867
