### PR TITLE
update semconv dependency to otelgo's semconv package

### DIFF
--- a/.chloggen/codeboten_remove-internal-semconv-dep.yaml
+++ b/.chloggen/codeboten_remove-internal-semconv-dep.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Replace `go.opentelemetry.io/collector/semconv` usage with `go.opentelemetry.io/otel/semconv`"
+
+# One or more tracking issues or pull requests related to the change
+issues: [12991]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -109,7 +109,6 @@ var replaceModules = []string{
 	"/receiver/receivertest",
 	"/receiver/receiverhelper",
 	"/receiver/xreceiver",
-	"/semconv",
 	"/service",
 	"/service/hostcapabilities",
 }

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -23,7 +23,7 @@ require (
 	go.opentelemetry.io/collector/receiver/receivertest v0.125.0
 	go.opentelemetry.io/collector/scraper v0.125.0
 	go.opentelemetry.io/collector/scraper/scrapertest v0.125.0
-	go.opentelemetry.io/collector/semconv v0.125.0
+	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
 	go.opentelemetry.io/otel/sdk/metric v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
@@ -66,7 +66,6 @@ require (
 	go.opentelemetry.io/collector/processor/xprocessor v0.125.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.125.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
-	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -94,8 +93,6 @@ replace go.opentelemetry.io/collector/pdata => ../../pdata
 replace go.opentelemetry.io/collector/pdata/testdata => ../../pdata/testdata
 
 replace go.opentelemetry.io/collector/receiver => ../../receiver
-
-replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics.go
@@ -7,12 +7,13 @@ import (
 	"strconv"
 	"time"
 
+	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
 // AttributeEnumAttr specifies the value enum_attr attribute.

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_logs.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_logs.go
@@ -3,11 +3,12 @@
 package metadata
 
 import (
+	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
 // LogsBuilder provides an interface for scrapers to report logs while taking care of all the transformations

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
@@ -7,12 +7,13 @@ import (
 	"strconv"
 	"time"
 
+	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
 // AttributeEnumAttr specifies the value enum_attr attribute.

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_logs.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_logs.go
@@ -3,11 +3,12 @@
 package metadata
 
 import (
+	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/scraper"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
 // LogsBuilder provides an interface for scrapers to report logs while taking care of all the transformations

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics.go
@@ -7,12 +7,13 @@ import (
 	"strconv"
 	"time"
 
+	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/scraper"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
 // AttributeEnumAttr specifies the value enum_attr attribute.

--- a/cmd/mdatagen/internal/templates/logs.go.tmpl
+++ b/cmd/mdatagen/internal/templates/logs.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/{{ .Status.Class }}"
 	{{- end }}
 	{{- if .SemConvVersion }}
-	conventions "go.opentelemetry.io/collector/semconv/v{{ .SemConvVersion }}"
+	conventions "go.opentelemetry.io/otel/semconv/v{{ .SemConvVersion }}"
 	{{- end }}
 )
 

--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/collector/{{ .Status.Class }}"
 	{{- end }}
 	{{- if .SemConvVersion }}
-	conventions "go.opentelemetry.io/collector/semconv/v{{ .SemConvVersion }}"
+	conventions "go.opentelemetry.io/otel/semconv/v{{ .SemConvVersion }}"
 	{{- end }}
 	{{ if .ResourceAttributes -}}
 	"go.opentelemetry.io/collector/filter"

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -110,6 +110,5 @@ replaces:
   - go.opentelemetry.io/collector/receiver/otlpreceiver => ../../receiver/otlpreceiver
   - go.opentelemetry.io/collector/receiver/receivertest => ../../receiver/receivertest
   - go.opentelemetry.io/collector/receiver/xreceiver => ../../receiver/xreceiver
-  - go.opentelemetry.io/collector/semconv => ../../semconv
   - go.opentelemetry.io/collector/service => ../../service
   - go.opentelemetry.io/collector/service/hostcapabilities => ../../service/hostcapabilities

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -131,7 +131,6 @@ require (
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.125.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.125.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.125.0 // indirect
-	go.opentelemetry.io/collector/semconv v0.125.0 // indirect
 	go.opentelemetry.io/collector/service v0.125.0 // indirect
 	go.opentelemetry.io/collector/service/hostcapabilities v0.125.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
@@ -319,8 +318,6 @@ replace go.opentelemetry.io/collector/receiver/otlpreceiver => ../../receiver/ot
 replace go.opentelemetry.io/collector/receiver/receivertest => ../../receiver/receivertest
 
 replace go.opentelemetry.io/collector/receiver/xreceiver => ../../receiver/xreceiver
-
-replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/service => ../../service
 

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -108,7 +108,6 @@ require (
 	go.opentelemetry.io/collector/processor/xprocessor v0.125.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.125.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.125.0 // indirect
-	go.opentelemetry.io/collector/semconv v0.125.0 // indirect
 	go.opentelemetry.io/collector/service/hostcapabilities v0.125.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
@@ -213,8 +212,6 @@ replace go.opentelemetry.io/collector/component/componentstatus => ../../compone
 replace go.opentelemetry.io/collector/connector => ../../connector
 
 replace go.opentelemetry.io/collector/connector/connectortest => ../../connector/connectortest
-
-replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/processor => ../../processor
 

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -90,7 +90,6 @@ require (
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.125.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.125.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.125.0 // indirect
-	go.opentelemetry.io/collector/semconv v0.125.0 // indirect
 	go.opentelemetry.io/collector/service/hostcapabilities v0.125.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.35.0 // indirect
@@ -157,8 +156,6 @@ replace go.opentelemetry.io/collector/config/configtelemetry => ../config/config
 replace go.opentelemetry.io/collector/processor => ../processor
 
 replace go.opentelemetry.io/collector/consumer => ../consumer
-
-replace go.opentelemetry.io/collector/semconv => ../semconv
 
 replace go.opentelemetry.io/collector/receiver => ../receiver
 

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -86,7 +86,6 @@ require (
 	go.opentelemetry.io/collector/processor/xprocessor v0.125.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.31.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.125.0 // indirect
-	go.opentelemetry.io/collector/semconv v0.125.0 // indirect
 	go.opentelemetry.io/collector/service/hostcapabilities v0.125.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/otelconf v0.15.0 // indirect
@@ -162,8 +161,6 @@ replace go.opentelemetry.io/collector/component/componenttest => ../../component
 replace go.opentelemetry.io/collector/extension => ../../extension
 
 replace go.opentelemetry.io/collector/exporter => ../../exporter
-
-replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/consumer/xconsumer => ../../consumer/xconsumer
 

--- a/service/go.mod
+++ b/service/go.mod
@@ -44,7 +44,6 @@ require (
 	go.opentelemetry.io/collector/receiver v1.31.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.125.0
 	go.opentelemetry.io/collector/receiver/xreceiver v0.125.0
-	go.opentelemetry.io/collector/semconv v0.125.0
 	go.opentelemetry.io/collector/service/hostcapabilities v0.125.0
 	go.opentelemetry.io/contrib/otelconf v0.15.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.35.0
@@ -178,8 +177,6 @@ replace go.opentelemetry.io/collector/processor => ../processor
 replace go.opentelemetry.io/collector/processor/processortest => ../processor/processortest
 
 replace go.opentelemetry.io/collector/consumer => ../consumer
-
-replace go.opentelemetry.io/collector/semconv => ../semconv
 
 replace go.opentelemetry.io/collector/service/hostcapabilities => ./hostcapabilities
 

--- a/service/hostcapabilities/go.mod
+++ b/service/hostcapabilities/go.mod
@@ -80,7 +80,7 @@ replace (
 	go.opentelemetry.io/collector/receiver => ../../receiver
 	go.opentelemetry.io/collector/receiver/receivertest => ../../receiver/receivertest
 	go.opentelemetry.io/collector/receiver/xreceiver => ../../receiver/xreceiver
-	go.opentelemetry.io/collector/semconv => ../../semconv
+
 	go.opentelemetry.io/collector/service => ..
 )
 

--- a/service/internal/resource/config.go
+++ b/service/internal/resource/config.go
@@ -7,9 +7,9 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 
 	"go.opentelemetry.io/collector/component"
-	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
 )
 
 // New resource from telemetry configuration.
@@ -23,22 +23,22 @@ func New(buildInfo component.BuildInfo, resourceCfg map[string]*string) *resourc
 		}
 	}
 
-	if _, ok := resourceCfg[semconv.AttributeServiceName]; !ok {
+	if _, ok := resourceCfg[string(semconv.ServiceNameKey)]; !ok {
 		// AttributeServiceName is not specified in the config. Use the default service name.
-		telAttrs = append(telAttrs, attribute.String(semconv.AttributeServiceName, buildInfo.Command))
+		telAttrs = append(telAttrs, semconv.ServiceNameKey.String(buildInfo.Command))
 	}
 
-	if _, ok := resourceCfg[semconv.AttributeServiceInstanceID]; !ok {
+	if _, ok := resourceCfg[string(semconv.ServiceInstanceIDKey)]; !ok {
 		// AttributeServiceInstanceID is not specified in the config. Auto-generate one.
 		instanceUUID, _ := uuid.NewRandom()
 		instanceID := instanceUUID.String()
-		telAttrs = append(telAttrs, attribute.String(semconv.AttributeServiceInstanceID, instanceID))
+		telAttrs = append(telAttrs, semconv.ServiceInstanceIDKey.String(instanceID))
 	}
 
-	if _, ok := resourceCfg[semconv.AttributeServiceVersion]; !ok {
+	if _, ok := resourceCfg[string(semconv.ServiceVersionKey)]; !ok {
 		// AttributeServiceVersion is not specified in the config. Use the actual
 		// build version.
-		telAttrs = append(telAttrs, attribute.String(semconv.AttributeServiceVersion, buildInfo.Version))
+		telAttrs = append(telAttrs, semconv.ServiceVersionKey.String(buildInfo.Version))
 	}
 	return resource.NewWithAttributes(semconv.SchemaURL, telAttrs...)
 }

--- a/service/internal/resource/config_test.go
+++ b/service/internal/resource/config_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
 )
 
 const (
@@ -125,21 +125,21 @@ func TestBuildResource(t *testing.T) {
 	res := pdataFromSdk(otelRes)
 
 	assert.Equal(t, 3, res.Attributes().Len())
-	value, ok := res.Attributes().Get(semconv.AttributeServiceName)
+	value, ok := res.Attributes().Get("service.name")
 	assert.True(t, ok)
 	assert.Equal(t, buildInfo.Command, value.AsString())
-	value, ok = res.Attributes().Get(semconv.AttributeServiceVersion)
+	value, ok = res.Attributes().Get("service.version")
 	assert.True(t, ok)
 	assert.Equal(t, buildInfo.Version, value.AsString())
 
-	_, ok = res.Attributes().Get(semconv.AttributeServiceInstanceID)
+	_, ok = res.Attributes().Get("service.instance.id")
 	assert.True(t, ok)
 
 	// Check override by nil
 	resMap = map[string]*string{
-		semconv.AttributeServiceName:       nil,
-		semconv.AttributeServiceVersion:    nil,
-		semconv.AttributeServiceInstanceID: nil,
+		string(semconv.ServiceNameKey):       nil,
+		string(semconv.ServiceVersionKey):    nil,
+		string(semconv.ServiceInstanceIDKey): nil,
 	}
 	otelRes = New(buildInfo, resMap)
 	res = pdataFromSdk(otelRes)
@@ -150,21 +150,21 @@ func TestBuildResource(t *testing.T) {
 	// Check override values
 	strPtr := func(v string) *string { return &v }
 	resMap = map[string]*string{
-		semconv.AttributeServiceName:       strPtr("a"),
-		semconv.AttributeServiceVersion:    strPtr("b"),
-		semconv.AttributeServiceInstanceID: strPtr("c"),
+		string(semconv.ServiceNameKey):       strPtr("a"),
+		string(semconv.ServiceVersionKey):    strPtr("b"),
+		string(semconv.ServiceInstanceIDKey): strPtr("c"),
 	}
 	otelRes = New(buildInfo, resMap)
 	res = pdataFromSdk(otelRes)
 
 	assert.Equal(t, 3, res.Attributes().Len())
-	value, ok = res.Attributes().Get(semconv.AttributeServiceName)
+	value, ok = res.Attributes().Get("service.name")
 	assert.True(t, ok)
 	assert.Equal(t, "a", value.AsString())
-	value, ok = res.Attributes().Get(semconv.AttributeServiceVersion)
+	value, ok = res.Attributes().Get("service.version")
 	assert.True(t, ok)
 	assert.Equal(t, "b", value.AsString())
-	value, ok = res.Attributes().Get(semconv.AttributeServiceInstanceID)
+	value, ok = res.Attributes().Get("service.instance.id")
 	assert.True(t, ok)
 	assert.Equal(t, "c", value.AsString())
 }

--- a/service/service.go
+++ b/service/service.go
@@ -16,6 +16,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+	semconv118 "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -30,8 +32,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
-	semconv118 "go.opentelemetry.io/collector/semconv/v1.18.0"
-	semconv "go.opentelemetry.io/collector/semconv/v1.26.0"
 	"go.opentelemetry.io/collector/service/extensions"
 	"go.opentelemetry.io/collector/service/internal/builders"
 	"go.opentelemetry.io/collector/service/internal/graph"
@@ -436,9 +436,9 @@ func configureViews(level configtelemetry.Level) []config.View {
 				Stream: &config.ViewStream{
 					AttributeKeys: &config.IncludeExclude{
 						Excluded: []string{
-							semconv118.AttributeNetSockPeerAddr,
-							semconv118.AttributeNetSockPeerPort,
-							semconv118.AttributeNetSockPeerName,
+							string(semconv118.NetSockPeerAddrKey),
+							string(semconv118.NetSockPeerPortKey),
+							string(semconv118.NetSockPeerNameKey),
 						},
 					},
 				},
@@ -450,8 +450,8 @@ func configureViews(level configtelemetry.Level) []config.View {
 				Stream: &config.ViewStream{
 					AttributeKeys: &config.IncludeExclude{
 						Excluded: []string{
-							semconv118.AttributeNetHostName,
-							semconv118.AttributeNetHostPort,
+							string(semconv118.NetHostNameKey),
+							string(semconv118.NetHostPortKey),
 						},
 					},
 				},

--- a/service/telemetry/logger_test.go
+++ b/service/telemetry/logger_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
-	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
 )
 
 type shutdownable interface {
@@ -183,16 +183,16 @@ func TestOTLPLogExport(t *testing.T) {
 		rl := logs.ResourceLogs().At(0)
 
 		resourceAttrs := rl.Resource().Attributes().AsRaw()
-		assert.Equal(t, resourceAttrs[semconv.AttributeServiceName], service)
-		assert.Equal(t, resourceAttrs[semconv.AttributeServiceVersion], version)
+		assert.Equal(t, resourceAttrs[string(semconv.ServiceNameKey)], service)
+		assert.Equal(t, resourceAttrs[string(semconv.ServiceVersionKey)], version)
 		assert.Equal(t, resourceAttrs[testAttribute], testValue)
 
 		// Check that the resource attributes are not duplicated in the log records
 		sl := rl.ScopeLogs().At(0)
 		logRecord := sl.LogRecords().At(0)
 		attrs := logRecord.Attributes().AsRaw()
-		assert.NotContains(t, attrs, semconv.AttributeServiceName)
-		assert.NotContains(t, attrs, semconv.AttributeServiceVersion)
+		assert.NotContains(t, attrs, string(semconv.ServiceNameKey))
+		assert.NotContains(t, attrs, string(semconv.ServiceVersionKey))
 		assert.NotContains(t, attrs, testAttribute)
 
 		receivedLogs++
@@ -233,8 +233,8 @@ func TestOTLPLogExport(t *testing.T) {
 				Resource: &config.Resource{
 					SchemaUrl: ptr(""),
 					Attributes: []config.AttributeNameValue{
-						{Name: semconv.AttributeServiceName, Value: service},
-						{Name: semconv.AttributeServiceVersion, Value: version},
+						{Name: string(semconv.ServiceNameKey), Value: service},
+						{Name: string(semconv.ServiceVersionKey), Value: version},
 						{Name: testAttribute, Value: testValue},
 					},
 				},

--- a/service/telemetry/metrics_test.go
+++ b/service/telemetry/metrics_test.go
@@ -17,9 +17,9 @@ import (
 	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
-	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
 	"go.opentelemetry.io/collector/service/internal/promtest"
 )
 
@@ -116,9 +116,9 @@ func TestTelemetryInit(t *testing.T) {
 					Resource: &config.Resource{
 						SchemaUrl: ptr(""),
 						Attributes: []config.AttributeNameValue{
-							{Name: semconv.AttributeServiceInstanceID, Value: testInstanceID},
-							{Name: semconv.AttributeServiceName, Value: "otelcol"},
-							{Name: semconv.AttributeServiceVersion, Value: "latest"},
+							{Name: string(semconv.ServiceInstanceIDKey), Value: testInstanceID},
+							{Name: string(semconv.ServiceNameKey), Value: "otelcol"},
+							{Name: string(semconv.ServiceVersionKey), Value: "latest"},
 						},
 					},
 				}),
@@ -167,16 +167,16 @@ func createTestMetrics(t *testing.T, mp metric.MeterProvider) {
 	grpcExampleCounter, err := mp.Meter("go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc").Int64Counter(metricPrefix + grpcPrefix + counterName)
 	require.NoError(t, err)
 	grpcExampleCounter.Add(context.Background(), 11, metric.WithAttributeSet(attribute.NewSet(
-		attribute.String(semconv.AttributeNetSockPeerAddr, ""),
-		attribute.String(semconv.AttributeNetSockPeerPort, ""),
-		attribute.String(semconv.AttributeNetSockPeerName, ""),
+		attribute.String(string(semconv.NetSockPeerAddrKey), ""),
+		attribute.String(string(semconv.NetSockPeerPortKey), ""),
+		attribute.String(string(semconv.NetSockPeerNameKey), ""),
 	)))
 
 	httpExampleCounter, err := mp.Meter("go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp").Int64Counter(metricPrefix + httpPrefix + counterName)
 	require.NoError(t, err)
 	httpExampleCounter.Add(context.Background(), 10, metric.WithAttributeSet(attribute.NewSet(
-		attribute.String(semconv.AttributeNetHostName, ""),
-		attribute.String(semconv.AttributeNetHostPort, ""),
+		attribute.String(string(semconv.NetHostNameKey), ""),
+		attribute.String(string(semconv.NetHostPortKey), ""),
 	)))
 }
 
@@ -235,9 +235,9 @@ func TestInstrumentEnabled(t *testing.T) {
 			Resource: &config.Resource{
 				SchemaUrl: ptr(""),
 				Attributes: []config.AttributeNameValue{
-					{Name: semconv.AttributeServiceInstanceID, Value: testInstanceID},
-					{Name: semconv.AttributeServiceName, Value: "otelcol"},
-					{Name: semconv.AttributeServiceVersion, Value: "latest"},
+					{Name: string(semconv.ServiceInstanceIDKey), Value: testInstanceID},
+					{Name: string(semconv.ServiceNameKey), Value: "otelcol"},
+					{Name: string(semconv.ServiceVersionKey), Value: "latest"},
 				},
 			},
 		}),


### PR DESCRIPTION
This updates the calls to the collector's internal semconv package with otelgo's instead. The main difference is how the keys can be used, they will need to be cast as strings where they key name is needed, otherwise it's not a huge change. This would allow us to stop producing our own semconv package once contrib is moved as well.

Related to https://github.com/open-telemetry/opentelemetry-collector/issues/10346, https://github.com/open-telemetry/opentelemetry-collector/issues/11828, https://github.com/open-telemetry/opentelemetry-collector/issues/11807