### PR TITLE
remove deprecated aliases

### DIFF
--- a/.chloggen/codeboten_remove-deprecated-funcs.yaml
+++ b/.chloggen/codeboten_remove-deprecated-funcs.yaml
@@ -10,7 +10,7 @@ component: configauth
 note: "Removes deprecated `configauth.Authentication` and `extensionauthtest.NewErrorClient`"
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [12992]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_remove-deprecated-funcs.yaml
+++ b/.chloggen/codeboten_remove-deprecated-funcs.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configauth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Removes deprecated `configauth.Authentication` and `extensionauthtest.NewErrorClient`"
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The following have been removed:
+  - `configauth.Authentication` use `configauth.Config` instead
+  - `extensionauthtest.NewErrorClient` use `extensionauthtest.NewErr` instead
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -22,9 +22,6 @@ var (
 	errNotServer             = errors.New("requested authenticator is not a server authenticator")
 )
 
-// Deprecated: [v0.125.0] Use Config instead.
-type Authentication = Config
-
 // Config defines the auth settings for the receiver.
 type Config struct {
 	// AuthenticatorID specifies the name of the extension to use in order to authenticate the incoming data point.

--- a/extension/extensionauth/extensionauthtest/err.go
+++ b/extension/extensionauth/extensionauthtest/err.go
@@ -28,9 +28,6 @@ type errClient struct {
 	extensionauth.ServerAuthenticateFunc
 }
 
-// Deprecated: [v0.125.0] Use NewErr.
-var NewErrorClient = NewErr
-
 // NewErr returns a new [extension.Extension] that implements all
 // extensionauth interface and always returns an error.
 func NewErr(err error) extension.Extension {


### PR DESCRIPTION
Removes:
- configauth.Authentication use configauth.Config instead
- extensionauthtest.NewErrorClient use extensionauthtest.NewErr instead
