### PR TITLE
[chore] Make mapstructure hooks safe against untyped nils

### DIFF
--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -307,6 +307,10 @@ func isStringyStructure(t reflect.Type) bool {
 	return false
 }
 
+// safeWrapDecodeHookFunc wraps a DecodeHookFuncValue to ensure that it is safe to call all
+// methods in fromVal.
+//
+// Use this only if the hook does not need to be called on nil values.
 func safeWrapDecodeHookFunc(
 	f mapstructure.DecodeHookFuncValue,
 ) mapstructure.DecodeHookFuncValue {

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -18,8 +18,8 @@ import (
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/v2"
 
-	"go.opentelemetry.io/collector/confmap/internal"
 	encoder "go.opentelemetry.io/collector/confmap/internal/mapstructure"
+	"go.opentelemetry.io/collector/confmap/internal/third_party/composehook"
 )
 
 const (
@@ -235,7 +235,7 @@ func decodeConfig(m *Conf, result any, errorUnused bool, skipTopLevelUnmarshaler
 		TagName:          MapstructureTag,
 		WeaklyTypedInput: false,
 		MatchName:        caseSensitiveMatchName,
-		DecodeHook: internal.ComposeDecodeHookFunc(
+		DecodeHook: composehook.ComposeDecodeHookFunc(
 			useExpandValue(),
 			expandNilStructPointersHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -307,8 +307,8 @@ func isStringyStructure(t reflect.Type) bool {
 	return false
 }
 
-// safeWrapDecodeHookFunc wraps a DecodeHookFuncValue to ensure that it is safe to call all
-// methods in fromVal.
+// safeWrapDecodeHookFunc wraps a DecodeHookFuncValue to ensure fromVal is a valid `reflect.Value`
+// object and therefore it is safe to call `reflect.Value` methods on fromVal.
 //
 // Use this only if the hook does not need to be called on untyped nil values.
 // Typed nil values are safe to call and will be passed to the hook.

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -310,7 +310,9 @@ func isStringyStructure(t reflect.Type) bool {
 // safeWrapDecodeHookFunc wraps a DecodeHookFuncValue to ensure that it is safe to call all
 // methods in fromVal.
 //
-// Use this only if the hook does not need to be called on nil values.
+// Use this only if the hook does not need to be called on untyped nil values.
+// Typed nil values are safe to call and will be passed to the hook.
+// See https://github.com/golang/go/issues/51649
 func safeWrapDecodeHookFunc(
 	f mapstructure.DecodeHookFuncValue,
 ) mapstructure.DecodeHookFuncValue {

--- a/confmap/internal/compose_hook.go
+++ b/confmap/internal/compose_hook.go
@@ -36,8 +36,8 @@ func typedDecodeHook(h mapstructure.DecodeHookFunc) mapstructure.DecodeHookFunc 
 
 // cachedDecodeHook takes a raw DecodeHookFunc (an any) and turns
 // it into a closure to be used directly
-// if the type fails to convert we return a closure always erroring to keep the previous behaviour
-func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, to reflect.Value) (any, error) {
+// if the type fails to convert we return a closure always erroring to keep the previous behavior
+func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(reflect.Value, reflect.Value) (any, error) {
 	switch f := typedDecodeHook(raw).(type) {
 	case mapstructure.DecodeHookFuncType:
 		return func(from reflect.Value, to reflect.Value) (any, error) {
@@ -60,7 +60,7 @@ func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, 
 			return f(from, to)
 		}
 	default:
-		return func(from reflect.Value, to reflect.Value) (any, error) {
+		return func(reflect.Value, reflect.Value) (any, error) {
 			return nil, errors.New("invalid decode hook signature")
 		}
 	}
@@ -75,7 +75,7 @@ func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, 
 // This is a copy of [mapstructure.ComposeDecodeHookFunc] but with
 // validation added.
 func ComposeDecodeHookFunc(fs ...mapstructure.DecodeHookFunc) mapstructure.DecodeHookFunc {
-	cached := make([]func(from reflect.Value, to reflect.Value) (any, error), 0, len(fs))
+	cached := make([]func(reflect.Value, reflect.Value) (any, error), 0, len(fs))
 	for _, f := range fs {
 		cached = append(cached, cachedDecodeHook(f))
 	}

--- a/confmap/internal/compose_hook.go
+++ b/confmap/internal/compose_hook.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 )
 
-// typedDecodeHook takes a raw DecodeHookFunc (an interface{}) and turns
+// typedDecodeHook takes a raw DecodeHookFunc (an any) and turns
 // it into the proper DecodeHookFunc type, such as DecodeHookFuncType.
 func typedDecodeHook(h mapstructure.DecodeHookFunc) mapstructure.DecodeHookFunc {
 	// Create variables here so we can reference them with the reflect pkg
@@ -20,7 +20,7 @@ func typedDecodeHook(h mapstructure.DecodeHookFunc) mapstructure.DecodeHookFunc 
 
 	// Fill in the variables into this interface and the rest is done
 	// automatically using the reflect package.
-	potential := []interface{}{f3, f1, f2}
+	potential := []any{f3, f1, f2}
 
 	v := reflect.ValueOf(h)
 	vt := v.Type()
@@ -34,13 +34,13 @@ func typedDecodeHook(h mapstructure.DecodeHookFunc) mapstructure.DecodeHookFunc 
 	return nil
 }
 
-// cachedDecodeHook takes a raw DecodeHookFunc (an interface{}) and turns
+// cachedDecodeHook takes a raw DecodeHookFunc (an any) and turns
 // it into a closure to be used directly
 // if the type fails to convert we return a closure always erroring to keep the previous behaviour
-func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, to reflect.Value) (interface{}, error) {
+func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, to reflect.Value) (any, error) {
 	switch f := typedDecodeHook(raw).(type) {
 	case mapstructure.DecodeHookFuncType:
-		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+		return func(from reflect.Value, to reflect.Value) (any, error) {
 			// CHANGE FROM UPSTREAM: check if from is valid and return nil if not
 			if !from.IsValid() {
 				return nil, nil
@@ -48,7 +48,7 @@ func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, 
 			return f(from.Type(), to.Type(), from.Interface())
 		}
 	case mapstructure.DecodeHookFuncKind:
-		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+		return func(from reflect.Value, to reflect.Value) (any, error) {
 			// CHANGE FROM UPSTREAM: check if from is valid and return nil if not
 			if !from.IsValid() {
 				return nil, nil
@@ -56,11 +56,11 @@ func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, 
 			return f(from.Kind(), to.Kind(), from.Interface())
 		}
 	case mapstructure.DecodeHookFuncValue:
-		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+		return func(from reflect.Value, to reflect.Value) (any, error) {
 			return f(from, to)
 		}
 	default:
-		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+		return func(from reflect.Value, to reflect.Value) (any, error) {
 			return nil, errors.New("invalid decode hook signature")
 		}
 	}
@@ -75,11 +75,11 @@ func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, 
 // This is a copy of [mapstructure.ComposeDecodeHookFunc] but with
 // validation added.
 func ComposeDecodeHookFunc(fs ...mapstructure.DecodeHookFunc) mapstructure.DecodeHookFunc {
-	cached := make([]func(from reflect.Value, to reflect.Value) (interface{}, error), 0, len(fs))
+	cached := make([]func(from reflect.Value, to reflect.Value) (any, error), 0, len(fs))
 	for _, f := range fs {
 		cached = append(cached, cachedDecodeHook(f))
 	}
-	return func(f reflect.Value, t reflect.Value) (interface{}, error) {
+	return func(f reflect.Value, t reflect.Value) (any, error) {
 		var err error
 
 		// CHANGE FROM UPSTREAM: check if f is valid before calling f.Interface()

--- a/confmap/internal/compose_hook.go
+++ b/confmap/internal/compose_hook.go
@@ -41,6 +41,7 @@ func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, 
 	switch f := typedDecodeHook(raw).(type) {
 	case mapstructure.DecodeHookFuncType:
 		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+			// CHANGE FROM UPSTREAM: check if from is valid and return nil if not
 			if !from.IsValid() {
 				return nil, nil
 			}
@@ -48,6 +49,7 @@ func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, 
 		}
 	case mapstructure.DecodeHookFuncKind:
 		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+			// CHANGE FROM UPSTREAM: check if from is valid and return nil if not
 			if !from.IsValid() {
 				return nil, nil
 			}
@@ -79,6 +81,8 @@ func ComposeDecodeHookFunc(fs ...mapstructure.DecodeHookFunc) mapstructure.Decod
 	}
 	return func(f reflect.Value, t reflect.Value) (interface{}, error) {
 		var err error
+
+		// CHANGE FROM UPSTREAM: check if f is valid before calling f.Interface()
 		var data any
 		if f.IsValid() {
 			data = f.Interface()

--- a/confmap/internal/compose_hook.go
+++ b/confmap/internal/compose_hook.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/confmap/internal/mapstructure"
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// typedDecodeHook takes a raw DecodeHookFunc (an interface{}) and turns
+// it into the proper DecodeHookFunc type, such as DecodeHookFuncType.
+func typedDecodeHook(h mapstructure.DecodeHookFunc) mapstructure.DecodeHookFunc {
+	// Create variables here so we can reference them with the reflect pkg
+	var f1 mapstructure.DecodeHookFuncType
+	var f2 mapstructure.DecodeHookFuncKind
+	var f3 mapstructure.DecodeHookFuncValue
+
+	// Fill in the variables into this interface and the rest is done
+	// automatically using the reflect package.
+	potential := []interface{}{f3, f1, f2}
+
+	v := reflect.ValueOf(h)
+	vt := v.Type()
+	for _, raw := range potential {
+		pt := reflect.ValueOf(raw).Type()
+		if vt.ConvertibleTo(pt) {
+			return v.Convert(pt).Interface()
+		}
+	}
+
+	return nil
+}
+
+// cachedDecodeHook takes a raw DecodeHookFunc (an interface{}) and turns
+// it into a closure to be used directly
+// if the type fails to convert we return a closure always erroring to keep the previous behaviour
+func cachedDecodeHook(raw mapstructure.DecodeHookFunc) func(from reflect.Value, to reflect.Value) (interface{}, error) {
+	switch f := typedDecodeHook(raw).(type) {
+	case mapstructure.DecodeHookFuncType:
+		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+			if !from.IsValid() {
+				return nil, nil
+			}
+			return f(from.Type(), to.Type(), from.Interface())
+		}
+	case mapstructure.DecodeHookFuncKind:
+		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+			if !from.IsValid() {
+				return nil, nil
+			}
+			return f(from.Kind(), to.Kind(), from.Interface())
+		}
+	case mapstructure.DecodeHookFuncValue:
+		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+			return f(from, to)
+		}
+	default:
+		return func(from reflect.Value, to reflect.Value) (interface{}, error) {
+			return nil, errors.New("invalid decode hook signature")
+		}
+	}
+}
+
+// ComposeDecodeHookFunc creates a single DecodeHookFunc that
+// automatically composes multiple DecodeHookFuncs.
+//
+// The composed funcs are called in order, with the result of the
+// previous transformation.
+//
+// This is a copy of [mapstructure.ComposeDecodeHookFunc] but with
+// validation added.
+func ComposeDecodeHookFunc(fs ...mapstructure.DecodeHookFunc) mapstructure.DecodeHookFunc {
+	cached := make([]func(from reflect.Value, to reflect.Value) (interface{}, error), 0, len(fs))
+	for _, f := range fs {
+		cached = append(cached, cachedDecodeHook(f))
+	}
+	return func(f reflect.Value, t reflect.Value) (interface{}, error) {
+		var err error
+		var data any
+		if f.IsValid() {
+			data = f.Interface()
+		}
+
+		newFrom := f
+		for _, c := range cached {
+			data, err = c(newFrom, t)
+			if err != nil {
+				return nil, err
+			}
+			newFrom = reflect.ValueOf(data)
+		}
+
+		return data, nil
+	}
+}

--- a/confmap/internal/compose_hook.go
+++ b/confmap/internal/compose_hook.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/collector/confmap/internal/mapstructure"
+package internal // import "go.opentelemetry.io/collector/confmap/internal"
 
 import (
 	"errors"

--- a/confmap/internal/third_party/composehook/compose_hook.go
+++ b/confmap/internal/third_party/composehook/compose_hook.go
@@ -1,7 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/collector/confmap/internal"
+// This code is a modified version of https://github.com/go-viper/mapstructure
+// Copyright (c) 2013 Mitchell Hashimoto
+
+package composehook // import "go.opentelemetry.io/collector/confmap/internal/third_party/composehook"
 
 import (
 	"errors"

--- a/confmap/internal/third_party/composehook/compose_hook.go
+++ b/confmap/internal/third_party/composehook/compose_hook.go
@@ -1,8 +1,6 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-// This code is a modified version of https://github.com/go-viper/mapstructure
 // Copyright (c) 2013 Mitchell Hashimoto
+// SPDX-License-Identifier: MIT
+// This code is a modified version of https://github.com/go-viper/mapstructure
 
 package composehook // import "go.opentelemetry.io/collector/confmap/internal/third_party/composehook"
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

If we enable `DecodeNil` as true, we may have [untyped nils](https://go.dev/doc/faq#nil_error) being passed. Unfortunately, these are not valid values for `reflect`, which leads to surprising behavior such as golang/go/issues/51649.

Unfortunately, the default hooks from mapstructure do not deal with this properly. To account for this, we:
- Vendor and change the `ComposeDecodeHookFunc` function so that this case is accounted for the kinds of hooks that just won't work with untyped nils
- Create a safe wrapper for the hooks that do work with untyped nils. This wrapper is used in all hooks, but in the interest of keeping as close to what I would imagine upstream will accept, I did not add this to the compose function.

This should not have any end-user observable behavior.

<!-- Issue number if applicable -->
#### Link to tracking issue

Attempt to work around https://github.com/open-telemetry/opentelemetry-collector/pull/12996#issuecomment-2862859367

Working towards #12981