### PR TITLE
Avoid allocating too much memory, sampling logic is not re-applied

### DIFF
--- a/.chloggen/fix-13014.yaml
+++ b/.chloggen/fix-13014.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: telemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid allocating too much memory, sampling logic is not re-applied
+
+# One or more tracking issues or pull requests related to the change
+issues: [13014]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fix-13014.yaml
+++ b/.chloggen/fix-13014.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: telemetry
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Avoid allocating too much memory, sampling logic is not re-applied
+note: Allocate less memory per component when OTLP exporting of logs is disabled
 
 # One or more tracking issues or pull requests related to the change
 issues: [13014]

--- a/internal/telemetry/componentattribute/logger_test.go
+++ b/internal/telemetry/componentattribute/logger_test.go
@@ -90,7 +90,7 @@ func TestCore(t *testing.T) {
 			createLogger: func() (*zap.Logger, logRecorder) {
 				core, observed := createZapCore()
 				recorder := logtest.NewRecorder()
-				core = componentattribute.NewOTelTeeCoreWithAttributes(core, recorder, "testinstr", zap.DebugLevel, attribute.NewSet())
+				core = componentattribute.NewOTelTeeCoreWithAttributes(core, recorder, "testinstr", zap.DebugLevel, attribute.NewSet(), func(c zapcore.Core) zapcore.Core { return c })
 				return zap.New(core), logRecorder{zapLogs: observed, otelLogs: recorder}
 			},
 			check: func(t *testing.T, rec logRecorder) {

--- a/internal/telemetry/componentattribute/logger_zap.go
+++ b/internal/telemetry/componentattribute/logger_zap.go
@@ -76,6 +76,7 @@ type otelTeeCoreWithAttributes struct {
 	lp          log.LoggerProvider
 	scopeName   string
 	level       zapcore.Level
+	wrapper     func(zapcore.Core) zapcore.Core
 }
 
 var _ coreWithAttributes = (*otelTeeCoreWithAttributes)(nil)
@@ -84,7 +85,7 @@ var _ coreWithAttributes = (*otelTeeCoreWithAttributes)(nil)
 // logs, component attributes are injected as instrumentation scope attributes.
 //
 // This is used when service::telemetry::logs::processors is configured.
-func NewOTelTeeCoreWithAttributes(consoleCore zapcore.Core, lp log.LoggerProvider, scopeName string, level zapcore.Level, attrs attribute.Set) zapcore.Core {
+func NewOTelTeeCoreWithAttributes(consoleCore zapcore.Core, lp log.LoggerProvider, scopeName string, level zapcore.Level, attrs attribute.Set, wrapper func(zapcore.Core) zapcore.Core) zapcore.Core {
 	// TODO: Use `otelzap.WithAttributes` and remove `LoggerProviderWithAttributes`
 	// once we've upgraded to otelzap v0.11.0.
 	lpwa := LoggerProviderWithAttributes(lp, attrs)
@@ -97,45 +98,17 @@ func NewOTelTeeCoreWithAttributes(consoleCore zapcore.Core, lp log.LoggerProvide
 	}
 
 	return &otelTeeCoreWithAttributes{
-		Core:        zapcore.NewTee(consoleCore, otelCore),
+		Core:        zapcore.NewTee(consoleCore, wrapper(otelCore)),
 		consoleCore: consoleCore,
 		lp:          lp,
 		scopeName:   scopeName,
 		level:       level,
+		wrapper:     wrapper,
 	}
 }
 
 func (ocwa *otelTeeCoreWithAttributes) withAttributeSet(attrs attribute.Set) zapcore.Core {
-	return NewOTelTeeCoreWithAttributes(
-		tryWithAttributeSet(ocwa.consoleCore, attrs),
-		ocwa.lp, ocwa.scopeName, ocwa.level,
-		attrs,
-	)
-}
-
-type wrapperCoreWithAttributes struct {
-	zapcore.Core
-	from    zapcore.Core
-	wrapper func(zapcore.Core) zapcore.Core
-}
-
-var _ coreWithAttributes = (*wrapperCoreWithAttributes)(nil)
-
-// NewWrapperCoreWithAttributes applies a wrapper function to a core, similar to [zap.WrapCore]. The resulting wrapped core
-// allows setting component attributes on the inner core and reapplying the wrapper function when
-// needed.
-//
-// This is used when adding [zapcore.NewSamplerWithOptions] to our logger stack.
-func NewWrapperCoreWithAttributes(from zapcore.Core, wrapper func(zapcore.Core) zapcore.Core) zapcore.Core {
-	return &wrapperCoreWithAttributes{
-		Core:    wrapper(from),
-		from:    from,
-		wrapper: wrapper,
-	}
-}
-
-func (wcwa *wrapperCoreWithAttributes) withAttributeSet(attrs attribute.Set) zapcore.Core {
-	return NewWrapperCoreWithAttributes(tryWithAttributeSet(wcwa.from, attrs), wcwa.wrapper)
+	return NewOTelTeeCoreWithAttributes(tryWithAttributeSet(ocwa.consoleCore, attrs), ocwa.lp, ocwa.scopeName, ocwa.level, attrs, ocwa.wrapper)
 }
 
 // ZapLoggerWithAttributes creates a Zap Logger with a new set of injected component attributes.

--- a/service/telemetry/logger_test.go
+++ b/service/telemetry/logger_test.go
@@ -98,7 +98,7 @@ func TestNewLogger(t *testing.T) {
 					InitialFields:     map[string]any(nil),
 				},
 			},
-			wantCoreType: "*componentattribute.wrapperCoreWithAttributes",
+			wantCoreType: "*componentattribute.consoleCoreWithAttributes",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Avoid re-creating sampler counters every time we wrap with attributes.

<!-- Issue number if applicable -->
#### Link to tracking issue
Updates #13014 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
