### PR TITLE
[chore] Clarify that Unmarshaler only supports structs

### DIFF
--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -543,6 +543,7 @@ func marshalerHookFunc(orig any) mapstructure.DecodeHookFuncValue {
 }
 
 // Unmarshaler interface may be implemented by types to customize their behavior when being unmarshaled from a Conf.
+// Only types with struct or pointer to struct kind are supported.
 type Unmarshaler interface {
 	// Unmarshal a Conf into the struct in a custom way.
 	// The Conf for this specific component may be nil or empty if no config available.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Clarifies usage of `confmap.Unmarshaler`. This is a limitation that currently exists since mapstructure will fail to map between the types.
