### PR TITLE
[confmap] Add Conf.Delete method

### DIFF
--- a/.chloggen/mx-psi_confmap-delete.yaml
+++ b/.chloggen/mx-psi_confmap-delete.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a `Conf.Delete` method to remove a path from the configuration map.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13064]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -182,8 +182,8 @@ func (l *Conf) Merge(in *Conf) error {
 }
 
 // Delete a path from the Conf.
-// Return true if the path is deleted.
-// If the path is not set (so the operation is a no-op), it returns false.
+// If the path exists, deletes it and returns true.
+// If the path does not exist, does nothing and returns false.
 func (l *Conf) Delete(key string) bool {
 	wasSet := l.IsSet(key)
 	l.k.Delete(key)

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -181,6 +181,15 @@ func (l *Conf) Merge(in *Conf) error {
 	return l.k.Merge(in.k)
 }
 
+// Delete a path from the Conf.
+// Return true if the path is deleted.
+// If the path is not set (so the operation is a no-op), it returns false.
+func (l *Conf) Delete(key string) bool {
+	wasSet := l.IsSet(key)
+	l.k.Delete(key)
+	return wasSet
+}
+
 // mergeAppend merges the input given configuration into the existing config.
 // Note that the given map may be modified.
 // Additionally, mergeAppend performs deduplication when merging lists.

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -1053,3 +1053,39 @@ func TestStringyTypes(t *testing.T) {
 		assert.Equal(t, tt.isStringy, isStringyStructure(to))
 	}
 }
+
+func TestConfDelete(t *testing.T) {
+	tests := []struct {
+		path      string
+		stringMap map[string]any
+	}{
+		{
+			path:      "key",
+			stringMap: map[string]any{"key": "value"},
+		},
+		{
+			path: "map::expanded",
+			stringMap: map[string]any{"map": map[string]any{
+				"expanded": expandedValue{
+					Value:    0o1234,
+					Original: "01234",
+				},
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			cm := NewFromStringMap(test.stringMap)
+
+			assert.True(t, cm.IsSet(test.path))
+			assert.True(t, cm.Delete(test.path))
+			assert.Nil(t, cm.Get(test.path))
+			assert.False(t, cm.IsSet(test.path))
+
+			assert.False(t, cm.Delete(test.path))
+			assert.Nil(t, cm.Get(test.path))
+			assert.False(t, cm.IsSet(test.path))
+		})
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds a method to delete a path from a `Conf` object.

I needed this for #13060