### PR TITLE
Support items & bytes sizer in persistent queue

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -44,6 +44,8 @@ To use the persistent queue, the following setting needs to be set:
 The maximum number of batches stored to disk can be controlled using `sending_queue.queue_size` parameter (which,
 similarly as for in-memory buffering, defaults to 1000 batches).
 
+All sizer types (`requests`, `bytes`, and `items`) are supported with persistent queue. When using `bytes` or `items` sizers with persistent queue, you can also enable the `batch` feature for time-based batching.
+
 When persistent queue is enabled, the batches are being buffered using the provided storage extension - [filestorage] is a popular and safe choice. If the collector instance is killed while having some items in the persistent queue, on restart the items will be picked and the exporting is continued.
 
 ```

--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -82,14 +82,13 @@ func (cfg *Config) Validate() error {
 		return errors.New("`queue_size` must be positive")
 	}
 
-	// Only support request sizer for persistent queue at this moment.
 	if cfg.StorageID != nil && cfg.WaitForResult {
 		return errors.New("`wait_for_result` is not supported with a persistent queue configured with `storage`")
 	}
 
-	// Only support request sizer for persistent queue at this moment.
-	if cfg.StorageID != nil && cfg.Sizer != request.SizerTypeRequests {
-		return errors.New("persistent queue configured with `storage` only supports `requests` sizer")
+	if cfg.StorageID != nil && cfg.Sizer != request.SizerTypeRequests &&
+		cfg.Sizer != request.SizerTypeBytes && cfg.Sizer != request.SizerTypeItems {
+		return errors.New("persistent queue configured with `storage` only supports `requests`, `bytes`, or `items` sizer")
 	}
 
 	if cfg.Batch != nil {


### PR DESCRIPTION
Fixes: #12881

#### Description

I am running into an issue where the persistent queue option in `sending_queue` as well as the `batch` config are not compatible, because `batch` doesn't support `requests` sizer (only supports `items` and `bytes`), but the persistent queue only supports the `requests` sizer when storage is enabled.

So currently they cannot be used together.

With this change, the `queuebatch` persistent queue also supports the `bytes` and `items` sizer and not just `requests`. However, if batching is enabled, we still only support `items` and `bytes`. Support for `requests` in the batch feature will be tackled in a different issue: https://github.com/open-telemetry/opentelemetry-collector/issues/12880.

Changes - 
The actual implementation already has the necessary support for different sizer types:
- `pq.set.sizer.Sizeof(req)` works for any sizer type
- queue already tracks whether it's using the requests sizer via the isRequestSized flag
- backup mechanism for queue size is already implemented and works regardless of sizer type

Therefore, we only need to allow the config to accept the other sizer types.


#### Link to tracking issue
Fixes #12881

#### Testing
Unit tests.

#### Documentation
Updated `README.md`.