### PR TITLE
Add MoveAndAppendTo to pdata primitive slices

### DIFF
--- a/.chloggen/pdata-primitive-slices-moveappendto.yaml
+++ b/.chloggen/pdata-primitive-slices-moveappendto.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Introduce `MoveAndAppendTo` methods to the generated primitive slices
+
+# One or more tracking issues or pull requests related to the change
+issues: [13074]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice.go.tmpl
@@ -113,6 +113,20 @@ func (ms {{ .structName }}) MoveTo(dest {{ .structName }}) {
 	*ms.getOrig() = nil
 }
 
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (ms {{ .structName }}) MoveAndAppendTo(dest {{ .structName }}) {
+  ms.getState().AssertMutable()
+  dest.getState().AssertMutable()
+  if *dest.getOrig() == nil {
+    // We can simply move the entire vector and avoid any allocations.
+    *dest.getOrig() = *ms.getOrig()
+  } else {
+    *dest.getOrig() = append(*dest.getOrig(), *ms.getOrig()...)
+  }
+  *ms.getOrig() = nil
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms {{ .structName }}) CopyTo(dest {{ .structName }}) {
 	dest.getState().AssertMutable()

--- a/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice_test.go.tmpl
+++ b/pdata/internal/cmd/pdatagen/internal/templates/primitive_slice_test.go.tmpl
@@ -132,6 +132,26 @@ func Test{{ .structName }}All(t *testing.T) {
 	assert.Equal(t, ms.Len(), c, "All elements should have been visited")
 }
 
+
+func Test{{ .structName }}MoveAndAppendTo(t *testing.T) {
+  // Test moving from an empty slice
+  ms := New{{ .structName }}()
+  ms2 := New{{ .structName }}()
+  ms.MoveAndAppendTo(ms2)
+  assert.Equal(t, New{{ .structName }}(), ms2)
+  assert.Equal(t, ms.Len(), 0)
+
+  // Test moving to empty slice
+  ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
+  ms.MoveAndAppendTo(ms2)
+  assert.Equal(t, ms2.Len(), 3)
+
+  // Test moving to a non empty slice
+  ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
+  ms.MoveAndAppendTo(ms2)
+  assert.Equal(t, ms2.Len(), 6)
+}
+
 func Test{{ .structName }}Equal(t *testing.T) {
 	ms := New{{ .structName }}()
 	ms2 := New{{ .structName }}()

--- a/pdata/pcommon/generated_byteslice.go
+++ b/pdata/pcommon/generated_byteslice.go
@@ -114,6 +114,20 @@ func (ms ByteSlice) MoveTo(dest ByteSlice) {
 	*ms.getOrig() = nil
 }
 
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (ms ByteSlice) MoveAndAppendTo(dest ByteSlice) {
+	ms.getState().AssertMutable()
+	dest.getState().AssertMutable()
+	if *dest.getOrig() == nil {
+		// We can simply move the entire vector and avoid any allocations.
+		*dest.getOrig() = *ms.getOrig()
+	} else {
+		*dest.getOrig() = append(*dest.getOrig(), *ms.getOrig()...)
+	}
+	*ms.getOrig() = nil
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms ByteSlice) CopyTo(dest ByteSlice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_byteslice_test.go
+++ b/pdata/pcommon/generated_byteslice_test.go
@@ -98,6 +98,25 @@ func TestByteSliceAll(t *testing.T) {
 	assert.Equal(t, ms.Len(), c, "All elements should have been visited")
 }
 
+func TestByteSliceMoveAndAppendTo(t *testing.T) {
+	// Test moving from an empty slice
+	ms := NewByteSlice()
+	ms2 := NewByteSlice()
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, NewByteSlice(), ms2)
+	assert.Equal(t, ms.Len(), 0)
+
+	// Test moving to empty slice
+	ms.FromRaw([]byte{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 3)
+
+	// Test moving to a non empty slice
+	ms.FromRaw([]byte{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 6)
+}
+
 func TestByteSliceEqual(t *testing.T) {
 	ms := NewByteSlice()
 	ms2 := NewByteSlice()

--- a/pdata/pcommon/generated_float64slice.go
+++ b/pdata/pcommon/generated_float64slice.go
@@ -114,6 +114,20 @@ func (ms Float64Slice) MoveTo(dest Float64Slice) {
 	*ms.getOrig() = nil
 }
 
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (ms Float64Slice) MoveAndAppendTo(dest Float64Slice) {
+	ms.getState().AssertMutable()
+	dest.getState().AssertMutable()
+	if *dest.getOrig() == nil {
+		// We can simply move the entire vector and avoid any allocations.
+		*dest.getOrig() = *ms.getOrig()
+	} else {
+		*dest.getOrig() = append(*dest.getOrig(), *ms.getOrig()...)
+	}
+	*ms.getOrig() = nil
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms Float64Slice) CopyTo(dest Float64Slice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_float64slice_test.go
+++ b/pdata/pcommon/generated_float64slice_test.go
@@ -98,6 +98,25 @@ func TestFloat64SliceAll(t *testing.T) {
 	assert.Equal(t, ms.Len(), c, "All elements should have been visited")
 }
 
+func TestFloat64SliceMoveAndAppendTo(t *testing.T) {
+	// Test moving from an empty slice
+	ms := NewFloat64Slice()
+	ms2 := NewFloat64Slice()
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, NewFloat64Slice(), ms2)
+	assert.Equal(t, ms.Len(), 0)
+
+	// Test moving to empty slice
+	ms.FromRaw([]float64{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 3)
+
+	// Test moving to a non empty slice
+	ms.FromRaw([]float64{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 6)
+}
+
 func TestFloat64SliceEqual(t *testing.T) {
 	ms := NewFloat64Slice()
 	ms2 := NewFloat64Slice()

--- a/pdata/pcommon/generated_int32slice.go
+++ b/pdata/pcommon/generated_int32slice.go
@@ -114,6 +114,20 @@ func (ms Int32Slice) MoveTo(dest Int32Slice) {
 	*ms.getOrig() = nil
 }
 
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (ms Int32Slice) MoveAndAppendTo(dest Int32Slice) {
+	ms.getState().AssertMutable()
+	dest.getState().AssertMutable()
+	if *dest.getOrig() == nil {
+		// We can simply move the entire vector and avoid any allocations.
+		*dest.getOrig() = *ms.getOrig()
+	} else {
+		*dest.getOrig() = append(*dest.getOrig(), *ms.getOrig()...)
+	}
+	*ms.getOrig() = nil
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms Int32Slice) CopyTo(dest Int32Slice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_int32slice_test.go
+++ b/pdata/pcommon/generated_int32slice_test.go
@@ -98,6 +98,25 @@ func TestInt32SliceAll(t *testing.T) {
 	assert.Equal(t, ms.Len(), c, "All elements should have been visited")
 }
 
+func TestInt32SliceMoveAndAppendTo(t *testing.T) {
+	// Test moving from an empty slice
+	ms := NewInt32Slice()
+	ms2 := NewInt32Slice()
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, NewInt32Slice(), ms2)
+	assert.Equal(t, ms.Len(), 0)
+
+	// Test moving to empty slice
+	ms.FromRaw([]int32{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 3)
+
+	// Test moving to a non empty slice
+	ms.FromRaw([]int32{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 6)
+}
+
 func TestInt32SliceEqual(t *testing.T) {
 	ms := NewInt32Slice()
 	ms2 := NewInt32Slice()

--- a/pdata/pcommon/generated_int64slice.go
+++ b/pdata/pcommon/generated_int64slice.go
@@ -114,6 +114,20 @@ func (ms Int64Slice) MoveTo(dest Int64Slice) {
 	*ms.getOrig() = nil
 }
 
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (ms Int64Slice) MoveAndAppendTo(dest Int64Slice) {
+	ms.getState().AssertMutable()
+	dest.getState().AssertMutable()
+	if *dest.getOrig() == nil {
+		// We can simply move the entire vector and avoid any allocations.
+		*dest.getOrig() = *ms.getOrig()
+	} else {
+		*dest.getOrig() = append(*dest.getOrig(), *ms.getOrig()...)
+	}
+	*ms.getOrig() = nil
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms Int64Slice) CopyTo(dest Int64Slice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_int64slice_test.go
+++ b/pdata/pcommon/generated_int64slice_test.go
@@ -98,6 +98,25 @@ func TestInt64SliceAll(t *testing.T) {
 	assert.Equal(t, ms.Len(), c, "All elements should have been visited")
 }
 
+func TestInt64SliceMoveAndAppendTo(t *testing.T) {
+	// Test moving from an empty slice
+	ms := NewInt64Slice()
+	ms2 := NewInt64Slice()
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, NewInt64Slice(), ms2)
+	assert.Equal(t, ms.Len(), 0)
+
+	// Test moving to empty slice
+	ms.FromRaw([]int64{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 3)
+
+	// Test moving to a non empty slice
+	ms.FromRaw([]int64{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 6)
+}
+
 func TestInt64SliceEqual(t *testing.T) {
 	ms := NewInt64Slice()
 	ms2 := NewInt64Slice()

--- a/pdata/pcommon/generated_stringslice.go
+++ b/pdata/pcommon/generated_stringslice.go
@@ -114,6 +114,20 @@ func (ms StringSlice) MoveTo(dest StringSlice) {
 	*ms.getOrig() = nil
 }
 
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (ms StringSlice) MoveAndAppendTo(dest StringSlice) {
+	ms.getState().AssertMutable()
+	dest.getState().AssertMutable()
+	if *dest.getOrig() == nil {
+		// We can simply move the entire vector and avoid any allocations.
+		*dest.getOrig() = *ms.getOrig()
+	} else {
+		*dest.getOrig() = append(*dest.getOrig(), *ms.getOrig()...)
+	}
+	*ms.getOrig() = nil
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms StringSlice) CopyTo(dest StringSlice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_stringslice_test.go
+++ b/pdata/pcommon/generated_stringslice_test.go
@@ -98,6 +98,25 @@ func TestStringSliceAll(t *testing.T) {
 	assert.Equal(t, ms.Len(), c, "All elements should have been visited")
 }
 
+func TestStringSliceMoveAndAppendTo(t *testing.T) {
+	// Test moving from an empty slice
+	ms := NewStringSlice()
+	ms2 := NewStringSlice()
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, NewStringSlice(), ms2)
+	assert.Equal(t, ms.Len(), 0)
+
+	// Test moving to empty slice
+	ms.FromRaw([]string{"a", "b", "c"})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 3)
+
+	// Test moving to a non empty slice
+	ms.FromRaw([]string{"a", "b", "c"})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 6)
+}
+
 func TestStringSliceEqual(t *testing.T) {
 	ms := NewStringSlice()
 	ms2 := NewStringSlice()

--- a/pdata/pcommon/generated_uint64slice.go
+++ b/pdata/pcommon/generated_uint64slice.go
@@ -114,6 +114,20 @@ func (ms UInt64Slice) MoveTo(dest UInt64Slice) {
 	*ms.getOrig() = nil
 }
 
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (ms UInt64Slice) MoveAndAppendTo(dest UInt64Slice) {
+	ms.getState().AssertMutable()
+	dest.getState().AssertMutable()
+	if *dest.getOrig() == nil {
+		// We can simply move the entire vector and avoid any allocations.
+		*dest.getOrig() = *ms.getOrig()
+	} else {
+		*dest.getOrig() = append(*dest.getOrig(), *ms.getOrig()...)
+	}
+	*ms.getOrig() = nil
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms UInt64Slice) CopyTo(dest UInt64Slice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_uint64slice_test.go
+++ b/pdata/pcommon/generated_uint64slice_test.go
@@ -98,6 +98,25 @@ func TestUInt64SliceAll(t *testing.T) {
 	assert.Equal(t, ms.Len(), c, "All elements should have been visited")
 }
 
+func TestUInt64SliceMoveAndAppendTo(t *testing.T) {
+	// Test moving from an empty slice
+	ms := NewUInt64Slice()
+	ms2 := NewUInt64Slice()
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, NewUInt64Slice(), ms2)
+	assert.Equal(t, ms.Len(), 0)
+
+	// Test moving to empty slice
+	ms.FromRaw([]uint64{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 3)
+
+	// Test moving to a non empty slice
+	ms.FromRaw([]uint64{1, 2, 3})
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 6)
+}
+
 func TestUInt64SliceEqual(t *testing.T) {
 	ms := NewUInt64Slice()
 	ms2 := NewUInt64Slice()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

pdata primitive slices are missing `MoveAndAppendTo`, and we're going to start needing it with the profiles proto upgrade (which has a dictionary object with primitive type slices that we will need to merge at some point)