### PR TITLE
Enable X25519MLKEM768 for TLS 1.3

### DIFF
--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -482,4 +482,5 @@ var tlsCurveTypes = map[string]tls.CurveID{
 	"P384":   tls.CurveP384,
 	"P521":   tls.CurveP521,
 	"X25519": tls.X25519,
+	"X25519MLKEM768": tls.X25519MLKEM768,
 }

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -882,6 +882,11 @@ func TestCurvePreferences(t *testing.T) {
 		expectedErr      string
 	}{
 		{
+			name:             "X25519MLKEM768",
+			preferences:      []string{"X25519MLKEM768"},
+			expectedCurveIDs: []tls.CurveID{tls.X25519MLKEM768},
+		},
+		{
 			name:             "X25519",
 			preferences:      []string{"X25519"},
 			expectedCurveIDs: []tls.CurveID{tls.X25519},

--- a/config/configtls/go.mod
+++ b/config/configtls/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtls
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e


### PR DESCRIPTION

#### Description
Enable X25519MLKEM768 for TLS 1.3.
This requires bumping go to 1.24.0
#### Link to tracking issue



#### Testing


#### Documentation


