### PR TITLE
fix(pdata/plog): unmarshal event_name from json

### DIFF
--- a/.chloggen/ip_fix-event-name-unmarshal-json.yaml
+++ b/.chloggen/ip_fix-event-name-unmarshal-json.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: pdata/plog/json
+component: pdata
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix event_name skipped when unmarshalling LogRecord from JSON

--- a/.chloggen/ip_fix-event-name-unmarshal-json.yaml
+++ b/.chloggen/ip_fix-event-name-unmarshal-json.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata/plog/json
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix event_name skipped when unmarshalling LogRecord from JSON
+
+# One or more tracking issues or pull requests related to the change
+issues: [13127]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pdata/plog/json.go
+++ b/pdata/plog/json.go
@@ -108,6 +108,8 @@ func (ms LogRecord) unmarshalJsoniter(iter *jsoniter.Iterator) {
 			ms.orig.SeverityNumber = otlplogs.SeverityNumber(json.ReadEnumValue(iter, otlplogs.SeverityNumber_value))
 		case "severity_text", "severityText":
 			ms.orig.SeverityText = iter.ReadString()
+		case "event_name", "eventName":
+			ms.orig.EventName = iter.ReadString()
 		case "body":
 			json.ReadValue(iter, &ms.orig.Body)
 		case "attributes":

--- a/pdata/plog/json_test.go
+++ b/pdata/plog/json_test.go
@@ -44,6 +44,7 @@ var logsOTLP = func() Logs {
 	lg.SetObservedTimestamp(pcommon.Timestamp(1684623646539558000))
 	lg.Attributes().PutStr("sdkVersion", "1.0.1")
 	lg.SetFlags(DefaultLogRecordFlags.WithIsSampled(true))
+	lg.SetEventName("someEvent")
 	return ld
 }()
 
@@ -57,7 +58,7 @@ func TestLogsJSON(t *testing.T) {
 	assert.Equal(t, logsOTLP, got)
 }
 
-var logsJSON = `{"resourceLogs":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"testHost"}}],"droppedAttributesCount":1},"scopeLogs":[{"scope":{"name":"name","version":"version","droppedAttributesCount":1},"logRecords":[{"timeUnixNano":"1684617382541971000","observedTimeUnixNano":"1684623646539558000","severityNumber":17,"severityText":"Error","body":{"stringValue":"hello world"},"attributes":[{"key":"sdkVersion","value":{"stringValue":"1.0.1"}}],"droppedAttributesCount":1,"flags":1,"traceId":"0102030405060708090a0b0c0d0e0f10","spanId":"1112131415161718"}],"schemaUrl":"scope_schema"}],"schemaUrl":"resource_schema"}]}`
+var logsJSON = `{"resourceLogs":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"testHost"}}],"droppedAttributesCount":1},"scopeLogs":[{"scope":{"name":"name","version":"version","droppedAttributesCount":1},"logRecords":[{"eventName":"someEvent","timeUnixNano":"1684617382541971000","observedTimeUnixNano":"1684623646539558000","severityNumber":17,"severityText":"Error","body":{"stringValue":"hello world"},"attributes":[{"key":"sdkVersion","value":{"stringValue":"1.0.1"}}],"droppedAttributesCount":1,"flags":1,"traceId":"0102030405060708090a0b0c0d0e0f10","spanId":"1112131415161718"}],"schemaUrl":"scope_schema"}],"schemaUrl":"resource_schema"}]}`
 
 func TestJSONUnmarshal(t *testing.T) {
 	decoder := &JSONUnmarshaler{}


### PR DESCRIPTION
#### Description
This PR adds missing logic to process `event_name` field when unmarshaling LogRecords from JSON.

#### Testing
Added `eventName` to json (un)marshal tests.

Fixes #13127

