### PR TITLE
Validate TLS config: return error if cert or key is missing

### DIFF
--- a/.chloggen/fix-tls-validation.yaml
+++ b/.chloggen/fix-tls-validation.yaml
@@ -1,0 +1,4 @@
+change_type: changed
+component: configtls
+note: Validate TLS config earlier: return error if certificate or key is missing.
+issues: [13134]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -914,11 +914,6 @@ This release includes 2 very important breaking changes.
 
 - `configrpc`: Use own compressors for zstd. Before this change, the zstd compressor we used didn't respect the max message size. This addresses [GHSA-c74f-6mfw-mm4v](https://github.com/open-telemetry/opentelemetry-collector/security/advisories/GHSA-c74f-6mfw-mm4v) for `configgrpc` (#10323)
 
-# Unreleased
-
-### Changed
-- Validate TLS config earlier: return error if certificate or key is missing. ([#13134](https://github.com/open-telemetry/opentelemetry-collector/pull/13134))
-g
 
 ## v1.9.0/v0.102.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -914,6 +914,12 @@ This release includes 2 very important breaking changes.
 
 - `configrpc`: Use own compressors for zstd. Before this change, the zstd compressor we used didn't respect the max message size. This addresses [GHSA-c74f-6mfw-mm4v](https://github.com/open-telemetry/opentelemetry-collector/security/advisories/GHSA-c74f-6mfw-mm4v) for `configgrpc` (#10323)
 
+# Unreleased
+
+### Changed
+- Validate TLS config earlier: return error if certificate or key is missing. ([#13134](https://github.com/open-telemetry/opentelemetry-collector/pull/13134))
+g
+
 ## v1.9.0/v0.102.0
 
 **This release addresses [GHSA-c74f-6mfw-mm4v](https://github.com/open-telemetry/opentelemetry-collector/security/advisories/GHSA-c74f-6mfw-mm4v) for `confighttp`.**

--- a/config/configtls/config_test.go
+++ b/config/configtls/config_test.go
@@ -1,0 +1,67 @@
+package configtls
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_Validate_CertKeyPresence(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    Config
+		expectErr bool
+	}{
+		{
+			name:      "no cert or key",
+			config:    Config{},
+			expectErr: false,
+		},
+		{
+			name:      "only CertFile",
+			config:    Config{CertFile: "cert.pem"},
+			expectErr: true,
+		},
+		{
+			name:      "only KeyFile",
+			config:    Config{KeyFile: "key.pem"},
+			expectErr: true,
+		},
+		{
+			name:      "CertFile and KeyFile",
+			config:    Config{CertFile: "cert.pem", KeyFile: "Key.pem"},
+			expectErr: false,
+		},
+		{
+			name:      "CertPem and KeyPem",
+			config:    Config{CertPem: "cert", KeyPem: "key"},
+			expectErr: false,
+		},
+		{
+			name:      "CertFile and KeyPem(mixed)",
+			config:    Config{CertFile: "cert.pem", KeyPem: "key"},
+			expectErr: false,
+		},
+		{
+			name:      "CertPem only",
+			config:    Config{CertPem: "cert"},
+			expectErr: true,
+		},
+		{
+			name:      "KeyPem only",
+			config:    Config{KeyPem: "key"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/config/configtls/config_test.go
+++ b/config/configtls/config_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package configtls
 
 import (

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -208,6 +208,14 @@ func (c Config) Validate() error {
 		return errors.New("invalid TLS configuration: min_version cannot be greater than max_version")
 	}
 
+	certProvided := c.CertFile != "" || c.CertPem != ""
+	keyProvided := c.KeyFile != "" || c.KeyPem != ""
+
+	// If cert or key is provided, require both to be present
+	if certProvided != keyProvided {
+		return errors.New("TLS configuration must include certificate and key (CertFile/CertPem and KeyFile/KeyPem)")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
 ### Description

If TLS is configured without a certificate or key, it currently fails at runtime with a TLS handshake error. current change fixes #13130 by adding a validation check in configtls.Config.Validate() to ensure that TLS configurations include both a certificate and a key.

missing certs caused confusing runtime handshake errors. With this change, users get clear validation error earlier.

Fixes #13130