### PR TITLE
docs: none values should not take any value

### DIFF
--- a/docs/rfcs/optional-config-type.md
+++ b/docs/rfcs/optional-config-type.md
@@ -59,7 +59,7 @@ func Some[T any](value T) Optional[T] {
 	return Optional[T]{value: value, hasValue: true}
 }
 
-func None[T any](value T) Optional[T] {
+func None[T any]() Optional[T] {
 	return Optional[T]{}
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Creating an empty Optional[T] type should not require the value.

See: https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configoptional/optional.go#L109