### PR TITLE
Persist trace context encoded as w3c trace-context

### DIFF
--- a/.chloggen/jackgopack4-add-spancontext-persistentqueue.yaml
+++ b/.chloggen/jackgopack4-add-spancontext-persistentqueue.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: 'exporterhelper'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `exporter.PropagateSpanContext` to enable propagating SpanContext along with telemetry requests in the persistent queue"
+
+# One or more tracking issues or pull requests related to the change
+issues: [11740, 12212, 12934]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change will allow internal telemetry spans to be processed when using persistent queue/storage.
+  When enabled, requests will use approximately 128 bytes more in persistent storage.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/queuebatch/persistent_queue_context.go
+++ b/exporter/exporterhelper/internal/queuebatch/persistent_queue_context.go
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+
+import (
+	"context"
+	"strconv"
+
+	"go.opentelemetry.io/otel/propagation"
+
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+// persistRequestContextFeatureGate controls whether request context should be persisted in the queue.
+var persistRequestContextFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"exporter.PersistRequestContext",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterFromVersion("v0.127.0"),
+	featuregate.WithRegisterDescription("controls whether context should be stored alongside requests in the persistent queue"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/pull/12934"),
+)
+
+var tracePropagator = propagation.TraceContext{}
+
+func marshalSpanContext(ctx context.Context) []byte {
+	if !persistRequestContextFeatureGate.IsEnabled() {
+		return nil
+	}
+	carrier := newByteMapCarrier()
+	tracePropagator.Inject(ctx, carrier)
+	return carrier.Bytes()
+}
+
+func unmarshalSpanContext(b []byte) context.Context {
+	ctx := context.Background()
+	if !persistRequestContextFeatureGate.IsEnabled() || b == nil {
+		return ctx
+	}
+	carrier := &byteMapCarrier{buf: b}
+	tracePropagator.Extract(ctx, carrier)
+	return ctx
+}
+
+func getContextKey(index uint64) string {
+	return strconv.FormatUint(index, 10) + "_context"
+}
+
+// byteMapCarrier implements propagation.TextMapCarrier on top of a byte slice.
+// The format is a sequence of key-value pairs encoded as:
+//   - 1 byte length of key
+//   - key string
+//   - '=' character
+//   - value string
+//   - NUL terminator (0 byte)
+type byteMapCarrier struct{ buf []byte }
+
+var _ propagation.TextMapCarrier = (*byteMapCarrier)(nil)
+
+// defaultCarrierCap is a capacity for the byteMapCarrier buffer that should fit typical `traceparent` and `tracestate`
+// keys and values.
+const defaultCarrierCap = 128
+
+func newByteMapCarrier() *byteMapCarrier {
+	return &byteMapCarrier{buf: make([]byte, 0, defaultCarrierCap)}
+}
+
+func (c *byteMapCarrier) Set(k, v string) {
+	c.buf = append(c.buf, byte(len(k)))
+	c.buf = append(c.buf, k...)
+	c.buf = append(c.buf, '=')
+	c.buf = append(c.buf, v...)
+	c.buf = append(c.buf, 0) // NUL terminator
+}
+
+func (c *byteMapCarrier) Get(k string) string {
+	for i := 0; i < len(c.buf); {
+		l := int(c.buf[i])
+		i++
+		if i+l > len(c.buf) {
+			return ""
+		}
+		key := string(c.buf[i : i+l])
+		i += l
+		if i >= len(c.buf) || c.buf[i] != '=' {
+			return ""
+		}
+		i++
+		valStart := i
+		for i < len(c.buf) && c.buf[i] != 0 {
+			i++
+		}
+		val := string(c.buf[valStart:i])
+		i++ // skip NUL
+		if key == k {
+			return val
+		}
+	}
+	return ""
+}
+
+func (c *byteMapCarrier) Keys() []string {
+	var out []string
+	for i := 0; i < len(c.buf); {
+		l := int(c.buf[i])
+		i++
+		out = append(out, string(c.buf[i:i+l]))
+		i += l
+		for i < len(c.buf) && c.buf[i] != 0 {
+			i++
+		}
+		i++ // skip '=' / NUL block
+	}
+	return out
+}
+
+func (c *byteMapCarrier) Bytes() []byte { return c.buf }

--- a/exporter/exporterhelper/internal/queuebatch/persistent_queue_context_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/persistent_queue_context_test.go
@@ -1,0 +1,242 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/storagetest"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/pipeline"
+)
+
+func TestGetAndMarshalSpanContext_FeatureGateDisabled(t *testing.T) {
+	data := marshalSpanContext(context.Background())
+	require.Nil(t, data)
+}
+
+func TestPersistentQueue_GetNextItem_ContextUnmarshalFails(t *testing.T) {
+	require.NoError(t, featuregate.GlobalRegistry().Set("exporter.PersistRequestContext", true))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set("exporter.PersistRequestContext", false))
+	}()
+
+	ext := storagetest.NewMockStorageExtension(nil)
+	pq := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
+
+	// Insert an item with a valid span context
+	tid, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	sid, _ := trace.SpanIDFromHex("0102030405060708")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: 0x01,
+		TraceState: trace.TraceState{},
+		Remote:     true,
+	})
+	ctxWithSC := trace.ContextWithSpanContext(context.Background(), sc)
+	req := uint64(42)
+	require.NoError(t, pq.Offer(ctxWithSC, req))
+
+	// Corrupt the stored context for index 0
+	corrupted := []byte(`corrupted`)
+	require.NoError(t, pq.client.Set(context.Background(), getContextKey(0), corrupted))
+
+	// Now getNextItem should succeed for the request, but context unmarshal will fail
+	_, gotReq, _, restoredCtx, err := pq.getNextItem(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, req, gotReq)
+	restoredSC := trace.SpanContextFromContext(restoredCtx)
+	require.False(t, restoredSC.IsValid(), "restored context should not have a valid span context if context unmarshal fails")
+}
+
+func TestPersistentQueue_RetrieveAndEnqueueNotDispatchedReqs_SpanContextUnmarshal(t *testing.T) {
+	// Enable the feature gate
+	require.NoError(t, featuregate.GlobalRegistry().Set("exporter.PersistRequestContext", true))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set("exporter.PersistRequestContext", false))
+	}()
+
+	t.Run("SuccessfulUnmarshal", func(t *testing.T) {
+		ext := storagetest.NewMockStorageExtension(nil)
+		pq := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
+
+		// Create a valid span context
+		validSC := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    [16]byte{1, 2, 3, 4},
+			SpanID:     [8]byte{5, 6, 7, 8},
+			TraceFlags: trace.FlagsSampled,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), validSC)
+
+		// Add items with the valid span context
+		req1 := uint64(50)
+		req2 := uint64(60)
+		require.NoError(t, pq.Offer(ctx, req1))
+		require.NoError(t, pq.Offer(ctx, req2))
+
+		// Manually mark items as dispatched (simulating them being read but not finished)
+		pq.mu.Lock()
+		pq.metadata.CurrentlyDispatchedItems = []uint64{0, 1}
+		// Update the storage with currently dispatched items
+		require.NoError(t, pq.client.Set(context.Background(), currentlyDispatchedItemsKey, itemIndexArrayToBytes(pq.metadata.CurrentlyDispatchedItems)))
+		pq.mu.Unlock()
+
+		// Shutdown the queue
+		require.NoError(t, pq.Shutdown(context.Background()))
+
+		// Create a new queue from the same storage - this should trigger retrieveAndEnqueueNotDispatchedReqs
+		newPQ := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
+
+		// Verify items were moved back to the queue with context preserved
+		require.Equal(t, int64(2), newPQ.Size())
+
+		// Read the first item and verify context is preserved
+		restoredCtx1, readReq1, done1, found1 := newPQ.Read(context.Background())
+		require.True(t, found1)
+		require.Equal(t, req1, readReq1)
+		require.NotNil(t, done1)
+
+		restoredSC1 := trace.SpanContextFromContext(restoredCtx1)
+		require.True(t, restoredSC1.IsValid())
+		require.Equal(t, validSC.TraceID(), restoredSC1.TraceID())
+		require.Equal(t, validSC.SpanID(), restoredSC1.SpanID())
+
+		// Read the second item and verify context is preserved
+		restoredCtx2, readReq2, done2, found2 := newPQ.Read(context.Background())
+		require.True(t, found2)
+		require.Equal(t, req2, readReq2)
+		require.NotNil(t, done2)
+
+		restoredSC2 := trace.SpanContextFromContext(restoredCtx2)
+		require.True(t, restoredSC2.IsValid())
+		require.Equal(t, validSC.TraceID(), restoredSC2.TraceID())
+		require.Equal(t, validSC.SpanID(), restoredSC2.SpanID())
+	})
+
+	t.Run("FailedUnmarshal", func(t *testing.T) {
+		ext := storagetest.NewMockStorageExtension(nil)
+		pq := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
+
+		// Create a valid span context
+		validSC := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    [16]byte{1, 2, 3, 4},
+			SpanID:     [8]byte{5, 6, 7, 8},
+			TraceFlags: trace.FlagsSampled,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), validSC)
+
+		// Add items with the valid span context
+		req1 := uint64(50)
+		req2 := uint64(60)
+		require.NoError(t, pq.Offer(ctx, req1))
+		require.NoError(t, pq.Offer(ctx, req2))
+
+		// Manually mark items as dispatched (simulating them being read but not finished)
+		pq.mu.Lock()
+		pq.metadata.CurrentlyDispatchedItems = []uint64{0, 1}
+		// Update the storage with currently dispatched items
+		require.NoError(t, pq.client.Set(context.Background(), currentlyDispatchedItemsKey, itemIndexArrayToBytes(pq.metadata.CurrentlyDispatchedItems)))
+		pq.mu.Unlock()
+
+		// Corrupt the stored context data with invalid JSON
+		corruptedData := []byte(`{"invalid": "json"}`)
+		require.NoError(t, pq.client.Set(context.Background(), getContextKey(0), corruptedData))
+		require.NoError(t, pq.client.Set(context.Background(), getContextKey(1), corruptedData))
+
+		// Shutdown the queue
+		require.NoError(t, pq.Shutdown(context.Background()))
+
+		// Create a new queue from the same storage - this should trigger retrieveAndEnqueueNotDispatchedReqs
+		newPQ := createTestPersistentQueueWithRequestsCapacity(t, ext, 1000)
+
+		// Verify items were moved back to the queue but context is not preserved
+		require.Equal(t, int64(2), newPQ.Size())
+
+		// Read the first item and verify context is not preserved
+		restoredCtx1, readReq1, done1, found1 := newPQ.Read(context.Background())
+		require.True(t, found1)
+		require.Equal(t, req1, readReq1)
+		require.NotNil(t, done1)
+
+		restoredSC1 := trace.SpanContextFromContext(restoredCtx1)
+		require.False(t, restoredSC1.IsValid())
+
+		// Read the second item and verify context is not preserved
+		restoredCtx2, readReq2, done2, found2 := newPQ.Read(context.Background())
+		require.True(t, found2)
+		require.Equal(t, req2, readReq2)
+		require.NotNil(t, done2)
+
+		restoredSC2 := trace.SpanContextFromContext(restoredCtx2)
+		require.False(t, restoredSC2.IsValid())
+	})
+}
+
+func TestPersistentQueue_SpanContextRoundTrip(t *testing.T) {
+	require.NoError(t, featuregate.GlobalRegistry().Set("exporter.PersistRequestContext", true))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set("exporter.PersistRequestContext", false))
+	}()
+	// Setup a minimal persistent queue using uint64Encoding and uint64
+	pq := newPersistentQueue[uint64](persistentQueueSettings[uint64]{
+		sizer:     request.RequestsSizer[uint64]{},
+		capacity:  10,
+		signal:    pipeline.SignalTraces,
+		storageID: component.ID{},
+		encoding:  uint64Encoding{},
+		id:        component.NewID(exportertest.NopType),
+		telemetry: componenttest.NewNopTelemetrySettings(),
+	}).(*persistentQueue[uint64])
+
+	ext := storagetest.NewMockStorageExtension(nil)
+	client, err := ext.GetClient(context.Background(), component.KindExporter, pq.set.id, pq.set.signal.String())
+	require.NoError(t, err)
+	pq.initClient(context.Background(), client)
+
+	// Create a valid SpanContext
+	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	spanID, _ := trace.SpanIDFromHex("0102030405060708")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: 0x01,
+		TraceState: trace.TraceState{},
+		Remote:     true,
+	})
+	ctxWithSC := trace.ContextWithSpanContext(context.Background(), sc)
+
+	// Offer a request with this context
+	req := uint64(42)
+	require.NoError(t, pq.Offer(ctxWithSC, req))
+
+	// Read the request and restored context
+	restoredCtx, gotReq, _, ok := pq.Read(context.Background())
+	require.True(t, ok)
+	require.Equal(t, req, gotReq)
+	restoredSC := trace.SpanContextFromContext(restoredCtx)
+	require.True(t, restoredSC.IsValid())
+	require.Equal(t, sc.TraceID(), restoredSC.TraceID())
+	require.Equal(t, sc.SpanID(), restoredSC.SpanID())
+	require.Equal(t, sc.TraceFlags(), restoredSC.TraceFlags())
+	require.Equal(t, sc.TraceState().String(), restoredSC.TraceState().String())
+	require.Equal(t, sc.IsRemote(), restoredSC.IsRemote())
+
+	// Also test with a context with no SpanContext
+	req2 := uint64(99)
+	require.NoError(t, pq.Offer(context.Background(), req2))
+	restoredCtx2, gotReq2, _, ok2 := pq.Read(context.Background())
+	require.True(t, ok2)
+	require.Equal(t, req2, gotReq2)
+	restoredSC2 := trace.SpanContextFromContext(restoredCtx2)
+	require.False(t, restoredSC2.IsValid())
+}

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exportertest v0.127.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.127.0
 	go.opentelemetry.io/collector/extension/xextension v0.127.0
+	go.opentelemetry.io/collector/featuregate v1.33.0
 	go.opentelemetry.io/collector/pdata v1.33.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.127.0
 	go.opentelemetry.io/collector/pdata/testdata v0.127.0
@@ -53,7 +54,6 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.127.0 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.127.0 // indirect
 	go.opentelemetry.io/collector/extension v1.33.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.33.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.127.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.33.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.127.0 // indirect


### PR DESCRIPTION
Trying an alternative to https://github.com/open-telemetry/opentelemetry-collector/pull/12934 that uses w3c trace-context encoding built on top of a bytes buffer