### PR TITLE
Make all NewDefault* functions return structs instead of pointers

### DIFF
--- a/.chloggen/mx-psi_newdefault-nopointer.yaml
+++ b/.chloggen/mx-psi_newdefault-nopointer.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc,confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unify return type of `NewDefault*Config` functions to return a struct instead of a pointer.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13169]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -52,8 +52,8 @@ type KeepaliveClientConfig struct {
 }
 
 // NewDefaultKeepaliveClientConfig returns a new instance of KeepaliveClientConfig with default values.
-func NewDefaultKeepaliveClientConfig() *KeepaliveClientConfig {
-	return &KeepaliveClientConfig{
+func NewDefaultKeepaliveClientConfig() KeepaliveClientConfig {
+	return KeepaliveClientConfig{
 		Time:    time.Second * 10,
 		Timeout: time.Second * 10,
 	}
@@ -111,11 +111,15 @@ type ClientConfig struct {
 	Middlewares []configmiddleware.Config `mapstructure:"middlewares,omitempty"`
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 // NewDefaultClientConfig returns a new instance of ClientConfig with default values.
-func NewDefaultClientConfig() *ClientConfig {
-	return &ClientConfig{
+func NewDefaultClientConfig() ClientConfig {
+	return ClientConfig{
 		TLS:          configtls.NewDefaultClientConfig(),
-		Keepalive:    NewDefaultKeepaliveClientConfig(),
+		Keepalive:    ptr(NewDefaultKeepaliveClientConfig()),
 		BalancerName: BalancerName(),
 	}
 }
@@ -129,10 +133,10 @@ type KeepaliveServerConfig struct {
 }
 
 // NewDefaultKeepaliveServerConfig returns a new instance of KeepaliveServerConfig with default values.
-func NewDefaultKeepaliveServerConfig() *KeepaliveServerConfig {
-	return &KeepaliveServerConfig{
-		ServerParameters:  NewDefaultKeepaliveServerParameters(),
-		EnforcementPolicy: NewDefaultKeepaliveEnforcementPolicy(),
+func NewDefaultKeepaliveServerConfig() KeepaliveServerConfig {
+	return KeepaliveServerConfig{
+		ServerParameters:  ptr(NewDefaultKeepaliveServerParameters()),
+		EnforcementPolicy: ptr(NewDefaultKeepaliveEnforcementPolicy()),
 	}
 }
 
@@ -150,8 +154,8 @@ type KeepaliveServerParameters struct {
 }
 
 // NewDefaultKeepaliveServerParameters creates and returns a new instance of KeepaliveServerParameters with default settings.
-func NewDefaultKeepaliveServerParameters() *KeepaliveServerParameters {
-	return &KeepaliveServerParameters{}
+func NewDefaultKeepaliveServerParameters() KeepaliveServerParameters {
+	return KeepaliveServerParameters{}
 }
 
 // KeepaliveEnforcementPolicy allow configuration of the keepalive.EnforcementPolicy.
@@ -165,8 +169,8 @@ type KeepaliveEnforcementPolicy struct {
 }
 
 // NewDefaultKeepaliveEnforcementPolicy creates and returns a new instance of KeepaliveEnforcementPolicy with default settings.
-func NewDefaultKeepaliveEnforcementPolicy() *KeepaliveEnforcementPolicy {
-	return &KeepaliveEnforcementPolicy{}
+func NewDefaultKeepaliveEnforcementPolicy() KeepaliveEnforcementPolicy {
+	return KeepaliveEnforcementPolicy{}
 }
 
 // ServerConfig defines common settings for a gRPC server configuration.
@@ -210,9 +214,9 @@ type ServerConfig struct {
 }
 
 // NewDefaultServerConfig returns a new instance of ServerConfig with default values.
-func NewDefaultServerConfig() *ServerConfig {
-	return &ServerConfig{
-		Keepalive: NewDefaultKeepaliveServerConfig(),
+func NewDefaultServerConfig() ServerConfig {
+	return ServerConfig{
+		Keepalive: ptr(NewDefaultKeepaliveServerConfig()),
 	}
 }
 

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -60,9 +60,10 @@ func TestNewDefaultKeepaliveClientConfig(t *testing.T) {
 }
 
 func TestNewDefaultClientConfig(t *testing.T) {
+	keepalive := NewDefaultKeepaliveClientConfig()
 	expected := &ClientConfig{
 		TLS:          configtls.NewDefaultClientConfig(),
-		Keepalive:    NewDefaultKeepaliveClientConfig(),
+		Keepalive:    &keepalive,
 		BalancerName: BalancerName(),
 	}
 
@@ -87,17 +88,20 @@ func TestNewDefaultKeepaliveEnforcementPolicy(t *testing.T) {
 }
 
 func TestNewDefaultKeepaliveServerConfig(t *testing.T) {
+	serverParameters := NewDefaultKeepaliveServerParameters()
+	enforcementPolicy := NewDefaultKeepaliveEnforcementPolicy()
 	expected := &KeepaliveServerConfig{
-		ServerParameters:  NewDefaultKeepaliveServerParameters(),
-		EnforcementPolicy: NewDefaultKeepaliveEnforcementPolicy(),
+		ServerParameters:  &serverParameters,
+		EnforcementPolicy: &enforcementPolicy,
 	}
 	result := NewDefaultKeepaliveServerConfig()
 	assert.Equal(t, expected, result)
 }
 
 func TestNewDefaultServerConfig(t *testing.T) {
+	keepalive := NewDefaultKeepaliveServerConfig()
 	expected := &ServerConfig{
-		Keepalive: NewDefaultKeepaliveServerConfig(),
+		Keepalive: &keepalive,
 	}
 
 	result := NewDefaultServerConfig()

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -51,7 +51,7 @@ func newMockAuthServer(auth func(ctx context.Context, sources map[string][]strin
 }
 
 func TestNewDefaultKeepaliveClientConfig(t *testing.T) {
-	expectedKeepaliveClientConfig := &KeepaliveClientConfig{
+	expectedKeepaliveClientConfig := KeepaliveClientConfig{
 		Time:    time.Second * 10,
 		Timeout: time.Second * 10,
 	}
@@ -61,7 +61,7 @@ func TestNewDefaultKeepaliveClientConfig(t *testing.T) {
 
 func TestNewDefaultClientConfig(t *testing.T) {
 	keepalive := NewDefaultKeepaliveClientConfig()
-	expected := &ClientConfig{
+	expected := ClientConfig{
 		TLS:          configtls.NewDefaultClientConfig(),
 		Keepalive:    &keepalive,
 		BalancerName: BalancerName(),
@@ -73,14 +73,14 @@ func TestNewDefaultClientConfig(t *testing.T) {
 }
 
 func TestNewDefaultKeepaliveServerParameters(t *testing.T) {
-	expectedParams := &KeepaliveServerParameters{}
+	expectedParams := KeepaliveServerParameters{}
 	params := NewDefaultKeepaliveServerParameters()
 
 	assert.Equal(t, expectedParams, params)
 }
 
 func TestNewDefaultKeepaliveEnforcementPolicy(t *testing.T) {
-	expectedPolicy := &KeepaliveEnforcementPolicy{}
+	expectedPolicy := KeepaliveEnforcementPolicy{}
 
 	policy := NewDefaultKeepaliveEnforcementPolicy()
 
@@ -88,20 +88,17 @@ func TestNewDefaultKeepaliveEnforcementPolicy(t *testing.T) {
 }
 
 func TestNewDefaultKeepaliveServerConfig(t *testing.T) {
-	serverParameters := NewDefaultKeepaliveServerParameters()
-	enforcementPolicy := NewDefaultKeepaliveEnforcementPolicy()
-	expected := &KeepaliveServerConfig{
-		ServerParameters:  &serverParameters,
-		EnforcementPolicy: &enforcementPolicy,
+	expected := KeepaliveServerConfig{
+		ServerParameters:  ptr(NewDefaultKeepaliveServerParameters()),
+		EnforcementPolicy: ptr(NewDefaultKeepaliveEnforcementPolicy()),
 	}
 	result := NewDefaultKeepaliveServerConfig()
 	assert.Equal(t, expected, result)
 }
 
 func TestNewDefaultServerConfig(t *testing.T) {
-	keepalive := NewDefaultKeepaliveServerConfig()
-	expected := &ServerConfig{
-		Keepalive: &keepalive,
+	expected := ServerConfig{
+		Keepalive: ptr(NewDefaultKeepaliveServerConfig()),
 	}
 
 	result := NewDefaultServerConfig()

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -373,12 +373,16 @@ type ServerConfig struct {
 	Middlewares []configmiddleware.Config `mapstructure:"middleware,omitempty"`
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 // NewDefaultServerConfig returns ServerConfig type object with default values.
 // We encourage to use this function to create an object of ServerConfig.
 func NewDefaultServerConfig() ServerConfig {
 	return ServerConfig{
 		ResponseHeaders:   map[string]configopaque.String{},
-		CORS:              NewDefaultCORSConfig(),
+		CORS:              ptr(NewDefaultCORSConfig()),
 		WriteTimeout:      30 * time.Second,
 		ReadHeaderTimeout: 1 * time.Minute,
 		IdleTimeout:       1 * time.Minute,
@@ -594,8 +598,8 @@ type CORSConfig struct {
 }
 
 // NewDefaultCORSConfig creates a default cross-origin resource sharing (CORS) configuration.
-func NewDefaultCORSConfig() *CORSConfig {
-	return &CORSConfig{}
+func NewDefaultCORSConfig() CORSConfig {
+	return CORSConfig{}
 }
 
 func authInterceptor(next http.Handler, server extensionauth.Server, requestParams []string, serverOpts *internal.ToServerOptions) http.Handler {

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -740,7 +740,7 @@ func TestHttpCors(t *testing.T) {
 		},
 		{
 			name:             "emptyCORS",
-			CORSConfig:       NewDefaultCORSConfig(),
+			CORSConfig:       ptr(NewDefaultCORSConfig()),
 			allowedWorks:     false,
 			disallowedWorks:  false,
 			extraHeaderWorks: false,

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -31,7 +31,7 @@ func NewFactory() exporter.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	clientCfg := *configgrpc.NewDefaultClientConfig()
+	clientCfg := configgrpc.NewDefaultClientConfig()
 	// Default to gzip compression
 	clientCfg.Compression = configcompression.TypeGzip
 	// We almost read 0 bytes, so no need to tune ReadBufferSize.

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -163,6 +163,10 @@ func TestUnmarshalConfig(t *testing.T) {
 		}, cfg)
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func TestUnmarshalConfigUnix(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "uds.yaml"))
 	require.NoError(t, err)
@@ -178,12 +182,12 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 						Transport: confignet.TransportTypeUnix,
 					},
 					ReadBufferSize: 512 * 1024,
-					Keepalive:      configgrpc.NewDefaultKeepaliveServerConfig(),
+					Keepalive:      ptr(configgrpc.NewDefaultKeepaliveServerConfig()),
 				}),
 				HTTP: configoptional.Some(HTTPConfig{
 					ServerConfig: confighttp.ServerConfig{
 						Endpoint:        "/tmp/http_otlp.sock",
-						CORS:            confighttp.NewDefaultCORSConfig(),
+						CORS:            ptr(confighttp.NewDefaultCORSConfig()),
 						ResponseHeaders: map[string]configopaque.String{},
 					},
 					TracesURLPath:  defaultTracesURLPath,

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -57,7 +57,7 @@ func createDefaultConfig() component.Config {
 
 	return &Config{
 		Protocols: Protocols{
-			GRPC: configoptional.Default(*grpcCfg),
+			GRPC: configoptional.Default(grpcCfg),
 			HTTP: configoptional.Default(HTTPConfig{
 				ServerConfig:   httpCfg,
 				TracesURLPath:  defaultTracesURLPath,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Some `NewDefault*Config` functions return `*Config`, while others return `Config`. As far as I can tell, this is solely because it was easier to write the code for existing usages of the configs. I think that's not the right approach: in my opinion, we should return either always `Config` or always `*Config`, and the former seems to be more natural to me (since the pointer should never be nil)