### PR TITLE
[exporterhelper] Preserve request span context in the persistent queue

### DIFF
--- a/.chloggen/persist-request-context.yaml
+++ b/.chloggen/persist-request-context.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an option to preserve request span context in the persistent queue
+
+# One or more tracking issues or pull requests related to the change
+issues: [11740]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Currently, it is behind the exporter.PersistRequestContext feature gate, which can be enabled by adding 
+  `--feature-gates=exporter.PersistRequestContext` to the collector command line. An exporter buffer stored by
+  a previous version of the collector (or by a collector with the feature gate disabled) can be read by a newer
+  collector with the feature enabled. However, the reverse is not supported: a buffer stored by a newer collector with
+  the feature enabled cannot be read by an older collector (or by a collector with the feature gate disabled).
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue/encoding.go
+++ b/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue/encoding.go
@@ -1,0 +1,218 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistentqueue // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue"
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+
+	"go.opentelemetry.io/otel/propagation"
+
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+// PersistRequestContextFeatureGate controls whether request context should be preserved in the persistent queue.
+var PersistRequestContextFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"exporter.PersistRequestContext",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterFromVersion("v0.128.0"),
+	featuregate.WithRegisterDescription("controls whether context should be stored alongside requests in the persistent queue"),
+)
+
+type Encoding[T any] interface {
+	// Marshal is a function that can marshal a request into bytes.
+	Marshal(T) ([]byte, error)
+
+	// Unmarshal is a function that can unmarshal bytes into a request.
+	Unmarshal([]byte) (T, error)
+}
+
+// Encoder provides an interface for marshaling and unmarshaling requests along with their context.
+type Encoder[T any] struct {
+	encoding Encoding[T]
+}
+
+func NewEncoder[T any](encoding Encoding[T]) Encoder[T] {
+	return Encoder[T]{
+		encoding: encoding,
+	}
+}
+
+// requestDataKey is the key used to store request data in bytesMap.
+const requestDataKey = "req"
+
+var tracePropagator = propagation.TraceContext{}
+
+func (re Encoder[T]) Marshal(ctx context.Context, req T) ([]byte, error) {
+	if !PersistRequestContextFeatureGate.IsEnabled() {
+		return re.encoding.Marshal(req)
+	}
+
+	bm := newBytesMap()
+	tracePropagator.Inject(ctx, &bytesMapCarrier{bytesMap: bm})
+	reqBuf, err := re.encoding.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	if err := bm.set(requestDataKey, reqBuf); err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	return *bm, nil
+}
+
+func (re Encoder[T]) Unmarshal(b []byte) (T, context.Context, error) {
+	if !PersistRequestContextFeatureGate.IsEnabled() {
+		req, err := re.encoding.Unmarshal(b)
+		return req, context.Background(), err
+	}
+
+	bm := bytesMapFromBytes(b)
+	if bm == nil {
+		// Fall back to unmarshalling of the request alone.
+		// This can happen if the data persisted by the version that doesn't support the context unmarshaling.
+		req, err := re.encoding.Unmarshal(b)
+		return req, context.Background(), err
+	}
+	ctx := tracePropagator.Extract(context.Background(), &bytesMapCarrier{bytesMap: bm})
+	reqBuf, err := bm.get(requestDataKey)
+	var req T
+	if err != nil {
+		return req, context.Background(), fmt.Errorf("failed to read serialized request data: %w", err)
+	}
+	req, err = re.encoding.Unmarshal(reqBuf)
+	return req, ctx, err
+}
+
+// bytesMap is a slice of bytes that represents a map-like structure for storing key-value pairs.
+// It's optimized for efficient memory usage for low number of key-value pairs with big values.
+// The format is a sequence of key-value pairs encoded as:
+//   - 1 byte length of the key
+//   - key bytes
+//   - 4 byte length of the value
+//   - value bytes
+type bytesMap []byte
+
+const (
+	// prefix bytes to denote the bytesMap serialization: 0x00 magic byte + 0x01 version of the encoder.
+	magicByte      = byte(0x00)
+	formatV1Byte   = byte(0x01)
+	prefixBytesLen = 2
+
+	initialCapacity = 256
+)
+
+func newBytesMap() *bytesMap {
+	bm := bytesMap(make([]byte, 0, initialCapacity))
+	bm = append(bm, magicByte, formatV1Byte)
+	return &bm
+}
+
+// set sets the specified key in the map. Must be called only once for each key.
+func (bm *bytesMap) set(key string, val []byte) error {
+	if len(key) > math.MaxUint8 {
+		return errors.New("key param is too long")
+	}
+	valSize := len(val)
+	if uint64(valSize) > math.MaxUint32 {
+		return fmt.Errorf("value is too large to persist, size %d", valSize)
+	}
+
+	*bm = append(*bm, byte(len(key)))
+	*bm = append(*bm, key...)
+
+	var lenBuf [4]byte
+	binary.LittleEndian.PutUint32(lenBuf[:], uint32(valSize)) //nolint:gosec // disable G115
+	*bm = append(*bm, lenBuf[:]...)
+	*bm = append(*bm, val...)
+
+	return nil
+}
+
+// get scans sequentially for the first matching key and returns the value as bytes.
+func (bm *bytesMap) get(k string) ([]byte, error) {
+	for i := prefixBytesLen; i < len(*bm); {
+		kl := int([]byte(*bm)[i])
+		i++
+
+		if i+kl > len(*bm) {
+			return nil, io.ErrUnexpectedEOF
+		}
+		key := string([]byte(*bm)[i : i+kl])
+		i += kl
+
+		if i+4 > len(*bm) {
+			return nil, io.ErrUnexpectedEOF
+		}
+		vLen := binary.LittleEndian.Uint32([]byte(*bm)[i:])
+		i += 4
+
+		if i+int(vLen) > len(*bm) {
+			return nil, io.ErrUnexpectedEOF
+		}
+		val := []byte(*bm)[i : i+int(vLen)]
+		i += int(vLen)
+
+		if key == k {
+			return val, nil
+		}
+	}
+	return nil, nil
+}
+
+// keys returns header names in encounter order.
+func (bm *bytesMap) keys() []string {
+	var out []string
+	for i := prefixBytesLen; i < len(*bm); {
+		kl := int([]byte(*bm)[i])
+		i++
+
+		if i+kl > len(*bm) {
+			break // malformed entry
+		}
+		out = append(out, string([]byte(*bm)[i:i+kl]))
+		i += kl
+
+		if i+4 > len(*bm) {
+			break // malformed entry
+		}
+		vLen := binary.LittleEndian.Uint32([]byte(*bm)[i:])
+		i += 4 + int(vLen)
+	}
+	return out
+}
+
+func bytesMapFromBytes(b []byte) *bytesMap {
+	if len(b) < prefixBytesLen || b[0] != magicByte || b[1] != formatV1Byte {
+		return nil
+	}
+	return (*bytesMap)(&b)
+}
+
+// bytesMapCarrier implements propagation.TextMapCarrier on top of bytesMap.
+type bytesMapCarrier struct {
+	*bytesMap
+}
+
+var _ propagation.TextMapCarrier = (*bytesMapCarrier)(nil)
+
+// Set appends a new string entry; if the key already exists it is left unchanged.
+func (c *bytesMapCarrier) Set(k, v string) {
+	_ = c.set(k, []byte(v))
+}
+
+// Get scans sequentially for the first matching key.
+func (c *bytesMapCarrier) Get(k string) string {
+	v, _ := c.get(k)
+	return string(v)
+}
+
+// Keys returns header names in encounter order.
+func (c *bytesMapCarrier) Keys() []string {
+	return c.keys()
+}

--- a/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue/encoding_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue/encoding_test.go
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistentqueue // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue"
+
+import (
+	"context"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+func TestBytesMap(t *testing.T) {
+	data := []struct {
+		key string
+		val []byte
+	}{
+		{"key1", []byte("value1")},
+		{"key2", []byte("value2")},
+		{"key3", []byte("value3")},
+		{"key4", []byte("value4")},
+	}
+
+	bm := newBytesMap()
+	for _, d := range data {
+		err := bm.set(d.key, d.val)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, []string{"key1", "key2", "key3", "key4"}, bm.keys())
+
+	buf, err := bm.get("key2")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value2"), buf)
+	buf, err = bm.get("key4")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value4"), buf)
+
+	buf, err = bm.get("nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, buf)
+
+	err = bm.set(strings.Repeat("x", 300), []byte("too long key"))
+	require.EqualError(t, err, "key param is too long")
+
+	bm = newBytesMap()
+
+	// invalid key length
+	*bm = append(*bm, 4, 'k', 'e', 'y')
+	_, err = bm.get("key1")
+	require.Error(t, err)
+	assert.Empty(t, bm.keys())
+
+	// missing value length
+	*bm = append(*bm, '1')
+	_, err = bm.get("key1")
+	require.Error(t, err)
+	assert.Equal(t, []string{"key1"}, bm.keys())
+
+	// missing value
+	*bm = binary.LittleEndian.AppendUint32(*bm, 1)
+	_, err = bm.get("key1")
+	require.Error(t, err)
+	assert.Equal(t, []string{"key1"}, bm.keys())
+}
+
+func TestBytesMapCarrier(t *testing.T) {
+	carrier := &bytesMapCarrier{bytesMap: newBytesMap()}
+
+	carrier.Set("key1", "val1")
+	carrier.Set("key2", "val2")
+
+	assert.Equal(t, []string{"key1", "key2"}, carrier.Keys())
+	assert.Equal(t, "val2", carrier.Get("key2"))
+	assert.Equal(t, "val1", carrier.Get("key1"))
+}
+
+func TestEncoder(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("0102030405060708")
+	require.NoError(t, err)
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: 0x01,
+		TraceState: trace.TraceState{},
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+	req := uint64(123)
+	enc := NewEncoder(Uint64Encoding{})
+	fgOrigState := PersistRequestContextFeatureGate.IsEnabled()
+
+	tests := []struct {
+		name             string
+		fgEnabledOnWrite bool
+		fgEnabledOnRead  bool
+		wantSpanCtx      trace.SpanContext
+		wantReadErr      error
+	}{
+		{
+			name: "feature_gate_disabled_on_write_and_read",
+		},
+		{
+			name:             "feature_gate_enabled_on_write_and_read",
+			fgEnabledOnWrite: true,
+			fgEnabledOnRead:  true,
+			wantSpanCtx:      spanCtx,
+		},
+		{
+			name:            "feature_gate_disabled_on_write_enabled_on_read",
+			fgEnabledOnRead: true,
+		},
+		{
+			name:             "feature_gate_enabled_on_write_disabled_on_read",
+			fgEnabledOnWrite: true,
+			wantReadErr:      ErrInvalidValue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, featuregate.GlobalRegistry().Set(PersistRequestContextFeatureGate.ID(), tt.fgEnabledOnWrite))
+			defer func() {
+				require.NoError(t, featuregate.GlobalRegistry().Set(PersistRequestContextFeatureGate.ID(), fgOrigState))
+			}()
+			buf, err := enc.Marshal(ctx, req)
+			require.NoError(t, err)
+
+			require.NoError(t, featuregate.GlobalRegistry().Set(PersistRequestContextFeatureGate.ID(), tt.fgEnabledOnRead))
+			gotReq, gotCtx, err := enc.Unmarshal(buf)
+			assert.Equal(t, tt.wantReadErr, err)
+			if err == nil {
+				assert.Equal(t, req, gotReq)
+				gotSpanCtx := trace.SpanContextFromContext(gotCtx)
+				assert.Equal(t, tt.wantSpanCtx, gotSpanCtx)
+			}
+		})
+	}
+}

--- a/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue/encodingtest.go
+++ b/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue/encodingtest.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistentqueue // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue"
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+var ErrInvalidValue = errors.New("invalid value")
+
+type Uint64Encoding struct{}
+
+var _ Encoding[uint64] = Uint64Encoding{}
+
+func (Uint64Encoding) Marshal(val uint64) ([]byte, error) {
+	return binary.LittleEndian.AppendUint64([]byte{}, val), nil
+}
+
+func (Uint64Encoding) Unmarshal(bytes []byte) (uint64, error) {
+	if len(bytes) != 8 {
+		return 0, ErrInvalidValue
+	}
+	return binary.LittleEndian.Uint64(bytes), nil
+}

--- a/exporter/exporterhelper/internal/queuebatch/persistent_queue.go
+++ b/exporter/exporterhelper/internal/queuebatch/persistent_queue.go
@@ -57,7 +57,7 @@ type persistentQueueSettings[T any] struct {
 	blockOnOverflow bool
 	signal          pipeline.Signal
 	storageID       component.ID
-	encoding        Encoding[T]
+	encoder         persistentqueue.Encoder[T]
 	id              component.ID
 	telemetry       component.TelemetrySettings
 }
@@ -254,7 +254,7 @@ func (pq *persistentQueue[T]) putInternal(ctx context.Context, req T) error {
 		}
 	}
 
-	reqBuf, err := pq.set.encoding.Marshal(req)
+	reqBuf, err := pq.set.encoder.Marshal(ctx, req)
 	if err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func (pq *persistentQueue[T]) Read(ctx context.Context) (context.Context, T, Don
 
 		// Read until either a successful retrieved element or no more elements in the storage.
 		for pq.metadata.ReadIndex != pq.metadata.WriteIndex {
-			index, req, consumed := pq.getNextItem(ctx)
+			index, req, reqCtx, consumed := pq.getNextItem(ctx)
 			// Ensure the used size and the channel size are in sync.
 			if pq.metadata.ReadIndex == pq.metadata.WriteIndex {
 				pq.metadata.QueueSize = 0
@@ -304,7 +304,7 @@ func (pq *persistentQueue[T]) Read(ctx context.Context) (context.Context, T, Don
 			if consumed {
 				id := indexDonePool.Get().(*indexDone)
 				id.reset(index, pq.set.sizer.Sizeof(req), pq)
-				return context.Background(), req, id, true
+				return reqCtx, req, id, true
 			}
 		}
 
@@ -317,7 +317,7 @@ func (pq *persistentQueue[T]) Read(ctx context.Context) (context.Context, T, Don
 // getNextItem pulls the next available item from the persistent storage along with its index. Once processing is
 // finished, the index should be called with onDone to clean up the storage. If no new item is available,
 // returns false.
-func (pq *persistentQueue[T]) getNextItem(ctx context.Context) (uint64, T, bool) {
+func (pq *persistentQueue[T]) getNextItem(ctx context.Context) (uint64, T, context.Context, bool) {
 	index := pq.metadata.ReadIndex
 	// Increase here, so even if errors happen below, it always iterates
 	pq.metadata.ReadIndex++
@@ -329,8 +329,9 @@ func (pq *persistentQueue[T]) getNextItem(ctx context.Context) (uint64, T, bool)
 		getOp)
 
 	var request T
+	restoredCtx := context.Background()
 	if err == nil {
-		request, err = pq.set.encoding.Unmarshal(getOp.Value)
+		request, restoredCtx, err = pq.set.encoder.Unmarshal(getOp.Value)
 	}
 
 	if err != nil {
@@ -340,14 +341,14 @@ func (pq *persistentQueue[T]) getNextItem(ctx context.Context) (uint64, T, bool)
 			pq.logger.Error("Error deleting item from queue", zap.Error(err))
 		}
 
-		return 0, request, false
+		return 0, request, restoredCtx, false
 	}
 
 	// Increase the reference count, so the client is not closed while the request is being processed.
 	// The client cannot be closed because we hold the lock since last we checked `stopped`.
 	pq.refClient++
 
-	return index, request, true
+	return index, request, restoredCtx, true
 }
 
 // onDone should be called to remove the item of the given index from the queue once processing is finished.
@@ -439,13 +440,13 @@ func (pq *persistentQueue[T]) retrieveAndEnqueueNotDispatchedReqs(ctx context.Co
 			pq.logger.Warn("Failed retrieving item", zap.String(zapKey, op.Key), zap.Error(errValueNotSet))
 			continue
 		}
-		req, err := pq.set.encoding.Unmarshal(op.Value)
+		req, reqCtx, err := pq.set.encoder.Unmarshal(op.Value)
 		// If error happened or item is nil, it will be efficiently ignored
 		if err != nil {
 			pq.logger.Warn("Failed unmarshalling item", zap.String(zapKey, op.Key), zap.Error(err))
 			continue
 		}
-		if pq.putInternal(ctx, req) != nil {
+		if pq.putInternal(reqCtx, req) != nil {
 			errCount++
 		}
 	}

--- a/exporter/exporterhelper/internal/queuebatch/persistent_queue_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/persistent_queue_test.go
@@ -5,7 +5,6 @@ package queuebatch
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -18,16 +17,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/experr"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/hosttest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/storagetest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
 	"go.opentelemetry.io/collector/extension/xextension/storage"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pipeline"
 )
 
@@ -39,19 +41,6 @@ func (is *itemsSizer) Sizeof(val uint64) int64 {
 		return math.MaxInt64
 	}
 	return int64(val)
-}
-
-type uint64Encoding struct{}
-
-func (uint64Encoding) Marshal(val uint64) ([]byte, error) {
-	return binary.LittleEndian.AppendUint64([]byte{}, val), nil
-}
-
-func (uint64Encoding) Unmarshal(bytes []byte) (uint64, error) {
-	if len(bytes) < 8 {
-		return 0, errInvalidValue
-	}
-	return binary.LittleEndian.Uint64(bytes), nil
 }
 
 func newFakeBoundedStorageClient(maxSizeInBytes int) *fakeBoundedStorageClient {
@@ -221,7 +210,7 @@ func createAndStartTestPersistentQueue(t *testing.T, sizer request.Sizer[uint64]
 		capacity:  capacity,
 		signal:    pipeline.SignalTraces,
 		storageID: component.ID{},
-		encoding:  uint64Encoding{},
+		encoder:   persistentqueue.NewEncoder(persistentqueue.Uint64Encoding{}),
 		id:        component.NewID(exportertest.NopType),
 		telemetry: componenttest.NewNopTelemetrySettings(),
 	})
@@ -244,7 +233,7 @@ func createTestPersistentQueueWithClient(client storage.Client) *persistentQueue
 		capacity:  1000,
 		signal:    pipeline.SignalTraces,
 		storageID: component.ID{},
-		encoding:  uint64Encoding{},
+		encoder:   persistentqueue.NewEncoder(persistentqueue.Uint64Encoding{}),
 		id:        component.NewID(exportertest.NopType),
 		telemetry: componenttest.NewNopTelemetrySettings(),
 	}).(*persistentQueue[uint64])
@@ -268,7 +257,7 @@ func createTestPersistentQueueWithCapacityLimiter(tb testing.TB, ext storage.Ext
 		capacity:  capacity,
 		signal:    pipeline.SignalTraces,
 		storageID: component.ID{},
-		encoding:  uint64Encoding{},
+		encoder:   persistentqueue.NewEncoder(persistentqueue.Uint64Encoding{}),
 		id:        component.NewID(exportertest.NopType),
 		telemetry: componenttest.NewNopTelemetrySettings(),
 	}).(*persistentQueue[uint64])
@@ -416,7 +405,7 @@ func TestPersistentBlockingQueue(t *testing.T) {
 				blockOnOverflow: true,
 				signal:          pipeline.SignalTraces,
 				storageID:       component.ID{},
-				encoding:        uint64Encoding{},
+				encoder:         persistentqueue.NewEncoder(persistentqueue.Uint64Encoding{}),
 				id:              component.NewID(exportertest.NopType),
 				telemetry:       componenttest.NewNopTelemetrySettings(),
 			})
@@ -913,7 +902,7 @@ func TestPersistentQueue_ShutdownWhileConsuming(t *testing.T) {
 }
 
 func TestPersistentQueue_StorageFull(t *testing.T) {
-	marshaled, err := uint64Encoding{}.Marshal(uint64(50))
+	marshaled, err := persistentqueue.Uint64Encoding{}.Marshal(uint64(50))
 	require.NoError(t, err)
 	maxSizeInBytes := len(marshaled) * 5 // arbitrary small number
 
@@ -1204,4 +1193,60 @@ func requireCurrentlyDispatchedItemsEqual(t *testing.T, pq *persistentQueue[uint
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	assert.ElementsMatch(t, compare, pq.metadata.CurrentlyDispatchedItems)
+}
+
+func TestPersistentQueue_SpanContextRoundTrip(t *testing.T) {
+	fgOrigState := persistentqueue.PersistRequestContextFeatureGate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(persistentqueue.PersistRequestContextFeatureGate.ID(), true))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(persistentqueue.PersistRequestContextFeatureGate.ID(), fgOrigState))
+	})
+
+	pq := newPersistentQueue[uint64](persistentQueueSettings[uint64]{
+		sizer:     request.RequestsSizer[uint64]{},
+		capacity:  10,
+		signal:    pipeline.SignalTraces,
+		storageID: component.ID{},
+		encoder:   persistentqueue.NewEncoder[uint64](persistentqueue.Uint64Encoding{}),
+		id:        component.NewID(exportertest.NopType),
+		telemetry: componenttest.NewNopTelemetrySettings(),
+	}).(*persistentQueue[uint64])
+	ext := storagetest.NewMockStorageExtension(nil)
+	client, err := ext.GetClient(context.Background(), component.KindExporter, pq.set.id, pq.set.signal.String())
+	require.NoError(t, err)
+	pq.initClient(context.Background(), client)
+	t.Cleanup(func() {
+		assert.NoError(t, pq.Shutdown(context.Background()))
+	})
+
+	traceID, err := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("0102030405060708")
+	require.NoError(t, err)
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: 0x01,
+		TraceState: trace.TraceState{},
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+	req := uint64(42)
+	require.NoError(t, pq.Offer(ctx, req))
+
+	// send request with span context
+	gotCtx, gotReq, _, ok := pq.Read(context.Background())
+	require.True(t, ok)
+	require.Equal(t, req, gotReq)
+	restoredSpanCtx := trace.SpanContextFromContext(gotCtx)
+	require.True(t, restoredSpanCtx.IsValid())
+	require.Equal(t, spanCtx, restoredSpanCtx)
+
+	// send request without span context
+	req = uint64(99)
+	require.NoError(t, pq.Offer(context.Background(), req))
+	gotCtx, gotReq, _, ok = pq.Read(context.Background())
+	require.True(t, ok)
+	require.Equal(t, req, gotReq)
+	require.False(t, trace.SpanContextFromContext(gotCtx).IsValid())
 }

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch/internal/persistentqueue"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
 	"go.opentelemetry.io/collector/pipeline"
@@ -98,7 +99,7 @@ func newQueueBatch(
 			blockOnOverflow: cfg.BlockOnOverflow,
 			signal:          set.Signal,
 			storageID:       *cfg.StorageID,
-			encoding:        set.Encoding,
+			encoder:         persistentqueue.NewEncoder[request.Request](set.Encoding),
 			id:              set.ID,
 			telemetry:       set.Telemetry,
 		}), cfg.NumConsumers, b.Consume)

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exportertest v0.127.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.127.0
 	go.opentelemetry.io/collector/extension/xextension v0.127.0
+	go.opentelemetry.io/collector/featuregate v1.33.0
 	go.opentelemetry.io/collector/pdata v1.33.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.127.0
 	go.opentelemetry.io/collector/pdata/testdata v0.127.0
@@ -53,7 +54,6 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.127.0 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.127.0 // indirect
 	go.opentelemetry.io/collector/extension v1.33.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.33.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.127.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.33.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.127.0 // indirect


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-collector/pull/13166 without memory allocation optimizations.

This change makes it possible to propagate span context through the Collector with enable persistent queue.

Currently, it is behind the exporter.PersistRequestContext feature gate, which can be enabled by adding `--feature-gates=exporter.PersistRequestContext` to the collector command line. An exporter buffer stored by a previous version of the collector (or by a collector with the feature gate disabled) can be read by a newer collector with the feature enabled. However, the reverse is not supported: a buffer stored by a newer collector with the feature enabled cannot be read by an older collector (or by a collector with the feature gate disabled).

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/11740