### PR TITLE
Use full TracerProvider config from otelconf

### DIFF
--- a/.chloggen/internal-trace-sampling.yaml
+++ b/.chloggen/internal-trace-sampling.yaml
@@ -10,7 +10,7 @@ component: service
 note: Support setting `sampler` and `limits` under `service::telemetry::traces`
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [13201]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/internal-trace-sampling.yaml
+++ b/.chloggen/internal-trace-sampling.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support setting `sampler` and `limits` under `service::telemetry::traces`
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This allows users to enable sampling and set span limits on internal Collector traces using the
+  OpenTelemetry SDK declarative configuration.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/service/service.go
+++ b/service/service.go
@@ -151,10 +151,8 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 				LoggerProvider: &config.LoggerProvider{
 					Processors: cfg.Telemetry.Logs.Processors,
 				},
-				MeterProvider: mpConfig,
-				TracerProvider: &config.TracerProvider{
-					Processors: cfg.Telemetry.Traces.Processors,
-				},
+				MeterProvider:  mpConfig,
+				TracerProvider: &cfg.Telemetry.Traces.TracerProvider,
 				Resource: &config.Resource{
 					SchemaUrl:  &sch,
 					Attributes: attributes(res, cfg.Telemetry),

--- a/service/telemetry/internal/migration/testdata/v0.3.0_traces.yaml
+++ b/service/telemetry/internal/migration/testdata/v0.3.0_traces.yaml
@@ -19,3 +19,8 @@ processors:
           headers:
           - name: "key1"
             value: "value1"
+sampler:
+  parent_based:
+    root:
+      trace_id_ratio_based:
+        ratio: 0.01

--- a/service/telemetry/internal/migration/v0.3.0.go
+++ b/service/telemetry/internal/migration/v0.3.0.go
@@ -22,9 +22,8 @@ type TracesConfigV030 struct {
 	// tracecontext and  b3 are supported. By default, the value is set to empty list and
 	// context propagation is disabled.
 	Propagators []string `mapstructure:"propagators"`
-	// Processors allow configuration of span processors to emit spans to
-	// any number of supported backends.
-	Processors []config.SpanProcessor `mapstructure:"processors"`
+
+	config.TracerProvider `mapstructure:",squash"`
 }
 
 func (c *TracesConfigV030) Unmarshal(conf *confmap.Conf) error {


### PR DESCRIPTION
#### Description

This PR changes the config struct corresponding to `service::telemetry::traces` to embed the full `TracerProvider` config struct from `otelconf`, instead of including only its `Processors` field.

Something similar was previously done for the `MeterProvider` struct in #12433.

This has the effect of letting users enable sampling on internal Collector traces using [the `sampler` section of the declarative config](https://github.com/open-telemetry/opentelemetry-configuration/blob/9c8ff31553a6a48c09fe99a288596e28b63c4cdb/examples/kitchen-sink.yaml#L294).

#### Link to tracking issue
I couldn't find any relevant issue.

#### Testing
I added a basic example of using the `sampler` to `service/telemetry/internal/migration/testdata/v0.3.0_traces.yaml` to test that we can unmarshal this section properly.

#### Documentation
Just a changelog.