### PR TITLE
Add feature gate to disable log teeing when telemetry provider is set

### DIFF
--- a/.chloggen/fg_teeing.yaml
+++ b/.chloggen/fg_teeing.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds feature gate for disabling tee'ing when telemetry provider is configured.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13209]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/service/go.mod
+++ b/service/go.mod
@@ -45,6 +45,7 @@ require (
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.0
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.0
 	go.opentelemetry.io/collector/service/hostcapabilities v0.128.0
+	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0
 	go.opentelemetry.io/contrib/otelconf v0.16.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.36.0
 	go.opentelemetry.io/otel v1.36.0
@@ -111,7 +112,6 @@ require (
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.34.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.0 // indirect
-	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/contrib/zpages v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.12.2 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds a feature gate for disabling the console logging when a telemetry provider is configured for the Collector.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/13019

<!--Describe what testing was performed and which tests were added.-->
#### Testing

##### Manual testing notes

1. Start a "back-end" Collector:

```console
docker run \
  -p 127.0.0.1:4318:4318 \
  otel/opentelemetry-collector-contrib:0.128.0 \
  2>&1 | tee collector-output.txt
```

2. Using the following configuration, start a Collector with the featureGate enabled:
`config.yaml`:
```yaml
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317

exporters:
  debug:
    verbosity: normal

service:
  telemetry:
    logs:
      processors:
        - batch:
            exporter:
              otlp:
                protocol: http/protobuf
                endpoint: http://0.0.0.0:4318

  pipelines:
    metrics:
      receivers: [otlp]
      exporters: [debug]
```

`./bin/otelcorecol_darwin_arm64 --config ~/otelcol/corecol/config.yaml --feature-gates=+telemetry.disableConsoleLoggingWhenProviderEnabled`

3. Ensure that the back-end Collector receives the logs and that the monitored Collector does not log to the console


<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->

Probably https://opentelemetry.io/docs/collector/internal-telemetry/ could mention the feature gate.
