### PR TITLE
[chore] Avoid using the default port for internal metrics in tests

### DIFF
--- a/otelcol/testdata/otelcol-invalid-receiver-type.yaml
+++ b/otelcol/testdata/otelcol-invalid-receiver-type.yaml
@@ -15,7 +15,7 @@ service:
             exporter:
               prometheus:
                 host: "localhost"
-                port: 8888
+                port: 9999
   pipelines:
     traces:
       receivers: [nop_logs]

--- a/otelcol/testdata/otelcol-invalid.yaml
+++ b/otelcol/testdata/otelcol-invalid.yaml
@@ -15,7 +15,7 @@ service:
             exporter:
               prometheus:
                 host: "localhost"
-                port: 8888
+                port: 9999
   pipelines:
     traces:
       receivers: [nop]

--- a/otelcol/testdata/otelcol-invalidprop.yaml
+++ b/otelcol/testdata/otelcol-invalidprop.yaml
@@ -19,7 +19,7 @@ service:
             exporter:
               prometheus:
                 host: "localhost"
-                port: 8888
+                port: 9999
   pipelines:
     traces:
       receivers: [nop]

--- a/otelcol/testdata/otelcol-nop.yaml
+++ b/otelcol/testdata/otelcol-nop.yaml
@@ -21,7 +21,7 @@ service:
             exporter:
               prometheus:
                 host: "localhost"
-                port: 8888
+                port: 9999
   extensions: [nop]
   pipelines:
     traces:

--- a/otelcol/testdata/otelcol-statuswatcher.yaml
+++ b/otelcol/testdata/otelcol-statuswatcher.yaml
@@ -19,7 +19,7 @@ service:
             exporter:
               prometheus:
                 host: "localhost"
-                port: 8888
+                port: 9999
   extensions: [statuswatcher]
   pipelines:
     traces:

--- a/otelcol/testdata/otelcol-validprop.yaml
+++ b/otelcol/testdata/otelcol-validprop.yaml
@@ -19,7 +19,7 @@ service:
             exporter:
               prometheus:
                 host: "localhost"
-                port: 8888
+                port: 9999
   pipelines:
     traces:
       receivers: [nop]


### PR DESCRIPTION
This causes errors running the tests on machines that have the collector running on them.