### PR TITLE
[exporterhelper] Preserve client address in persistent queue

### DIFF
--- a/.chloggen/persist-request-context.yaml
+++ b/.chloggen/persist-request-context.yaml
@@ -5,16 +5,16 @@ change_type: enhancement
 component: exporterhelper
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Preserve request span context and client metadata in the persistent queue.
+note: Preserve request span context and client information in the persistent queue.
 
 # One or more tracking issues or pull requests related to the change
-issues: [11740, 13220]
+issues: [11740, 13220, 13232]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  It allows internal collector spans and client metadata to propagate through the persistent queue used by 
+  It allows internal collector spans and client information to propagate through the persistent queue used by 
   the exporters. The same way as it's done for the in-memory queue.
   Currently, it is behind the exporter.PersistRequestContext feature gate, which can be enabled by adding 
   `--feature-gates=exporter.PersistRequestContext` to the collector command line. An exporter buffer stored by

--- a/pdata/xpdata/request/context.go
+++ b/pdata/xpdata/request/context.go
@@ -5,6 +5,7 @@ package request // import "go.opentelemetry.io/collector/pdata/xpdata/request"
 
 import (
 	"context"
+	"net"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -19,20 +20,21 @@ var readOnlyState = pdataint.StateReadOnly
 
 // encodeContext encodes the context into a map of strings.
 func encodeContext(ctx context.Context) internal.RequestContext {
-	return internal.RequestContext{
-		SpanContext:    encodeSpanContext(ctx),
-		ClientMetadata: encodeClientMetadata(ctx),
-	}
+	rc := internal.RequestContext{}
+	encodeSpanContext(ctx, &rc)
+	encodeClientMetadata(ctx, &rc)
+	encodeClientAddress(ctx, &rc)
+	return rc
 }
 
-func encodeSpanContext(ctx context.Context) *internal.SpanContext {
+func encodeSpanContext(ctx context.Context, rc *internal.RequestContext) {
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if !spanCtx.IsValid() {
-		return nil
+		return
 	}
 	traceID := spanCtx.TraceID()
 	spanID := spanCtx.SpanID()
-	return &internal.SpanContext{
+	rc.SpanContext = &internal.SpanContext{
 		TraceId:    traceID[:],
 		SpanId:     spanID[:],
 		TraceFlags: uint32(spanCtx.TraceFlags()),
@@ -41,7 +43,7 @@ func encodeSpanContext(ctx context.Context) *internal.SpanContext {
 	}
 }
 
-func encodeClientMetadata(ctx context.Context) []protocommon.KeyValue {
+func encodeClientMetadata(ctx context.Context, rc *internal.RequestContext) {
 	clientMetadata := client.FromContext(ctx).Metadata
 	metadataMap, metadataFound := pcommon.Map{}, false
 	for k := range clientMetadata.Keys() {
@@ -54,9 +56,35 @@ func encodeClientMetadata(ctx context.Context) []protocommon.KeyValue {
 		}
 	}
 	if metadataFound {
-		return *pdataint.GetOrigMap(pdataint.Map(metadataMap))
+		rc.ClientMetadata = *pdataint.GetOrigMap(pdataint.Map(metadataMap))
 	}
-	return nil
+}
+
+func encodeClientAddress(ctx context.Context, rc *internal.RequestContext) {
+	switch a := client.FromContext(ctx).Addr.(type) {
+	case *net.IPAddr:
+		rc.ClientAddress = &internal.RequestContext_Ip{Ip: &internal.IPAddr{
+			Ip:   a.IP,
+			Zone: a.Zone,
+		}}
+	case *net.TCPAddr:
+		rc.ClientAddress = &internal.RequestContext_Tcp{Tcp: &internal.TCPAddr{
+			Ip:   a.IP,
+			Port: int32(a.Port), //nolint:gosec // G115
+			Zone: a.Zone,
+		}}
+	case *net.UDPAddr:
+		rc.ClientAddress = &internal.RequestContext_Udp{Udp: &internal.UDPAddr{
+			Ip:   a.IP,
+			Port: int32(a.Port), //nolint:gosec // G115
+			Zone: a.Zone,
+		}}
+	case *net.UnixAddr:
+		rc.ClientAddress = &internal.RequestContext_Unix{Unix: &internal.UnixAddr{
+			Name: a.Name,
+			Net:  a.Net,
+		}}
+	}
 }
 
 // decodeContext decodes the context from the bytes map.
@@ -65,7 +93,15 @@ func decodeContext(ctx context.Context, rc *internal.RequestContext) context.Con
 		return ctx
 	}
 	ctx = decodeSpanContext(ctx, rc.SpanContext)
-	return decodeClientMetadata(ctx, rc.ClientMetadata)
+	metadataMap := decodeClientMetadata(rc.ClientMetadata)
+	clientAddress := decodeClientAddress(rc)
+	if len(metadataMap) > 0 || clientAddress != nil {
+		ctx = client.NewContext(ctx, client.Info{
+			Metadata: client.NewMetadata(metadataMap),
+			Addr:     clientAddress,
+		})
+	}
+	return ctx
 }
 
 func decodeSpanContext(ctx context.Context, sc *internal.SpanContext) context.Context {
@@ -86,9 +122,9 @@ func decodeSpanContext(ctx context.Context, sc *internal.SpanContext) context.Co
 	}))
 }
 
-func decodeClientMetadata(ctx context.Context, clientMetadata []protocommon.KeyValue) context.Context {
+func decodeClientMetadata(clientMetadata []protocommon.KeyValue) map[string][]string {
 	if len(clientMetadata) == 0 {
-		return ctx
+		return nil
 	}
 	metadataMap := make(map[string][]string, len(clientMetadata))
 	for k, vals := range pcommon.Map(pdataint.NewMap(&clientMetadata, &readOnlyState)).All() {
@@ -97,5 +133,33 @@ func decodeClientMetadata(ctx context.Context, clientMetadata []protocommon.KeyV
 			metadataMap[k][i] = v.Str()
 		}
 	}
-	return client.NewContext(ctx, client.Info{Metadata: client.NewMetadata(metadataMap)})
+	return metadataMap
+}
+
+func decodeClientAddress(rc *internal.RequestContext) net.Addr {
+	switch a := rc.ClientAddress.(type) {
+	case *internal.RequestContext_Ip:
+		return &net.IPAddr{
+			IP:   a.Ip.Ip,
+			Zone: a.Ip.Zone,
+		}
+	case *internal.RequestContext_Tcp:
+		return &net.TCPAddr{
+			IP:   a.Tcp.Ip,
+			Port: int(a.Tcp.Port),
+			Zone: a.Tcp.Zone,
+		}
+	case *internal.RequestContext_Udp:
+		return &net.UDPAddr{
+			IP:   a.Udp.Ip,
+			Port: int(a.Udp.Port),
+			Zone: a.Udp.Zone,
+		}
+	case *internal.RequestContext_Unix:
+		return &net.UnixAddr{
+			Name: a.Unix.Name,
+			Net:  a.Unix.Net,
+		}
+	}
+	return nil
 }

--- a/pdata/xpdata/request/internal/request.pb.go
+++ b/pdata/xpdata/request/internal/request.pb.go
@@ -108,18 +108,250 @@ func (m *SpanContext) GetRemote() bool {
 	return false
 }
 
+type IPAddr struct {
+	Ip   []byte `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	Zone string `protobuf:"bytes,2,opt,name=zone,proto3" json:"zone,omitempty"`
+}
+
+func (m *IPAddr) Reset()         { *m = IPAddr{} }
+func (m *IPAddr) String() string { return proto.CompactTextString(m) }
+func (*IPAddr) ProtoMessage()    {}
+func (*IPAddr) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b47c551a6764db21, []int{1}
+}
+func (m *IPAddr) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *IPAddr) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_IPAddr.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *IPAddr) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_IPAddr.Merge(m, src)
+}
+func (m *IPAddr) XXX_Size() int {
+	return m.Size()
+}
+func (m *IPAddr) XXX_DiscardUnknown() {
+	xxx_messageInfo_IPAddr.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_IPAddr proto.InternalMessageInfo
+
+func (m *IPAddr) GetIp() []byte {
+	if m != nil {
+		return m.Ip
+	}
+	return nil
+}
+
+func (m *IPAddr) GetZone() string {
+	if m != nil {
+		return m.Zone
+	}
+	return ""
+}
+
+type TCPAddr struct {
+	Ip   []byte `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	Port int32  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	Zone string `protobuf:"bytes,3,opt,name=zone,proto3" json:"zone,omitempty"`
+}
+
+func (m *TCPAddr) Reset()         { *m = TCPAddr{} }
+func (m *TCPAddr) String() string { return proto.CompactTextString(m) }
+func (*TCPAddr) ProtoMessage()    {}
+func (*TCPAddr) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b47c551a6764db21, []int{2}
+}
+func (m *TCPAddr) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *TCPAddr) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_TCPAddr.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *TCPAddr) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TCPAddr.Merge(m, src)
+}
+func (m *TCPAddr) XXX_Size() int {
+	return m.Size()
+}
+func (m *TCPAddr) XXX_DiscardUnknown() {
+	xxx_messageInfo_TCPAddr.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_TCPAddr proto.InternalMessageInfo
+
+func (m *TCPAddr) GetIp() []byte {
+	if m != nil {
+		return m.Ip
+	}
+	return nil
+}
+
+func (m *TCPAddr) GetPort() int32 {
+	if m != nil {
+		return m.Port
+	}
+	return 0
+}
+
+func (m *TCPAddr) GetZone() string {
+	if m != nil {
+		return m.Zone
+	}
+	return ""
+}
+
+type UDPAddr struct {
+	Ip   []byte `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	Port int32  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	Zone string `protobuf:"bytes,3,opt,name=zone,proto3" json:"zone,omitempty"`
+}
+
+func (m *UDPAddr) Reset()         { *m = UDPAddr{} }
+func (m *UDPAddr) String() string { return proto.CompactTextString(m) }
+func (*UDPAddr) ProtoMessage()    {}
+func (*UDPAddr) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b47c551a6764db21, []int{3}
+}
+func (m *UDPAddr) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *UDPAddr) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_UDPAddr.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *UDPAddr) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UDPAddr.Merge(m, src)
+}
+func (m *UDPAddr) XXX_Size() int {
+	return m.Size()
+}
+func (m *UDPAddr) XXX_DiscardUnknown() {
+	xxx_messageInfo_UDPAddr.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_UDPAddr proto.InternalMessageInfo
+
+func (m *UDPAddr) GetIp() []byte {
+	if m != nil {
+		return m.Ip
+	}
+	return nil
+}
+
+func (m *UDPAddr) GetPort() int32 {
+	if m != nil {
+		return m.Port
+	}
+	return 0
+}
+
+func (m *UDPAddr) GetZone() string {
+	if m != nil {
+		return m.Zone
+	}
+	return ""
+}
+
+type UnixAddr struct {
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Net  string `protobuf:"bytes,2,opt,name=net,proto3" json:"net,omitempty"`
+}
+
+func (m *UnixAddr) Reset()         { *m = UnixAddr{} }
+func (m *UnixAddr) String() string { return proto.CompactTextString(m) }
+func (*UnixAddr) ProtoMessage()    {}
+func (*UnixAddr) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b47c551a6764db21, []int{4}
+}
+func (m *UnixAddr) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *UnixAddr) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_UnixAddr.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *UnixAddr) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UnixAddr.Merge(m, src)
+}
+func (m *UnixAddr) XXX_Size() int {
+	return m.Size()
+}
+func (m *UnixAddr) XXX_DiscardUnknown() {
+	xxx_messageInfo_UnixAddr.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_UnixAddr proto.InternalMessageInfo
+
+func (m *UnixAddr) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *UnixAddr) GetNet() string {
+	if m != nil {
+		return m.Net
+	}
+	return ""
+}
+
 // RequestContext represents metadata associated with a telemetry export request.
 type RequestContext struct {
 	SpanContext *SpanContext `protobuf:"bytes,1,opt,name=span_context,json=spanContext,proto3" json:"span_context,omitempty"`
 	// ClientMetadata contains additional metadata about the client making the request.
 	ClientMetadata []v1.KeyValue `protobuf:"bytes,2,rep,name=client_metadata,json=clientMetadata,proto3" json:"client_metadata"`
+	// ClientAddress contains the address of the client making the request.
+	//
+	// Types that are valid to be assigned to ClientAddress:
+	//	*RequestContext_Ip
+	//	*RequestContext_Tcp
+	//	*RequestContext_Udp
+	//	*RequestContext_Unix
+	ClientAddress isRequestContext_ClientAddress `protobuf_oneof:"client_address"`
 }
 
 func (m *RequestContext) Reset()         { *m = RequestContext{} }
 func (m *RequestContext) String() string { return proto.CompactTextString(m) }
 func (*RequestContext) ProtoMessage()    {}
 func (*RequestContext) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b47c551a6764db21, []int{1}
+	return fileDescriptor_b47c551a6764db21, []int{5}
 }
 func (m *RequestContext) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -148,6 +380,37 @@ func (m *RequestContext) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RequestContext proto.InternalMessageInfo
 
+type isRequestContext_ClientAddress interface {
+	isRequestContext_ClientAddress()
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type RequestContext_Ip struct {
+	Ip *IPAddr `protobuf:"bytes,3,opt,name=ip,proto3,oneof" json:"ip,omitempty"`
+}
+type RequestContext_Tcp struct {
+	Tcp *TCPAddr `protobuf:"bytes,4,opt,name=tcp,proto3,oneof" json:"tcp,omitempty"`
+}
+type RequestContext_Udp struct {
+	Udp *UDPAddr `protobuf:"bytes,5,opt,name=udp,proto3,oneof" json:"udp,omitempty"`
+}
+type RequestContext_Unix struct {
+	Unix *UnixAddr `protobuf:"bytes,6,opt,name=unix,proto3,oneof" json:"unix,omitempty"`
+}
+
+func (*RequestContext_Ip) isRequestContext_ClientAddress()   {}
+func (*RequestContext_Tcp) isRequestContext_ClientAddress()  {}
+func (*RequestContext_Udp) isRequestContext_ClientAddress()  {}
+func (*RequestContext_Unix) isRequestContext_ClientAddress() {}
+
+func (m *RequestContext) GetClientAddress() isRequestContext_ClientAddress {
+	if m != nil {
+		return m.ClientAddress
+	}
+	return nil
+}
+
 func (m *RequestContext) GetSpanContext() *SpanContext {
 	if m != nil {
 		return m.SpanContext
@@ -162,6 +425,44 @@ func (m *RequestContext) GetClientMetadata() []v1.KeyValue {
 	return nil
 }
 
+func (m *RequestContext) GetIp() *IPAddr {
+	if x, ok := m.GetClientAddress().(*RequestContext_Ip); ok {
+		return x.Ip
+	}
+	return nil
+}
+
+func (m *RequestContext) GetTcp() *TCPAddr {
+	if x, ok := m.GetClientAddress().(*RequestContext_Tcp); ok {
+		return x.Tcp
+	}
+	return nil
+}
+
+func (m *RequestContext) GetUdp() *UDPAddr {
+	if x, ok := m.GetClientAddress().(*RequestContext_Udp); ok {
+		return x.Udp
+	}
+	return nil
+}
+
+func (m *RequestContext) GetUnix() *UnixAddr {
+	if x, ok := m.GetClientAddress().(*RequestContext_Unix); ok {
+		return x.Unix
+	}
+	return nil
+}
+
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RequestContext) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
+		(*RequestContext_Ip)(nil),
+		(*RequestContext_Tcp)(nil),
+		(*RequestContext_Udp)(nil),
+		(*RequestContext_Unix)(nil),
+	}
+}
+
 type TracesRequest struct {
 	FormatVersion  uint32          `protobuf:"fixed32,1,opt,name=format_version,json=formatVersion,proto3" json:"format_version,omitempty"`
 	RequestContext *RequestContext `protobuf:"bytes,2,opt,name=request_context,json=requestContext,proto3" json:"request_context,omitempty"`
@@ -172,7 +473,7 @@ func (m *TracesRequest) Reset()         { *m = TracesRequest{} }
 func (m *TracesRequest) String() string { return proto.CompactTextString(m) }
 func (*TracesRequest) ProtoMessage()    {}
 func (*TracesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b47c551a6764db21, []int{2}
+	return fileDescriptor_b47c551a6764db21, []int{6}
 }
 func (m *TracesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -232,7 +533,7 @@ func (m *MetricsRequest) Reset()         { *m = MetricsRequest{} }
 func (m *MetricsRequest) String() string { return proto.CompactTextString(m) }
 func (*MetricsRequest) ProtoMessage()    {}
 func (*MetricsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b47c551a6764db21, []int{3}
+	return fileDescriptor_b47c551a6764db21, []int{7}
 }
 func (m *MetricsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -292,7 +593,7 @@ func (m *LogsRequest) Reset()         { *m = LogsRequest{} }
 func (m *LogsRequest) String() string { return proto.CompactTextString(m) }
 func (*LogsRequest) ProtoMessage()    {}
 func (*LogsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b47c551a6764db21, []int{4}
+	return fileDescriptor_b47c551a6764db21, []int{8}
 }
 func (m *LogsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -352,7 +653,7 @@ func (m *ProfilesRequest) Reset()         { *m = ProfilesRequest{} }
 func (m *ProfilesRequest) String() string { return proto.CompactTextString(m) }
 func (*ProfilesRequest) ProtoMessage()    {}
 func (*ProfilesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b47c551a6764db21, []int{5}
+	return fileDescriptor_b47c551a6764db21, []int{9}
 }
 func (m *ProfilesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -404,6 +705,10 @@ func (m *ProfilesRequest) GetProfilesData() *v1development.ProfilesData {
 
 func init() {
 	proto.RegisterType((*SpanContext)(nil), "opentelemetry.collector.pdata.xpdata.internal.SpanContext")
+	proto.RegisterType((*IPAddr)(nil), "opentelemetry.collector.pdata.xpdata.internal.IPAddr")
+	proto.RegisterType((*TCPAddr)(nil), "opentelemetry.collector.pdata.xpdata.internal.TCPAddr")
+	proto.RegisterType((*UDPAddr)(nil), "opentelemetry.collector.pdata.xpdata.internal.UDPAddr")
+	proto.RegisterType((*UnixAddr)(nil), "opentelemetry.collector.pdata.xpdata.internal.UnixAddr")
 	proto.RegisterType((*RequestContext)(nil), "opentelemetry.collector.pdata.xpdata.internal.RequestContext")
 	proto.RegisterType((*TracesRequest)(nil), "opentelemetry.collector.pdata.xpdata.internal.TracesRequest")
 	proto.RegisterType((*MetricsRequest)(nil), "opentelemetry.collector.pdata.xpdata.internal.MetricsRequest")
@@ -416,46 +721,57 @@ func init() {
 }
 
 var fileDescriptor_b47c551a6764db21 = []byte{
-	// 613 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x95, 0xcd, 0x6e, 0xd3, 0x40,
-	0x10, 0xc7, 0xb3, 0x6d, 0x49, 0xd2, 0x75, 0x3e, 0x24, 0x0b, 0x41, 0xe8, 0xc1, 0x8d, 0x2c, 0x15,
-	0x2c, 0x0a, 0x6b, 0xa5, 0xbd, 0x00, 0x12, 0x97, 0x80, 0x90, 0x22, 0x08, 0x42, 0x2e, 0xca, 0x01,
-	0xa9, 0x8a, 0x16, 0x67, 0x63, 0x59, 0xb2, 0xbd, 0x66, 0xbd, 0xb5, 0xda, 0xb7, 0xe0, 0xce, 0x03,
-	0xd1, 0x63, 0x8f, 0x9c, 0x50, 0x95, 0x9c, 0x38, 0xf1, 0x08, 0xa0, 0xfd, 0x70, 0xea, 0x54, 0xbe,
-	0xf4, 0x96, 0x53, 0x66, 0x66, 0xff, 0x33, 0xbb, 0xbf, 0x9d, 0xf5, 0x04, 0x1e, 0xa6, 0x33, 0xcc,
-	0xb1, 0x7b, 0xae, 0x7e, 0x18, 0xf9, 0x76, 0x46, 0x32, 0xee, 0x86, 0x09, 0x27, 0x2c, 0xc1, 0x51,
-	0x11, 0x40, 0x29, 0xa3, 0x9c, 0x9a, 0xcf, 0x69, 0x4a, 0x12, 0x4e, 0x22, 0x12, 0x13, 0xce, 0x2e,
-	0x90, 0x4f, 0xa3, 0x88, 0xf8, 0x9c, 0x32, 0x24, 0xb3, 0x91, 0x2a, 0x82, 0x8a, 0xe4, 0xbd, 0xfb,
-	0x01, 0x0d, 0xa8, 0xcc, 0x74, 0x85, 0xa5, 0x8a, 0xec, 0x39, 0x6b, 0x45, 0x5c, 0xb5, 0xce, 0x19,
-	0xf6, 0x89, 0x9b, 0x0f, 0x94, 0xa1, 0x95, 0xcf, 0xaa, 0x94, 0xc2, 0x0e, 0xfd, 0x4c, 0x68, 0xb5,
-	0xa9, 0xd5, 0x8f, 0xab, 0xd4, 0x11, 0x0d, 0xa4, 0x54, 0xfc, 0x6a, 0xdd, 0xd3, 0x2a, 0x9d, 0x4f,
-	0xe3, 0x98, 0x26, 0x42, 0xa9, 0x2c, 0xad, 0x7d, 0x59, 0xa5, 0x4d, 0x19, 0x9d, 0x87, 0x11, 0x11,
-	0x75, 0x67, 0x24, 0x27, 0x11, 0x4d, 0x63, 0x92, 0xf0, 0x55, 0x58, 0xa5, 0xda, 0x3f, 0x00, 0x34,
-	0x4e, 0x52, 0x9c, 0xbc, 0xa1, 0x09, 0x27, 0xe7, 0xdc, 0x7c, 0x04, 0x9b, 0x92, 0x6d, 0x1a, 0xce,
-	0x7a, 0xa0, 0x0f, 0x9c, 0x96, 0xd7, 0x90, 0xfe, 0x68, 0x66, 0x3e, 0x84, 0x8d, 0x2c, 0xc5, 0x89,
-	0x58, 0xd9, 0x92, 0x2b, 0x75, 0xe1, 0x8e, 0x66, 0xe6, 0x3e, 0x34, 0x54, 0xce, 0x3c, 0xc2, 0x41,
-	0xd6, 0xdb, 0xee, 0x03, 0xa7, 0xe1, 0x41, 0x19, 0x7a, 0x27, 0x22, 0x37, 0x82, 0x8c, 0x63, 0x4e,
-	0x7a, 0x3b, 0x7d, 0xe0, 0xec, 0x6a, 0xc1, 0x89, 0x88, 0x98, 0x0f, 0x60, 0x9d, 0x91, 0x98, 0x72,
-	0xd2, 0xbb, 0xd7, 0x07, 0x4e, 0xd3, 0xd3, 0x9e, 0xfd, 0x13, 0xc0, 0x8e, 0xa7, 0x7a, 0x5b, 0x1c,
-	0xf0, 0x14, 0xb6, 0xe4, 0x29, 0x7c, 0xe5, 0xcb, 0x43, 0x1a, 0x47, 0xaf, 0xd0, 0x9d, 0x7a, 0x8e,
-	0x4a, 0xc8, 0x9e, 0x91, 0x95, 0xf8, 0x27, 0xb0, 0xeb, 0x47, 0x21, 0x49, 0xf8, 0x34, 0x26, 0x1c,
-	0x8b, 0xa4, 0xde, 0x56, 0x7f, 0xdb, 0x31, 0x8e, 0x9e, 0xdc, 0xda, 0x41, 0x5e, 0x1f, 0xd2, 0x6d,
-	0xc8, 0x07, 0xe8, 0x3d, 0xb9, 0x98, 0xe0, 0xe8, 0x8c, 0x0c, 0x77, 0x2e, 0x7f, 0xef, 0xd7, 0xbc,
-	0x8e, 0xaa, 0x32, 0xd6, 0x45, 0xec, 0x3f, 0x00, 0xb6, 0x3f, 0x0b, 0xe0, 0x4c, 0xf3, 0x98, 0x07,
-	0xb0, 0x33, 0xa7, 0x2c, 0xc6, 0x7c, 0x9a, 0x13, 0x96, 0x85, 0x34, 0x91, 0x28, 0x0d, 0xaf, 0xad,
-	0xa2, 0x13, 0x15, 0x34, 0xe7, 0xb0, 0xab, 0x5f, 0xf7, 0x0a, 0x79, 0x4b, 0x22, 0xbf, 0xbe, 0x23,
-	0xf2, 0xfa, 0x3d, 0x7a, 0x1d, 0xb6, 0x7e, 0xaf, 0x23, 0xdd, 0xa3, 0x6c, 0x2a, 0xa1, 0xb7, 0xe5,
-	0x1e, 0x4e, 0x25, 0xb4, 0x7a, 0xfc, 0xf9, 0x00, 0x29, 0xa0, 0xb7, 0x98, 0x63, 0xdd, 0x4d, 0x69,
-	0xdb, 0x7f, 0x01, 0xec, 0x8c, 0xd5, 0xa3, 0xdf, 0x50, 0xd8, 0x8f, 0xb0, 0xa5, 0xbf, 0xca, 0x32,
-	0xed, 0x61, 0x25, 0x6d, 0xf1, 0xf9, 0xe6, 0x03, 0xa4, 0xa1, 0x24, 0xb0, 0x11, 0xdf, 0x38, 0xf6,
-	0x35, 0x80, 0xc6, 0x07, 0x1a, 0x6c, 0x2a, 0xee, 0x10, 0xee, 0x8a, 0xc9, 0x52, 0x66, 0x3d, 0xa8,
-	0x64, 0x95, 0xf3, 0x27, 0x1f, 0x20, 0xc1, 0x22, 0x29, 0x9b, 0x91, 0xb6, 0xec, 0x7f, 0x00, 0x76,
-	0x3f, 0xe9, 0xd9, 0xb1, 0xa1, 0x98, 0xa7, 0xb0, 0x5d, 0x4c, 0xb7, 0x32, 0xea, 0x8b, 0x4a, 0xd4,
-	0xd5, 0x1c, 0x5c, 0x1b, 0x8f, 0xa8, 0x40, 0x94, 0xf4, 0xad, 0xb4, 0xe4, 0x0d, 0xc7, 0x97, 0x0b,
-	0x0b, 0x5c, 0x2d, 0x2c, 0x70, 0xbd, 0xb0, 0xc0, 0xf7, 0xa5, 0x55, 0xbb, 0x5a, 0x5a, 0xb5, 0x5f,
-	0x4b, 0xab, 0xf6, 0xe5, 0x38, 0xa0, 0xb7, 0xf6, 0x08, 0xc5, 0xac, 0xd6, 0x30, 0xee, 0xda, 0x7f,
-	0x57, 0x01, 0xf3, 0xb5, 0x2e, 0xcf, 0x71, 0xfc, 0x3f, 0x00, 0x00, 0xff, 0xff, 0x6b, 0x8c, 0x37,
-	0x86, 0xdb, 0x06, 0x00, 0x00,
+	// 785 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x56, 0xcd, 0x6e, 0xd3, 0x4c,
+	0x14, 0x8d, 0x93, 0x34, 0x3f, 0xe3, 0x34, 0xad, 0xac, 0x4f, 0x1f, 0xa1, 0x8b, 0x34, 0xb2, 0x54,
+	0x88, 0x68, 0x71, 0x48, 0x2b, 0x7e, 0x25, 0x16, 0x4d, 0x2b, 0x68, 0x80, 0xa0, 0xca, 0xfd, 0x59,
+	0x20, 0x55, 0xd1, 0x60, 0x4f, 0x22, 0x4b, 0xf6, 0x8c, 0xb1, 0x27, 0x51, 0xca, 0x1b, 0xb0, 0x63,
+	0xcf, 0x0b, 0x75, 0xd9, 0x25, 0x2b, 0x54, 0xb5, 0x2b, 0x56, 0x3c, 0x02, 0x68, 0xee, 0x4c, 0xd2,
+	0xa4, 0x32, 0x8b, 0x88, 0x4d, 0x57, 0xb9, 0x73, 0x7d, 0xee, 0xf1, 0x3d, 0x33, 0xc7, 0x73, 0x83,
+	0xd6, 0x43, 0x17, 0x73, 0xdc, 0x18, 0xc9, 0x9f, 0x88, 0x7c, 0x1a, 0x90, 0x98, 0x37, 0x3c, 0xca,
+	0x49, 0x44, 0xb1, 0x3f, 0x4e, 0x58, 0x61, 0xc4, 0x38, 0x33, 0x1e, 0xb2, 0x90, 0x50, 0x4e, 0x7c,
+	0x12, 0x10, 0x1e, 0x9d, 0x5a, 0x0e, 0xf3, 0x7d, 0xe2, 0x70, 0x16, 0x59, 0x50, 0x6d, 0x49, 0x12,
+	0x6b, 0x5c, 0xbc, 0xf2, 0x5f, 0x9f, 0xf5, 0x19, 0x54, 0x36, 0x44, 0x24, 0x49, 0x56, 0xea, 0x33,
+	0x24, 0x0d, 0xf9, 0x9c, 0x47, 0xd8, 0x21, 0x8d, 0x61, 0x53, 0x06, 0x0a, 0xb9, 0x91, 0x84, 0x14,
+	0xb1, 0xe7, 0xc4, 0x02, 0xab, 0x42, 0x85, 0xbe, 0x97, 0x84, 0xf6, 0x59, 0x1f, 0xa0, 0xe2, 0x57,
+	0xe1, 0x1e, 0x24, 0xe1, 0x1c, 0x16, 0x04, 0x8c, 0x0a, 0xa4, 0x8c, 0x14, 0xf6, 0x79, 0x12, 0x36,
+	0x8c, 0x58, 0xcf, 0xf3, 0x89, 0xe0, 0x75, 0xc9, 0x90, 0xf8, 0x2c, 0x0c, 0x08, 0xe5, 0x93, 0xb4,
+	0x2c, 0x35, 0xbf, 0x69, 0x48, 0x3f, 0x08, 0x31, 0xdd, 0x61, 0x94, 0x93, 0x11, 0x37, 0xee, 0xa2,
+	0x02, 0x68, 0xeb, 0x7a, 0x6e, 0x45, 0xab, 0x69, 0xf5, 0x92, 0x9d, 0x87, 0x75, 0xdb, 0x35, 0xee,
+	0xa0, 0x7c, 0x1c, 0x62, 0x2a, 0x9e, 0xa4, 0xe1, 0x49, 0x4e, 0x2c, 0xdb, 0xae, 0xb1, 0x8a, 0x74,
+	0x59, 0xd3, 0xf3, 0x71, 0x3f, 0xae, 0x64, 0x6a, 0x5a, 0x3d, 0x6f, 0x23, 0x48, 0xbd, 0x12, 0x99,
+	0x6b, 0x40, 0xcc, 0x31, 0x27, 0x95, 0x6c, 0x4d, 0xab, 0x17, 0x15, 0xe0, 0x40, 0x64, 0x8c, 0xff,
+	0x51, 0x2e, 0x22, 0x01, 0xe3, 0xa4, 0xb2, 0x50, 0xd3, 0xea, 0x05, 0x5b, 0xad, 0xcc, 0x0d, 0x94,
+	0x6b, 0xef, 0x6f, 0xbb, 0x6e, 0x64, 0x94, 0x51, 0xda, 0x0b, 0x55, 0x47, 0x69, 0x2f, 0x34, 0x0c,
+	0x94, 0xfd, 0xcc, 0x28, 0x81, 0x4e, 0x8a, 0x36, 0xc4, 0xe6, 0x36, 0xca, 0x1f, 0xee, 0xfc, 0x15,
+	0x1e, 0xb2, 0x88, 0x03, 0x7c, 0xc1, 0x86, 0x78, 0x42, 0x91, 0x99, 0xa5, 0x38, 0xda, 0xfd, 0x37,
+	0x8a, 0x47, 0xa8, 0x70, 0x44, 0xbd, 0x11, 0x70, 0x18, 0x28, 0x4b, 0x71, 0x40, 0x80, 0xa5, 0x68,
+	0x43, 0x6c, 0x2c, 0xa3, 0x0c, 0x25, 0x5c, 0x35, 0x2e, 0x42, 0xf3, 0x4b, 0x16, 0x95, 0x6d, 0xe9,
+	0xe0, 0xf1, 0x31, 0x9c, 0xa0, 0x12, 0xec, 0xb5, 0x23, 0xd7, 0x40, 0xa0, 0x6f, 0xbe, 0xb0, 0xe6,
+	0x72, 0xb6, 0x35, 0x75, 0xb0, 0xb6, 0x1e, 0x4f, 0x9d, 0xf2, 0x31, 0x5a, 0x72, 0x7c, 0x8f, 0x50,
+	0xde, 0x0d, 0x08, 0xc7, 0xa2, 0xa8, 0x92, 0xae, 0x65, 0xea, 0xfa, 0xe6, 0xfd, 0x1b, 0x6f, 0x00,
+	0x93, 0x58, 0xca, 0x6c, 0xc3, 0xa6, 0xf5, 0x96, 0x9c, 0x1e, 0x63, 0x7f, 0x40, 0x5a, 0xd9, 0xb3,
+	0x1f, 0xab, 0x29, 0xbb, 0x2c, 0x59, 0x3a, 0x8a, 0xc4, 0x78, 0x0d, 0x7b, 0x96, 0x81, 0x66, 0x1f,
+	0xcf, 0xd9, 0xac, 0x3c, 0xe8, 0xbd, 0x14, 0x6c, 0xf6, 0x1b, 0x94, 0xe1, 0x4e, 0x08, 0x4e, 0xd1,
+	0x37, 0x9f, 0xcc, 0xc9, 0xa4, 0x4c, 0xb0, 0x97, 0xb2, 0x05, 0x89, 0xe0, 0x1a, 0xb8, 0x21, 0x38,
+	0x6b, 0x7e, 0x2e, 0xe5, 0x06, 0xc1, 0x35, 0x70, 0x43, 0xa3, 0x83, 0xb2, 0x03, 0xea, 0x8d, 0x2a,
+	0x39, 0x20, 0x7b, 0x3a, 0x2f, 0x99, 0xf2, 0xc5, 0x5e, 0xca, 0x06, 0x9a, 0xd6, 0x32, 0x52, 0x3b,
+	0xd8, 0xc5, 0xae, 0x1b, 0x91, 0x38, 0x36, 0x7f, 0x6a, 0x68, 0xf1, 0x50, 0x7c, 0x18, 0xb1, 0x72,
+	0x84, 0xb1, 0x86, 0xca, 0x3d, 0x16, 0x05, 0x98, 0x77, 0x87, 0x24, 0x8a, 0x3d, 0x46, 0xc1, 0x0c,
+	0x79, 0x7b, 0x51, 0x66, 0x8f, 0x65, 0xd2, 0xe8, 0xa1, 0x25, 0x75, 0x0b, 0x4e, 0x4c, 0x93, 0x86,
+	0x26, 0x5f, 0xce, 0xd9, 0xe4, 0xac, 0x13, 0xed, 0x72, 0x34, 0xeb, 0xcc, 0xb6, 0xfa, 0x96, 0xe3,
+	0x2e, 0xd8, 0x46, 0x9e, 0x75, 0x3d, 0xd1, 0x36, 0xf2, 0x92, 0x1c, 0x36, 0x2d, 0x29, 0x68, 0x17,
+	0x73, 0xac, 0xbe, 0x7a, 0x88, 0xcd, 0x5f, 0x1a, 0x2a, 0x77, 0xe4, 0xe5, 0x78, 0x4b, 0xc5, 0xbe,
+	0x47, 0x25, 0x75, 0x7b, 0x4f, 0xab, 0x5d, 0x4f, 0x54, 0x3b, 0xbe, 0xe6, 0x87, 0x4d, 0x4b, 0x89,
+	0x02, 0xc1, 0x7a, 0x70, 0xbd, 0x30, 0x2f, 0x34, 0xa4, 0xbf, 0x63, 0xfd, 0xdb, 0x2a, 0xb7, 0x85,
+	0x8a, 0x62, 0x02, 0x4d, 0x6b, 0x5d, 0x4b, 0xd4, 0x0a, 0x73, 0x6a, 0xd8, 0xb4, 0x84, 0x16, 0x50,
+	0x59, 0xf0, 0x55, 0x64, 0xfe, 0xd6, 0xd0, 0xd2, 0xbe, 0x9a, 0x31, 0xb7, 0x54, 0xe6, 0x09, 0x5a,
+	0x1c, 0x4f, 0xc1, 0x69, 0xa9, 0xcf, 0x12, 0xa5, 0x4e, 0xe6, 0xe5, 0xcc, 0x18, 0xb5, 0xc6, 0x12,
+	0x41, 0x7d, 0x29, 0x9c, 0x5a, 0xb5, 0x3a, 0x67, 0x97, 0x55, 0xed, 0xfc, 0xb2, 0xaa, 0x5d, 0x5c,
+	0x56, 0xb5, 0xaf, 0x57, 0xd5, 0xd4, 0xf9, 0x55, 0x35, 0xf5, 0xfd, 0xaa, 0x9a, 0xfa, 0xb0, 0xd5,
+	0x67, 0x37, 0xde, 0xe1, 0x89, 0x99, 0xae, 0xc4, 0x34, 0x66, 0xfe, 0xe3, 0x8c, 0xc5, 0x7c, 0xcc,
+	0x41, 0x1f, 0x5b, 0x7f, 0x02, 0x00, 0x00, 0xff, 0xff, 0x03, 0x9d, 0x12, 0x6d, 0x03, 0x09, 0x00,
+	0x00,
 }
 
 func (m *SpanContext) Marshal() (dAtA []byte, err error) {
@@ -518,6 +834,164 @@ func (m *SpanContext) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *IPAddr) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *IPAddr) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *IPAddr) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Zone) > 0 {
+		i -= len(m.Zone)
+		copy(dAtA[i:], m.Zone)
+		i = encodeVarintRequest(dAtA, i, uint64(len(m.Zone)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Ip) > 0 {
+		i -= len(m.Ip)
+		copy(dAtA[i:], m.Ip)
+		i = encodeVarintRequest(dAtA, i, uint64(len(m.Ip)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TCPAddr) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TCPAddr) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TCPAddr) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Zone) > 0 {
+		i -= len(m.Zone)
+		copy(dAtA[i:], m.Zone)
+		i = encodeVarintRequest(dAtA, i, uint64(len(m.Zone)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Port != 0 {
+		i = encodeVarintRequest(dAtA, i, uint64(m.Port))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Ip) > 0 {
+		i -= len(m.Ip)
+		copy(dAtA[i:], m.Ip)
+		i = encodeVarintRequest(dAtA, i, uint64(len(m.Ip)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UDPAddr) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UDPAddr) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *UDPAddr) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Zone) > 0 {
+		i -= len(m.Zone)
+		copy(dAtA[i:], m.Zone)
+		i = encodeVarintRequest(dAtA, i, uint64(len(m.Zone)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Port != 0 {
+		i = encodeVarintRequest(dAtA, i, uint64(m.Port))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Ip) > 0 {
+		i -= len(m.Ip)
+		copy(dAtA[i:], m.Ip)
+		i = encodeVarintRequest(dAtA, i, uint64(len(m.Ip)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UnixAddr) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UnixAddr) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *UnixAddr) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Net) > 0 {
+		i -= len(m.Net)
+		copy(dAtA[i:], m.Net)
+		i = encodeVarintRequest(dAtA, i, uint64(len(m.Net)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintRequest(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *RequestContext) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -538,6 +1012,15 @@ func (m *RequestContext) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.ClientAddress != nil {
+		{
+			size := m.ClientAddress.Size()
+			i -= size
+			if _, err := m.ClientAddress.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
 	if len(m.ClientMetadata) > 0 {
 		for iNdEx := len(m.ClientMetadata) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -567,6 +1050,90 @@ func (m *RequestContext) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *RequestContext_Ip) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RequestContext_Ip) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Ip != nil {
+		{
+			size, err := m.Ip.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintRequest(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *RequestContext_Tcp) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RequestContext_Tcp) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Tcp != nil {
+		{
+			size, err := m.Tcp.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintRequest(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x22
+	}
+	return len(dAtA) - i, nil
+}
+func (m *RequestContext_Udp) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RequestContext_Udp) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Udp != nil {
+		{
+			size, err := m.Udp.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintRequest(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x2a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *RequestContext_Unix) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RequestContext_Unix) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Unix != nil {
+		{
+			size, err := m.Unix.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintRequest(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x32
+	}
+	return len(dAtA) - i, nil
+}
 func (m *TracesRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -817,6 +1384,80 @@ func (m *SpanContext) Size() (n int) {
 	return n
 }
 
+func (m *IPAddr) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Ip)
+	if l > 0 {
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	l = len(m.Zone)
+	if l > 0 {
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	return n
+}
+
+func (m *TCPAddr) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Ip)
+	if l > 0 {
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	if m.Port != 0 {
+		n += 1 + sovRequest(uint64(m.Port))
+	}
+	l = len(m.Zone)
+	if l > 0 {
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	return n
+}
+
+func (m *UDPAddr) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Ip)
+	if l > 0 {
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	if m.Port != 0 {
+		n += 1 + sovRequest(uint64(m.Port))
+	}
+	l = len(m.Zone)
+	if l > 0 {
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	return n
+}
+
+func (m *UnixAddr) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	l = len(m.Net)
+	if l > 0 {
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	return n
+}
+
 func (m *RequestContext) Size() (n int) {
 	if m == nil {
 		return 0
@@ -833,9 +1474,60 @@ func (m *RequestContext) Size() (n int) {
 			n += 1 + l + sovRequest(uint64(l))
 		}
 	}
+	if m.ClientAddress != nil {
+		n += m.ClientAddress.Size()
+	}
 	return n
 }
 
+func (m *RequestContext_Ip) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Ip != nil {
+		l = m.Ip.Size()
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	return n
+}
+func (m *RequestContext_Tcp) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Tcp != nil {
+		l = m.Tcp.Size()
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	return n
+}
+func (m *RequestContext_Udp) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Udp != nil {
+		l = m.Udp.Size()
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	return n
+}
+func (m *RequestContext_Unix) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Unix != nil {
+		l = m.Unix.Size()
+		n += 1 + l + sovRequest(uint64(l))
+	}
+	return n
+}
 func (m *TracesRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1102,6 +1794,506 @@ func (m *SpanContext) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *IPAddr) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRequest
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: IPAddr: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: IPAddr: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ip", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ip = append(m.Ip[:0], dAtA[iNdEx:postIndex]...)
+			if m.Ip == nil {
+				m.Ip = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Zone", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Zone = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRequest(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TCPAddr) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRequest
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TCPAddr: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TCPAddr: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ip", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ip = append(m.Ip[:0], dAtA[iNdEx:postIndex]...)
+			if m.Ip == nil {
+				m.Ip = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Port", wireType)
+			}
+			m.Port = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Port |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Zone", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Zone = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRequest(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *UDPAddr) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRequest
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: UDPAddr: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: UDPAddr: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ip", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ip = append(m.Ip[:0], dAtA[iNdEx:postIndex]...)
+			if m.Ip == nil {
+				m.Ip = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Port", wireType)
+			}
+			m.Port = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Port |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Zone", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Zone = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRequest(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *UnixAddr) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRequest
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: UnixAddr: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: UnixAddr: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Net", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Net = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRequest(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *RequestContext) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1200,6 +2392,146 @@ func (m *RequestContext) Unmarshal(dAtA []byte) error {
 			if err := m.ClientMetadata[len(m.ClientMetadata)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ip", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &IPAddr{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.ClientAddress = &RequestContext_Ip{v}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Tcp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &TCPAddr{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.ClientAddress = &RequestContext_Tcp{v}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Udp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &UDPAddr{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.ClientAddress = &RequestContext_Udp{v}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Unix", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRequest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRequest
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRequest
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &UnixAddr{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.ClientAddress = &RequestContext_Unix{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pdata/xpdata/request/internal/request.proto
+++ b/pdata/xpdata/request/internal/request.proto
@@ -21,12 +21,42 @@ message SpanContext {
   bool remote = 5;
 }
 
+message IPAddr {
+  bytes ip = 1;
+  string zone = 2;
+}
+
+message TCPAddr {
+  bytes ip = 1;
+  int32 port = 2;
+  string zone = 3;
+}
+
+message UDPAddr {
+  bytes ip = 1;
+  int32 port = 2;
+  string zone = 3;
+}
+
+message UnixAddr {
+  string name = 1;
+  string net = 2;
+}
+
 // RequestContext represents metadata associated with a telemetry export request.
 message RequestContext {
   SpanContext span_context = 1;
 
   // ClientMetadata contains additional metadata about the client making the request.
   repeated opentelemetry.proto.common.v1.KeyValue client_metadata = 2 [ (gogoproto.nullable) = false ];
+
+  // ClientAddress contains the address of the client making the request.
+  oneof client_address {
+    IPAddr ip = 3;
+    TCPAddr tcp = 4;
+    UDPAddr udp = 5;
+    UnixAddr unix = 6;
+  }
 }
 
 // The following messages are wrappers around standard OpenTelemetry data types.


### PR DESCRIPTION
Preserve client address in persistent queue as part of the request context 

A follow-up to https://github.com/open-telemetry/opentelemetry-collector/pull/13220