### PR TITLE
Emit `outcome: failure` in obsconsumer

### DIFF
--- a/service/internal/obsconsumer/downstream.go
+++ b/service/internal/obsconsumer/downstream.go
@@ -1,0 +1,35 @@
+package obsconsumer
+
+type downstreamError struct {
+	inner error
+}
+
+var _ error = downstreamError{}
+
+func (de downstreamError) Error() string {
+	return de.inner.Error()
+}
+
+func MarkAsDownstream(err error) error {
+	return downstreamError{
+		inner: err,
+	}
+}
+
+func IsDownstream(err error) bool {
+	if _, ok := err.(downstreamError); ok {
+		return true
+	}
+	if wrapper, ok := err.(interface{ Unwrap() error }); ok {
+		return IsDownstream(wrapper.Unwrap())
+	}
+	if wrapper, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, suberr := range wrapper.Unwrap() {
+			if !IsDownstream(suberr) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}

--- a/service/internal/obsconsumer/logs.go
+++ b/service/internal/obsconsumer/logs.go
@@ -62,7 +62,12 @@ func (c obsLogs) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 
 	err := c.consumer.ConsumeLogs(ctx, ld)
 	if err != nil {
-		attrs = &c.withFailureAttrs
+		if IsDownstream(err) {
+			attrs = &c.withRefusedAttrs
+		} else {
+			attrs = &c.withFailureAttrs
+			err = MarkAsDownstream(err)
+		}
 	}
 	return err
 }

--- a/service/internal/obsconsumer/logs_test.go
+++ b/service/internal/obsconsumer/logs_test.go
@@ -161,6 +161,7 @@ func TestLogsConsumeFailure(t *testing.T) {
 
 	ctx := context.Background()
 	expectedErr := errors.New("test error")
+	downstreamErr := obsconsumer.MarkAsDownstream(expectedErr)
 	mockConsumer := &mockLogsConsumer{err: expectedErr}
 
 	reader := sdkmetric.NewManualReader()
@@ -180,7 +181,7 @@ func TestLogsConsumeFailure(t *testing.T) {
 	sl.LogRecords().AppendEmpty()
 
 	err = consumer.ConsumeLogs(ctx, ld)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	var rm metricdata.ResourceMetrics
 	err = reader.Collect(ctx, &rm)
@@ -298,6 +299,7 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 
 	ctx := context.Background()
 	expectedErr := errors.New("test error")
+	downstreamErr := obsconsumer.MarkAsDownstream(expectedErr)
 	mockConsumer := &mockLogsConsumer{}
 
 	reader := sdkmetric.NewManualReader()
@@ -328,7 +330,7 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 	sl := r.ScopeLogs().AppendEmpty()
 	sl.LogRecords().AppendEmpty()
 	err = consumer.ConsumeLogs(ctx, ld2)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	// Third batch: 2 successful items
 	mockConsumer.err = nil
@@ -348,7 +350,7 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 	sl = r.ScopeLogs().AppendEmpty()
 	sl.LogRecords().AppendEmpty()
 	err = consumer.ConsumeLogs(ctx, ld4)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	var rm metricdata.ResourceMetrics
 	err = reader.Collect(ctx, &rm)

--- a/service/internal/obsconsumer/metrics.go
+++ b/service/internal/obsconsumer/metrics.go
@@ -62,7 +62,12 @@ func (c obsMetrics) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) erro
 
 	err := c.consumer.ConsumeMetrics(ctx, md)
 	if err != nil {
-		attrs = &c.withFailureAttrs
+		if IsDownstream(err) {
+			attrs = &c.withRefusedAttrs
+		} else {
+			attrs = &c.withFailureAttrs
+			err = MarkAsDownstream(err)
+		}
 	}
 	return err
 }

--- a/service/internal/obsconsumer/metrics_test.go
+++ b/service/internal/obsconsumer/metrics_test.go
@@ -162,6 +162,7 @@ func TestMetricsConsumeFailure(t *testing.T) {
 
 	ctx := context.Background()
 	expectedErr := errors.New("test error")
+	downstreamErr := obsconsumer.MarkAsDownstream(expectedErr)
 	mockConsumer := &mockMetricsConsumer{err: expectedErr}
 
 	reader := sdkmetric.NewManualReader()
@@ -182,7 +183,7 @@ func TestMetricsConsumeFailure(t *testing.T) {
 	m.SetEmptyGauge().DataPoints().AppendEmpty()
 
 	err = consumer.ConsumeMetrics(ctx, md)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	var metrics metricdata.ResourceMetrics
 	err = reader.Collect(ctx, &metrics)
@@ -303,6 +304,7 @@ func TestMetricsMultipleItemsMixedOutcomes(t *testing.T) {
 
 	ctx := context.Background()
 	expectedErr := errors.New("test error")
+	downstreamErr := obsconsumer.MarkAsDownstream(expectedErr)
 	mockConsumer := &mockMetricsConsumer{}
 
 	reader := sdkmetric.NewManualReader()
@@ -335,7 +337,7 @@ func TestMetricsMultipleItemsMixedOutcomes(t *testing.T) {
 	m := sm.Metrics().AppendEmpty()
 	m.SetEmptyGauge().DataPoints().AppendEmpty()
 	err = consumer.ConsumeMetrics(ctx, md2)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	// Third batch: 2 successful items
 	mockConsumer.err = nil
@@ -357,7 +359,7 @@ func TestMetricsMultipleItemsMixedOutcomes(t *testing.T) {
 	m = sm.Metrics().AppendEmpty()
 	m.SetEmptyGauge().DataPoints().AppendEmpty()
 	err = consumer.ConsumeMetrics(ctx, md4)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	var metrics metricdata.ResourceMetrics
 	err = reader.Collect(ctx, &metrics)

--- a/service/internal/obsconsumer/option.go
+++ b/service/internal/obsconsumer/option.go
@@ -29,6 +29,7 @@ func WithStaticDataPointAttribute(attr attribute.KeyValue) Option {
 type compiledOptions struct {
 	withSuccessAttrs metric.AddOption
 	withFailureAttrs metric.AddOption
+	withRefusedAttrs metric.AddOption
 }
 
 func (o *options) compile() compiledOptions {
@@ -40,8 +41,13 @@ func (o *options) compile() compiledOptions {
 	failureAttrs = append(failureAttrs, attribute.String(ComponentOutcome, "failure"))
 	failureAttrs = append(failureAttrs, o.staticDataPointAttributes...)
 
+	refusedAttrs := make([]attribute.KeyValue, 0, 1+len(o.staticDataPointAttributes))
+	refusedAttrs = append(failureAttrs, attribute.String(ComponentOutcome, "refused"))
+	refusedAttrs = append(failureAttrs, o.staticDataPointAttributes...)
+
 	return compiledOptions{
 		withSuccessAttrs: metric.WithAttributes(successAttrs...),
 		withFailureAttrs: metric.WithAttributes(failureAttrs...),
+		withRefusedAttrs: metric.WithAttributes(refusedAttrs...),
 	}
 }

--- a/service/internal/obsconsumer/profiles.go
+++ b/service/internal/obsconsumer/profiles.go
@@ -63,7 +63,12 @@ func (c obsProfiles) ConsumeProfiles(ctx context.Context, pd pprofile.Profiles) 
 
 	err := c.consumer.ConsumeProfiles(ctx, pd)
 	if err != nil {
-		attrs = &c.withFailureAttrs
+		if IsDownstream(err) {
+			attrs = &c.withRefusedAttrs
+		} else {
+			attrs = &c.withFailureAttrs
+			err = MarkAsDownstream(err)
+		}
 	}
 	return err
 }

--- a/service/internal/obsconsumer/profiles_test.go
+++ b/service/internal/obsconsumer/profiles_test.go
@@ -162,6 +162,7 @@ func TestProfilesConsumeFailure(t *testing.T) {
 
 	ctx := context.Background()
 	expectedErr := errors.New("test error")
+	downstreamErr := obsconsumer.MarkAsDownstream(expectedErr)
 	mockConsumer := &mockProfilesConsumer{err: expectedErr}
 
 	reader := sdkmetric.NewManualReader()
@@ -181,7 +182,7 @@ func TestProfilesConsumeFailure(t *testing.T) {
 	sp.Profiles().AppendEmpty().Sample().AppendEmpty()
 
 	err = consumer.ConsumeProfiles(ctx, pd)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	var rm metricdata.ResourceMetrics
 	err = reader.Collect(ctx, &rm)
@@ -299,6 +300,7 @@ func TestProfilesMultipleItemsMixedOutcomes(t *testing.T) {
 
 	ctx := context.Background()
 	expectedErr := errors.New("test error")
+	downstreamErr := obsconsumer.MarkAsDownstream(expectedErr)
 	mockConsumer := &mockProfilesConsumer{}
 
 	reader := sdkmetric.NewManualReader()
@@ -329,7 +331,7 @@ func TestProfilesMultipleItemsMixedOutcomes(t *testing.T) {
 	sp := r.ScopeProfiles().AppendEmpty()
 	sp.Profiles().AppendEmpty().Sample().AppendEmpty()
 	err = consumer.ConsumeProfiles(ctx, pd2)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	// Third batch: 2 successful items
 	mockConsumer.err = nil
@@ -349,7 +351,7 @@ func TestProfilesMultipleItemsMixedOutcomes(t *testing.T) {
 	sp = r.ScopeProfiles().AppendEmpty()
 	sp.Profiles().AppendEmpty().Sample().AppendEmpty()
 	err = consumer.ConsumeProfiles(ctx, pd4)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	var rm metricdata.ResourceMetrics
 	err = reader.Collect(ctx, &rm)

--- a/service/internal/obsconsumer/traces.go
+++ b/service/internal/obsconsumer/traces.go
@@ -62,7 +62,12 @@ func (c obsTraces) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 
 	err := c.consumer.ConsumeTraces(ctx, td)
 	if err != nil {
-		attrs = &c.withFailureAttrs
+		if IsDownstream(err) {
+			attrs = &c.withRefusedAttrs
+		} else {
+			attrs = &c.withFailureAttrs
+			err = MarkAsDownstream(err)
+		}
 	}
 	return err
 }

--- a/service/internal/obsconsumer/traces_test.go
+++ b/service/internal/obsconsumer/traces_test.go
@@ -162,6 +162,7 @@ func TestTracesConsumeFailure(t *testing.T) {
 
 	ctx := context.Background()
 	expectedErr := errors.New("test error")
+	downstreamErr := obsconsumer.MarkAsDownstream(expectedErr)
 	mockConsumer := &mockTracesConsumer{err: expectedErr}
 
 	reader := sdkmetric.NewManualReader()
@@ -181,7 +182,7 @@ func TestTracesConsumeFailure(t *testing.T) {
 	ss.Spans().AppendEmpty()
 
 	err = consumer.ConsumeTraces(ctx, td)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	var rm metricdata.ResourceMetrics
 	err = reader.Collect(ctx, &rm)
@@ -299,6 +300,7 @@ func TestTracesMultipleItemsMixedOutcomes(t *testing.T) {
 
 	ctx := context.Background()
 	expectedErr := errors.New("test error")
+	downstreamErr := obsconsumer.MarkAsDownstream(expectedErr)
 	mockConsumer := &mockTracesConsumer{}
 
 	reader := sdkmetric.NewManualReader()
@@ -329,7 +331,7 @@ func TestTracesMultipleItemsMixedOutcomes(t *testing.T) {
 	ss := r.ScopeSpans().AppendEmpty()
 	ss.Spans().AppendEmpty()
 	err = consumer.ConsumeTraces(ctx, td2)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	// Third batch: 2 successful items
 	mockConsumer.err = nil
@@ -349,7 +351,7 @@ func TestTracesMultipleItemsMixedOutcomes(t *testing.T) {
 	ss = r.ScopeSpans().AppendEmpty()
 	ss.Spans().AppendEmpty()
 	err = consumer.ConsumeTraces(ctx, td4)
-	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, downstreamErr, err)
 
 	var rm metricdata.ResourceMetrics
 	err = reader.Collect(ctx, &rm)


### PR DESCRIPTION
#### Description
The last remaining part of #12676 is to implement the `outcome: failure` part of the Pipeline Component Telemetry RFC ([see here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md#auto-instrumented-metrics)). This is done by introducing a `downstream` error wrapper struct, to distinguish between errors coming from the next component from errors bubbled from further downstream.

#### Important note
This PR implements things slightly differently from what the text of the RFC describes.

If a pipeline contains components `A → B` and an error occurs in B, this PR records:
- `otelcol.component.outcome = failure` in the `otelcol.*.consumed.*` metric for B
- `otelcol.component.outcome = refused` in the `otelcol.*.produced.*` metric for A

whereas the RFC would set both `outcome`s to `failure`.

This is programmatically simpler — no need to have different behavior between the `obsconsumer` around the output of A and the one around the input of B — but more importantly, I think it is clearer for users as well: `outcome = failure` only occurs on metrics associated with the component where the failure actually occurred.

This subtlety wasn't discussed in-depth in #11956 which introduced `outcome = refused`, so I took the liberty to make this change. If necessary, I can file another RFC amendment to match, or, if there are objections, implement the RFC as-is instead.

#### Link to tracking issue
Fixes #12676

#### Testing
I've updated the existing tests in `obsconsumer` to expect a `downstream`-wrapped error to exit the `obsconsumer` layer. I may add more tests later.

#### Documentation
None.
