### PR TITLE
Preserve metric names during metricrequest

### DIFF
--- a/.chloggen/fix_preserve-metric-names-request-split.yml
+++ b/.chloggen/fix_preserve-metric-names-request-split.yml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes an issue in exporterhelper's sending_queue where metric names were lost during metricRequest splitting.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13236]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, when large batches of metrics were processed, the splitting logic in `metric_batch.go` could
+  cause the `name` field of some metrics to disappear. This fix ensures that all metric fields are
+  properly preserved when `metricRequest` objects are split.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/metrics_batch.go
+++ b/exporter/exporterhelper/metrics_batch.go
@@ -174,20 +174,20 @@ func extractMetricDataPoints(srcMetric pmetric.Metric, capacity int, sz sizer.Me
 	var removedSize int
 	switch srcMetric.Type() {
 	case pmetric.MetricTypeGauge:
-		destMetric, removedSize = extractGaugeDataPoints(srcMetric.Gauge(), capacity, sz)
+		destMetric, removedSize = extractGaugeDataPoints(srcMetric, capacity, sz)
 	case pmetric.MetricTypeSum:
-		destMetric, removedSize = extractSumDataPoints(srcMetric.Sum(), capacity, sz)
+		destMetric, removedSize = extractSumDataPoints(srcMetric, capacity, sz)
 	case pmetric.MetricTypeHistogram:
-		destMetric, removedSize = extractHistogramDataPoints(srcMetric.Histogram(), capacity, sz)
+		destMetric, removedSize = extractHistogramDataPoints(srcMetric, capacity, sz)
 	case pmetric.MetricTypeExponentialHistogram:
-		destMetric, removedSize = extractExponentialHistogramDataPoints(srcMetric.ExponentialHistogram(), capacity, sz)
+		destMetric, removedSize = extractExponentialHistogramDataPoints(srcMetric, capacity, sz)
 	case pmetric.MetricTypeSummary:
-		destMetric, removedSize = extractSummaryDataPoints(srcMetric.Summary(), capacity, sz)
+		destMetric, removedSize = extractSummaryDataPoints(srcMetric, capacity, sz)
 	}
 	return destMetric, removedSize
 }
 
-func extractGaugeDataPoints(srcGauge pmetric.Gauge, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
+func extractGaugeDataPoints(srcMetric pmetric.Metric, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
 	m := pmetric.NewMetric()
 	destGauge := m.SetEmptyGauge()
 
@@ -195,7 +195,7 @@ func extractGaugeDataPoints(srcGauge pmetric.Gauge, capacity int, sz sizer.Metri
 	capacityLeft := capacity - (sz.DeltaSize(capacity) - capacity) - sz.MetricSize(m)
 	removedSize := 0
 
-	srcGauge.DataPoints().RemoveIf(func(srcDP pmetric.NumberDataPoint) bool {
+	srcMetric.Gauge().DataPoints().RemoveIf(func(srcDP pmetric.NumberDataPoint) bool {
 		// If the no more capacity left just return.
 		if capacityLeft == 0 {
 			return false
@@ -216,13 +216,14 @@ func extractGaugeDataPoints(srcGauge pmetric.Gauge, capacity int, sz sizer.Metri
 	return m, removedSize
 }
 
-func extractSumDataPoints(srcSum pmetric.Sum, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
+func extractSumDataPoints(srcMetric pmetric.Metric, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
 	m := pmetric.NewMetric()
+	srcMetric.CopyTo(m)
 	destSum := m.SetEmptySum()
 	// Take into account that this can have max "capacity", so when added to the parent will need space for the extra delta size.
 	capacityLeft := capacity - (sz.DeltaSize(capacity) - capacity) - sz.MetricSize(m)
 	removedSize := 0
-	srcSum.DataPoints().RemoveIf(func(srcDP pmetric.NumberDataPoint) bool {
+	srcMetric.Sum().DataPoints().RemoveIf(func(srcDP pmetric.NumberDataPoint) bool {
 		// If the no more capacity left just return.
 		if capacityLeft == 0 {
 			return false
@@ -243,13 +244,14 @@ func extractSumDataPoints(srcSum pmetric.Sum, capacity int, sz sizer.MetricsSize
 	return m, removedSize
 }
 
-func extractHistogramDataPoints(srcHistogram pmetric.Histogram, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
+func extractHistogramDataPoints(srcMetric pmetric.Metric, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
 	m := pmetric.NewMetric()
+	srcMetric.CopyTo(m)
 	destHistogram := m.SetEmptyHistogram()
 	// Take into account that this can have max "capacity", so when added to the parent will need space for the extra delta size.
 	capacityLeft := capacity - (sz.DeltaSize(capacity) - capacity) - sz.MetricSize(m)
 	removedSize := 0
-	srcHistogram.DataPoints().RemoveIf(func(srcDP pmetric.HistogramDataPoint) bool {
+	srcMetric.Histogram().DataPoints().RemoveIf(func(srcDP pmetric.HistogramDataPoint) bool {
 		// If the no more capacity left just return.
 		if capacityLeft == 0 {
 			return false
@@ -270,13 +272,14 @@ func extractHistogramDataPoints(srcHistogram pmetric.Histogram, capacity int, sz
 	return m, removedSize
 }
 
-func extractExponentialHistogramDataPoints(srcExponentialHistogram pmetric.ExponentialHistogram, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
+func extractExponentialHistogramDataPoints(srcMetric pmetric.Metric, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
 	m := pmetric.NewMetric()
+	srcMetric.CopyTo(m)
 	destExponentialHistogram := m.SetEmptyExponentialHistogram()
 	// Take into account that this can have max "capacity", so when added to the parent will need space for the extra delta size.
 	capacityLeft := capacity - (sz.DeltaSize(capacity) - capacity) - sz.MetricSize(m)
 	removedSize := 0
-	srcExponentialHistogram.DataPoints().RemoveIf(func(srcDP pmetric.ExponentialHistogramDataPoint) bool {
+	srcMetric.ExponentialHistogram().DataPoints().RemoveIf(func(srcDP pmetric.ExponentialHistogramDataPoint) bool {
 		// If the no more capacity left just return.
 		if capacityLeft == 0 {
 			return false
@@ -297,13 +300,14 @@ func extractExponentialHistogramDataPoints(srcExponentialHistogram pmetric.Expon
 	return m, removedSize
 }
 
-func extractSummaryDataPoints(srcSummary pmetric.Summary, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
+func extractSummaryDataPoints(srcMetric pmetric.Metric, capacity int, sz sizer.MetricsSizer) (pmetric.Metric, int) {
 	m := pmetric.NewMetric()
+	srcMetric.CopyTo(m)
 	destSummary := m.SetEmptySummary()
 	// Take into account that this can have max "capacity", so when added to the parent will need space for the extra delta size.
 	capacityLeft := capacity - (sz.DeltaSize(capacity) - capacity) - sz.MetricSize(m)
 	removedSize := 0
-	srcSummary.DataPoints().RemoveIf(func(srcDP pmetric.SummaryDataPoint) bool {
+	srcMetric.Summary().DataPoints().RemoveIf(func(srcDP pmetric.SummaryDataPoint) bool {
 		// If the no more capacity left just return.
 		if capacityLeft == 0 {
 			return false

--- a/exporter/exporterhelper/metrics_batch_test.go
+++ b/exporter/exporterhelper/metrics_batch_test.go
@@ -334,7 +334,7 @@ func TestExtractGaugeDataPoints(t *testing.T) {
 
 			sz := &mockMetricsSizer{dpSize: 1}
 
-			destMetric, removedSize := extractGaugeDataPoints(gauge, tt.capacity, sz)
+			destMetric, removedSize := extractGaugeDataPoints(srcMetric, tt.capacity, sz)
 
 			assert.Equal(t, tt.expectedPoints, destMetric.Gauge().DataPoints().Len())
 			if tt.expectedPoints > 0 {
@@ -382,7 +382,7 @@ func TestExtractSumDataPoints(t *testing.T) {
 
 			sz := &mockMetricsSizer{dpSize: 1}
 
-			destMetric, removedSize := extractSumDataPoints(sum, tt.capacity, sz)
+			destMetric, removedSize := extractSumDataPoints(srcMetric, tt.capacity, sz)
 
 			assert.Equal(t, tt.expectedPoints, destMetric.Sum().DataPoints().Len())
 			if tt.expectedPoints > 0 {
@@ -431,7 +431,7 @@ func TestExtractHistogramDataPoints(t *testing.T) {
 
 			sz := &mockMetricsSizer{dpSize: 1}
 
-			destMetric, removedSize := extractHistogramDataPoints(histogram, tt.capacity, sz)
+			destMetric, removedSize := extractHistogramDataPoints(srcMetric, tt.capacity, sz)
 
 			assert.Equal(t, tt.expectedPoints, destMetric.Histogram().DataPoints().Len())
 			if tt.expectedPoints > 0 {
@@ -479,7 +479,7 @@ func TestExtractExponentialHistogramDataPoints(t *testing.T) {
 
 			sz := &mockMetricsSizer{dpSize: 1}
 
-			destMetric, removedSize := extractExponentialHistogramDataPoints(expHistogram, tt.capacity, sz)
+			destMetric, removedSize := extractExponentialHistogramDataPoints(srcMetric, tt.capacity, sz)
 
 			assert.Equal(t, tt.expectedPoints, destMetric.ExponentialHistogram().DataPoints().Len())
 			if tt.expectedPoints > 0 {
@@ -527,7 +527,7 @@ func TestExtractSummaryDataPoints(t *testing.T) {
 
 			sz := &mockMetricsSizer{dpSize: 1}
 
-			destMetric, removedSize := extractSummaryDataPoints(summary, tt.capacity, sz)
+			destMetric, removedSize := extractSummaryDataPoints(srcMetric, tt.capacity, sz)
 
 			assert.Equal(t, tt.expectedPoints, destMetric.Summary().DataPoints().Len())
 			if tt.expectedPoints > 0 {


### PR DESCRIPTION
#### Description
This PR fixes an issue in exporter/exporterhelper's sending_queue where metric names were lost during metricRequest splitting. Previously, when large batches of metrics were processed, the splitting logic in metric_batch.go could cause the name field of some metrics to disappear. This fix ensures that all metric fields are properly preserved when metricRequest objects are split.

#### Link to tracking issue
Fixes #13236 
