### PR TITLE
[chore] use pseudoversions for xpdata

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -122,7 +122,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.34.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.128.0 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-20250620153441-35668a11dade // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/processor/processorhelper v0.128.0 // indirect

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -51,7 +51,7 @@ require (
 	go.opentelemetry.io/collector/extension/xextension v0.128.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.34.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.0 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-20250620153441-35668a11dade // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.34.0 // indirect

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -16,7 +16,7 @@ require (
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.0
 	go.opentelemetry.io/collector/pdata/testdata v0.128.0
-	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-20250620153441-35668a11dade
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/sdk v1.36.0

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -39,7 +39,7 @@ require (
 	go.opentelemetry.io/collector/extension/xextension v0.128.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.34.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.0 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-20250620153441-35668a11dade // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -20,7 +20,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.34.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.0
 	go.opentelemetry.io/collector/pdata/testdata v0.128.0
-	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-20250620153441-35668a11dade
 	go.opentelemetry.io/collector/pipeline v0.128.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -69,7 +69,7 @@ require (
 	go.opentelemetry.io/collector/extension/xextension v0.128.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.34.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.0 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-20250620153441-35668a11dade // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.34.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -69,7 +69,7 @@ require (
 	go.opentelemetry.io/collector/extension/xextension v0.128.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.34.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.0 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-20250620153441-35668a11dade // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.34.0 // indirect

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -102,7 +102,7 @@ require (
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.0 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-20250620153441-35668a11dade // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/processor v1.34.0 // indirect
 	go.opentelemetry.io/collector/processor/processortest v0.128.0 // indirect

--- a/pdata/xpdata/go.mod
+++ b/pdata/xpdata/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/client v1.34.0
 	go.opentelemetry.io/collector/pdata v1.34.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.0
 	go.opentelemetry.io/collector/pdata/testdata v0.128.0


### PR DESCRIPTION
#### Description
use pseudoversions for xpdata similar to https://github.com/open-telemetry/opentelemetry-collector/pull/13162
v0.0.0-00010101000000-000000000000 does not exist and fails the `update-otel` workflow in contrib

#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40839
