### PR TITLE
[pdata] Fix copying of optional fields when the source is unset

### DIFF
--- a/.chloggen/pdata-fix-copy-optional-field.yaml
+++ b/.chloggen/pdata-fix-copy-optional-field.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix copying of optional fields when the source is unset.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13268]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pdata/internal/cmd/pdatagen/internal/base_fields.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_fields.go
@@ -281,6 +281,10 @@ const accessorsOptionalPrimitiveTestTemplate = `func Test{{ .structName }}_{{ .f
 	{{- end }}
 	ms.Remove{{ .fieldName }}()
 	assert.False(t, ms.Has{{ .fieldName }}())
+	dest := New{{ .structName }}()
+	dest.Set{{ .fieldName }}({{ .testValue }})
+	ms.CopyTo(dest)
+	assert.False(t, dest.Has{{ .fieldName }}())
 }`
 
 type baseField interface {
@@ -860,7 +864,9 @@ func (opv *optionalPrimitiveValue) GenerateSetWithTestValue(ms *messageValueStru
 }
 
 func (opv *optionalPrimitiveValue) GenerateCopyOrig(ms *messageValueStruct) string {
-	return "if src." + opv.fieldName + "_ != nil {\n" +
+	return "if src." + opv.fieldName + "_ == nil {\n" +
+		"\tdest." + opv.fieldName + "_ = nil\n" +
+		"} else {\n" +
 		"\tdest." + opv.fieldName + "_ = &" + ms.originFullName + "_" + opv.fieldName + "{" + opv.fieldName + ": src.Get" + opv.fieldName + "()}\n" +
 		"}"
 }

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint.go
@@ -236,13 +236,19 @@ func copyOrigExponentialHistogramDataPoint(dest, src *otlpmetrics.ExponentialHis
 	copyOrigExponentialHistogramDataPointBuckets(&dest.Negative, &src.Negative)
 	dest.Exemplars = copyOrigExemplarSlice(dest.Exemplars, src.Exemplars)
 	dest.Flags = src.Flags
-	if src.Sum_ != nil {
+	if src.Sum_ == nil {
+		dest.Sum_ = nil
+	} else {
 		dest.Sum_ = &otlpmetrics.ExponentialHistogramDataPoint_Sum{Sum: src.GetSum()}
 	}
-	if src.Min_ != nil {
+	if src.Min_ == nil {
+		dest.Min_ = nil
+	} else {
 		dest.Min_ = &otlpmetrics.ExponentialHistogramDataPoint_Min{Min: src.GetMin()}
 	}
-	if src.Max_ != nil {
+	if src.Max_ == nil {
+		dest.Max_ = nil
+	} else {
 		dest.Max_ = &otlpmetrics.ExponentialHistogramDataPoint_Max{Max: src.GetMax()}
 	}
 	dest.ZeroThreshold = src.ZeroThreshold

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
@@ -138,6 +138,10 @@ func TestExponentialHistogramDataPoint_Sum(t *testing.T) {
 	assert.InDelta(t, float64(17.13), ms.Sum(), 0.01)
 	ms.RemoveSum()
 	assert.False(t, ms.HasSum())
+	dest := NewExponentialHistogramDataPoint()
+	dest.SetSum(float64(17.13))
+	ms.CopyTo(dest)
+	assert.False(t, dest.HasSum())
 }
 
 func TestExponentialHistogramDataPoint_Min(t *testing.T) {
@@ -148,6 +152,10 @@ func TestExponentialHistogramDataPoint_Min(t *testing.T) {
 	assert.InDelta(t, float64(9.23), ms.Min(), 0.01)
 	ms.RemoveMin()
 	assert.False(t, ms.HasMin())
+	dest := NewExponentialHistogramDataPoint()
+	dest.SetMin(float64(9.23))
+	ms.CopyTo(dest)
+	assert.False(t, dest.HasMin())
 }
 
 func TestExponentialHistogramDataPoint_Max(t *testing.T) {
@@ -158,6 +166,10 @@ func TestExponentialHistogramDataPoint_Max(t *testing.T) {
 	assert.InDelta(t, float64(182.55), ms.Max(), 0.01)
 	ms.RemoveMax()
 	assert.False(t, ms.HasMax())
+	dest := NewExponentialHistogramDataPoint()
+	dest.SetMax(float64(182.55))
+	ms.CopyTo(dest)
+	assert.False(t, dest.HasMax())
 }
 
 func TestExponentialHistogramDataPoint_ZeroThreshold(t *testing.T) {

--- a/pdata/pmetric/generated_histogramdatapoint.go
+++ b/pdata/pmetric/generated_histogramdatapoint.go
@@ -198,13 +198,19 @@ func copyOrigHistogramDataPoint(dest, src *otlpmetrics.HistogramDataPoint) {
 	dest.ExplicitBounds = internal.CopyOrigFloat64Slice(dest.ExplicitBounds, src.ExplicitBounds)
 	dest.Exemplars = copyOrigExemplarSlice(dest.Exemplars, src.Exemplars)
 	dest.Flags = src.Flags
-	if src.Sum_ != nil {
+	if src.Sum_ == nil {
+		dest.Sum_ = nil
+	} else {
 		dest.Sum_ = &otlpmetrics.HistogramDataPoint_Sum{Sum: src.GetSum()}
 	}
-	if src.Min_ != nil {
+	if src.Min_ == nil {
+		dest.Min_ = nil
+	} else {
 		dest.Min_ = &otlpmetrics.HistogramDataPoint_Min{Min: src.GetMin()}
 	}
-	if src.Max_ != nil {
+	if src.Max_ == nil {
+		dest.Max_ = nil
+	} else {
 		dest.Max_ = &otlpmetrics.HistogramDataPoint_Max{Max: src.GetMax()}
 	}
 }

--- a/pdata/pmetric/generated_histogramdatapoint_test.go
+++ b/pdata/pmetric/generated_histogramdatapoint_test.go
@@ -110,6 +110,10 @@ func TestHistogramDataPoint_Sum(t *testing.T) {
 	assert.InDelta(t, float64(17.13), ms.Sum(), 0.01)
 	ms.RemoveSum()
 	assert.False(t, ms.HasSum())
+	dest := NewHistogramDataPoint()
+	dest.SetSum(float64(17.13))
+	ms.CopyTo(dest)
+	assert.False(t, dest.HasSum())
 }
 
 func TestHistogramDataPoint_Min(t *testing.T) {
@@ -120,6 +124,10 @@ func TestHistogramDataPoint_Min(t *testing.T) {
 	assert.InDelta(t, float64(9.23), ms.Min(), 0.01)
 	ms.RemoveMin()
 	assert.False(t, ms.HasMin())
+	dest := NewHistogramDataPoint()
+	dest.SetMin(float64(9.23))
+	ms.CopyTo(dest)
+	assert.False(t, dest.HasMin())
 }
 
 func TestHistogramDataPoint_Max(t *testing.T) {
@@ -130,6 +138,10 @@ func TestHistogramDataPoint_Max(t *testing.T) {
 	assert.InDelta(t, float64(182.55), ms.Max(), 0.01)
 	ms.RemoveMax()
 	assert.False(t, ms.HasMax())
+	dest := NewHistogramDataPoint()
+	dest.SetMax(float64(182.55))
+	ms.CopyTo(dest)
+	assert.False(t, dest.HasMax())
 }
 
 func generateTestHistogramDataPoint() HistogramDataPoint {

--- a/pdata/pprofile/generated_location.go
+++ b/pdata/pprofile/generated_location.go
@@ -112,7 +112,9 @@ func (ms Location) CopyTo(dest Location) {
 }
 
 func copyOrigLocation(dest, src *otlpprofiles.Location) {
-	if src.MappingIndex_ != nil {
+	if src.MappingIndex_ == nil {
+		dest.MappingIndex_ = nil
+	} else {
 		dest.MappingIndex_ = &otlpprofiles.Location_MappingIndex{MappingIndex: src.GetMappingIndex()}
 	}
 	dest.Address = src.Address

--- a/pdata/pprofile/generated_location_test.go
+++ b/pdata/pprofile/generated_location_test.go
@@ -49,6 +49,10 @@ func TestLocation_MappingIndex(t *testing.T) {
 	assert.Equal(t, int32(1), ms.MappingIndex())
 	ms.RemoveMappingIndex()
 	assert.False(t, ms.HasMappingIndex())
+	dest := NewLocation()
+	dest.SetMappingIndex(int32(1))
+	ms.CopyTo(dest)
+	assert.False(t, dest.HasMappingIndex())
 }
 
 func TestLocation_Address(t *testing.T) {

--- a/pdata/pprofile/generated_sample.go
+++ b/pdata/pprofile/generated_sample.go
@@ -121,7 +121,9 @@ func copyOrigSample(dest, src *otlpprofiles.Sample) {
 	dest.LocationsLength = src.LocationsLength
 	dest.Value = internal.CopyOrigInt64Slice(dest.Value, src.Value)
 	dest.AttributeIndices = internal.CopyOrigInt32Slice(dest.AttributeIndices, src.AttributeIndices)
-	if src.LinkIndex_ != nil {
+	if src.LinkIndex_ == nil {
+		dest.LinkIndex_ = nil
+	} else {
 		dest.LinkIndex_ = &otlpprofiles.Sample_LinkIndex{LinkIndex: src.GetLinkIndex()}
 	}
 	dest.TimestampsUnixNano = internal.CopyOrigUInt64Slice(dest.TimestampsUnixNano, src.TimestampsUnixNano)

--- a/pdata/pprofile/generated_sample_test.go
+++ b/pdata/pprofile/generated_sample_test.go
@@ -81,6 +81,10 @@ func TestSample_LinkIndex(t *testing.T) {
 	assert.Equal(t, int32(1), ms.LinkIndex())
 	ms.RemoveLinkIndex()
 	assert.False(t, ms.HasLinkIndex())
+	dest := NewSample()
+	dest.SetLinkIndex(int32(1))
+	ms.CopyTo(dest)
+	assert.False(t, dest.HasLinkIndex())
 }
 
 func TestSample_TimestampsUnixNano(t *testing.T) {


### PR DESCRIPTION
If destination has an optional field set to some value but source has it unset, we need to unset the field on the destination instead of keeping the old value.

Found this bug while working on https://github.com/open-telemetry/opentelemetry-collector/pull/13267