### PR TITLE
Add separate print commands for initial and validated configuration

### DIFF
--- a/.chloggen/print-config-redaction.yaml
+++ b/.chloggen/print-config-redaction.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otelcol
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add print-command which will print yaml or json with redaction; extend print-initial-config with json support.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/otelcol/command.go
+++ b/otelcol/command.go
@@ -42,7 +42,8 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 	rootCmd.AddCommand(newFeatureGateCommand())
 	rootCmd.AddCommand(newComponentsCommand(set))
 	rootCmd.AddCommand(newValidateSubCommand(set, flagSet))
-	rootCmd.AddCommand(newConfigPrintSubCommand(set, flagSet))
+	rootCmd.AddCommand(newPrintInitialConfigSubCommand(set, flagSet))
+	rootCmd.AddCommand(newPrintValidatedConfigSubCommand(set, flagSet))
 	rootCmd.Flags().AddGoFlagSet(flagSet)
 	return rootCmd
 }

--- a/otelcol/command.go
+++ b/otelcol/command.go
@@ -43,7 +43,7 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 	rootCmd.AddCommand(newComponentsCommand(set))
 	rootCmd.AddCommand(newValidateSubCommand(set, flagSet))
 	rootCmd.AddCommand(newPrintInitialConfigSubCommand(set, flagSet))
-	rootCmd.AddCommand(newPrintValidatedConfigSubCommand(set, flagSet))
+	rootCmd.AddCommand(newPrintTypedConfigSubCommand(set, flagSet))
 	rootCmd.Flags().AddGoFlagSet(flagSet)
 	return rootCmd
 }

--- a/otelcol/command_print.go
+++ b/otelcol/command_print.go
@@ -4,9 +4,12 @@
 package otelcol // import "go.opentelemetry.io/collector/otelcol"
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
@@ -22,12 +25,38 @@ var printCommandFeatureFlag = featuregate.GlobalRegistry().MustRegister(
 	featuregate.WithRegisterDescription("if set to true, turns on the print-initial-config command"),
 )
 
-// newConfigPrintSubCommand constructs a new config print sub command using the given CollectorSettings.
-func newConfigPrintSubCommand(set CollectorSettings, flagSet *flag.FlagSet) *cobra.Command {
+// printConfigData formats and prints configuration data using available configuration providers
+func printConfigData(data map[string]any, format string) error {
+	if format == "" {
+		format = "yaml"
+	}
+
+	// Handle JSON output using standard library
+	if strings.EqualFold(format, "json") {
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(data)
+	}
+
+	if strings.EqualFold(format, "yaml") {
+		b, err := yaml.Marshal(data)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", b)
+		return nil
+	}
+	return fmt.Errorf("Unrecognized print-format value: %s", format)
+}
+
+// newPrintInitialConfigSubCommand constructs a new config print sub command using the given CollectorSettings.
+func newPrintInitialConfigSubCommand(set CollectorSettings, flagSet *flag.FlagSet) *cobra.Command {
+	var outputFormat string
+
 	cmd := &cobra.Command{
 		Use:   "print-initial-config",
-		Short: "Prints the Collector's configuration in YAML format after all config sources are resolved and merged",
-		Long:  `Note: This command prints the final yaml configuration before it is unmarshaled into config structs, which may contain sensitive values.`,
+		Short: "Prints the Collector's configuration in YAML or JSON format after all config sources are resolved and merged",
+		Long:  `Note: This command prints the final configuration before it is unmarshaled into config structs, which may contain sensitive values. Use --format to specify output format.`,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !printCommandFeatureFlag.IsEnabled() {
@@ -45,14 +74,60 @@ func newConfigPrintSubCommand(set CollectorSettings, flagSet *flag.FlagSet) *cob
 			if err != nil {
 				return fmt.Errorf("error while resolving config: %w", err)
 			}
-			b, err := yaml.Marshal(conf.ToStringMap())
-			if err != nil {
-				return fmt.Errorf("error while marshaling to YAML: %w", err)
-			}
-			fmt.Printf("%s\n", b)
-			return nil
+			return printConfigData(conf.ToStringMap(), outputFormat)
 		},
 	}
+
+	formatHelp := fmt.Sprintf("Output format. Available: yaml,json (defaults to yaml)")
+	cmd.Flags().StringVar(&outputFormat, "format", "yaml", formatHelp)
+	cmd.Flags().AddGoFlagSet(flagSet)
+	return cmd
+}
+
+// newPrintValidatedConfigSubCommand constructs a new validated config print sub command using the given CollectorSettings.
+func newPrintValidatedConfigSubCommand(set CollectorSettings, flagSet *flag.FlagSet) *cobra.Command {
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use:   "print-config",
+		Short: "Prints the Collector's validated configuration with defaults resolved",
+		Long:  `This command validates the configuration and prints it with component defaults applied. This output is suitable for sharing as it masks sensitive values.`,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := updateSettingsUsingFlags(&set, flagSet)
+			if err != nil {
+				return err
+			}
+
+			// Create config provider
+			configProvider, err := NewConfigProvider(set.ConfigProviderSettings)
+			if err != nil {
+				return fmt.Errorf("failed to create config provider: %w", err)
+			}
+
+			// Get factories and validate
+			factories, err := set.Factories()
+			if err != nil {
+				return fmt.Errorf("failed to get factories: %w", err)
+			}
+
+			cfg, err := configProvider.Get(cmd.Context(), factories)
+			if err != nil {
+				return fmt.Errorf("failed to get config: %w", err)
+			}
+
+			// Convert config back to map for output
+			confMap := confmap.New()
+			if err := confMap.Marshal(cfg); err != nil {
+				return fmt.Errorf("failed to marshal config: %w", err)
+			}
+
+			return printConfigData(confMap.ToStringMap(), outputFormat)
+		},
+	}
+
+	formatHelp := fmt.Sprintf("Output format. Available: yaml,json (defaults to yaml)")
+	cmd.Flags().StringVar(&outputFormat, "format", "yaml", formatHelp)
 	cmd.Flags().AddGoFlagSet(flagSet)
 	return cmd
 }

--- a/otelcol/command_print.go
+++ b/otelcol/command_print.go
@@ -84,8 +84,8 @@ func newPrintInitialConfigSubCommand(set CollectorSettings, flagSet *flag.FlagSe
 	return cmd
 }
 
-// newPrintValidatedConfigSubCommand constructs a new validated config print sub command using the given CollectorSettings.
-func newPrintValidatedConfigSubCommand(set CollectorSettings, flagSet *flag.FlagSet) *cobra.Command {
+// newPrintTypedConfigSubCommand constructs a new validated config print sub command using the given CollectorSettings.
+func newPrintTypedConfigSubCommand(set CollectorSettings, flagSet *flag.FlagSet) *cobra.Command {
 	var outputFormat string
 
 	cmd := &cobra.Command{

--- a/otelcol/command_print_test.go
+++ b/otelcol/command_print_test.go
@@ -4,341 +4,339 @@
 package otelcol // import "go.opentelemetry.io/collector/otelcol"
 
 import (
-	"bytes"
-	"os"
-	"testing"
+        "bytes"
+        "os"
+        "testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
+        yaml "sigs.k8s.io/yaml/goyaml.v3"
 
-	"go.opentelemetry.io/collector/confmap"
-	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
-	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
-	"go.opentelemetry.io/collector/connector/connectortest"
-	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	"go.opentelemetry.io/collector/extension/extensiontest"
-	"go.opentelemetry.io/collector/featuregate"
-	"go.opentelemetry.io/collector/processor/processortest"
-	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+        "go.opentelemetry.io/collector/confmap"
+        "go.opentelemetry.io/collector/confmap/provider/fileprovider"
+        "go.opentelemetry.io/collector/confmap/provider/yamlprovider"
+        "go.opentelemetry.io/collector/connector/connectortest"
+        "go.opentelemetry.io/collector/exporter/otlpexporter"
+        "go.opentelemetry.io/collector/extension/extensiontest"
+        "go.opentelemetry.io/collector/featuregate"
+        "go.opentelemetry.io/collector/processor/processortest"
+        "go.opentelemetry.io/collector/receiver/otlpreceiver"
 )
 
 // otlpFactories creates factories that include OTLP components for testing sensitive data
 func otlpFactories() (Factories, error) {
-	var factories Factories
-	var err error
+        var factories Factories
+        var err error
 
-	if factories.Receivers, err = MakeFactoryMap(otlpreceiver.NewFactory()); err != nil {
-		return Factories{}, err
-	}
+        if factories.Receivers, err = MakeFactoryMap(otlpreceiver.NewFactory()); err != nil {
+                return Factories{}, err
+        }
 
-	if factories.Exporters, err = MakeFactoryMap(otlpexporter.NewFactory()); err != nil {
-		return Factories{}, err
-	}
+        if factories.Exporters, err = MakeFactoryMap(otlpexporter.NewFactory()); err != nil {
+                return Factories{}, err
+        }
 
-	if factories.Processors, err = MakeFactoryMap(processortest.NewNopFactory()); err != nil {
-		return Factories{}, err
-	}
+        if factories.Processors, err = MakeFactoryMap(processortest.NewNopFactory()); err != nil {
+                return Factories{}, err
+        }
 
-	if factories.Extensions, err = MakeFactoryMap(extensiontest.NewNopFactory()); err != nil {
-		return Factories{}, err
-	}
+        if factories.Extensions, err = MakeFactoryMap(extensiontest.NewNopFactory()); err != nil {
+                return Factories{}, err
+        }
 
-	if factories.Connectors, err = MakeFactoryMap(connectortest.NewNopFactory()); err != nil {
-		return Factories{}, err
-	}
+        if factories.Connectors, err = MakeFactoryMap(connectortest.NewNopFactory()); err != nil {
+                return Factories{}, err
+        }
 
-	return factories, nil
+        return factories, nil
 }
 
 func TestPrintInitialConfigCommand(t *testing.T) {
-	tests := []struct {
-		name      string
-		set       confmap.ResolverSettings
-		errString string
-	}{
-		{
-			name:      "no URIs",
-			set:       confmap.ResolverSettings{},
-			errString: "at least one config flag must be provided",
-		},
-		{
-			name: "valid URI - file not found",
-			set: confmap.ResolverSettings{
-				URIs: []string{"file:blabla.yaml"},
-				ProviderFactories: []confmap.ProviderFactory{
-					fileprovider.NewFactory(),
-				},
-				DefaultScheme: "file",
-			},
-			errString: "cannot retrieve the configuration: unable to read the file",
-		},
-		{
-			name: "valid URI",
-			set: confmap.ResolverSettings{
-				URIs: []string{"yaml:processors::batch/foo::timeout: 3s"},
-				ProviderFactories: []confmap.ProviderFactory{
-					yamlprovider.NewFactory(),
-				},
-				DefaultScheme: "yaml",
-			},
-		},
-		{
-			name: "valid URI - no provider set",
-			set: confmap.ResolverSettings{
-				URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
-				DefaultScheme: "yaml",
-			},
-			errString: "at least one Provider must be supplied",
-		},
-		{
-			name: "valid URI - invalid scheme name",
-			set: confmap.ResolverSettings{
-				URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
-				DefaultScheme: "foo",
-				ProviderFactories: []confmap.ProviderFactory{
-					yamlprovider.NewFactory(),
-				},
-			},
-			errString: "configuration: DefaultScheme not found in providers list",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), true))
-			defer func() {
-				require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), false))
-			}()
+        tests := []struct {
+                name      string
+                set       confmap.ResolverSettings
+                errString string
+        }{
+                {
+                        name:      "no URIs",
+                        set:       confmap.ResolverSettings{},
+                        errString: "at least one config flag must be provided",
+                },
+                {
+                        name: "valid URI - file not found",
+                        set: confmap.ResolverSettings{
+                                URIs: []string{"file:blabla.yaml"},
+                                ProviderFactories: []confmap.ProviderFactory{
+                                        fileprovider.NewFactory(),
+                                },
+                                DefaultScheme: "file",
+                        },
+                        errString: "cannot retrieve the configuration: unable to read the file",
+                },
+                {
+                        name: "valid URI",
+                        set: confmap.ResolverSettings{
+                                URIs: []string{"yaml:processors::batch/foo::timeout: 3s"},
+                                ProviderFactories: []confmap.ProviderFactory{
+                                        yamlprovider.NewFactory(),
+                                },
+                                DefaultScheme: "yaml",
+                        },
+                },
+                {
+                        name: "valid URI - no provider set",
+                        set: confmap.ResolverSettings{
+                                URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
+                                DefaultScheme: "yaml",
+                        },
+                        errString: "at least one Provider must be supplied",
+                },
+                {
+                        name: "valid URI - invalid scheme name",
+                        set: confmap.ResolverSettings{
+                                URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
+                                DefaultScheme: "foo",
+                                ProviderFactories: []confmap.ProviderFactory{
+                                        yamlprovider.NewFactory(),
+                                },
+                        },
+                        errString: "configuration: DefaultScheme not found in providers list",
+                },
+        }
+        for _, test := range tests {
+                t.Run(test.name, func(t *testing.T) {
+                        require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), true))
+                        defer func() {
+                                require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), false))
+                        }()
 
-			set := ConfigProviderSettings{
-				ResolverSettings: test.set,
-			}
-			cmd := newPrintInitialConfigSubCommand(CollectorSettings{ConfigProviderSettings: set}, flags(featuregate.GlobalRegistry()))
-			err := cmd.Execute()
-			if test.errString != "" {
-				require.ErrorContains(t, err, test.errString)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+                        set := ConfigProviderSettings{
+                                ResolverSettings: test.set,
+                        }
+                        cmd := newPrintInitialConfigSubCommand(CollectorSettings{ConfigProviderSettings: set}, flags(featuregate.GlobalRegistry()))
+                        err := cmd.Execute()
+                        if test.errString != "" {
+                                require.ErrorContains(t, err, test.errString)
+                        } else {
+                                require.NoError(t, err)
+                        }
+                })
+        }
 }
 
 func TestPrintInitialConfigCommandFeaturegateDisabled(t *testing.T) {
-	cmd := newPrintInitialConfigSubCommand(CollectorSettings{ConfigProviderSettings: ConfigProviderSettings{
-		ResolverSettings: confmap.ResolverSettings{
-			URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
-			DefaultScheme: "foo",
-			ProviderFactories: []confmap.ProviderFactory{
-				yamlprovider.NewFactory(),
-			},
-		},
-	}}, flags(featuregate.GlobalRegistry()))
-	err := cmd.Execute()
-	require.ErrorContains(t, err, "print-initial-config is currently experimental, use the otelcol.printInitialConfig feature gate to enable this command")
+        cmd := newPrintInitialConfigSubCommand(CollectorSettings{ConfigProviderSettings: ConfigProviderSettings{
+                ResolverSettings: confmap.ResolverSettings{
+                        URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
+                        DefaultScheme: "foo",
+                        ProviderFactories: []confmap.ProviderFactory{
+                                yamlprovider.NewFactory(),
+                        },
+                },
+        }}, flags(featuregate.GlobalRegistry()))
+        err := cmd.Execute()
+        require.ErrorContains(t, err, "print-initial-config is currently experimental, use the otelcol.printInitialConfig feature gate to enable this command")
 }
 
 func TestPrintInitialConfig(t *testing.T) {
-	tests := []struct {
-		name        string
-		configs     []string
-		finalConfig string
-	}{
-		{
-			name: "two-configs",
-			configs: []string{
-				"file:testdata/configs/1-config-first.yaml",
-				"file:testdata/configs/1-config-second.yaml",
-			},
-			finalConfig: "testdata/configs/1-config-output.yaml",
-		},
-		{
-			name: "two-configs-yaml",
-			configs: []string{
-				"file:testdata/configs/1-config-first.yaml",
-				"file:testdata/configs/1-config-second.yaml",
-				"yaml:service::pipelines::logs::receivers: [foo,bar]",
-				"yaml:service::pipelines::logs::exporters: [foo,bar]",
-			},
-			finalConfig: "testdata/configs/2-config-output.yaml",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), true))
-			defer func() {
-				require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), false))
-			}()
-			set := ConfigProviderSettings{
-				ResolverSettings: confmap.ResolverSettings{
-					URIs: test.configs,
-					ProviderFactories: []confmap.ProviderFactory{
-						fileprovider.NewFactory(),
-						yamlprovider.NewFactory(),
-					},
-					DefaultScheme: "file",
-				},
-			}
-			tmpFile, err := os.CreateTemp(t.TempDir(), "*")
-			require.NoError(t, err)
-			t.Cleanup(func() { _ = tmpFile.Close() })
+        tests := []struct {
+                name        string
+                configs     []string
+                finalConfig string
+        }{
+                {
+                        name: "two-configs",
+                        configs: []string{
+                                "file:testdata/configs/1-config-first.yaml",
+                                "file:testdata/configs/1-config-second.yaml",
+                        },
+                        finalConfig: "testdata/configs/1-config-output.yaml",
+                },
+                {
+                        name: "two-configs-yaml",
+                        configs: []string{
+                                "file:testdata/configs/1-config-first.yaml",
+                                "file:testdata/configs/1-config-second.yaml",
+                                "yaml:service::pipelines::logs::receivers: [foo,bar]",
+                                "yaml:service::pipelines::logs::exporters: [foo,bar]",
+                        },
+                        finalConfig: "testdata/configs/2-config-output.yaml",
+                },
+        }
+        for _, test := range tests {
+                t.Run(test.name, func(t *testing.T) {
+                        require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), true))
+                        defer func() {
+                                require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), false))
+                        }()
+                        set := ConfigProviderSettings{
+                                ResolverSettings: confmap.ResolverSettings{
+                                        URIs: test.configs,
+                                        ProviderFactories: []confmap.ProviderFactory{
+                                                fileprovider.NewFactory(),
+                                                yamlprovider.NewFactory(),
+                                        },
+                                        DefaultScheme: "file",
+                                },
+                        }
+                        tmpFile, err := os.CreateTemp(t.TempDir(), "*")
+                        require.NoError(t, err)
+                        t.Cleanup(func() { _ = tmpFile.Close() })
 
-			// save the os.Stdout and temporarily set it to temp file
-			oldStdout := os.Stdout
-			os.Stdout = tmpFile
+                        // save the os.Stdout and temporarily set it to temp file
+                        oldStdout := os.Stdout
+                        os.Stdout = tmpFile
 
-			cmd := newPrintInitialConfigSubCommand(CollectorSettings{ConfigProviderSettings: set}, flags(featuregate.GlobalRegistry()))
-			require.NoError(t, cmd.Execute())
+                        cmd := newPrintInitialConfigSubCommand(CollectorSettings{ConfigProviderSettings: set}, flags(featuregate.GlobalRegistry()))
+                        require.NoError(t, cmd.Execute())
 
-			// restore os.Stdout
-			os.Stdout = oldStdout
+                        // restore os.Stdout
+                        os.Stdout = oldStdout
 
-			expectedOutput, err := os.ReadFile(test.finalConfig)
-			require.NoError(t, err)
+                        expectedOutput, err := os.ReadFile(test.finalConfig)
+                        require.NoError(t, err)
 
-			actualOutput, err := os.ReadFile(tmpFile.Name())
-			require.NoError(t, err)
+                        actualOutput, err := os.ReadFile(tmpFile.Name())
+                        require.NoError(t, err)
 
-			actualConfig := make(map[string]any, 0)
-			expectedConfig := make(map[string]any, 0)
+                        actualConfig := make(map[string]any, 0)
+                        expectedConfig := make(map[string]any, 0)
 
-			require.NoError(t, yaml.Unmarshal(bytes.TrimSpace(actualOutput), actualConfig))
-			require.NoError(t, yaml.Unmarshal(bytes.TrimSpace(expectedOutput), expectedConfig))
+                        require.NoError(t, yaml.Unmarshal(bytes.TrimSpace(actualOutput), actualConfig))
+                        require.NoError(t, yaml.Unmarshal(bytes.TrimSpace(expectedOutput), expectedConfig))
 
-			require.Equal(t, expectedConfig, actualConfig)
-		})
-	}
+                        require.Equal(t, expectedConfig, actualConfig)
+                })
+        }
 }
 
-func TestPrintValidatedConfigCommand(t *testing.T) {
-	// Test with minimal nop configuration
-	factories, err := nopFactories()
-	require.NoError(t, err)
+func TestPrintTypedConfigCommand(t *testing.T) {
+        // Test with minimal nop configuration
+        factories, err := nopFactories()
+        require.NoError(t, err)
 
-	set := CollectorSettings{
-		Factories: func() (Factories, error) { return factories, nil },
-		ConfigProviderSettings: ConfigProviderSettings{
-			ResolverSettings: confmap.ResolverSettings{
-				URIs:              []string{"yaml:service:\n  pipelines:\n    traces:\n      receivers: [nop]\n      exporters: [nop]"},
-				ProviderFactories: []confmap.ProviderFactory{yamlprovider.NewFactory()},
-				DefaultScheme:     "yaml",
-			},
-		},
-	}
+        set := CollectorSettings{
+                Factories: func() (Factories, error) { return factories, nil },
+                ConfigProviderSettings: ConfigProviderSettings{
+                        ResolverSettings: confmap.ResolverSettings{
+                                URIs:              []string{"yaml:service:\n  pipelines:\n    traces:\n      receivers: [nop]\n      exporters: [nop]"},
+                                ProviderFactories: []confmap.ProviderFactory{yamlprovider.NewFactory()},
+                                DefaultScheme:     "yaml",
+                        },
+                },
+        }
 
-	cmd := newPrintValidatedConfigSubCommand(set, flags(featuregate.GlobalRegistry()))
-	require.NoError(t, cmd.Execute())
+        cmd := newPrintTypedConfigSubCommand(set, flags(featuregate.GlobalRegistry()))
+        require.NoError(t, cmd.Execute())
 }
 
-func TestPrintValidatedConfigCommandJSON(t *testing.T) {
-	// Test JSON format output with DefaultScheme override
-	factories, err := nopFactories()
-	require.NoError(t, err)
+func TestPrintTypedConfigCommandJSON(t *testing.T) {
+        // Test JSON format output with DefaultScheme override
+        factories, err := nopFactories()
+        require.NoError(t, err)
 
-	set := CollectorSettings{
-		Factories: func() (Factories, error) { return factories, nil },
-		ConfigProviderSettings: ConfigProviderSettings{
-			ResolverSettings: confmap.ResolverSettings{
-				URIs:              []string{"yaml:service:\n  pipelines:\n    traces:\n      receivers: [nop]\n      exporters: [nop]"},
-				ProviderFactories: []confmap.ProviderFactory{yamlprovider.NewFactory()},
-				DefaultScheme:     "yaml", // YAML as default scheme
-			},
-		},
-	}
+        set := CollectorSettings{
+                Factories: func() (Factories, error) { return factories, nil },
+                ConfigProviderSettings: ConfigProviderSettings{
+                        ResolverSettings: confmap.ResolverSettings{
+                                URIs:              []string{"yaml:service:\n  pipelines:\n    traces:\n      receivers: [nop]\n      exporters: [nop]"},
+                                ProviderFactories: []confmap.ProviderFactory{yamlprovider.NewFactory()},
+                                DefaultScheme:     "yaml", // YAML as default scheme
+                        },
+                },
+        }
 
-	// Create command with JSON format flag
-	cmd := newPrintValidatedConfigSubCommand(set, flags(featuregate.GlobalRegistry()))
-	cmd.SetArgs([]string{"--format", "json"})
-	require.NoError(t, cmd.Execute())
+        // Create command with JSON format flag
+        cmd := newPrintTypedConfigSubCommand(set, flags(featuregate.GlobalRegistry()))
+        cmd.SetArgs([]string{"--format", "json"})
+        require.NoError(t, cmd.Execute())
 }
 
 func TestPrintConfigCommandWithSensitiveData(t *testing.T) {
-	// Test that print-config shows [REDACTED] for sensitive data
-	factories, err := otlpFactories()
-	require.NoError(t, err)
+        // Test that print-config shows [REDACTED] for sensitive data
+        factories, err := otlpFactories()
+        require.NoError(t, err)
 
-	set := CollectorSettings{
-		Factories: func() (Factories, error) { return factories, nil },
-		ConfigProviderSettings: ConfigProviderSettings{
-			ResolverSettings: confmap.ResolverSettings{
-				URIs:              []string{"file:testdata/config_with_sensitive_data.yaml"},
-				ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory()},
-				DefaultScheme:     "file",
-			},
-		},
-	}
+        set := CollectorSettings{
+                Factories: func() (Factories, error) { return factories, nil },
+                ConfigProviderSettings: ConfigProviderSettings{
+                        ResolverSettings: confmap.ResolverSettings{
+                                URIs:              []string{"file:testdata/config_with_sensitive_data.yaml"},
+                                ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory()},
+                                DefaultScheme:     "file",
+                        },
+                },
+        }
 
-	// Capture output
-	var buf bytes.Buffer
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+        // Capture output
+        var buf bytes.Buffer
+        oldStdout := os.Stdout
+        r, w, _ := os.Pipe()
+        os.Stdout = w
 
-	cmd := newPrintValidatedConfigSubCommand(set, flags(featuregate.GlobalRegistry()))
-	err = cmd.Execute()
+        cmd := newPrintTypedConfigSubCommand(set, flags(featuregate.GlobalRegistry()))
+        err = cmd.Execute()
 
-	// Restore stdout and get output
-	w.Close()
-	os.Stdout = oldStdout
-	buf.ReadFrom(r)
-	output := buf.String()
+        // Restore stdout and get output
+        w.Close()
+        os.Stdout = oldStdout
+        buf.ReadFrom(r)
+        output := buf.String()
 
-	// Should succeed with OTLP factories and show [REDACTED] for sensitive data
-	require.NoError(t, err, "Command should execute successfully with OTLP factories")
-	
-	// Verify that sensitive data is redacted
-	assert.Contains(t, output, "[REDACTED]")
-	assert.NotContains(t, output, "Bearer secret-token")
-	assert.NotContains(t, output, "super-secret-key")
+        // Should succeed with OTLP factories and show [REDACTED] for sensitive data
+        require.NoError(t, err, "Command should execute successfully with OTLP factories")
 
-	// Verify basic structure is still there
-	assert.Contains(t, output, "receivers:")
-	assert.Contains(t, output, "exporters:")
-	assert.Contains(t, output, "service:")
+        // Verify that sensitive data is redacted
+        assert.Contains(t, output, "[REDACTED]")
+        assert.NotContains(t, output, "Bearer secret-token")
+        assert.NotContains(t, output, "super-secret-key")
+
+        // Verify basic structure is still there
+        assert.Contains(t, output, "receivers:")
+        assert.Contains(t, output, "exporters:")
+        assert.Contains(t, output, "service:")
 }
 
 func TestPrintInitialConfigWithSensitiveData(t *testing.T) {
-	// Test that print-initial-config shows the raw configuration values (not redacted)
-	require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), true))
-	defer func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), false))
-	}()
+        // Test that print-initial-config shows the raw configuration values (not redacted)
+        require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), true))
+        defer func() {
+                require.NoError(t, featuregate.GlobalRegistry().Set(printCommandFeatureFlag.ID(), false))
+        }()
 
-	set := ConfigProviderSettings{
-		ResolverSettings: confmap.ResolverSettings{
-			URIs:              []string{"file:testdata/config_with_sensitive_data.yaml"},
-			ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory()},
-			DefaultScheme:     "file",
-		},
-	}
+        set := ConfigProviderSettings{
+                ResolverSettings: confmap.ResolverSettings{
+                        URIs:              []string{"file:testdata/config_with_sensitive_data.yaml"},
+                        ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory()},
+                        DefaultScheme:     "file",
+                },
+        }
 
-	// Capture output
-	var buf bytes.Buffer
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+        // Capture output
+        var buf bytes.Buffer
+        oldStdout := os.Stdout
+        r, w, _ := os.Pipe()
+        os.Stdout = w
 
-	cmd := newPrintInitialConfigSubCommand(CollectorSettings{ConfigProviderSettings: set}, flags(featuregate.GlobalRegistry()))
-	err := cmd.Execute()
+        cmd := newPrintInitialConfigSubCommand(CollectorSettings{ConfigProviderSettings: set}, flags(featuregate.GlobalRegistry()))
+        err := cmd.Execute()
 
-	// Restore stdout and get output
-	w.Close()
-	os.Stdout = oldStdout
-	buf.ReadFrom(r)
-	output := buf.String()
+        // Restore stdout and get output
+        w.Close()
+        os.Stdout = oldStdout
+        buf.ReadFrom(r)
+        output := buf.String()
 
-	// Initial config should succeed since it doesn't validate against factories
-	require.NoError(t, err, "Command should execute successfully")
-	
-	// Verify output contains the raw sensitive data, not [REDACTED]
-	assert.Contains(t, output, "Bearer secret-token")
-	assert.Contains(t, output, "super-secret-key")
-	assert.NotContains(t, output, "[REDACTED]")
+        // Initial config should succeed since it doesn't validate against factories
+        require.NoError(t, err, "Command should execute successfully")
 
-	// Verify basic structure is there
-	assert.Contains(t, output, "receivers:")
-	assert.Contains(t, output, "exporters:")
-	assert.Contains(t, output, "service:")
+        // Verify output contains the raw sensitive data, not [REDACTED]
+        assert.Contains(t, output, "Bearer secret-token")
+        assert.Contains(t, output, "super-secret-key")
+        assert.NotContains(t, output, "[REDACTED]")
 
-	// Note: print-initial-config shows raw values from the config file
+        // Verify basic structure is there
+        assert.Contains(t, output, "receivers:")
+        assert.Contains(t, output, "exporters:")
+        assert.Contains(t, output, "service:")
 }

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/connector/connectortest v0.128.0
 	go.opentelemetry.io/collector/exporter v0.128.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.0
+	go.opentelemetry.io/collector/exporter/otlpexporter v1.34.0
 	go.opentelemetry.io/collector/extension v1.34.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.128.0
 	go.opentelemetry.io/collector/featuregate v1.34.0
@@ -23,6 +24,7 @@ require (
 	go.opentelemetry.io/collector/processor v1.34.0
 	go.opentelemetry.io/collector/processor/processortest v0.128.0
 	go.opentelemetry.io/collector/receiver v1.34.0
+	go.opentelemetry.io/collector/receiver/otlpreceiver v1.34.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.0
 	go.opentelemetry.io/collector/service v0.128.0
 	go.opentelemetry.io/contrib/otelconf v0.16.0
@@ -41,17 +43,23 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/snappy v1.0.0 // indirect
+	github.com/google/go-tpm v0.9.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/knadh/koanf/providers/confmap v1.0.0 // indirect
 	github.com/knadh/koanf/v2 v2.2.1 // indirect
@@ -60,37 +68,62 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/rs/cors v1.11.1 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.5 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/collector v0.128.0 // indirect
+	go.opentelemetry.io/collector/client v1.34.0 // indirect
 	go.opentelemetry.io/collector/component/componenttest v0.128.0 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.128.0 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.34.0 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.128.0 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.128.0 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.128.0 // indirect
+	go.opentelemetry.io/collector/config/confignet v1.34.0 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.34.0 // indirect
+	go.opentelemetry.io/collector/config/configoptional v0.128.0 // indirect
+	go.opentelemetry.io/collector/config/configretry v1.34.0 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.34.0 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.128.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.34.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.0 // indirect
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.0 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.0 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.34.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.0 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.0 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.128.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.0 // indirect
+	go.opentelemetry.io/collector/internal/sharedcomponent v0.128.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.34.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.128.0 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.0.0-20250620153441-35668a11dade // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.128.0 // indirect
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.128.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.0 // indirect
 	go.opentelemetry.io/collector/service/hostcapabilities v0.128.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.36.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.12.2 // indirect
@@ -111,6 +144,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.6.0 // indirect
+	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	gonum.org/v1/gonum v0.16.0 // indirect
@@ -225,3 +259,21 @@ replace go.opentelemetry.io/collector/extension/extensionmiddleware => ../extens
 replace go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest => ../extension/extensionmiddleware/extensionmiddlewaretest
 
 replace go.opentelemetry.io/collector/pdata/xpdata => ../pdata/xpdata
+
+replace go.opentelemetry.io/collector/receiver/otlpreceiver => ../receiver/otlpreceiver
+
+replace go.opentelemetry.io/collector/internal/sharedcomponent => ../internal/sharedcomponent
+
+replace go.opentelemetry.io/collector/config/configgrpc => ../config/configgrpc
+
+replace go.opentelemetry.io/collector/config/configoptional => ../config/configoptional
+
+replace go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper => ../exporter/exporterhelper/xexporterhelper
+
+replace go.opentelemetry.io/collector/receiver/receiverhelper => ../receiver/receiverhelper
+
+replace go.opentelemetry.io/collector/exporter/otlpexporter => ../exporter/otlpexporter
+
+replace go.opentelemetry.io/collector/consumer/consumererror/xconsumererror => ../consumer/consumererror/xconsumererror
+
+replace go.opentelemetry.io/collector/config/confignet => ../config/confignet

--- a/otelcol/go.sum
+++ b/otelcol/go.sum
@@ -14,6 +14,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e h1:2jjYsGgM13xId2Ku+UGDQTO5It50LhT6lljiVJvBj1Y=
 github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e/go.mod h1:uAyTlAUxchYuiFjTHmuIEJ4nGSm7iOPaGcAyA81fJ80=
+github.com/foxboron/swtpm_test v0.0.0-20230726224112-46aaafdf7006 h1:50sW4r0PcvlpG4PV8tYh2RVCapszJgaOLRCS2subvV4=
+github.com/foxboron/swtpm_test v0.0.0-20230726224112-46aaafdf7006/go.mod h1:eIXCMsMYCaqq9m1KSSxXwQG11krpuNPGP3k0uaWrbas=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -39,6 +41,8 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-tpm v0.9.5 h1:ocUmnDebX54dnW+MQWGQRbdaAcJELsa6PqZhJ48KwVU=
 github.com/google/go-tpm v0.9.5/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u6bVUY=
+github.com/google/go-tpm-tools v0.4.4 h1:oiQfAIkc6xTy9Fl5NKTeTJkBTlXdHsxAofmQyxBKY98=
+github.com/google/go-tpm-tools v0.4.4/go.mod h1:T8jXkp2s+eltnCDIsXR84/MTcVU9Ja7bh3Mit0pa4AY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -77,6 +81,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mostynb/go-grpc-compression v1.2.3 h1:42/BKWMy0KEJGSdWvzqIyOZ95YcR9mLPqKctH7Uo//I=
+github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1Vjs47Km/Y2FE6ouQ7Lg=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
@@ -120,6 +126,8 @@ go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJyS
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 h1:u2E32P7j1a/gRgZDWhIXC+Shd4rLg70mnE7QLI/Ssnw=
 go.opentelemetry.io/contrib/bridges/otelzap v0.11.0/go.mod h1:pJPCLM8gzX4ASqLlyAXjHBEYxgbOQJ/9bidWxD6PEPQ=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0/go.mod h1:snMWehoOh2wsEwnvvwtDyFCxVeDAODenXHtn5vzrKjo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/contrib/otelconf v0.16.0 h1:mTYGRlZtpc/zDaTaUQSnsZ1hyoRONaS4Od/Ny5++lhE=

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -234,3 +234,21 @@ replace go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmid
 replace go.opentelemetry.io/collector/extension/extensionmiddleware => ../../extension/extensionmiddleware
 
 replace go.opentelemetry.io/collector/pdata/xpdata => ../../pdata/xpdata
+
+replace go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper => ../../exporter/exporterhelper/xexporterhelper
+
+replace go.opentelemetry.io/collector/receiver/otlpreceiver => ../../receiver/otlpreceiver
+
+replace go.opentelemetry.io/collector/consumer/consumererror/xconsumererror => ../../consumer/consumererror/xconsumererror
+
+replace go.opentelemetry.io/collector/internal/sharedcomponent => ../../internal/sharedcomponent
+
+replace go.opentelemetry.io/collector/config/configgrpc => ../../config/configgrpc
+
+replace go.opentelemetry.io/collector/exporter/otlpexporter => ../../exporter/otlpexporter
+
+replace go.opentelemetry.io/collector/config/confignet => ../../config/confignet
+
+replace go.opentelemetry.io/collector/receiver/receiverhelper => ../../receiver/receiverhelper
+
+replace go.opentelemetry.io/collector/config/configoptional => ../../config/configoptional

--- a/otelcol/testdata/config_with_sensitive_data.yaml
+++ b/otelcol/testdata/config_with_sensitive_data.yaml
@@ -1,0 +1,31 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+        tls:
+          cert_file: /path/to/cert.pem
+          key_file: /path/to/key.pem
+          client_ca_file: /path/to/ca.pem
+      http:
+        endpoint: localhost:4318
+        tls:
+          cert_file: /path/to/http-cert.pem
+          key_file: /path/to/http-key.pem
+
+exporters:
+  otlp:
+    endpoint: https://example.com:4317
+    headers:
+      authorization: "Bearer secret-token"
+      x-api-key: "super-secret-key"
+    tls:
+      cert_file: /path/to/client-cert.pem
+      key_file: /path/to/client-key.pem
+      ca_file: /path/to/ca.pem
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/service/README.md
+++ b/service/README.md
@@ -155,3 +155,13 @@ extensions:
 ```bash
    ./otelcorecol print-initial-config --config=file:file.yaml --config=http:http://remote:8080/config --config=file:file2.yaml
 ```
+
+This command shows the resolved configuration before validation, which may contain sensitive values.
+
+## How to examine the validated configuration with component defaults applied?
+
+```bash
+   ./otelcorecol print-config --config=file:examples/local/otel-config.yaml --format=yaml
+```
+
+This command validates the configuration through the full component pipeline and shows the final configuration with all component defaults resolved. Sensitive values (like headers and certificates) are redacted for security. Supports both `--format=yaml` and `--format=json` output.

--- a/service/go.mod
+++ b/service/go.mod
@@ -245,3 +245,21 @@ replace go.opentelemetry.io/collector/config/configmiddleware => ../config/confi
 replace go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest => ../extension/extensionmiddleware/extensionmiddlewaretest
 
 replace go.opentelemetry.io/collector/pdata/xpdata => ../pdata/xpdata
+
+replace go.opentelemetry.io/collector/consumer/consumererror/xconsumererror => ../consumer/consumererror/xconsumererror
+
+replace go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper => ../exporter/exporterhelper/xexporterhelper
+
+replace go.opentelemetry.io/collector/receiver/receiverhelper => ../receiver/receiverhelper
+
+replace go.opentelemetry.io/collector/config/configoptional => ../config/configoptional
+
+replace go.opentelemetry.io/collector/config/confignet => ../config/confignet
+
+replace go.opentelemetry.io/collector/receiver/otlpreceiver => ../receiver/otlpreceiver
+
+replace go.opentelemetry.io/collector/exporter/otlpexporter => ../exporter/otlpexporter
+
+replace go.opentelemetry.io/collector/config/configgrpc => ../config/configgrpc
+
+replace go.opentelemetry.io/collector/internal/sharedcomponent => ../internal/sharedcomponent

--- a/service/hostcapabilities/go.mod
+++ b/service/hostcapabilities/go.mod
@@ -97,3 +97,21 @@ replace go.opentelemetry.io/collector/config/configmiddleware => ../../config/co
 replace go.opentelemetry.io/collector/extension/extensionmiddleware => ../../extension/extensionmiddleware
 
 replace go.opentelemetry.io/collector/pdata/xpdata => ../../pdata/xpdata
+
+replace go.opentelemetry.io/collector/consumer/consumererror/xconsumererror => ../../consumer/consumererror/xconsumererror
+
+replace go.opentelemetry.io/collector/config/configgrpc => ../../config/configgrpc
+
+replace go.opentelemetry.io/collector/internal/sharedcomponent => ../../internal/sharedcomponent
+
+replace go.opentelemetry.io/collector/config/confignet => ../../config/confignet
+
+replace go.opentelemetry.io/collector/config/configoptional => ../../config/configoptional
+
+replace go.opentelemetry.io/collector/receiver/receiverhelper => ../../receiver/receiverhelper
+
+replace go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper => ../../exporter/exporterhelper/xexporterhelper
+
+replace go.opentelemetry.io/collector/exporter/otlpexporter => ../../exporter/otlpexporter
+
+replace go.opentelemetry.io/collector/receiver/otlpreceiver => ../../receiver/otlpreceiver


### PR DESCRIPTION

This PR introduces two distinct print commands to provide different views of the OpenTelemetry Collector configuration:

In my opinion, the `print-initial-config` command is dangerous because it prints a raw configuration object as `map[string]string` instead of printing the structured object with its correct configuration type. I would advocate to remove this feature instead of finishing the feature gate because it allows printing redacted strings.

The new command parses the configuration using the correct type, then prints it but does not validate it. It will be useful for a user to both debug validation problems and to see the exact configuration a component is using, by default, after configuration has been applied.

## New/Modified Commands:

- print-initial-config - (Modified) Shows the raw resolved configuration before validation (may contain sensitive values)
- print-config - (New) Shows the validated configuration with component defaults applied and sensitive data redacted

Both commands support --format flag with yaml and json options:
- print-config validates configuration through the full component pipeline and redacts sensitive data
- print-initial-config shows raw configuration values without validation (behind feature gate)

Documented, tested.
