### PR TITLE
[chore] [pdata] Use internal.CopyOrigSlice for pcommon.Slice

### DIFF
--- a/pdata/pcommon/slice.go
+++ b/pdata/pcommon/slice.go
@@ -78,17 +78,7 @@ func (es Slice) All() iter.Seq2[int, Value] {
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es Slice) CopyTo(dest Slice) {
 	dest.getState().AssertMutable()
-	srcLen := es.Len()
-	destCap := cap(*dest.getOrig())
-	if srcLen <= destCap {
-		(*dest.getOrig()) = (*dest.getOrig())[:srcLen:destCap]
-	} else {
-		(*dest.getOrig()) = make([]otlpcommon.AnyValue, srcLen)
-	}
-
-	for i := range *es.getOrig() {
-		newValue(&(*es.getOrig())[i], es.getState()).CopyTo(newValue(&(*dest.getOrig())[i], dest.getState()))
-	}
+	*dest.getOrig() = internal.CopyOrigSlice(*dest.getOrig(), *es.getOrig())
 }
 
 // EnsureCapacity is an operation that ensures the slice has at least the specified capacity.


### PR DESCRIPTION
This was missed in https://github.com/open-telemetry/opentelemetry-collector/pull/13267