### PR TITLE
[DO NOT MERGE] [pdata] Try append for slice.CopyTo

### DIFF
--- a/pdata/internal/wrapper_slice.go
+++ b/pdata/internal/wrapper_slice.go
@@ -25,12 +25,9 @@ func NewSlice(orig *[]otlpcommon.AnyValue, state *State) Slice {
 }
 
 func CopyOrigSlice(dest, src []otlpcommon.AnyValue) []otlpcommon.AnyValue {
-	if cap(dest) < len(src) {
-		dest = make([]otlpcommon.AnyValue, len(src))
-	}
-	dest = dest[:len(src)]
+	dest = dest[:0]
 	for i := 0; i < len(src); i++ {
-		CopyOrigValue(&dest[i], &src[i])
+		dest = append(dest, CopyValue(src[i]))
 	}
 	return dest
 }

--- a/pdata/internal/wrapper_slice_test.go
+++ b/pdata/internal/wrapper_slice_test.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/pdata/internal"
+
+import (
+	"testing"
+
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
+)
+
+func BenchmarkCopyOrigSlice(b *testing.B) {
+	tests := []struct {
+		name   string
+		srcLen int
+	}{
+		{name: "0_to_7", srcLen: 0},
+		{name: "1_to_7", srcLen: 1},
+		{name: "7_to_7", srcLen: 7},
+		{name: "10_to_7", srcLen: 10},
+		{name: "20_to_7", srcLen: 20},
+		{name: "50_to_7", srcLen: 50},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			src := make([]otlpcommon.AnyValue, tt.srcLen)
+			for i := 0; i < tt.srcLen; i++ {
+				src[i] = otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "test_value"}}
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				dest := GenerateTestSlice()
+				CopyOrigSlice(*dest.orig, src)
+			}
+		})
+	}
+}

--- a/pdata/internal/wrapper_value.go
+++ b/pdata/internal/wrapper_value.go
@@ -62,6 +62,31 @@ func CopyOrigValue(dest, src *otlpcommon.AnyValue) {
 	}
 }
 
+func CopyValue(src otlpcommon.AnyValue) otlpcommon.AnyValue {
+	switch sv := src.Value.(type) {
+	case *otlpcommon.AnyValue_KvlistValue:
+		mv := &otlpcommon.AnyValue_KvlistValue{KvlistValue: &otlpcommon.KeyValueList{}}
+		if sv.KvlistValue != nil {
+			mv.KvlistValue.Values = CopyOrigMap(mv.KvlistValue.Values, sv.KvlistValue.Values)
+		}
+		return otlpcommon.AnyValue{Value: mv}
+	case *otlpcommon.AnyValue_ArrayValue:
+		dv := &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{}}
+		if sv.ArrayValue != nil {
+			dv.ArrayValue.Values = CopyOrigSlice(dv.ArrayValue.Values, sv.ArrayValue.Values)
+		}
+		return otlpcommon.AnyValue{Value: dv}
+	case *otlpcommon.AnyValue_BytesValue:
+		bv := &otlpcommon.AnyValue_BytesValue{}
+		bv.BytesValue = make([]byte, len(sv.BytesValue))
+		copy(bv.BytesValue, sv.BytesValue)
+		return otlpcommon.AnyValue{Value: bv}
+	default:
+		// Primitive immutable type, no need for deep copy.
+		return otlpcommon.AnyValue{Value: sv}
+	}
+}
+
 func FillTestValue(dest Value) {
 	dest.orig.Value = &otlpcommon.AnyValue_StringValue{StringValue: "v"}
 }


### PR DESCRIPTION
Trying consolidating the CopyTo logic for slices as suggested in https://github.com/open-telemetry/opentelemetry-collector/pull/13267#discussion_r2168540752

@bogdandrutu looks like the compiler is not that smart and we cannot use the append approach for the complex slices. See the results:

before
```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/collector/pdata/internal
cpu: Apple M1 Max
BenchmarkCopyOrigSlice
BenchmarkCopyOrigSlice/0_to_7-10         	 6696460	       187.7 ns/op	     252 B/op	      10 allocs/op
BenchmarkCopyOrigSlice/1_to_7-10         	 6324669	       181.4 ns/op	     252 B/op	      10 allocs/op
BenchmarkCopyOrigSlice/7_to_7-10         	 6145800	       191.6 ns/op	     252 B/op	      10 allocs/op
BenchmarkCopyOrigSlice/10_to_7-10        	 4897490	       247.2 ns/op	     412 B/op	      11 allocs/op
BenchmarkCopyOrigSlice/20_to_7-10        	 3922288	       306.8 ns/op	     572 B/op	      11 allocs/op
BenchmarkCopyOrigSlice/50_to_7-10        	 2775319	       430.0 ns/op	    1148 B/op	      11 allocs/op
PASS
```

after
```
BenchmarkCopyOrigSlice/0_to_7-10         	 6255495	       188.3 ns/op	     252 B/op	      10 allocs/op
BenchmarkCopyOrigSlice/1_to_7-10         	 5359400	       186.6 ns/op	     252 B/op	      10 allocs/op
BenchmarkCopyOrigSlice/7_to_7-10         	 5916748	       206.2 ns/op	     252 B/op	      10 allocs/op
BenchmarkCopyOrigSlice/10_to_7-10        	 4371021	       264.9 ns/op	     476 B/op	      11 allocs/op
BenchmarkCopyOrigSlice/20_to_7-10        	 3081704	       395.6 ns/op	     924 B/op	      12 allocs/op
BenchmarkCopyOrigSlice/50_to_7-10        	 1881642	       631.2 ns/op	    1948 B/op	      13 allocs/op
PASS
```

10 allocations are spent to regenerate the destination slice