### PR TITLE
service: allow telemetry.Factory to be injected

### DIFF
--- a/otelcol/factories.go
+++ b/otelcol/factories.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/service/telemetry"
 )
 
 // Factories struct holds in a single type all component factories that
@@ -31,6 +32,9 @@ type Factories struct {
 
 	// Connectors maps connector type names in the config to the respective factory.
 	Connectors map[component.Type]connector.Factory
+
+	// Telemetry holds a factory for the collector's internal telemetry.
+	Telemetry telemetry.Factory
 
 	// ReceiverModules maps receiver types to their respective go modules.
 	ReceiverModules map[component.Type]string

--- a/otelcol/unmarshaler.go
+++ b/otelcol/unmarshaler.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/service"
-	"go.opentelemetry.io/collector/service/telemetry"
 )
 
 type configSettings struct {
@@ -27,9 +26,6 @@ type configSettings struct {
 // unmarshal the configSettings from a confmap.Conf.
 // After the config is unmarshalled, `Validate()` must be called to validate.
 func unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
-	telFactory := telemetry.NewFactory()
-	defaultTelConfig := *telFactory.CreateDefaultConfig().(*telemetry.Config)
-
 	// Unmarshal top level sections and validate.
 	cfg := &configSettings{
 		Receivers:  configunmarshaler.NewConfigs(factories.Receivers),
@@ -39,7 +35,7 @@ func unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
 		Extensions: configunmarshaler.NewConfigs(factories.Extensions),
 		// TODO: Add a component.ServiceFactory to allow this to be defined by the Service.
 		Service: service.Config{
-			Telemetry: defaultTelConfig,
+			Telemetry: factories.Telemetry.CreateDefaultConfig(),
 		},
 	}
 

--- a/service/config.go
+++ b/service/config.go
@@ -4,15 +4,15 @@
 package service // import "go.opentelemetry.io/collector/service"
 
 import (
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/service/extensions"
 	"go.opentelemetry.io/collector/service/pipelines"
-	"go.opentelemetry.io/collector/service/telemetry"
 )
 
 // Config defines the configurable components of the Service.
 type Config struct {
 	// Telemetry is the configuration for collector's own telemetry.
-	Telemetry telemetry.Config `mapstructure:"telemetry"`
+	Telemetry component.Config `mapstructure:"telemetry"`
 
 	// Extensions are the ordered list of extensions configured for the service.
 	Extensions extensions.Config `mapstructure:"extensions,omitempty"`

--- a/service/telemetry/attributes.go
+++ b/service/telemetry/attributes.go
@@ -1,16 +1,14 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package service // import "go.opentelemetry.io/collector/service"
+package telemetry // import "go.opentelemetry.io/collector/service/telemetry"
 
 import (
 	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
-
-	"go.opentelemetry.io/collector/service/telemetry"
 )
 
-func attributes(res *sdkresource.Resource, cfg telemetry.Config) []config.AttributeNameValue {
+func attributes(res *sdkresource.Resource, cfg telemetryConfig) []config.AttributeNameValue {
 	attrsMap := map[string]any{}
 	for _, r := range res.Attributes() {
 		attrsMap[string(r.Key)] = r.Value.AsString()

--- a/service/telemetry/attributes_test.go
+++ b/service/telemetry/attributes_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package service // import "go.opentelemetry.io/collector/service"
+package telemetry // import "go.opentelemetry.io/collector/service/telemetry"
 
 import (
 	"testing"

--- a/service/telemetry/metrics.go
+++ b/service/telemetry/metrics.go
@@ -4,22 +4,167 @@
 package telemetry // import "go.opentelemetry.io/collector/service/telemetry"
 
 import (
-	"errors"
-
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/noop"
+	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+	semconv118 "go.opentelemetry.io/otel/semconv/v1.18.0"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
-// newMeterProvider creates a new MeterProvider from Config.
-func newMeterProvider(set Settings, cfg Config) (metric.MeterProvider, error) {
-	if cfg.Metrics.Level == configtelemetry.LevelNone || len(cfg.Metrics.Readers) == 0 {
-		return noop.NewMeterProvider(), nil
+// TODO views should be passed in as options to Factory.CreateMeterProvider
+// from the service package, so they are independent of the telemetry
+// implementation. This isn't workable at present as sdk.MeterProvider()
+// does not allow options.
+
+func dropViewOption(selector *config.ViewSelector) config.View {
+	return config.View{
+		Selector: selector,
+		Stream: &config.ViewStream{
+			Aggregation: &config.ViewStreamAggregation{
+				Drop: config.ViewStreamAggregationDrop{},
+			},
+		},
+	}
+}
+
+func configureViews(level configtelemetry.Level) []config.View {
+	views := []config.View{}
+
+	if level < configtelemetry.LevelDetailed {
+		// Drop all otelhttp and otelgrpc metrics if the level is not detailed.
+		views = append(views,
+			dropViewOption(&config.ViewSelector{
+				MeterName: ptr("go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"),
+			}),
+			dropViewOption(&config.ViewSelector{
+				MeterName: ptr("go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"),
+			}),
+		)
 	}
 
-	if set.SDK != nil {
-		return set.SDK.MeterProvider(), nil
+	// Make sure to add the AttributeKeys view after the AggregationDrop view:
+	// Only the first view outputting a given metric identity is actually used, so placing the
+	// AttributeKeys view first would never drop the metrics regadless of level.
+	if disableHighCardinalityMetricsFeatureGate.IsEnabled() {
+		views = append(views, []config.View{
+			{
+				Selector: &config.ViewSelector{
+					MeterName: ptr("go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"),
+				},
+				Stream: &config.ViewStream{
+					AttributeKeys: &config.IncludeExclude{
+						Excluded: []string{
+							string(semconv118.NetSockPeerAddrKey),
+							string(semconv118.NetSockPeerPortKey),
+							string(semconv118.NetSockPeerNameKey),
+						},
+					},
+				},
+			},
+			{
+				Selector: &config.ViewSelector{
+					MeterName: ptr("go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"),
+				},
+				Stream: &config.ViewStream{
+					AttributeKeys: &config.IncludeExclude{
+						Excluded: []string{
+							string(semconv118.NetHostNameKey),
+							string(semconv118.NetHostPortKey),
+						},
+					},
+				},
+			},
+		}...)
 	}
-	return nil, errors.New("no sdk set")
+
+	// otel-arrow library metrics
+	// See https://github.com/open-telemetry/otel-arrow/blob/c39257/pkg/otel/arrow_record/consumer.go#L174-L176
+	if level < configtelemetry.LevelNormal {
+		scope := ptr("otel-arrow/pkg/otel/arrow_record")
+		views = append(views,
+			dropViewOption(&config.ViewSelector{
+				MeterName:      scope,
+				InstrumentName: ptr("arrow_batch_records"),
+			}),
+			dropViewOption(&config.ViewSelector{
+				MeterName:      scope,
+				InstrumentName: ptr("arrow_schema_resets"),
+			}),
+			dropViewOption(&config.ViewSelector{
+				MeterName:      scope,
+				InstrumentName: ptr("arrow_memory_inuse"),
+			}),
+		)
+	}
+
+	// contrib's internal/otelarrow/netstats metrics
+	// See
+	// - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/a25f05/internal/otelarrow/netstats/netstats.go#L130
+	// - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/a25f05/internal/otelarrow/netstats/netstats.go#L165
+	if level < configtelemetry.LevelDetailed {
+		scope := ptr("github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow/netstats")
+
+		views = append(views,
+			// Compressed size metrics.
+			dropViewOption(&config.ViewSelector{
+				MeterName:      scope,
+				InstrumentName: ptr("otelcol_*_compressed_size"),
+			}),
+			dropViewOption(&config.ViewSelector{
+				MeterName:      scope,
+				InstrumentName: ptr("otelcol_*_compressed_size"),
+			}),
+
+			// makeRecvMetrics for exporters.
+			dropViewOption(&config.ViewSelector{
+				MeterName:      scope,
+				InstrumentName: ptr("otelcol_exporter_recv"),
+			}),
+			dropViewOption(&config.ViewSelector{
+				MeterName:      scope,
+				InstrumentName: ptr("otelcol_exporter_recv_wire"),
+			}),
+
+			// makeSentMetrics for receivers.
+			dropViewOption(&config.ViewSelector{
+				MeterName:      scope,
+				InstrumentName: ptr("otelcol_receiver_sent"),
+			}),
+			dropViewOption(&config.ViewSelector{
+				MeterName:      scope,
+				InstrumentName: ptr("otelcol_receiver_sent_wire"),
+			}),
+		)
+	}
+
+	// Batch processor metrics
+	scope := ptr("go.opentelemetry.io/collector/processor/batchprocessor")
+	if level < configtelemetry.LevelNormal {
+		views = append(views, dropViewOption(&config.ViewSelector{
+			MeterName: scope,
+		}))
+	} else if level < configtelemetry.LevelDetailed {
+		views = append(views, dropViewOption(&config.ViewSelector{
+			MeterName:      scope,
+			InstrumentName: ptr("otelcol_processor_batch_batch_send_size_bytes"),
+		}))
+	}
+
+	// Internal graph metrics
+	graphScope := ptr("go.opentelemetry.io/collector/service")
+	if level < configtelemetry.LevelDetailed {
+		views = append(views, dropViewOption(&config.ViewSelector{
+			MeterName:      graphScope,
+			InstrumentName: ptr("otelcol.*.consumed.size"),
+		}))
+		views = append(views, dropViewOption(&config.ViewSelector{
+			MeterName:      graphScope,
+			InstrumentName: ptr("otelcol.*.produced.size"),
+		}))
+	}
+
+	return views
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/service/telemetry/providers.go
+++ b/service/telemetry/providers.go
@@ -1,0 +1,97 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/multierr"
+
+	"go.opentelemetry.io/collector/service/internal/resource"
+)
+
+func newProviders(ctx context.Context, set Settings, cfg telemetryConfig) (_ Providers, resultErr error) {
+	res := resource.New(set.BuildInfo, cfg.Resource)
+	sdk, err := newSDK(ctx, set, cfg, res)
+	if err != nil {
+		return Providers{}, fmt.Errorf("failed to create SDK: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = multierr.Append(resultErr, sdk.Shutdown(ctx))
+		}
+	}()
+
+	logger, loggerProvider, err := newLogger(ctx, set, cfg, res, sdk)
+	if err != nil {
+		return Providers{}, fmt.Errorf("failed to create logger provider: %w", err)
+	}
+
+	var meterProvider metric.MeterProvider
+	if cfg.Metrics.Level == configtelemetry.LevelNone || len(cfg.Metrics.Readers) == 0 {
+		logger.Info("Internal metrics telemetry disabled")
+		meterProvider = noopmetric.NewMeterProvider()
+	} else {
+		meterProvider = sdk.MeterProvider()
+	}
+
+	var tracerProvider trace.TracerProvider
+	if noopTracerProvider.IsEnabled() || cfg.Traces.Level == configtelemetry.LevelNone {
+		logger.Info("Internal trace telemetry disabled")
+		tracerProvider = &noopNoContextTracerProvider{}
+	} else {
+		propagator, err := textMapPropagatorFromConfig(cfg.Traces.Propagators)
+		if err != nil {
+			return Providers{}, err
+		}
+		otel.SetTextMapPropagator(propagator)
+		tracerProvider = sdk.TracerProvider()
+	}
+
+	return Providers{
+		Logger:         logger,
+		LoggerProvider: loggerProvider,
+		MeterProvider:  meterProvider,
+		TracerProvider: tracerProvider,
+	}, nil
+}
+
+func newSDK(ctx context.Context, set Settings, cfg telemetryConfig, res *sdkresource.Resource) (*config.SDK, error) {
+	sch := semconv.SchemaURL
+
+	mpConfig := &cfg.Metrics.MeterProvider
+	if mpConfig.Views == nil {
+		mpConfig.Views = configureViews(cfg.Metrics.Level)
+	}
+	if cfg.Metrics.Level == configtelemetry.LevelNone {
+		mpConfig.Readers = []config.MetricReader{}
+	}
+
+	sdk, err := config.NewSDK(
+		config.WithContext(ctx),
+		config.WithOpenTelemetryConfiguration(
+			config.OpenTelemetryConfiguration{
+				LoggerProvider: &config.LoggerProvider{
+					Processors: cfg.Logs.Processors,
+				},
+				MeterProvider:  mpConfig,
+				TracerProvider: &cfg.Traces.TracerProvider,
+				Resource: &config.Resource{
+					SchemaUrl:  &sch,
+					Attributes: attributes(res, cfg),
+				},
+			},
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SDK: %w", err)
+	}
+	return &sdk, nil
+}

--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -8,13 +8,11 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/contrib/propagators/b3"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
 	"go.opentelemetry.io/otel/trace/noop"
 
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/featuregate"
 )
 
@@ -48,24 +46,6 @@ type noopNoContextTracerProvider struct {
 
 func (n *noopNoContextTracerProvider) Tracer(_ string, _ ...trace.TracerOption) trace.Tracer {
 	return &noopNoContextTracer{}
-}
-
-// newTracerProvider creates a new TracerProvider from Config.
-func newTracerProvider(set Settings, cfg Config) (trace.TracerProvider, error) {
-	if noopTracerProvider.IsEnabled() || cfg.Traces.Level == configtelemetry.LevelNone {
-		return &noopNoContextTracerProvider{}, nil
-	}
-
-	if tp, err := textMapPropagatorFromConfig(cfg.Traces.Propagators); err == nil {
-		otel.SetTextMapPropagator(tp)
-	} else {
-		return nil, err
-	}
-
-	if set.SDK != nil {
-		return set.SDK.TracerProvider(), nil
-	}
-	return nil, errors.New("no sdk set")
 }
 
 func textMapPropagatorFromConfig(props []string) (propagation.TextMapPropagator, error) {


### PR DESCRIPTION
#### Description

- Change service.Config.Telemetry's type to component.Config, so the concrete type can be controlled by the factory.
- Add service.Config.Settings.TelemetryFactory, so callers (i.e. otelcol) can inject the factory.
- Add otelcol.Factories.Telemetry, so distributions can control the telemetry factory, and inject it into the service settings.
- Change the telemetry.Factory interface to create all the providers together. There's a few reasons for this:
  * The service always creates all of them
  * At least in the default implementation, they are tightly coupled in that they share an SDK object
  * It simplifies accessing the logger during creation of meter and tracer providers, e.g. to log that they are disabled
- Add a telemetry.Factory method for creating a pcommon.Resource. This is needed since the resource may be configured through service::telemetry, which is now opaque to the service code.
- Move the view configuration into service/telemetry. This is not ideal, and should rather be injected as options when creating the MeterProvider. This is not currently possible, as otelconf does not support it.

#### Link to tracking issue
Fixes #4970

#### Testing

<!--Describe the documentation added.-->

#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
