### PR TITLE
Update release procedure document

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -87,9 +87,9 @@ Before the release, make sure there are no open release blockers in [core](https
 
    - `make push-tags MODSET=contrib-base`
 
-4. Wait for the new tag build to pass successfully.
+4. Wait for the new tag build to pass successfully. A new `v0.85.0` release should be automatically created on Github by now, with the description containing the changelog for the new release.
 
-5. A new `v0.85.0` release should be automatically created on Github by now. Edit it and use the contents from the CHANGELOG.md as the release's description. At the top of the release notes add a section listing the unmaintained components ([example](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.114.0)).
+5. Manually edit the release description, and add a section listing the unmaintained components at the top ([example](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.114.0)). The list of unmaintained components can be found by [searching for issues with the "unmaintained" label](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue%20state%3Aopen%20label%3Aunmaintained).
 
 ## Producing the artifacts
 
@@ -137,7 +137,16 @@ releases and add new schedules to the bottom of the list.
 ## Troubleshooting
 
 1. `unknown revision internal/coreinternal/v0.85.0` -- This is typically an indication that there's a dependency on a new module. You can fix it by adding a new `replaces` entry to the `go.mod` for the affected module.
-2. `commitChangesToNewBranch failed: invalid merge` -- This is a [known issue](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/47) with our release tooling. The current workaround is to clone a fresh copy of the repository and try again. Note that you may need to set up a `fork` remote pointing to your own fork for the release tooling to work properly.
+2. `unable to tag modules: unable to load repo config: branch config: invalid merge` when running `make push-tags` -- This is a [known issue](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/47) with our release tooling, caused by a bug in `go-git`.
+
+    It occurs if you have branches in your local repository whose entry in `.git/config` has a `merge` attribute not starting with `refs/heads`. This can typically happen when checking out PR branches using the Github CLI tool, for which the `merge` attribute starts with `refs/pull`.
+
+    A possible workaround is to:
+    - Comment out the problematic lines with `sed -E -i.bak 's/(merge = refs\/pull)/#\1/' .git/config`;
+    - Try `make push-tags` again;
+    - Restore the config with `mv .git/config.bak .git/config`.
+
+    If that doesn't work, you can clone a fresh copy of the repository and try again. Note that you may need to set up a `fork` remote pointing to your own fork for the release tooling to work properly.
 3. `could not run Go Mod Tidy: go mod tidy failed` when running `multimod` -- This is a [known issue](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/46) with our release tooling. The current workaround is to run `make gotidy` manually after the multimod tool fails and commit the result.
 4. `Incorrect version "X" of "go.opentelemetry.io/collector/component" is included in "X"` in CI after `make update-otel` -- It could be because the make target was run too soon after updating Core and the goproxy hasn't updated yet.  Try running `export GOPROXY=direct` and then `make update-otel`.
 5. `error: failed to push some refs to 'https://github.com/open-telemetry/opentelemetry-collector-contrib.git'` during `make push-tags` -- If you encounter this error the `make push-tags` target will terminate without pushing all the tags. Using the output of the `make push-tags` target, save all the un-pushed the tags in `tags.txt` and then use this make target to complete the push:
@@ -161,8 +170,6 @@ releases and add new schedules to the bottom of the list.
    fix and re-run the release; it is safe to re-run the workflows that already
    succeeded. Publishing container images can be done multiple times, and
    publishing artifacts to GitHub will fail without any adverse effects.
-
-8. `unable to tag modules: unable to load repo config: branch config: invalid merge` when running `make push-tags` -- this is likely a bug with go-git. The current work-around is to clone the repository again and push the tags from the fresh clone.  
 
 ## Bugfix releases
 
@@ -219,8 +226,6 @@ Once a module is ready to be released under the `1.x` version scheme, file a PR 
 
 | Date       | Version  | Release manager                                      |
 |------------|----------|------------------------------------------------------|
-| 2025-06-09 | v0.128.0 | [@bogdandrutu](https://github.com/bogdandrutu)       |
-| 2025-06-30 | v0.129.0 | [@jade-guiton-dd](https://github.com/jade-guiton-dd) |
 | 2025-07-14 | v0.130.0 | [@jmacd](https://github.com/jmacd)                   |
 | 2025-07-28 | v0.131.0 | [@mx-psi](https://github.com/mx-psi)                 |
 | 2025-08-11 | v0.132.0 | [@evan-bradley](https://github.com/evan-bradley)     |
@@ -228,4 +233,6 @@ Once a module is ready to be released under the `1.x` version scheme, file a PR 
 | 2025-09-08 | v0.134.0 | [@atoulme](https://github.com/atoulme)               |
 | 2025-09-22 | v0.135.0 | [@songy23](https://github.com/songy23)               |
 | 2025-10-06 | v0.136.0 | [@dmitryax](https://github.com/dmitryax)             |
-| 2025-10-13 | v0.137.0 | [@codeboten](https://github.com/codeboten)           |
+| 2025-10-20 | v0.137.0 | [@codeboten](https://github.com/codeboten)           |
+| 2025-11-03 | v0.138.0 | [@bogdandrutu](https://github.com/bogdandrutu)       |
+| 2025-11-17 | v0.139.0 | [@jade-guiton-dd](https://github.com/jade-guiton-dd) |


### PR DESCRIPTION
#### Description

A few changes:
- Update the section about releasing `collector-contrib` to reflect the fact that the Github release is now automatically populated with the changelog (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38730)
- Update recommendations for dealing with https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/47 with a new workaround (commenting out the unrecognized "merge" entries in `.git/config`)
- Remove what looks like a second reference to the same issue?
- Put myself and Bogdan back at the end of the release rotation
- Correct the date for the release of v0.137.0, which is only one week after v0.136.0. Feel free to tell me if this wasn't a mistake.