### PR TITLE
[service] Enable scope information in default Prometheus exporter

### DIFF
--- a/.chloggen/prom_enable_scope_info.yaml
+++ b/.chloggen/prom_enable_scope_info.yaml
@@ -1,0 +1,38 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Default internal metrics config now enables `otel_scope_` labels
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  By default, the Collector exports its internal metrics using a Prometheus
+  exporter from the opentelemetry-go repository. With this change, the Collector
+  no longer sets "without_scope_info" to true in its configuration.
+
+  This means that all exported metrics will have `otel_scope_name`,
+  `otel_scope_schema_url`, and `otel_scope_version` labels corresponding to the
+  instrumentation scope metadata for that metric.
+
+  This notably prevents an error when multiple metrics are only distinguished
+  by their instrumentation scopes and end up aliased during export.
+
+  If this is not desired behavior, a Prometheus exporter can be explicitly
+  configured with this option enabled.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/prom_enable_scope_info.yaml
+++ b/.chloggen/prom_enable_scope_info.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: breaking
+change_type: 'bug_fix'
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: service
@@ -10,7 +10,7 @@ component: service
 note: Default internal metrics config now enables `otel_scope_` labels
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [12939, 13344]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -4,7 +4,7 @@ module go.opentelemetry.io/collector/cmd/otelcorecol
 
 go 1.23.0
 
-toolchain go1.23.10
+toolchain go1.24.4
 
 require (
 	go.opentelemetry.io/collector/component v1.35.0

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -4,7 +4,7 @@ module go.opentelemetry.io/collector/cmd/otelcorecol
 
 go 1.23.0
 
-toolchain go1.24.4
+toolchain go1.23.10
 
 require (
 	go.opentelemetry.io/collector/component v1.35.0

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -113,7 +113,6 @@ func TestConfmapMarshalConfig(t *testing.T) {
 									"with_resource_constant_labels": map[string]any{
 										"included": []any{},
 									},
-									"without_scope_info":  true,
 									"without_type_suffix": true,
 									"without_units":       true,
 								},

--- a/service/internal/promtest/server_util.go
+++ b/service/internal/promtest/server_util.go
@@ -36,7 +36,6 @@ func addrToPrometheus(address string) *config.Prometheus {
 	return &config.Prometheus{
 		Host:              &host,
 		Port:              &portInt,
-		WithoutScopeInfo:  ptr(true),
 		WithoutUnits:      ptr(true),
 		WithoutTypeSuffix: ptr(true),
 		WithResourceConstantLabels: &config.IncludeExclude{

--- a/service/telemetry/factory.go
+++ b/service/telemetry/factory.go
@@ -104,7 +104,6 @@ func createDefaultConfig() component.Config {
 				Readers: []config.MetricReader{
 					{
 						Pull: &config.PullMetricReader{Exporter: config.PullMetricExporter{Prometheus: &config.Prometheus{
-							WithoutScopeInfo:  newPtr(true),
 							WithoutUnits:      newPtr(true),
 							WithoutTypeSuffix: newPtr(true),
 							Host:              &metricsHost,

--- a/service/telemetry/metrics_test.go
+++ b/service/telemetry/metrics_test.go
@@ -28,6 +28,7 @@ const (
 	otelPrefix   = "otel_sdk_"
 	grpcPrefix   = "grpc_"
 	httpPrefix   = "http_"
+	scopeName    = "collector_test"
 	counterName  = "test_counter"
 )
 
@@ -49,30 +50,39 @@ func TestTelemetryInit(t *testing.T) {
 				metricPrefix + otelPrefix + counterName: {
 					value: 13,
 					labels: map[string]string{
-						"service_name":        "otelcol",
-						"service_version":     "latest",
-						"service_instance_id": testInstanceID,
+						"service_name":          "otelcol",
+						"service_version":       "latest",
+						"service_instance_id":   testInstanceID,
+						"otel_scope_name":       scopeName,
+						"otel_scope_schema_url": "",
+						"otel_scope_version":    "",
 					},
 				},
 				metricPrefix + grpcPrefix + counterName: {
 					value: 11,
 					labels: map[string]string{
-						"net_sock_peer_addr":  "",
-						"net_sock_peer_name":  "",
-						"net_sock_peer_port":  "",
-						"service_name":        "otelcol",
-						"service_version":     "latest",
-						"service_instance_id": testInstanceID,
+						"net_sock_peer_addr":    "",
+						"net_sock_peer_name":    "",
+						"net_sock_peer_port":    "",
+						"service_name":          "otelcol",
+						"service_version":       "latest",
+						"service_instance_id":   testInstanceID,
+						"otel_scope_name":       "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc",
+						"otel_scope_schema_url": "",
+						"otel_scope_version":    "",
 					},
 				},
 				metricPrefix + httpPrefix + counterName: {
 					value: 10,
 					labels: map[string]string{
-						"net_host_name":       "",
-						"net_host_port":       "",
-						"service_name":        "otelcol",
-						"service_version":     "latest",
-						"service_instance_id": testInstanceID,
+						"net_host_name":         "",
+						"net_host_port":         "",
+						"service_name":          "otelcol",
+						"service_version":       "latest",
+						"service_instance_id":   testInstanceID,
+						"otel_scope_name":       "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+						"otel_scope_schema_url": "",
+						"otel_scope_version":    "",
 					},
 				},
 				"target_info": {
@@ -160,7 +170,7 @@ func TestTelemetryInit(t *testing.T) {
 
 func createTestMetrics(t *testing.T, mp metric.MeterProvider) {
 	// Creates a OTel Go counter
-	counter, err := mp.Meter("collector_test").Int64Counter(metricPrefix+otelPrefix+counterName, metric.WithUnit("ms"))
+	counter, err := mp.Meter(scopeName).Int64Counter(metricPrefix+otelPrefix+counterName, metric.WithUnit("ms"))
 	require.NoError(t, err)
 	counter.Add(context.Background(), 13)
 


### PR DESCRIPTION
#### Description

This changes the config for the default Prometheus exporter to remove `disable_scope_info: true`. This prevent errors in the exporter caused by metrics only differentiated by their scope being considered aliasing, which will become more common when the `telemetry.newPipelineTelemetry` feature gate graduates (see tracking issue for details).

I marked this as a "breaking change", but I'm not sure if we make guarantees about the format of the Prometheus metrics we emit?

#### Link to tracking issue

Fixes #12939

#### Testing

I updated some tests to reflect the additional labels added to Prometheus metrics.

I performed manual testing and confirmed that the reproduction case in the tracking issue no longer emits an error when the feature gate is enabled.
