### PR TITLE
[chore] update readme badges to align the sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   <a href="https://github.com/open-telemetry/opentelemetry-collector/releases">
     <img alt="GitHub release (latest by date including pre-releases)" src="https://img.shields.io/github/v/release/open-telemetry/opentelemetry-collector?include_prereleases&style=for-the-badge">
   </a>
+  </br>
   <a href="https://www.bestpractices.dev/projects/8404"><img src="https://www.bestpractices.dev/projects/8404/badge">
   </a>
   <a href="https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:opentelemetry">


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The badges currently in main branch:
![image](https://github.com/user-attachments/assets/98486920-7ca2-40a2-b98a-f92b180dea88)

The badges after the fix:
![image](https://github.com/user-attachments/assets/0ea50453-942d-440e-a650-a8672504af01)
Now the smaller ones are at the same line, makes it looks a little bit better.

Sorry this may looks like a spam PR. I created it as I previously can not make my PR go through the merge queue in this repo, as I am still interested in some work in this repo, I raised this pr to test if my commits / CLA can pass the merge queue now. 


<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
