### PR TITLE
[chore] Promote Vihas as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ the role of the [release manager](./docs/release.md#release-manager).
 
 - [Andrzej Stencel](https://github.com/andrzej-stencel), Elastic
 - [Chao Weng](https://github.com/sincejune), AppDynamics
+- [Vihas Makwana](https://github.com/VihasMakwana), Elastic
 - Actively seeking contributors to triage issues
 
 For more information about the triager role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Promotes @VihasMakwana as triager. @VihasMakwana is a contrib triager and has been doing excellent work in core, including pushing for RFCs and features such as #13256, #13224 and #11775. Thank you for your work @VihasMakwana !

cc @open-telemetry/collector-approvers 