### PR TITLE
[chore] convert configgrpc.KeepaliveServerConfig.ServerParameters and…

### DIFF
--- a/.chloggen/13252-configgrpc-keepalive-configoptional.yaml
+++ b/.chloggen/13252-configgrpc-keepalive-configoptional.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update optional fields to use `configoptional.Optional` field for optional values.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13252, 13364]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Specifically, the following fields have been updated to `configoptional`:
+  - `KeepaliveServerConfig.ServerParameters` (`KeepaliveServerParameters` type)
+  - `KeepaliveServerConfig.EnforcementPolicy` (`KeepaliveEnforcementPolicy` type)
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -484,13 +484,13 @@ func (gss *ServerConfig) getGrpcServerOptions(
 	if gss.Keepalive.HasValue() {
 		keepaliveConfig := gss.Keepalive.Get()
 		if keepaliveConfig.ServerParameters.HasValue() {
-			svrParams := keepaliveConfig.ServerParameters
+			svrParams := keepaliveConfig.ServerParameters.Get()
 			opts = append(opts, grpc.KeepaliveParams(keepalive.ServerParameters{
-				MaxConnectionIdle:     svrParams.Get().MaxConnectionIdle,
-				MaxConnectionAge:      svrParams.Get().MaxConnectionAge,
-				MaxConnectionAgeGrace: svrParams.Get().MaxConnectionAgeGrace,
-				Time:                  svrParams.Get().Time,
-				Timeout:               svrParams.Get().Timeout,
+				MaxConnectionIdle:     svrParams.MaxConnectionIdle,
+				MaxConnectionAge:      svrParams.MaxConnectionAge,
+				MaxConnectionAgeGrace: svrParams.MaxConnectionAgeGrace,
+				Time:                  svrParams.Time,
+				Timeout:               svrParams.Timeout,
 			}))
 		}
 		// The default values referenced in the GRPC are set within the server, so this code doesn't need

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -90,8 +90,8 @@ func TestNewDefaultKeepaliveEnforcementPolicy(t *testing.T) {
 
 func TestNewDefaultKeepaliveServerConfig(t *testing.T) {
 	expected := KeepaliveServerConfig{
-		ServerParameters:  ptr(NewDefaultKeepaliveServerParameters()),
-		EnforcementPolicy: ptr(NewDefaultKeepaliveEnforcementPolicy()),
+		ServerParameters:  configoptional.Some(NewDefaultKeepaliveServerParameters()),
+		EnforcementPolicy: configoptional.Some(NewDefaultKeepaliveEnforcementPolicy()),
 	}
 	result := NewDefaultKeepaliveServerConfig()
 	assert.Equal(t, expected, result)
@@ -391,17 +391,17 @@ func TestAllGrpcServerSettingsExceptAuth(t *testing.T) {
 		ReadBufferSize:       1024,
 		WriteBufferSize:      1024,
 		Keepalive: configoptional.Some(KeepaliveServerConfig{
-			ServerParameters: &KeepaliveServerParameters{
+			ServerParameters: configoptional.Some(KeepaliveServerParameters{
 				MaxConnectionIdle:     time.Second,
 				MaxConnectionAge:      time.Second,
 				MaxConnectionAgeGrace: time.Second,
 				Time:                  time.Second,
 				Timeout:               time.Second,
-			},
-			EnforcementPolicy: &KeepaliveEnforcementPolicy{
+			}),
+			EnforcementPolicy: configoptional.Some(KeepaliveEnforcementPolicy{
 				MinTime:             time.Second,
 				PermitWithoutStream: true,
-			},
+			}),
 		}),
 	}
 	opts, err := gss.getGrpcServerOptions(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), []ToServerOption{})

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -122,17 +122,17 @@ func TestUnmarshalConfig(t *testing.T) {
 					ReadBufferSize:       1024,
 					WriteBufferSize:      1024,
 					Keepalive: configoptional.Some(configgrpc.KeepaliveServerConfig{
-						ServerParameters: &configgrpc.KeepaliveServerParameters{
+						ServerParameters: configoptional.Some(configgrpc.KeepaliveServerParameters{
 							MaxConnectionIdle:     11 * time.Second,
 							MaxConnectionAge:      12 * time.Second,
 							MaxConnectionAgeGrace: 13 * time.Second,
 							Time:                  30 * time.Second,
 							Timeout:               5 * time.Second,
-						},
-						EnforcementPolicy: &configgrpc.KeepaliveEnforcementPolicy{
+						}),
+						EnforcementPolicy: configoptional.Some(configgrpc.KeepaliveEnforcementPolicy{
 							MinTime:             10 * time.Second,
 							PermitWithoutStream: true,
-						},
+						}),
 					}),
 				}),
 				HTTP: configoptional.Some(HTTPConfig{


### PR DESCRIPTION
… EnforcementPolicy to configoptional

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
converts `configgrpc.KeepaliveServerConfig.ServerParameters` and `configgrpc.KeepaliveServerConfig.EnforcementPolicy` from pointers to `configoptional` type
<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13250 and follow-up to missed code in #13252 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
existing unit/ci tests
<!--Describe the documentation added.-->
#### Documentation
update chloggen from #13252
<!--Please delete paragraphs that you did not use before submitting.-->
