### PR TITLE
wip: add stability level and semcon ref in mdatagen for metrics

### DIFF
--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -343,7 +343,7 @@ func TestLoadMetadata(t *testing.T) {
 						"request_duration": {
 							Signal: Signal{
 								Enabled:     true,
-								Stability:   Stability{Level: "alpha"},
+								Stability:   Stability{Level: "development"},
 								Description: "Duration of request",
 							},
 							Unit: strPtr("s"),
@@ -370,7 +370,7 @@ func TestLoadMetadata(t *testing.T) {
 						"queue_length": {
 							Signal: Signal{
 								Enabled:               true,
-								Stability:             Stability{Level: "alpha"},
+								Stability:             Stability{Level: "development"},
 								Description:           "This metric is optional and therefore not initialized in NewTelemetryBuilder.",
 								ExtendedDocumentation: "For example this metric only exists if feature A is enabled.",
 							},

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -354,6 +354,9 @@ type Signal struct {
 	// The stability level of the signal.
 	Stability Stability `mapstructure:"stability"`
 
+	// The stability level of the metric.
+	SemanticConvention *SemanticConvention `mapstructure:"semantic_convention"`
+
 	// Extended documentation of the signal. If specified, this will be appended to the description used in generated documentation.
 	ExtendedDocumentation string `mapstructure:"extended_documentation"`
 

--- a/cmd/mdatagen/internal/metric.go
+++ b/cmd/mdatagen/internal/metric.go
@@ -47,6 +47,10 @@ type Metric struct {
 	Prefix string `mapstructure:"prefix"`
 }
 
+type SemanticConvention struct {
+	SemanticConventionRef string `mapstructure:"semconv_ref"`
+}
+
 type Stability struct {
 	Level string `mapstructure:"level"`
 	From  string `mapstructure:"from"`
@@ -62,8 +66,37 @@ func (s Stability) String() string {
 	return fmt.Sprintf(" [%s]", s.Level)
 }
 
+//	func (s *Stability) Unmarshal(parser *confmap.Conf) error {
+//		if !parser.IsSet("stability.level") {
+//			s.Level = "development"
+//		}
+//		return nil
+//	}
+//
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+//func (s *Stability) UnmarshalText(text []byte) error {
+//	switch vtStr := string(text); vtStr {
+//	case "stable":
+//		s.Level = component.StabilityLevelStable.String()
+//	case "deprecated":
+//		s.Level = component.StabilityLevelDeprecated.String()
+//	case "development":
+//		s.Level = component.StabilityLevelDevelopment.String()
+//	default:
+//		s.Level = component.StabilityLevelDevelopment.String()
+//	}
+//	return nil
+//}
+
 func (m *Metric) validate() error {
 	var errs error
+
+	if m.Stability.Level == component.StabilityLevelStable.String() {
+		if m.SemanticConvention.SemanticConventionRef == "" {
+			errs = errors.Join(errs, errors.New(`stable metrics should have stable semantic convention ref set`))
+		}
+	}
+
 	if m.Sum == nil && m.Gauge == nil && m.Histogram == nil {
 		errs = errors.Join(errs, errors.New("missing metric type key, "+
 			"one of the following has to be specified: sum, gauge, histogram"))

--- a/cmd/mdatagen/internal/samplereceiver/documentation.md
+++ b/cmd/mdatagen/internal/samplereceiver/documentation.md
@@ -62,6 +62,28 @@ Monotonic cumulative sum int metric with string input_type enabled by default.
 | slice_attr | Attribute with a slice value. | Any Slice | false |
 | map_attr | Attribute with a map value. | Any Map | false |
 
+### system.cpu.time
+
+Monotonic cumulative sum int metric enabled by default.
+
+The metric will be become optional soon.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability | Semantic Convention |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- | ------------------- |
+| s | Sum | Int | Cumulative | true | stable | [system.cpu.time](https://github.com/open-telemetry/semantic-conventions/blob/v1.35.0/docs/system/system-metrics.md#metric-systemcputime) |
+
+#### Attributes
+
+| Name | Description | Values | Optional |
+| ---- | ----------- | ------ | -------- |
+| string_attr | Attribute with any string value. | Any Str | false |
+| state | Integer attribute with overridden name. | Any Int | false |
+| enum_attr | Attribute with a known set of string values. | Str: ``red``, ``green``, ``blue`` | false |
+| slice_attr | Attribute with a slice value. | Any Slice | false |
+| map_attr | Attribute with a map value. | Any Map | false |
+| optional_int_attr | An optional attribute with an integer value | Any Int | true |
+| optional_string_attr | An optional attribute with any string value | Any Str | true |
+
 ## Optional Metrics
 
 The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
@@ -214,7 +236,7 @@ Queue capacity - sync gauge example.
 
 ### otelcol_queue_length
 
-This metric is optional and therefore not initialized in NewTelemetryBuilder. [alpha]
+This metric is optional and therefore not initialized in NewTelemetryBuilder. [development]
 
 For example this metric only exists if feature A is enabled.
 

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
@@ -33,6 +33,7 @@ type MetricsConfig struct {
 	MetricInputType          MetricConfig `mapstructure:"metric.input_type"`
 	OptionalMetric           MetricConfig `mapstructure:"optional.metric"`
 	OptionalMetricEmptyUnit  MetricConfig `mapstructure:"optional.metric.empty_unit"`
+	SystemCPUTime            MetricConfig `mapstructure:"system.cpu.time"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -51,6 +52,9 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		OptionalMetricEmptyUnit: MetricConfig{
 			Enabled: false,
+		},
+		SystemCPUTime: MetricConfig{
+			Enabled: true,
 		},
 	}
 }

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
@@ -32,6 +32,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MetricInputType:          MetricConfig{Enabled: true},
 					OptionalMetric:           MetricConfig{Enabled: true},
 					OptionalMetricEmptyUnit:  MetricConfig{Enabled: true},
+					SystemCPUTime:            MetricConfig{Enabled: true},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					MapResourceAttr:                  ResourceAttributeConfig{Enabled: true},
@@ -54,6 +55,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MetricInputType:          MetricConfig{Enabled: false},
 					OptionalMetric:           MetricConfig{Enabled: false},
 					OptionalMetricEmptyUnit:  MetricConfig{Enabled: false},
+					SystemCPUTime:            MetricConfig{Enabled: false},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					MapResourceAttr:                  ResourceAttributeConfig{Enabled: false},

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -124,7 +124,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.QueueLength, err = builder.meter.Int64ObservableGauge(
 		"otelcol_queue_length",
-		metric.WithDescription("This metric is optional and therefore not initialized in NewTelemetryBuilder. [alpha]"),
+		metric.WithDescription("This metric is optional and therefore not initialized in NewTelemetryBuilder. [development]"),
 		metric.WithUnit("{items}"),
 	)
 	errs = errors.Join(errs, err)

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/testdata/config.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/testdata/config.yaml
@@ -11,6 +11,8 @@ all_set:
       enabled: true
     optional.metric.empty_unit:
       enabled: true
+    system.cpu.time:
+      enabled: true
   events:
     default.event:
       enabled: true
@@ -46,6 +48,8 @@ none_set:
     optional.metric:
       enabled: false
     optional.metric.empty_unit:
+      enabled: false
+    system.cpu.time:
       enabled: false
   events:
     default.event:

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
@@ -71,7 +71,7 @@ func AssertEqualQueueCapacity(t *testing.T, tt *componenttest.Telemetry, dps []m
 func AssertEqualQueueLength(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_queue_length",
-		Description: "This metric is optional and therefore not initialized in NewTelemetryBuilder. [alpha]",
+		Description: "This metric is optional and therefore not initialized in NewTelemetryBuilder. [development]",
 		Unit:        "{items}",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -141,6 +141,22 @@ events:
     attributes: [ string_attr, overridden_int_attr, enum_attr, slice_attr, map_attr ]
 
 metrics:
+  system.cpu.time:
+    enabled: true
+    stability:
+      level: stable
+    description: Monotonic cumulative sum int metric enabled by default.
+    extended_documentation: The metric will be become optional soon.
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [ string_attr, overridden_int_attr, enum_attr, slice_attr, map_attr, optional_int_attr, optional_string_attr ]
+    warnings:
+      if_enabled_not_set: This metric will be disabled by default soon.
+    semantic_convention:
+      semconv_ref: https://github.com/open-telemetry/semantic-conventions/blob/v1.35.0/docs/system/system-metrics.md#metric-systemcputime
   default.metric:
     enabled: true
     description: Monotonic cumulative sum int metric enabled by default.
@@ -231,7 +247,7 @@ telemetry:
     queue_length:
       enabled: true
       stability:
-        level: alpha
+        level: development
       description: This metric is optional and therefore not initialized in NewTelemetryBuilder.
       extended_documentation: For example this metric only exists if feature A is enabled.
       unit: "{items}"

--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -12,11 +12,13 @@
 
 {{- end }}
 
-| Unit | Metric Type | Value Type |{{ if $metric.Data.HasAggregated }} Aggregation Temporality |{{ end }}{{ if $metric.Data.HasMonotonic }} Monotonic |{{ end }}
-| ---- | ----------- | ---------- |{{ if $metric.Data.HasAggregated }} ----------------------- |{{ end }}{{ if $metric.Data.HasMonotonic }} --------- |{{ end }}
+| Unit | Metric Type | Value Type |{{ if $metric.Data.HasAggregated }} Aggregation Temporality |{{ end }}{{ if $metric.Data.HasMonotonic }} Monotonic |{{ end }}{{ if $metric.Stability.Level }} Stability |{{ end }}{{ if $metric.SemanticConvention }} Semantic Convention |{{ end }}
+| ---- | ----------- | ---------- |{{ if $metric.Data.HasAggregated }} ----------------------- |{{ end }}{{ if $metric.Data.HasMonotonic }} --------- |{{ end }}{{ if $metric.Stability.Level }} --------- |{{ end }}{{ if $metric.SemanticConvention }} ------------------- |{{ end }}
 | {{ $metric.Unit }} | {{ $metric.Data.Type }} | {{ $metric.Data.MetricValueType }} |
 {{- if $metric.Data.HasAggregated }} {{ $metric.Data.AggregationTemporality }} |{{ end }}
 {{- if $metric.Data.HasMonotonic }} {{ $metric.Data.Monotonic }} |{{ end }}
+{{- if $metric.Stability.Level }} {{ $metric.Stability.Level }} |{{ end }}
+{{- if $metric.SemanticConvention }} [{{ $metricName }}]({{ $metric.SemanticConvention.SemanticConventionRef }}) |{{ end }}
 
 {{- if $metric.Attributes }}
 

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -85,6 +85,15 @@ attributes:
 # being described below.
 metrics:
   <metric.name>:
+    # Required: the metric stability
+    stability:
+      # Required: the level of stability
+      level: <development|stable|deprecated>
+      # Optional: the version current stability was introduced
+      from:
+    # Optional: the reference to a semantic convention. Required when stability_level equals stable
+    semantic_convention:
+      semconv_ref:
     # Required: whether the metric is collected by default.
     enabled: bool
     # Required: metric description.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

WiP for https://github.com/open-telemetry/opentelemetry-collector/issues/13297 to illustrate the idea described at https://github.com/open-telemetry/opentelemetry-collector/issues/13297#issuecomment-3057087920.

The change only affects the generated documentation and has no effect on the generated code.

Example documentation generated:

| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability | Semantic Convention |
| ---- | ----------- | ---------- | ----------------------- | --------- | --------- | ------------------- |
| s | Sum | Int | Cumulative | true | stable | [system.cpu.time](https://github.com/open-telemetry/semantic-conventions/blob/v1.35.0/docs/system/system-metrics.md#metric-systemcputime) |

Unit, Value-Type probably should not be required is SemConv ref exists since there is essentially no enforcement right now on those being in alignment with what the respective semantic convention defines. 


<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
