### PR TITLE
Remove deprecated NewProfilesExporter

### DIFF
--- a/.chloggen/remove-newprofilesexporter.yaml
+++ b/.chloggen/remove-newprofilesexporter.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: xexporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated NewProfilesExporter function from xexporterhelper package
+
+# One or more tracking issues or pull requests related to the change
+issues: [13391]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -132,9 +132,6 @@ func NewProfiles(
 		append([]exporterhelper.Option{internal.WithQueueBatchSettings(NewProfilesQueueBatchSettings())}, options...)...)
 }
 
-// Deprecated: [v0.130.0] use NewProfiles.
-var NewProfilesExporter = NewProfiles
-
 // requestConsumeFromProfiles returns a RequestConsumeFunc that consumes pprofile.Profiles.
 func requestConsumeFromProfiles(pusher xconsumer.ConsumeProfilesFunc) exporterhelper.RequestConsumeFunc {
 	return func(ctx context.Context, request exporterhelper.Request) error {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This method was deprecated in 0.130.0. Since that release has happened, we can now remove it.
See https://github.com/open-telemetry/opentelemetry-collector/pull/13372