### PR TITLE
[confighttp] - Expose an option to set `ForceAttemptHttp2` setting

### DIFF
--- a/confmap/resolver_test.go
+++ b/confmap/resolver_test.go
@@ -512,3 +512,15 @@ func runScenario(t *testing.T, path string) {
 		})
 	}
 }
+
+func TestTags(t *testing.T) {
+	if true {
+		require.NoError(t, featuregate.GlobalRegistry().Set(enableMergeAppendOption.ID(), true))
+		defer func() {
+			// Restore previous value.
+			require.NoError(t, featuregate.GlobalRegistry().Set(enableMergeAppendOption.ID(), false))
+		}()
+	}
+	b, _ := os.ReadFile("testdata/config.yml")
+	NewRetrievedFromYAML(b)
+}

--- a/confmap/testdata/config.yml
+++ b/confmap/testdata/config.yml
@@ -1,0 +1,23 @@
+receivers:
+    nop:
+    nop/myreceiver:
+
+processors:
+    nop:
+    nop/myprocessor:
+
+exporters:
+    nop:
+    nop/myexporter:
+
+extensions:
+    nop:
+    nop/myextension:
+
+service:
+    extensions: !mode=append&duplicates=true [nop]
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [nop]
+            exporters: [nop]

--- a/otel.yaml
+++ b/otel.yaml
@@ -1,0 +1,17 @@
+receivers:
+  nop:
+    
+
+exporters:
+  influxdb:
+    endpoint: null
+    org: null
+    bucket: "production"
+    token: "${INFLUXD_TOKEN}"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [nop]
+      exporters: [influxdb]
+    


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

We make use golang's `DefaultTransport`, which uses [HTTP/2 by default](https://cs.opensource.google/go/go/+/refs/tags/go1.24.5:src/net/http/transport.go;l=51). 

However, some of our settings are only applicable while using HTTP/1 transport (`MaxConnsPerHost`, `MaxIdleConnsPerHost` and `MaxIdleConns`). 
Users wanting to force such settings should have an option to use HTTP/1 by disabling `ForceAttemptHTTP2` to `false`.

By default, `ForceAttemptHTTP2` is set to `true` for backward compatibility.
