### PR TITLE
[chore]: enable-all rules from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,6 +78,29 @@ linters:
             - pkg: go.opentelemetry.io/proto
               desc: Use go.opentelemetry.io/collector/pdata instead
 
+    gocritic:
+      disabled-checks:
+        - appendCombine
+        - commentedOutCode
+        - deferInLoop
+        - emptyStringTest
+        - evalOrder
+        - filepathJoin
+        - httpNoBody
+        - hugeParam
+        - importShadow
+        - nestingReduce
+        - paramTypeCombine
+        - rangeValCopy
+        - regexpSimplify
+        - sloppyReassign
+        - sprintfQuotedString
+        - typeAssertChain
+        - typeUnparen
+        - unnamedResult
+        - whyNoLint
+      enable-all: true
+
     gosec:
       excludes:
         - G104 # FIXME

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,7 +87,6 @@ linters:
         - importShadow
         - paramTypeCombine
         - rangeValCopy
-        - regexpSimplify
         - sloppyReassign
         - unnamedResult
         - whyNoLint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,7 +95,6 @@ linters:
         - regexpSimplify
         - sloppyReassign
         - sprintfQuotedString
-        - typeAssertChain
         - unnamedResult
         - whyNoLint
       enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,7 +83,6 @@ linters:
         - commentedOutCode
         - deferInLoop
         - filepathJoin
-        - httpNoBody
         - hugeParam
         - importShadow
         - nestingReduce

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,7 +85,6 @@ linters:
         - filepathJoin
         - hugeParam
         - importShadow
-        - nestingReduce
         - paramTypeCombine
         - rangeValCopy
         - regexpSimplify

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,7 +82,6 @@ linters:
       disabled-checks:
         - commentedOutCode
         - deferInLoop
-        - evalOrder
         - filepathJoin
         - httpNoBody
         - hugeParam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,7 +87,6 @@ linters:
         - importShadow
         - paramTypeCombine
         - rangeValCopy
-        - sloppyReassign
         - unnamedResult
         - whyNoLint
       enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,6 @@ linters:
         - rangeValCopy
         - regexpSimplify
         - sloppyReassign
-        - sprintfQuotedString
         - unnamedResult
         - whyNoLint
       enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,7 +96,6 @@ linters:
         - sloppyReassign
         - sprintfQuotedString
         - typeAssertChain
-        - typeUnparen
         - unnamedResult
         - whyNoLint
       enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,7 +80,6 @@ linters:
 
     gocritic:
       disabled-checks:
-        - appendCombine
         - commentedOutCode
         - deferInLoop
         - emptyStringTest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,7 +82,6 @@ linters:
       disabled-checks:
         - commentedOutCode
         - deferInLoop
-        - emptyStringTest
         - evalOrder
         - filepathJoin
         - httpNoBody

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -128,8 +128,7 @@ func Compile(cfg *Config) error {
 		}
 	}
 
-	args = append(args, "-ldflags="+ldflags)
-	args = append(args, "-gcflags="+gcflags)
+	args = append(args, "-ldflags="+ldflags, "-gcflags="+gcflags)
 
 	if cfg.Distribution.BuildTags != "" {
 		args = append(args, "-tags", cfg.Distribution.BuildTags)

--- a/cmd/mdatagen/internal/command.go
+++ b/cmd/mdatagen/internal/command.go
@@ -89,33 +89,38 @@ func run(ymlPath string) error {
 	if md.Status != nil {
 		if !slices.Contains(nonComponents, md.Status.Class) {
 			toGenerate[filepath.Join(tmplDir, "status.go.tmpl")] = filepath.Join(codeDir, "generated_status.go")
-			if err = generateFile(filepath.Join(tmplDir, "component_test.go.tmpl"),
-				filepath.Join(ymlDir, "generated_component_test.go"), md, packageName); err != nil {
+			err = generateFile(filepath.Join(tmplDir, "component_test.go.tmpl"),
+				filepath.Join(ymlDir, "generated_component_test.go"), md, packageName)
+			if err != nil {
 				return err
 			}
 		} else {
 			if _, err = os.Stat(filepath.Join(codeDir, "generated_status.go")); err == nil {
-				if err = os.Remove(filepath.Join(codeDir, "generated_status.go")); err != nil {
+				err = os.Remove(filepath.Join(codeDir, "generated_status.go"))
+				if err != nil {
 					return err
 				}
 			}
 			if _, err = os.Stat(filepath.Join(ymlDir, "generated_component_test.go")); err == nil {
-				if err = os.Remove(filepath.Join(ymlDir, "generated_component_test.go")); err != nil {
+				err = os.Remove(filepath.Join(ymlDir, "generated_component_test.go"))
+				if err != nil {
 					return err
 				}
 			}
 		}
 
-		if err = generateFile(filepath.Join(tmplDir, "package_test.go.tmpl"),
-			filepath.Join(ymlDir, "generated_package_test.go"), md, packageName); err != nil {
+		err = generateFile(filepath.Join(tmplDir, "package_test.go.tmpl"),
+			filepath.Join(ymlDir, "generated_package_test.go"), md, packageName)
+		if err != nil {
 			return err
 		}
 
 		if _, err = os.Stat(filepath.Join(ymlDir, "README.md")); err == nil {
-			if err = inlineReplace(
+			err = inlineReplace(
 				filepath.Join(tmplDir, "readme.md.tmpl"),
 				filepath.Join(ymlDir, "README.md"),
-				md, statusStart, statusEnd, md.GeneratedPackageName); err != nil {
+				md, statusStart, statusEnd, md.GeneratedPackageName)
+			if err != nil {
 				return err
 			}
 		}
@@ -138,22 +143,26 @@ func run(ymlPath string) error {
 		toGenerate[filepath.Join(tmplDir, "telemetrytest_test.go.tmpl")] = filepath.Join(testDir, "generated_telemetrytest_test.go")
 	} else {
 		if _, err = os.Stat(filepath.Join(ymlDir, "generated_telemetry.go")); err == nil {
-			if err = os.Remove(filepath.Join(ymlDir, "generated_telemetry.go")); err != nil {
+			err = os.Remove(filepath.Join(ymlDir, "generated_telemetry.go"))
+			if err != nil {
 				return err
 			}
 		}
 		if _, err = os.Stat(filepath.Join(ymlDir, "generated_telemetry_test.go")); err == nil {
-			if err = os.Remove(filepath.Join(ymlDir, "generated_telemetry_test.go")); err != nil {
+			err = os.Remove(filepath.Join(ymlDir, "generated_telemetry_test.go"))
+			if err != nil {
 				return err
 			}
 		}
 		if _, err = os.Stat(filepath.Join(ymlDir, "generated_telemetrytest.go")); err == nil {
-			if err = os.Remove(filepath.Join(ymlDir, "generated_telemetrytest.go")); err != nil {
+			err = os.Remove(filepath.Join(ymlDir, "generated_telemetrytest.go"))
+			if err != nil {
 				return err
 			}
 		}
 		if _, err = os.Stat(filepath.Join(ymlDir, "generated_telemetrytest_test.go")); err == nil {
-			if err = os.Remove(filepath.Join(ymlDir, "generated_telemetrytest_test.go")); err != nil {
+			err = os.Remove(filepath.Join(ymlDir, "generated_telemetrytest_test.go"))
+			if err != nil {
 				return err
 			}
 		}
@@ -198,7 +207,7 @@ func run(ymlPath string) error {
 	}
 
 	for tmpl, dst := range toGenerate {
-		if err = generateFile(tmpl, dst, md, md.GeneratedPackageName); err != nil {
+		if err := generateFile(tmpl, dst, md, md.GeneratedPackageName); err != nil {
 			return err
 		}
 	}

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -40,7 +40,8 @@ func LoadMetadata(filePath string) (Metadata, error) {
 	}
 
 	md := Metadata{ShortFolderName: shortFolderName(filePath), Tests: Tests{Host: "componenttest.NewNopHost()"}}
-	if err = conf.Unmarshal(&md); err != nil {
+	err = conf.Unmarshal(&md)
+	if err != nil {
 		return md, err
 	}
 	if md.ScopeName == "" {
@@ -53,7 +54,7 @@ func LoadMetadata(filePath string) (Metadata, error) {
 		md.GeneratedPackageName = "metadata"
 	}
 
-	if err = md.Validate(); err != nil {
+	if err := md.Validate(); err != nil {
 		return md, err
 	}
 

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -318,7 +318,7 @@ func (a Attribute) Name() AttributeName {
 
 func (a Attribute) TestValue() string {
 	if a.Enum != nil {
-		return fmt.Sprintf(`"%s"`, a.Enum[0])
+		return fmt.Sprintf(`%q`, a.Enum[0])
 	}
 	switch a.Type.ValueType {
 	case pcommon.ValueTypeEmpty:

--- a/cmd/mdatagen/internal/metric.go
+++ b/cmd/mdatagen/internal/metric.go
@@ -53,10 +53,10 @@ type Stability struct {
 }
 
 func (s Stability) String() string {
-	if len(s.Level) == 0 || strings.EqualFold(s.Level, component.StabilityLevelStable.String()) {
+	if s.Level == "" || strings.EqualFold(s.Level, component.StabilityLevelStable.String()) {
 		return ""
 	}
-	if len(s.From) > 0 {
+	if s.From != "" {
 		return fmt.Sprintf(" [%s since %s]", s.Level, s.From)
 	}
 	return fmt.Sprintf(" [%s]", s.Level)

--- a/component/componentstatus/status_test.go
+++ b/component/componentstatus/status_test.go
@@ -106,8 +106,8 @@ func Test_ReportStatus(t *testing.T) {
 }
 
 var (
-	_ = (component.Host)(nil)
-	_ = (Reporter)(nil)
+	_ = component.Host(nil)
+	_ = Reporter(nil)
 )
 
 type reporter struct {
@@ -122,7 +122,7 @@ func (r *reporter) Report(_ *Event) {
 	r.reportStatusCalled = true
 }
 
-var _ = (component.Host)(nil)
+var _ = component.Host(nil)
 
 type host struct {
 	reportStatusCalled bool

--- a/component/identifiable.go
+++ b/component/identifiable.go
@@ -49,7 +49,7 @@ func (t Type) MarshalText() ([]byte, error) {
 // - start with an ASCII alphabetic character and
 // - can only contain ASCII alphanumeric characters and '_'.
 func NewType(ty string) (Type, error) {
-	if len(ty) == 0 {
+	if ty == "" {
 		return Type{}, errors.New("id must not be empty")
 	}
 	if !typeRegexp.MatchString(ty) {

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -285,8 +285,7 @@ func (gcs *ClientConfig) addHeadersIfAbsent(ctx context.Context) context.Context
 	existingMd, _ := metadata.FromOutgoingContext(ctx)
 	for k, v := range gcs.Headers {
 		if len(existingMd.Get(k)) == 0 {
-			kv = append(kv, k)
-			kv = append(kv, string(v))
+			kv = append(kv, k, string(v))
 		}
 	}
 	return metadata.AppendToOutgoingContext(ctx, kv...)

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -355,7 +355,7 @@ func (gcs *ClientConfig) getGrpcDialOptions(
 	}
 
 	if gcs.BalancerName != "" {
-		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%s"}`, gcs.BalancerName)))
+		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":%q}`, gcs.BalancerName)))
 	}
 
 	if gcs.Authority != "" {

--- a/config/configgrpc/configgrpc_benchmark_test.go
+++ b/config/configgrpc/configgrpc_benchmark_test.go
@@ -27,9 +27,10 @@ func BenchmarkCompressors(b *testing.B) {
 	payloads := setupTestPayloads()
 
 	compressors := make([]encoding.Compressor, 0)
-	compressors = append(compressors, encoding.GetCompressor(gzip.Name))
-	compressors = append(compressors, encoding.GetCompressor(zstd.Name))
-	compressors = append(compressors, encoding.GetCompressor(snappy.Name))
+	compressors = append(compressors,
+		encoding.GetCompressor(gzip.Name),
+		encoding.GetCompressor(zstd.Name),
+		encoding.GetCompressor(snappy.Name))
 
 	for _, payload := range payloads {
 		for _, compressor := range compressors {
@@ -114,57 +115,60 @@ func setupTestPayloads() []testPayload {
 
 	// log payloads
 	logMarshaler := &logMarshaler{Marshaler: &plog.ProtoMarshaler{}}
-	payloads = append(payloads, testPayload{
-		name:      "sm_log_request",
-		message:   testdata.GenerateLogs(1),
-		marshaler: logMarshaler,
-	})
-	payloads = append(payloads, testPayload{
-		name:      "md_log_request",
-		message:   testdata.GenerateLogs(2),
-		marshaler: logMarshaler,
-	})
-	payloads = append(payloads, testPayload{
-		name:      "lg_log_request",
-		message:   testdata.GenerateLogs(50),
-		marshaler: logMarshaler,
-	})
+	payloads = append(payloads,
+		testPayload{
+			name:      "sm_log_request",
+			message:   testdata.GenerateLogs(1),
+			marshaler: logMarshaler,
+		},
+		testPayload{
+			name:      "md_log_request",
+			message:   testdata.GenerateLogs(2),
+			marshaler: logMarshaler,
+		},
+		testPayload{
+			name:      "lg_log_request",
+			message:   testdata.GenerateLogs(50),
+			marshaler: logMarshaler,
+		})
 
 	// trace payloads
 	tracesMarshaler := &traceMarshaler{Marshaler: &ptrace.ProtoMarshaler{}}
-	payloads = append(payloads, testPayload{
-		name:      "sm_trace_request",
-		message:   testdata.GenerateTraces(1),
-		marshaler: tracesMarshaler,
-	})
-	payloads = append(payloads, testPayload{
-		name:      "md_trace_request",
-		message:   testdata.GenerateTraces(2),
-		marshaler: tracesMarshaler,
-	})
-	payloads = append(payloads, testPayload{
-		name:      "lg_trace_request",
-		message:   testdata.GenerateTraces(50),
-		marshaler: tracesMarshaler,
-	})
+	payloads = append(payloads,
+		testPayload{
+			name:      "sm_trace_request",
+			message:   testdata.GenerateTraces(1),
+			marshaler: tracesMarshaler,
+		},
+		testPayload{
+			name:      "md_trace_request",
+			message:   testdata.GenerateTraces(2),
+			marshaler: tracesMarshaler,
+		},
+		testPayload{
+			name:      "lg_trace_request",
+			message:   testdata.GenerateTraces(50),
+			marshaler: tracesMarshaler,
+		})
 
 	// metric payloads
 	metricsMarshaler := &metricsMarshaler{Marshaler: &pmetric.ProtoMarshaler{}}
-	payloads = append(payloads, testPayload{
-		name:      "sm_metric_request",
-		message:   testdata.GenerateMetrics(1),
-		marshaler: metricsMarshaler,
-	})
-	payloads = append(payloads, testPayload{
-		name:      "md_metric_request",
-		message:   testdata.GenerateMetrics(2),
-		marshaler: metricsMarshaler,
-	})
-	payloads = append(payloads, testPayload{
-		name:      "lg_metric_request",
-		message:   testdata.GenerateMetrics(50),
-		marshaler: metricsMarshaler,
-	})
+	payloads = append(payloads,
+		testPayload{
+			name:      "sm_metric_request",
+			message:   testdata.GenerateMetrics(1),
+			marshaler: metricsMarshaler,
+		},
+		testPayload{
+			name:      "md_metric_request",
+			message:   testdata.GenerateMetrics(2),
+			marshaler: metricsMarshaler,
+		},
+		testPayload{
+			name:      "lg_metric_request",
+			message:   testdata.GenerateMetrics(50),
+			marshaler: metricsMarshaler,
+		})
 
 	return payloads
 }

--- a/config/confighttp/client_middleware_test.go
+++ b/config/confighttp/client_middleware_test.go
@@ -123,7 +123,7 @@ func TestClientMiddlewares(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a request to the test server
-			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
 			require.NoError(t, err)
 
 			// Send the request

--- a/config/confighttp/clientinfohandler.go
+++ b/config/confighttp/clientinfohandler.go
@@ -38,7 +38,7 @@ func contextWithClient(req *http.Request, includeMetadata bool) context.Context 
 
 	if includeMetadata {
 		md := req.Header.Clone()
-		if len(md.Get(client.MetadataHostName)) == 0 && req.Host != "" {
+		if md.Get(client.MetadataHostName) == "" && req.Host != "" {
 			md.Add(client.MetadataHostName, req.Host)
 		}
 

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -396,7 +396,7 @@ func TestHTTPContentCompressionRequestWithNilBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
 	require.NoError(t, err, "failed to create request to test handler")
 
 	client := srv.Client()

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -205,7 +205,7 @@ func (hcs *ClientConfig) ToClient(ctx context.Context, host component.Host, sett
 		transport2.PingTimeout = hcs.HTTP2PingTimeout
 	}
 
-	clientTransport := (http.RoundTripper)(transport)
+	clientTransport := http.RoundTripper(transport)
 
 	// Apply middlewares in reverse order so they execute in
 	// forward order. The first middleware runs after authentication.

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -864,7 +864,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 	require.NotNil(t, srv)
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req := httptest.NewRequest(http.MethodOptions, "/", http.NoBody)
 	req.Header.Set("Origin", "http://localhost")
 	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
 	srv.Handler.ServeHTTP(rec, req)
@@ -929,7 +929,7 @@ func TestHttpServerHeaders(t *testing.T) {
 }
 
 func verifyCorsResp(t *testing.T, url string, origin string, set configoptional.Optional[CORSConfig], extraHeader bool, wantStatus int, wantAllowed bool) {
-	req, err := http.NewRequest(http.MethodOptions, url, nil)
+	req, err := http.NewRequest(http.MethodOptions, url, http.NoBody)
 	require.NoError(t, err, "Error creating trace OPTIONS request: %v", err)
 	req.Header.Set("Origin", origin)
 	if extraHeader {
@@ -964,7 +964,7 @@ func verifyCorsResp(t *testing.T, url string, origin string, set configoptional.
 }
 
 func verifyHeadersResp(t *testing.T, url string, expected map[string]configopaque.String) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	require.NoError(t, err, "Error creating request")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -1010,7 +1010,7 @@ func TestHttpClientHeaders(t *testing.T) {
 				Headers:         tt.headers,
 			}
 			client, _ := setting.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
-			req, err := http.NewRequest(http.MethodGet, setting.Endpoint, nil)
+			req, err := http.NewRequest(http.MethodGet, setting.Endpoint, http.NoBody)
 			require.NoError(t, err)
 			_, err = client.Do(req)
 			assert.NoError(t, err)
@@ -1046,7 +1046,7 @@ func TestHttpClientHostHeader(t *testing.T) {
 			Headers:         tt.headers,
 		}
 		client, _ := setting.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
-		req, err := http.NewRequest(http.MethodGet, setting.Endpoint, nil)
+		req, err := http.NewRequest(http.MethodGet, setting.Endpoint, http.NoBody)
 		require.NoError(t, err)
 		_, err = client.Do(req)
 		assert.NoError(t, err)
@@ -1179,7 +1179,7 @@ func TestServerAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	// tt
-	srv.Handler.ServeHTTP(&httptest.ResponseRecorder{}, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.Handler.ServeHTTP(&httptest.ResponseRecorder{}, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
 
 	// verify
 	assert.True(t, handlerCalled)
@@ -1223,7 +1223,7 @@ func TestFailedServerAuth(t *testing.T) {
 
 	// tt
 	response := &httptest.ResponseRecorder{}
-	srv.Handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.Handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
 
 	// verify
 	assert.Equal(t, http.StatusUnauthorized, response.Result().StatusCode)
@@ -1261,7 +1261,7 @@ func TestFailedServerAuthWithErrorHandler(t *testing.T) {
 
 	// tt
 	response := &httptest.ResponseRecorder{}
-	srv.Handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.Handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
 
 	// verify
 	assert.Equal(t, http.StatusInternalServerError, response.Result().StatusCode)
@@ -1290,7 +1290,7 @@ func TestServerWithErrorHandler(t *testing.T) {
 	// tt
 	response := &httptest.ResponseRecorder{}
 
-	req, err := http.NewRequest(http.MethodGet, srv.Addr, nil)
+	req, err := http.NewRequest(http.MethodGet, srv.Addr, http.NoBody)
 	require.NoError(t, err, "Error creating request: %v", err)
 	req.Header.Set("Content-Encoding", "something-invalid")
 
@@ -1447,7 +1447,7 @@ func TestAuthWithQueryParams(t *testing.T) {
 	require.NoError(t, err)
 
 	// tt
-	srv.Handler.ServeHTTP(&httptest.ResponseRecorder{}, httptest.NewRequest(http.MethodGet, "/?auth=1", nil))
+	srv.Handler.ServeHTTP(&httptest.ResponseRecorder{}, httptest.NewRequest(http.MethodGet, "/?auth=1", http.NoBody))
 
 	// verify
 	assert.True(t, handlerCalled)

--- a/config/confighttp/server_middleware_test.go
+++ b/config/confighttp/server_middleware_test.go
@@ -112,7 +112,7 @@ func TestServerMiddleware(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a test request
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 
 			// Create a response recorder
 			rec := httptest.NewRecorder()

--- a/config/confighttp/xconfighttp/options_test.go
+++ b/config/confighttp/xconfighttp/options_test.go
@@ -48,7 +48,7 @@ func TestServerWithOtelHTTPOptions(t *testing.T) {
 
 	for _, path := range []string{"/path", "/foobar"} {
 		response := &httptest.ResponseRecorder{}
-		req, err := http.NewRequest(http.MethodGet, srv.Addr+path, nil)
+		req, err := http.NewRequest(http.MethodGet, srv.Addr+path, http.NoBody)
 		require.NoError(t, err)
 		srv.Handler.ServeHTTP(response, req)
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)

--- a/config/configtls/tpm_test.go
+++ b/config/configtls/tpm_test.go
@@ -73,7 +73,7 @@ func TestTPM_loadCertificate(t *testing.T) {
 
 	// this is delegated to the TPM
 	signer := tlsCertificate.PrivateKey.(crypto.Signer)
-	signature, _ := signer.Sign((io.Reader)(nil), b, crypto.SHA256)
+	signature, _ := signer.Sign(io.Reader(nil), b, crypto.SHA256)
 
 	// load the key again to get access to verify function
 	loadedTPMKey, err := keyfile.Decode(tpmKey)

--- a/confmap/confmaptest/configtest.go
+++ b/confmap/confmaptest/configtest.go
@@ -23,7 +23,7 @@ func LoadConf(fileName string) (*confmap.Conf, error) {
 	}
 
 	var rawConf map[string]any
-	if err = yaml.Unmarshal(content, &rawConf); err != nil {
+	if err := yaml.Unmarshal(content, &rawConf); err != nil {
 		return nil, err
 	}
 

--- a/confmap/provider/envprovider/provider.go
+++ b/confmap/provider/envprovider/provider.go
@@ -60,7 +60,7 @@ func (emp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFu
 		} else {
 			emp.logger.Warn("Configuration references unset environment variable", zap.String("name", envVarName))
 		}
-	} else if len(val) == 0 {
+	} else if val == "" {
 		emp.logger.Info("Configuration references empty environment variable", zap.String("name", envVarName))
 	}
 

--- a/confmap/xconfmap/config.go
+++ b/confmap/xconfmap/config.go
@@ -180,20 +180,17 @@ func fieldName(field reflect.StructField) string {
 }
 
 func stringifyMapKey(val reflect.Value) string {
-	var key string
-
-	if str, ok := val.Interface().(string); ok {
-		key = str
-	} else if stringer, ok := val.Interface().(fmt.Stringer); ok {
-		key = stringer.String()
-	} else {
+	switch v := val.Interface().(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
 		switch val.Kind() {
 		case reflect.Ptr, reflect.Interface, reflect.Struct, reflect.Slice, reflect.Array, reflect.Map:
-			key = fmt.Sprintf("[%T key]", val.Interface())
+			return fmt.Sprintf("[%T key]", val.Interface())
 		default:
-			key = fmt.Sprintf("%v", val.Interface())
+			return fmt.Sprintf("%v", val.Interface())
 		}
 	}
-
-	return key
 }

--- a/confmap/xconfmap/config.go
+++ b/confmap/xconfmap/config.go
@@ -172,7 +172,7 @@ func fieldName(field reflect.StructField) string {
 	}
 	// Even if the mapstructure tag exists, the field name may not
 	// be available, so set it if it is still blank.
-	if len(fieldName) == 0 {
+	if fieldName == "" {
 		fieldName = strings.ToLower(field.Name)
 	}
 

--- a/consumer/consumertest/consumer.go
+++ b/consumer/consumertest/consumer.go
@@ -38,10 +38,10 @@ type Consumer interface {
 }
 
 var (
-	_ consumer.Logs      = (Consumer)(nil)
-	_ consumer.Metrics   = (Consumer)(nil)
-	_ consumer.Traces    = (Consumer)(nil)
-	_ xconsumer.Profiles = (Consumer)(nil)
+	_ consumer.Logs      = Consumer(nil)
+	_ consumer.Metrics   = Consumer(nil)
+	_ consumer.Traces    = Consumer(nil)
+	_ xconsumer.Profiles = Consumer(nil)
 )
 
 type nonMutatingConsumer struct{}

--- a/exporter/debugexporter/internal/normal/common.go
+++ b/exporter/debugexporter/internal/normal/common.go
@@ -29,26 +29,26 @@ func writeAttributesString(attributesMap pcommon.Map) (attributesString string) 
 }
 
 func writeResourceDetails(schemaURL string) (resourceDetails string) {
-	if len(schemaURL) > 0 {
+	if schemaURL != "" {
 		resourceDetails = " [" + schemaURL + "]"
 	}
 	return resourceDetails
 }
 
 func writeScopeDetails(name string, version string, schemaURL string) (scopeDetails string) {
-	if len(name) > 0 {
+	if name != "" {
 		scopeDetails += name
 	}
-	if len(version) > 0 {
+	if version != "" {
 		scopeDetails += "@" + version
 	}
-	if len(schemaURL) > 0 {
-		if len(scopeDetails) > 0 {
+	if schemaURL != "" {
+		if scopeDetails != "" {
 			scopeDetails += " "
 		}
 		scopeDetails += "[" + schemaURL + "]"
 	}
-	if len(scopeDetails) > 0 {
+	if scopeDetails != "" {
 		scopeDetails = " " + scopeDetails
 	}
 	return scopeDetails

--- a/exporter/debugexporter/internal/otlptext/traces.go
+++ b/exporter/debugexporter/internal/otlptext/traces.go
@@ -39,7 +39,7 @@ func (textTracesMarshaler) MarshalTraces(td ptrace.Traces) ([]byte, error) {
 				buf.logAttr("ID", span.SpanID())
 				buf.logAttr("Name", span.Name())
 				buf.logAttr("Kind", span.Kind().String())
-				if ts := span.TraceState().AsRaw(); len(ts) != 0 {
+				if ts := span.TraceState().AsRaw(); ts != "" {
 					buf.logAttr("TraceState", ts)
 				}
 				buf.logAttr("Start time", span.StartTimestamp().String())

--- a/exporter/exporterhelper/internal/queue/persistent_queue.go
+++ b/exporter/exporterhelper/internal/queue/persistent_queue.go
@@ -180,7 +180,7 @@ func (pq *persistentQueue[T]) loadQueueMetadata(ctx context.Context) error {
 	}
 
 	metadata := &pq.metadata
-	if err = metadata.Unmarshal(buf); err != nil {
+	if err := metadata.Unmarshal(buf); err != nil {
 		return err
 	}
 
@@ -308,7 +308,7 @@ func (pq *persistentQueue[T]) putInternal(ctx context.Context, req T) error {
 		storage.SetOperation(metadataKey, metadataBuf),
 		storage.SetOperation(getItemKey(pq.metadata.WriteIndex-1), reqBuf),
 	}
-	if err = pq.client.Batch(ctx, ops...); err != nil {
+	if err := pq.client.Batch(ctx, ops...); err != nil {
 		// At this moment, metadata may be updated in the storage, so we cannot just revert changes to the
 		// metadata, rely on the sizes being fixed on complete draining.
 		return err

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -53,7 +53,7 @@ func (c *Config) sanitizedEndpoint() string {
 	case strings.HasPrefix(c.ClientConfig.Endpoint, "https://"):
 		return strings.TrimPrefix(c.ClientConfig.Endpoint, "https://")
 	case strings.HasPrefix(c.ClientConfig.Endpoint, "dns://"):
-		r := regexp.MustCompile("^dns://[/]?")
+		r := regexp.MustCompile(`^dns:///?`)
 		return r.ReplaceAllString(c.ClientConfig.Endpoint, "")
 	default:
 		return c.ClientConfig.Endpoint

--- a/extension/extensionmiddleware/server_test.go
+++ b/extension/extensionmiddleware/server_test.go
@@ -25,7 +25,7 @@ func TestGetHTTPHandlerFunc(t *testing.T) {
 		require.NoError(t, err)
 
 		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
 		require.Equal(t, http.StatusNoContent, rr.Code)
 	})
 
@@ -47,7 +47,7 @@ func TestGetHTTPHandlerFunc(t *testing.T) {
 		require.NotNil(t, handler)
 
 		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
 		require.True(t, called)
 		require.Equal(t, http.StatusOK, rr.Code)
 	})

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -20,7 +20,7 @@ var (
 
 	// idRegexp is used to validate the ID of a Gate.
 	// IDs' characters must be alphanumeric or dots.
-	idRegexp = regexp.MustCompile(`^[0-9a-zA-Z\.]*$`)
+	idRegexp = regexp.MustCompile(`^[0-9a-zA-Z.]*$`)
 )
 
 // ErrAlreadyRegistered is returned when adding a Gate that is already registered.

--- a/internal/memorylimiter/cgroups/mountpoint.go
+++ b/internal/memorylimiter/cgroups/mountpoint.go
@@ -98,30 +98,31 @@ func NewMountPointFromLine(line string) (*MountPoint, error) {
 	}
 
 	for i, field := range fields[_miFieldIDOptionalFields:] {
-		if field == _mountInfoOptionalFieldsSep {
-			fsTypeStart := _miFieldIDOptionalFields + i + 1
-
-			if len(fields) != fsTypeStart+_miFieldCountSecondHalf {
-				return nil, mountPointFormatInvalidError{line}
-			}
-
-			miFieldIDFSType := _miFieldOffsetFSType + fsTypeStart
-			miFieldIDMountSource := _miFieldOffsetMountSource + fsTypeStart
-			miFieldIDSuperOptions := _miFieldOffsetSuperOptions + fsTypeStart
-
-			return &MountPoint{
-				MountID:        mountID,
-				ParentID:       parentID,
-				DeviceID:       fields[_miFieldIDDeviceID],
-				Root:           fields[_miFieldIDRoot],
-				MountPoint:     fields[_miFieldIDMountPoint],
-				Options:        strings.Split(fields[_miFieldIDOptions], _mountInfoOptsSep),
-				OptionalFields: fields[_miFieldIDOptionalFields:(fsTypeStart - 1)],
-				FSType:         fields[miFieldIDFSType],
-				MountSource:    fields[miFieldIDMountSource],
-				SuperOptions:   strings.Split(fields[miFieldIDSuperOptions], _mountInfoOptsSep),
-			}, nil
+		if field != _mountInfoOptionalFieldsSep {
+			continue
 		}
+		fsTypeStart := _miFieldIDOptionalFields + i + 1
+
+		if len(fields) != fsTypeStart+_miFieldCountSecondHalf {
+			return nil, mountPointFormatInvalidError{line}
+		}
+
+		miFieldIDFSType := _miFieldOffsetFSType + fsTypeStart
+		miFieldIDMountSource := _miFieldOffsetMountSource + fsTypeStart
+		miFieldIDSuperOptions := _miFieldOffsetSuperOptions + fsTypeStart
+
+		return &MountPoint{
+			MountID:        mountID,
+			ParentID:       parentID,
+			DeviceID:       fields[_miFieldIDDeviceID],
+			Root:           fields[_miFieldIDRoot],
+			MountPoint:     fields[_miFieldIDMountPoint],
+			Options:        strings.Split(fields[_miFieldIDOptions], _mountInfoOptsSep),
+			OptionalFields: fields[_miFieldIDOptionalFields:(fsTypeStart - 1)],
+			FSType:         fields[miFieldIDFSType],
+			MountSource:    fields[miFieldIDMountSource],
+			SuperOptions:   strings.Split(fields[miFieldIDSuperOptions], _mountInfoOptsSep),
+		}, nil
 	}
 
 	return nil, mountPointFormatInvalidError{line}

--- a/internal/telemetry/componentattribute/tracer_provider.go
+++ b/internal/telemetry/componentattribute/tracer_provider.go
@@ -24,14 +24,14 @@ type tracerProviderWithAttributesSdk struct {
 
 // TracerProviderWithAttributes creates a TracerProvider with a new set of injected instrumentation scope attributes.
 func TracerProviderWithAttributes(tp trace.TracerProvider, attrs attribute.Set) trace.TracerProvider {
-	if tpwa, ok := tp.(tracerProviderWithAttributesSdk); ok {
+	switch tpwa := tp.(type) {
+	case tracerProviderWithAttributesSdk:
 		tp = tpwa.TracerProvider
-	} else if tpwa, ok := tp.(tracerProviderWithAttributes); ok {
+	case tracerProviderWithAttributes:
 		tp = tpwa.TracerProvider
-	}
-	if tpSdk, ok := tp.(*sdkTrace.TracerProvider); ok {
+	case *sdkTrace.TracerProvider:
 		return tracerProviderWithAttributesSdk{
-			TracerProvider: tpSdk,
+			TracerProvider: tpwa,
 			attrs:          attrs.ToSlice(),
 		}
 	}

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -272,7 +272,7 @@ func (col *Collector) DryRun(ctx context.Context) error {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	if err = xconfmap.Validate(cfg); err != nil {
+	if err := xconfmap.Validate(cfg); err != nil {
 		return err
 	}
 
@@ -348,7 +348,7 @@ LOOP:
 				col.service.Logger().Error("Config watch failed", zap.Error(err))
 				break LOOP
 			}
-			if err = col.reloadConfiguration(ctx); err != nil {
+			if err := col.reloadConfiguration(ctx); err != nil {
 				return err
 			}
 		case err := <-col.asyncErrorChannel:

--- a/otelcol/configprovider_test.go
+++ b/otelcol/configprovider_test.go
@@ -48,8 +48,8 @@ func TestConfigProviderYaml(t *testing.T) {
 
 	yamlProvider := newFakeProvider("yaml", func(_ context.Context, _ string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
 		var rawConf any
-		if err = yaml.Unmarshal(yamlBytes, &rawConf); err != nil {
-			return nil, err
+		if yamlErr := yaml.Unmarshal(yamlBytes, &rawConf); yamlErr != nil {
+			return nil, yamlErr
 		}
 		return confmap.NewRetrieved(rawConf)
 	})

--- a/otelcol/unmarshaler.go
+++ b/otelcol/unmarshaler.go
@@ -42,6 +42,6 @@ func unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
 			Telemetry: defaultTelConfig,
 		},
 	}
-
-	return cfg, v.Unmarshal(&cfg)
+	err := v.Unmarshal(&cfg)
+	return cfg, err
 }

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -88,7 +88,8 @@ func Build(ctx context.Context, set Settings) (*Graph, error) {
 		return nil, err
 	}
 	pipelines.createEdges()
-	return pipelines, pipelines.buildComponents(ctx, set)
+	err := pipelines.buildComponents(ctx, set)
+	return pipelines, err
 }
 
 // Creates a node for each instance of a component and adds it to the graph.

--- a/service/service.go
+++ b/service/service.go
@@ -543,14 +543,15 @@ func configureViews(level configtelemetry.Level) []config.View {
 	// Internal graph metrics
 	graphScope := ptr("go.opentelemetry.io/collector/service")
 	if level < configtelemetry.LevelDetailed {
-		views = append(views, dropViewOption(&config.ViewSelector{
-			MeterName:      graphScope,
-			InstrumentName: ptr("otelcol.*.consumed.size"),
-		}))
-		views = append(views, dropViewOption(&config.ViewSelector{
-			MeterName:      graphScope,
-			InstrumentName: ptr("otelcol.*.produced.size"),
-		}))
+		views = append(views,
+			dropViewOption(&config.ViewSelector{
+				MeterName:      graphScope,
+				InstrumentName: ptr("otelcol.*.consumed.size"),
+			}),
+			dropViewOption(&config.ViewSelector{
+				MeterName:      graphScope,
+				InstrumentName: ptr("otelcol.*.produced.size"),
+			}))
 	}
 
 	return views

--- a/service/service.go
+++ b/service/service.go
@@ -231,12 +231,14 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		// ignore other errors as they represent invalid state transitions and are considered benign.
 	})
 
-	if err = srv.initGraph(ctx, cfg); err != nil {
+	err = srv.initGraph(ctx, cfg)
+	if err != nil {
 		return nil, err
 	}
 
 	// process the configuration and initialize the pipeline
-	if err = srv.initExtensions(ctx, cfg.Extensions); err != nil {
+	err = srv.initExtensions(ctx, cfg.Extensions)
+	if err != nil {
 		return nil, err
 	}
 

--- a/service/telemetry/metrics_test.go
+++ b/service/telemetry/metrics_test.go
@@ -195,7 +195,7 @@ func getMetricsFromPrometheus(t *testing.T, endpoint string) map[string]*io_prom
 		Timeout: 10 * time.Second,
 	}
 
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint, http.NoBody)
 	require.NoError(t, err)
 
 	var rr *http.Response


### PR DESCRIPTION
#### Description

Enables all rules from [go-critic](https://golangci-lint.run/usage/linters/#gocritic) by default and disable the one that needs to be fixed

* https://go-critic.com/overview.html#appendcombine
* https://go-critic.com/overview.html#emptystringtest
* https://go-critic.com/overview.html#evalorder
* https://go-critic.com/overview.html#httpnobody
* https://go-critic.com/overview.html#nestingreduce
* https://go-critic.com/overview.html#regexpsimplify
* https://go-critic.com/overview.html#sloppyreassign
* https://go-critic.com/overview.html#sprintfquotedstring
* https://go-critic.com/overview.html#typeassertchain
* https://go-critic.com/overview.html#typeunparen