### PR TITLE
Remove unused context.Context parameter from config methods

### DIFF
--- a/.chloggen/13436.yaml
+++ b/.chloggen/13436.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: config
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove unused context.Context parameter from config methods"
+
+# One or more tracking issues or pull requests related to the change
+issues: [13436]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -7,7 +7,6 @@
 package configauth // import "go.opentelemetry.io/collector/config/configauth"
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -32,7 +31,7 @@ type Config struct {
 
 // GetServerAuthenticator attempts to select the appropriate extensionauth.Server from the list of extensions,
 // based on the requested extension name. If an authenticator is not found, an error is returned.
-func (a Config) GetServerAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.Server, error) {
+func (a Config) GetServerAuthenticator(extensions map[component.ID]component.Component) (extensionauth.Server, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if server, ok := ext.(extensionauth.Server); ok {
 			return server, nil
@@ -46,7 +45,7 @@ func (a Config) GetServerAuthenticator(_ context.Context, extensions map[compone
 // GetHTTPClientAuthenticator attempts to select the appropriate extensionauth.Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by HTTP clients.
-func (a Config) GetHTTPClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.HTTPClient, error) {
+func (a Config) GetHTTPClientAuthenticator(extensions map[component.ID]component.Component) (extensionauth.HTTPClient, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if client, ok := ext.(extensionauth.HTTPClient); ok {
 			return client, nil
@@ -59,7 +58,7 @@ func (a Config) GetHTTPClientAuthenticator(_ context.Context, extensions map[com
 // GetGRPCClientAuthenticator attempts to select the appropriate extensionauth.Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by gRPC clients.
-func (a Config) GetGRPCClientAuthenticator(_ context.Context, extensions map[component.ID]component.Component) (extensionauth.GRPCClient, error) {
+func (a Config) GetGRPCClientAuthenticator(extensions map[component.ID]component.Component) (extensionauth.GRPCClient, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if client, ok := ext.(extensionauth.GRPCClient); ok {
 			return client, nil

--- a/config/configauth/configauth_test.go
+++ b/config/configauth/configauth_test.go
@@ -4,7 +4,6 @@
 package configauth
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,7 @@ func TestGetServer(t *testing.T) {
 				mockID: tt.authenticator,
 			}
 
-			authenticator, err := cfg.GetServerAuthenticator(context.Background(), ext)
+			authenticator, err := cfg.GetServerAuthenticator(ext)
 
 			// verify
 			if tt.expected != nil {
@@ -63,7 +62,7 @@ func TestGetServerFails(t *testing.T) {
 		AuthenticatorID: component.MustNewID("does_not_exist"),
 	}
 
-	authenticator, err := cfg.GetServerAuthenticator(context.Background(), map[component.ID]component.Component{})
+	authenticator, err := cfg.GetServerAuthenticator(map[component.ID]component.Component{})
 	require.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }
@@ -95,7 +94,7 @@ func TestGetHTTPClient(t *testing.T) {
 				mockID: tt.authenticator,
 			}
 
-			authenticator, err := cfg.GetHTTPClientAuthenticator(context.Background(), ext)
+			authenticator, err := cfg.GetHTTPClientAuthenticator(ext)
 
 			// verify
 			if tt.expected != nil {
@@ -113,7 +112,7 @@ func TestGetGRPCClientFails(t *testing.T) {
 	cfg := &Config{
 		AuthenticatorID: component.MustNewID("does_not_exist"),
 	}
-	authenticator, err := cfg.GetGRPCClientAuthenticator(context.Background(), map[component.ID]component.Component{})
+	authenticator, err := cfg.GetGRPCClientAuthenticator(map[component.ID]component.Component{})
 	require.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }

--- a/config/configgrpc/client_middleware_test.go
+++ b/config/configgrpc/client_middleware_test.go
@@ -195,7 +195,7 @@ func TestClientMiddlewareToClientErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test creating the client with middleware errors
-			_, err := tc.config.ToClientConn(context.Background(), tc.host, componenttest.NewNopTelemetrySettings())
+			_, err := tc.config.ToClientConn(tc.host, componenttest.NewNopTelemetrySettings())
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errText)
 		})

--- a/config/confighttp/client_middleware_test.go
+++ b/config/confighttp/client_middleware_test.go
@@ -4,7 +4,6 @@
 package confighttp
 
 import (
-	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -119,7 +118,7 @@ func TestClientMiddlewares(t *testing.T) {
 			}
 
 			// Create the client
-			client, err := clientConfig.ToClient(context.Background(), host, componenttest.NewNopTelemetrySettings())
+			client, err := clientConfig.ToClient(host, componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			// Create a request to the test server
@@ -191,7 +190,7 @@ func TestClientMiddlewareErrors(t *testing.T) {
 	for _, tc := range httpTests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Trying to create the client should fail
-			_, err := tc.config.ToClient(context.Background(), tc.host, componenttest.NewNopTelemetrySettings())
+			_, err := tc.config.ToClient(tc.host, componenttest.NewNopTelemetrySettings())
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errText)
 		})
@@ -247,7 +246,7 @@ func TestGRPCClientMiddlewareErrors(t *testing.T) {
 			// For gRPC, we need to use the configgrpc.ClientConfig structure
 			// We'll test the middleware failure path here using the HTTP client approach,
 			// as the middleware resolution logic is the same
-			_, err := tc.config.ToClient(context.Background(), tc.host, componenttest.NewNopTelemetrySettings())
+			_, err := tc.config.ToClient(tc.host, componenttest.NewNopTelemetrySettings())
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errText)
 		})

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -179,7 +178,7 @@ func TestHTTPClientCompression(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			client, err := clientSettings.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
+			client, err := clientSettings.ToClient(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 			res, err := client.Do(req)
 			if tt.shouldError {

--- a/config/confighttp/confighttp_example_test.go
+++ b/config/confighttp/confighttp_example_test.go
@@ -4,7 +4,6 @@
 package confighttp
 
 import (
-	"context"
 	"net/http"
 
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -15,7 +14,6 @@ func ExampleServerConfig() {
 	settings.Endpoint = "localhost:443"
 
 	s, err := settings.ToServer(
-		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
@@ -23,7 +21,7 @@ func ExampleServerConfig() {
 		panic(err)
 	}
 
-	l, err := settings.ToListener(context.Background())
+	l, err := settings.ToListener()
 	if err != nil {
 		panic(err)
 	}

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -164,7 +164,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tel := componenttest.NewNopTelemetrySettings()
 			tel.TracerProvider = nil
-			client, err := tt.settings.ToClient(context.Background(), host, tel)
+			client, err := tt.settings.ToClient(host, tel)
 			if tt.shouldError {
 				assert.Error(t, err)
 				return
@@ -216,7 +216,7 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tel := componenttest.NewNopTelemetrySettings()
 			tel.TracerProvider = nil
-			client, err := tt.settings.ToClient(context.Background(), host, tel)
+			client, err := tt.settings.ToClient(host, tel)
 			require.NoError(t, err)
 			transport := client.Transport.(*http.Transport)
 			assert.Equal(t, 1024, transport.ReadBufferSize)
@@ -265,7 +265,7 @@ func TestProxyURL(t *testing.T) {
 
 			tel := componenttest.NewNopTelemetrySettings()
 			tel.TracerProvider = nil
-			client, err := s.ToClient(context.Background(), componenttest.NewNopHost(), tel)
+			client, err := s.ToClient(componenttest.NewNopHost(), tel)
 
 			if tt.err {
 				require.Error(t, err)
@@ -335,7 +335,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.err, func(t *testing.T) {
-			_, err := tt.settings.ToClient(context.Background(), host, componenttest.NewNopTelemetrySettings())
+			_, err := tt.settings.ToClient(host, componenttest.NewNopTelemetrySettings())
 			assert.Regexp(t, tt.err, err)
 		})
 	}
@@ -464,7 +464,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Omit TracerProvider and MeterProvider in TelemetrySettings as otelhttp.Transport cannot be introspected
-			client, err := tt.settings.ToClient(context.Background(), tt.host, nilProvidersSettings)
+			client, err := tt.settings.ToClient(tt.host, nilProvidersSettings)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return
@@ -536,7 +536,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.err, func(t *testing.T) {
-			_, err := tt.settings.ToListener(context.Background())
+			_, err := tt.settings.ToListener()
 			assert.Regexp(t, tt.err, err)
 		})
 	}
@@ -671,11 +671,10 @@ func TestHttpReception(t *testing.T) {
 				Endpoint: "localhost:0",
 				TLS:      tt.tlsServerCreds,
 			}
-			ln, err := hss.ToListener(context.Background())
+			ln, err := hss.ToListener()
 			require.NoError(t, err)
 
 			s, err := hss.ToServer(
-				context.Background(),
 				componenttest.NewNopHost(),
 				componenttest.NewNopTelemetrySettings(),
 				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -700,7 +699,7 @@ func TestHttpReception(t *testing.T) {
 				TLS:      *tt.tlsClientCreds,
 			}
 
-			client, errClient := hcs.ToClient(context.Background(), componenttest.NewNopHost(), nilProvidersSettings)
+			client, errClient := hcs.ToClient(componenttest.NewNopHost(), nilProvidersSettings)
 			require.NoError(t, errClient)
 
 			if tt.forceHTTP1 {
@@ -784,11 +783,10 @@ func TestHttpCors(t *testing.T) {
 				CORS:     tt.CORSConfig,
 			}
 
-			ln, err := hss.ToListener(context.Background())
+			ln, err := hss.ToListener()
 			require.NoError(t, err)
 
 			s, err := hss.ToServer(
-				context.Background(),
 				componenttest.NewNopHost(),
 				componenttest.NewNopTelemetrySettings(),
 				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -829,7 +827,6 @@ func TestHttpCorsInvalidSettings(t *testing.T) {
 
 	// This effectively does not enable CORS but should also not cause an error
 	s, err := hss.ToServer(
-		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
@@ -859,7 +856,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 		},
 	}
 
-	srv, err := hss.ToServer(context.Background(), host, componenttest.NewNopTelemetrySettings(), nil)
+	srv, err := hss.ToServer(host, componenttest.NewNopTelemetrySettings(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 
@@ -902,11 +899,10 @@ func TestHttpServerHeaders(t *testing.T) {
 				ResponseHeaders: tt.headers,
 			}
 
-			ln, err := hss.ToListener(context.Background())
+			ln, err := hss.ToListener()
 			require.NoError(t, err)
 
 			s, err := hss.ToServer(
-				context.Background(),
 				componenttest.NewNopHost(),
 				componenttest.NewNopTelemetrySettings(),
 				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1009,7 +1005,7 @@ func TestHttpClientHeaders(t *testing.T) {
 				Timeout:         0,
 				Headers:         tt.headers,
 			}
-			client, _ := setting.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
+			client, _ := setting.ToClient(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			req, err := http.NewRequest(http.MethodGet, setting.Endpoint, nil)
 			require.NoError(t, err)
 			_, err = client.Do(req)
@@ -1045,7 +1041,7 @@ func TestHttpClientHostHeader(t *testing.T) {
 			Timeout:         0,
 			Headers:         tt.headers,
 		}
-		client, _ := setting.ToClient(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
+		client, _ := setting.ToClient(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 		req, err := http.NewRequest(http.MethodGet, setting.Endpoint, nil)
 		require.NoError(t, err)
 		_, err = client.Do(req)
@@ -1064,7 +1060,7 @@ func TestHttpTransportOptions(t *testing.T) {
 	clientConfig.IdleConnTimeout = time.Duration(100)
 	clientConfig.MaxConnsPerHost = 100
 	clientConfig.MaxIdleConnsPerHost = 100
-	client, err := clientConfig.ToClient(context.Background(), &mockHost{}, settings)
+	client, err := clientConfig.ToClient(&mockHost{}, settings)
 	require.NoError(t, err)
 	transport, ok := client.Transport.(*http.Transport)
 	require.True(t, ok, "client.Transport is not an *http.Transport")
@@ -1078,7 +1074,7 @@ func TestHttpTransportOptions(t *testing.T) {
 	clientConfig.IdleConnTimeout = 0
 	clientConfig.MaxConnsPerHost = 0
 	clientConfig.IdleConnTimeout = time.Duration(0)
-	client, err = clientConfig.ToClient(context.Background(), &mockHost{}, settings)
+	client, err = clientConfig.ToClient(&mockHost{}, settings)
 	require.NoError(t, err)
 	transport, ok = client.Transport.(*http.Transport)
 	require.True(t, ok, "client.Transport is not an *http.Transport")
@@ -1175,7 +1171,7 @@ func TestServerAuth(t *testing.T) {
 		handlerCalled = true
 	})
 
-	srv, err := hss.ToServer(context.Background(), host, componenttest.NewNopTelemetrySettings(), handler)
+	srv, err := hss.ToServer(host, componenttest.NewNopTelemetrySettings(), handler)
 	require.NoError(t, err)
 
 	// tt
@@ -1195,7 +1191,7 @@ func TestInvalidServerAuth(t *testing.T) {
 		}),
 	}
 
-	srv, err := hss.ToServer(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), http.NewServeMux())
+	srv, err := hss.ToServer(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), http.NewServeMux())
 	require.Error(t, err)
 	require.Nil(t, srv)
 }
@@ -1218,7 +1214,7 @@ func TestFailedServerAuth(t *testing.T) {
 		},
 	}
 
-	srv, err := hss.ToServer(context.Background(), host, componenttest.NewNopTelemetrySettings(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv, err := hss.ToServer(host, componenttest.NewNopTelemetrySettings(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	require.NoError(t, err)
 
 	// tt
@@ -1256,7 +1252,7 @@ func TestFailedServerAuthWithErrorHandler(t *testing.T) {
 		http.Error(w, err, http.StatusInternalServerError)
 	}
 
-	srv, err := hss.ToServer(context.Background(), host, componenttest.NewNopTelemetrySettings(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), WithErrorHandler(eh))
+	srv, err := hss.ToServer(host, componenttest.NewNopTelemetrySettings(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), WithErrorHandler(eh))
 	require.NoError(t, err)
 
 	// tt
@@ -1280,7 +1276,6 @@ func TestServerWithErrorHandler(t *testing.T) {
 	}
 
 	srv, err := hss.ToServer(
-		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
@@ -1308,7 +1303,6 @@ func TestServerWithDecoder(t *testing.T) {
 	}
 
 	srv, err := hss.ToServer(
-		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
@@ -1335,7 +1329,6 @@ func TestServerWithDecompression(t *testing.T) {
 	body := []byte(strings.Repeat("a", 1000*1000)) // 1 MB
 
 	srv, err := hss.ToServer(
-		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
 		http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
@@ -1403,7 +1396,6 @@ func TestDefaultMaxRequestBodySize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.settings.ToServer(
-				context.Background(),
 				componenttest.NewNopHost(),
 				componenttest.NewNopTelemetrySettings(),
 				http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
@@ -1443,7 +1435,7 @@ func TestAuthWithQueryParams(t *testing.T) {
 		handlerCalled = true
 	})
 
-	srv, err := hss.ToServer(context.Background(), host, componenttest.NewNopTelemetrySettings(), handler)
+	srv, err := hss.ToServer(host, componenttest.NewNopTelemetrySettings(), handler)
 	require.NoError(t, err)
 
 	// tt
@@ -1511,7 +1503,6 @@ func BenchmarkHttpRequest(b *testing.B) {
 	}
 
 	s, err := hss.ToServer(
-		context.Background(),
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings(),
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1519,7 +1510,7 @@ func BenchmarkHttpRequest(b *testing.B) {
 			assert.NoError(b, errWrite)
 		}))
 	require.NoError(b, err)
-	ln, err := hss.ToListener(context.Background())
+	ln, err := hss.ToListener()
 	require.NoError(b, err)
 
 	go func() {
@@ -1538,12 +1529,12 @@ func BenchmarkHttpRequest(b *testing.B) {
 		b.Run(bb.name, func(b *testing.B) {
 			var c *http.Client
 			if !bb.clientPerThread {
-				c, err = hcs.ToClient(context.Background(), componenttest.NewNopHost(), nilProvidersSettings)
+				c, err = hcs.ToClient(componenttest.NewNopHost(), nilProvidersSettings)
 				require.NoError(b, err)
 			}
 			b.RunParallel(func(pb *testing.PB) {
 				if c == nil {
-					c, err = hcs.ToClient(context.Background(), componenttest.NewNopHost(), nilProvidersSettings)
+					c, err = hcs.ToClient(componenttest.NewNopHost(), nilProvidersSettings)
 					require.NoError(b, err)
 				}
 				if bb.forceHTTP1 {
@@ -1603,7 +1594,6 @@ func TestHTTPServerTelemetry_Tracing(t *testing.T) {
 			config := NewDefaultServerConfig()
 			config.Endpoint = "localhost:0"
 			srv, err := config.ToServer(
-				context.Background(),
 				componenttest.NewNopHost(),
 				telemetry.NewTelemetrySettings(),
 				testcase.handler,
@@ -1611,7 +1601,7 @@ func TestHTTPServerTelemetry_Tracing(t *testing.T) {
 			require.NoError(t, err)
 
 			done := make(chan struct{})
-			lis, err := config.ToListener(context.Background())
+			lis, err := config.ToListener()
 			require.NoError(t, err)
 			go func() {
 				defer close(done)

--- a/config/confighttp/server_middleware_test.go
+++ b/config/confighttp/server_middleware_test.go
@@ -4,7 +4,6 @@
 package confighttp
 
 import (
-	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -104,7 +103,6 @@ func TestServerMiddleware(t *testing.T) {
 
 			// Create the server
 			srv, err := cfg.ToServer(
-				context.Background(),
 				host,
 				componenttest.NewNopTelemetrySettings(),
 				handler,
@@ -184,7 +182,6 @@ func TestServerMiddlewareErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Trying to create the server should fail
 			_, err := tc.config.ToServer(
-				context.Background(),
 				tc.host,
 				componenttest.NewNopTelemetrySettings(),
 				handler,
@@ -239,7 +236,6 @@ func TestServerMiddlewareErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Trying to create the server should fail
 			_, err := tc.config.ToServer(
-				context.Background(),
 				tc.host,
 				componenttest.NewNopTelemetrySettings(),
 				handler,

--- a/config/confighttp/xconfighttp/options_test.go
+++ b/config/confighttp/xconfighttp/options_test.go
@@ -31,7 +31,6 @@ func TestServerWithOtelHTTPOptions(t *testing.T) {
 	telemetry.TracerProvider = tp
 
 	srv, err := hss.ToServer(
-		context.Background(),
 		componenttest.NewNopHost(),
 		telemetry,
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),

--- a/config/configmiddleware/configmiddleware.go
+++ b/config/configmiddleware/configmiddleware.go
@@ -6,7 +6,6 @@
 package configmiddleware // import "go.opentelemetry.io/collector/config/configmiddleware"
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -38,7 +37,7 @@ type Config struct {
 // returns the HTTP client wrapper function. If a middleware is not
 // found, an error is returned.  This should only be used by HTTP
 // clients.
-func (m Config) GetHTTPClientRoundTripper(_ context.Context, extensions map[component.ID]component.Component) (func(http.RoundTripper) (http.RoundTripper, error), error) {
+func (m Config) GetHTTPClientRoundTripper(extensions map[component.ID]component.Component) (func(http.RoundTripper) (http.RoundTripper, error), error) {
 	if ext, found := extensions[m.ID]; found {
 		if client, ok := ext.(extensionmiddleware.HTTPClient); ok {
 			return client.GetHTTPRoundTripper, nil
@@ -53,7 +52,7 @@ func (m Config) GetHTTPClientRoundTripper(_ context.Context, extensions map[comp
 // returns the http.Handler wrapper function. If a middleware is not
 // found, an error is returned.  This should only be used by HTTP
 // servers.
-func (m Config) GetHTTPServerHandler(_ context.Context, extensions map[component.ID]component.Component) (func(http.Handler) (http.Handler, error), error) {
+func (m Config) GetHTTPServerHandler(extensions map[component.ID]component.Component) (func(http.Handler) (http.Handler, error), error) {
 	if ext, found := extensions[m.ID]; found {
 		if server, ok := ext.(extensionmiddleware.HTTPServer); ok {
 			return server.GetHTTPHandler, nil
@@ -68,7 +67,7 @@ func (m Config) GetHTTPServerHandler(_ context.Context, extensions map[component
 // extensionmiddleware.GRPCClient from the map of extensions, and
 // returns the gRPC dial options. If a middleware is not found, an
 // error is returned.  This should only be used by gRPC clients.
-func (m Config) GetGRPCClientOptions(_ context.Context, extensions map[component.ID]component.Component) ([]grpc.DialOption, error) {
+func (m Config) GetGRPCClientOptions(extensions map[component.ID]component.Component) ([]grpc.DialOption, error) {
 	if ext, found := extensions[m.ID]; found {
 		if client, ok := ext.(extensionmiddleware.GRPCClient); ok {
 			return client.GetGRPCClientOptions()
@@ -82,7 +81,7 @@ func (m Config) GetGRPCClientOptions(_ context.Context, extensions map[component
 // extensionmiddleware.GRPCServer from the map of extensions, and
 // returns the gRPC server options. If a middleware is not found, an
 // error is returned.  This should only be used by gRPC servers.
-func (m Config) GetGRPCServerOptions(_ context.Context, extensions map[component.ID]component.Component) ([]grpc.ServerOption, error) {
+func (m Config) GetGRPCServerOptions(extensions map[component.ID]component.Component) ([]grpc.ServerOption, error) {
 	if ext, found := extensions[m.ID]; found {
 		if server, ok := ext.(extensionmiddleware.GRPCServer); ok {
 			return server.GetGRPCServerOptions()

--- a/config/configmiddleware/configmiddleware_test.go
+++ b/config/configmiddleware/configmiddleware_test.go
@@ -4,7 +4,6 @@
 package configmiddleware
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,8 +23,6 @@ type mockWrongType struct {
 }
 
 func TestConfig_GetHTTPServerHandler(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name       string
 		middleware Config
@@ -64,7 +61,7 @@ func TestConfig_GetHTTPServerHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, err := tt.middleware.GetHTTPServerHandler(ctx, tt.extensions)
+			value, err := tt.middleware.GetHTTPServerHandler(tt.extensions)
 
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -77,8 +74,6 @@ func TestConfig_GetHTTPServerHandler(t *testing.T) {
 }
 
 func TestConfig_GetHTTPClientRoundTripper(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name       string
 		middleware Config
@@ -117,7 +112,7 @@ func TestConfig_GetHTTPClientRoundTripper(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, err := tt.middleware.GetHTTPClientRoundTripper(ctx, tt.extensions)
+			value, err := tt.middleware.GetHTTPClientRoundTripper(tt.extensions)
 
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -130,8 +125,6 @@ func TestConfig_GetHTTPClientRoundTripper(t *testing.T) {
 }
 
 func TestConfig_GetGRPCServerOptions(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name       string
 		middleware Config
@@ -180,7 +173,7 @@ func TestConfig_GetGRPCServerOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, err := tt.middleware.GetGRPCServerOptions(ctx, tt.extensions)
+			value, err := tt.middleware.GetGRPCServerOptions(tt.extensions)
 
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -193,8 +186,6 @@ func TestConfig_GetGRPCServerOptions(t *testing.T) {
 }
 
 func TestConfig_GetGRPCClientOptions(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name       string
 		middleware Config
@@ -243,7 +234,7 @@ func TestConfig_GetGRPCClientOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, err := tt.middleware.GetGRPCClientOptions(ctx, tt.extensions)
+			value, err := tt.middleware.GetGRPCClientOptions(tt.extensions)
 
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -4,7 +4,6 @@
 package configtls // import "go.opentelemetry.io/collector/config/configtls"
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -403,7 +402,7 @@ func (c Config) loadCert(caPath string) (*x509.CertPool, error) {
 }
 
 // LoadTLSConfig loads the TLS configuration.
-func (c ClientConfig) LoadTLSConfig(_ context.Context) (*tls.Config, error) {
+func (c ClientConfig) LoadTLSConfig() (*tls.Config, error) {
 	if c.Insecure && !c.hasCA() {
 		return nil, nil
 	}
@@ -418,7 +417,7 @@ func (c ClientConfig) LoadTLSConfig(_ context.Context) (*tls.Config, error) {
 }
 
 // LoadTLSConfig loads the TLS configuration.
-func (c ServerConfig) LoadTLSConfig(_ context.Context) (*tls.Config, error) {
+func (c ServerConfig) LoadTLSConfig() (*tls.Config, error) {
 	tlsCfg, err := c.loadTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS config: %w", err)

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -4,7 +4,6 @@
 package configtls
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -276,7 +275,7 @@ func TestLoadTLSClientConfigError(t *testing.T) {
 			KeyFile:  "doesnt/exist",
 		},
 	}
-	_, err := tlsSetting.LoadTLSConfig(context.Background())
+	_, err := tlsSetting.LoadTLSConfig()
 	assert.Error(t, err)
 }
 
@@ -284,19 +283,19 @@ func TestLoadTLSClientConfig(t *testing.T) {
 	tlsSetting := ClientConfig{
 		Insecure: true,
 	}
-	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
+	tlsCfg, err := tlsSetting.LoadTLSConfig()
 	require.NoError(t, err)
 	assert.Nil(t, tlsCfg)
 
 	tlsSetting = ClientConfig{}
-	tlsCfg, err = tlsSetting.LoadTLSConfig(context.Background())
+	tlsCfg, err = tlsSetting.LoadTLSConfig()
 	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 
 	tlsSetting = ClientConfig{
 		InsecureSkipVerify: true,
 	}
-	tlsCfg, err = tlsSetting.LoadTLSConfig(context.Background())
+	tlsCfg, err = tlsSetting.LoadTLSConfig()
 	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 	assert.True(t, tlsCfg.InsecureSkipVerify)
@@ -309,19 +308,19 @@ func TestLoadTLSServerConfigError(t *testing.T) {
 			KeyFile:  "doesnt/exist",
 		},
 	}
-	_, err := tlsSetting.LoadTLSConfig(context.Background())
+	_, err := tlsSetting.LoadTLSConfig()
 	require.Error(t, err)
 
 	tlsSetting = ServerConfig{
 		ClientCAFile: "doesnt/exist",
 	}
-	_, err = tlsSetting.LoadTLSConfig(context.Background())
+	_, err = tlsSetting.LoadTLSConfig()
 	assert.Error(t, err)
 }
 
 func TestLoadTLSServerConfig(t *testing.T) {
 	tlsSetting := ServerConfig{}
-	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
+	tlsCfg, err := tlsSetting.LoadTLSConfig()
 	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 }
@@ -336,7 +335,7 @@ func TestLoadTLSServerConfigReload(t *testing.T) {
 		ReloadClientCAFile: true,
 	}
 
-	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
+	tlsCfg, err := tlsSetting.LoadTLSConfig()
 	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 
@@ -366,7 +365,7 @@ func TestLoadTLSServerConfigFailingReload(t *testing.T) {
 		ReloadClientCAFile: true,
 	}
 
-	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
+	tlsCfg, err := tlsSetting.LoadTLSConfig()
 	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 
@@ -396,7 +395,7 @@ func TestLoadTLSServerConfigFailingInitialLoad(t *testing.T) {
 		ReloadClientCAFile: true,
 	}
 
-	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
+	tlsCfg, err := tlsSetting.LoadTLSConfig()
 	require.Error(t, err)
 	assert.Nil(t, tlsCfg)
 }
@@ -409,7 +408,7 @@ func TestLoadTLSServerConfigWrongPath(t *testing.T) {
 		ReloadClientCAFile: true,
 	}
 
-	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
+	tlsCfg, err := tlsSetting.LoadTLSConfig()
 	require.Error(t, err)
 	assert.Nil(t, tlsCfg)
 }
@@ -424,7 +423,7 @@ func TestLoadTLSServerConfigFailing(t *testing.T) {
 		ReloadClientCAFile: true,
 	}
 
-	tlsCfg, err := tlsSetting.LoadTLSConfig(context.Background())
+	tlsCfg, err := tlsSetting.LoadTLSConfig()
 	require.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
 
@@ -792,7 +791,7 @@ func TestSystemCertPool(t *testing.T) {
 			serverConfig := ServerConfig{
 				Config: test.tlsConfig,
 			}
-			c, err := serverConfig.LoadTLSConfig(context.Background())
+			c, err := serverConfig.LoadTLSConfig()
 			if test.wantErr != nil {
 				require.ErrorContains(t, err, test.wantErr.Error())
 			} else {
@@ -802,7 +801,7 @@ func TestSystemCertPool(t *testing.T) {
 			clientConfig := ClientConfig{
 				Config: test.tlsConfig,
 			}
-			c, err = clientConfig.LoadTLSConfig(context.Background())
+			c, err = clientConfig.LoadTLSConfig()
 			if test.wantErr != nil {
 				assert.ErrorContains(t, err, test.wantErr.Error())
 			} else {
@@ -914,7 +913,7 @@ func TestCurvePreferences(t *testing.T) {
 				CurvePreferences: test.preferences,
 			},
 		}
-		config, err := tlsSetting.LoadTLSConfig(context.Background())
+		config, err := tlsSetting.LoadTLSConfig()
 		if test.expectedErr == "" {
 			require.NoError(t, err)
 			require.ElementsMatchf(t, test.expectedCurveIDs, config.CurvePreferences, "expected %v, got %v", test.expectedCurveIDs, config.CurvePreferences)

--- a/docs/rfcs/optional-config-type.md
+++ b/docs/rfcs/optional-config-type.md
@@ -142,7 +142,7 @@ func NewDefaultServerConfig() ServerConfig {
 	}
 }
 
-func (hss *ServerConfig) ToListener(ctx context.Context) (net.Listener, error) {
+func (hss *ServerConfig) ToListener() (net.Listener, error) {
 	listener, err := net.Listen("tcp", hss.Endpoint)
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func (hss *ServerConfig) ToListener(ctx context.Context) (net.Listener, error) {
 
 	if hss.TLSSetting.HasValue() {
 		var tlsCfg *tls.Config
-		tlsCfg, err = hss.TLSSetting.Value().LoadTLSConfig(ctx)
+		tlsCfg, err = hss.TLSSetting.Value().LoadTLSConfig()
 		if err != nil {
 			return nil, err
 		}
@@ -161,7 +161,7 @@ func (hss *ServerConfig) ToListener(ctx context.Context) (net.Listener, error) {
 	return listener, nil
 }
 
-func (hss *ServerConfig) ToServer(_ context.Context, host component.Host, settings component.TelemetrySettings, handler http.Handler, opts ...ToServerOption) (*http.Server, error) {
+func (hss *ServerConfig) ToServer(host component.Host, settings component.TelemetrySettings, handler http.Handler, opts ...ToServerOption) (*http.Server, error) {
 	// ...
 
 	handler = httpContentDecompressor(
@@ -175,7 +175,7 @@ func (hss *ServerConfig) ToServer(_ context.Context, host component.Host, settin
 	// ...
 
 	if hss.Auth.HasValue() {
-		server, err := hss.Auth.Value().GetServerAuthenticator(context.Background(), host.GetExtensions())
+		server, err := hss.Auth.Value().GetServerAuthenticator(host.GetExtensions())
 		if err != nil {
 			return nil, err
 		}

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -61,9 +61,9 @@ func newExporter(cfg component.Config, set exporter.Settings) *baseExporter {
 
 // start actually creates the gRPC connection. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
-func (e *baseExporter) start(ctx context.Context, host component.Host) (err error) {
+func (e *baseExporter) start(_ context.Context, host component.Host) (err error) {
 	agentOpt := configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))
-	if e.clientConn, err = e.config.ClientConfig.ToClientConn(ctx, host, e.settings, agentOpt); err != nil {
+	if e.clientConn, err = e.config.ClientConfig.ToClientConn(host, e.settings, agentOpt); err != nil {
 		return err
 	}
 	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -81,8 +81,8 @@ func newExporter(cfg component.Config, set exporter.Settings) (*baseExporter, er
 
 // start actually creates the HTTP client. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
-func (e *baseExporter) start(ctx context.Context, host component.Host) error {
-	client, err := e.config.ClientConfig.ToClient(ctx, host, e.settings)
+func (e *baseExporter) start(_ context.Context, host component.Host) error {
+	client, err := e.config.ClientConfig.ToClient(host, e.settings)
 	if err != nil {
 		return err
 	}

--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -46,7 +46,7 @@ type registerableTracerProvider interface {
 	UnregisterSpanProcessor(SpanProcessor trace.SpanProcessor)
 }
 
-func (zpe *zpagesExtension) Start(ctx context.Context, host component.Host) error {
+func (zpe *zpagesExtension) Start(_ context.Context, host component.Host) error {
 	zPagesMux := http.NewServeMux()
 
 	sdktracer, ok := zpe.telemetry.TracerProvider.(registerableTracerProvider)
@@ -75,13 +75,13 @@ func (zpe *zpagesExtension) Start(ctx context.Context, host component.Host) erro
 
 	// Start the listener here so we can have earlier failure if port is
 	// already in use.
-	ln, err := zpe.config.ToListener(ctx)
+	ln, err := zpe.config.ToListener()
 	if err != nil {
 		return err
 	}
 
 	zpe.telemetry.Logger.Info("Starting zPages extension", zap.Any("config", zpe.config))
-	zpe.server, err = zpe.config.ToServer(ctx, host, zpe.telemetry, zPagesMux)
+	zpe.server, err = zpe.config.ToServer(host, zpe.telemetry, zPagesMux)
 	if err != nil {
 		return err
 	}

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -94,7 +94,7 @@ func (r *otlpReceiver) startGRPCServer(host component.Host) error {
 
 	grpcCfg := r.cfg.GRPC.Get()
 	var err error
-	if r.serverGRPC, err = grpcCfg.ToServer(context.Background(), host, r.settings.TelemetrySettings); err != nil {
+	if r.serverGRPC, err = grpcCfg.ToServer(host, r.settings.TelemetrySettings); err != nil {
 		return err
 	}
 
@@ -131,7 +131,7 @@ func (r *otlpReceiver) startGRPCServer(host component.Host) error {
 	return nil
 }
 
-func (r *otlpReceiver) startHTTPServer(ctx context.Context, host component.Host) error {
+func (r *otlpReceiver) startHTTPServer(host component.Host) error {
 	// If HTTP is not enabled, nothing to start.
 	if !r.cfg.HTTP.HasValue() {
 		return nil
@@ -168,13 +168,13 @@ func (r *otlpReceiver) startHTTPServer(ctx context.Context, host component.Host)
 	}
 
 	var err error
-	if r.serverHTTP, err = httpCfg.ServerConfig.ToServer(ctx, host, r.settings.TelemetrySettings, httpMux, confighttp.WithErrorHandler(errorHandler)); err != nil {
+	if r.serverHTTP, err = httpCfg.ServerConfig.ToServer(host, r.settings.TelemetrySettings, httpMux, confighttp.WithErrorHandler(errorHandler)); err != nil {
 		return err
 	}
 
 	r.settings.Logger.Info("Starting HTTP server", zap.String("endpoint", httpCfg.ServerConfig.Endpoint))
 	var hln net.Listener
-	if hln, err = httpCfg.ServerConfig.ToListener(ctx); err != nil {
+	if hln, err = httpCfg.ServerConfig.ToListener(); err != nil {
 		return err
 	}
 
@@ -195,7 +195,7 @@ func (r *otlpReceiver) Start(ctx context.Context, host component.Host) error {
 	if err := r.startGRPCServer(host); err != nil {
 		return err
 	}
-	if err := r.startHTTPServer(ctx, host); err != nil {
+	if err := r.startHTTPServer(host); err != nil {
 		// It's possible that a valid GRPC server configuration was specified,
 		// but an invalid HTTP configuration. If that's the case, the successfully
 		// started GRPC server must be shutdown to ensure no goroutines are leaked.


### PR DESCRIPTION
#### Description

Remove unused context.Context parameter from config methods

This is breaking several usages in otelcol contrib that will need to be fixed when updating otelcol.
