### PR TITLE
Enable `exporter.PersistRequestContext` feature gate by default

### DIFF
--- a/.chloggen/enable-persist-request-context-by-default.yaml
+++ b/.chloggen/enable-persist-request-context-by-default.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable `exporter.PersistRequestContext` feature gate by default.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13437]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Request context is now preserved by default when using persistent queues.
+  Note that Auth extensions context is not propagated through the persistent queue.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -49,6 +49,8 @@ similarly as for in-memory buffering, defaults to 1000 batches).
 
 When persistent queue is enabled, the batches are being buffered using the provided storage extension - [filestorage] is a popular and safe choice. If the collector instance is killed while having some items in the persistent queue, on restart the items will be picked and the exporting is continued.
 
+**Context Propagation**: Request context (including client metadata and span context) is preserved when using persistent queues. However, context set by Auth extensions is **not** propagated through the persistent queue. Auth extension context is ignored when data is persisted to disk, which means authentication/authorization information will not be available when the persisted data is processed.
+
 ```
                                                               ┌─Consumer #1─┐
                                                               │    ┌───┐    │

--- a/exporter/exporterhelper/internal/queue/fg.go
+++ b/exporter/exporterhelper/internal/queue/fg.go
@@ -8,7 +8,7 @@ import "go.opentelemetry.io/collector/featuregate"
 // PersistRequestContextFeatureGate controls whether request context should be preserved in the persistent queue.
 var PersistRequestContextFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"exporter.PersistRequestContext",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterFromVersion("v0.128.0"),
 	featuregate.WithRegisterDescription("controls whether context should be stored alongside requests in the persistent queue"),
 )


### PR DESCRIPTION
Related issue: https://github.com/open-telemetry/opentelemetry-collector/issues/13242