### PR TITLE
[chore]: enable fatcontext linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - depguard
     - errcheck
     - errorlint
+    - fatcontext
     - gocritic
     - gosec
     - govet


### PR DESCRIPTION
#### Description

Enable and fixes [fatcontext](https://golangci-lint.run/usage/linters/#fatcontext) linter