### PR TITLE
Fix JSON unmarshal and add e2e tests

### DIFF
--- a/.chloggen/fix-unmarshal-json.yaml
+++ b/.chloggen/fix-unmarshal-json.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: xpdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix unmarshaling JSON for entities, add e2e tests to avoid this in the future.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13480]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pdata/internal/wrapper_entityref.go
+++ b/pdata/internal/wrapper_entityref.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/pdata/internal"
+
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+func UnmarshalJSONIterEntityRef(ms EntityRef, iter *jsoniter.Iterator) {
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, f string) bool {
+		switch f {
+		case "schemaUrl", "schema_url":
+			ms.orig.SchemaUrl = iter.ReadString()
+		case "type":
+			ms.orig.Type = iter.ReadString()
+		case "idKeys", "id_keys":
+			UnmarshalJSONStreamStringSlice(NewStringSlice(&ms.orig.IdKeys, ms.state), iter)
+		case "descriptionKeys", "description_keys":
+			UnmarshalJSONStreamStringSlice(NewStringSlice(&ms.orig.DescriptionKeys, ms.state), iter)
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+}

--- a/pdata/internal/wrapper_entityrefslice.go
+++ b/pdata/internal/wrapper_entityrefslice.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/pdata/internal"
+
+import (
+	jsoniter "github.com/json-iterator/go"
+
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
+)
+
+func UnmarshalJSONIterEntityRefSlice(ms EntityRefSlice, iter *jsoniter.Iterator) {
+	iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
+		*ms.orig = append(*ms.orig, &otlpcommon.EntityRef{})
+		UnmarshalJSONIterEntityRef(NewEntityRef((*ms.orig)[len(*ms.orig)-1], ms.state), iter)
+		return true
+	})
+}

--- a/pdata/internal/wrapper_map.go
+++ b/pdata/internal/wrapper_map.go
@@ -47,8 +47,19 @@ func GenerateTestMap() Map {
 }
 
 func FillTestMap(dest Map) {
-	*dest.orig = nil
-	*dest.orig = append(*dest.orig, otlpcommon.KeyValue{Key: "k", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "v"}}})
+	*dest.orig = []otlpcommon.KeyValue{
+		{Key: "str", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value"}}},
+		{Key: "bool", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BoolValue{BoolValue: true}}},
+		{Key: "double", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_DoubleValue{DoubleValue: 3.14}}},
+		{Key: "int", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: 123}}},
+		{Key: "bytes", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BytesValue{BytesValue: []byte{1, 2, 3}}}},
+		{Key: "array", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{
+			ArrayValue: &otlpcommon.ArrayValue{Values: []otlpcommon.AnyValue{{Value: &otlpcommon.AnyValue_IntValue{IntValue: 321}}}},
+		}}},
+		{Key: "map", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_KvlistValue{
+			KvlistValue: &otlpcommon.KeyValueList{Values: []otlpcommon.KeyValue{{Key: "key", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value"}}}}},
+		}}},
+	}
 }
 
 func UnmarshalJSONIterMap(ms Map, iter *jsoniter.Iterator) {

--- a/pdata/internal/wrapper_resource.go
+++ b/pdata/internal/wrapper_resource.go
@@ -16,6 +16,8 @@ func UnmarshalJSONIterResource(ms Resource, iter *jsoniter.Iterator) {
 			UnmarshalJSONIterMap(NewMap(&ms.orig.Attributes, ms.state), iter)
 		case "droppedAttributesCount", "dropped_attributes_count":
 			ms.orig.DroppedAttributesCount = json.ReadUint32(iter)
+		case "entityRefs", "entity_refs":
+			UnmarshalJSONIterEntityRefSlice(NewEntityRefSlice(&ms.orig.EntityRefs, ms.state), iter)
 		default:
 			iter.Skip()
 		}

--- a/pdata/internal/wrapper_stringslice.go
+++ b/pdata/internal/wrapper_stringslice.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/pdata/internal"
+
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+func UnmarshalJSONStreamStringSlice(ms StringSlice, iter *jsoniter.Iterator) {
+	iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
+		*ms.orig = append(*ms.orig, iter.ReadString())
+		return true
+	})
+}

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -23,7 +23,7 @@ func TestMap(t *testing.T) {
 
 	putString := NewMap()
 	putString.PutStr("k", "v")
-	assert.Equal(t, Map(internal.GenerateTestMap()), putString)
+	assert.Equal(t, generateTestStringMap(t), putString)
 
 	putInt := NewMap()
 	putInt.PutInt("k", 123)
@@ -541,6 +541,12 @@ func generateTestEmptyMap(t *testing.T) Map {
 func generateTestEmptySlice(t *testing.T) Map {
 	m := NewMap()
 	assert.NoError(t, m.FromRaw(map[string]any{"k": []any(nil)}))
+	return m
+}
+
+func generateTestStringMap(t *testing.T) Map {
+	m := NewMap()
+	assert.NoError(t, m.FromRaw(map[string]any{"k": "v"}))
 	return m
 }
 

--- a/pdata/plog/json_test.go
+++ b/pdata/plog/json_test.go
@@ -74,6 +74,20 @@ func TestJSONMarshal(t *testing.T) {
 	assert.JSONEq(t, logsJSON, string(jsonBuf))
 }
 
+func TestJSONMarshalAndUnmarshal(t *testing.T) {
+	want := NewLogs()
+	fillTestResourceLogsSlice(want.ResourceLogs())
+
+	encoder := &JSONMarshaler{}
+	jsonBuf, err := encoder.MarshalLogs(want)
+	require.NoError(t, err)
+
+	decoder := &JSONUnmarshaler{}
+	got, err := decoder.UnmarshalLogs(jsonBuf)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func TestJSONUnmarshalInvalid(t *testing.T) {
 	jsonStr := `{"extra":"", "resourceLogs": "extra"}`
 	decoder := &JSONUnmarshaler{}

--- a/pdata/pmetric/json_test.go
+++ b/pdata/pmetric/json_test.go
@@ -49,6 +49,20 @@ func TestMetricsJSON_Marshal(t *testing.T) {
 	assert.JSONEq(t, metricsJSON, string(jsonBuf))
 }
 
+func TestJSONMarshalAndUnmarshal(t *testing.T) {
+	want := NewMetrics()
+	fillTestResourceMetricsSlice(want.ResourceMetrics())
+
+	encoder := &JSONMarshaler{}
+	jsonBuf, err := encoder.MarshalMetrics(want)
+	require.NoError(t, err)
+
+	decoder := &JSONUnmarshaler{}
+	got, err := decoder.UnmarshalMetrics(jsonBuf)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 var metricsSumOTLPFull = func() Metrics {
 	metric := NewMetrics()
 	rs := metric.ResourceMetrics().AppendEmpty()

--- a/pdata/pprofile/json_test.go
+++ b/pdata/pprofile/json_test.go
@@ -135,6 +135,20 @@ func TestJSONMarshal(t *testing.T) {
 	assert.JSONEq(t, profilesJSON, string(jsonBuf))
 }
 
+func TestJSONMarshalAndUnmarshal(t *testing.T) {
+	want := NewProfiles()
+	fillTestResourceProfilesSlice(want.ResourceProfiles())
+
+	encoder := &JSONMarshaler{}
+	jsonBuf, err := encoder.MarshalProfiles(want)
+	require.NoError(t, err)
+
+	decoder := &JSONUnmarshaler{}
+	got, err := decoder.UnmarshalProfiles(jsonBuf)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func TestJSONUnmarshalInvalid(t *testing.T) {
 	jsonStr := `{"extra":"", "resourceProfiles": "extra"}`
 	decoder := &JSONUnmarshaler{}

--- a/pdata/ptrace/json_test.go
+++ b/pdata/ptrace/json_test.go
@@ -116,6 +116,20 @@ func TestJSONUnmarshalInvalid(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestJSONMarshalAndUnmarshal(t *testing.T) {
+	want := NewTraces()
+	fillTestResourceSpansSlice(want.ResourceSpans())
+
+	encoder := &JSONMarshaler{}
+	jsonBuf, err := encoder.MarshalTraces(want)
+	require.NoError(t, err)
+
+	decoder := &JSONUnmarshaler{}
+	got, err := decoder.UnmarshalTraces(jsonBuf)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func TestUnmarshalJsoniterTraceData(t *testing.T) {
 	jsonStr := `{"extra":"", "resourceSpans": [{"extra":""}]}`
 	iter := jsoniter.ConfigFastest.BorrowIterator([]byte(jsonStr))


### PR DESCRIPTION
When Entity was added, we forgot to update the unmarshal logic. Add e2e tests so that this cannot happened in the future.