### PR TITLE
[exporter/otlphttp] add custom profiles_endpoint config setting

### DIFF
--- a/.chloggen/13504.yaml
+++ b/.chloggen/13504.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlphttpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `profiles_endpoint` configuration option to allow custom endpoint for profiles data export"
+
+# One or more tracking issues or pull requests related to the change
+issues: [13504]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `profiles_endpoint` configuration follows the same pattern as `traces_endpoint`, `metrics_endpoint`, and `logs_endpoint`.
+  When specified, profiles data will be sent to the custom URL instead of the default `{endpoint}/v1development/profiles`.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user] 

--- a/exporter/otlphttpexporter/README.md
+++ b/exporter/otlphttpexporter/README.md
@@ -34,6 +34,7 @@ The following settings can be optionally configured:
 - `metrics_endpoint` (no default): The target URL to send metric data to (e.g.: https://example.com:4318/v1/metrics).
    If this setting is present the `endpoint` setting is ignored for metrics.
 - `logs_endpoint` (no default): The target URL to send log data to (e.g.: https://example.com:4318/v1/logs).
+- `profiles_endpoint` (no default): The target URL to send profile data to (e.g.: https://example.com:4318/v1development/profiles).
    If this setting is present the `endpoint` setting is ignored for logs.
 - `tls`: see [TLS Configuration Settings](../../config/configtls/README.md) for the full set of available options.
 - `timeout` (default = 30s): HTTP request time limit. For details see https://golang.org/pkg/net/http/#Client

--- a/exporter/otlphttpexporter/config.go
+++ b/exporter/otlphttpexporter/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	// The URL to send logs to. If omitted the Endpoint + "/v1/logs" will be used.
 	LogsEndpoint string `mapstructure:"logs_endpoint"`
 
+	// The URL to send profiles to. If omitted the Endpoint + "/v1development/profiles" will be used.
+	ProfilesEndpoint string `mapstructure:"profiles_endpoint"`
+
 	// The encoding to export telemetry (default: "proto")
 	Encoding EncodingType `mapstructure:"encoding"`
 }
@@ -66,7 +69,7 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
-	if cfg.ClientConfig.Endpoint == "" && cfg.TracesEndpoint == "" && cfg.MetricsEndpoint == "" && cfg.LogsEndpoint == "" {
+	if cfg.ClientConfig.Endpoint == "" && cfg.TracesEndpoint == "" && cfg.MetricsEndpoint == "" && cfg.LogsEndpoint == "" && cfg.ProfilesEndpoint == "" {
 		return errors.New("at least one endpoint must be specified")
 	}
 	return nil

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -83,6 +83,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				MaxConnsPerHost:     defaultMaxConnsPerHost,
 				IdleConnTimeout:     defaultIdleConnTimeout,
 			},
+			ProfilesEndpoint: "https://custom.profiles.endpoint:8080/v1development/profiles",
 		}, cfg)
 }
 
@@ -135,6 +136,70 @@ func TestUnmarshalEncoding(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expected, encoding)
+			}
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr bool
+	}{
+		{
+			name: "no endpoints specified",
+			cfg: &Config{
+				ClientConfig: confighttp.ClientConfig{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "main endpoint specified",
+			cfg: &Config{
+				ClientConfig: confighttp.ClientConfig{
+					Endpoint: "http://localhost:4318",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "only traces endpoint specified",
+			cfg: &Config{
+				ClientConfig:   confighttp.ClientConfig{},
+				TracesEndpoint: "http://localhost:4318/v1/traces",
+			},
+			wantErr: false,
+		},
+		{
+			name: "only profiles endpoint specified",
+			cfg: &Config{
+				ClientConfig:     confighttp.ClientConfig{},
+				ProfilesEndpoint: "http://localhost:4318/v1development/profiles",
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple endpoints specified",
+			cfg: &Config{
+				ClientConfig:     confighttp.ClientConfig{},
+				TracesEndpoint:   "http://localhost:4318/v1/traces",
+				MetricsEndpoint:  "http://localhost:4318/v1/metrics",
+				LogsEndpoint:     "http://localhost:4318/v1/logs",
+				ProfilesEndpoint: "http://localhost:4318/v1development/profiles",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "at least one endpoint must be specified")
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -161,7 +161,7 @@ func createProfiles(
 	}
 	oCfg := cfg.(*Config)
 
-	oce.profilesURL, err = composeSignalURL(oCfg, "", "profiles", "v1development")
+	oce.profilesURL, err = composeSignalURL(oCfg, oCfg.ProfilesEndpoint, "profiles", "v1development")
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -210,6 +210,17 @@ func TestCreateProfiles(t *testing.T) {
 	require.NotNil(t, oexp)
 }
 
+func TestCreateProfilesWithCustomEndpoint(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.ProfilesEndpoint = "http://" + testutil.GetAvailableLocalAddress(t) + "/custom/profiles"
+
+	set := exportertest.NewNopSettings(factory.Type())
+	oexp, err := factory.(xexporter.Factory).CreateProfiles(context.Background(), set, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, oexp)
+}
+
 func TestComposeSignalURL(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
@@ -231,4 +242,16 @@ func TestComposeSignalURL(t *testing.T) {
 	url, err = composeSignalURL(cfg, "", "traces", "v2")
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:4318/v2/traces", url)
+
+	// Test profiles endpoint with v1development
+	cfg.ClientConfig.Endpoint = "http://localhost:4318"
+	url, err = composeSignalURL(cfg, "", "profiles", "v1development")
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:4318/v1development/profiles", url)
+
+	// Test with custom profiles endpoint override
+	cfg.ClientConfig.Endpoint = "http://localhost:4318"
+	url, err = composeSignalURL(cfg, "http://custom:9090/profiles", "profiles", "v1development")
+	require.NoError(t, err)
+	assert.Equal(t, "http://custom:9090/profiles", url)
 }

--- a/exporter/otlphttpexporter/testdata/config.yaml
+++ b/exporter/otlphttpexporter/testdata/config.yaml
@@ -23,3 +23,4 @@ headers:
   header1: "234"
   another: "somevalue"
 compression: gzip
+profiles_endpoint: "https://custom.profiles.endpoint:8080/v1development/profiles"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds `profiles_endpoint` config setting for otlphttpexporter
<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13504

<!--Describe what testing was performed and which tests were added.-->
#### Testing
unit and manual testing
<!--Describe the documentation added.-->
#### Documentation
updated example config and README.md
<!--Please delete paragraphs that you did not use before submitting.-->
