### PR TITLE
[chore] service/telemetry: remove Settings.AsyncErrorChannel

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -169,11 +169,10 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 
 	telFactory := telemetry.NewFactory()
 	telset := telemetry.Settings{
-		AsyncErrorChannel: set.AsyncErrorChannel,
-		BuildInfo:         set.BuildInfo,
-		ZapOptions:        set.LoggingOptions,
-		SDK:               &sdk,
-		Resource:          res,
+		BuildInfo:  set.BuildInfo,
+		ZapOptions: set.LoggingOptions,
+		SDK:        &sdk,
+		Resource:   res,
 	}
 
 	logger, loggerProvider, err := telFactory.CreateLogger(ctx, telset, &cfg.Telemetry)

--- a/service/telemetry/factory.go
+++ b/service/telemetry/factory.go
@@ -29,11 +29,10 @@ var useLocalHostAsDefaultMetricsAddressFeatureGate = featuregate.GlobalRegistry(
 
 // Settings holds configuration for building Telemetry.
 type Settings struct {
-	BuildInfo         component.BuildInfo
-	AsyncErrorChannel chan error
-	ZapOptions        []zap.Option
-	SDK               *config.SDK
-	Resource          *resource.Resource
+	BuildInfo  component.BuildInfo
+	ZapOptions []zap.Option
+	SDK        *config.SDK
+	Resource   *resource.Resource
 }
 
 // Factory is factory interface for telemetry.


### PR DESCRIPTION
#### Description

Cleanup - the field is unused, so remove it.

#### Link to tracking issue

Preparation work for https://github.com/open-telemetry/opentelemetry-collector/issues/4970

#### Testing

N/A, non-functional change.

#### Documentation

N/A