### PR TITLE
[chore] skip go.opentelemetry.io/otel v0.59.x in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,7 +78,8 @@
       "groupName": "All go.opentelemetry.io/contrib packages",
       "matchSourceUrls": [
         "https://go.opentelemetry.io/otel{/,}**"
-      ]
+      ],
+      "ignoreVersions": ["v0.59.*"]
     },
     {
       "matchManagers": [


### PR DESCRIPTION
#### Description
skip go.opentelemetry.io/otel v0.59.x in renovate, follow-up of https://github.com/open-telemetry/opentelemetry-collector/pull/13540