### PR TITLE
[chore] remove more references to the batch processor

### DIFF
--- a/confmap/provider/yamlprovider/provider_test.go
+++ b/confmap/provider/yamlprovider/provider_test.go
@@ -38,13 +38,13 @@ func TestInvalidYAML(t *testing.T) {
 
 func TestOneValue(t *testing.T) {
 	sp := createProvider()
-	ret, err := sp.Retrieve(context.Background(), "yaml:processors::batch::timeout: 2s", nil)
+	ret, err := sp.Retrieve(context.Background(), "yaml:processors::test::timeout: 2s", nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"processors": map[string]any{
-			"batch": map[string]any{
+			"test": map[string]any{
 				"timeout": "2s",
 			},
 		},
@@ -54,13 +54,13 @@ func TestOneValue(t *testing.T) {
 
 func TestNamedComponent(t *testing.T) {
 	sp := createProvider()
-	ret, err := sp.Retrieve(context.Background(), "yaml:processors::batch/foo::timeout: 3s", nil)
+	ret, err := sp.Retrieve(context.Background(), "yaml:processors::test/foo::timeout: 3s", nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"processors": map[string]any{
-			"batch/foo": map[string]any{
+			"test/foo": map[string]any{
 				"timeout": "3s",
 			},
 		},
@@ -70,16 +70,16 @@ func TestNamedComponent(t *testing.T) {
 
 func TestMapEntry(t *testing.T) {
 	sp := createProvider()
-	ret, err := sp.Retrieve(context.Background(), "yaml:processors: {batch/foo::timeout: 3s, batch::timeout: 2s}", nil)
+	ret, err := sp.Retrieve(context.Background(), "yaml:processors: {test/foo::timeout: 3s, test::timeout: 2s}", nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"processors": map[string]any{
-			"batch/foo": map[string]any{
+			"test/foo": map[string]any{
 				"timeout": "3s",
 			},
-			"batch": map[string]any{
+			"test": map[string]any{
 				"timeout": "2s",
 			},
 		},
@@ -106,16 +106,16 @@ func TestArrayEntry(t *testing.T) {
 
 func TestNewLine(t *testing.T) {
 	sp := createProvider()
-	ret, err := sp.Retrieve(context.Background(), "yaml:processors::batch/foo::timeout: 3s\nprocessors::batch::timeout: 2s", nil)
+	ret, err := sp.Retrieve(context.Background(), "yaml:processors::test/foo::timeout: 3s\nprocessors::test::timeout: 2s", nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"processors": map[string]any{
-			"batch/foo": map[string]any{
+			"test/foo": map[string]any{
 				"timeout": "3s",
 			},
-			"batch": map[string]any{
+			"test": map[string]any{
 				"timeout": "2s",
 			},
 		},
@@ -125,11 +125,11 @@ func TestNewLine(t *testing.T) {
 
 func TestDotSeparator(t *testing.T) {
 	sp := createProvider()
-	ret, err := sp.Retrieve(context.Background(), "yaml:processors.batch.timeout: 4s", nil)
+	ret, err := sp.Retrieve(context.Background(), "yaml:processors.test.timeout: 4s", nil)
 	require.NoError(t, err)
 	retMap, err := ret.AsConf()
 	require.NoError(t, err)
-	assert.Equal(t, map[string]any{"processors.batch.timeout": "4s"}, retMap.ToStringMap())
+	assert.Equal(t, map[string]any{"processors.test.timeout": "4s"}, retMap.ToStringMap())
 	assert.NoError(t, sp.Shutdown(context.Background()))
 }
 

--- a/connector/forwardconnector/README.md
+++ b/connector/forwardconnector/README.md
@@ -43,7 +43,7 @@ connectors:
 
 ### Example Usage
 
-Annotate distinct log streams, then merge them together, batch, and export.
+Annotate distinct log streams, then merge them together, and export.
 
 ```yaml
 receivers:
@@ -119,7 +119,6 @@ service:
         - foo
       processors:
         - filter
-        - batch
       exporters:
         - bar
       # - forward

--- a/docs/rfcs/component-universal-telemetry.md
+++ b/docs/rfcs/component-universal-telemetry.md
@@ -5,7 +5,7 @@
 The collector should be observable and this must naturally include observability of its pipeline components. Pipeline components
 are those components of the collector which directly interact with data, specifically receivers, processors, exporters, and connectors.
 
-It is understood that each _type_ (`filelog`, `batch`, etc) of component may emit telemetry describing its internal workings,
+It is understood that each _type_ (`filelog`, `otlp`, etc) of component may emit telemetry describing its internal workings,
 and that these internally derived signals may vary greatly based on the concerns and maturity of each component. Naturally
 though, there is much we can do to normalize the telemetry emitted from and about pipeline components.
 

--- a/docs/rfcs/processing.md
+++ b/docs/rfcs/processing.md
@@ -279,8 +279,7 @@ pipelines:
 ```
 
 The expressions would be executed in order, with each expression either mutating an input telemetry, dropping input
-telemetry, or adding additional telemetry (usually for stateful processors like batch processor which will drop telemetry
-for a window and then add them all at the same time). One caveat to note is that we would like to implement optimizations
+telemetry, or adding additional telemetry. One caveat to note is that we would like to implement optimizations
 in the transform engine, for example to only apply filtering once for multiple operations with a shared filter. Functions
 with unknown side effects may cause issues with optimization we will need to explore.
 

--- a/otelcol/command_print_test.go
+++ b/otelcol/command_print_test.go
@@ -42,7 +42,7 @@ func TestPrintCommand(t *testing.T) {
 		{
 			name: "valid URI",
 			set: confmap.ResolverSettings{
-				URIs: []string{"yaml:processors::batch/foo::timeout: 3s"},
+				URIs: []string{"yaml:processors::test/foo::timeout: 3s"},
 				ProviderFactories: []confmap.ProviderFactory{
 					yamlprovider.NewFactory(),
 				},
@@ -52,7 +52,7 @@ func TestPrintCommand(t *testing.T) {
 		{
 			name: "valid URI - no provider set",
 			set: confmap.ResolverSettings{
-				URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
+				URIs:          []string{"yaml:processors::test/foo::timeout: 3s"},
 				DefaultScheme: "yaml",
 			},
 			errString: "at least one Provider must be supplied",
@@ -60,7 +60,7 @@ func TestPrintCommand(t *testing.T) {
 		{
 			name: "valid URI - invalid scheme name",
 			set: confmap.ResolverSettings{
-				URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
+				URIs:          []string{"yaml:processors::test/foo::timeout: 3s"},
 				DefaultScheme: "foo",
 				ProviderFactories: []confmap.ProviderFactory{
 					yamlprovider.NewFactory(),
@@ -93,7 +93,7 @@ func TestPrintCommand(t *testing.T) {
 func TestPrintCommandFeaturegateDisabled(t *testing.T) {
 	cmd := newConfigPrintSubCommand(CollectorSettings{ConfigProviderSettings: ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
-			URIs:          []string{"yaml:processors::batch/foo::timeout: 3s"},
+			URIs:          []string{"yaml:processors::test/foo::timeout: 3s"},
 			DefaultScheme: "foo",
 			ProviderFactories: []confmap.ProviderFactory{
 				yamlprovider.NewFactory(),

--- a/pdata/ptrace/doc_test.go
+++ b/pdata/ptrace/doc_test.go
@@ -152,7 +152,7 @@ func ExampleSpan_Links() {
 	scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
 	span := scopeSpans.Spans().AppendEmpty()
 
-	span.SetName("batch-processor")
+	span.SetName("memlimit-processor")
 	span.SetKind(ptrace.SpanKindInternal)
 
 	// Add links to other spans

--- a/processor/README.md
+++ b/processor/README.md
@@ -1,9 +1,7 @@
 # General Information
 
 Processors are used at various stages of a pipeline. Generally, a processor
-pre-processes data before it is exported (e.g. modify attributes or sample) or
-helps ensure that data makes it through a pipeline successfully (e.g.
-batch/retry).
+pre-processes data before it is exported (e.g. modify attributes or sample).
 
 Some important aspects of pipelines and processors to be aware of:
 - [Recommended Processors](#recommended-processors)


### PR DESCRIPTION
Non functional change, just updating more documentation to remove references to the batch processor.
