### PR TITLE
[chore] service/telemetry: remove deprecated feature gate check

### DIFF
--- a/service/telemetry/tracer.go
+++ b/service/telemetry/tracer.go
@@ -18,7 +18,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 )
 
-var noopTracerProvider = featuregate.GlobalRegistry().MustRegister("service.noopTracerProvider",
+var _ = featuregate.GlobalRegistry().MustRegister("service.noopTracerProvider",
 	featuregate.StageDeprecated,
 	featuregate.WithRegisterFromVersion("v0.107.0"),
 	featuregate.WithRegisterToVersion("v0.109.0"),
@@ -52,7 +52,7 @@ func (n *noopNoContextTracerProvider) Tracer(_ string, _ ...trace.TracerOption) 
 
 // newTracerProvider creates a new TracerProvider from Config.
 func newTracerProvider(set Settings, cfg Config) (trace.TracerProvider, error) {
-	if noopTracerProvider.IsEnabled() || cfg.Traces.Level == configtelemetry.LevelNone {
+	if cfg.Traces.Level == configtelemetry.LevelNone {
 		return &noopNoContextTracerProvider{}, nil
 	}
 


### PR DESCRIPTION
#### Description

The `service.noopTracerProvider` feature gate is now deprecated, and cannot be enabled, therefore we can remove any code that references it.

#### Link to tracking issue

Relates to https://github.com/open-telemetry/opentelemetry-collector/issues/13492

#### Testing

Manually verified the feature gate cannot be enabled.

#### Documentation

None