### PR TITLE
[chore]: Use misspell instead of cSpell

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -11,11 +11,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Run cSpell
-        uses: streetsidesoftware/cspell-action@dcd03dc3e8a59ec2e360d0c62db517baa0b4bb6d # v7.2.0
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          files: |
-            **/*.{md,yaml,yml}
-          config: '.github/workflows/utils/cspell.json'
-          check_dot_files: true
+          go-version: oldstable
+          cache: false
+      - name: Cache Go
+        id: go-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/go/bin
+            ~/go/pkg/mod
+          key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+      - name: Run Spell Check
+        run: make misspell


### PR DESCRIPTION
#### Description

To help ensure that the tooling is consistent across each of the projects, and local environments, this uses the local tooling already adopted in the collector to validate any spelling issues within the project. 


