### PR TITLE
[chore] Fix ignored paths in cspell CI

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -1,6 +1,9 @@
 name: Spell Check
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read
@@ -15,6 +18,7 @@ jobs:
       - name: Run cSpell
         uses: streetsidesoftware/cspell-action@dcd03dc3e8a59ec2e360d0c62db517baa0b4bb6d # v7.2.0
         with:
+          incremental_files_only: false
           files: |
             **/*.{md,yaml,yml}
           config: '.github/workflows/utils/cspell.json'

--- a/.github/workflows/utils/cspell.json
+++ b/.github/workflows/utils/cspell.json
@@ -274,6 +274,7 @@
       "jmacd",
       "jpkrohling",
       "jsoniter",
+      "jsonpb",
       "kafkaexporter",
       "kafkaexporter's",
       "kafkareceiver",
@@ -369,6 +370,7 @@
       "pprof",
       "pprofextension",
       "pprofile",
+      "pprofiles",
       "pprofileotlp",
       "preconfigured",
       "priya",
@@ -445,6 +447,7 @@
       "testdata",
       "testfunc",
       "testonly",
+      "testprocessor",
       "testprovider",
       "testresults",
       "testutil",
@@ -499,6 +502,7 @@
       "zpagesextension",
       "zstd"
     ],
+    "globRoot": "../../..",
     "ignorePaths": [
       ".golangci.yml",
       ".github/**/*"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes cspell workflow to:
1. Run only once on PRs instead of one because of the push and one because of the PR
2. Run on all files to avoid issues with the incremental mode
3. Use `globRoot` option to make sure that we ignore the right files (thanks @jade-guiton-dd!)
