### PR TITLE
[chore] Move all cspell config to cspell.json to make it easier to run locally

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -18,8 +18,6 @@ jobs:
       - name: Run cSpell
         uses: streetsidesoftware/cspell-action@dcd03dc3e8a59ec2e360d0c62db517baa0b4bb6d # v7.2.0
         with:
+          # Do not add any further config here, instead use the config file
           incremental_files_only: false
-          files: |
-            **/*.{md,yaml,yml}
           config: '.github/workflows/utils/cspell.json'
-          check_dot_files: true

--- a/.github/workflows/utils/cspell.json
+++ b/.github/workflows/utils/cspell.json
@@ -503,9 +503,13 @@
       "zstd"
     ],
     "enableGlobDot": true,
+    "useGitignore": true,
     "files": ["**/*.{md,yaml,yml}"],
     "globRoot": "../../..",
     "ignorePaths": [
+      ".git/*",
+      ".git/!{COMMIT_EDITMSG,EDITMSG}",
+      ".git/*/**",
       ".golangci.yml",
       ".github/**/*"
     ]

--- a/.github/workflows/utils/cspell.json
+++ b/.github/workflows/utils/cspell.json
@@ -502,6 +502,8 @@
       "zpagesextension",
       "zstd"
     ],
+    "enableGlobDot": true,
+    "files": ["**/*.{md,yaml,yml}"],
     "globRoot": "../../..",
     "ignorePaths": [
       ".golangci.yml",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Moves all configuration to cspell.json. The incremental configuration is part of the action only.

This will make it easier to run cspell locally, you now only have to run:

```sh
cspell --config .github/workflows/utils/cspell.json
```
