### PR TITLE
[chore] fix renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,7 +79,7 @@
       "matchSourceUrls": [
         "https://go.opentelemetry.io/otel{/,}**"
       ],
-      "ignoreVersions": ["v0.59.0", "v0.59.1"]
+      "allowedVersions": "!/v0.59.*/"
     },
     {
       "matchManagers": [


### PR DESCRIPTION
#### Description
fix for once and for all, apologies for the back and force
`ignoreVersions` is no longer present in latest renovate, they require to use `allowedVersions` with negated regex: https://docs.renovatebot.com/configuration-options/#ignore-versions-with-negated-regex-syntax

#### Link to tracking issue
Fixes http://github.com/open-telemetry/opentelemetry-collector/issues/13557