### PR TITLE
[componenttest] Remove `GetFactory` from nopHost

### DIFF
--- a/.chloggen/componenttest-remove-getfactory.yaml
+++ b/.chloggen/componenttest-remove-getfactory.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: componenttest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `GetFactory` from the host returned by `NewNopHost`
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This method is no longer part of the `component.Host` interface.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -7,16 +7,14 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
+var _ component.Host = (*nopHost)(nil)
+
 // nopHost mocks a receiver.ReceiverHost for test purposes.
 type nopHost struct{}
 
 // NewNopHost returns a new instance of nopHost with proper defaults for most tests.
 func NewNopHost() component.Host {
 	return &nopHost{}
-}
-
-func (nh *nopHost) GetFactory(component.Kind, component.Type) component.Factory {
-	return nil
 }
 
 func (nh *nopHost) GetExtensions() map[component.ID]component.Component {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `GetFactory` method was moved from `component.Host` to `hostcapabilities.ComponentFactory`. From what I can tell, this method is not used on the no-op host anywhere in core, and introduces an implicit loop in the dependency graph, so we should remove it before `componenttest` is made stable.

<!-- Issue number if applicable -->
#### Link to tracking issue

Works toward https://github.com/open-telemetry/opentelemetry-collector/issues/13490


