### PR TITLE
[exporterhelper] Validate Queue.Batch config

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -79,10 +79,16 @@ func (cfg *Config) Validate() error {
 		return errors.New("`wait_for_result` is not supported with a persistent queue configured with `storage`")
 	}
 
-	if cfg.Batch.HasValue() && cfg.Batch.Get().Sizer == cfg.Sizer {
-		// Avoid situations where the queue is not able to hold any data.
-		if cfg.Batch.Get().MinSize > cfg.QueueSize {
-			return errors.New("`min_size` must be less than or equal to `queue_size`")
+	if cfg.Batch.HasValue() {
+		if err := cfg.Batch.Get().Validate(); err != nil {
+			return err
+		}
+
+		if cfg.Batch.Get().Sizer == cfg.Sizer {
+			// Avoid situations where the queue is not able to hold any data.
+			if cfg.Batch.Get().MinSize > cfg.QueueSize {
+				return errors.New("`min_size` must be less than or equal to `queue_size`")
+			}
 		}
 	}
 

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -40,6 +40,10 @@ func TestConfig_Validate(t *testing.T) {
 	require.EqualError(t, cfg.Validate(), "`min_size` must be less than or equal to `queue_size`")
 
 	cfg = newTestConfig()
+	cfg.Batch.Get().Sizer = request.SizerType{}
+	require.EqualError(t, cfg.Validate(), "`batch` supports only `items` or `bytes` sizer")
+
+	cfg = newTestConfig()
 	cfg.Sizer = request.SizerTypeBytes
 	require.NoError(t, cfg.Validate())
 
@@ -66,6 +70,10 @@ func TestBatchConfig_Validate(t *testing.T) {
 
 	cfg = newTestBatchConfig()
 	cfg.Sizer = request.SizerTypeRequests
+	require.EqualError(t, cfg.Validate(), "`batch` supports only `items` or `bytes` sizer")
+
+	cfg = newTestBatchConfig()
+	cfg.Sizer = request.SizerType{}
 	require.EqualError(t, cfg.Validate(), "`batch` supports only `items` or `bytes` sizer")
 
 	cfg = newTestBatchConfig()


### PR DESCRIPTION
#### Description

The QueueBatch is not validating Batch configuration.
I may have expected the configoptional package to handle the validate reflection and do this automatically (?) but it doesn't.

Addresses missing error, see regression fixed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41830.

#### Link to tracking issue
Part of #13579 

#### Testing

Added

#### Documentation

n/a