### PR TITLE
[chore] fix metrics template when the metrics type is histogram

### DIFF
--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -126,7 +126,34 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	dp := m.data.{{ $metric.Data.Type }}().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	{{- if eq $metric.Data.Type "Histogram" }}
+	// For histogram metrics, set count, sum, and bucket data
+	dp.SetCount(1)
+	dp.SetSum(val)
+	{{- if $metric.Data.Boundaries }}
+	// Set explicit bucket boundaries
+	boundaries := []float64{ {{- range $i, $boundary := $metric.Data.Boundaries }}{{ if $i }}, {{ end }}{{ $boundary }}{{ end -}} }
+	dp.ExplicitBounds().FromRaw(boundaries)
+
+	// Find the appropriate bucket for the value
+	bucketCounts := make([]uint64, {{ len $metric.Data.Boundaries | inc }})
+	bucketIndex := len(boundaries) // Default to the last bucket (+Inf)
+	for i, boundary := range boundaries {
+		if val < boundary {
+			bucketIndex = i
+			break
+		}
+	}
+	bucketCounts[bucketIndex] = 1
+	dp.BucketCounts().FromRaw(bucketCounts)
+	{{- else }}
+	// No explicit boundaries defined
+	dp.ExplicitBounds().FromRaw([]float64{})
+	dp.BucketCounts().FromRaw([]uint64{1})
+	{{- end }}
+	{{- else }}
 	dp.Set{{ $metric.Data.MetricValueType }}Value(val)
+	{{- end }}
 	{{- range $metric.Attributes }}
     {{- if not (attributeInfo .).Optional -}}
 	{{- template "putAttribute" . -}}

--- a/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
@@ -188,11 +188,31 @@ func TestMetricsBuilder(t *testing.T) {
 					dp := ms.At(i).{{ $metric.Data.Type }}().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
+					{{- if eq $metric.Data.Type "Histogram" }}
+					// Histogram specific assertions
+					assert.Equal(t, uint64(1), dp.Count())
+					assert.Equal(t, float64(1), dp.Sum())
+					{{- if $metric.Data.Boundaries }}
+					// Verify bucket boundaries
+					assert.Equal(t, {{ len $metric.Data.Boundaries }}, dp.ExplicitBounds().Len())
+					{{- range $i, $boundary := $metric.Data.Boundaries }}
+					assert.Equal(t, float64({{ $boundary }}), dp.ExplicitBounds().At({{ $i }}))
+					{{- end }}
+					// Verify bucket counts (value 1 should go in appropriate bucket)
+					assert.Equal(t, {{ len $metric.Data.Boundaries | inc }}, dp.BucketCounts().Len())
+					{{- else }}
+					// No explicit boundaries
+					assert.Equal(t, 0, dp.ExplicitBounds().Len())
+					assert.Equal(t, 1, dp.BucketCounts().Len())
+					assert.Equal(t, uint64(1), dp.BucketCounts().At(0))
+					{{- end }}
+					{{- else }}
 					assert.Equal(t, pmetric.NumberDataPointValueType{{ $metric.Data.MetricValueType }}, dp.ValueType())
 					{{- if eq $metric.Data.MetricValueType.BasicType "float64" }}
 					assert.InDelta(t, {{ $metric.Data.MetricValueType.BasicType }}(1), dp.{{ $metric.Data.MetricValueType }}Value(), 0.01)
 					{{- else }}
 					assert.Equal(t, {{ $metric.Data.MetricValueType.BasicType }}(1), dp.{{ $metric.Data.MetricValueType }}Value())
+					{{- end }}
 					{{- end }}
 
 					{{- range $i, $attr := $metric.Attributes }}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When the type of metrics is histogram, the compiling must be failed.
This PR handle the generated code according to the type.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13575 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
