### PR TITLE
[memorylimiter] do not throw an error when asked to shutdown out of order

### DIFF
--- a/.chloggen/shutdown_memorylimiter.yaml
+++ b/.chloggen/shutdown_memorylimiter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: memorylimiterextension, memorylimiterprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Memory limiter extension and processor shutdown don't throw an error if the component was not started first.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9687]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The components would throw an error if they were shut down before being started.
+  With this change, they will no longer return an error, conforming to the lifecycle of components expected.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/memorylimiterextension/factory_test.go
+++ b/extension/memorylimiterextension/factory_test.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
-	"go.opentelemetry.io/collector/internal/memorylimiter"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -45,10 +44,10 @@ func TestCreate(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, tp)
 	// test if we can shutdown a monitoring routine that has not started
-	require.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
+	require.NoError(t, tp.Shutdown(context.Background()))
 	assert.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 
 	assert.NoError(t, tp.Shutdown(context.Background()))
-	// verify that no monitoring routine is running
-	assert.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
+	// verify that shutdown twice works:
+	assert.NoError(t, tp.Shutdown(context.Background()))
 }

--- a/extension/memorylimiterextension/generated_component_test.go
+++ b/extension/memorylimiterextension/generated_component_test.go
@@ -33,6 +33,12 @@ func TestComponentLifecycle(t *testing.T) {
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
 	require.NoError(t, sub.Unmarshal(&cfg))
+	t.Run("shutdown", func(t *testing.T) {
+		e, err := factory.Create(context.Background(), extensiontest.NewNopSettings(typ), cfg)
+		require.NoError(t, err)
+		err = e.Shutdown(context.Background())
+		require.NoError(t, err)
+	})
 	t.Run("lifecycle", func(t *testing.T) {
 		firstExt, err := factory.Create(context.Background(), extensiontest.NewNopSettings(typ), cfg)
 		require.NoError(t, err)

--- a/extension/memorylimiterextension/metadata.yaml
+++ b/extension/memorylimiterextension/metadata.yaml
@@ -13,5 +13,3 @@ tests:
     check_interval: 5s
     limit_mib: 400
     spike_limit_mib: 50
-  # TODO: https://github.com/open-telemetry/opentelemetry-collector/issues/9686
-  skip_shutdown: true

--- a/internal/memorylimiter/memorylimiter.go
+++ b/internal/memorylimiter/memorylimiter.go
@@ -27,9 +27,6 @@ var (
 	// that data is being refused due to high memory usage.
 	ErrDataRefused = errors.New("data refused due to high memory usage")
 
-	// ErrShutdownNotStarted indicates no memorylimiter has not started when shutdown
-	ErrShutdownNotStarted = errors.New("no existing monitoring routine is running")
-
 	// GetMemoryFn and ReadMemStatsFn make it overridable by tests
 	GetMemoryFn    = iruntime.TotalMemory
 	ReadMemStatsFn = runtime.ReadMemStats
@@ -121,7 +118,7 @@ func (ml *MemoryLimiter) Shutdown(context.Context) error {
 
 	switch ml.refCounter {
 	case 0:
-		return ErrShutdownNotStarted
+		return nil
 	case 1:
 		ml.ticker.Stop()
 		close(ml.closed)

--- a/processor/memorylimiterprocessor/factory_test.go
+++ b/processor/memorylimiterprocessor/factory_test.go
@@ -17,7 +17,6 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/internal/memorylimiter"
 	"go.opentelemetry.io/collector/internal/telemetry"
 	"go.opentelemetry.io/collector/internal/telemetry/componentattribute"
 	"go.opentelemetry.io/collector/pipeline"
@@ -59,7 +58,7 @@ func TestCreateProcessor(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, tp)
 	// test if we can shutdown a monitoring routine that has not started
-	require.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
+	require.NoError(t, tp.Shutdown(context.Background()))
 	require.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 
 	mp, err := factory.CreateMetrics(context.Background(), set, cfg, consumertest.NewNop())
@@ -82,13 +81,13 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NoError(t, mp.Shutdown(context.Background()))
 	assert.NoError(t, pp.Shutdown(context.Background()))
 	// verify that no monitoring routine is running
-	require.ErrorIs(t, tp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
+	require.NoError(t, tp.Shutdown(context.Background()))
 
 	// start and shutdown a new monitoring routine
 	assert.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, lp.Shutdown(context.Background()))
-	// calling it again should throw an error
-	require.ErrorIs(t, lp.Shutdown(context.Background()), memorylimiter.ErrShutdownNotStarted)
+	// calling it again should throw no error
+	require.NoError(t, lp.Shutdown(context.Background()))
 
 	var createLoggerCount int
 	for _, log := range observer.All() {

--- a/processor/memorylimiterprocessor/generated_component_test.go
+++ b/processor/memorylimiterprocessor/generated_component_test.go
@@ -69,6 +69,12 @@ func TestComponentLifecycle(t *testing.T) {
 	require.NoError(t, sub.Unmarshal(&cfg))
 
 	for _, tt := range tests {
+		t.Run(tt.name+"-shutdown", func(t *testing.T) {
+			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
+			require.NoError(t, err)
+			err = c.Shutdown(context.Background())
+			require.NoError(t, err)
+		})
 		t.Run(tt.name+"-lifecycle", func(t *testing.T) {
 			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
 			require.NoError(t, err)

--- a/processor/memorylimiterprocessor/metadata.yaml
+++ b/processor/memorylimiterprocessor/metadata.yaml
@@ -14,8 +14,6 @@ tests:
     check_interval: 5s
     limit_mib: 400
     spike_limit_mib: 50
-  # TODO: https://github.com/open-telemetry/opentelemetry-collector/issues/9687
-  skip_shutdown: true
 
 telemetry:
   metrics:


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Memory limiter extension and processor shutdown don't throw an error if the component was not started first.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #9687
