### PR TITLE
Fix Logger.With followed by componentattribute.WithAttributeSet

### DIFF
--- a/internal/telemetry/componentattribute/logger_test.go
+++ b/internal/telemetry/componentattribute/logger_test.go
@@ -225,3 +225,24 @@ type constantClock time.Time
 
 func (c constantClock) Now() time.Time                       { return time.Time(c) }
 func (c constantClock) NewTicker(time.Duration) *time.Ticker { return &time.Ticker{} }
+
+func TestLoggerWith(t *testing.T) {
+	core, observed := createZapCore()
+	logger := zap.New(core)
+	logger = logger.With(zap.String("postexisting", "value"))
+	logger = ZapLoggerWithAttributes(logger, attribute.NewSet(attribute.String("component.attr", "value")))
+	logger.Info("test")
+
+	observedLogs := observed.All()
+	require.Len(t, observedLogs, 1)
+	expectedContext := []string{
+		"preexisting",
+		"component.attr",
+		"postexisting",
+	}
+	require.Equal(t, "test", observedLogs[0].Message)
+	require.Len(t, observedLogs[0].Context, len(expectedContext))
+	for i, field := range observedLogs[0].Context {
+		require.Equal(t, expectedContext[i], field.Key)
+	}
+}

--- a/internal/telemetry/componentattribute/logger_zap.go
+++ b/internal/telemetry/componentattribute/logger_zap.go
@@ -42,7 +42,8 @@ func tryWithAttributeSet(c zapcore.Core, attrs attribute.Set) zapcore.Core {
 
 type consoleCoreWithAttributes struct {
 	zapcore.Core
-	from zapcore.Core
+	from        zapcore.Core
+	extraFields []zap.Field
 }
 
 var _ coreWithAttributes = (*consoleCoreWithAttributes)(nil)
@@ -50,19 +51,27 @@ var _ coreWithAttributes = (*consoleCoreWithAttributes)(nil)
 // NewConsoleCoreWithAttributes wraps a Zap core in order to inject component attributes as Zap fields.
 //
 // This is used for the Collector's console output.
-func NewConsoleCoreWithAttributes(c zapcore.Core, attrs attribute.Set) zapcore.Core {
+func NewConsoleCoreWithAttributes(c zapcore.Core, attrs attribute.Set, extraFields ...zap.Field) zapcore.Core {
 	var fields []zap.Field
 	for _, kv := range attrs.ToSlice() {
 		fields = append(fields, zap.String(string(kv.Key), kv.Value.AsString()))
 	}
 	return &consoleCoreWithAttributes{
-		Core: c.With(fields),
+		Core: c.With(fields).With(extraFields),
 		from: c,
 	}
 }
 
+func (ccwa *consoleCoreWithAttributes) With(fields []zapcore.Field) zapcore.Core {
+	return &consoleCoreWithAttributes{
+		Core:        ccwa.Core.With(fields),
+		from:        ccwa.from,
+		extraFields: append(ccwa.extraFields, fields...),
+	}
+}
+
 func (ccwa *consoleCoreWithAttributes) withAttributeSet(attrs attribute.Set) zapcore.Core {
-	return NewConsoleCoreWithAttributes(ccwa.from, attrs)
+	return NewConsoleCoreWithAttributes(ccwa.from, attrs, ccwa.extraFields...)
 }
 
 type otelTeeCoreWithAttributes struct {


### PR DESCRIPTION
#### Description

This PR fixes a small bug in componentattribute, where adding fields to a Logger with `Logger.With`, then calling `componentattribute.WithAttributeSet` would silently fail to set component attributes.

This is fixed by overriding the `Core.With` method on `consoleCoreWithAttributes`, to make sure that we wrap the modified inner core in a `consoleCoreWithAttributes` before returning it.

I added an `extraFields` field to `consoleCoreWithAttributes` so we can ensure Zap Fields are added in the same order (first component attributes, then custom user fields) when updating the component attributes.

This bug doesn't affect `otelTeeCoreWithAttributes`, which already does this.

The `componentattribute` API is currently internal, and none of the components that use it (the memorylimiter processor and OTLP receiver) use `Logger.With`, so there is currently no way to trigger this bug, hence the lack of a changelog.

#### Testing

I added a unit test which checks this specific use case. I confirmed that it failed before the change and now succeeds.
