### PR TITLE
[chore] Fix lint for GOOS=windows (on Windows and other OSes)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 # https://github.com/github/linguist.
 
 go.sum linguist-generated=true
+
+# To avoid git status and other tools reporting files due to different line endings
+# normalize the line endings to LF
+* text=auto eol=lf

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -51,7 +51,7 @@ $(TOOLS_BIN_DIR):
 	mkdir -p $@
 
 $(TOOLS_BIN_NAMES): $(TOOLS_BIN_DIR) $(TOOLS_MOD_DIR)/go.mod
-	cd $(TOOLS_MOD_DIR) && $(GOCMD) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))
+	cd $(TOOLS_MOD_DIR) && GOOS="" GOARCH="" $(GOCMD) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))
 
 .PHONY: test
 test: $(GOTESTSUM)

--- a/cmd/mdatagen/third_party/golint/golint.go
+++ b/cmd/mdatagen/third_party/golint/golint.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd.
 
-package golint
+package golint // import "go.opentelemetry.io/collector/cmd/mdatagen/third_party/golint"
 
 // See https://github.com/golang/lint/blob/d0100b6bd8b389f0385611eb39152c4d7c3a7905/lint.go#L771
 

--- a/config/configtls/tpm_open_windows.go
+++ b/config/configtls/tpm_open_windows.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-tpm/tpmutil"
 )
 
-func openTPM(path string) func() (transport.TPMCloser, error) {
+func openTPM(_ string) func() (transport.TPMCloser, error) {
 	return func() (transport.TPMCloser, error) {
 		tpm, err := tpmutil.OpenTPM()
 		if err != nil {

--- a/exporter/debugexporter/internal/otlptext/known_sync_error_windows.go
+++ b/exporter/debugexporter/internal/otlptext/known_sync_error_windows.go
@@ -5,12 +5,16 @@
 
 package otlptext // import "go.opentelemetry.io/collector/exporter/debugexporter/internal/otlptext"
 
-import "golang.org/x/sys/windows"
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
 
 // knownSyncError returns true if the given error is one of the known
 // non-actionable errors returned by Sync on Windows:
 //
 // - sync /dev/stderr: The handle is invalid.
 func knownSyncError(err error) bool {
-	return err == windows.ERROR_INVALID_HANDLE
+	return errors.Is(err, windows.ERROR_INVALID_HANDLE)
 }

--- a/otelcol/collector_windows.go
+++ b/otelcol/collector_windows.go
@@ -49,7 +49,7 @@ func (s *windowsService) Execute(args []string, requests <-chan svc.ChangeReques
 
 	changes <- svc.Status{State: svc.StartPending}
 	if err = s.start(elog, colErrorChannel); err != nil {
-		elog.Error(3, fmt.Sprintf("failed to start service: %v", err))
+		_ = elog.Error(3, fmt.Sprintf("failed to start service: %v", err))
 		return false, 1064 // 1064: ERROR_EXCEPTION_IN_SERVICE
 	}
 	changes <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
@@ -62,13 +62,13 @@ func (s *windowsService) Execute(args []string, requests <-chan svc.ChangeReques
 		case svc.Stop, svc.Shutdown:
 			changes <- svc.Status{State: svc.StopPending}
 			if err = s.stop(colErrorChannel); err != nil {
-				elog.Error(3, fmt.Sprintf("errors occurred while shutting down the service: %v", err))
+				_ = elog.Error(3, fmt.Sprintf("errors occurred while shutting down the service: %v", err))
 			}
 			changes <- svc.Status{State: svc.Stopped}
 			return false, 0
 
 		default:
-			elog.Error(3, fmt.Sprintf("unexpected service control request #%d", req.Cmd))
+			_ = elog.Error(3, fmt.Sprintf("unexpected service control request #%d", req.Cmd))
 			return false, 1052 // 1052: ERROR_INVALID_SERVICE_CONTROL
 		}
 	}
@@ -186,7 +186,7 @@ func (w windowsEventLogCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) 
 func (w windowsEventLogCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	buf, err := w.encoder.EncodeEntry(ent, fields)
 	if err != nil {
-		w.elog.Warning(2, fmt.Sprintf("failed encoding log entry %v\r\n", err))
+		_ = w.elog.Warning(2, fmt.Sprintf("failed encoding log entry %v\r\n", err))
 		return err
 	}
 	msg := buf.String()


### PR DESCRIPTION
Fix lint target when `GOOS=windows` and ensure that is possible to run `make lint` from other OSes. This is part of the work to release the collector for Windows ARM, tracked via https://github.com/open-telemetry/opentelemetry-collector-releases/issues/412

The golang sources were changed for it to pass lint when `GOOS=windows`, I will look into adding that to CI so it doesn't regress again.