### PR TITLE
Bump minimum Go version to 1.24

### DIFF
--- a/.chloggen/go1.24.yaml
+++ b/.chloggen/go1.24.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Increase minimum Go version to 1.24
+
+# One or more tracking issues or pull requests related to the change
+issues: [13627]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.github/workflows/builder-snapshot.yaml
+++ b/.github/workflows/builder-snapshot.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_PRO_VERSION }}
-          args: check --verbose -f .core/cmd/builder/.goreleaser.yml
+          args: check --verbose -f .core/cmd/builder/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_PRO_VERSION }}
-          args: --snapshot --clean -f .core/cmd/builder/.goreleaser.yml
+          args: --snapshot --clean -f .core/cmd/builder/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ section of the general project contributing guide.
 Working with the project sources requires the following tools:
 
 1. [git](https://git-scm.com/)
-2. [go](https://golang.org/) (version 1.23 and up)
+2. [go](https://golang.org/) (version 1.24 and up)
 3. [make](https://www.gnu.org/software/make/)
 4. [docker](https://www.docker.com/)
 
@@ -249,7 +249,7 @@ before merging (but see the above paragraph about writing good commit messages i
 
 ## General Notes
 
-This project uses Go 1.23.* and [Github Actions.](https://github.com/features/actions)
+This project uses Go 1.24.* and [Github Actions.](https://github.com/features/actions)
 
 It is recommended to run `make gofmt all` before submitting your PR.
 

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -77,7 +77,7 @@ fmt: common/gofmt common/goimports common/gofumpt
 .PHONY: tidy
 tidy:
 	rm -fr go.sum
-	$(GOCMD) mod tidy -compat=1.23.0
+	$(GOCMD) mod tidy -compat=1.24.0
 
 .PHONY: lint
 lint: $(LINT)

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/client
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/client
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -3,7 +3,7 @@
 
 module go.opentelemetry.io/collector/cmd/builder
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/knadh/koanf/parsers/yaml v1.1.0

--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -3,7 +3,7 @@
 
 module go.opentelemetry.io/collector/cmd/builder
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/knadh/koanf/parsers/yaml v1.1.0

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -148,7 +148,7 @@ func GetModules(cfg *Config) error {
 		return nil
 	}
 
-	if _, err := runGoCommand(cfg, "mod", "tidy", "-compat=1.23"); err != nil {
+	if _, err := runGoCommand(cfg, "mod", "tidy", "-compat=1.24"); err != nil {
 		return fmt.Errorf("failed to update go.mod: %w", err)
 	}
 

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -2,7 +2,7 @@
 
 module {{.Distribution.Module}}
 
-go 1.23
+go 1.24
 
 require (
 	{{- range .ConfmapConverters}}

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/cmd/mdatagen
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/cmd/mdatagen
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -2,9 +2,7 @@
 
 module go.opentelemetry.io/collector/cmd/otelcorecol
 
-go 1.23.0
-
-toolchain go1.23.12
+go 1.24.0
 
 require (
 	go.opentelemetry.io/collector/component v1.38.0

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -2,7 +2,7 @@
 
 module go.opentelemetry.io/collector/cmd/otelcorecol
 
-go 1.24.0
+go 1.24
 
 require (
 	go.opentelemetry.io/collector/component v1.38.0

--- a/component/componentstatus/go.mod
+++ b/component/componentstatus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component/componentstatus
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/component/componentstatus/go.mod
+++ b/component/componentstatus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component/componentstatus
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/component/componenttest/go.mod
+++ b/component/componenttest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component/componenttest
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/component/componenttest/go.mod
+++ b/component/componenttest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component/componenttest
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/component/go.mod
+++ b/component/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/component/go.mod
+++ b/component/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configauth/go.mod
+++ b/config/configauth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configauth
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configauth/go.mod
+++ b/config/configauth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configauth
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configcompression/go.mod
+++ b/config/configcompression/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configcompression
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configcompression/go.mod
+++ b/config/configcompression/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configcompression
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configgrpc
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/mostynb/go-grpc-compression v1.2.3

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configgrpc
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/mostynb/go-grpc-compression v1.2.3

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confighttp
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/golang/snappy v1.0.0

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confighttp
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/golang/snappy v1.0.0

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confighttp/xconfighttp
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confighttp/xconfighttp
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configmiddleware/go.mod
+++ b/config/configmiddleware/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configmiddleware
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configmiddleware/go.mod
+++ b/config/configmiddleware/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configmiddleware
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/confignet/go.mod
+++ b/config/confignet/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confignet
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/confignet/go.mod
+++ b/config/confignet/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confignet
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configopaque/go.mod
+++ b/config/configopaque/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configopaque
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configopaque/go.mod
+++ b/config/configopaque/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configopaque
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configoptional/go.mod
+++ b/config/configoptional/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configoptional
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configoptional/go.mod
+++ b/config/configoptional/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configoptional
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configretry/go.mod
+++ b/config/configretry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configretry
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/config/configretry/go.mod
+++ b/config/configretry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configretry
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/config/configtelemetry/go.mod
+++ b/config/configtelemetry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtelemetry
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configtelemetry/go.mod
+++ b/config/configtelemetry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtelemetry
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/config/configtls/go.mod
+++ b/config/configtls/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtls
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e

--- a/config/configtls/go.mod
+++ b/config/configtls/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtls
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.4.0

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.4.0

--- a/confmap/internal/e2e/go.mod
+++ b/confmap/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/internal/e2e
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/internal/e2e/go.mod
+++ b/confmap/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/internal/e2e
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/envprovider/go.mod
+++ b/confmap/provider/envprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/envprovider
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/envprovider/go.mod
+++ b/confmap/provider/envprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/envprovider
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/fileprovider/go.mod
+++ b/confmap/provider/fileprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/fileprovider
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/fileprovider/go.mod
+++ b/confmap/provider/fileprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/fileprovider
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/httpprovider/go.mod
+++ b/confmap/provider/httpprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpprovider
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/httpprovider/go.mod
+++ b/confmap/provider/httpprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpprovider
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/httpsprovider/go.mod
+++ b/confmap/provider/httpsprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpsprovider
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/httpsprovider/go.mod
+++ b/confmap/provider/httpsprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpsprovider
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/yamlprovider/go.mod
+++ b/confmap/provider/yamlprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/yamlprovider
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/provider/yamlprovider/go.mod
+++ b/confmap/provider/yamlprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/yamlprovider
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/xconfmap/go.mod
+++ b/confmap/xconfmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/xconfmap
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/confmap/xconfmap/go.mod
+++ b/confmap/xconfmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/xconfmap
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/connectortest
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/connectortest
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/google/uuid v1.6.0

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/forwardconnector
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/forwardconnector
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/connector/xconnector/go.mod
+++ b/connector/xconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/xconnector
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/connector/xconnector/go.mod
+++ b/connector/xconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/xconnector
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/consumererror/go.mod
+++ b/consumer/consumererror/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumererror
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/consumererror/go.mod
+++ b/consumer/consumererror/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumererror
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/consumererror/xconsumererror/go.mod
+++ b/consumer/consumererror/xconsumererror/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumererror/xconsumererror
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/consumererror/xconsumererror/go.mod
+++ b/consumer/consumererror/xconsumererror/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumererror/xconsumererror
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/consumertest/go.mod
+++ b/consumer/consumertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumertest
 
-go 1.23.0
+go 1.24.0
 
 replace go.opentelemetry.io/collector/consumer => ../
 

--- a/consumer/consumertest/go.mod
+++ b/consumer/consumertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumertest
 
-go 1.24.0
+go 1.24
 
 replace go.opentelemetry.io/collector/consumer => ../
 

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/xconsumer/go.mod
+++ b/consumer/xconsumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/xconsumer
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/consumer/xconsumer/go.mod
+++ b/consumer/xconsumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/xconsumer
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/debugexporter
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/debugexporter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/exportertest
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/google/uuid v1.6.0

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/exportertest
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/nopexporter
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/nopexporter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlpexporter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlpexporter
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlphttpexporter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlphttpexporter
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/xexporter/go.mod
+++ b/exporter/xexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/xexporter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/exporter/xexporter/go.mod
+++ b/exporter/xexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/xexporter
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensionauth/extensionauthtest/go.mod
+++ b/extension/extensionauth/extensionauthtest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensionauth/extensionauthtest/go.mod
+++ b/extension/extensionauth/extensionauthtest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensionauth/go.mod
+++ b/extension/extensionauth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionauth
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensionauth/go.mod
+++ b/extension/extensionauth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionauth
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensioncapabilities/go.mod
+++ b/extension/extensioncapabilities/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensioncapabilities
 
-go 1.23.0
+go 1.24.0
 
 require (
 	go.opentelemetry.io/collector/component v1.38.0

--- a/extension/extensioncapabilities/go.mod
+++ b/extension/extensioncapabilities/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensioncapabilities
 
-go 1.24.0
+go 1.24
 
 require (
 	go.opentelemetry.io/collector/component v1.38.0

--- a/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensionmiddleware/go.mod
+++ b/extension/extensionmiddleware/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionmiddleware
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensionmiddleware/go.mod
+++ b/extension/extensionmiddleware/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionmiddleware
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/extensiontest/go.mod
+++ b/extension/extensiontest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensiontest
 
-go 1.24.0
+go 1.24
 
 replace go.opentelemetry.io/collector/extension => ..
 

--- a/extension/extensiontest/go.mod
+++ b/extension/extensiontest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensiontest
 
-go 1.23.0
+go 1.24.0
 
 replace go.opentelemetry.io/collector/extension => ..
 

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/memorylimiterextension
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/memorylimiterextension
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/xextension/go.mod
+++ b/extension/xextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/xextension
 
-go 1.23.0
+go 1.24.0
 
 require (
 	go.opentelemetry.io/collector/component v1.38.0

--- a/extension/xextension/go.mod
+++ b/extension/xextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/xextension
 
-go 1.24.0
+go 1.24
 
 require (
 	go.opentelemetry.io/collector/component v1.38.0

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/zpagesextension
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/zpagesextension
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/featuregate/go.mod
+++ b/featuregate/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/featuregate
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/hashicorp/go-version v1.7.0

--- a/featuregate/go.mod
+++ b/featuregate/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/featuregate
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/hashicorp/go-version v1.7.0

--- a/filter/go.mod
+++ b/filter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/filter
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/filter/go.mod
+++ b/filter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/filter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module go.opentelemetry.io/collector
 // For the OpenTelemetry Collector Core distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module go.opentelemetry.io/collector
 // For the OpenTelemetry Collector Core distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/cmd/pdatagen/go.mod
+++ b/internal/cmd/pdatagen/go.mod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/collector/internal/cmd/pdatagen
 
-go 1.23.0
+go 1.24.0
 
 require github.com/ettle/strcase v0.2.0

--- a/internal/cmd/pdatagen/go.mod
+++ b/internal/cmd/pdatagen/go.mod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/collector/internal/cmd/pdatagen
 
-go 1.24.0
+go 1.24
 
 require github.com/ettle/strcase v0.2.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/e2e
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/prometheus/common v0.65.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/e2e
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/prometheus/common v0.65.0

--- a/internal/fanoutconsumer/go.mod
+++ b/internal/fanoutconsumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/fanoutconsumer
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/fanoutconsumer/go.mod
+++ b/internal/fanoutconsumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/fanoutconsumer
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/memorylimiter/go.mod
+++ b/internal/memorylimiter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/memorylimiter
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/shirou/gopsutil/v4 v4.25.7

--- a/internal/memorylimiter/go.mod
+++ b/internal/memorylimiter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/memorylimiter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/shirou/gopsutil/v4 v4.25.7

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/sharedcomponent
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/sharedcomponent
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/telemetry/go.mod
+++ b/internal/telemetry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/telemetry
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/telemetry/go.mod
+++ b/internal/telemetry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/telemetry
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,8 +1,6 @@
 module go.opentelemetry.io/collector/internal/tools
 
-go 1.24
-
-toolchain go1.24.0
+go 1.25
 
 require (
 	github.com/a8m/envsubst v1.4.3

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/otelcol
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/spf13/cobra v1.9.1

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/otelcol
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/spf13/cobra v1.9.1

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/otelcol/otelcoltest
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/otelcol/otelcoltest
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pdata/go.mod
+++ b/pdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pdata/go.mod
+++ b/pdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pdata/pprofile/go.mod
+++ b/pdata/pprofile/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/pprofile
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pdata/pprofile/go.mod
+++ b/pdata/pprofile/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/pprofile
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/testdata
 
-go 1.24.0
+go 1.24
 
 require (
 	go.opentelemetry.io/collector/pdata v1.38.0

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/testdata
 
-go 1.23.0
+go 1.24.0
 
 require (
 	go.opentelemetry.io/collector/pdata v1.38.0

--- a/pdata/xpdata/go.mod
+++ b/pdata/xpdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/xpdata
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pdata/xpdata/go.mod
+++ b/pdata/xpdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/xpdata
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pipeline/go.mod
+++ b/pipeline/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pipeline
 
-go 1.24.0
+go 1.24
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pipeline/go.mod
+++ b/pipeline/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pipeline
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pipeline/xpipeline/go.mod
+++ b/pipeline/xpipeline/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pipeline/xpipeline
 
-go 1.23.0
+go 1.24.0
 
 require go.opentelemetry.io/collector/pipeline v1.38.0
 

--- a/pipeline/xpipeline/go.mod
+++ b/pipeline/xpipeline/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pipeline/xpipeline
 
-go 1.24.0
+go 1.24
 
 require go.opentelemetry.io/collector/pipeline v1.38.0
 

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/batchprocessor
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/batchprocessor
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/memorylimiterprocessor
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/memorylimiterprocessor
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/processorhelper/go.mod
+++ b/processor/processorhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processorhelper
 
-go 1.23.0
+go 1.24.0
 
 replace go.opentelemetry.io/collector/processor => ../
 

--- a/processor/processorhelper/go.mod
+++ b/processor/processorhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processorhelper
 
-go 1.24.0
+go 1.24
 
 replace go.opentelemetry.io/collector/processor => ../
 

--- a/processor/processorhelper/xprocessorhelper/go.mod
+++ b/processor/processorhelper/xprocessorhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/processorhelper/xprocessorhelper/go.mod
+++ b/processor/processorhelper/xprocessorhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processortest
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processortest
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/xprocessor/go.mod
+++ b/processor/xprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/xprocessor
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/xprocessor/go.mod
+++ b/processor/xprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/xprocessor
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/nopreceiver
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/nopreceiver
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/otlpreceiver
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/klauspost/compress v1.18.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/otlpreceiver
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/klauspost/compress v1.18.0

--- a/receiver/receiverhelper/go.mod
+++ b/receiver/receiverhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/receiverhelper
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/receiverhelper/go.mod
+++ b/receiver/receiverhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/receiverhelper
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/receivertest
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/google/uuid v1.6.0

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/receivertest
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/receiver/xreceiver/go.mod
+++ b/receiver/xreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/xreceiver
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/xreceiver/go.mod
+++ b/receiver/xreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/xreceiver
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     "dependencies"
   ],
   "constraints": {
-    "go": "1.23"
+    "go": "1.24"
   },
   "extends": [
     "config:recommended",

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/scraper/scraperhelper/go.mod
+++ b/scraper/scraperhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/scraperhelper
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/scraper/scraperhelper/go.mod
+++ b/scraper/scraperhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/scraperhelper
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/scraper/scrapertest/go.mod
+++ b/scraper/scrapertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/scrapertest
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/google/uuid v1.6.0

--- a/scraper/scrapertest/go.mod
+++ b/scraper/scrapertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/scrapertest
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/service
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/service
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/google/uuid v1.6.0

--- a/service/hostcapabilities/go.mod
+++ b/service/hostcapabilities/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/service/hostcapabilities
 
-go 1.23.0
+go 1.24.0
 
 require (
 	go.opentelemetry.io/collector/component v1.38.0

--- a/service/hostcapabilities/go.mod
+++ b/service/hostcapabilities/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/service/hostcapabilities
 
-go 1.24.0
+go 1.24
 
 require (
 	go.opentelemetry.io/collector/component v1.38.0


### PR DESCRIPTION
#### Description

[Go 1.25.0](https://go.dev/doc/devel/release#go1.25.0) is released, time to bump the minimum supported version.

#### Link to tracking issue

N/A

#### Testing

N/A

#### Documentation

Updated