### PR TITLE
[chore] Use go 1.24 in internal/tools

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/tools
 
-go 1.25
+go 1.24
 
 require (
 	github.com/a8m/envsubst v1.4.3


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Follow-up to https://github.com/open-telemetry/opentelemetry-collector/pull/13627, it looks like version `1.25` snuck into the internal/tools go.mod.
