### PR TITLE
[chore] Re-write the internal.State in pdata to support multiple properties.

### DIFF
--- a/internal/cmd/pdatagen/internal/one_of_message_value.go
+++ b/internal/cmd/pdatagen/internal/one_of_message_value.go
@@ -41,8 +41,9 @@ const oneOfMessageAccessorsTestTemplate = `func Test{{ .structName }}_{{ .fieldN
 	internal.FillOrigTest{{ .returnType }}(ms.orig.Get{{ .originOneOfFieldName }}().(*{{ .originStructType }}).{{ .fieldName }})
 	assert.Equal(t, {{ .typeName }}, ms.{{ .originOneOfTypeFuncName }}())
 	assert.Equal(t, generateTest{{ .returnType }}(), ms.{{ .fieldName }}())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { new{{ .structName }}(&{{ .originStructName }}{}, &sharedState).SetEmpty{{ .fieldName }}() })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { new{{ .structName }}(&{{ .originStructName }}{}, sharedState).SetEmpty{{ .fieldName }}() })
 }
 `
 

--- a/internal/cmd/pdatagen/internal/one_of_primitive_value.go
+++ b/internal/cmd/pdatagen/internal/one_of_primitive_value.go
@@ -39,8 +39,9 @@ const oneOfPrimitiveAccessorTestTemplate = `func Test{{ .structName }}_{{ .acces
 	assert.Equal(t, {{ .testValue }}, ms.{{ .accessorFieldName }}())
 	{{- end }}
 	assert.Equal(t, {{ .typeName }}, ms.{{ .originOneOfTypeFuncName }}())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { new{{ .structName }}(&{{ .originStructName }}{}, &sharedState).Set{{ .accessorFieldName }}({{ .testValue }}) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { new{{ .structName }}(&{{ .originStructName }}{}, sharedState).Set{{ .accessorFieldName }}({{ .testValue }}) })
 }
 `
 

--- a/internal/cmd/pdatagen/internal/primitive_field.go
+++ b/internal/cmd/pdatagen/internal/primitive_field.go
@@ -40,8 +40,9 @@ const primitiveAccessorsTestTemplate = `func Test{{ .structName }}_{{ .fieldName
 	{{- else }}
 	assert.Equal(t, {{ .testValue }}, ms.{{ .fieldName }}())
 	{{- end }}
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { new{{ .structName }}(&{{ .originStructName }}{}, &sharedState).Set{{ .fieldName }}({{ .testValue }}) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { new{{ .structName }}(&{{ .originStructName }}{}, sharedState).Set{{ .fieldName }}({{ .testValue }}) })
 }`
 
 const primitiveSetTestTemplate = `orig.{{ .originFieldName }} = {{ .testValue }}`

--- a/internal/cmd/pdatagen/internal/templates/message.go.tmpl
+++ b/internal/cmd/pdatagen/internal/templates/message.go.tmpl
@@ -41,8 +41,7 @@ func new{{ .structName }}(orig *{{ .originFullName }}, state *internal.State) {{
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func New{{ .structName }}() {{ .structName }} {
-	state := internal.StateMutable
-	return new{{ .structName }}(&{{ .originFullName }}{}, &state)
+	return new{{ .structName }}(&{{ .originFullName }}{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/internal/cmd/pdatagen/internal/templates/message_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/templates/message_internal.go.tmpl
@@ -33,8 +33,7 @@ func New{{ .structName }}(orig *{{ .originFullName }}, state *State) {{ .structN
 func GenerateTest{{ .structName }}() {{ .structName }} {
 	orig := {{ .originFullName }}{}
 	FillOrigTest{{ .originName }}(&orig)
-	state := StateMutable
-	return New{{ .structName }}(&orig, &state)
+	return New{{ .structName }}(&orig, NewState())
 }
 
 {{ end }}

--- a/internal/cmd/pdatagen/internal/templates/message_test.go.tmpl
+++ b/internal/cmd/pdatagen/internal/templates/message_test.go.tmpl
@@ -20,9 +20,10 @@ func Test{{ .structName }}_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTest{{ .structName }}(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTest{{ .structName }}(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(new{{ .structName }}(&{{ .originFullName }}{}, &sharedState)) })
-	assert.Panics(t, func() { new{{ .structName }}(&{{ .originFullName }}{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(new{{ .structName }}(&{{ .originFullName }}{}, sharedState)) })
+	assert.Panics(t, func() { new{{ .structName }}(&{{ .originFullName }}{}, sharedState).MoveTo(dest) })
 }
 
 func Test{{ .structName }}_CopyTo(t *testing.T) {
@@ -33,8 +34,9 @@ func Test{{ .structName }}_CopyTo(t *testing.T) {
 	orig = generateTest{{ .structName }}()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(new{{ .structName }}(&{{ .originFullName }}{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(new{{ .structName }}(&{{ .originFullName }}{}, sharedState)) })
 }
 
 {{ range .fields }}

--- a/internal/cmd/pdatagen/internal/templates/primitive_slice.go.tmpl
+++ b/internal/cmd/pdatagen/internal/templates/primitive_slice.go.tmpl
@@ -30,8 +30,7 @@ func (ms {{ .structName }}) getState() *internal.State {
 // New{{ .structName }} creates a new empty {{ .structName }}.
 func New{{ .structName }}() {{ .structName }} {
 	orig := []{{ .itemType }}(nil)
-	state := internal.StateMutable
-	return {{ .structName }}(internal.New{{ .structName }}(&orig, &state))
+	return {{ .structName }}(internal.New{{ .structName }}(&orig, internal.NewState()))
 }
 
 // AsRaw returns a copy of the []{{ .itemType }} slice.

--- a/internal/cmd/pdatagen/internal/templates/primitive_slice_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/templates/primitive_slice_internal.go.tmpl
@@ -31,8 +31,7 @@ func New{{ .structName }}(orig *[]{{ .itemType }}, state *State) {{ .structName 
 
 func GenerateTest{{ .structName }}() {{ .structName }} {
 	orig := GenerateOrigTest{{ .elementOriginName }}Slice()
-	state := StateMutable
-	return New{{ .structName }}(&orig, &state)
+	return New{{ .structName }}(&orig, NewState())
 }
 
 func CopyOrig{{ .elementOriginName }}Slice(dst, src []{{ .itemType }}) []{{ .itemType }} {

--- a/internal/cmd/pdatagen/internal/templates/primitive_slice_test.go.tmpl
+++ b/internal/cmd/pdatagen/internal/templates/primitive_slice_test.go.tmpl
@@ -76,8 +76,9 @@ func TestNew{{ .structName }}(t *testing.T) {
 
 func Test{{ .structName }}ReadOnly(t *testing.T) {
 	raw := []{{ .itemType }}{ {{ .testOrigVal }}}
-	state := internal.StateReadOnly
-	ms := {{ .structName }}(internal.New{{ .structName }}(&raw, &state))
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	ms := {{ .structName }}(internal.New{{ .structName }}(&raw, sharedState))
 
 	assert.Equal(t, 3, ms.Len())
 	{{- if eq .itemType "float64" }}

--- a/internal/cmd/pdatagen/internal/templates/slice.go.tmpl
+++ b/internal/cmd/pdatagen/internal/templates/slice.go.tmpl
@@ -40,8 +40,7 @@ func new{{ .structName }}(orig *[]{{ .originElementType }}, state *internal.Stat
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func New{{ .structName }}() {{ .structName }} {
 	orig := []{{ .originElementType }}(nil)
-	state := internal.StateMutable
-	return new{{ .structName }}(&orig, &state)
+	return new{{ .structName }}(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/internal/cmd/pdatagen/internal/templates/slice_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/templates/slice_internal.go.tmpl
@@ -32,8 +32,7 @@ func New{{ .structName }}(orig *[]{{ .originElementType }}, state *State) {{ .st
 
 func GenerateTest{{ .structName }}() {{ .structName }} {
 	orig := GenerateOrigTest{{ .elementOriginName }}Slice()
-	state := StateMutable
-	return New{{ .structName }}(&orig, &state)
+	return New{{ .structName }}(&orig, NewState())
 }
 {{ end }}
 

--- a/internal/cmd/pdatagen/internal/templates/slice_test.go.tmpl
+++ b/internal/cmd/pdatagen/internal/templates/slice_test.go.tmpl
@@ -15,8 +15,7 @@ import (
 func Test{{ .structName }}(t *testing.T) {
 	es := New{{ .structName }}()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = new{{ .structName }}(&[]{{ .originElementType }}{}, &state)
+	es = new{{ .structName }}(&[]{{ .originElementType }}{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	{{ if eq .elementName "Value" -}}
@@ -39,8 +38,9 @@ func Test{{ .structName }}(t *testing.T) {
 }
 
 func Test{{ .structName }}ReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := new{{ .structName }}(&[]{{ .originElementType }}{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := new{{ .structName }}(&[]{{ .originElementType }}{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/internal/generated_wrapper_anyvalueslice.go
+++ b/pdata/internal/generated_wrapper_anyvalueslice.go
@@ -30,8 +30,7 @@ func NewSlice(orig *[]otlpcommon.AnyValue, state *State) Slice {
 
 func GenerateTestSlice() Slice {
 	orig := GenerateOrigTestAnyValueSlice()
-	state := StateMutable
-	return NewSlice(&orig, &state)
+	return NewSlice(&orig, NewState())
 }
 
 func CopyOrigAnyValueSlice(dest, src []otlpcommon.AnyValue) []otlpcommon.AnyValue {

--- a/pdata/internal/generated_wrapper_byteslice.go
+++ b/pdata/internal/generated_wrapper_byteslice.go
@@ -31,8 +31,7 @@ func NewByteSlice(orig *[]byte, state *State) ByteSlice {
 
 func GenerateTestByteSlice() ByteSlice {
 	orig := GenerateOrigTestByteSlice()
-	state := StateMutable
-	return NewByteSlice(&orig, &state)
+	return NewByteSlice(&orig, NewState())
 }
 
 func CopyOrigByteSlice(dst, src []byte) []byte {

--- a/pdata/internal/generated_wrapper_entityref.go
+++ b/pdata/internal/generated_wrapper_entityref.go
@@ -34,8 +34,7 @@ func NewEntityRef(orig *otlpcommon.EntityRef, state *State) EntityRef {
 func GenerateTestEntityRef() EntityRef {
 	orig := otlpcommon.EntityRef{}
 	FillOrigTestEntityRef(&orig)
-	state := StateMutable
-	return NewEntityRef(&orig, &state)
+	return NewEntityRef(&orig, NewState())
 }
 
 func NewOrigEntityRef() otlpcommon.EntityRef {

--- a/pdata/internal/generated_wrapper_entityrefslice.go
+++ b/pdata/internal/generated_wrapper_entityrefslice.go
@@ -30,8 +30,7 @@ func NewEntityRefSlice(orig *[]*otlpcommon.EntityRef, state *State) EntityRefSli
 
 func GenerateTestEntityRefSlice() EntityRefSlice {
 	orig := GenerateOrigTestEntityRefSlice()
-	state := StateMutable
-	return NewEntityRefSlice(&orig, &state)
+	return NewEntityRefSlice(&orig, NewState())
 }
 
 func CopyOrigEntityRefSlice(dest, src []*otlpcommon.EntityRef) []*otlpcommon.EntityRef {

--- a/pdata/internal/generated_wrapper_exportlogsservicerequest.go
+++ b/pdata/internal/generated_wrapper_exportlogsservicerequest.go
@@ -34,8 +34,7 @@ func NewLogs(orig *otlpcollectorlogs.ExportLogsServiceRequest, state *State) Log
 func GenerateTestLogs() Logs {
 	orig := otlpcollectorlogs.ExportLogsServiceRequest{}
 	FillOrigTestExportLogsServiceRequest(&orig)
-	state := StateMutable
-	return NewLogs(&orig, &state)
+	return NewLogs(&orig, NewState())
 }
 
 func NewOrigExportLogsServiceRequest() otlpcollectorlogs.ExportLogsServiceRequest {

--- a/pdata/internal/generated_wrapper_exportmetricsservicerequest.go
+++ b/pdata/internal/generated_wrapper_exportmetricsservicerequest.go
@@ -34,8 +34,7 @@ func NewMetrics(orig *otlpcollectormetrics.ExportMetricsServiceRequest, state *S
 func GenerateTestMetrics() Metrics {
 	orig := otlpcollectormetrics.ExportMetricsServiceRequest{}
 	FillOrigTestExportMetricsServiceRequest(&orig)
-	state := StateMutable
-	return NewMetrics(&orig, &state)
+	return NewMetrics(&orig, NewState())
 }
 
 func NewOrigExportMetricsServiceRequest() otlpcollectormetrics.ExportMetricsServiceRequest {

--- a/pdata/internal/generated_wrapper_exportprofilesservicerequest.go
+++ b/pdata/internal/generated_wrapper_exportprofilesservicerequest.go
@@ -34,8 +34,7 @@ func NewProfiles(orig *otlpcollectorprofiles.ExportProfilesServiceRequest, state
 func GenerateTestProfiles() Profiles {
 	orig := otlpcollectorprofiles.ExportProfilesServiceRequest{}
 	FillOrigTestExportProfilesServiceRequest(&orig)
-	state := StateMutable
-	return NewProfiles(&orig, &state)
+	return NewProfiles(&orig, NewState())
 }
 
 func NewOrigExportProfilesServiceRequest() otlpcollectorprofiles.ExportProfilesServiceRequest {

--- a/pdata/internal/generated_wrapper_exporttraceservicerequest.go
+++ b/pdata/internal/generated_wrapper_exporttraceservicerequest.go
@@ -34,8 +34,7 @@ func NewTraces(orig *otlpcollectortrace.ExportTraceServiceRequest, state *State)
 func GenerateTestTraces() Traces {
 	orig := otlpcollectortrace.ExportTraceServiceRequest{}
 	FillOrigTestExportTraceServiceRequest(&orig)
-	state := StateMutable
-	return NewTraces(&orig, &state)
+	return NewTraces(&orig, NewState())
 }
 
 func NewOrigExportTraceServiceRequest() otlpcollectortrace.ExportTraceServiceRequest {

--- a/pdata/internal/generated_wrapper_float64slice.go
+++ b/pdata/internal/generated_wrapper_float64slice.go
@@ -29,8 +29,7 @@ func NewFloat64Slice(orig *[]float64, state *State) Float64Slice {
 
 func GenerateTestFloat64Slice() Float64Slice {
 	orig := GenerateOrigTestFloat64Slice()
-	state := StateMutable
-	return NewFloat64Slice(&orig, &state)
+	return NewFloat64Slice(&orig, NewState())
 }
 
 func CopyOrigFloat64Slice(dst, src []float64) []float64 {

--- a/pdata/internal/generated_wrapper_instrumentationscope.go
+++ b/pdata/internal/generated_wrapper_instrumentationscope.go
@@ -34,8 +34,7 @@ func NewInstrumentationScope(orig *otlpcommon.InstrumentationScope, state *State
 func GenerateTestInstrumentationScope() InstrumentationScope {
 	orig := otlpcommon.InstrumentationScope{}
 	FillOrigTestInstrumentationScope(&orig)
-	state := StateMutable
-	return NewInstrumentationScope(&orig, &state)
+	return NewInstrumentationScope(&orig, NewState())
 }
 
 func NewOrigInstrumentationScope() otlpcommon.InstrumentationScope {

--- a/pdata/internal/generated_wrapper_int32slice.go
+++ b/pdata/internal/generated_wrapper_int32slice.go
@@ -29,8 +29,7 @@ func NewInt32Slice(orig *[]int32, state *State) Int32Slice {
 
 func GenerateTestInt32Slice() Int32Slice {
 	orig := GenerateOrigTestInt32Slice()
-	state := StateMutable
-	return NewInt32Slice(&orig, &state)
+	return NewInt32Slice(&orig, NewState())
 }
 
 func CopyOrigInt32Slice(dst, src []int32) []int32 {

--- a/pdata/internal/generated_wrapper_int64slice.go
+++ b/pdata/internal/generated_wrapper_int64slice.go
@@ -29,8 +29,7 @@ func NewInt64Slice(orig *[]int64, state *State) Int64Slice {
 
 func GenerateTestInt64Slice() Int64Slice {
 	orig := GenerateOrigTestInt64Slice()
-	state := StateMutable
-	return NewInt64Slice(&orig, &state)
+	return NewInt64Slice(&orig, NewState())
 }
 
 func CopyOrigInt64Slice(dst, src []int64) []int64 {

--- a/pdata/internal/generated_wrapper_resource.go
+++ b/pdata/internal/generated_wrapper_resource.go
@@ -34,8 +34,7 @@ func NewResource(orig *otlpresource.Resource, state *State) Resource {
 func GenerateTestResource() Resource {
 	orig := otlpresource.Resource{}
 	FillOrigTestResource(&orig)
-	state := StateMutable
-	return NewResource(&orig, &state)
+	return NewResource(&orig, NewState())
 }
 
 func NewOrigResource() otlpresource.Resource {

--- a/pdata/internal/generated_wrapper_stringslice.go
+++ b/pdata/internal/generated_wrapper_stringslice.go
@@ -29,8 +29,7 @@ func NewStringSlice(orig *[]string, state *State) StringSlice {
 
 func GenerateTestStringSlice() StringSlice {
 	orig := GenerateOrigTestStringSlice()
-	state := StateMutable
-	return NewStringSlice(&orig, &state)
+	return NewStringSlice(&orig, NewState())
 }
 
 func CopyOrigStringSlice(dst, src []string) []string {

--- a/pdata/internal/generated_wrapper_uint64slice.go
+++ b/pdata/internal/generated_wrapper_uint64slice.go
@@ -29,8 +29,7 @@ func NewUInt64Slice(orig *[]uint64, state *State) UInt64Slice {
 
 func GenerateTestUInt64Slice() UInt64Slice {
 	orig := GenerateOrigTestUint64Slice()
-	state := StateMutable
-	return NewUInt64Slice(&orig, &state)
+	return NewUInt64Slice(&orig, NewState())
 }
 
 func CopyOrigUint64Slice(dst, src []uint64) []uint64 {

--- a/pdata/internal/state.go
+++ b/pdata/internal/state.go
@@ -7,16 +7,26 @@ package internal // import "go.opentelemetry.io/collector/pdata/internal"
 type State int32
 
 const (
-	// StateMutable indicates that the data is exclusive to the current consumer.
-	StateMutable State = iota
-
-	// StateReadOnly indicates that the data is shared with other consumers.
-	StateReadOnly
+	defaultState     State = 0
+	stateReadOnlyBit       = State(1 << 0)
 )
+
+func NewState() *State {
+	state := defaultState
+	return &state
+}
+
+func (state *State) MarkReadOnly() {
+	*state |= stateReadOnlyBit
+}
+
+func (state *State) IsReadOnly() bool {
+	return *state&stateReadOnlyBit != 0
+}
 
 // AssertMutable panics if the state is not StateMutable.
 func (state *State) AssertMutable() {
-	if *state != StateMutable {
+	if *state&stateReadOnlyBit != 0 {
 		panic("invalid access to shared data")
 	}
 }

--- a/pdata/internal/state_test.go
+++ b/pdata/internal/state_test.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssertMutable(t *testing.T) {
+	assert.NotPanics(t, func() { NewState().AssertMutable() })
+	assert.Panics(t, func() {
+		state := NewState()
+		state.MarkReadOnly()
+		state.AssertMutable()
+	})
+}
+
+func BenchmarkAssertMutable(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	mutable := NewState()
+	for n := 0; n < b.N; n++ {
+		mutable.AssertMutable()
+	}
+}

--- a/pdata/internal/wrapper_logs.go
+++ b/pdata/internal/wrapper_logs.go
@@ -22,8 +22,7 @@ func LogsToProto(l Logs) otlplogs.LogsData {
 // LogsFromProto internal helper to convert protobuf representation to Logs.
 // This function set exclusive state assuming that it's called only once per Logs.
 func LogsFromProto(orig otlplogs.LogsData) Logs {
-	state := StateMutable
 	return NewLogs(&otlpcollectorlog.ExportLogsServiceRequest{
 		ResourceLogs: orig.ResourceLogs,
-	}, &state)
+	}, NewState())
 }

--- a/pdata/internal/wrapper_map.go
+++ b/pdata/internal/wrapper_map.go
@@ -26,6 +26,5 @@ func NewMap(orig *[]otlpcommon.KeyValue, state *State) Map {
 
 func GenerateTestMap() Map {
 	orig := GenerateOrigTestKeyValueSlice()
-	state := StateMutable
-	return NewMap(&orig, &state)
+	return NewMap(&orig, NewState())
 }

--- a/pdata/internal/wrapper_metrics.go
+++ b/pdata/internal/wrapper_metrics.go
@@ -22,8 +22,7 @@ func MetricsToProto(l Metrics) otlpmetrics.MetricsData {
 // MetricsFromProto internal helper to convert protobuf representation to Metrics.
 // This function set exclusive state assuming that it's called only once per Metrics.
 func MetricsFromProto(orig otlpmetrics.MetricsData) Metrics {
-	state := StateMutable
 	return NewMetrics(&otlpcollectormetrics.ExportMetricsServiceRequest{
 		ResourceMetrics: orig.ResourceMetrics,
-	}, &state)
+	}, NewState())
 }

--- a/pdata/internal/wrapper_profiles.go
+++ b/pdata/internal/wrapper_profiles.go
@@ -23,9 +23,8 @@ func ProfilesToProto(l Profiles) otlpprofile.ProfilesData {
 // ProfilesFromProto internal helper to convert protobuf representation to Profiles.
 // This function set exclusive state assuming that it's called only once per Profiles.
 func ProfilesFromProto(orig otlpprofile.ProfilesData) Profiles {
-	state := StateMutable
 	return NewProfiles(&otlpcollectorprofile.ExportProfilesServiceRequest{
 		ResourceProfiles: orig.ResourceProfiles,
 		Dictionary:       orig.Dictionary,
-	}, &state)
+	}, NewState())
 }

--- a/pdata/internal/wrapper_traces.go
+++ b/pdata/internal/wrapper_traces.go
@@ -22,8 +22,7 @@ func TracesToProto(l Traces) otlptrace.TracesData {
 // TracesFromProto internal helper to convert protobuf representation to Traces.
 // This function set exclusive state assuming that it's called only once per Traces.
 func TracesFromProto(orig otlptrace.TracesData) Traces {
-	state := StateMutable
 	return NewTraces(&otlpcollectortrace.ExportTraceServiceRequest{
 		ResourceSpans: orig.ResourceSpans,
-	}, &state)
+	}, NewState())
 }

--- a/pdata/internal/wrapper_tracestate.go
+++ b/pdata/internal/wrapper_tracestate.go
@@ -27,8 +27,7 @@ func NewTraceState(orig *string, state *State) TraceState {
 func GenerateTestTraceState() TraceState {
 	var orig string
 	FillOrigTestTraceState(&orig)
-	state := StateMutable
-	return NewTraceState(&orig, &state)
+	return NewTraceState(&orig, NewState())
 }
 
 // MarshalJSONOrigTraceState marshals all properties from the current struct to the destination stream.

--- a/pdata/internal/wrapper_value.go
+++ b/pdata/internal/wrapper_value.go
@@ -68,8 +68,7 @@ func CopyOrigAnyValue(dest, src *otlpcommon.AnyValue) {
 func GenerateTestValue() Value {
 	var orig otlpcommon.AnyValue
 	FillOrigTestAnyValue(&orig)
-	state := StateMutable
-	return NewValue(&orig, &state)
+	return NewValue(&orig, NewState())
 }
 
 // MarshalJSONOrigAnyValue marshals all properties from the current struct to the destination stream.

--- a/pdata/pcommon/generated_byteslice.go
+++ b/pdata/pcommon/generated_byteslice.go
@@ -31,8 +31,7 @@ func (ms ByteSlice) getState() *internal.State {
 // NewByteSlice creates a new empty ByteSlice.
 func NewByteSlice() ByteSlice {
 	orig := []byte(nil)
-	state := internal.StateMutable
-	return ByteSlice(internal.NewByteSlice(&orig, &state))
+	return ByteSlice(internal.NewByteSlice(&orig, internal.NewState()))
 }
 
 // AsRaw returns a copy of the []byte slice.

--- a/pdata/pcommon/generated_byteslice_test.go
+++ b/pdata/pcommon/generated_byteslice_test.go
@@ -50,8 +50,9 @@ func TestNewByteSlice(t *testing.T) {
 
 func TestByteSliceReadOnly(t *testing.T) {
 	raw := []byte{1, 2, 3}
-	state := internal.StateReadOnly
-	ms := ByteSlice(internal.NewByteSlice(&raw, &state))
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	ms := ByteSlice(internal.NewByteSlice(&raw, sharedState))
 
 	assert.Equal(t, 3, ms.Len())
 	assert.Equal(t, byte(1), ms.At(0))

--- a/pdata/pcommon/generated_float64slice.go
+++ b/pdata/pcommon/generated_float64slice.go
@@ -31,8 +31,7 @@ func (ms Float64Slice) getState() *internal.State {
 // NewFloat64Slice creates a new empty Float64Slice.
 func NewFloat64Slice() Float64Slice {
 	orig := []float64(nil)
-	state := internal.StateMutable
-	return Float64Slice(internal.NewFloat64Slice(&orig, &state))
+	return Float64Slice(internal.NewFloat64Slice(&orig, internal.NewState()))
 }
 
 // AsRaw returns a copy of the []float64 slice.

--- a/pdata/pcommon/generated_float64slice_test.go
+++ b/pdata/pcommon/generated_float64slice_test.go
@@ -50,8 +50,9 @@ func TestNewFloat64Slice(t *testing.T) {
 
 func TestFloat64SliceReadOnly(t *testing.T) {
 	raw := []float64{1.1, 2.2, 3.3}
-	state := internal.StateReadOnly
-	ms := Float64Slice(internal.NewFloat64Slice(&raw, &state))
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	ms := Float64Slice(internal.NewFloat64Slice(&raw, sharedState))
 
 	assert.Equal(t, 3, ms.Len())
 	assert.InDelta(t, float64(1.1), ms.At(0), 0.01)

--- a/pdata/pcommon/generated_instrumentationscope.go
+++ b/pdata/pcommon/generated_instrumentationscope.go
@@ -29,8 +29,7 @@ func newInstrumentationScope(orig *otlpcommon.InstrumentationScope, state *inter
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewInstrumentationScope() InstrumentationScope {
-	state := internal.StateMutable
-	return newInstrumentationScope(&otlpcommon.InstrumentationScope{}, &state)
+	return newInstrumentationScope(&otlpcommon.InstrumentationScope{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pcommon/generated_instrumentationscope_test.go
+++ b/pdata/pcommon/generated_instrumentationscope_test.go
@@ -23,9 +23,10 @@ func TestInstrumentationScope_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestInstrumentationScope(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestInstrumentationScope(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newInstrumentationScope(&otlpcommon.InstrumentationScope{}, &sharedState)) })
-	assert.Panics(t, func() { newInstrumentationScope(&otlpcommon.InstrumentationScope{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newInstrumentationScope(&otlpcommon.InstrumentationScope{}, sharedState)) })
+	assert.Panics(t, func() { newInstrumentationScope(&otlpcommon.InstrumentationScope{}, sharedState).MoveTo(dest) })
 }
 
 func TestInstrumentationScope_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestInstrumentationScope_CopyTo(t *testing.T) {
 	orig = generateTestInstrumentationScope()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newInstrumentationScope(&otlpcommon.InstrumentationScope{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newInstrumentationScope(&otlpcommon.InstrumentationScope{}, sharedState)) })
 }
 
 func TestInstrumentationScope_Name(t *testing.T) {
@@ -45,8 +47,9 @@ func TestInstrumentationScope_Name(t *testing.T) {
 	assert.Empty(t, ms.Name())
 	ms.SetName("test_name")
 	assert.Equal(t, "test_name", ms.Name())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newInstrumentationScope(&otlpcommon.InstrumentationScope{}, &sharedState).SetName("test_name") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newInstrumentationScope(&otlpcommon.InstrumentationScope{}, sharedState).SetName("test_name") })
 }
 
 func TestInstrumentationScope_Version(t *testing.T) {
@@ -54,9 +57,10 @@ func TestInstrumentationScope_Version(t *testing.T) {
 	assert.Empty(t, ms.Version())
 	ms.SetVersion("test_version")
 	assert.Equal(t, "test_version", ms.Version())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newInstrumentationScope(&otlpcommon.InstrumentationScope{}, &sharedState).SetVersion("test_version")
+		newInstrumentationScope(&otlpcommon.InstrumentationScope{}, sharedState).SetVersion("test_version")
 	})
 }
 
@@ -72,9 +76,10 @@ func TestInstrumentationScope_DroppedAttributesCount(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.DroppedAttributesCount())
 	ms.SetDroppedAttributesCount(uint32(13))
 	assert.Equal(t, uint32(13), ms.DroppedAttributesCount())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newInstrumentationScope(&otlpcommon.InstrumentationScope{}, &sharedState).SetDroppedAttributesCount(uint32(13))
+		newInstrumentationScope(&otlpcommon.InstrumentationScope{}, sharedState).SetDroppedAttributesCount(uint32(13))
 	})
 }
 

--- a/pdata/pcommon/generated_int32slice.go
+++ b/pdata/pcommon/generated_int32slice.go
@@ -31,8 +31,7 @@ func (ms Int32Slice) getState() *internal.State {
 // NewInt32Slice creates a new empty Int32Slice.
 func NewInt32Slice() Int32Slice {
 	orig := []int32(nil)
-	state := internal.StateMutable
-	return Int32Slice(internal.NewInt32Slice(&orig, &state))
+	return Int32Slice(internal.NewInt32Slice(&orig, internal.NewState()))
 }
 
 // AsRaw returns a copy of the []int32 slice.

--- a/pdata/pcommon/generated_int32slice_test.go
+++ b/pdata/pcommon/generated_int32slice_test.go
@@ -50,8 +50,9 @@ func TestNewInt32Slice(t *testing.T) {
 
 func TestInt32SliceReadOnly(t *testing.T) {
 	raw := []int32{1, 2, 3}
-	state := internal.StateReadOnly
-	ms := Int32Slice(internal.NewInt32Slice(&raw, &state))
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	ms := Int32Slice(internal.NewInt32Slice(&raw, sharedState))
 
 	assert.Equal(t, 3, ms.Len())
 	assert.Equal(t, int32(1), ms.At(0))

--- a/pdata/pcommon/generated_int64slice.go
+++ b/pdata/pcommon/generated_int64slice.go
@@ -31,8 +31,7 @@ func (ms Int64Slice) getState() *internal.State {
 // NewInt64Slice creates a new empty Int64Slice.
 func NewInt64Slice() Int64Slice {
 	orig := []int64(nil)
-	state := internal.StateMutable
-	return Int64Slice(internal.NewInt64Slice(&orig, &state))
+	return Int64Slice(internal.NewInt64Slice(&orig, internal.NewState()))
 }
 
 // AsRaw returns a copy of the []int64 slice.

--- a/pdata/pcommon/generated_int64slice_test.go
+++ b/pdata/pcommon/generated_int64slice_test.go
@@ -50,8 +50,9 @@ func TestNewInt64Slice(t *testing.T) {
 
 func TestInt64SliceReadOnly(t *testing.T) {
 	raw := []int64{1, 2, 3}
-	state := internal.StateReadOnly
-	ms := Int64Slice(internal.NewInt64Slice(&raw, &state))
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	ms := Int64Slice(internal.NewInt64Slice(&raw, sharedState))
 
 	assert.Equal(t, 3, ms.Len())
 	assert.Equal(t, int64(1), ms.At(0))

--- a/pdata/pcommon/generated_resource.go
+++ b/pdata/pcommon/generated_resource.go
@@ -29,8 +29,7 @@ func newResource(orig *otlpresource.Resource, state *internal.State) Resource {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResource() Resource {
-	state := internal.StateMutable
-	return newResource(&otlpresource.Resource{}, &state)
+	return newResource(&otlpresource.Resource{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pcommon/generated_resource_test.go
+++ b/pdata/pcommon/generated_resource_test.go
@@ -23,9 +23,10 @@ func TestResource_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResource(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestResource(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newResource(&otlpresource.Resource{}, &sharedState)) })
-	assert.Panics(t, func() { newResource(&otlpresource.Resource{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newResource(&otlpresource.Resource{}, sharedState)) })
+	assert.Panics(t, func() { newResource(&otlpresource.Resource{}, sharedState).MoveTo(dest) })
 }
 
 func TestResource_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestResource_CopyTo(t *testing.T) {
 	orig = generateTestResource()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newResource(&otlpresource.Resource{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newResource(&otlpresource.Resource{}, sharedState)) })
 }
 
 func TestResource_Attributes(t *testing.T) {
@@ -52,8 +54,9 @@ func TestResource_DroppedAttributesCount(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.DroppedAttributesCount())
 	ms.SetDroppedAttributesCount(uint32(13))
 	assert.Equal(t, uint32(13), ms.DroppedAttributesCount())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newResource(&otlpresource.Resource{}, &sharedState).SetDroppedAttributesCount(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newResource(&otlpresource.Resource{}, sharedState).SetDroppedAttributesCount(uint32(13)) })
 }
 
 func generateTestResource() Resource {

--- a/pdata/pcommon/generated_slice.go
+++ b/pdata/pcommon/generated_slice.go
@@ -30,8 +30,7 @@ func newSlice(orig *[]otlpcommon.AnyValue, state *internal.State) Slice {
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewSlice() Slice {
 	orig := []otlpcommon.AnyValue(nil)
-	state := internal.StateMutable
-	return newSlice(&orig, &state)
+	return newSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pcommon/generated_slice_test.go
+++ b/pdata/pcommon/generated_slice_test.go
@@ -18,8 +18,7 @@ import (
 func TestSlice(t *testing.T) {
 	es := NewSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newSlice(&[]otlpcommon.AnyValue{}, &state)
+	es = newSlice(&[]otlpcommon.AnyValue{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewValueEmpty()
@@ -34,8 +33,9 @@ func TestSlice(t *testing.T) {
 }
 
 func TestSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newSlice(&[]otlpcommon.AnyValue{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newSlice(&[]otlpcommon.AnyValue{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pcommon/generated_stringslice.go
+++ b/pdata/pcommon/generated_stringslice.go
@@ -31,8 +31,7 @@ func (ms StringSlice) getState() *internal.State {
 // NewStringSlice creates a new empty StringSlice.
 func NewStringSlice() StringSlice {
 	orig := []string(nil)
-	state := internal.StateMutable
-	return StringSlice(internal.NewStringSlice(&orig, &state))
+	return StringSlice(internal.NewStringSlice(&orig, internal.NewState()))
 }
 
 // AsRaw returns a copy of the []string slice.

--- a/pdata/pcommon/generated_stringslice_test.go
+++ b/pdata/pcommon/generated_stringslice_test.go
@@ -50,8 +50,9 @@ func TestNewStringSlice(t *testing.T) {
 
 func TestStringSliceReadOnly(t *testing.T) {
 	raw := []string{"a", "b", "c"}
-	state := internal.StateReadOnly
-	ms := StringSlice(internal.NewStringSlice(&raw, &state))
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	ms := StringSlice(internal.NewStringSlice(&raw, sharedState))
 
 	assert.Equal(t, 3, ms.Len())
 	assert.Equal(t, string("a"), ms.At(0))

--- a/pdata/pcommon/generated_uint64slice.go
+++ b/pdata/pcommon/generated_uint64slice.go
@@ -31,8 +31,7 @@ func (ms UInt64Slice) getState() *internal.State {
 // NewUInt64Slice creates a new empty UInt64Slice.
 func NewUInt64Slice() UInt64Slice {
 	orig := []uint64(nil)
-	state := internal.StateMutable
-	return UInt64Slice(internal.NewUInt64Slice(&orig, &state))
+	return UInt64Slice(internal.NewUInt64Slice(&orig, internal.NewState()))
 }
 
 // AsRaw returns a copy of the []uint64 slice.

--- a/pdata/pcommon/generated_uint64slice_test.go
+++ b/pdata/pcommon/generated_uint64slice_test.go
@@ -50,8 +50,9 @@ func TestNewUInt64Slice(t *testing.T) {
 
 func TestUInt64SliceReadOnly(t *testing.T) {
 	raw := []uint64{1, 2, 3}
-	state := internal.StateReadOnly
-	ms := UInt64Slice(internal.NewUInt64Slice(&raw, &state))
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	ms := UInt64Slice(internal.NewUInt64Slice(&raw, sharedState))
 
 	assert.Equal(t, 3, ms.Len())
 	assert.Equal(t, uint64(1), ms.At(0))

--- a/pdata/pcommon/map.go
+++ b/pdata/pcommon/map.go
@@ -21,8 +21,7 @@ type Map internal.Map
 // NewMap creates a Map with 0 elements.
 func NewMap() Map {
 	orig := []otlpcommon.KeyValue(nil)
-	state := internal.StateMutable
-	return Map(internal.NewMap(&orig, &state))
+	return Map(internal.NewMap(&orig, internal.NewState()))
 }
 
 func (m Map) getOrig() *[]otlpcommon.KeyValue {

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -18,8 +18,7 @@ func TestMap(t *testing.T) {
 
 	val, exist := NewMap().Get("test_key")
 	assert.False(t, exist)
-	state := internal.StateMutable
-	assert.Equal(t, newValue(nil, &state), val)
+	assert.Equal(t, newValue(nil, internal.NewState()), val)
 
 	putString := NewMap()
 	putString.PutStr("k", "v")
@@ -55,10 +54,11 @@ func TestMap(t *testing.T) {
 }
 
 func TestMapReadOnly(t *testing.T) {
-	state := internal.StateReadOnly
+	state := internal.NewState()
+	state.MarkReadOnly()
 	m := newMap(&[]otlpcommon.KeyValue{
 		{Key: "k1", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "v1"}}},
-	}, &state)
+	}, state)
 
 	assert.Equal(t, 1, m.Len())
 
@@ -188,8 +188,7 @@ func TestMapWithEmpty(t *testing.T) {
 			Value: otlpcommon.AnyValue{Value: nil},
 		},
 	}
-	state := internal.StateMutable
-	sm := newMap(&origWithNil, &state)
+	sm := newMap(&origWithNil, internal.NewState())
 	val, exist := sm.Get("test_key")
 	assert.True(t, exist)
 	assert.Equal(t, ValueTypeStr, val.Type())

--- a/pdata/pcommon/trace_state.go
+++ b/pdata/pcommon/trace_state.go
@@ -14,8 +14,7 @@ import (
 type TraceState internal.TraceState
 
 func NewTraceState() TraceState {
-	state := internal.StateMutable
-	return TraceState(internal.NewTraceState(new(string), &state))
+	return TraceState(internal.NewTraceState(new(string), internal.NewState()))
 }
 
 func (ms TraceState) getOrig() *string {

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -71,50 +71,42 @@ type Value internal.Value
 
 // NewValueEmpty creates a new Value with an empty value.
 func NewValueEmpty() Value {
-	state := internal.StateMutable
-	return newValue(&otlpcommon.AnyValue{}, &state)
+	return newValue(&otlpcommon.AnyValue{}, internal.NewState())
 }
 
 // NewValueStr creates a new Value with the given string value.
 func NewValueStr(v string) Value {
-	state := internal.StateMutable
-	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: v}}, &state)
+	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: v}}, internal.NewState())
 }
 
 // NewValueInt creates a new Value with the given int64 value.
 func NewValueInt(v int64) Value {
-	state := internal.StateMutable
-	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: v}}, &state)
+	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: v}}, internal.NewState())
 }
 
 // NewValueDouble creates a new Value with the given float64 value.
 func NewValueDouble(v float64) Value {
-	state := internal.StateMutable
-	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_DoubleValue{DoubleValue: v}}, &state)
+	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_DoubleValue{DoubleValue: v}}, internal.NewState())
 }
 
 // NewValueBool creates a new Value with the given bool value.
 func NewValueBool(v bool) Value {
-	state := internal.StateMutable
-	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BoolValue{BoolValue: v}}, &state)
+	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BoolValue{BoolValue: v}}, internal.NewState())
 }
 
 // NewValueMap creates a new Value of map type.
 func NewValueMap() Value {
-	state := internal.StateMutable
-	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_KvlistValue{KvlistValue: &otlpcommon.KeyValueList{}}}, &state)
+	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_KvlistValue{KvlistValue: &otlpcommon.KeyValueList{}}}, internal.NewState())
 }
 
 // NewValueSlice creates a new Value of array type.
 func NewValueSlice() Value {
-	state := internal.StateMutable
-	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{}}}, &state)
+	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{}}}, internal.NewState())
 }
 
 // NewValueBytes creates a new empty Value of byte type.
 func NewValueBytes() Value {
-	state := internal.StateMutable
-	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BytesValue{BytesValue: nil}}, &state)
+	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BytesValue{BytesValue: nil}}, internal.NewState())
 }
 
 func newValue(orig *otlpcommon.AnyValue, state *internal.State) Value {

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -46,8 +46,9 @@ func TestValue(t *testing.T) {
 }
 
 func TestValueReadOnly(t *testing.T) {
-	state := internal.StateReadOnly
-	v := newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "v"}}, &state)
+	state := internal.NewState()
+	state.MarkReadOnly()
+	v := newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "v"}}, state)
 
 	assert.Equal(t, ValueTypeStr, v.Type())
 	assert.Equal(t, "v", v.Str())
@@ -158,8 +159,7 @@ func TestValueMap(t *testing.T) {
 
 	// Test nil KvlistValue case for Map() func.
 	orig := &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_KvlistValue{KvlistValue: nil}}
-	state := internal.StateMutable
-	m1 = newValue(orig, &state)
+	m1 = newValue(orig, internal.NewState())
 	assert.Equal(t, Map{}, m1.Map())
 }
 
@@ -196,8 +196,7 @@ func TestValueSlice(t *testing.T) {
 	assert.Equal(t, "somestr", v.Str())
 
 	// Test nil values case for Slice() func.
-	state := internal.StateMutable
-	a1 = newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: nil}}, &state)
+	a1 = newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: nil}}, internal.NewState())
 	assert.Equal(t, newSlice(nil, nil), a1.Slice())
 }
 
@@ -250,28 +249,26 @@ func TestValue_MoveTo(t *testing.T) {
 }
 
 func TestValue_CopyTo(t *testing.T) {
-	state := internal.StateMutable
-
 	// Test nil KvlistValue case for Map() func.
 	dest := NewValueEmpty()
 	orig := &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_KvlistValue{KvlistValue: nil}}
-	newValue(orig, &state).CopyTo(dest)
+	newValue(orig, internal.NewState()).CopyTo(dest)
 	assert.Nil(t, dest.getOrig().Value.(*otlpcommon.AnyValue_KvlistValue).KvlistValue)
 
 	// Test nil ArrayValue case for Slice() func.
 	dest = NewValueEmpty()
 	orig = &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: nil}}
-	newValue(orig, &state).CopyTo(dest)
+	newValue(orig, internal.NewState()).CopyTo(dest)
 	assert.Nil(t, dest.getOrig().Value.(*otlpcommon.AnyValue_ArrayValue).ArrayValue)
 
 	// Test copy empty value.
 	orig = &otlpcommon.AnyValue{}
-	newValue(orig, &state).CopyTo(dest)
+	newValue(orig, internal.NewState()).CopyTo(dest)
 	assert.Nil(t, dest.getOrig().Value)
 
 	av := NewValueEmpty()
 	destVal := otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{}}
-	av.CopyTo(newValue(&destVal, &state))
+	av.CopyTo(newValue(&destVal, internal.NewState()))
 	assert.Nil(t, destVal.Value)
 }
 
@@ -280,8 +277,7 @@ func TestSliceWithNilValues(t *testing.T) {
 		{},
 		{Value: &otlpcommon.AnyValue_StringValue{StringValue: "test_value"}},
 	}
-	state := internal.StateMutable
-	sm := newSlice(&origWithNil, &state)
+	sm := newSlice(&origWithNil, internal.NewState())
 
 	val := sm.At(0)
 	assert.Equal(t, ValueTypeEmpty, val.Type())

--- a/pdata/plog/generated_logrecord.go
+++ b/pdata/plog/generated_logrecord.go
@@ -34,8 +34,7 @@ func newLogRecord(orig *otlplogs.LogRecord, state *internal.State) LogRecord {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLogRecord() LogRecord {
-	state := internal.StateMutable
-	return newLogRecord(&otlplogs.LogRecord{}, &state)
+	return newLogRecord(&otlplogs.LogRecord{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/generated_logrecord_test.go
+++ b/pdata/plog/generated_logrecord_test.go
@@ -25,9 +25,10 @@ func TestLogRecord_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLogRecord(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestLogRecord(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newLogRecord(&otlplogs.LogRecord{}, &sharedState)) })
-	assert.Panics(t, func() { newLogRecord(&otlplogs.LogRecord{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newLogRecord(&otlplogs.LogRecord{}, sharedState)) })
+	assert.Panics(t, func() { newLogRecord(&otlplogs.LogRecord{}, sharedState).MoveTo(dest) })
 }
 
 func TestLogRecord_CopyTo(t *testing.T) {
@@ -38,8 +39,9 @@ func TestLogRecord_CopyTo(t *testing.T) {
 	orig = generateTestLogRecord()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newLogRecord(&otlplogs.LogRecord{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newLogRecord(&otlplogs.LogRecord{}, sharedState)) })
 }
 
 func TestLogRecord_Timestamp(t *testing.T) {
@@ -71,8 +73,9 @@ func TestLogRecord_SeverityText(t *testing.T) {
 	assert.Empty(t, ms.SeverityText())
 	ms.SetSeverityText("test_severitytext")
 	assert.Equal(t, "test_severitytext", ms.SeverityText())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newLogRecord(&otlplogs.LogRecord{}, &sharedState).SetSeverityText("test_severitytext") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newLogRecord(&otlplogs.LogRecord{}, sharedState).SetSeverityText("test_severitytext") })
 }
 
 func TestLogRecord_Body(t *testing.T) {
@@ -94,8 +97,9 @@ func TestLogRecord_DroppedAttributesCount(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.DroppedAttributesCount())
 	ms.SetDroppedAttributesCount(uint32(13))
 	assert.Equal(t, uint32(13), ms.DroppedAttributesCount())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newLogRecord(&otlplogs.LogRecord{}, &sharedState).SetDroppedAttributesCount(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newLogRecord(&otlplogs.LogRecord{}, sharedState).SetDroppedAttributesCount(uint32(13)) })
 }
 
 func TestLogRecord_Flags(t *testing.T) {
@@ -127,8 +131,9 @@ func TestLogRecord_EventName(t *testing.T) {
 	assert.Empty(t, ms.EventName())
 	ms.SetEventName("test_eventname")
 	assert.Equal(t, "test_eventname", ms.EventName())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newLogRecord(&otlplogs.LogRecord{}, &sharedState).SetEventName("test_eventname") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newLogRecord(&otlplogs.LogRecord{}, sharedState).SetEventName("test_eventname") })
 }
 
 func generateTestLogRecord() LogRecord {

--- a/pdata/plog/generated_logrecordslice.go
+++ b/pdata/plog/generated_logrecordslice.go
@@ -34,8 +34,7 @@ func newLogRecordSlice(orig *[]*otlplogs.LogRecord, state *internal.State) LogRe
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewLogRecordSlice() LogRecordSlice {
 	orig := []*otlplogs.LogRecord(nil)
-	state := internal.StateMutable
-	return newLogRecordSlice(&orig, &state)
+	return newLogRecordSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/plog/generated_logrecordslice_test.go
+++ b/pdata/plog/generated_logrecordslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestLogRecordSlice(t *testing.T) {
 	es := NewLogRecordSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newLogRecordSlice(&[]*otlplogs.LogRecord{}, &state)
+	es = newLogRecordSlice(&[]*otlplogs.LogRecord{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewLogRecord()
@@ -35,8 +34,9 @@ func TestLogRecordSlice(t *testing.T) {
 }
 
 func TestLogRecordSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newLogRecordSlice(&[]*otlplogs.LogRecord{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newLogRecordSlice(&[]*otlplogs.LogRecord{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/plog/generated_logs.go
+++ b/pdata/plog/generated_logs.go
@@ -30,8 +30,7 @@ func newLogs(orig *otlpcollectorlogs.ExportLogsServiceRequest, state *internal.S
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLogs() Logs {
-	state := internal.StateMutable
-	return newLogs(&otlpcollectorlogs.ExportLogsServiceRequest{}, &state)
+	return newLogs(&otlpcollectorlogs.ExportLogsServiceRequest{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/generated_logs_test.go
+++ b/pdata/plog/generated_logs_test.go
@@ -23,9 +23,10 @@ func TestLogs_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLogs(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestLogs(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newLogs(&otlpcollectorlogs.ExportLogsServiceRequest{}, &sharedState)) })
-	assert.Panics(t, func() { newLogs(&otlpcollectorlogs.ExportLogsServiceRequest{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newLogs(&otlpcollectorlogs.ExportLogsServiceRequest{}, sharedState)) })
+	assert.Panics(t, func() { newLogs(&otlpcollectorlogs.ExportLogsServiceRequest{}, sharedState).MoveTo(dest) })
 }
 
 func TestLogs_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestLogs_CopyTo(t *testing.T) {
 	orig = generateTestLogs()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newLogs(&otlpcollectorlogs.ExportLogsServiceRequest{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newLogs(&otlpcollectorlogs.ExportLogsServiceRequest{}, sharedState)) })
 }
 
 func TestLogs_ResourceLogs(t *testing.T) {

--- a/pdata/plog/generated_resourcelogs.go
+++ b/pdata/plog/generated_resourcelogs.go
@@ -33,8 +33,7 @@ func newResourceLogs(orig *otlplogs.ResourceLogs, state *internal.State) Resourc
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResourceLogs() ResourceLogs {
-	state := internal.StateMutable
-	return newResourceLogs(&otlplogs.ResourceLogs{}, &state)
+	return newResourceLogs(&otlplogs.ResourceLogs{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/generated_resourcelogs_test.go
+++ b/pdata/plog/generated_resourcelogs_test.go
@@ -24,9 +24,10 @@ func TestResourceLogs_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResourceLogs(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestResourceLogs(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newResourceLogs(&otlplogs.ResourceLogs{}, &sharedState)) })
-	assert.Panics(t, func() { newResourceLogs(&otlplogs.ResourceLogs{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newResourceLogs(&otlplogs.ResourceLogs{}, sharedState)) })
+	assert.Panics(t, func() { newResourceLogs(&otlplogs.ResourceLogs{}, sharedState).MoveTo(dest) })
 }
 
 func TestResourceLogs_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestResourceLogs_CopyTo(t *testing.T) {
 	orig = generateTestResourceLogs()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newResourceLogs(&otlplogs.ResourceLogs{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newResourceLogs(&otlplogs.ResourceLogs{}, sharedState)) })
 }
 
 func TestResourceLogs_Resource(t *testing.T) {
@@ -60,8 +62,9 @@ func TestResourceLogs_SchemaUrl(t *testing.T) {
 	assert.Empty(t, ms.SchemaUrl())
 	ms.SetSchemaUrl("test_schemaurl")
 	assert.Equal(t, "test_schemaurl", ms.SchemaUrl())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newResourceLogs(&otlplogs.ResourceLogs{}, &sharedState).SetSchemaUrl("test_schemaurl") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newResourceLogs(&otlplogs.ResourceLogs{}, sharedState).SetSchemaUrl("test_schemaurl") })
 }
 
 func generateTestResourceLogs() ResourceLogs {

--- a/pdata/plog/generated_resourcelogsslice.go
+++ b/pdata/plog/generated_resourcelogsslice.go
@@ -34,8 +34,7 @@ func newResourceLogsSlice(orig *[]*otlplogs.ResourceLogs, state *internal.State)
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewResourceLogsSlice() ResourceLogsSlice {
 	orig := []*otlplogs.ResourceLogs(nil)
-	state := internal.StateMutable
-	return newResourceLogsSlice(&orig, &state)
+	return newResourceLogsSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/plog/generated_resourcelogsslice_test.go
+++ b/pdata/plog/generated_resourcelogsslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestResourceLogsSlice(t *testing.T) {
 	es := NewResourceLogsSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newResourceLogsSlice(&[]*otlplogs.ResourceLogs{}, &state)
+	es = newResourceLogsSlice(&[]*otlplogs.ResourceLogs{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewResourceLogs()
@@ -35,8 +34,9 @@ func TestResourceLogsSlice(t *testing.T) {
 }
 
 func TestResourceLogsSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newResourceLogsSlice(&[]*otlplogs.ResourceLogs{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newResourceLogsSlice(&[]*otlplogs.ResourceLogs{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/plog/generated_scopelogs.go
+++ b/pdata/plog/generated_scopelogs.go
@@ -33,8 +33,7 @@ func newScopeLogs(orig *otlplogs.ScopeLogs, state *internal.State) ScopeLogs {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewScopeLogs() ScopeLogs {
-	state := internal.StateMutable
-	return newScopeLogs(&otlplogs.ScopeLogs{}, &state)
+	return newScopeLogs(&otlplogs.ScopeLogs{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/generated_scopelogs_test.go
+++ b/pdata/plog/generated_scopelogs_test.go
@@ -24,9 +24,10 @@ func TestScopeLogs_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestScopeLogs(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestScopeLogs(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newScopeLogs(&otlplogs.ScopeLogs{}, &sharedState)) })
-	assert.Panics(t, func() { newScopeLogs(&otlplogs.ScopeLogs{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newScopeLogs(&otlplogs.ScopeLogs{}, sharedState)) })
+	assert.Panics(t, func() { newScopeLogs(&otlplogs.ScopeLogs{}, sharedState).MoveTo(dest) })
 }
 
 func TestScopeLogs_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestScopeLogs_CopyTo(t *testing.T) {
 	orig = generateTestScopeLogs()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newScopeLogs(&otlplogs.ScopeLogs{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newScopeLogs(&otlplogs.ScopeLogs{}, sharedState)) })
 }
 
 func TestScopeLogs_Scope(t *testing.T) {
@@ -60,8 +62,9 @@ func TestScopeLogs_SchemaUrl(t *testing.T) {
 	assert.Empty(t, ms.SchemaUrl())
 	ms.SetSchemaUrl("test_schemaurl")
 	assert.Equal(t, "test_schemaurl", ms.SchemaUrl())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newScopeLogs(&otlplogs.ScopeLogs{}, &sharedState).SetSchemaUrl("test_schemaurl") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newScopeLogs(&otlplogs.ScopeLogs{}, sharedState).SetSchemaUrl("test_schemaurl") })
 }
 
 func generateTestScopeLogs() ScopeLogs {

--- a/pdata/plog/generated_scopelogsslice.go
+++ b/pdata/plog/generated_scopelogsslice.go
@@ -34,8 +34,7 @@ func newScopeLogsSlice(orig *[]*otlplogs.ScopeLogs, state *internal.State) Scope
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewScopeLogsSlice() ScopeLogsSlice {
 	orig := []*otlplogs.ScopeLogs(nil)
-	state := internal.StateMutable
-	return newScopeLogsSlice(&orig, &state)
+	return newScopeLogsSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/plog/generated_scopelogsslice_test.go
+++ b/pdata/plog/generated_scopelogsslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestScopeLogsSlice(t *testing.T) {
 	es := NewScopeLogsSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newScopeLogsSlice(&[]*otlplogs.ScopeLogs{}, &state)
+	es = newScopeLogsSlice(&[]*otlplogs.ScopeLogs{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewScopeLogs()
@@ -35,8 +34,9 @@ func TestScopeLogsSlice(t *testing.T) {
 }
 
 func TestScopeLogsSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newScopeLogsSlice(&[]*otlplogs.ScopeLogs{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newScopeLogsSlice(&[]*otlplogs.ScopeLogs{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/plog/logs.go
+++ b/pdata/plog/logs.go
@@ -3,18 +3,14 @@
 
 package plog // import "go.opentelemetry.io/collector/pdata/plog"
 
-import (
-	"go.opentelemetry.io/collector/pdata/internal"
-)
-
 // MarkReadOnly marks the Logs as shared so that no further modifications can be done on it.
 func (ms Logs) MarkReadOnly() {
-	internal.SetLogsState(internal.Logs(ms), internal.StateReadOnly)
+	ms.getState().MarkReadOnly()
 }
 
 // IsReadOnly returns true if this Logs instance is read-only.
 func (ms Logs) IsReadOnly() bool {
-	return *ms.getState() == internal.StateReadOnly
+	return ms.getState().IsReadOnly()
 }
 
 // LogRecordCount calculates the total number of log records.

--- a/pdata/plog/plogotlp/generated_exportpartialsuccess.go
+++ b/pdata/plog/plogotlp/generated_exportpartialsuccess.go
@@ -32,8 +32,7 @@ func newExportPartialSuccess(orig *otlpcollectorlogs.ExportLogsPartialSuccess, s
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportPartialSuccess() ExportPartialSuccess {
-	state := internal.StateMutable
-	return newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, &state)
+	return newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/plogotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/plog/plogotlp/generated_exportpartialsuccess_test.go
@@ -23,12 +23,11 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, sharedState)) })
 	assert.Panics(t, func() {
-		ms.MoveTo(newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, &sharedState))
-	})
-	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, &sharedState).MoveTo(dest)
+		newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, sharedState).MoveTo(dest)
 	})
 }
 
@@ -40,10 +39,9 @@ func TestExportPartialSuccess_CopyTo(t *testing.T) {
 	orig = generateTestExportPartialSuccess()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() {
-		ms.CopyTo(newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, &sharedState))
-	})
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, sharedState)) })
 }
 
 func TestExportPartialSuccess_RejectedLogRecords(t *testing.T) {
@@ -51,9 +49,10 @@ func TestExportPartialSuccess_RejectedLogRecords(t *testing.T) {
 	assert.Equal(t, int64(0), ms.RejectedLogRecords())
 	ms.SetRejectedLogRecords(int64(13))
 	assert.Equal(t, int64(13), ms.RejectedLogRecords())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, &sharedState).SetRejectedLogRecords(int64(13))
+		newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, sharedState).SetRejectedLogRecords(int64(13))
 	})
 }
 
@@ -62,9 +61,10 @@ func TestExportPartialSuccess_ErrorMessage(t *testing.T) {
 	assert.Empty(t, ms.ErrorMessage())
 	ms.SetErrorMessage("test_errormessage")
 	assert.Equal(t, "test_errormessage", ms.ErrorMessage())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, &sharedState).SetErrorMessage("test_errormessage")
+		newExportPartialSuccess(&otlpcollectorlogs.ExportLogsPartialSuccess{}, sharedState).SetErrorMessage("test_errormessage")
 	})
 }
 

--- a/pdata/plog/plogotlp/generated_exportresponse.go
+++ b/pdata/plog/plogotlp/generated_exportresponse.go
@@ -32,8 +32,7 @@ func newExportResponse(orig *otlpcollectorlogs.ExportLogsServiceResponse, state 
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportResponse() ExportResponse {
-	state := internal.StateMutable
-	return newExportResponse(&otlpcollectorlogs.ExportLogsServiceResponse{}, &state)
+	return newExportResponse(&otlpcollectorlogs.ExportLogsServiceResponse{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/plogotlp/generated_exportresponse_test.go
+++ b/pdata/plog/plogotlp/generated_exportresponse_test.go
@@ -23,9 +23,10 @@ func TestExportResponse_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportResponse(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExportResponse(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newExportResponse(&otlpcollectorlogs.ExportLogsServiceResponse{}, &sharedState)) })
-	assert.Panics(t, func() { newExportResponse(&otlpcollectorlogs.ExportLogsServiceResponse{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newExportResponse(&otlpcollectorlogs.ExportLogsServiceResponse{}, sharedState)) })
+	assert.Panics(t, func() { newExportResponse(&otlpcollectorlogs.ExportLogsServiceResponse{}, sharedState).MoveTo(dest) })
 }
 
 func TestExportResponse_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestExportResponse_CopyTo(t *testing.T) {
 	orig = generateTestExportResponse()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newExportResponse(&otlpcollectorlogs.ExportLogsServiceResponse{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newExportResponse(&otlpcollectorlogs.ExportLogsServiceResponse{}, sharedState)) })
 }
 
 func TestExportResponse_PartialSuccess(t *testing.T) {

--- a/pdata/plog/plogotlp/grpc.go
+++ b/pdata/plog/plogotlp/grpc.go
@@ -43,8 +43,7 @@ func (c *grpcClient) Export(ctx context.Context, request ExportRequest, opts ...
 	if err != nil {
 		return ExportResponse{}, err
 	}
-	state := internal.StateMutable
-	return ExportResponse{orig: rsp, state: &state}, err
+	return ExportResponse{orig: rsp, state: internal.NewState()}, err
 }
 
 func (c *grpcClient) unexported() {}
@@ -84,7 +83,6 @@ type rawLogsServer struct {
 
 func (s rawLogsServer) Export(ctx context.Context, request *otlpcollectorlog.ExportLogsServiceRequest) (*otlpcollectorlog.ExportLogsServiceResponse, error) {
 	otlp.MigrateLogs(request.ResourceLogs)
-	state := internal.StateMutable
-	rsp, err := s.srv.Export(ctx, ExportRequest{orig: request, state: &state})
+	rsp, err := s.srv.Export(ctx, ExportRequest{orig: request, state: internal.NewState()})
 	return rsp.orig, err
 }

--- a/pdata/plog/plogotlp/request.go
+++ b/pdata/plog/plogotlp/request.go
@@ -24,10 +24,9 @@ type ExportRequest struct {
 
 // NewExportRequest returns an empty ExportRequest.
 func NewExportRequest() ExportRequest {
-	state := internal.StateMutable
 	return ExportRequest{
 		orig:  &otlpcollectorlog.ExportLogsServiceRequest{},
-		state: &state,
+		state: internal.NewState(),
 	}
 }
 

--- a/pdata/pmetric/generated_exemplar.go
+++ b/pdata/pmetric/generated_exemplar.go
@@ -37,8 +37,7 @@ func newExemplar(orig *otlpmetrics.Exemplar, state *internal.State) Exemplar {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExemplar() Exemplar {
-	state := internal.StateMutable
-	return newExemplar(&otlpmetrics.Exemplar{}, &state)
+	return newExemplar(&otlpmetrics.Exemplar{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_exemplar_test.go
+++ b/pdata/pmetric/generated_exemplar_test.go
@@ -25,9 +25,10 @@ func TestExemplar_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExemplar(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExemplar(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newExemplar(&otlpmetrics.Exemplar{}, &sharedState)) })
-	assert.Panics(t, func() { newExemplar(&otlpmetrics.Exemplar{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newExemplar(&otlpmetrics.Exemplar{}, sharedState)) })
+	assert.Panics(t, func() { newExemplar(&otlpmetrics.Exemplar{}, sharedState).MoveTo(dest) })
 }
 
 func TestExemplar_CopyTo(t *testing.T) {
@@ -38,8 +39,9 @@ func TestExemplar_CopyTo(t *testing.T) {
 	orig = generateTestExemplar()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newExemplar(&otlpmetrics.Exemplar{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newExemplar(&otlpmetrics.Exemplar{}, sharedState)) })
 }
 
 func TestExemplar_FilteredAttributes(t *testing.T) {
@@ -68,8 +70,9 @@ func TestExemplar_DoubleValue(t *testing.T) {
 	ms.SetDoubleValue(float64(3.1415926))
 	assert.InDelta(t, float64(3.1415926), ms.DoubleValue(), 0.01)
 	assert.Equal(t, ExemplarValueTypeDouble, ms.ValueType())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newExemplar(&otlpmetrics.Exemplar{}, &sharedState).SetDoubleValue(float64(3.1415926)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newExemplar(&otlpmetrics.Exemplar{}, sharedState).SetDoubleValue(float64(3.1415926)) })
 }
 
 func TestExemplar_IntValue(t *testing.T) {
@@ -78,8 +81,9 @@ func TestExemplar_IntValue(t *testing.T) {
 	ms.SetIntValue(int64(13))
 	assert.Equal(t, int64(13), ms.IntValue())
 	assert.Equal(t, ExemplarValueTypeInt, ms.ValueType())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newExemplar(&otlpmetrics.Exemplar{}, &sharedState).SetIntValue(int64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newExemplar(&otlpmetrics.Exemplar{}, sharedState).SetIntValue(int64(13)) })
 }
 
 func TestExemplar_SpanID(t *testing.T) {

--- a/pdata/pmetric/generated_exemplarslice.go
+++ b/pdata/pmetric/generated_exemplarslice.go
@@ -33,8 +33,7 @@ func newExemplarSlice(orig *[]otlpmetrics.Exemplar, state *internal.State) Exemp
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewExemplarSlice() ExemplarSlice {
 	orig := []otlpmetrics.Exemplar(nil)
-	state := internal.StateMutable
-	return newExemplarSlice(&orig, &state)
+	return newExemplarSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pmetric/generated_exemplarslice_test.go
+++ b/pdata/pmetric/generated_exemplarslice_test.go
@@ -18,8 +18,7 @@ import (
 func TestExemplarSlice(t *testing.T) {
 	es := NewExemplarSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newExemplarSlice(&[]otlpmetrics.Exemplar{}, &state)
+	es = newExemplarSlice(&[]otlpmetrics.Exemplar{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewExemplar()
@@ -34,8 +33,9 @@ func TestExemplarSlice(t *testing.T) {
 }
 
 func TestExemplarSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newExemplarSlice(&[]otlpmetrics.Exemplar{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newExemplarSlice(&[]otlpmetrics.Exemplar{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pmetric/generated_exponentialhistogram.go
+++ b/pdata/pmetric/generated_exponentialhistogram.go
@@ -33,8 +33,7 @@ func newExponentialHistogram(orig *otlpmetrics.ExponentialHistogram, state *inte
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExponentialHistogram() ExponentialHistogram {
-	state := internal.StateMutable
-	return newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, &state)
+	return newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_exponentialhistogram_test.go
+++ b/pdata/pmetric/generated_exponentialhistogram_test.go
@@ -23,9 +23,10 @@ func TestExponentialHistogram_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExponentialHistogram(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExponentialHistogram(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, &sharedState)) })
-	assert.Panics(t, func() { newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, sharedState)) })
+	assert.Panics(t, func() { newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, sharedState).MoveTo(dest) })
 }
 
 func TestExponentialHistogram_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestExponentialHistogram_CopyTo(t *testing.T) {
 	orig = generateTestExponentialHistogram()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newExponentialHistogram(&otlpmetrics.ExponentialHistogram{}, sharedState)) })
 }
 
 func TestExponentialHistogram_DataPoints(t *testing.T) {

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint.go
@@ -36,8 +36,7 @@ func newExponentialHistogramDataPoint(orig *otlpmetrics.ExponentialHistogramData
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExponentialHistogramDataPoint() ExponentialHistogramDataPoint {
-	state := internal.StateMutable
-	return newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &state)
+	return newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
@@ -24,12 +24,13 @@ func TestExponentialHistogramDataPoint_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExponentialHistogramDataPoint(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExponentialHistogramDataPoint(), dest)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState))
+		ms.MoveTo(newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, sharedState))
 	})
 	assert.Panics(t, func() {
-		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState).MoveTo(dest)
+		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, sharedState).MoveTo(dest)
 	})
 }
 
@@ -41,9 +42,10 @@ func TestExponentialHistogramDataPoint_CopyTo(t *testing.T) {
 	orig = generateTestExponentialHistogramDataPoint()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState))
+		ms.CopyTo(newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, sharedState))
 	})
 }
 
@@ -75,9 +77,10 @@ func TestExponentialHistogramDataPoint_Count(t *testing.T) {
 	assert.Equal(t, uint64(0), ms.Count())
 	ms.SetCount(uint64(13))
 	assert.Equal(t, uint64(13), ms.Count())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState).SetCount(uint64(13))
+		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, sharedState).SetCount(uint64(13))
 	})
 }
 
@@ -100,9 +103,10 @@ func TestExponentialHistogramDataPoint_Scale(t *testing.T) {
 	assert.Equal(t, int32(0), ms.Scale())
 	ms.SetScale(int32(13))
 	assert.Equal(t, int32(13), ms.Scale())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState).SetScale(int32(13))
+		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, sharedState).SetScale(int32(13))
 	})
 }
 
@@ -111,9 +115,10 @@ func TestExponentialHistogramDataPoint_ZeroCount(t *testing.T) {
 	assert.Equal(t, uint64(0), ms.ZeroCount())
 	ms.SetZeroCount(uint64(13))
 	assert.Equal(t, uint64(13), ms.ZeroCount())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState).SetZeroCount(uint64(13))
+		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, sharedState).SetZeroCount(uint64(13))
 	})
 }
 
@@ -179,9 +184,10 @@ func TestExponentialHistogramDataPoint_ZeroThreshold(t *testing.T) {
 	assert.InDelta(t, float64(0), ms.ZeroThreshold(), 0.01)
 	ms.SetZeroThreshold(float64(3.1415926))
 	assert.InDelta(t, float64(3.1415926), ms.ZeroThreshold(), 0.01)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState).SetZeroThreshold(float64(3.1415926))
+		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, sharedState).SetZeroThreshold(float64(3.1415926))
 	})
 }
 

--- a/pdata/pmetric/generated_exponentialhistogramdatapointbuckets.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointbuckets.go
@@ -33,8 +33,7 @@ func newExponentialHistogramDataPointBuckets(orig *otlpmetrics.ExponentialHistog
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExponentialHistogramDataPointBuckets() ExponentialHistogramDataPointBuckets {
-	state := internal.StateMutable
-	return newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, &state)
+	return newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_exponentialhistogramdatapointbuckets_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointbuckets_test.go
@@ -24,12 +24,13 @@ func TestExponentialHistogramDataPointBuckets_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExponentialHistogramDataPointBuckets(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExponentialHistogramDataPointBuckets(), dest)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, &sharedState))
+		ms.MoveTo(newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, sharedState))
 	})
 	assert.Panics(t, func() {
-		newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, &sharedState).MoveTo(dest)
+		newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, sharedState).MoveTo(dest)
 	})
 }
 
@@ -41,9 +42,10 @@ func TestExponentialHistogramDataPointBuckets_CopyTo(t *testing.T) {
 	orig = generateTestExponentialHistogramDataPointBuckets()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, &sharedState))
+		ms.CopyTo(newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, sharedState))
 	})
 }
 
@@ -52,9 +54,10 @@ func TestExponentialHistogramDataPointBuckets_Offset(t *testing.T) {
 	assert.Equal(t, int32(0), ms.Offset())
 	ms.SetOffset(int32(13))
 	assert.Equal(t, int32(13), ms.Offset())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, &sharedState).SetOffset(int32(13))
+		newExponentialHistogramDataPointBuckets(&otlpmetrics.ExponentialHistogramDataPoint_Buckets{}, sharedState).SetOffset(int32(13))
 	})
 }
 

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
@@ -34,8 +34,7 @@ func newExponentialHistogramDataPointSlice(orig *[]*otlpmetrics.ExponentialHisto
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewExponentialHistogramDataPointSlice() ExponentialHistogramDataPointSlice {
 	orig := []*otlpmetrics.ExponentialHistogramDataPoint(nil)
-	state := internal.StateMutable
-	return newExponentialHistogramDataPointSlice(&orig, &state)
+	return newExponentialHistogramDataPointSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestExponentialHistogramDataPointSlice(t *testing.T) {
 	es := NewExponentialHistogramDataPointSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newExponentialHistogramDataPointSlice(&[]*otlpmetrics.ExponentialHistogramDataPoint{}, &state)
+	es = newExponentialHistogramDataPointSlice(&[]*otlpmetrics.ExponentialHistogramDataPoint{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewExponentialHistogramDataPoint()
@@ -35,8 +34,9 @@ func TestExponentialHistogramDataPointSlice(t *testing.T) {
 }
 
 func TestExponentialHistogramDataPointSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newExponentialHistogramDataPointSlice(&[]*otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newExponentialHistogramDataPointSlice(&[]*otlpmetrics.ExponentialHistogramDataPoint{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pmetric/generated_gauge.go
+++ b/pdata/pmetric/generated_gauge.go
@@ -32,8 +32,7 @@ func newGauge(orig *otlpmetrics.Gauge, state *internal.State) Gauge {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewGauge() Gauge {
-	state := internal.StateMutable
-	return newGauge(&otlpmetrics.Gauge{}, &state)
+	return newGauge(&otlpmetrics.Gauge{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_gauge_test.go
+++ b/pdata/pmetric/generated_gauge_test.go
@@ -23,9 +23,10 @@ func TestGauge_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestGauge(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestGauge(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newGauge(&otlpmetrics.Gauge{}, &sharedState)) })
-	assert.Panics(t, func() { newGauge(&otlpmetrics.Gauge{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newGauge(&otlpmetrics.Gauge{}, sharedState)) })
+	assert.Panics(t, func() { newGauge(&otlpmetrics.Gauge{}, sharedState).MoveTo(dest) })
 }
 
 func TestGauge_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestGauge_CopyTo(t *testing.T) {
 	orig = generateTestGauge()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newGauge(&otlpmetrics.Gauge{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newGauge(&otlpmetrics.Gauge{}, sharedState)) })
 }
 
 func TestGauge_DataPoints(t *testing.T) {

--- a/pdata/pmetric/generated_histogram.go
+++ b/pdata/pmetric/generated_histogram.go
@@ -32,8 +32,7 @@ func newHistogram(orig *otlpmetrics.Histogram, state *internal.State) Histogram 
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewHistogram() Histogram {
-	state := internal.StateMutable
-	return newHistogram(&otlpmetrics.Histogram{}, &state)
+	return newHistogram(&otlpmetrics.Histogram{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_histogram_test.go
+++ b/pdata/pmetric/generated_histogram_test.go
@@ -23,9 +23,10 @@ func TestHistogram_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestHistogram(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestHistogram(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newHistogram(&otlpmetrics.Histogram{}, &sharedState)) })
-	assert.Panics(t, func() { newHistogram(&otlpmetrics.Histogram{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newHistogram(&otlpmetrics.Histogram{}, sharedState)) })
+	assert.Panics(t, func() { newHistogram(&otlpmetrics.Histogram{}, sharedState).MoveTo(dest) })
 }
 
 func TestHistogram_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestHistogram_CopyTo(t *testing.T) {
 	orig = generateTestHistogram()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newHistogram(&otlpmetrics.Histogram{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newHistogram(&otlpmetrics.Histogram{}, sharedState)) })
 }
 
 func TestHistogram_DataPoints(t *testing.T) {

--- a/pdata/pmetric/generated_histogramdatapoint.go
+++ b/pdata/pmetric/generated_histogramdatapoint.go
@@ -33,8 +33,7 @@ func newHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint, state *internal
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewHistogramDataPoint() HistogramDataPoint {
-	state := internal.StateMutable
-	return newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, &state)
+	return newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_histogramdatapoint_test.go
+++ b/pdata/pmetric/generated_histogramdatapoint_test.go
@@ -24,9 +24,10 @@ func TestHistogramDataPoint_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestHistogramDataPoint(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestHistogramDataPoint(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, &sharedState)) })
-	assert.Panics(t, func() { newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, sharedState)) })
+	assert.Panics(t, func() { newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, sharedState).MoveTo(dest) })
 }
 
 func TestHistogramDataPoint_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestHistogramDataPoint_CopyTo(t *testing.T) {
 	orig = generateTestHistogramDataPoint()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, sharedState)) })
 }
 
 func TestHistogramDataPoint_Attributes(t *testing.T) {
@@ -69,8 +71,9 @@ func TestHistogramDataPoint_Count(t *testing.T) {
 	assert.Equal(t, uint64(0), ms.Count())
 	ms.SetCount(uint64(13))
 	assert.Equal(t, uint64(13), ms.Count())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, &sharedState).SetCount(uint64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{}, sharedState).SetCount(uint64(13)) })
 }
 
 func TestHistogramDataPoint_Sum(t *testing.T) {

--- a/pdata/pmetric/generated_histogramdatapointslice.go
+++ b/pdata/pmetric/generated_histogramdatapointslice.go
@@ -34,8 +34,7 @@ func newHistogramDataPointSlice(orig *[]*otlpmetrics.HistogramDataPoint, state *
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewHistogramDataPointSlice() HistogramDataPointSlice {
 	orig := []*otlpmetrics.HistogramDataPoint(nil)
-	state := internal.StateMutable
-	return newHistogramDataPointSlice(&orig, &state)
+	return newHistogramDataPointSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pmetric/generated_histogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_histogramdatapointslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestHistogramDataPointSlice(t *testing.T) {
 	es := NewHistogramDataPointSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newHistogramDataPointSlice(&[]*otlpmetrics.HistogramDataPoint{}, &state)
+	es = newHistogramDataPointSlice(&[]*otlpmetrics.HistogramDataPoint{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewHistogramDataPoint()
@@ -35,8 +34,9 @@ func TestHistogramDataPointSlice(t *testing.T) {
 }
 
 func TestHistogramDataPointSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newHistogramDataPointSlice(&[]*otlpmetrics.HistogramDataPoint{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newHistogramDataPointSlice(&[]*otlpmetrics.HistogramDataPoint{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pmetric/generated_metric.go
+++ b/pdata/pmetric/generated_metric.go
@@ -34,8 +34,7 @@ func newMetric(orig *otlpmetrics.Metric, state *internal.State) Metric {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewMetric() Metric {
-	state := internal.StateMutable
-	return newMetric(&otlpmetrics.Metric{}, &state)
+	return newMetric(&otlpmetrics.Metric{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_metric_test.go
+++ b/pdata/pmetric/generated_metric_test.go
@@ -24,9 +24,10 @@ func TestMetric_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestMetric(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestMetric(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newMetric(&otlpmetrics.Metric{}, &sharedState)) })
-	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newMetric(&otlpmetrics.Metric{}, sharedState)) })
+	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, sharedState).MoveTo(dest) })
 }
 
 func TestMetric_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestMetric_CopyTo(t *testing.T) {
 	orig = generateTestMetric()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newMetric(&otlpmetrics.Metric{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newMetric(&otlpmetrics.Metric{}, sharedState)) })
 }
 
 func TestMetric_Name(t *testing.T) {
@@ -46,8 +48,9 @@ func TestMetric_Name(t *testing.T) {
 	assert.Empty(t, ms.Name())
 	ms.SetName("test_name")
 	assert.Equal(t, "test_name", ms.Name())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).SetName("test_name") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, sharedState).SetName("test_name") })
 }
 
 func TestMetric_Description(t *testing.T) {
@@ -55,8 +58,9 @@ func TestMetric_Description(t *testing.T) {
 	assert.Empty(t, ms.Description())
 	ms.SetDescription("test_description")
 	assert.Equal(t, "test_description", ms.Description())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).SetDescription("test_description") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, sharedState).SetDescription("test_description") })
 }
 
 func TestMetric_Unit(t *testing.T) {
@@ -64,8 +68,9 @@ func TestMetric_Unit(t *testing.T) {
 	assert.Empty(t, ms.Unit())
 	ms.SetUnit("test_unit")
 	assert.Equal(t, "test_unit", ms.Unit())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).SetUnit("test_unit") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, sharedState).SetUnit("test_unit") })
 }
 
 func TestMetric_Type(t *testing.T) {
@@ -80,8 +85,9 @@ func TestMetric_Gauge(t *testing.T) {
 	internal.FillOrigTestGauge(ms.orig.GetData().(*otlpmetrics.Metric_Gauge).Gauge)
 	assert.Equal(t, MetricTypeGauge, ms.Type())
 	assert.Equal(t, generateTestGauge(), ms.Gauge())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).SetEmptyGauge() })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, sharedState).SetEmptyGauge() })
 }
 
 func TestMetric_Sum(t *testing.T) {
@@ -91,8 +97,9 @@ func TestMetric_Sum(t *testing.T) {
 	internal.FillOrigTestSum(ms.orig.GetData().(*otlpmetrics.Metric_Sum).Sum)
 	assert.Equal(t, MetricTypeSum, ms.Type())
 	assert.Equal(t, generateTestSum(), ms.Sum())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).SetEmptySum() })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, sharedState).SetEmptySum() })
 }
 
 func TestMetric_Histogram(t *testing.T) {
@@ -102,8 +109,9 @@ func TestMetric_Histogram(t *testing.T) {
 	internal.FillOrigTestHistogram(ms.orig.GetData().(*otlpmetrics.Metric_Histogram).Histogram)
 	assert.Equal(t, MetricTypeHistogram, ms.Type())
 	assert.Equal(t, generateTestHistogram(), ms.Histogram())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).SetEmptyHistogram() })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, sharedState).SetEmptyHistogram() })
 }
 
 func TestMetric_ExponentialHistogram(t *testing.T) {
@@ -113,8 +121,9 @@ func TestMetric_ExponentialHistogram(t *testing.T) {
 	internal.FillOrigTestExponentialHistogram(ms.orig.GetData().(*otlpmetrics.Metric_ExponentialHistogram).ExponentialHistogram)
 	assert.Equal(t, MetricTypeExponentialHistogram, ms.Type())
 	assert.Equal(t, generateTestExponentialHistogram(), ms.ExponentialHistogram())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).SetEmptyExponentialHistogram() })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, sharedState).SetEmptyExponentialHistogram() })
 }
 
 func TestMetric_Summary(t *testing.T) {
@@ -124,8 +133,9 @@ func TestMetric_Summary(t *testing.T) {
 	internal.FillOrigTestSummary(ms.orig.GetData().(*otlpmetrics.Metric_Summary).Summary)
 	assert.Equal(t, MetricTypeSummary, ms.Type())
 	assert.Equal(t, generateTestSummary(), ms.Summary())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, &sharedState).SetEmptySummary() })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMetric(&otlpmetrics.Metric{}, sharedState).SetEmptySummary() })
 }
 
 func TestMetric_Metadata(t *testing.T) {

--- a/pdata/pmetric/generated_metrics.go
+++ b/pdata/pmetric/generated_metrics.go
@@ -30,8 +30,7 @@ func newMetrics(orig *otlpcollectormetrics.ExportMetricsServiceRequest, state *i
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewMetrics() Metrics {
-	state := internal.StateMutable
-	return newMetrics(&otlpcollectormetrics.ExportMetricsServiceRequest{}, &state)
+	return newMetrics(&otlpcollectormetrics.ExportMetricsServiceRequest{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_metrics_test.go
+++ b/pdata/pmetric/generated_metrics_test.go
@@ -23,9 +23,10 @@ func TestMetrics_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestMetrics(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestMetrics(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newMetrics(&otlpcollectormetrics.ExportMetricsServiceRequest{}, &sharedState)) })
-	assert.Panics(t, func() { newMetrics(&otlpcollectormetrics.ExportMetricsServiceRequest{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newMetrics(&otlpcollectormetrics.ExportMetricsServiceRequest{}, sharedState)) })
+	assert.Panics(t, func() { newMetrics(&otlpcollectormetrics.ExportMetricsServiceRequest{}, sharedState).MoveTo(dest) })
 }
 
 func TestMetrics_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestMetrics_CopyTo(t *testing.T) {
 	orig = generateTestMetrics()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newMetrics(&otlpcollectormetrics.ExportMetricsServiceRequest{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newMetrics(&otlpcollectormetrics.ExportMetricsServiceRequest{}, sharedState)) })
 }
 
 func TestMetrics_ResourceMetrics(t *testing.T) {

--- a/pdata/pmetric/generated_metricslice.go
+++ b/pdata/pmetric/generated_metricslice.go
@@ -34,8 +34,7 @@ func newMetricSlice(orig *[]*otlpmetrics.Metric, state *internal.State) MetricSl
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewMetricSlice() MetricSlice {
 	orig := []*otlpmetrics.Metric(nil)
-	state := internal.StateMutable
-	return newMetricSlice(&orig, &state)
+	return newMetricSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pmetric/generated_metricslice_test.go
+++ b/pdata/pmetric/generated_metricslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestMetricSlice(t *testing.T) {
 	es := NewMetricSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newMetricSlice(&[]*otlpmetrics.Metric{}, &state)
+	es = newMetricSlice(&[]*otlpmetrics.Metric{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewMetric()
@@ -35,8 +34,9 @@ func TestMetricSlice(t *testing.T) {
 }
 
 func TestMetricSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newMetricSlice(&[]*otlpmetrics.Metric{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newMetricSlice(&[]*otlpmetrics.Metric{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pmetric/generated_numberdatapoint.go
+++ b/pdata/pmetric/generated_numberdatapoint.go
@@ -33,8 +33,7 @@ func newNumberDataPoint(orig *otlpmetrics.NumberDataPoint, state *internal.State
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewNumberDataPoint() NumberDataPoint {
-	state := internal.StateMutable
-	return newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, &state)
+	return newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_numberdatapoint_test.go
+++ b/pdata/pmetric/generated_numberdatapoint_test.go
@@ -24,9 +24,10 @@ func TestNumberDataPoint_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestNumberDataPoint(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestNumberDataPoint(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, &sharedState)) })
-	assert.Panics(t, func() { newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, sharedState)) })
+	assert.Panics(t, func() { newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, sharedState).MoveTo(dest) })
 }
 
 func TestNumberDataPoint_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestNumberDataPoint_CopyTo(t *testing.T) {
 	orig = generateTestNumberDataPoint()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, sharedState)) })
 }
 
 func TestNumberDataPoint_Attributes(t *testing.T) {
@@ -75,9 +77,10 @@ func TestNumberDataPoint_DoubleValue(t *testing.T) {
 	ms.SetDoubleValue(float64(3.1415926))
 	assert.InDelta(t, float64(3.1415926), ms.DoubleValue(), 0.01)
 	assert.Equal(t, NumberDataPointValueTypeDouble, ms.ValueType())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, &sharedState).SetDoubleValue(float64(3.1415926))
+		newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, sharedState).SetDoubleValue(float64(3.1415926))
 	})
 }
 
@@ -87,8 +90,9 @@ func TestNumberDataPoint_IntValue(t *testing.T) {
 	ms.SetIntValue(int64(13))
 	assert.Equal(t, int64(13), ms.IntValue())
 	assert.Equal(t, NumberDataPointValueTypeInt, ms.ValueType())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, &sharedState).SetIntValue(int64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newNumberDataPoint(&otlpmetrics.NumberDataPoint{}, sharedState).SetIntValue(int64(13)) })
 }
 
 func TestNumberDataPoint_Exemplars(t *testing.T) {

--- a/pdata/pmetric/generated_numberdatapointslice.go
+++ b/pdata/pmetric/generated_numberdatapointslice.go
@@ -34,8 +34,7 @@ func newNumberDataPointSlice(orig *[]*otlpmetrics.NumberDataPoint, state *intern
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewNumberDataPointSlice() NumberDataPointSlice {
 	orig := []*otlpmetrics.NumberDataPoint(nil)
-	state := internal.StateMutable
-	return newNumberDataPointSlice(&orig, &state)
+	return newNumberDataPointSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pmetric/generated_numberdatapointslice_test.go
+++ b/pdata/pmetric/generated_numberdatapointslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestNumberDataPointSlice(t *testing.T) {
 	es := NewNumberDataPointSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newNumberDataPointSlice(&[]*otlpmetrics.NumberDataPoint{}, &state)
+	es = newNumberDataPointSlice(&[]*otlpmetrics.NumberDataPoint{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewNumberDataPoint()
@@ -35,8 +34,9 @@ func TestNumberDataPointSlice(t *testing.T) {
 }
 
 func TestNumberDataPointSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newNumberDataPointSlice(&[]*otlpmetrics.NumberDataPoint{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newNumberDataPointSlice(&[]*otlpmetrics.NumberDataPoint{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pmetric/generated_resourcemetrics.go
+++ b/pdata/pmetric/generated_resourcemetrics.go
@@ -33,8 +33,7 @@ func newResourceMetrics(orig *otlpmetrics.ResourceMetrics, state *internal.State
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResourceMetrics() ResourceMetrics {
-	state := internal.StateMutable
-	return newResourceMetrics(&otlpmetrics.ResourceMetrics{}, &state)
+	return newResourceMetrics(&otlpmetrics.ResourceMetrics{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_resourcemetrics_test.go
+++ b/pdata/pmetric/generated_resourcemetrics_test.go
@@ -24,9 +24,10 @@ func TestResourceMetrics_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResourceMetrics(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestResourceMetrics(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newResourceMetrics(&otlpmetrics.ResourceMetrics{}, &sharedState)) })
-	assert.Panics(t, func() { newResourceMetrics(&otlpmetrics.ResourceMetrics{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newResourceMetrics(&otlpmetrics.ResourceMetrics{}, sharedState)) })
+	assert.Panics(t, func() { newResourceMetrics(&otlpmetrics.ResourceMetrics{}, sharedState).MoveTo(dest) })
 }
 
 func TestResourceMetrics_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestResourceMetrics_CopyTo(t *testing.T) {
 	orig = generateTestResourceMetrics()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newResourceMetrics(&otlpmetrics.ResourceMetrics{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newResourceMetrics(&otlpmetrics.ResourceMetrics{}, sharedState)) })
 }
 
 func TestResourceMetrics_Resource(t *testing.T) {
@@ -60,10 +62,9 @@ func TestResourceMetrics_SchemaUrl(t *testing.T) {
 	assert.Empty(t, ms.SchemaUrl())
 	ms.SetSchemaUrl("test_schemaurl")
 	assert.Equal(t, "test_schemaurl", ms.SchemaUrl())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() {
-		newResourceMetrics(&otlpmetrics.ResourceMetrics{}, &sharedState).SetSchemaUrl("test_schemaurl")
-	})
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newResourceMetrics(&otlpmetrics.ResourceMetrics{}, sharedState).SetSchemaUrl("test_schemaurl") })
 }
 
 func generateTestResourceMetrics() ResourceMetrics {

--- a/pdata/pmetric/generated_resourcemetricsslice.go
+++ b/pdata/pmetric/generated_resourcemetricsslice.go
@@ -34,8 +34,7 @@ func newResourceMetricsSlice(orig *[]*otlpmetrics.ResourceMetrics, state *intern
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewResourceMetricsSlice() ResourceMetricsSlice {
 	orig := []*otlpmetrics.ResourceMetrics(nil)
-	state := internal.StateMutable
-	return newResourceMetricsSlice(&orig, &state)
+	return newResourceMetricsSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pmetric/generated_resourcemetricsslice_test.go
+++ b/pdata/pmetric/generated_resourcemetricsslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestResourceMetricsSlice(t *testing.T) {
 	es := NewResourceMetricsSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newResourceMetricsSlice(&[]*otlpmetrics.ResourceMetrics{}, &state)
+	es = newResourceMetricsSlice(&[]*otlpmetrics.ResourceMetrics{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewResourceMetrics()
@@ -35,8 +34,9 @@ func TestResourceMetricsSlice(t *testing.T) {
 }
 
 func TestResourceMetricsSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newResourceMetricsSlice(&[]*otlpmetrics.ResourceMetrics{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newResourceMetricsSlice(&[]*otlpmetrics.ResourceMetrics{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pmetric/generated_scopemetrics.go
+++ b/pdata/pmetric/generated_scopemetrics.go
@@ -33,8 +33,7 @@ func newScopeMetrics(orig *otlpmetrics.ScopeMetrics, state *internal.State) Scop
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewScopeMetrics() ScopeMetrics {
-	state := internal.StateMutable
-	return newScopeMetrics(&otlpmetrics.ScopeMetrics{}, &state)
+	return newScopeMetrics(&otlpmetrics.ScopeMetrics{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_scopemetrics_test.go
+++ b/pdata/pmetric/generated_scopemetrics_test.go
@@ -24,9 +24,10 @@ func TestScopeMetrics_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestScopeMetrics(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestScopeMetrics(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newScopeMetrics(&otlpmetrics.ScopeMetrics{}, &sharedState)) })
-	assert.Panics(t, func() { newScopeMetrics(&otlpmetrics.ScopeMetrics{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newScopeMetrics(&otlpmetrics.ScopeMetrics{}, sharedState)) })
+	assert.Panics(t, func() { newScopeMetrics(&otlpmetrics.ScopeMetrics{}, sharedState).MoveTo(dest) })
 }
 
 func TestScopeMetrics_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestScopeMetrics_CopyTo(t *testing.T) {
 	orig = generateTestScopeMetrics()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newScopeMetrics(&otlpmetrics.ScopeMetrics{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newScopeMetrics(&otlpmetrics.ScopeMetrics{}, sharedState)) })
 }
 
 func TestScopeMetrics_Scope(t *testing.T) {
@@ -60,8 +62,9 @@ func TestScopeMetrics_SchemaUrl(t *testing.T) {
 	assert.Empty(t, ms.SchemaUrl())
 	ms.SetSchemaUrl("test_schemaurl")
 	assert.Equal(t, "test_schemaurl", ms.SchemaUrl())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newScopeMetrics(&otlpmetrics.ScopeMetrics{}, &sharedState).SetSchemaUrl("test_schemaurl") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newScopeMetrics(&otlpmetrics.ScopeMetrics{}, sharedState).SetSchemaUrl("test_schemaurl") })
 }
 
 func generateTestScopeMetrics() ScopeMetrics {

--- a/pdata/pmetric/generated_scopemetricsslice.go
+++ b/pdata/pmetric/generated_scopemetricsslice.go
@@ -34,8 +34,7 @@ func newScopeMetricsSlice(orig *[]*otlpmetrics.ScopeMetrics, state *internal.Sta
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewScopeMetricsSlice() ScopeMetricsSlice {
 	orig := []*otlpmetrics.ScopeMetrics(nil)
-	state := internal.StateMutable
-	return newScopeMetricsSlice(&orig, &state)
+	return newScopeMetricsSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pmetric/generated_scopemetricsslice_test.go
+++ b/pdata/pmetric/generated_scopemetricsslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestScopeMetricsSlice(t *testing.T) {
 	es := NewScopeMetricsSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newScopeMetricsSlice(&[]*otlpmetrics.ScopeMetrics{}, &state)
+	es = newScopeMetricsSlice(&[]*otlpmetrics.ScopeMetrics{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewScopeMetrics()
@@ -35,8 +34,9 @@ func TestScopeMetricsSlice(t *testing.T) {
 }
 
 func TestScopeMetricsSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newScopeMetricsSlice(&[]*otlpmetrics.ScopeMetrics{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newScopeMetricsSlice(&[]*otlpmetrics.ScopeMetrics{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pmetric/generated_sum.go
+++ b/pdata/pmetric/generated_sum.go
@@ -32,8 +32,7 @@ func newSum(orig *otlpmetrics.Sum, state *internal.State) Sum {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSum() Sum {
-	state := internal.StateMutable
-	return newSum(&otlpmetrics.Sum{}, &state)
+	return newSum(&otlpmetrics.Sum{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_sum_test.go
+++ b/pdata/pmetric/generated_sum_test.go
@@ -23,9 +23,10 @@ func TestSum_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSum(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestSum(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newSum(&otlpmetrics.Sum{}, &sharedState)) })
-	assert.Panics(t, func() { newSum(&otlpmetrics.Sum{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newSum(&otlpmetrics.Sum{}, sharedState)) })
+	assert.Panics(t, func() { newSum(&otlpmetrics.Sum{}, sharedState).MoveTo(dest) })
 }
 
 func TestSum_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestSum_CopyTo(t *testing.T) {
 	orig = generateTestSum()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newSum(&otlpmetrics.Sum{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newSum(&otlpmetrics.Sum{}, sharedState)) })
 }
 
 func TestSum_DataPoints(t *testing.T) {
@@ -60,8 +62,9 @@ func TestSum_IsMonotonic(t *testing.T) {
 	assert.False(t, ms.IsMonotonic())
 	ms.SetIsMonotonic(true)
 	assert.True(t, ms.IsMonotonic())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSum(&otlpmetrics.Sum{}, &sharedState).SetIsMonotonic(true) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSum(&otlpmetrics.Sum{}, sharedState).SetIsMonotonic(true) })
 }
 
 func generateTestSum() Sum {

--- a/pdata/pmetric/generated_summary.go
+++ b/pdata/pmetric/generated_summary.go
@@ -32,8 +32,7 @@ func newSummary(orig *otlpmetrics.Summary, state *internal.State) Summary {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSummary() Summary {
-	state := internal.StateMutable
-	return newSummary(&otlpmetrics.Summary{}, &state)
+	return newSummary(&otlpmetrics.Summary{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_summary_test.go
+++ b/pdata/pmetric/generated_summary_test.go
@@ -23,9 +23,10 @@ func TestSummary_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSummary(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestSummary(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newSummary(&otlpmetrics.Summary{}, &sharedState)) })
-	assert.Panics(t, func() { newSummary(&otlpmetrics.Summary{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newSummary(&otlpmetrics.Summary{}, sharedState)) })
+	assert.Panics(t, func() { newSummary(&otlpmetrics.Summary{}, sharedState).MoveTo(dest) })
 }
 
 func TestSummary_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestSummary_CopyTo(t *testing.T) {
 	orig = generateTestSummary()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newSummary(&otlpmetrics.Summary{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newSummary(&otlpmetrics.Summary{}, sharedState)) })
 }
 
 func TestSummary_DataPoints(t *testing.T) {

--- a/pdata/pmetric/generated_summarydatapoint.go
+++ b/pdata/pmetric/generated_summarydatapoint.go
@@ -33,8 +33,7 @@ func newSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint, state *internal.Sta
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSummaryDataPoint() SummaryDataPoint {
-	state := internal.StateMutable
-	return newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, &state)
+	return newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_summarydatapoint_test.go
+++ b/pdata/pmetric/generated_summarydatapoint_test.go
@@ -24,9 +24,10 @@ func TestSummaryDataPoint_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSummaryDataPoint(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestSummaryDataPoint(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, &sharedState)) })
-	assert.Panics(t, func() { newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, sharedState)) })
+	assert.Panics(t, func() { newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, sharedState).MoveTo(dest) })
 }
 
 func TestSummaryDataPoint_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestSummaryDataPoint_CopyTo(t *testing.T) {
 	orig = generateTestSummaryDataPoint()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, sharedState)) })
 }
 
 func TestSummaryDataPoint_Attributes(t *testing.T) {
@@ -69,8 +71,9 @@ func TestSummaryDataPoint_Count(t *testing.T) {
 	assert.Equal(t, uint64(0), ms.Count())
 	ms.SetCount(uint64(13))
 	assert.Equal(t, uint64(13), ms.Count())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, &sharedState).SetCount(uint64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, sharedState).SetCount(uint64(13)) })
 }
 
 func TestSummaryDataPoint_Sum(t *testing.T) {
@@ -78,8 +81,9 @@ func TestSummaryDataPoint_Sum(t *testing.T) {
 	assert.InDelta(t, float64(0), ms.Sum(), 0.01)
 	ms.SetSum(float64(3.1415926))
 	assert.InDelta(t, float64(3.1415926), ms.Sum(), 0.01)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, &sharedState).SetSum(float64(3.1415926)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{}, sharedState).SetSum(float64(3.1415926)) })
 }
 
 func TestSummaryDataPoint_QuantileValues(t *testing.T) {

--- a/pdata/pmetric/generated_summarydatapointslice.go
+++ b/pdata/pmetric/generated_summarydatapointslice.go
@@ -34,8 +34,7 @@ func newSummaryDataPointSlice(orig *[]*otlpmetrics.SummaryDataPoint, state *inte
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewSummaryDataPointSlice() SummaryDataPointSlice {
 	orig := []*otlpmetrics.SummaryDataPoint(nil)
-	state := internal.StateMutable
-	return newSummaryDataPointSlice(&orig, &state)
+	return newSummaryDataPointSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pmetric/generated_summarydatapointslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestSummaryDataPointSlice(t *testing.T) {
 	es := NewSummaryDataPointSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newSummaryDataPointSlice(&[]*otlpmetrics.SummaryDataPoint{}, &state)
+	es = newSummaryDataPointSlice(&[]*otlpmetrics.SummaryDataPoint{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewSummaryDataPoint()
@@ -35,8 +34,9 @@ func TestSummaryDataPointSlice(t *testing.T) {
 }
 
 func TestSummaryDataPointSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newSummaryDataPointSlice(&[]*otlpmetrics.SummaryDataPoint{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newSummaryDataPointSlice(&[]*otlpmetrics.SummaryDataPoint{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pmetric/generated_summarydatapointvalueatquantile.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantile.go
@@ -32,8 +32,7 @@ func newSummaryDataPointValueAtQuantile(orig *otlpmetrics.SummaryDataPoint_Value
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSummaryDataPointValueAtQuantile() SummaryDataPointValueAtQuantile {
-	state := internal.StateMutable
-	return newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &state)
+	return newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_summarydatapointvalueatquantile_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantile_test.go
@@ -23,12 +23,13 @@ func TestSummaryDataPointValueAtQuantile_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSummaryDataPointValueAtQuantile(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestSummaryDataPointValueAtQuantile(), dest)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &sharedState))
+		ms.MoveTo(newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, sharedState))
 	})
 	assert.Panics(t, func() {
-		newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &sharedState).MoveTo(dest)
+		newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, sharedState).MoveTo(dest)
 	})
 }
 
@@ -40,9 +41,10 @@ func TestSummaryDataPointValueAtQuantile_CopyTo(t *testing.T) {
 	orig = generateTestSummaryDataPointValueAtQuantile()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &sharedState))
+		ms.CopyTo(newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, sharedState))
 	})
 }
 
@@ -51,9 +53,10 @@ func TestSummaryDataPointValueAtQuantile_Quantile(t *testing.T) {
 	assert.InDelta(t, float64(0), ms.Quantile(), 0.01)
 	ms.SetQuantile(float64(3.1415926))
 	assert.InDelta(t, float64(3.1415926), ms.Quantile(), 0.01)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &sharedState).SetQuantile(float64(3.1415926))
+		newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, sharedState).SetQuantile(float64(3.1415926))
 	})
 }
 
@@ -62,9 +65,10 @@ func TestSummaryDataPointValueAtQuantile_Value(t *testing.T) {
 	assert.InDelta(t, float64(0), ms.Value(), 0.01)
 	ms.SetValue(float64(3.1415926))
 	assert.InDelta(t, float64(3.1415926), ms.Value(), 0.01)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &sharedState).SetValue(float64(3.1415926))
+		newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, sharedState).SetValue(float64(3.1415926))
 	})
 }
 

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
@@ -34,8 +34,7 @@ func newSummaryDataPointValueAtQuantileSlice(orig *[]*otlpmetrics.SummaryDataPoi
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewSummaryDataPointValueAtQuantileSlice() SummaryDataPointValueAtQuantileSlice {
 	orig := []*otlpmetrics.SummaryDataPoint_ValueAtQuantile(nil)
-	state := internal.StateMutable
-	return newSummaryDataPointValueAtQuantileSlice(&orig, &state)
+	return newSummaryDataPointValueAtQuantileSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestSummaryDataPointValueAtQuantileSlice(t *testing.T) {
 	es := NewSummaryDataPointValueAtQuantileSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newSummaryDataPointValueAtQuantileSlice(&[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &state)
+	es = newSummaryDataPointValueAtQuantileSlice(&[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewSummaryDataPointValueAtQuantile()
@@ -35,8 +34,9 @@ func TestSummaryDataPointValueAtQuantileSlice(t *testing.T) {
 }
 
 func TestSummaryDataPointValueAtQuantileSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newSummaryDataPointValueAtQuantileSlice(&[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newSummaryDataPointValueAtQuantileSlice(&[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pmetric/metrics.go
+++ b/pdata/pmetric/metrics.go
@@ -3,13 +3,14 @@
 
 package pmetric // import "go.opentelemetry.io/collector/pdata/pmetric"
 
-import (
-	"go.opentelemetry.io/collector/pdata/internal"
-)
+// MarkReadOnly marks the Metrics as shared so that no further modifications can be done on it.
+func (ms Metrics) MarkReadOnly() {
+	ms.getState().MarkReadOnly()
+}
 
 // IsReadOnly returns true if this Metrics instance is read-only.
 func (ms Metrics) IsReadOnly() bool {
-	return *ms.getState() == internal.StateReadOnly
+	return ms.getState().IsReadOnly()
 }
 
 // MetricCount calculates the total number of metrics.
@@ -54,9 +55,4 @@ func (ms Metrics) DataPointCount() (dataPointCount int) {
 		}
 	}
 	return
-}
-
-// MarkReadOnly marks the Metrics as shared so that no further modifications can be done on it.
-func (ms Metrics) MarkReadOnly() {
-	internal.SetMetricsState(internal.Metrics(ms), internal.StateReadOnly)
 }

--- a/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess.go
@@ -32,8 +32,7 @@ func newExportPartialSuccess(orig *otlpcollectormetrics.ExportMetricsPartialSucc
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportPartialSuccess() ExportPartialSuccess {
-	state := internal.StateMutable
-	return newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, &state)
+	return newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess_test.go
@@ -23,12 +23,13 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, &sharedState))
+		ms.MoveTo(newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, sharedState))
 	})
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, &sharedState).MoveTo(dest)
+		newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, sharedState).MoveTo(dest)
 	})
 }
 
@@ -40,9 +41,10 @@ func TestExportPartialSuccess_CopyTo(t *testing.T) {
 	orig = generateTestExportPartialSuccess()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, &sharedState))
+		ms.CopyTo(newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, sharedState))
 	})
 }
 
@@ -51,9 +53,10 @@ func TestExportPartialSuccess_RejectedDataPoints(t *testing.T) {
 	assert.Equal(t, int64(0), ms.RejectedDataPoints())
 	ms.SetRejectedDataPoints(int64(13))
 	assert.Equal(t, int64(13), ms.RejectedDataPoints())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, &sharedState).SetRejectedDataPoints(int64(13))
+		newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, sharedState).SetRejectedDataPoints(int64(13))
 	})
 }
 
@@ -62,9 +65,10 @@ func TestExportPartialSuccess_ErrorMessage(t *testing.T) {
 	assert.Empty(t, ms.ErrorMessage())
 	ms.SetErrorMessage("test_errormessage")
 	assert.Equal(t, "test_errormessage", ms.ErrorMessage())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, &sharedState).SetErrorMessage("test_errormessage")
+		newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{}, sharedState).SetErrorMessage("test_errormessage")
 	})
 }
 

--- a/pdata/pmetric/pmetricotlp/generated_exportresponse.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportresponse.go
@@ -32,8 +32,7 @@ func newExportResponse(orig *otlpcollectormetrics.ExportMetricsServiceResponse, 
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportResponse() ExportResponse {
-	state := internal.StateMutable
-	return newExportResponse(&otlpcollectormetrics.ExportMetricsServiceResponse{}, &state)
+	return newExportResponse(&otlpcollectormetrics.ExportMetricsServiceResponse{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/pmetricotlp/generated_exportresponse_test.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportresponse_test.go
@@ -23,12 +23,13 @@ func TestExportResponse_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportResponse(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExportResponse(), dest)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExportResponse(&otlpcollectormetrics.ExportMetricsServiceResponse{}, &sharedState))
+		ms.MoveTo(newExportResponse(&otlpcollectormetrics.ExportMetricsServiceResponse{}, sharedState))
 	})
 	assert.Panics(t, func() {
-		newExportResponse(&otlpcollectormetrics.ExportMetricsServiceResponse{}, &sharedState).MoveTo(dest)
+		newExportResponse(&otlpcollectormetrics.ExportMetricsServiceResponse{}, sharedState).MoveTo(dest)
 	})
 }
 
@@ -40,9 +41,10 @@ func TestExportResponse_CopyTo(t *testing.T) {
 	orig = generateTestExportResponse()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExportResponse(&otlpcollectormetrics.ExportMetricsServiceResponse{}, &sharedState))
+		ms.CopyTo(newExportResponse(&otlpcollectormetrics.ExportMetricsServiceResponse{}, sharedState))
 	})
 }
 

--- a/pdata/pmetric/pmetricotlp/grpc.go
+++ b/pdata/pmetric/pmetricotlp/grpc.go
@@ -43,8 +43,7 @@ func (c *grpcClient) Export(ctx context.Context, request ExportRequest, opts ...
 	if err != nil {
 		return ExportResponse{}, err
 	}
-	state := internal.StateMutable
-	return ExportResponse{orig: rsp, state: &state}, err
+	return ExportResponse{orig: rsp, state: internal.NewState()}, err
 }
 
 func (c *grpcClient) unexported() {}
@@ -84,7 +83,6 @@ type rawMetricsServer struct {
 
 func (s rawMetricsServer) Export(ctx context.Context, request *otlpcollectormetrics.ExportMetricsServiceRequest) (*otlpcollectormetrics.ExportMetricsServiceResponse, error) {
 	otlp.MigrateMetrics(request.ResourceMetrics)
-	state := internal.StateMutable
-	rsp, err := s.srv.Export(ctx, ExportRequest{orig: request, state: &state})
+	rsp, err := s.srv.Export(ctx, ExportRequest{orig: request, state: internal.NewState()})
 	return rsp.orig, err
 }

--- a/pdata/pmetric/pmetricotlp/request.go
+++ b/pdata/pmetric/pmetricotlp/request.go
@@ -23,10 +23,9 @@ type ExportRequest struct {
 
 // NewExportRequest returns an empty ExportRequest.
 func NewExportRequest() ExportRequest {
-	state := internal.StateMutable
 	return ExportRequest{
 		orig:  &otlpcollectormetrics.ExportMetricsServiceRequest{},
-		state: &state,
+		state: internal.NewState(),
 	}
 }
 

--- a/pdata/pprofile/generated_attribute.go
+++ b/pdata/pprofile/generated_attribute.go
@@ -33,8 +33,7 @@ func newAttribute(orig *otlpcommon.KeyValue, state *internal.State) Attribute {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewAttribute() Attribute {
-	state := internal.StateMutable
-	return newAttribute(&otlpcommon.KeyValue{}, &state)
+	return newAttribute(&otlpcommon.KeyValue{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_attribute_test.go
+++ b/pdata/pprofile/generated_attribute_test.go
@@ -24,9 +24,10 @@ func TestAttribute_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestAttribute(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestAttribute(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newAttribute(&otlpcommon.KeyValue{}, &sharedState)) })
-	assert.Panics(t, func() { newAttribute(&otlpcommon.KeyValue{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newAttribute(&otlpcommon.KeyValue{}, sharedState)) })
+	assert.Panics(t, func() { newAttribute(&otlpcommon.KeyValue{}, sharedState).MoveTo(dest) })
 }
 
 func TestAttribute_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestAttribute_CopyTo(t *testing.T) {
 	orig = generateTestAttribute()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newAttribute(&otlpcommon.KeyValue{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newAttribute(&otlpcommon.KeyValue{}, sharedState)) })
 }
 
 func TestAttribute_Key(t *testing.T) {
@@ -46,8 +48,9 @@ func TestAttribute_Key(t *testing.T) {
 	assert.Empty(t, ms.Key())
 	ms.SetKey("test_key")
 	assert.Equal(t, "test_key", ms.Key())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newAttribute(&otlpcommon.KeyValue{}, &sharedState).SetKey("test_key") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newAttribute(&otlpcommon.KeyValue{}, sharedState).SetKey("test_key") })
 }
 
 func TestAttribute_Value(t *testing.T) {

--- a/pdata/pprofile/generated_attributetableslice.go
+++ b/pdata/pprofile/generated_attributetableslice.go
@@ -33,8 +33,7 @@ func newAttributeTableSlice(orig *[]otlpcommon.KeyValue, state *internal.State) 
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewAttributeTableSlice() AttributeTableSlice {
 	orig := []otlpcommon.KeyValue(nil)
-	state := internal.StateMutable
-	return newAttributeTableSlice(&orig, &state)
+	return newAttributeTableSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_attributetableslice_test.go
+++ b/pdata/pprofile/generated_attributetableslice_test.go
@@ -18,8 +18,7 @@ import (
 func TestAttributeTableSlice(t *testing.T) {
 	es := NewAttributeTableSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newAttributeTableSlice(&[]otlpcommon.KeyValue{}, &state)
+	es = newAttributeTableSlice(&[]otlpcommon.KeyValue{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewAttribute()
@@ -34,8 +33,9 @@ func TestAttributeTableSlice(t *testing.T) {
 }
 
 func TestAttributeTableSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newAttributeTableSlice(&[]otlpcommon.KeyValue{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newAttributeTableSlice(&[]otlpcommon.KeyValue{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_attributeunit.go
+++ b/pdata/pprofile/generated_attributeunit.go
@@ -32,8 +32,7 @@ func newAttributeUnit(orig *otlpprofiles.AttributeUnit, state *internal.State) A
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewAttributeUnit() AttributeUnit {
-	state := internal.StateMutable
-	return newAttributeUnit(&otlpprofiles.AttributeUnit{}, &state)
+	return newAttributeUnit(&otlpprofiles.AttributeUnit{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_attributeunit_test.go
+++ b/pdata/pprofile/generated_attributeunit_test.go
@@ -23,9 +23,10 @@ func TestAttributeUnit_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestAttributeUnit(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestAttributeUnit(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newAttributeUnit(&otlpprofiles.AttributeUnit{}, &sharedState)) })
-	assert.Panics(t, func() { newAttributeUnit(&otlpprofiles.AttributeUnit{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newAttributeUnit(&otlpprofiles.AttributeUnit{}, sharedState)) })
+	assert.Panics(t, func() { newAttributeUnit(&otlpprofiles.AttributeUnit{}, sharedState).MoveTo(dest) })
 }
 
 func TestAttributeUnit_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestAttributeUnit_CopyTo(t *testing.T) {
 	orig = generateTestAttributeUnit()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newAttributeUnit(&otlpprofiles.AttributeUnit{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newAttributeUnit(&otlpprofiles.AttributeUnit{}, sharedState)) })
 }
 
 func TestAttributeUnit_AttributeKeyStrindex(t *testing.T) {
@@ -45,9 +47,10 @@ func TestAttributeUnit_AttributeKeyStrindex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.AttributeKeyStrindex())
 	ms.SetAttributeKeyStrindex(int32(13))
 	assert.Equal(t, int32(13), ms.AttributeKeyStrindex())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newAttributeUnit(&otlpprofiles.AttributeUnit{}, &sharedState).SetAttributeKeyStrindex(int32(13))
+		newAttributeUnit(&otlpprofiles.AttributeUnit{}, sharedState).SetAttributeKeyStrindex(int32(13))
 	})
 }
 
@@ -56,8 +59,9 @@ func TestAttributeUnit_UnitStrindex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.UnitStrindex())
 	ms.SetUnitStrindex(int32(13))
 	assert.Equal(t, int32(13), ms.UnitStrindex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newAttributeUnit(&otlpprofiles.AttributeUnit{}, &sharedState).SetUnitStrindex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newAttributeUnit(&otlpprofiles.AttributeUnit{}, sharedState).SetUnitStrindex(int32(13)) })
 }
 
 func generateTestAttributeUnit() AttributeUnit {

--- a/pdata/pprofile/generated_attributeunitslice.go
+++ b/pdata/pprofile/generated_attributeunitslice.go
@@ -34,8 +34,7 @@ func newAttributeUnitSlice(orig *[]*otlpprofiles.AttributeUnit, state *internal.
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewAttributeUnitSlice() AttributeUnitSlice {
 	orig := []*otlpprofiles.AttributeUnit(nil)
-	state := internal.StateMutable
-	return newAttributeUnitSlice(&orig, &state)
+	return newAttributeUnitSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_attributeunitslice_test.go
+++ b/pdata/pprofile/generated_attributeunitslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestAttributeUnitSlice(t *testing.T) {
 	es := NewAttributeUnitSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newAttributeUnitSlice(&[]*otlpprofiles.AttributeUnit{}, &state)
+	es = newAttributeUnitSlice(&[]*otlpprofiles.AttributeUnit{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewAttributeUnit()
@@ -35,8 +34,9 @@ func TestAttributeUnitSlice(t *testing.T) {
 }
 
 func TestAttributeUnitSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newAttributeUnitSlice(&[]*otlpprofiles.AttributeUnit{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newAttributeUnitSlice(&[]*otlpprofiles.AttributeUnit{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_function.go
+++ b/pdata/pprofile/generated_function.go
@@ -32,8 +32,7 @@ func newFunction(orig *otlpprofiles.Function, state *internal.State) Function {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewFunction() Function {
-	state := internal.StateMutable
-	return newFunction(&otlpprofiles.Function{}, &state)
+	return newFunction(&otlpprofiles.Function{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_function_test.go
+++ b/pdata/pprofile/generated_function_test.go
@@ -23,9 +23,10 @@ func TestFunction_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestFunction(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestFunction(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newFunction(&otlpprofiles.Function{}, &sharedState)) })
-	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newFunction(&otlpprofiles.Function{}, sharedState)) })
+	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, sharedState).MoveTo(dest) })
 }
 
 func TestFunction_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestFunction_CopyTo(t *testing.T) {
 	orig = generateTestFunction()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newFunction(&otlpprofiles.Function{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newFunction(&otlpprofiles.Function{}, sharedState)) })
 }
 
 func TestFunction_NameStrindex(t *testing.T) {
@@ -45,8 +47,9 @@ func TestFunction_NameStrindex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.NameStrindex())
 	ms.SetNameStrindex(int32(13))
 	assert.Equal(t, int32(13), ms.NameStrindex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, &sharedState).SetNameStrindex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, sharedState).SetNameStrindex(int32(13)) })
 }
 
 func TestFunction_SystemNameStrindex(t *testing.T) {
@@ -54,8 +57,9 @@ func TestFunction_SystemNameStrindex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.SystemNameStrindex())
 	ms.SetSystemNameStrindex(int32(13))
 	assert.Equal(t, int32(13), ms.SystemNameStrindex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, &sharedState).SetSystemNameStrindex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, sharedState).SetSystemNameStrindex(int32(13)) })
 }
 
 func TestFunction_FilenameStrindex(t *testing.T) {
@@ -63,8 +67,9 @@ func TestFunction_FilenameStrindex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.FilenameStrindex())
 	ms.SetFilenameStrindex(int32(13))
 	assert.Equal(t, int32(13), ms.FilenameStrindex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, &sharedState).SetFilenameStrindex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, sharedState).SetFilenameStrindex(int32(13)) })
 }
 
 func TestFunction_StartLine(t *testing.T) {
@@ -72,8 +77,9 @@ func TestFunction_StartLine(t *testing.T) {
 	assert.Equal(t, int64(0), ms.StartLine())
 	ms.SetStartLine(int64(13))
 	assert.Equal(t, int64(13), ms.StartLine())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, &sharedState).SetStartLine(int64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newFunction(&otlpprofiles.Function{}, sharedState).SetStartLine(int64(13)) })
 }
 
 func generateTestFunction() Function {

--- a/pdata/pprofile/generated_functionslice.go
+++ b/pdata/pprofile/generated_functionslice.go
@@ -34,8 +34,7 @@ func newFunctionSlice(orig *[]*otlpprofiles.Function, state *internal.State) Fun
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewFunctionSlice() FunctionSlice {
 	orig := []*otlpprofiles.Function(nil)
-	state := internal.StateMutable
-	return newFunctionSlice(&orig, &state)
+	return newFunctionSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_functionslice_test.go
+++ b/pdata/pprofile/generated_functionslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestFunctionSlice(t *testing.T) {
 	es := NewFunctionSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newFunctionSlice(&[]*otlpprofiles.Function{}, &state)
+	es = newFunctionSlice(&[]*otlpprofiles.Function{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewFunction()
@@ -35,8 +34,9 @@ func TestFunctionSlice(t *testing.T) {
 }
 
 func TestFunctionSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newFunctionSlice(&[]*otlpprofiles.Function{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newFunctionSlice(&[]*otlpprofiles.Function{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_line.go
+++ b/pdata/pprofile/generated_line.go
@@ -32,8 +32,7 @@ func newLine(orig *otlpprofiles.Line, state *internal.State) Line {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLine() Line {
-	state := internal.StateMutable
-	return newLine(&otlpprofiles.Line{}, &state)
+	return newLine(&otlpprofiles.Line{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_line_test.go
+++ b/pdata/pprofile/generated_line_test.go
@@ -23,9 +23,10 @@ func TestLine_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLine(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestLine(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newLine(&otlpprofiles.Line{}, &sharedState)) })
-	assert.Panics(t, func() { newLine(&otlpprofiles.Line{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newLine(&otlpprofiles.Line{}, sharedState)) })
+	assert.Panics(t, func() { newLine(&otlpprofiles.Line{}, sharedState).MoveTo(dest) })
 }
 
 func TestLine_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestLine_CopyTo(t *testing.T) {
 	orig = generateTestLine()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newLine(&otlpprofiles.Line{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newLine(&otlpprofiles.Line{}, sharedState)) })
 }
 
 func TestLine_FunctionIndex(t *testing.T) {
@@ -45,8 +47,9 @@ func TestLine_FunctionIndex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.FunctionIndex())
 	ms.SetFunctionIndex(int32(13))
 	assert.Equal(t, int32(13), ms.FunctionIndex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newLine(&otlpprofiles.Line{}, &sharedState).SetFunctionIndex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newLine(&otlpprofiles.Line{}, sharedState).SetFunctionIndex(int32(13)) })
 }
 
 func TestLine_Line(t *testing.T) {
@@ -54,8 +57,9 @@ func TestLine_Line(t *testing.T) {
 	assert.Equal(t, int64(0), ms.Line())
 	ms.SetLine(int64(13))
 	assert.Equal(t, int64(13), ms.Line())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newLine(&otlpprofiles.Line{}, &sharedState).SetLine(int64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newLine(&otlpprofiles.Line{}, sharedState).SetLine(int64(13)) })
 }
 
 func TestLine_Column(t *testing.T) {
@@ -63,8 +67,9 @@ func TestLine_Column(t *testing.T) {
 	assert.Equal(t, int64(0), ms.Column())
 	ms.SetColumn(int64(13))
 	assert.Equal(t, int64(13), ms.Column())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newLine(&otlpprofiles.Line{}, &sharedState).SetColumn(int64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newLine(&otlpprofiles.Line{}, sharedState).SetColumn(int64(13)) })
 }
 
 func generateTestLine() Line {

--- a/pdata/pprofile/generated_lineslice.go
+++ b/pdata/pprofile/generated_lineslice.go
@@ -34,8 +34,7 @@ func newLineSlice(orig *[]*otlpprofiles.Line, state *internal.State) LineSlice {
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewLineSlice() LineSlice {
 	orig := []*otlpprofiles.Line(nil)
-	state := internal.StateMutable
-	return newLineSlice(&orig, &state)
+	return newLineSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_lineslice_test.go
+++ b/pdata/pprofile/generated_lineslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestLineSlice(t *testing.T) {
 	es := NewLineSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newLineSlice(&[]*otlpprofiles.Line{}, &state)
+	es = newLineSlice(&[]*otlpprofiles.Line{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewLine()
@@ -35,8 +34,9 @@ func TestLineSlice(t *testing.T) {
 }
 
 func TestLineSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newLineSlice(&[]*otlpprofiles.Line{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newLineSlice(&[]*otlpprofiles.Line{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_link.go
+++ b/pdata/pprofile/generated_link.go
@@ -34,8 +34,7 @@ func newLink(orig *otlpprofiles.Link, state *internal.State) Link {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLink() Link {
-	state := internal.StateMutable
-	return newLink(&otlpprofiles.Link{}, &state)
+	return newLink(&otlpprofiles.Link{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_link_test.go
+++ b/pdata/pprofile/generated_link_test.go
@@ -25,9 +25,10 @@ func TestLink_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLink(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestLink(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newLink(&otlpprofiles.Link{}, &sharedState)) })
-	assert.Panics(t, func() { newLink(&otlpprofiles.Link{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newLink(&otlpprofiles.Link{}, sharedState)) })
+	assert.Panics(t, func() { newLink(&otlpprofiles.Link{}, sharedState).MoveTo(dest) })
 }
 
 func TestLink_CopyTo(t *testing.T) {
@@ -38,8 +39,9 @@ func TestLink_CopyTo(t *testing.T) {
 	orig = generateTestLink()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newLink(&otlpprofiles.Link{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newLink(&otlpprofiles.Link{}, sharedState)) })
 }
 
 func TestLink_TraceID(t *testing.T) {

--- a/pdata/pprofile/generated_linkslice.go
+++ b/pdata/pprofile/generated_linkslice.go
@@ -34,8 +34,7 @@ func newLinkSlice(orig *[]*otlpprofiles.Link, state *internal.State) LinkSlice {
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewLinkSlice() LinkSlice {
 	orig := []*otlpprofiles.Link(nil)
-	state := internal.StateMutable
-	return newLinkSlice(&orig, &state)
+	return newLinkSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_linkslice_test.go
+++ b/pdata/pprofile/generated_linkslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestLinkSlice(t *testing.T) {
 	es := NewLinkSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newLinkSlice(&[]*otlpprofiles.Link{}, &state)
+	es = newLinkSlice(&[]*otlpprofiles.Link{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewLink()
@@ -35,8 +34,9 @@ func TestLinkSlice(t *testing.T) {
 }
 
 func TestLinkSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newLinkSlice(&[]*otlpprofiles.Link{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newLinkSlice(&[]*otlpprofiles.Link{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_location.go
+++ b/pdata/pprofile/generated_location.go
@@ -33,8 +33,7 @@ func newLocation(orig *otlpprofiles.Location, state *internal.State) Location {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLocation() Location {
-	state := internal.StateMutable
-	return newLocation(&otlpprofiles.Location{}, &state)
+	return newLocation(&otlpprofiles.Location{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_location_test.go
+++ b/pdata/pprofile/generated_location_test.go
@@ -24,9 +24,10 @@ func TestLocation_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLocation(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestLocation(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newLocation(&otlpprofiles.Location{}, &sharedState)) })
-	assert.Panics(t, func() { newLocation(&otlpprofiles.Location{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newLocation(&otlpprofiles.Location{}, sharedState)) })
+	assert.Panics(t, func() { newLocation(&otlpprofiles.Location{}, sharedState).MoveTo(dest) })
 }
 
 func TestLocation_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestLocation_CopyTo(t *testing.T) {
 	orig = generateTestLocation()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newLocation(&otlpprofiles.Location{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newLocation(&otlpprofiles.Location{}, sharedState)) })
 }
 
 func TestLocation_MappingIndex(t *testing.T) {
@@ -60,8 +62,9 @@ func TestLocation_Address(t *testing.T) {
 	assert.Equal(t, uint64(0), ms.Address())
 	ms.SetAddress(uint64(13))
 	assert.Equal(t, uint64(13), ms.Address())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newLocation(&otlpprofiles.Location{}, &sharedState).SetAddress(uint64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newLocation(&otlpprofiles.Location{}, sharedState).SetAddress(uint64(13)) })
 }
 
 func TestLocation_Line(t *testing.T) {
@@ -76,8 +79,9 @@ func TestLocation_IsFolded(t *testing.T) {
 	assert.False(t, ms.IsFolded())
 	ms.SetIsFolded(true)
 	assert.True(t, ms.IsFolded())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newLocation(&otlpprofiles.Location{}, &sharedState).SetIsFolded(true) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newLocation(&otlpprofiles.Location{}, sharedState).SetIsFolded(true) })
 }
 
 func TestLocation_AttributeIndices(t *testing.T) {

--- a/pdata/pprofile/generated_locationslice.go
+++ b/pdata/pprofile/generated_locationslice.go
@@ -34,8 +34,7 @@ func newLocationSlice(orig *[]*otlpprofiles.Location, state *internal.State) Loc
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewLocationSlice() LocationSlice {
 	orig := []*otlpprofiles.Location(nil)
-	state := internal.StateMutable
-	return newLocationSlice(&orig, &state)
+	return newLocationSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_locationslice_test.go
+++ b/pdata/pprofile/generated_locationslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestLocationSlice(t *testing.T) {
 	es := NewLocationSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newLocationSlice(&[]*otlpprofiles.Location{}, &state)
+	es = newLocationSlice(&[]*otlpprofiles.Location{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewLocation()
@@ -35,8 +34,9 @@ func TestLocationSlice(t *testing.T) {
 }
 
 func TestLocationSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newLocationSlice(&[]*otlpprofiles.Location{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newLocationSlice(&[]*otlpprofiles.Location{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_mapping.go
+++ b/pdata/pprofile/generated_mapping.go
@@ -33,8 +33,7 @@ func newMapping(orig *otlpprofiles.Mapping, state *internal.State) Mapping {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewMapping() Mapping {
-	state := internal.StateMutable
-	return newMapping(&otlpprofiles.Mapping{}, &state)
+	return newMapping(&otlpprofiles.Mapping{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_mapping_test.go
+++ b/pdata/pprofile/generated_mapping_test.go
@@ -24,9 +24,10 @@ func TestMapping_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestMapping(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestMapping(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newMapping(&otlpprofiles.Mapping{}, &sharedState)) })
-	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newMapping(&otlpprofiles.Mapping{}, sharedState)) })
+	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, sharedState).MoveTo(dest) })
 }
 
 func TestMapping_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestMapping_CopyTo(t *testing.T) {
 	orig = generateTestMapping()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newMapping(&otlpprofiles.Mapping{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newMapping(&otlpprofiles.Mapping{}, sharedState)) })
 }
 
 func TestMapping_MemoryStart(t *testing.T) {
@@ -46,8 +48,9 @@ func TestMapping_MemoryStart(t *testing.T) {
 	assert.Equal(t, uint64(0), ms.MemoryStart())
 	ms.SetMemoryStart(uint64(13))
 	assert.Equal(t, uint64(13), ms.MemoryStart())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).SetMemoryStart(uint64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, sharedState).SetMemoryStart(uint64(13)) })
 }
 
 func TestMapping_MemoryLimit(t *testing.T) {
@@ -55,8 +58,9 @@ func TestMapping_MemoryLimit(t *testing.T) {
 	assert.Equal(t, uint64(0), ms.MemoryLimit())
 	ms.SetMemoryLimit(uint64(13))
 	assert.Equal(t, uint64(13), ms.MemoryLimit())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).SetMemoryLimit(uint64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, sharedState).SetMemoryLimit(uint64(13)) })
 }
 
 func TestMapping_FileOffset(t *testing.T) {
@@ -64,8 +68,9 @@ func TestMapping_FileOffset(t *testing.T) {
 	assert.Equal(t, uint64(0), ms.FileOffset())
 	ms.SetFileOffset(uint64(13))
 	assert.Equal(t, uint64(13), ms.FileOffset())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).SetFileOffset(uint64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, sharedState).SetFileOffset(uint64(13)) })
 }
 
 func TestMapping_FilenameStrindex(t *testing.T) {
@@ -73,8 +78,9 @@ func TestMapping_FilenameStrindex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.FilenameStrindex())
 	ms.SetFilenameStrindex(int32(13))
 	assert.Equal(t, int32(13), ms.FilenameStrindex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).SetFilenameStrindex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, sharedState).SetFilenameStrindex(int32(13)) })
 }
 
 func TestMapping_AttributeIndices(t *testing.T) {
@@ -89,8 +95,9 @@ func TestMapping_HasFunctions(t *testing.T) {
 	assert.False(t, ms.HasFunctions())
 	ms.SetHasFunctions(true)
 	assert.True(t, ms.HasFunctions())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).SetHasFunctions(true) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, sharedState).SetHasFunctions(true) })
 }
 
 func TestMapping_HasFilenames(t *testing.T) {
@@ -98,8 +105,9 @@ func TestMapping_HasFilenames(t *testing.T) {
 	assert.False(t, ms.HasFilenames())
 	ms.SetHasFilenames(true)
 	assert.True(t, ms.HasFilenames())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).SetHasFilenames(true) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, sharedState).SetHasFilenames(true) })
 }
 
 func TestMapping_HasLineNumbers(t *testing.T) {
@@ -107,8 +115,9 @@ func TestMapping_HasLineNumbers(t *testing.T) {
 	assert.False(t, ms.HasLineNumbers())
 	ms.SetHasLineNumbers(true)
 	assert.True(t, ms.HasLineNumbers())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).SetHasLineNumbers(true) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, sharedState).SetHasLineNumbers(true) })
 }
 
 func TestMapping_HasInlineFrames(t *testing.T) {
@@ -116,8 +125,9 @@ func TestMapping_HasInlineFrames(t *testing.T) {
 	assert.False(t, ms.HasInlineFrames())
 	ms.SetHasInlineFrames(true)
 	assert.True(t, ms.HasInlineFrames())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, &sharedState).SetHasInlineFrames(true) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newMapping(&otlpprofiles.Mapping{}, sharedState).SetHasInlineFrames(true) })
 }
 
 func generateTestMapping() Mapping {

--- a/pdata/pprofile/generated_mappingslice.go
+++ b/pdata/pprofile/generated_mappingslice.go
@@ -34,8 +34,7 @@ func newMappingSlice(orig *[]*otlpprofiles.Mapping, state *internal.State) Mappi
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewMappingSlice() MappingSlice {
 	orig := []*otlpprofiles.Mapping(nil)
-	state := internal.StateMutable
-	return newMappingSlice(&orig, &state)
+	return newMappingSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_mappingslice_test.go
+++ b/pdata/pprofile/generated_mappingslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestMappingSlice(t *testing.T) {
 	es := NewMappingSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newMappingSlice(&[]*otlpprofiles.Mapping{}, &state)
+	es = newMappingSlice(&[]*otlpprofiles.Mapping{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewMapping()
@@ -35,8 +34,9 @@ func TestMappingSlice(t *testing.T) {
 }
 
 func TestMappingSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newMappingSlice(&[]*otlpprofiles.Mapping{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newMappingSlice(&[]*otlpprofiles.Mapping{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_profile.go
+++ b/pdata/pprofile/generated_profile.go
@@ -34,8 +34,7 @@ func newProfile(orig *otlpprofiles.Profile, state *internal.State) Profile {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewProfile() Profile {
-	state := internal.StateMutable
-	return newProfile(&otlpprofiles.Profile{}, &state)
+	return newProfile(&otlpprofiles.Profile{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_profile_test.go
+++ b/pdata/pprofile/generated_profile_test.go
@@ -25,9 +25,10 @@ func TestProfile_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestProfile(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestProfile(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newProfile(&otlpprofiles.Profile{}, &sharedState)) })
-	assert.Panics(t, func() { newProfile(&otlpprofiles.Profile{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newProfile(&otlpprofiles.Profile{}, sharedState)) })
+	assert.Panics(t, func() { newProfile(&otlpprofiles.Profile{}, sharedState).MoveTo(dest) })
 }
 
 func TestProfile_CopyTo(t *testing.T) {
@@ -38,8 +39,9 @@ func TestProfile_CopyTo(t *testing.T) {
 	orig = generateTestProfile()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newProfile(&otlpprofiles.Profile{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newProfile(&otlpprofiles.Profile{}, sharedState)) })
 }
 
 func TestProfile_SampleType(t *testing.T) {
@@ -91,8 +93,9 @@ func TestProfile_Period(t *testing.T) {
 	assert.Equal(t, int64(0), ms.Period())
 	ms.SetPeriod(int64(13))
 	assert.Equal(t, int64(13), ms.Period())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newProfile(&otlpprofiles.Profile{}, &sharedState).SetPeriod(int64(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newProfile(&otlpprofiles.Profile{}, sharedState).SetPeriod(int64(13)) })
 }
 
 func TestProfile_CommentStrindices(t *testing.T) {
@@ -107,8 +110,9 @@ func TestProfile_DefaultSampleTypeIndex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.DefaultSampleTypeIndex())
 	ms.SetDefaultSampleTypeIndex(int32(13))
 	assert.Equal(t, int32(13), ms.DefaultSampleTypeIndex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newProfile(&otlpprofiles.Profile{}, &sharedState).SetDefaultSampleTypeIndex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newProfile(&otlpprofiles.Profile{}, sharedState).SetDefaultSampleTypeIndex(int32(13)) })
 }
 
 func TestProfile_ProfileID(t *testing.T) {
@@ -124,8 +128,9 @@ func TestProfile_DroppedAttributesCount(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.DroppedAttributesCount())
 	ms.SetDroppedAttributesCount(uint32(13))
 	assert.Equal(t, uint32(13), ms.DroppedAttributesCount())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newProfile(&otlpprofiles.Profile{}, &sharedState).SetDroppedAttributesCount(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newProfile(&otlpprofiles.Profile{}, sharedState).SetDroppedAttributesCount(uint32(13)) })
 }
 
 func TestProfile_OriginalPayloadFormat(t *testing.T) {
@@ -133,9 +138,10 @@ func TestProfile_OriginalPayloadFormat(t *testing.T) {
 	assert.Empty(t, ms.OriginalPayloadFormat())
 	ms.SetOriginalPayloadFormat("test_originalpayloadformat")
 	assert.Equal(t, "test_originalpayloadformat", ms.OriginalPayloadFormat())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newProfile(&otlpprofiles.Profile{}, &sharedState).SetOriginalPayloadFormat("test_originalpayloadformat")
+		newProfile(&otlpprofiles.Profile{}, sharedState).SetOriginalPayloadFormat("test_originalpayloadformat")
 	})
 }
 

--- a/pdata/pprofile/generated_profiles.go
+++ b/pdata/pprofile/generated_profiles.go
@@ -30,8 +30,7 @@ func newProfiles(orig *otlpcollectorprofiles.ExportProfilesServiceRequest, state
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewProfiles() Profiles {
-	state := internal.StateMutable
-	return newProfiles(&otlpcollectorprofiles.ExportProfilesServiceRequest{}, &state)
+	return newProfiles(&otlpcollectorprofiles.ExportProfilesServiceRequest{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_profiles_test.go
+++ b/pdata/pprofile/generated_profiles_test.go
@@ -23,9 +23,10 @@ func TestProfiles_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestProfiles(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestProfiles(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newProfiles(&otlpcollectorprofiles.ExportProfilesServiceRequest{}, &sharedState)) })
-	assert.Panics(t, func() { newProfiles(&otlpcollectorprofiles.ExportProfilesServiceRequest{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newProfiles(&otlpcollectorprofiles.ExportProfilesServiceRequest{}, sharedState)) })
+	assert.Panics(t, func() { newProfiles(&otlpcollectorprofiles.ExportProfilesServiceRequest{}, sharedState).MoveTo(dest) })
 }
 
 func TestProfiles_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestProfiles_CopyTo(t *testing.T) {
 	orig = generateTestProfiles()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newProfiles(&otlpcollectorprofiles.ExportProfilesServiceRequest{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newProfiles(&otlpcollectorprofiles.ExportProfilesServiceRequest{}, sharedState)) })
 }
 
 func TestProfiles_ResourceProfiles(t *testing.T) {

--- a/pdata/pprofile/generated_profilesdictionary.go
+++ b/pdata/pprofile/generated_profilesdictionary.go
@@ -33,8 +33,7 @@ func newProfilesDictionary(orig *otlpprofiles.ProfilesDictionary, state *interna
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewProfilesDictionary() ProfilesDictionary {
-	state := internal.StateMutable
-	return newProfilesDictionary(&otlpprofiles.ProfilesDictionary{}, &state)
+	return newProfilesDictionary(&otlpprofiles.ProfilesDictionary{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_profilesdictionary_test.go
+++ b/pdata/pprofile/generated_profilesdictionary_test.go
@@ -24,9 +24,10 @@ func TestProfilesDictionary_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestProfilesDictionary(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestProfilesDictionary(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newProfilesDictionary(&otlpprofiles.ProfilesDictionary{}, &sharedState)) })
-	assert.Panics(t, func() { newProfilesDictionary(&otlpprofiles.ProfilesDictionary{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newProfilesDictionary(&otlpprofiles.ProfilesDictionary{}, sharedState)) })
+	assert.Panics(t, func() { newProfilesDictionary(&otlpprofiles.ProfilesDictionary{}, sharedState).MoveTo(dest) })
 }
 
 func TestProfilesDictionary_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestProfilesDictionary_CopyTo(t *testing.T) {
 	orig = generateTestProfilesDictionary()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newProfilesDictionary(&otlpprofiles.ProfilesDictionary{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newProfilesDictionary(&otlpprofiles.ProfilesDictionary{}, sharedState)) })
 }
 
 func TestProfilesDictionary_MappingTable(t *testing.T) {

--- a/pdata/pprofile/generated_profilesslice.go
+++ b/pdata/pprofile/generated_profilesslice.go
@@ -34,8 +34,7 @@ func newProfilesSlice(orig *[]*otlpprofiles.Profile, state *internal.State) Prof
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewProfilesSlice() ProfilesSlice {
 	orig := []*otlpprofiles.Profile(nil)
-	state := internal.StateMutable
-	return newProfilesSlice(&orig, &state)
+	return newProfilesSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_profilesslice_test.go
+++ b/pdata/pprofile/generated_profilesslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestProfilesSlice(t *testing.T) {
 	es := NewProfilesSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newProfilesSlice(&[]*otlpprofiles.Profile{}, &state)
+	es = newProfilesSlice(&[]*otlpprofiles.Profile{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewProfile()
@@ -35,8 +34,9 @@ func TestProfilesSlice(t *testing.T) {
 }
 
 func TestProfilesSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newProfilesSlice(&[]*otlpprofiles.Profile{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newProfilesSlice(&[]*otlpprofiles.Profile{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_resourceprofiles.go
+++ b/pdata/pprofile/generated_resourceprofiles.go
@@ -33,8 +33,7 @@ func newResourceProfiles(orig *otlpprofiles.ResourceProfiles, state *internal.St
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResourceProfiles() ResourceProfiles {
-	state := internal.StateMutable
-	return newResourceProfiles(&otlpprofiles.ResourceProfiles{}, &state)
+	return newResourceProfiles(&otlpprofiles.ResourceProfiles{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_resourceprofiles_test.go
+++ b/pdata/pprofile/generated_resourceprofiles_test.go
@@ -24,9 +24,10 @@ func TestResourceProfiles_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResourceProfiles(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestResourceProfiles(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newResourceProfiles(&otlpprofiles.ResourceProfiles{}, &sharedState)) })
-	assert.Panics(t, func() { newResourceProfiles(&otlpprofiles.ResourceProfiles{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newResourceProfiles(&otlpprofiles.ResourceProfiles{}, sharedState)) })
+	assert.Panics(t, func() { newResourceProfiles(&otlpprofiles.ResourceProfiles{}, sharedState).MoveTo(dest) })
 }
 
 func TestResourceProfiles_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestResourceProfiles_CopyTo(t *testing.T) {
 	orig = generateTestResourceProfiles()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newResourceProfiles(&otlpprofiles.ResourceProfiles{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newResourceProfiles(&otlpprofiles.ResourceProfiles{}, sharedState)) })
 }
 
 func TestResourceProfiles_Resource(t *testing.T) {
@@ -60,9 +62,10 @@ func TestResourceProfiles_SchemaUrl(t *testing.T) {
 	assert.Empty(t, ms.SchemaUrl())
 	ms.SetSchemaUrl("test_schemaurl")
 	assert.Equal(t, "test_schemaurl", ms.SchemaUrl())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newResourceProfiles(&otlpprofiles.ResourceProfiles{}, &sharedState).SetSchemaUrl("test_schemaurl")
+		newResourceProfiles(&otlpprofiles.ResourceProfiles{}, sharedState).SetSchemaUrl("test_schemaurl")
 	})
 }
 

--- a/pdata/pprofile/generated_resourceprofilesslice.go
+++ b/pdata/pprofile/generated_resourceprofilesslice.go
@@ -34,8 +34,7 @@ func newResourceProfilesSlice(orig *[]*otlpprofiles.ResourceProfiles, state *int
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewResourceProfilesSlice() ResourceProfilesSlice {
 	orig := []*otlpprofiles.ResourceProfiles(nil)
-	state := internal.StateMutable
-	return newResourceProfilesSlice(&orig, &state)
+	return newResourceProfilesSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_resourceprofilesslice_test.go
+++ b/pdata/pprofile/generated_resourceprofilesslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestResourceProfilesSlice(t *testing.T) {
 	es := NewResourceProfilesSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newResourceProfilesSlice(&[]*otlpprofiles.ResourceProfiles{}, &state)
+	es = newResourceProfilesSlice(&[]*otlpprofiles.ResourceProfiles{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewResourceProfiles()
@@ -35,8 +34,9 @@ func TestResourceProfilesSlice(t *testing.T) {
 }
 
 func TestResourceProfilesSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newResourceProfilesSlice(&[]*otlpprofiles.ResourceProfiles{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newResourceProfilesSlice(&[]*otlpprofiles.ResourceProfiles{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_sample.go
+++ b/pdata/pprofile/generated_sample.go
@@ -33,8 +33,7 @@ func newSample(orig *otlpprofiles.Sample, state *internal.State) Sample {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSample() Sample {
-	state := internal.StateMutable
-	return newSample(&otlpprofiles.Sample{}, &state)
+	return newSample(&otlpprofiles.Sample{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_sample_test.go
+++ b/pdata/pprofile/generated_sample_test.go
@@ -24,9 +24,10 @@ func TestSample_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSample(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestSample(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newSample(&otlpprofiles.Sample{}, &sharedState)) })
-	assert.Panics(t, func() { newSample(&otlpprofiles.Sample{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newSample(&otlpprofiles.Sample{}, sharedState)) })
+	assert.Panics(t, func() { newSample(&otlpprofiles.Sample{}, sharedState).MoveTo(dest) })
 }
 
 func TestSample_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestSample_CopyTo(t *testing.T) {
 	orig = generateTestSample()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newSample(&otlpprofiles.Sample{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newSample(&otlpprofiles.Sample{}, sharedState)) })
 }
 
 func TestSample_LocationsStartIndex(t *testing.T) {
@@ -46,8 +48,9 @@ func TestSample_LocationsStartIndex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.LocationsStartIndex())
 	ms.SetLocationsStartIndex(int32(13))
 	assert.Equal(t, int32(13), ms.LocationsStartIndex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSample(&otlpprofiles.Sample{}, &sharedState).SetLocationsStartIndex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSample(&otlpprofiles.Sample{}, sharedState).SetLocationsStartIndex(int32(13)) })
 }
 
 func TestSample_LocationsLength(t *testing.T) {
@@ -55,8 +58,9 @@ func TestSample_LocationsLength(t *testing.T) {
 	assert.Equal(t, int32(0), ms.LocationsLength())
 	ms.SetLocationsLength(int32(13))
 	assert.Equal(t, int32(13), ms.LocationsLength())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSample(&otlpprofiles.Sample{}, &sharedState).SetLocationsLength(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSample(&otlpprofiles.Sample{}, sharedState).SetLocationsLength(int32(13)) })
 }
 
 func TestSample_Value(t *testing.T) {

--- a/pdata/pprofile/generated_sampleslice.go
+++ b/pdata/pprofile/generated_sampleslice.go
@@ -34,8 +34,7 @@ func newSampleSlice(orig *[]*otlpprofiles.Sample, state *internal.State) SampleS
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewSampleSlice() SampleSlice {
 	orig := []*otlpprofiles.Sample(nil)
-	state := internal.StateMutable
-	return newSampleSlice(&orig, &state)
+	return newSampleSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_sampleslice_test.go
+++ b/pdata/pprofile/generated_sampleslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestSampleSlice(t *testing.T) {
 	es := NewSampleSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newSampleSlice(&[]*otlpprofiles.Sample{}, &state)
+	es = newSampleSlice(&[]*otlpprofiles.Sample{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewSample()
@@ -35,8 +34,9 @@ func TestSampleSlice(t *testing.T) {
 }
 
 func TestSampleSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newSampleSlice(&[]*otlpprofiles.Sample{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newSampleSlice(&[]*otlpprofiles.Sample{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_scopeprofiles.go
+++ b/pdata/pprofile/generated_scopeprofiles.go
@@ -33,8 +33,7 @@ func newScopeProfiles(orig *otlpprofiles.ScopeProfiles, state *internal.State) S
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewScopeProfiles() ScopeProfiles {
-	state := internal.StateMutable
-	return newScopeProfiles(&otlpprofiles.ScopeProfiles{}, &state)
+	return newScopeProfiles(&otlpprofiles.ScopeProfiles{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_scopeprofiles_test.go
+++ b/pdata/pprofile/generated_scopeprofiles_test.go
@@ -24,9 +24,10 @@ func TestScopeProfiles_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestScopeProfiles(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestScopeProfiles(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newScopeProfiles(&otlpprofiles.ScopeProfiles{}, &sharedState)) })
-	assert.Panics(t, func() { newScopeProfiles(&otlpprofiles.ScopeProfiles{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newScopeProfiles(&otlpprofiles.ScopeProfiles{}, sharedState)) })
+	assert.Panics(t, func() { newScopeProfiles(&otlpprofiles.ScopeProfiles{}, sharedState).MoveTo(dest) })
 }
 
 func TestScopeProfiles_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestScopeProfiles_CopyTo(t *testing.T) {
 	orig = generateTestScopeProfiles()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newScopeProfiles(&otlpprofiles.ScopeProfiles{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newScopeProfiles(&otlpprofiles.ScopeProfiles{}, sharedState)) })
 }
 
 func TestScopeProfiles_Scope(t *testing.T) {
@@ -60,8 +62,9 @@ func TestScopeProfiles_SchemaUrl(t *testing.T) {
 	assert.Empty(t, ms.SchemaUrl())
 	ms.SetSchemaUrl("test_schemaurl")
 	assert.Equal(t, "test_schemaurl", ms.SchemaUrl())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newScopeProfiles(&otlpprofiles.ScopeProfiles{}, &sharedState).SetSchemaUrl("test_schemaurl") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newScopeProfiles(&otlpprofiles.ScopeProfiles{}, sharedState).SetSchemaUrl("test_schemaurl") })
 }
 
 func generateTestScopeProfiles() ScopeProfiles {

--- a/pdata/pprofile/generated_scopeprofilesslice.go
+++ b/pdata/pprofile/generated_scopeprofilesslice.go
@@ -34,8 +34,7 @@ func newScopeProfilesSlice(orig *[]*otlpprofiles.ScopeProfiles, state *internal.
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewScopeProfilesSlice() ScopeProfilesSlice {
 	orig := []*otlpprofiles.ScopeProfiles(nil)
-	state := internal.StateMutable
-	return newScopeProfilesSlice(&orig, &state)
+	return newScopeProfilesSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_scopeprofilesslice_test.go
+++ b/pdata/pprofile/generated_scopeprofilesslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestScopeProfilesSlice(t *testing.T) {
 	es := NewScopeProfilesSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newScopeProfilesSlice(&[]*otlpprofiles.ScopeProfiles{}, &state)
+	es = newScopeProfilesSlice(&[]*otlpprofiles.ScopeProfiles{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewScopeProfiles()
@@ -35,8 +34,9 @@ func TestScopeProfilesSlice(t *testing.T) {
 }
 
 func TestScopeProfilesSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newScopeProfilesSlice(&[]*otlpprofiles.ScopeProfiles{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newScopeProfilesSlice(&[]*otlpprofiles.ScopeProfiles{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/generated_valuetype.go
+++ b/pdata/pprofile/generated_valuetype.go
@@ -32,8 +32,7 @@ func newValueType(orig *otlpprofiles.ValueType, state *internal.State) ValueType
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewValueType() ValueType {
-	state := internal.StateMutable
-	return newValueType(&otlpprofiles.ValueType{}, &state)
+	return newValueType(&otlpprofiles.ValueType{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_valuetype_test.go
+++ b/pdata/pprofile/generated_valuetype_test.go
@@ -23,9 +23,10 @@ func TestValueType_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestValueType(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestValueType(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newValueType(&otlpprofiles.ValueType{}, &sharedState)) })
-	assert.Panics(t, func() { newValueType(&otlpprofiles.ValueType{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newValueType(&otlpprofiles.ValueType{}, sharedState)) })
+	assert.Panics(t, func() { newValueType(&otlpprofiles.ValueType{}, sharedState).MoveTo(dest) })
 }
 
 func TestValueType_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestValueType_CopyTo(t *testing.T) {
 	orig = generateTestValueType()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newValueType(&otlpprofiles.ValueType{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newValueType(&otlpprofiles.ValueType{}, sharedState)) })
 }
 
 func TestValueType_TypeStrindex(t *testing.T) {
@@ -45,8 +47,9 @@ func TestValueType_TypeStrindex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.TypeStrindex())
 	ms.SetTypeStrindex(int32(13))
 	assert.Equal(t, int32(13), ms.TypeStrindex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newValueType(&otlpprofiles.ValueType{}, &sharedState).SetTypeStrindex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newValueType(&otlpprofiles.ValueType{}, sharedState).SetTypeStrindex(int32(13)) })
 }
 
 func TestValueType_UnitStrindex(t *testing.T) {
@@ -54,8 +57,9 @@ func TestValueType_UnitStrindex(t *testing.T) {
 	assert.Equal(t, int32(0), ms.UnitStrindex())
 	ms.SetUnitStrindex(int32(13))
 	assert.Equal(t, int32(13), ms.UnitStrindex())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newValueType(&otlpprofiles.ValueType{}, &sharedState).SetUnitStrindex(int32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newValueType(&otlpprofiles.ValueType{}, sharedState).SetUnitStrindex(int32(13)) })
 }
 
 func TestValueType_AggregationTemporality(t *testing.T) {

--- a/pdata/pprofile/generated_valuetypeslice.go
+++ b/pdata/pprofile/generated_valuetypeslice.go
@@ -34,8 +34,7 @@ func newValueTypeSlice(orig *[]*otlpprofiles.ValueType, state *internal.State) V
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewValueTypeSlice() ValueTypeSlice {
 	orig := []*otlpprofiles.ValueType(nil)
-	state := internal.StateMutable
-	return newValueTypeSlice(&orig, &state)
+	return newValueTypeSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/pprofile/generated_valuetypeslice_test.go
+++ b/pdata/pprofile/generated_valuetypeslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestValueTypeSlice(t *testing.T) {
 	es := NewValueTypeSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newValueTypeSlice(&[]*otlpprofiles.ValueType{}, &state)
+	es = newValueTypeSlice(&[]*otlpprofiles.ValueType{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewValueType()
@@ -35,8 +34,9 @@ func TestValueTypeSlice(t *testing.T) {
 }
 
 func TestValueTypeSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newValueTypeSlice(&[]*otlpprofiles.ValueType{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newValueTypeSlice(&[]*otlpprofiles.ValueType{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess.go
@@ -32,8 +32,7 @@ func newExportPartialSuccess(orig *otlpcollectorprofiles.ExportProfilesPartialSu
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportPartialSuccess() ExportPartialSuccess {
-	state := internal.StateMutable
-	return newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, &state)
+	return newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess_test.go
@@ -23,12 +23,13 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, &sharedState))
+		ms.MoveTo(newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, sharedState))
 	})
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, &sharedState).MoveTo(dest)
+		newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, sharedState).MoveTo(dest)
 	})
 }
 
@@ -40,9 +41,10 @@ func TestExportPartialSuccess_CopyTo(t *testing.T) {
 	orig = generateTestExportPartialSuccess()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, &sharedState))
+		ms.CopyTo(newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, sharedState))
 	})
 }
 
@@ -51,9 +53,10 @@ func TestExportPartialSuccess_RejectedProfiles(t *testing.T) {
 	assert.Equal(t, int64(0), ms.RejectedProfiles())
 	ms.SetRejectedProfiles(int64(13))
 	assert.Equal(t, int64(13), ms.RejectedProfiles())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, &sharedState).SetRejectedProfiles(int64(13))
+		newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, sharedState).SetRejectedProfiles(int64(13))
 	})
 }
 
@@ -62,9 +65,10 @@ func TestExportPartialSuccess_ErrorMessage(t *testing.T) {
 	assert.Empty(t, ms.ErrorMessage())
 	ms.SetErrorMessage("test_errormessage")
 	assert.Equal(t, "test_errormessage", ms.ErrorMessage())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, &sharedState).SetErrorMessage("test_errormessage")
+		newExportPartialSuccess(&otlpcollectorprofiles.ExportProfilesPartialSuccess{}, sharedState).SetErrorMessage("test_errormessage")
 	})
 }
 

--- a/pdata/pprofile/pprofileotlp/generated_exportresponse.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportresponse.go
@@ -32,8 +32,7 @@ func newExportResponse(orig *otlpcollectorprofiles.ExportProfilesServiceResponse
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportResponse() ExportResponse {
-	state := internal.StateMutable
-	return newExportResponse(&otlpcollectorprofiles.ExportProfilesServiceResponse{}, &state)
+	return newExportResponse(&otlpcollectorprofiles.ExportProfilesServiceResponse{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/pprofileotlp/generated_exportresponse_test.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportresponse_test.go
@@ -23,12 +23,13 @@ func TestExportResponse_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportResponse(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExportResponse(), dest)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExportResponse(&otlpcollectorprofiles.ExportProfilesServiceResponse{}, &sharedState))
+		ms.MoveTo(newExportResponse(&otlpcollectorprofiles.ExportProfilesServiceResponse{}, sharedState))
 	})
 	assert.Panics(t, func() {
-		newExportResponse(&otlpcollectorprofiles.ExportProfilesServiceResponse{}, &sharedState).MoveTo(dest)
+		newExportResponse(&otlpcollectorprofiles.ExportProfilesServiceResponse{}, sharedState).MoveTo(dest)
 	})
 }
 
@@ -40,9 +41,10 @@ func TestExportResponse_CopyTo(t *testing.T) {
 	orig = generateTestExportResponse()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExportResponse(&otlpcollectorprofiles.ExportProfilesServiceResponse{}, &sharedState))
+		ms.CopyTo(newExportResponse(&otlpcollectorprofiles.ExportProfilesServiceResponse{}, sharedState))
 	})
 }
 

--- a/pdata/pprofile/pprofileotlp/grpc.go
+++ b/pdata/pprofile/pprofileotlp/grpc.go
@@ -44,8 +44,7 @@ func (c *grpcClient) Export(ctx context.Context, request ExportRequest, opts ...
 	if err != nil {
 		return ExportResponse{}, err
 	}
-	state := internal.StateMutable
-	return ExportResponse{orig: rsp, state: &state}, err
+	return ExportResponse{orig: rsp, state: internal.NewState()}, err
 }
 
 func (c *grpcClient) unexported() {}
@@ -85,7 +84,6 @@ type rawProfilesServer struct {
 
 func (s rawProfilesServer) Export(ctx context.Context, request *otlpcollectorprofile.ExportProfilesServiceRequest) (*otlpcollectorprofile.ExportProfilesServiceResponse, error) {
 	otlp.MigrateProfiles(request.ResourceProfiles)
-	state := internal.StateMutable
-	rsp, err := s.srv.Export(ctx, ExportRequest{orig: request, state: &state})
+	rsp, err := s.srv.Export(ctx, ExportRequest{orig: request, state: internal.NewState()})
 	return rsp.orig, err
 }

--- a/pdata/pprofile/pprofileotlp/request.go
+++ b/pdata/pprofile/pprofileotlp/request.go
@@ -24,10 +24,9 @@ type ExportRequest struct {
 
 // NewExportRequest returns an empty ExportRequest.
 func NewExportRequest() ExportRequest {
-	state := internal.StateMutable
 	return ExportRequest{
 		orig:  &otlpcollectorprofile.ExportProfilesServiceRequest{},
-		state: &state,
+		state: internal.NewState(),
 	}
 }
 

--- a/pdata/pprofile/profiles.go
+++ b/pdata/pprofile/profiles.go
@@ -3,18 +3,14 @@
 
 package pprofile // import "go.opentelemetry.io/collector/pdata/pprofile"
 
-import (
-	"go.opentelemetry.io/collector/pdata/internal"
-)
-
 // MarkReadOnly marks the ResourceProfiles as shared so that no further modifications can be done on it.
 func (ms Profiles) MarkReadOnly() {
-	internal.SetProfilesState(internal.Profiles(ms), internal.StateReadOnly)
+	ms.getState().MarkReadOnly()
 }
 
 // IsReadOnly returns true if this ResourceProfiles instance is read-only.
 func (ms Profiles) IsReadOnly() bool {
-	return *ms.getState() == internal.StateReadOnly
+	return ms.getState().IsReadOnly()
 }
 
 // SampleCount calculates the total number of samples.

--- a/pdata/ptrace/generated_resourcespans.go
+++ b/pdata/ptrace/generated_resourcespans.go
@@ -33,8 +33,7 @@ func newResourceSpans(orig *otlptrace.ResourceSpans, state *internal.State) Reso
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResourceSpans() ResourceSpans {
-	state := internal.StateMutable
-	return newResourceSpans(&otlptrace.ResourceSpans{}, &state)
+	return newResourceSpans(&otlptrace.ResourceSpans{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_resourcespans_test.go
+++ b/pdata/ptrace/generated_resourcespans_test.go
@@ -24,9 +24,10 @@ func TestResourceSpans_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResourceSpans(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestResourceSpans(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newResourceSpans(&otlptrace.ResourceSpans{}, &sharedState)) })
-	assert.Panics(t, func() { newResourceSpans(&otlptrace.ResourceSpans{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newResourceSpans(&otlptrace.ResourceSpans{}, sharedState)) })
+	assert.Panics(t, func() { newResourceSpans(&otlptrace.ResourceSpans{}, sharedState).MoveTo(dest) })
 }
 
 func TestResourceSpans_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestResourceSpans_CopyTo(t *testing.T) {
 	orig = generateTestResourceSpans()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newResourceSpans(&otlptrace.ResourceSpans{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newResourceSpans(&otlptrace.ResourceSpans{}, sharedState)) })
 }
 
 func TestResourceSpans_Resource(t *testing.T) {
@@ -60,8 +62,9 @@ func TestResourceSpans_SchemaUrl(t *testing.T) {
 	assert.Empty(t, ms.SchemaUrl())
 	ms.SetSchemaUrl("test_schemaurl")
 	assert.Equal(t, "test_schemaurl", ms.SchemaUrl())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newResourceSpans(&otlptrace.ResourceSpans{}, &sharedState).SetSchemaUrl("test_schemaurl") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newResourceSpans(&otlptrace.ResourceSpans{}, sharedState).SetSchemaUrl("test_schemaurl") })
 }
 
 func generateTestResourceSpans() ResourceSpans {

--- a/pdata/ptrace/generated_resourcespansslice.go
+++ b/pdata/ptrace/generated_resourcespansslice.go
@@ -34,8 +34,7 @@ func newResourceSpansSlice(orig *[]*otlptrace.ResourceSpans, state *internal.Sta
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewResourceSpansSlice() ResourceSpansSlice {
 	orig := []*otlptrace.ResourceSpans(nil)
-	state := internal.StateMutable
-	return newResourceSpansSlice(&orig, &state)
+	return newResourceSpansSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/ptrace/generated_resourcespansslice_test.go
+++ b/pdata/ptrace/generated_resourcespansslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestResourceSpansSlice(t *testing.T) {
 	es := NewResourceSpansSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newResourceSpansSlice(&[]*otlptrace.ResourceSpans{}, &state)
+	es = newResourceSpansSlice(&[]*otlptrace.ResourceSpans{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewResourceSpans()
@@ -35,8 +34,9 @@ func TestResourceSpansSlice(t *testing.T) {
 }
 
 func TestResourceSpansSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newResourceSpansSlice(&[]*otlptrace.ResourceSpans{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newResourceSpansSlice(&[]*otlptrace.ResourceSpans{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/ptrace/generated_scopespans.go
+++ b/pdata/ptrace/generated_scopespans.go
@@ -33,8 +33,7 @@ func newScopeSpans(orig *otlptrace.ScopeSpans, state *internal.State) ScopeSpans
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewScopeSpans() ScopeSpans {
-	state := internal.StateMutable
-	return newScopeSpans(&otlptrace.ScopeSpans{}, &state)
+	return newScopeSpans(&otlptrace.ScopeSpans{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_scopespans_test.go
+++ b/pdata/ptrace/generated_scopespans_test.go
@@ -24,9 +24,10 @@ func TestScopeSpans_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestScopeSpans(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestScopeSpans(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newScopeSpans(&otlptrace.ScopeSpans{}, &sharedState)) })
-	assert.Panics(t, func() { newScopeSpans(&otlptrace.ScopeSpans{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newScopeSpans(&otlptrace.ScopeSpans{}, sharedState)) })
+	assert.Panics(t, func() { newScopeSpans(&otlptrace.ScopeSpans{}, sharedState).MoveTo(dest) })
 }
 
 func TestScopeSpans_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestScopeSpans_CopyTo(t *testing.T) {
 	orig = generateTestScopeSpans()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newScopeSpans(&otlptrace.ScopeSpans{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newScopeSpans(&otlptrace.ScopeSpans{}, sharedState)) })
 }
 
 func TestScopeSpans_Scope(t *testing.T) {
@@ -60,8 +62,9 @@ func TestScopeSpans_SchemaUrl(t *testing.T) {
 	assert.Empty(t, ms.SchemaUrl())
 	ms.SetSchemaUrl("test_schemaurl")
 	assert.Equal(t, "test_schemaurl", ms.SchemaUrl())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newScopeSpans(&otlptrace.ScopeSpans{}, &sharedState).SetSchemaUrl("test_schemaurl") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newScopeSpans(&otlptrace.ScopeSpans{}, sharedState).SetSchemaUrl("test_schemaurl") })
 }
 
 func generateTestScopeSpans() ScopeSpans {

--- a/pdata/ptrace/generated_scopespansslice.go
+++ b/pdata/ptrace/generated_scopespansslice.go
@@ -34,8 +34,7 @@ func newScopeSpansSlice(orig *[]*otlptrace.ScopeSpans, state *internal.State) Sc
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewScopeSpansSlice() ScopeSpansSlice {
 	orig := []*otlptrace.ScopeSpans(nil)
-	state := internal.StateMutable
-	return newScopeSpansSlice(&orig, &state)
+	return newScopeSpansSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/ptrace/generated_scopespansslice_test.go
+++ b/pdata/ptrace/generated_scopespansslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestScopeSpansSlice(t *testing.T) {
 	es := NewScopeSpansSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newScopeSpansSlice(&[]*otlptrace.ScopeSpans{}, &state)
+	es = newScopeSpansSlice(&[]*otlptrace.ScopeSpans{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewScopeSpans()
@@ -35,8 +34,9 @@ func TestScopeSpansSlice(t *testing.T) {
 }
 
 func TestScopeSpansSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newScopeSpansSlice(&[]*otlptrace.ScopeSpans{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newScopeSpansSlice(&[]*otlptrace.ScopeSpans{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/ptrace/generated_span.go
+++ b/pdata/ptrace/generated_span.go
@@ -35,8 +35,7 @@ func newSpan(orig *otlptrace.Span, state *internal.State) Span {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSpan() Span {
-	state := internal.StateMutable
-	return newSpan(&otlptrace.Span{}, &state)
+	return newSpan(&otlptrace.Span{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_span_test.go
+++ b/pdata/ptrace/generated_span_test.go
@@ -25,9 +25,10 @@ func TestSpan_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSpan(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestSpan(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newSpan(&otlptrace.Span{}, &sharedState)) })
-	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newSpan(&otlptrace.Span{}, sharedState)) })
+	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, sharedState).MoveTo(dest) })
 }
 
 func TestSpan_CopyTo(t *testing.T) {
@@ -38,8 +39,9 @@ func TestSpan_CopyTo(t *testing.T) {
 	orig = generateTestSpan()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newSpan(&otlptrace.Span{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newSpan(&otlptrace.Span{}, sharedState)) })
 }
 
 func TestSpan_TraceID(t *testing.T) {
@@ -78,8 +80,9 @@ func TestSpan_Flags(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.Flags())
 	ms.SetFlags(uint32(13))
 	assert.Equal(t, uint32(13), ms.Flags())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, &sharedState).SetFlags(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, sharedState).SetFlags(uint32(13)) })
 }
 
 func TestSpan_Name(t *testing.T) {
@@ -87,8 +90,9 @@ func TestSpan_Name(t *testing.T) {
 	assert.Empty(t, ms.Name())
 	ms.SetName("test_name")
 	assert.Equal(t, "test_name", ms.Name())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, &sharedState).SetName("test_name") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, sharedState).SetName("test_name") })
 }
 
 func TestSpan_Kind(t *testing.T) {
@@ -127,8 +131,9 @@ func TestSpan_DroppedAttributesCount(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.DroppedAttributesCount())
 	ms.SetDroppedAttributesCount(uint32(13))
 	assert.Equal(t, uint32(13), ms.DroppedAttributesCount())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, &sharedState).SetDroppedAttributesCount(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, sharedState).SetDroppedAttributesCount(uint32(13)) })
 }
 
 func TestSpan_Events(t *testing.T) {
@@ -143,8 +148,9 @@ func TestSpan_DroppedEventsCount(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.DroppedEventsCount())
 	ms.SetDroppedEventsCount(uint32(13))
 	assert.Equal(t, uint32(13), ms.DroppedEventsCount())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, &sharedState).SetDroppedEventsCount(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, sharedState).SetDroppedEventsCount(uint32(13)) })
 }
 
 func TestSpan_Links(t *testing.T) {
@@ -159,8 +165,9 @@ func TestSpan_DroppedLinksCount(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.DroppedLinksCount())
 	ms.SetDroppedLinksCount(uint32(13))
 	assert.Equal(t, uint32(13), ms.DroppedLinksCount())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, &sharedState).SetDroppedLinksCount(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSpan(&otlptrace.Span{}, sharedState).SetDroppedLinksCount(uint32(13)) })
 }
 
 func TestSpan_Status(t *testing.T) {

--- a/pdata/ptrace/generated_spanevent.go
+++ b/pdata/ptrace/generated_spanevent.go
@@ -34,8 +34,7 @@ func newSpanEvent(orig *otlptrace.Span_Event, state *internal.State) SpanEvent {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSpanEvent() SpanEvent {
-	state := internal.StateMutable
-	return newSpanEvent(&otlptrace.Span_Event{}, &state)
+	return newSpanEvent(&otlptrace.Span_Event{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_spanevent_test.go
+++ b/pdata/ptrace/generated_spanevent_test.go
@@ -24,9 +24,10 @@ func TestSpanEvent_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSpanEvent(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestSpanEvent(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newSpanEvent(&otlptrace.Span_Event{}, &sharedState)) })
-	assert.Panics(t, func() { newSpanEvent(&otlptrace.Span_Event{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newSpanEvent(&otlptrace.Span_Event{}, sharedState)) })
+	assert.Panics(t, func() { newSpanEvent(&otlptrace.Span_Event{}, sharedState).MoveTo(dest) })
 }
 
 func TestSpanEvent_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestSpanEvent_CopyTo(t *testing.T) {
 	orig = generateTestSpanEvent()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newSpanEvent(&otlptrace.Span_Event{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newSpanEvent(&otlptrace.Span_Event{}, sharedState)) })
 }
 
 func TestSpanEvent_Timestamp(t *testing.T) {
@@ -54,8 +56,9 @@ func TestSpanEvent_Name(t *testing.T) {
 	assert.Empty(t, ms.Name())
 	ms.SetName("test_name")
 	assert.Equal(t, "test_name", ms.Name())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSpanEvent(&otlptrace.Span_Event{}, &sharedState).SetName("test_name") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSpanEvent(&otlptrace.Span_Event{}, sharedState).SetName("test_name") })
 }
 
 func TestSpanEvent_Attributes(t *testing.T) {
@@ -70,8 +73,9 @@ func TestSpanEvent_DroppedAttributesCount(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.DroppedAttributesCount())
 	ms.SetDroppedAttributesCount(uint32(13))
 	assert.Equal(t, uint32(13), ms.DroppedAttributesCount())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSpanEvent(&otlptrace.Span_Event{}, &sharedState).SetDroppedAttributesCount(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSpanEvent(&otlptrace.Span_Event{}, sharedState).SetDroppedAttributesCount(uint32(13)) })
 }
 
 func generateTestSpanEvent() SpanEvent {

--- a/pdata/ptrace/generated_spaneventslice.go
+++ b/pdata/ptrace/generated_spaneventslice.go
@@ -34,8 +34,7 @@ func newSpanEventSlice(orig *[]*otlptrace.Span_Event, state *internal.State) Spa
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewSpanEventSlice() SpanEventSlice {
 	orig := []*otlptrace.Span_Event(nil)
-	state := internal.StateMutable
-	return newSpanEventSlice(&orig, &state)
+	return newSpanEventSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/ptrace/generated_spaneventslice_test.go
+++ b/pdata/ptrace/generated_spaneventslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestSpanEventSlice(t *testing.T) {
 	es := NewSpanEventSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newSpanEventSlice(&[]*otlptrace.Span_Event{}, &state)
+	es = newSpanEventSlice(&[]*otlptrace.Span_Event{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewSpanEvent()
@@ -35,8 +34,9 @@ func TestSpanEventSlice(t *testing.T) {
 }
 
 func TestSpanEventSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newSpanEventSlice(&[]*otlptrace.Span_Event{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newSpanEventSlice(&[]*otlptrace.Span_Event{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/ptrace/generated_spanlink.go
+++ b/pdata/ptrace/generated_spanlink.go
@@ -36,8 +36,7 @@ func newSpanLink(orig *otlptrace.Span_Link, state *internal.State) SpanLink {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSpanLink() SpanLink {
-	state := internal.StateMutable
-	return newSpanLink(&otlptrace.Span_Link{}, &state)
+	return newSpanLink(&otlptrace.Span_Link{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_spanlink_test.go
+++ b/pdata/ptrace/generated_spanlink_test.go
@@ -25,9 +25,10 @@ func TestSpanLink_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSpanLink(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestSpanLink(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newSpanLink(&otlptrace.Span_Link{}, &sharedState)) })
-	assert.Panics(t, func() { newSpanLink(&otlptrace.Span_Link{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newSpanLink(&otlptrace.Span_Link{}, sharedState)) })
+	assert.Panics(t, func() { newSpanLink(&otlptrace.Span_Link{}, sharedState).MoveTo(dest) })
 }
 
 func TestSpanLink_CopyTo(t *testing.T) {
@@ -38,8 +39,9 @@ func TestSpanLink_CopyTo(t *testing.T) {
 	orig = generateTestSpanLink()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newSpanLink(&otlptrace.Span_Link{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newSpanLink(&otlptrace.Span_Link{}, sharedState)) })
 }
 
 func TestSpanLink_TraceID(t *testing.T) {
@@ -77,8 +79,9 @@ func TestSpanLink_DroppedAttributesCount(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.DroppedAttributesCount())
 	ms.SetDroppedAttributesCount(uint32(13))
 	assert.Equal(t, uint32(13), ms.DroppedAttributesCount())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSpanLink(&otlptrace.Span_Link{}, &sharedState).SetDroppedAttributesCount(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSpanLink(&otlptrace.Span_Link{}, sharedState).SetDroppedAttributesCount(uint32(13)) })
 }
 
 func TestSpanLink_Flags(t *testing.T) {
@@ -86,8 +89,9 @@ func TestSpanLink_Flags(t *testing.T) {
 	assert.Equal(t, uint32(0), ms.Flags())
 	ms.SetFlags(uint32(13))
 	assert.Equal(t, uint32(13), ms.Flags())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newSpanLink(&otlptrace.Span_Link{}, &sharedState).SetFlags(uint32(13)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newSpanLink(&otlptrace.Span_Link{}, sharedState).SetFlags(uint32(13)) })
 }
 
 func generateTestSpanLink() SpanLink {

--- a/pdata/ptrace/generated_spanlinkslice.go
+++ b/pdata/ptrace/generated_spanlinkslice.go
@@ -34,8 +34,7 @@ func newSpanLinkSlice(orig *[]*otlptrace.Span_Link, state *internal.State) SpanL
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewSpanLinkSlice() SpanLinkSlice {
 	orig := []*otlptrace.Span_Link(nil)
-	state := internal.StateMutable
-	return newSpanLinkSlice(&orig, &state)
+	return newSpanLinkSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/ptrace/generated_spanlinkslice_test.go
+++ b/pdata/ptrace/generated_spanlinkslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestSpanLinkSlice(t *testing.T) {
 	es := NewSpanLinkSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newSpanLinkSlice(&[]*otlptrace.Span_Link{}, &state)
+	es = newSpanLinkSlice(&[]*otlptrace.Span_Link{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewSpanLink()
@@ -35,8 +34,9 @@ func TestSpanLinkSlice(t *testing.T) {
 }
 
 func TestSpanLinkSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newSpanLinkSlice(&[]*otlptrace.Span_Link{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newSpanLinkSlice(&[]*otlptrace.Span_Link{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/ptrace/generated_spanslice.go
+++ b/pdata/ptrace/generated_spanslice.go
@@ -34,8 +34,7 @@ func newSpanSlice(orig *[]*otlptrace.Span, state *internal.State) SpanSlice {
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewSpanSlice() SpanSlice {
 	orig := []*otlptrace.Span(nil)
-	state := internal.StateMutable
-	return newSpanSlice(&orig, &state)
+	return newSpanSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/ptrace/generated_spanslice_test.go
+++ b/pdata/ptrace/generated_spanslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestSpanSlice(t *testing.T) {
 	es := NewSpanSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newSpanSlice(&[]*otlptrace.Span{}, &state)
+	es = newSpanSlice(&[]*otlptrace.Span{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewSpan()
@@ -35,8 +34,9 @@ func TestSpanSlice(t *testing.T) {
 }
 
 func TestSpanSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newSpanSlice(&[]*otlptrace.Span{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newSpanSlice(&[]*otlptrace.Span{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })

--- a/pdata/ptrace/generated_status.go
+++ b/pdata/ptrace/generated_status.go
@@ -33,8 +33,7 @@ func newStatus(orig *otlptrace.Status, state *internal.State) Status {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewStatus() Status {
-	state := internal.StateMutable
-	return newStatus(&otlptrace.Status{}, &state)
+	return newStatus(&otlptrace.Status{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_status_test.go
+++ b/pdata/ptrace/generated_status_test.go
@@ -23,9 +23,10 @@ func TestStatus_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestStatus(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestStatus(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newStatus(&otlptrace.Status{}, &sharedState)) })
-	assert.Panics(t, func() { newStatus(&otlptrace.Status{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newStatus(&otlptrace.Status{}, sharedState)) })
+	assert.Panics(t, func() { newStatus(&otlptrace.Status{}, sharedState).MoveTo(dest) })
 }
 
 func TestStatus_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestStatus_CopyTo(t *testing.T) {
 	orig = generateTestStatus()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newStatus(&otlptrace.Status{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newStatus(&otlptrace.Status{}, sharedState)) })
 }
 
 func TestStatus_Message(t *testing.T) {
@@ -45,8 +47,9 @@ func TestStatus_Message(t *testing.T) {
 	assert.Empty(t, ms.Message())
 	ms.SetMessage("test_message")
 	assert.Equal(t, "test_message", ms.Message())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newStatus(&otlptrace.Status{}, &sharedState).SetMessage("test_message") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newStatus(&otlptrace.Status{}, sharedState).SetMessage("test_message") })
 }
 
 func TestStatus_Code(t *testing.T) {

--- a/pdata/ptrace/generated_traces.go
+++ b/pdata/ptrace/generated_traces.go
@@ -30,8 +30,7 @@ func newTraces(orig *otlpcollectortrace.ExportTraceServiceRequest, state *intern
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewTraces() Traces {
-	state := internal.StateMutable
-	return newTraces(&otlpcollectortrace.ExportTraceServiceRequest{}, &state)
+	return newTraces(&otlpcollectortrace.ExportTraceServiceRequest{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_traces_test.go
+++ b/pdata/ptrace/generated_traces_test.go
@@ -23,9 +23,10 @@ func TestTraces_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestTraces(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestTraces(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newTraces(&otlpcollectortrace.ExportTraceServiceRequest{}, &sharedState)) })
-	assert.Panics(t, func() { newTraces(&otlpcollectortrace.ExportTraceServiceRequest{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newTraces(&otlpcollectortrace.ExportTraceServiceRequest{}, sharedState)) })
+	assert.Panics(t, func() { newTraces(&otlpcollectortrace.ExportTraceServiceRequest{}, sharedState).MoveTo(dest) })
 }
 
 func TestTraces_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestTraces_CopyTo(t *testing.T) {
 	orig = generateTestTraces()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newTraces(&otlpcollectortrace.ExportTraceServiceRequest{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newTraces(&otlpcollectortrace.ExportTraceServiceRequest{}, sharedState)) })
 }
 
 func TestTraces_ResourceSpans(t *testing.T) {

--- a/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess.go
@@ -32,8 +32,7 @@ func newExportPartialSuccess(orig *otlpcollectortrace.ExportTracePartialSuccess,
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportPartialSuccess() ExportPartialSuccess {
-	state := internal.StateMutable
-	return newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, &state)
+	return newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess_test.go
@@ -23,12 +23,13 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, &sharedState))
+		ms.MoveTo(newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, sharedState))
 	})
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, &sharedState).MoveTo(dest)
+		newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, sharedState).MoveTo(dest)
 	})
 }
 
@@ -40,9 +41,10 @@ func TestExportPartialSuccess_CopyTo(t *testing.T) {
 	orig = generateTestExportPartialSuccess()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, &sharedState))
+		ms.CopyTo(newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, sharedState))
 	})
 }
 
@@ -51,9 +53,10 @@ func TestExportPartialSuccess_RejectedSpans(t *testing.T) {
 	assert.Equal(t, int64(0), ms.RejectedSpans())
 	ms.SetRejectedSpans(int64(13))
 	assert.Equal(t, int64(13), ms.RejectedSpans())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, &sharedState).SetRejectedSpans(int64(13))
+		newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, sharedState).SetRejectedSpans(int64(13))
 	})
 }
 
@@ -62,9 +65,10 @@ func TestExportPartialSuccess_ErrorMessage(t *testing.T) {
 	assert.Empty(t, ms.ErrorMessage())
 	ms.SetErrorMessage("test_errormessage")
 	assert.Equal(t, "test_errormessage", ms.ErrorMessage())
-	sharedState := internal.StateReadOnly
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, &sharedState).SetErrorMessage("test_errormessage")
+		newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{}, sharedState).SetErrorMessage("test_errormessage")
 	})
 }
 

--- a/pdata/ptrace/ptraceotlp/generated_exportresponse.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportresponse.go
@@ -32,8 +32,7 @@ func newExportResponse(orig *otlpcollectortrace.ExportTraceServiceResponse, stat
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportResponse() ExportResponse {
-	state := internal.StateMutable
-	return newExportResponse(&otlpcollectortrace.ExportTraceServiceResponse{}, &state)
+	return newExportResponse(&otlpcollectortrace.ExportTraceServiceResponse{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/ptraceotlp/generated_exportresponse_test.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportresponse_test.go
@@ -23,9 +23,10 @@ func TestExportResponse_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportResponse(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestExportResponse(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newExportResponse(&otlpcollectortrace.ExportTraceServiceResponse{}, &sharedState)) })
-	assert.Panics(t, func() { newExportResponse(&otlpcollectortrace.ExportTraceServiceResponse{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newExportResponse(&otlpcollectortrace.ExportTraceServiceResponse{}, sharedState)) })
+	assert.Panics(t, func() { newExportResponse(&otlpcollectortrace.ExportTraceServiceResponse{}, sharedState).MoveTo(dest) })
 }
 
 func TestExportResponse_CopyTo(t *testing.T) {
@@ -36,8 +37,9 @@ func TestExportResponse_CopyTo(t *testing.T) {
 	orig = generateTestExportResponse()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newExportResponse(&otlpcollectortrace.ExportTraceServiceResponse{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newExportResponse(&otlpcollectortrace.ExportTraceServiceResponse{}, sharedState)) })
 }
 
 func TestExportResponse_PartialSuccess(t *testing.T) {

--- a/pdata/ptrace/ptraceotlp/grpc.go
+++ b/pdata/ptrace/ptraceotlp/grpc.go
@@ -44,8 +44,7 @@ func (c *grpcClient) Export(ctx context.Context, request ExportRequest, opts ...
 	if err != nil {
 		return ExportResponse{}, err
 	}
-	state := internal.StateMutable
-	return ExportResponse{orig: rsp, state: &state}, err
+	return ExportResponse{orig: rsp, state: internal.NewState()}, err
 }
 
 func (c *grpcClient) unexported() {}
@@ -85,7 +84,6 @@ type rawTracesServer struct {
 
 func (s rawTracesServer) Export(ctx context.Context, request *otlpcollectortrace.ExportTraceServiceRequest) (*otlpcollectortrace.ExportTraceServiceResponse, error) {
 	otlp.MigrateTraces(request.ResourceSpans)
-	state := internal.StateMutable
-	rsp, err := s.srv.Export(ctx, ExportRequest{orig: request, state: &state})
+	rsp, err := s.srv.Export(ctx, ExportRequest{orig: request, state: internal.NewState()})
 	return rsp.orig, err
 }

--- a/pdata/ptrace/ptraceotlp/request.go
+++ b/pdata/ptrace/ptraceotlp/request.go
@@ -24,10 +24,9 @@ type ExportRequest struct {
 
 // NewExportRequest returns an empty ExportRequest.
 func NewExportRequest() ExportRequest {
-	state := internal.StateMutable
 	return ExportRequest{
 		orig:  &otlpcollectortrace.ExportTraceServiceRequest{},
-		state: &state,
+		state: internal.NewState(),
 	}
 }
 

--- a/pdata/ptrace/traces.go
+++ b/pdata/ptrace/traces.go
@@ -3,18 +3,14 @@
 
 package ptrace // import "go.opentelemetry.io/collector/pdata/ptrace"
 
-import (
-	"go.opentelemetry.io/collector/pdata/internal"
-)
-
 // MarkReadOnly marks the Traces as shared so that no further modifications can be done on it.
 func (ms Traces) MarkReadOnly() {
-	internal.SetTracesState(internal.Traces(ms), internal.StateReadOnly)
+	ms.getState().MarkReadOnly()
 }
 
 // IsReadOnly returns true if this Traces instance is read-only.
 func (ms Traces) IsReadOnly() bool {
-	return *ms.getState() == internal.StateReadOnly
+	return ms.getState().IsReadOnly()
 }
 
 // SpanCount calculates the total number of spans.

--- a/pdata/xpdata/entity/generated_entityref.go
+++ b/pdata/xpdata/entity/generated_entityref.go
@@ -28,8 +28,7 @@ func newEntityRef(orig *otlpcommon.EntityRef, state *internal.State) EntityRef {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewEntityRef() EntityRef {
-	state := internal.StateMutable
-	return newEntityRef(&otlpcommon.EntityRef{}, &state)
+	return newEntityRef(&otlpcommon.EntityRef{}, internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/xpdata/entity/generated_entityref_test.go
+++ b/pdata/xpdata/entity/generated_entityref_test.go
@@ -24,9 +24,10 @@ func TestEntityRef_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestEntityRef(), dest)
 	dest.MoveTo(dest)
 	assert.Equal(t, generateTestEntityRef(), dest)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.MoveTo(newEntityRef(&otlpcommon.EntityRef{}, &sharedState)) })
-	assert.Panics(t, func() { newEntityRef(&otlpcommon.EntityRef{}, &sharedState).MoveTo(dest) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newEntityRef(&otlpcommon.EntityRef{}, sharedState)) })
+	assert.Panics(t, func() { newEntityRef(&otlpcommon.EntityRef{}, sharedState).MoveTo(dest) })
 }
 
 func TestEntityRef_CopyTo(t *testing.T) {
@@ -37,8 +38,9 @@ func TestEntityRef_CopyTo(t *testing.T) {
 	orig = generateTestEntityRef()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { ms.CopyTo(newEntityRef(&otlpcommon.EntityRef{}, &sharedState)) })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.CopyTo(newEntityRef(&otlpcommon.EntityRef{}, sharedState)) })
 }
 
 func TestEntityRef_SchemaUrl(t *testing.T) {
@@ -46,8 +48,9 @@ func TestEntityRef_SchemaUrl(t *testing.T) {
 	assert.Empty(t, ms.SchemaUrl())
 	ms.SetSchemaUrl("test_schemaurl")
 	assert.Equal(t, "test_schemaurl", ms.SchemaUrl())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newEntityRef(&otlpcommon.EntityRef{}, &sharedState).SetSchemaUrl("test_schemaurl") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newEntityRef(&otlpcommon.EntityRef{}, sharedState).SetSchemaUrl("test_schemaurl") })
 }
 
 func TestEntityRef_Type(t *testing.T) {
@@ -55,8 +58,9 @@ func TestEntityRef_Type(t *testing.T) {
 	assert.Empty(t, ms.Type())
 	ms.SetType("test_type")
 	assert.Equal(t, "test_type", ms.Type())
-	sharedState := internal.StateReadOnly
-	assert.Panics(t, func() { newEntityRef(&otlpcommon.EntityRef{}, &sharedState).SetType("test_type") })
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newEntityRef(&otlpcommon.EntityRef{}, sharedState).SetType("test_type") })
 }
 
 func TestEntityRef_IdKeys(t *testing.T) {

--- a/pdata/xpdata/entity/generated_entityrefslice.go
+++ b/pdata/xpdata/entity/generated_entityrefslice.go
@@ -31,8 +31,7 @@ func newEntityRefSlice(orig *[]*otlpcommon.EntityRef, state *internal.State) Ent
 // Can use "EnsureCapacity" to initialize with a given capacity.
 func NewEntityRefSlice() EntityRefSlice {
 	orig := []*otlpcommon.EntityRef(nil)
-	state := internal.StateMutable
-	return newEntityRefSlice(&orig, &state)
+	return newEntityRefSlice(&orig, internal.NewState())
 }
 
 // Len returns the number of elements in the slice.

--- a/pdata/xpdata/entity/generated_entityrefslice_test.go
+++ b/pdata/xpdata/entity/generated_entityrefslice_test.go
@@ -19,8 +19,7 @@ import (
 func TestEntityRefSlice(t *testing.T) {
 	es := NewEntityRefSlice()
 	assert.Equal(t, 0, es.Len())
-	state := internal.StateMutable
-	es = newEntityRefSlice(&[]*otlpcommon.EntityRef{}, &state)
+	es = newEntityRefSlice(&[]*otlpcommon.EntityRef{}, internal.NewState())
 	assert.Equal(t, 0, es.Len())
 
 	emptyVal := NewEntityRef()
@@ -35,8 +34,9 @@ func TestEntityRefSlice(t *testing.T) {
 }
 
 func TestEntityRefSliceReadOnly(t *testing.T) {
-	sharedState := internal.StateReadOnly
-	es := newEntityRefSlice(&[]*otlpcommon.EntityRef{}, &sharedState)
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	es := newEntityRefSlice(&[]*otlpcommon.EntityRef{}, sharedState)
 	assert.Equal(t, 0, es.Len())
 	assert.Panics(t, func() { es.AppendEmpty() })
 	assert.Panics(t, func() { es.EnsureCapacity(2) })


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-collector/issues/13631