### PR TITLE
Deprecate Profiles.ProfilesDictionary in favor of Profiles.Dictionary.

### DIFF
--- a/.chloggen/dep-profiles-dict.yaml
+++ b/.chloggen/dep-profiles-dict.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata/pprofile
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate Profiles.ProfilesDictionary in favor of Profiles.Dictionary.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13644]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/debugexporter/internal/normal/profiles.go
+++ b/exporter/debugexporter/internal/normal/profiles.go
@@ -24,7 +24,7 @@ func NewNormalProfilesMarshaler() pprofile.Marshaler {
 
 func (normalProfilesMarshaler) MarshalProfiles(pd pprofile.Profiles) ([]byte, error) {
 	var buffer bytes.Buffer
-	dic := pd.ProfilesDictionary()
+	dic := pd.Dictionary()
 
 	for i := 0; i < pd.ResourceProfiles().Len(); i++ {
 		resourceProfiles := pd.ResourceProfiles().At(i)

--- a/exporter/debugexporter/internal/normal/profiles_test.go
+++ b/exporter/debugexporter/internal/normal/profiles_test.go
@@ -27,7 +27,7 @@ func TestMarshalProfiles(t *testing.T) {
 			name: "one profile",
 			input: func() pprofile.Profiles {
 				profiles := pprofile.NewProfiles()
-				dic := profiles.ProfilesDictionary()
+				dic := profiles.Dictionary()
 				a := dic.AttributeTable().AppendEmpty()
 				a.SetKey("key1")
 				a.Value().SetStr("value1")

--- a/exporter/debugexporter/internal/otlptext/profiles.go
+++ b/exporter/debugexporter/internal/otlptext/profiles.go
@@ -19,7 +19,7 @@ type textProfilesMarshaler struct{}
 // MarshalProfiles pprofile.Profiles to OTLP text.
 func (textProfilesMarshaler) MarshalProfiles(pd pprofile.Profiles) ([]byte, error) {
 	buf := dataBuffer{}
-	dic := pd.ProfilesDictionary()
+	dic := pd.Dictionary()
 	rps := pd.ResourceProfiles()
 
 	buf.logProfileMappings(dic.MappingTable())

--- a/exporter/debugexporter/internal/otlptext/profiles_test.go
+++ b/exporter/debugexporter/internal/otlptext/profiles_test.go
@@ -52,7 +52,7 @@ func TestProfilesText(t *testing.T) {
 
 // GenerateExtendedProfiles generates dummy profiling data with extended values for tests
 func extendProfiles(profiles pprofile.Profiles) pprofile.Profiles {
-	dic := profiles.ProfilesDictionary()
+	dic := profiles.Dictionary()
 	location := dic.LocationTable().AppendEmpty()
 	location.SetMappingIndex(3)
 	location.SetAddress(4)
@@ -120,7 +120,7 @@ func generateProfilesWithEntityRefs() pprofile.Profiles {
 	sample.SetLocationsLength(1)
 	sample.Value().FromRaw([]int64{100})
 
-	dic := pd.ProfilesDictionary()
+	dic := pd.Dictionary()
 	dic.StringTable().Append("")
 	dic.StringTable().Append("cpu")
 	dic.StringTable().Append("nanoseconds")

--- a/internal/cmd/pdatagen/internal/message_field.go
+++ b/internal/cmd/pdatagen/internal/message_field.go
@@ -36,10 +36,9 @@ const messageUnmarshalJSONTemplate = `case "{{ lowerFirst .fieldOriginFullName }
 	UnmarshalJSONOrig{{ .fieldOriginName }}(&orig.{{ .fieldOriginFullName }}, iter)`
 
 type MessageField struct {
-	fieldName           string
-	fieldOriginFullName string
-	protoID             uint32
-	returnMessage       *messageStruct
+	fieldName     string
+	protoID       uint32
+	returnMessage *messageStruct
 }
 
 func (mf *MessageField) GenerateAccessors(ms *messageStruct) string {
@@ -93,7 +92,7 @@ func (mf *MessageField) toProtoField() *ProtoField {
 	return &ProtoField{
 		Type:            pt,
 		ID:              mf.protoID,
-		Name:            mf.getFieldOriginFullName(),
+		Name:            mf.fieldName,
 		MessageFullName: mf.returnMessage.getOriginFullName(),
 	}
 }
@@ -103,7 +102,7 @@ func (mf *MessageField) templateFields(ms *messageStruct) map[string]any {
 		"messageHasWrapper":   usedByOtherDataTypes(mf.returnMessage.packageName),
 		"structName":          ms.getName(),
 		"fieldName":           mf.fieldName,
-		"fieldOriginFullName": mf.getFieldOriginFullName(),
+		"fieldOriginFullName": mf.fieldName,
 		"fieldOriginName":     mf.returnMessage.getOriginName(),
 		"lowerFieldName":      strings.ToLower(mf.fieldName),
 		"returnType":          mf.returnMessage.getName(),
@@ -116,13 +115,6 @@ func (mf *MessageField) templateFields(ms *messageStruct) map[string]any {
 		"origAccessor":  origAccessor(ms.getHasWrapper()),
 		"stateAccessor": stateAccessor(ms.getHasWrapper()),
 	}
-}
-
-func (mf *MessageField) getFieldOriginFullName() string {
-	if mf.fieldOriginFullName != "" {
-		return mf.fieldOriginFullName
-	}
-	return mf.fieldName
 }
 
 var _ Field = (*MessageField)(nil)

--- a/internal/cmd/pdatagen/internal/pprofile_package.go
+++ b/internal/cmd/pdatagen/internal/pprofile_package.go
@@ -83,10 +83,9 @@ var profiles = &messageStruct{
 			returnSlice: resourceProfilesSlice,
 		},
 		&MessageField{
-			fieldName:           "ProfilesDictionary",
-			fieldOriginFullName: "Dictionary",
-			protoID:             2,
-			returnMessage:       profilesDictionary,
+			fieldName:     "Dictionary",
+			protoID:       2,
+			returnMessage: profilesDictionary,
 		},
 	},
 	hasWrapper: true,

--- a/pdata/pprofile/generated_profiles.go
+++ b/pdata/pprofile/generated_profiles.go
@@ -51,8 +51,8 @@ func (ms Profiles) ResourceProfiles() ResourceProfilesSlice {
 	return newResourceProfilesSlice(&ms.getOrig().ResourceProfiles, ms.getState())
 }
 
-// ProfilesDictionary returns the profilesdictionary associated with this Profiles.
-func (ms Profiles) ProfilesDictionary() ProfilesDictionary {
+// Dictionary returns the dictionary associated with this Profiles.
+func (ms Profiles) Dictionary() ProfilesDictionary {
 	return newProfilesDictionary(&ms.getOrig().Dictionary, ms.getState())
 }
 

--- a/pdata/pprofile/generated_profiles_test.go
+++ b/pdata/pprofile/generated_profiles_test.go
@@ -49,11 +49,11 @@ func TestProfiles_ResourceProfiles(t *testing.T) {
 	assert.Equal(t, generateTestResourceProfilesSlice(), ms.ResourceProfiles())
 }
 
-func TestProfiles_ProfilesDictionary(t *testing.T) {
+func TestProfiles_Dictionary(t *testing.T) {
 	ms := NewProfiles()
-	assert.Equal(t, NewProfilesDictionary(), ms.ProfilesDictionary())
+	assert.Equal(t, NewProfilesDictionary(), ms.Dictionary())
 	internal.FillOrigTestProfilesDictionary(&ms.getOrig().Dictionary)
-	assert.Equal(t, generateTestProfilesDictionary(), ms.ProfilesDictionary())
+	assert.Equal(t, generateTestProfilesDictionary(), ms.Dictionary())
 }
 
 func generateTestProfiles() Profiles {

--- a/pdata/pprofile/pb_test.go
+++ b/pdata/pprofile/pb_test.go
@@ -19,11 +19,8 @@ func TestProtoProfilesUnmarshalerError(t *testing.T) {
 func TestProtoSizer(t *testing.T) {
 	marshaler := &ProtoMarshaler{}
 	td := NewProfiles()
-	td.ResourceProfiles().AppendEmpty().
-		ScopeProfiles().AppendEmpty().
-		Profiles().AppendEmpty()
-	td.ProfilesDictionary().
-		StringTable().Append("foobar")
+	td.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+	td.Dictionary().StringTable().Append("foobar")
 
 	size := marshaler.ProfilesSize(td)
 

--- a/pdata/pprofile/profiles.go
+++ b/pdata/pprofile/profiles.go
@@ -3,6 +3,11 @@
 
 package pprofile // import "go.opentelemetry.io/collector/pdata/pprofile"
 
+// Deprecated: [v0.133.0] use Dictionary().
+func (ms Profiles) ProfilesDictionary() ProfilesDictionary {
+	return ms.Dictionary()
+}
+
 // MarkReadOnly marks the ResourceProfiles as shared so that no further modifications can be done on it.
 func (ms Profiles) MarkReadOnly() {
 	ms.getState().MarkReadOnly()

--- a/pdata/testdata/profile.go
+++ b/pdata/testdata/profile.go
@@ -21,7 +21,7 @@ func GenerateProfiles(profilesCount int) pprofile.Profiles {
 	initResource(td.ResourceProfiles().AppendEmpty().Resource())
 	ss := td.ResourceProfiles().At(0).ScopeProfiles().AppendEmpty().Profiles()
 
-	dic := td.ProfilesDictionary()
+	dic := td.Dictionary()
 	dic.StringTable().Append("")
 	attr := dic.AttributeTable().AppendEmpty()
 	attr.SetKey("key")


### PR DESCRIPTION
This removes unnecessary duplication of "Profiles" prefix when the struct/package has already profile in it, also brings consistency with proto definition.