### PR TITLE
Implement refcounting for pipeline data owned memory

### DIFF
--- a/.chloggen/impl-ref.yaml
+++ b/.chloggen/impl-ref.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  Implement refcounting for pipeline data owned memory.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13631]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This feature is protected by `--featuregate=+pdata.useProtoPooling`.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/internal/queue/async_queue_test.go
+++ b/exporter/exporterhelper/internal/queue/async_queue_test.go
@@ -25,7 +25,7 @@ func TestAsyncMemoryQueue(t *testing.T) {
 		1, func(_ context.Context, _ int64, done Done) {
 			consumed.Add(1)
 			done.OnDone(nil)
-		})
+		}, set.ReferenceCounter)
 	require.NoError(t, ac.Start(context.Background(), componenttest.NewNopHost()))
 	for j := 0; j < 10; j++ {
 		require.NoError(t, ac.Offer(context.Background(), 10))
@@ -42,7 +42,7 @@ func TestAsyncMemoryQueueBlocking(t *testing.T) {
 		4, func(_ context.Context, _ int64, done Done) {
 			consumed.Add(1)
 			done.OnDone(nil)
-		})
+		}, set.ReferenceCounter)
 	require.NoError(t, ac.Start(context.Background(), componenttest.NewNopHost()))
 	wg := &sync.WaitGroup{}
 	for i := 0; i < 10; i++ {
@@ -68,7 +68,7 @@ func TestAsyncMemoryWaitForResultQueueBlocking(t *testing.T) {
 		4, func(_ context.Context, _ int64, done Done) {
 			consumed.Add(1)
 			done.OnDone(nil)
-		})
+		}, set.ReferenceCounter)
 	require.NoError(t, ac.Start(context.Background(), componenttest.NewNopHost()))
 	wg := &sync.WaitGroup{}
 	for i := 0; i < 10; i++ {
@@ -93,7 +93,7 @@ func TestAsyncMemoryQueueBlockingCancelled(t *testing.T) {
 		1, func(_ context.Context, _ int64, done Done) {
 			<-stop
 			done.OnDone(nil)
-		})
+		}, set.ReferenceCounter)
 	require.NoError(t, ac.Start(context.Background(), componenttest.NewNopHost()))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -122,7 +122,7 @@ func BenchmarkAsyncMemoryQueue(b *testing.B) {
 	ac := newAsyncQueue(newMemoryQueue[int64](set), 1, func(_ context.Context, _ int64, done Done) {
 		consumed.Add(1)
 		done.OnDone(nil)
-	})
+	}, set.ReferenceCounter)
 	require.NoError(b, ac.Start(context.Background(), componenttest.NewNopHost()))
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/exporter/exporterhelper/internal/queue/queue.go
+++ b/exporter/exporterhelper/internal/queue/queue.go
@@ -12,6 +12,16 @@ import (
 	"go.opentelemetry.io/collector/pipeline"
 )
 
+// ReferenceCounter is an optional interface that can be implemented to provide a way for the request data
+// to manage internal locally allocated memory and re-use across multiple requests, etc.
+//
+// The queue will only call Ref and Unref when requests are executed asynchronously, otherwise these
+// funcs are not called.
+type ReferenceCounter[T any] interface {
+	Ref(T)
+	Unref(T)
+}
+
 type Encoding[T any] interface {
 	// Marshal is a function that can marshal a request into bytes.
 	Marshal(context.Context, T) ([]byte, error)
@@ -55,18 +65,19 @@ type Queue[T any] interface {
 
 // Settings define internal parameters for a new Queue creation.
 type Settings[T any] struct {
-	ItemsSizer      request.Sizer[T]
-	BytesSizer      request.Sizer[T]
-	SizerType       request.SizerType
-	Capacity        int64
-	NumConsumers    int
-	WaitForResult   bool
-	BlockOnOverflow bool
-	Signal          pipeline.Signal
-	StorageID       *component.ID
-	Encoding        Encoding[T]
-	ID              component.ID
-	Telemetry       component.TelemetrySettings
+	ItemsSizer       request.Sizer[T]
+	BytesSizer       request.Sizer[T]
+	SizerType        request.SizerType
+	Capacity         int64
+	NumConsumers     int
+	WaitForResult    bool
+	BlockOnOverflow  bool
+	Signal           pipeline.Signal
+	StorageID        *component.ID
+	ReferenceCounter ReferenceCounter[T]
+	Encoding         Encoding[T]
+	ID               component.ID
+	Telemetry        component.TelemetrySettings
 }
 
 func (set *Settings[T]) activeSizer() request.Sizer[T] {
@@ -86,7 +97,7 @@ func NewQueue[T request.Request](set Settings[T], next ConsumeFunc[T]) (Queue[T]
 		return nil, err
 	}
 
-	oq, err := newObsQueue(set, newAsyncQueue(q, set.NumConsumers, next))
+	oq, err := newObsQueue(set, newAsyncQueue(q, set.NumConsumers, next, set.ReferenceCounter))
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/exporterhelper/internal/queue_sender.go
+++ b/exporter/exporterhelper/internal/queue_sender.go
@@ -16,10 +16,11 @@ import (
 
 // QueueBatchSettings is a subset of the queuebatch.Settings that are needed when used within an Exporter.
 type QueueBatchSettings[T any] struct {
-	Encoding    queue.Encoding[T]
-	ItemsSizer  request.Sizer[T]
-	BytesSizer  request.Sizer[T]
-	Partitioner queuebatch.Partitioner[T]
+	ReferenceCounter queue.ReferenceCounter[T]
+	Encoding         queue.Encoding[T]
+	ItemsSizer       request.Sizer[T]
+	BytesSizer       request.Sizer[T]
+	Partitioner      queuebatch.Partitioner[T]
 }
 
 // NewDefaultQueueConfig returns the default config for queuebatch.Config.

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
 	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
 	"go.opentelemetry.io/collector/pipeline"
 )
@@ -32,8 +33,9 @@ var (
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
 func NewLogsQueueBatchSettings() QueueBatchSettings {
 	return QueueBatchSettings{
-		Encoding:   logsEncoding{},
-		ItemsSizer: request.NewItemsSizer(),
+		ReferenceCounter: logsReferenceCounter{},
+		Encoding:         logsEncoding{},
+		ItemsSizer:       request.NewItemsSizer(),
 		BytesSizer: request.BaseSizer{
 			SizeofFunc: func(req request.Request) int64 {
 				return int64(logsMarshaler.LogsSize(req.(*logsRequest).ld))
@@ -41,6 +43,11 @@ func NewLogsQueueBatchSettings() QueueBatchSettings {
 		},
 	}
 }
+
+var (
+	_ request.Request      = (*logsRequest)(nil)
+	_ request.ErrorHandler = (*logsRequest)(nil)
+)
 
 type logsRequest struct {
 	ld         plog.Logs
@@ -84,9 +91,22 @@ func (logsEncoding) Marshal(ctx context.Context, req Request) ([]byte, error) {
 	return logsMarshaler.MarshalLogs(logs)
 }
 
+var _ queue.ReferenceCounter[Request] = logsReferenceCounter{}
+
+type logsReferenceCounter struct{}
+
+func (logsReferenceCounter) Ref(req Request) {
+	pref.RefLogs(req.(*logsRequest).ld)
+}
+
+func (logsReferenceCounter) Unref(req Request) {
+	pref.UnrefLogs(req.(*logsRequest).ld)
+}
+
 func (req *logsRequest) OnError(err error) Request {
 	var logError consumererror.Logs
 	if errors.As(err, &logError) {
+		// TODO: Add logic to unref the new request created here.
 		return newLogsRequest(logError.Data())
 	}
 	return req

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
 	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
 	"go.opentelemetry.io/collector/pipeline"
 )
@@ -32,8 +33,9 @@ var (
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
 func NewTracesQueueBatchSettings() QueueBatchSettings {
 	return QueueBatchSettings{
-		Encoding:   tracesEncoding{},
-		ItemsSizer: request.NewItemsSizer(),
+		ReferenceCounter: tracesReferenceCounter{},
+		Encoding:         tracesEncoding{},
+		ItemsSizer:       request.NewItemsSizer(),
 		BytesSizer: request.BaseSizer{
 			SizeofFunc: func(req request.Request) int64 {
 				return int64(tracesMarshaler.TracesSize(req.(*tracesRequest).td))
@@ -41,6 +43,11 @@ func NewTracesQueueBatchSettings() QueueBatchSettings {
 		},
 	}
 }
+
+var (
+	_ request.Request      = (*tracesRequest)(nil)
+	_ request.ErrorHandler = (*tracesRequest)(nil)
+)
 
 type tracesRequest struct {
 	td         ptrace.Traces
@@ -83,9 +90,22 @@ func (tracesEncoding) Marshal(ctx context.Context, req Request) ([]byte, error) 
 	return tracesMarshaler.MarshalTraces(traces)
 }
 
+var _ queue.ReferenceCounter[Request] = tracesReferenceCounter{}
+
+type tracesReferenceCounter struct{}
+
+func (tracesReferenceCounter) Ref(req Request) {
+	pref.RefTraces(req.(*tracesRequest).td)
+}
+
+func (tracesReferenceCounter) Unref(req Request) {
+	pref.UnrefTraces(req.(*tracesRequest).td)
+}
+
 func (req *tracesRequest) OnError(err error) Request {
 	var traceError consumererror.Traces
 	if errors.As(err, &traceError) {
+		// TODO: Add logic to unref the new request created here.
 		return newTracesRequest(traceError.Data())
 	}
 	return req

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -86,6 +86,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.38.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.132.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.132.0 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.132.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.132.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.132.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.132.0 // indirect

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -80,6 +80,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.38.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.132.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.132.0 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.132.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.132.0 // indirect
 	go.opentelemetry.io/collector/processor v1.38.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.132.0 // indirect

--- a/pdata/internal/state.go
+++ b/pdata/internal/state.go
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package internal // import "go.opentelemetry.io/collector/pdata/internal"
-
 import (
+	"sync/atomic"
+
 	"go.opentelemetry.io/collector/featuregate"
 )
 
@@ -24,29 +25,65 @@ var UseProtoPooling = featuregate.GlobalRegistry().MustRegister(
 )
 
 // State defines an ownership state of pmetric.Metrics, plog.Logs or ptrace.Traces.
-type State int32
+type State struct {
+	refs  atomic.Int32
+	state uint32
+}
 
 const (
-	defaultState     State = 0
-	stateReadOnlyBit       = State(1 << 0)
+	defaultState          uint32 = 0
+	stateReadOnlyBit             = uint32(1 << 0)
+	statePipelineOwnedBit        = uint32(1 << 1)
 )
 
 func NewState() *State {
-	state := defaultState
-	return &state
+	st := &State{
+		state: defaultState,
+	}
+	st.refs.Store(1)
+	return st
 }
 
-func (state *State) MarkReadOnly() {
-	*state |= stateReadOnlyBit
+func (st *State) MarkReadOnly() {
+	st.state |= stateReadOnlyBit
 }
 
-func (state *State) IsReadOnly() bool {
-	return *state&stateReadOnlyBit != 0
+func (st *State) IsReadOnly() bool {
+	return st.state&stateReadOnlyBit != 0
 }
 
 // AssertMutable panics if the state is not StateMutable.
-func (state *State) AssertMutable() {
-	if *state&stateReadOnlyBit != 0 {
+func (st *State) AssertMutable() {
+	if st.state&stateReadOnlyBit != 0 {
 		panic("invalid access to shared data")
+	}
+}
+
+// MarkPipelineOwned marks the data as owned by the pipeline, returns true if the data were
+// previously not owned by the pipeline, otherwise false.
+func (st *State) MarkPipelineOwned() bool {
+	if st.state&statePipelineOwnedBit != 0 {
+		return false
+	}
+	st.state |= statePipelineOwnedBit
+	return true
+}
+
+// Ref add one to the count of active references.
+func (st *State) Ref() {
+	st.refs.Add(1)
+}
+
+// Unref returns true if reference count got to 0 which means no more active references,
+// otherwise it returns false.
+func (st *State) Unref() bool {
+	refs := st.refs.Add(-1)
+	switch {
+	case refs > 0:
+		return false
+	case refs == 0:
+		return true
+	default:
+		panic("Cannot unref freed data")
 	}
 }

--- a/pdata/ptrace/traces_test.go
+++ b/pdata/ptrace/traces_test.go
@@ -64,15 +64,6 @@ func TestSpanCountWithEmpty(t *testing.T) {
 	}, new(internal.State)).SpanCount())
 }
 
-func TestToFromOtlp(t *testing.T) {
-	otlp := &otlpcollectortrace.ExportTraceServiceRequest{}
-	traces := newTraces(otlp, new(internal.State))
-	assert.Equal(t, NewTraces(), traces)
-	assert.Equal(t, otlp, traces.getOrig())
-	// More tests in ./tracedata/traces_test.go. Cannot have them here because of
-	// circular dependency.
-}
-
 func TestTracesCopyTo(t *testing.T) {
 	td := generateTestTraces()
 	tracesCopy := NewTraces()

--- a/pdata/xpdata/go.mod
+++ b/pdata/xpdata/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.38.0
+	go.opentelemetry.io/collector/featuregate v1.38.0
 	go.opentelemetry.io/collector/pdata v1.38.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.132.0
 	go.opentelemetry.io/collector/pdata/testdata v0.132.0
@@ -19,7 +20,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.38.0 // indirect
 	go.opentelemetry.io/otel v1.37.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.41.0 // indirect

--- a/pdata/xpdata/pref/gate.go
+++ b/pdata/xpdata/pref/gate.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pref // import "go.opentelemetry.io/collector/pdata/xpdata/pref"
+
+import (
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/pdata/internal"
+)
+
+// UseProtoPooling temporary expose public to allow testing.
+var UseProtoPooling = internal.UseProtoPooling
+
+var EnableRefCounting = featuregate.GlobalRegistry().MustRegister(
+	"pdata.enableRefCounting",
+	featuregate.StageBeta,
+	featuregate.WithRegisterDescription("When enabled, enables using ref counting to know when pdata memory can be freed up. This featuregate is here only to protect if unexpected bugs happens because of ref counting logic."),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/13631"),
+	featuregate.WithRegisterFromVersion("v0.133.0"),
+)

--- a/pdata/xpdata/pref/logs.go
+++ b/pdata/xpdata/pref/logs.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pref // import "go.opentelemetry.io/collector/pdata/xpdata/pref"
+
+import (
+	"reflect"
+
+	"go.opentelemetry.io/collector/pdata/internal"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// MarkPipelineOwnedLogs marks the plog.Logs data as owned by the pipeline, returns true if the data were
+// previously not owned by the pipeline, otherwise false.
+func MarkPipelineOwnedLogs(ld plog.Logs) bool {
+	return internal.GetLogsState(internal.Logs(ld)).MarkPipelineOwned()
+}
+
+func RefLogs(ld plog.Logs) {
+	if EnableRefCounting.IsEnabled() {
+		internal.GetLogsState(internal.Logs(ld)).Ref()
+	}
+}
+
+func UnrefLogs(ld plog.Logs) {
+	if EnableRefCounting.IsEnabled() {
+		if !internal.GetLogsState(internal.Logs(ld)).Unref() {
+			return
+		}
+		// Don't call DeleteOrigExportLogsServiceRequest without the gate because we reset the data and that may still cause issues.
+		if internal.UseProtoPooling.IsEnabled() {
+			internal.DeleteOrigExportLogsServiceRequest(internal.GetOrigLogs(internal.Logs(ld)), true)
+		}
+	}
+}
+
+// TODO: Generate this in pdata.
+
+func EqualLogs(ld1, ld2 plog.Logs) bool {
+	return reflect.DeepEqual(internal.GetOrigLogs(internal.Logs(ld1)), internal.GetOrigLogs(internal.Logs(ld2)))
+}

--- a/pdata/xpdata/pref/metrics.go
+++ b/pdata/xpdata/pref/metrics.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pref // import "go.opentelemetry.io/collector/pdata/xpdata/pref"
+
+import (
+	"reflect"
+
+	"go.opentelemetry.io/collector/pdata/internal"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// MarkPipelineOwnedMetrics marks the pmetric.Metrics data as owned by the pipeline, returns true if the data were
+// previously not owned by the pipeline, otherwise false.
+func MarkPipelineOwnedMetrics(md pmetric.Metrics) bool {
+	return internal.GetMetricsState(internal.Metrics(md)).MarkPipelineOwned()
+}
+
+func RefMetrics(md pmetric.Metrics) {
+	if EnableRefCounting.IsEnabled() {
+		internal.GetMetricsState(internal.Metrics(md)).Ref()
+	}
+}
+
+func UnrefMetrics(md pmetric.Metrics) {
+	if EnableRefCounting.IsEnabled() {
+		if !internal.GetMetricsState(internal.Metrics(md)).Unref() {
+			return
+		}
+		// Don't call DeleteOrigExportLogsServiceRequest without the gate because we reset the data and that may still cause issues.
+		if internal.UseProtoPooling.IsEnabled() {
+			internal.DeleteOrigExportMetricsServiceRequest(internal.GetOrigMetrics(internal.Metrics(md)), true)
+		}
+	}
+}
+
+// TODO: Generate this in pdata.
+
+func EqualMetrics(md1, md2 pmetric.Metrics) bool {
+	return reflect.DeepEqual(internal.GetOrigMetrics(internal.Metrics(md1)), internal.GetOrigMetrics(internal.Metrics(md2)))
+}

--- a/pdata/xpdata/pref/profiles.go
+++ b/pdata/xpdata/pref/profiles.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pref // import "go.opentelemetry.io/collector/pdata/xpdata/pref"
+
+import (
+	"reflect"
+
+	"go.opentelemetry.io/collector/pdata/internal"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+)
+
+// MarkPipelineOwnedProfiles marks the pprofile.Profiles data as owned by the pipeline, returns true if the data were
+// previously not owned by the pipeline, otherwise false.
+func MarkPipelineOwnedProfiles(pd pprofile.Profiles) bool {
+	return internal.GetProfilesState(internal.Profiles(pd)).MarkPipelineOwned()
+}
+
+func RefProfiles(pd pprofile.Profiles) {
+	if EnableRefCounting.IsEnabled() {
+		internal.GetProfilesState(internal.Profiles(pd)).Ref()
+	}
+}
+
+func UnrefProfiles(pd pprofile.Profiles) {
+	if EnableRefCounting.IsEnabled() {
+		if !internal.GetProfilesState(internal.Profiles(pd)).Unref() {
+			return
+		}
+		// Don't call DeleteOrigExportLogsServiceRequest without the gate because we reset the data and that may still cause issues.
+		if internal.UseProtoPooling.IsEnabled() {
+			internal.DeleteOrigExportProfilesServiceRequest(internal.GetOrigProfiles(internal.Profiles(pd)), true)
+		}
+	}
+}
+
+// TODO: Generate this in pdata.
+
+func EqualProfiles(pd1, pd2 pprofile.Profiles) bool {
+	return reflect.DeepEqual(internal.GetOrigProfiles(internal.Profiles(pd1)), internal.GetOrigProfiles(internal.Profiles(pd2)))
+}

--- a/pdata/xpdata/pref/traces.go
+++ b/pdata/xpdata/pref/traces.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pref // import "go.opentelemetry.io/collector/pdata/xpdata/pref"
+
+import (
+	"reflect"
+
+	"go.opentelemetry.io/collector/pdata/internal"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// MarkPipelineOwnedTraces marks the ptrace.Traces data as owned by the pipeline, returns true if the data were
+// previously not owned by the pipeline, otherwise false.
+func MarkPipelineOwnedTraces(td ptrace.Traces) bool {
+	return internal.GetTracesState(internal.Traces(td)).MarkPipelineOwned()
+}
+
+func RefTraces(td ptrace.Traces) {
+	internal.GetTracesState(internal.Traces(td)).Ref()
+}
+
+func UnrefTraces(td ptrace.Traces) {
+	if EnableRefCounting.IsEnabled() {
+		if !internal.GetTracesState(internal.Traces(td)).Unref() {
+			return
+		}
+		// Don't call DeleteOrigExportLogsServiceRequest without the gate because we reset the data and that may still cause issues.
+		if internal.UseProtoPooling.IsEnabled() {
+			internal.DeleteOrigExportTraceServiceRequest(internal.GetOrigTraces(internal.Traces(td)), true)
+		}
+	}
+}
+
+// TODO: Generate this in pdata.
+
+func EqualTraces(td1, td2 ptrace.Traces) bool {
+	return reflect.DeepEqual(internal.GetOrigTraces(internal.Traces(td1)), internal.GetOrigTraces(internal.Traces(td2)))
+}

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/consumer/consumertest v0.132.0
 	go.opentelemetry.io/collector/pdata v1.38.0
 	go.opentelemetry.io/collector/pdata/testdata v0.132.0
+	go.opentelemetry.io/collector/pdata/xpdata v0.132.0
 	go.opentelemetry.io/collector/processor v1.38.0
 	go.opentelemetry.io/collector/processor/processortest v0.132.0
 	go.opentelemetry.io/otel v1.37.0
@@ -76,6 +77,8 @@ replace go.opentelemetry.io/collector/confmap => ../../confmap
 replace go.opentelemetry.io/collector/pdata => ../../pdata
 
 replace go.opentelemetry.io/collector/pdata/testdata => ../../pdata/testdata
+
+replace go.opentelemetry.io/collector/pdata/xpdata => ../../pdata/xpdata
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -68,9 +68,9 @@ replace go.opentelemetry.io/collector/consumer/consumererror => ../../consumer/c
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-replace go.opentelemetry.io/collector/pdata/pprofile => ../../pdata/pprofile
-
 replace go.opentelemetry.io/collector/pdata => ../../pdata
+
+replace go.opentelemetry.io/collector/pdata/pprofile => ../../pdata/pprofile
 
 replace go.opentelemetry.io/collector/consumer/consumertest => ../../consumer/consumertest
 

--- a/service/go.mod
+++ b/service/go.mod
@@ -37,6 +37,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.38.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.132.0
 	go.opentelemetry.io/collector/pdata/testdata v0.132.0
+	go.opentelemetry.io/collector/pdata/xpdata v0.132.0
 	go.opentelemetry.io/collector/pipeline v1.38.0
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.132.0
 	go.opentelemetry.io/collector/processor v1.38.0

--- a/service/internal/graph/connector.go
+++ b/service/internal/graph/connector.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/service/internal/capabilityconsumer"
 	"go.opentelemetry.io/collector/service/internal/metadata"
 	"go.opentelemetry.io/collector/service/internal/obsconsumer"
+	"go.opentelemetry.io/collector/service/internal/refconsumer"
 )
 
 const pipelineIDAttrKey = "otelcol.pipeline.id"
@@ -116,24 +117,28 @@ func (n *connectorNode) buildTraces(
 			),
 			tb.ConnectorConsumedItems, tb.ConnectorConsumedSize,
 		)
+		n.consumer = refconsumer.NewTraces(n.consumer.(consumer.Traces))
 	case pipeline.SignalMetrics:
 		n.Component, err = builder.CreateMetricsToTraces(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewMetrics(n.Component.(consumer.Metrics), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewMetrics(n.consumer.(consumer.Metrics))
 	case pipeline.SignalLogs:
 		n.Component, err = builder.CreateLogsToTraces(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewLogs(n.Component.(consumer.Logs), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewLogs(n.consumer.(consumer.Logs))
 	case xpipeline.SignalProfiles:
 		n.Component, err = builder.CreateProfilesToTraces(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewProfiles(n.Component.(xconsumer.Profiles), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewProfiles(n.consumer.(xconsumer.Profiles))
 	}
 	return nil
 }
@@ -179,24 +184,28 @@ func (n *connectorNode) buildMetrics(
 			),
 			tb.ConnectorConsumedItems, tb.ConnectorConsumedSize,
 		)
+		n.consumer = refconsumer.NewMetrics(n.consumer.(consumer.Metrics))
 	case pipeline.SignalTraces:
 		n.Component, err = builder.CreateTracesToMetrics(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewTraces(n.Component.(consumer.Traces), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewTraces(n.consumer.(consumer.Traces))
 	case pipeline.SignalLogs:
 		n.Component, err = builder.CreateLogsToMetrics(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewLogs(n.Component.(consumer.Logs), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewLogs(n.consumer.(consumer.Logs))
 	case xpipeline.SignalProfiles:
 		n.Component, err = builder.CreateProfilesToMetrics(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewProfiles(n.Component.(xconsumer.Profiles), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewProfiles(n.consumer.(xconsumer.Profiles))
 	}
 	return nil
 }
@@ -242,24 +251,28 @@ func (n *connectorNode) buildLogs(
 			),
 			tb.ConnectorConsumedItems, tb.ConnectorConsumedSize,
 		)
+		n.consumer = refconsumer.NewLogs(n.consumer.(consumer.Logs))
 	case pipeline.SignalTraces:
 		n.Component, err = builder.CreateTracesToLogs(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewTraces(n.Component.(consumer.Traces), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewTraces(n.consumer.(consumer.Traces))
 	case pipeline.SignalMetrics:
 		n.Component, err = builder.CreateMetricsToLogs(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewMetrics(n.Component.(consumer.Metrics), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewMetrics(n.consumer.(consumer.Metrics))
 	case xpipeline.SignalProfiles:
 		n.Component, err = builder.CreateProfilesToLogs(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewProfiles(n.Component.(xconsumer.Profiles), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewProfiles(n.consumer.(xconsumer.Profiles))
 	}
 	return nil
 }
@@ -305,24 +318,28 @@ func (n *connectorNode) buildProfiles(
 			),
 			tb.ConnectorConsumedItems, tb.ConnectorConsumedSize,
 		)
+		n.consumer = refconsumer.NewProfiles(n.consumer.(xconsumer.Profiles))
 	case pipeline.SignalTraces:
 		n.Component, err = builder.CreateTracesToProfiles(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewTraces(n.Component.(consumer.Traces), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewTraces(n.consumer.(consumer.Traces))
 	case pipeline.SignalMetrics:
 		n.Component, err = builder.CreateMetricsToProfiles(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewMetrics(n.Component.(consumer.Metrics), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewMetrics(n.consumer.(consumer.Metrics))
 	case pipeline.SignalLogs:
 		n.Component, err = builder.CreateLogsToProfiles(ctx, set, next)
 		if err != nil {
 			return err
 		}
 		n.consumer = obsconsumer.NewLogs(n.Component.(consumer.Logs), tb.ConnectorConsumedItems, tb.ConnectorConsumedSize)
+		n.consumer = refconsumer.NewLogs(n.consumer.(consumer.Logs))
 	}
 	return nil
 }

--- a/service/internal/graph/exporter.go
+++ b/service/internal/graph/exporter.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/service/internal/builders"
 	"go.opentelemetry.io/collector/service/internal/metadata"
 	"go.opentelemetry.io/collector/service/internal/obsconsumer"
+	"go.opentelemetry.io/collector/service/internal/refconsumer"
 )
 
 var _ consumerNode = (*exporterNode)(nil)
@@ -68,24 +69,28 @@ func (n *exporterNode) buildComponent(
 			return fmt.Errorf("failed to create %q exporter for data type %q: %w", set.ID, n.pipelineType, err)
 		}
 		n.consumer = obsconsumer.NewTraces(n.Component.(consumer.Traces), tb.ExporterConsumedItems, tb.ExporterConsumedSize)
+		n.consumer = refconsumer.NewTraces(n.consumer.(consumer.Traces))
 	case pipeline.SignalMetrics:
 		n.Component, err = builder.CreateMetrics(ctx, set)
 		if err != nil {
 			return fmt.Errorf("failed to create %q exporter for data type %q: %w", set.ID, n.pipelineType, err)
 		}
 		n.consumer = obsconsumer.NewMetrics(n.Component.(consumer.Metrics), tb.ExporterConsumedItems, tb.ExporterConsumedSize)
+		n.consumer = refconsumer.NewMetrics(n.consumer.(consumer.Metrics))
 	case pipeline.SignalLogs:
 		n.Component, err = builder.CreateLogs(ctx, set)
 		if err != nil {
 			return fmt.Errorf("failed to create %q exporter for data type %q: %w", set.ID, n.pipelineType, err)
 		}
 		n.consumer = obsconsumer.NewLogs(n.Component.(consumer.Logs), tb.ExporterConsumedItems, tb.ExporterConsumedSize)
+		n.consumer = refconsumer.NewLogs(n.consumer.(consumer.Logs))
 	case xpipeline.SignalProfiles:
 		n.Component, err = builder.CreateProfiles(ctx, set)
 		if err != nil {
 			return fmt.Errorf("failed to create %q exporter for data type %q: %w", set.ID, n.pipelineType, err)
 		}
 		n.consumer = obsconsumer.NewProfiles(n.Component.(xconsumer.Profiles), tb.ExporterConsumedItems, tb.ExporterConsumedSize)
+		n.consumer = refconsumer.NewProfiles(n.consumer.(xconsumer.Profiles))
 	default:
 		return fmt.Errorf("error creating exporter %q for data type %q is not supported", set.ID, n.pipelineType)
 	}

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/testdata"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/pipeline/xpipeline"
 	"go.opentelemetry.io/collector/processor"
@@ -957,57 +958,33 @@ func testConnectorPipelinesGraph(t *testing.T) {
 			for _, e := range allExporters[pipeline.SignalTraces] {
 				tracesExporter := e.(consumer.Traces).(*testcomponents.ExampleExporter)
 				assert.Len(t, tracesExporter.Traces, tt.expectedPerExporter)
-				expectedMutable := testdata.GenerateTraces(1)
-				expectedReadOnly := testdata.GenerateTraces(1)
-				expectedReadOnly.MarkReadOnly()
+				expected := testdata.GenerateTraces(1)
 				for i := 0; i < tt.expectedPerExporter; i++ {
-					if tracesExporter.Traces[i].IsReadOnly() {
-						assert.Equal(t, expectedReadOnly, tracesExporter.Traces[i])
-					} else {
-						assert.Equal(t, expectedMutable, tracesExporter.Traces[i])
-					}
+					assert.True(t, pref.EqualTraces(expected, tracesExporter.Traces[i]))
 				}
 			}
 			for _, e := range allExporters[pipeline.SignalMetrics] {
 				metricsExporter := e.(consumer.Metrics).(*testcomponents.ExampleExporter)
 				assert.Len(t, metricsExporter.Metrics, tt.expectedPerExporter)
-				expectedMutable := testdata.GenerateMetrics(1)
-				expectedReadOnly := testdata.GenerateMetrics(1)
-				expectedReadOnly.MarkReadOnly()
+				expected := testdata.GenerateMetrics(1)
 				for i := 0; i < tt.expectedPerExporter; i++ {
-					if metricsExporter.Metrics[i].IsReadOnly() {
-						assert.Equal(t, expectedReadOnly, metricsExporter.Metrics[i])
-					} else {
-						assert.Equal(t, expectedMutable, metricsExporter.Metrics[i])
-					}
+					assert.True(t, pref.EqualMetrics(expected, metricsExporter.Metrics[i]))
 				}
 			}
 			for _, e := range allExporters[pipeline.SignalLogs] {
 				logsExporter := e.(consumer.Logs).(*testcomponents.ExampleExporter)
 				assert.Len(t, logsExporter.Logs, tt.expectedPerExporter)
-				expectedMutable := testdata.GenerateLogs(1)
-				expectedReadOnly := testdata.GenerateLogs(1)
-				expectedReadOnly.MarkReadOnly()
+				expected := testdata.GenerateLogs(1)
 				for i := 0; i < tt.expectedPerExporter; i++ {
-					if logsExporter.Logs[i].IsReadOnly() {
-						assert.Equal(t, expectedReadOnly, logsExporter.Logs[i])
-					} else {
-						assert.Equal(t, expectedMutable, logsExporter.Logs[i])
-					}
+					assert.True(t, pref.EqualLogs(expected, logsExporter.Logs[i]))
 				}
 			}
 			for _, e := range allExporters[xpipeline.SignalProfiles] {
 				profilesExporter := e.(xconsumer.Profiles).(*testcomponents.ExampleExporter)
 				assert.Len(t, profilesExporter.Profiles, tt.expectedPerExporter)
-				expectedMutable := testdata.GenerateProfiles(1)
-				expectedReadOnly := testdata.GenerateProfiles(1)
-				expectedReadOnly.MarkReadOnly()
+				expected := testdata.GenerateProfiles(1)
 				for i := 0; i < tt.expectedPerExporter; i++ {
-					if profilesExporter.Profiles[i].IsReadOnly() {
-						assert.Equal(t, expectedReadOnly, profilesExporter.Profiles[i])
-					} else {
-						assert.Equal(t, expectedMutable, profilesExporter.Profiles[i])
-					}
+					assert.True(t, pref.EqualProfiles(expected, profilesExporter.Profiles[i]))
 				}
 			}
 		})

--- a/service/internal/graph/processor.go
+++ b/service/internal/graph/processor.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/service/internal/builders"
 	"go.opentelemetry.io/collector/service/internal/metadata"
 	"go.opentelemetry.io/collector/service/internal/obsconsumer"
+	"go.opentelemetry.io/collector/service/internal/refconsumer"
 )
 
 var _ consumerNode = (*processorNode)(nil)
@@ -70,6 +71,7 @@ func (n *processorNode) buildComponent(ctx context.Context,
 			return fmt.Errorf("failed to create %q processor, in pipeline %q: %w", set.ID, n.pipelineID.String(), err)
 		}
 		n.consumer = obsconsumer.NewTraces(n.Component.(consumer.Traces), tb.ProcessorConsumedItems, tb.ProcessorConsumedSize)
+		n.consumer = refconsumer.NewTraces(n.consumer.(consumer.Traces))
 	case pipeline.SignalMetrics:
 		n.Component, err = builder.CreateMetrics(ctx, set,
 			obsconsumer.NewMetrics(next.(consumer.Metrics), tb.ProcessorProducedItems, tb.ProcessorProducedSize))
@@ -77,6 +79,7 @@ func (n *processorNode) buildComponent(ctx context.Context,
 			return fmt.Errorf("failed to create %q processor, in pipeline %q: %w", set.ID, n.pipelineID.String(), err)
 		}
 		n.consumer = obsconsumer.NewMetrics(n.Component.(consumer.Metrics), tb.ProcessorConsumedItems, tb.ProcessorConsumedSize)
+		n.consumer = refconsumer.NewMetrics(n.consumer.(consumer.Metrics))
 	case pipeline.SignalLogs:
 		n.Component, err = builder.CreateLogs(ctx, set,
 			obsconsumer.NewLogs(next.(consumer.Logs), tb.ProcessorProducedItems, tb.ProcessorProducedSize))
@@ -84,6 +87,7 @@ func (n *processorNode) buildComponent(ctx context.Context,
 			return fmt.Errorf("failed to create %q processor, in pipeline %q: %w", set.ID, n.pipelineID.String(), err)
 		}
 		n.consumer = obsconsumer.NewLogs(n.Component.(consumer.Logs), tb.ProcessorConsumedItems, tb.ProcessorConsumedSize)
+		n.consumer = refconsumer.NewLogs(n.consumer.(consumer.Logs))
 	case xpipeline.SignalProfiles:
 		n.Component, err = builder.CreateProfiles(ctx, set,
 			obsconsumer.NewProfiles(next.(xconsumer.Profiles), tb.ProcessorProducedItems, tb.ProcessorProducedSize))
@@ -91,6 +95,7 @@ func (n *processorNode) buildComponent(ctx context.Context,
 			return fmt.Errorf("failed to create %q processor, in pipeline %q: %w", set.ID, n.pipelineID.String(), err)
 		}
 		n.consumer = obsconsumer.NewProfiles(n.Component.(xconsumer.Profiles), tb.ProcessorConsumedItems, tb.ProcessorConsumedSize)
+		n.consumer = refconsumer.NewProfiles(n.consumer.(xconsumer.Profiles))
 	default:
 		return fmt.Errorf("error creating processor %q in pipeline %q, data type %q is not supported", set.ID, n.pipelineID.String(), n.pipelineID.Signal())
 	}

--- a/service/internal/refconsumer/logs.go
+++ b/service/internal/refconsumer/logs.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package refconsumer // import "go.opentelemetry.io/collector/service/internal/refconsumer"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+)
+
+func NewLogs(cons consumer.Logs) consumer.Logs {
+	return refLogs{
+		consumer: cons,
+	}
+}
+
+type refLogs struct {
+	consumer consumer.Logs
+}
+
+// ConsumeLogs measures telemetry before calling ConsumeLogs because the data may be mutated downstream
+func (c refLogs) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	if pref.MarkPipelineOwnedLogs(ld) {
+		defer pref.UnrefLogs(ld)
+	}
+	return c.consumer.ConsumeLogs(ctx, ld)
+}
+
+func (c refLogs) Capabilities() consumer.Capabilities {
+	return c.consumer.Capabilities()
+}

--- a/service/internal/refconsumer/logs_test.go
+++ b/service/internal/refconsumer/logs_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package refconsumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/internal/telemetry"
+	"go.opentelemetry.io/collector/pdata/testdata"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+)
+
+func TestLogsNopWhenGateDisabled(t *testing.T) {
+	initial := pref.UseProtoPooling.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pref.UseProtoPooling.ID(), false))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(telemetry.NewPipelineTelemetryGate.ID(), initial))
+	})
+
+	refCons := NewLogs(consumertest.NewNop())
+	ld := testdata.GenerateLogs(10)
+	assert.Equal(t, 10, ld.LogRecordCount())
+	require.NoError(t, refCons.ConsumeLogs(t.Context(), ld))
+	assert.Equal(t, 10, ld.LogRecordCount())
+}
+
+func TestLogs(t *testing.T) {
+	initial := pref.UseProtoPooling.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pref.UseProtoPooling.ID(), true))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(telemetry.NewPipelineTelemetryGate.ID(), initial))
+	})
+
+	refCons := NewLogs(consumertest.NewNop())
+	ld := testdata.GenerateLogs(10)
+	assert.Equal(t, 10, ld.LogRecordCount())
+	require.NoError(t, refCons.ConsumeLogs(t.Context(), ld))
+	// Data should be reset at this point.
+	assert.Equal(t, 0, ld.LogRecordCount())
+}

--- a/service/internal/refconsumer/metrics.go
+++ b/service/internal/refconsumer/metrics.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package refconsumer // import "go.opentelemetry.io/collector/service/internal/refconsumer"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+)
+
+func NewMetrics(cons consumer.Metrics) consumer.Metrics {
+	return refMetrics{
+		consumer: cons,
+	}
+}
+
+type refMetrics struct {
+	consumer consumer.Metrics
+}
+
+// ConsumeMetrics measures telemetry before calling ConsumeMetrics because the data may be mutated downstream
+func (c refMetrics) ConsumeMetrics(ctx context.Context, ld pmetric.Metrics) error {
+	if pref.MarkPipelineOwnedMetrics(ld) {
+		defer pref.UnrefMetrics(ld)
+	}
+	return c.consumer.ConsumeMetrics(ctx, ld)
+}
+
+func (c refMetrics) Capabilities() consumer.Capabilities {
+	return c.consumer.Capabilities()
+}

--- a/service/internal/refconsumer/metrics_test.go
+++ b/service/internal/refconsumer/metrics_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package refconsumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/internal/telemetry"
+	"go.opentelemetry.io/collector/pdata/testdata"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+)
+
+func TestMetricsNopWhenGateDisabled(t *testing.T) {
+	initial := pref.UseProtoPooling.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pref.UseProtoPooling.ID(), false))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(telemetry.NewPipelineTelemetryGate.ID(), initial))
+	})
+
+	refCons := NewMetrics(consumertest.NewNop())
+	md := testdata.GenerateMetrics(10)
+	assert.Equal(t, 10, md.MetricCount())
+	require.NoError(t, refCons.ConsumeMetrics(t.Context(), md))
+	assert.Equal(t, 10, md.MetricCount())
+}
+
+func TestMetrics(t *testing.T) {
+	initial := pref.UseProtoPooling.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pref.UseProtoPooling.ID(), true))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(telemetry.NewPipelineTelemetryGate.ID(), initial))
+	})
+
+	refCons := NewMetrics(consumertest.NewNop())
+	md := testdata.GenerateMetrics(10)
+	assert.Equal(t, 10, md.MetricCount())
+	require.NoError(t, refCons.ConsumeMetrics(t.Context(), md))
+	// Data shoumd be reset at this point.
+	assert.Equal(t, 0, md.MetricCount())
+}

--- a/service/internal/refconsumer/profiles.go
+++ b/service/internal/refconsumer/profiles.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package refconsumer // import "go.opentelemetry.io/collector/service/internal/refconsumer"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/xconsumer"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+)
+
+func NewProfiles(cons xconsumer.Profiles) xconsumer.Profiles {
+	return refProfiles{
+		consumer: cons,
+	}
+}
+
+type refProfiles struct {
+	consumer xconsumer.Profiles
+}
+
+// ConsumeProfiles measures telemetry before calling ConsumeProfiles because the data may be mutated downstream
+func (c refProfiles) ConsumeProfiles(ctx context.Context, ld pprofile.Profiles) error {
+	if pref.MarkPipelineOwnedProfiles(ld) {
+		defer pref.UnrefProfiles(ld)
+	}
+	return c.consumer.ConsumeProfiles(ctx, ld)
+}
+
+func (c refProfiles) Capabilities() consumer.Capabilities {
+	return c.consumer.Capabilities()
+}

--- a/service/internal/refconsumer/profiles_test.go
+++ b/service/internal/refconsumer/profiles_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package refconsumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/internal/telemetry"
+	"go.opentelemetry.io/collector/pdata/testdata"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+)
+
+func TestProfilesNopWhenGateDisabled(t *testing.T) {
+	initial := pref.UseProtoPooling.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pref.UseProtoPooling.ID(), false))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(telemetry.NewPipelineTelemetryGate.ID(), initial))
+	})
+
+	refCons := NewProfiles(consumertest.NewNop())
+	pd := testdata.GenerateProfiles(10)
+	assert.Equal(t, 10, pd.SampleCount())
+	require.NoError(t, refCons.ConsumeProfiles(t.Context(), pd))
+	assert.Equal(t, 10, pd.SampleCount())
+}
+
+func TestProfiles(t *testing.T) {
+	initial := pref.UseProtoPooling.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pref.UseProtoPooling.ID(), true))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(telemetry.NewPipelineTelemetryGate.ID(), initial))
+	})
+
+	refCons := NewProfiles(consumertest.NewNop())
+	pd := testdata.GenerateProfiles(10)
+	assert.Equal(t, 10, pd.SampleCount())
+	require.NoError(t, refCons.ConsumeProfiles(t.Context(), pd))
+	// Data shoupd be reset at this point.
+	assert.Equal(t, 0, pd.SampleCount())
+}

--- a/service/internal/refconsumer/traces.go
+++ b/service/internal/refconsumer/traces.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package refconsumer // import "go.opentelemetry.io/collector/service/internal/refconsumer"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+)
+
+func NewTraces(cons consumer.Traces) consumer.Traces {
+	return refTraces{
+		consumer: cons,
+	}
+}
+
+type refTraces struct {
+	consumer consumer.Traces
+}
+
+// ConsumeTraces measures telemetry before calling ConsumeTraces because the data may be mutated downstream
+func (c refTraces) ConsumeTraces(ctx context.Context, ld ptrace.Traces) error {
+	if pref.MarkPipelineOwnedTraces(ld) {
+		defer pref.UnrefTraces(ld)
+	}
+	return c.consumer.ConsumeTraces(ctx, ld)
+}
+
+func (c refTraces) Capabilities() consumer.Capabilities {
+	return c.consumer.Capabilities()
+}

--- a/service/internal/refconsumer/traces_test.go
+++ b/service/internal/refconsumer/traces_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package refconsumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/internal/telemetry"
+	"go.opentelemetry.io/collector/pdata/testdata"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+)
+
+func TestTracesNopWhenGateDisabled(t *testing.T) {
+	initial := pref.UseProtoPooling.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pref.UseProtoPooling.ID(), false))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(telemetry.NewPipelineTelemetryGate.ID(), initial))
+	})
+
+	refCons := NewTraces(consumertest.NewNop())
+	td := testdata.GenerateTraces(10)
+	assert.Equal(t, 10, td.SpanCount())
+	require.NoError(t, refCons.ConsumeTraces(t.Context(), td))
+	assert.Equal(t, 10, td.SpanCount())
+}
+
+func TestTraces(t *testing.T) {
+	initial := pref.UseProtoPooling.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pref.UseProtoPooling.ID(), true))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(telemetry.NewPipelineTelemetryGate.ID(), initial))
+	})
+
+	refCons := NewTraces(consumertest.NewNop())
+	td := testdata.GenerateTraces(10)
+	assert.Equal(t, 10, td.SpanCount())
+	require.NoError(t, refCons.ConsumeTraces(t.Context(), td))
+	// Data shoutd be reset at this point.
+	assert.Equal(t, 0, td.SpanCount())
+}

--- a/service/internal/testcomponents/example_exporter.go
+++ b/service/internal/testcomponents/example_exporter.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
 )
 
 var exporterType = component.MustNewType("exampleexporter")
@@ -59,25 +60,29 @@ type ExampleExporter struct {
 
 // ConsumeTraces receives ptrace.Traces for processing by the consumer.Traces.
 func (exp *ExampleExporter) ConsumeTraces(_ context.Context, td ptrace.Traces) error {
+	pref.RefTraces(td)
 	exp.Traces = append(exp.Traces, td)
 	return nil
 }
 
 // ConsumeMetrics receives pmetric.Metrics for processing by the Metrics.
 func (exp *ExampleExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
+	pref.RefMetrics(md)
 	exp.Metrics = append(exp.Metrics, md)
 	return nil
 }
 
 // ConsumeLogs receives plog.Logs for processing by the Logs.
 func (exp *ExampleExporter) ConsumeLogs(_ context.Context, ld plog.Logs) error {
+	pref.RefLogs(ld)
 	exp.Logs = append(exp.Logs, ld)
 	return nil
 }
 
 // ConsumeProfiles receives pprofile.Profiles for processing by the xconsumer.Profiles.
-func (exp *ExampleExporter) ConsumeProfiles(_ context.Context, td pprofile.Profiles) error {
-	exp.Profiles = append(exp.Profiles, td)
+func (exp *ExampleExporter) ConsumeProfiles(_ context.Context, pd pprofile.Profiles) error {
+	pref.RefProfiles(pd)
+	exp.Profiles = append(exp.Profiles, pd)
 	return nil
 }
 

--- a/service/internal/testcomponents/example_exporter_test.go
+++ b/service/internal/testcomponents/example_exporter_test.go
@@ -25,19 +25,19 @@ func TestExampleExporter(t *testing.T) {
 	assert.True(t, exp.Started())
 
 	assert.Empty(t, exp.Traces)
-	require.NoError(t, exp.ConsumeTraces(context.Background(), ptrace.Traces{}))
+	require.NoError(t, exp.ConsumeTraces(context.Background(), ptrace.NewTraces()))
 	assert.Len(t, exp.Traces, 1)
 
 	assert.Empty(t, exp.Metrics)
-	require.NoError(t, exp.ConsumeMetrics(context.Background(), pmetric.Metrics{}))
+	require.NoError(t, exp.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
 	assert.Len(t, exp.Metrics, 1)
 
 	assert.Empty(t, exp.Logs)
-	require.NoError(t, exp.ConsumeLogs(context.Background(), plog.Logs{}))
+	require.NoError(t, exp.ConsumeLogs(context.Background(), plog.NewLogs()))
 	assert.Len(t, exp.Logs, 1)
 
 	assert.Empty(t, exp.Profiles)
-	require.NoError(t, exp.ConsumeProfiles(context.Background(), pprofile.Profiles{}))
+	require.NoError(t, exp.ConsumeProfiles(context.Background(), pprofile.NewProfiles()))
 	assert.Len(t, exp.Profiles, 1)
 
 	assert.False(t, exp.Stopped())


### PR DESCRIPTION
This feature is protected by the beta featuregate `pdata.enableRefCounting` so that if unexpected problems occur to have a simple way to disable the problematic logic. If nothing goes wrong for 2 versions this featuregate will be marked as stable.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/13631