### PR TITLE
receiver/otlpreceiver: log listener addresses

### DIFF
--- a/.chloggen/otlpreciever-log-listenaddr.yaml
+++ b/.chloggen/otlpreciever-log-listenaddr.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Log the listening addresses of the receiver, rather than the configured endpoints.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13654]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -114,11 +114,11 @@ func (r *otlpReceiver) startGRPCServer(ctx context.Context, host component.Host)
 		pprofileotlp.RegisterGRPCServer(r.serverGRPC, profiles.New(r.nextProfiles))
 	}
 
-	r.settings.Logger.Info("Starting GRPC server", zap.String("endpoint", grpcCfg.NetAddr.Endpoint))
 	var gln net.Listener
 	if gln, err = grpcCfg.NetAddr.Listen(ctx); err != nil {
 		return err
 	}
+	r.settings.Logger.Info("Starting GRPC server", zap.String("endpoint", gln.Addr().String()))
 
 	r.shutdownWG.Add(1)
 	go func() {
@@ -172,11 +172,11 @@ func (r *otlpReceiver) startHTTPServer(ctx context.Context, host component.Host)
 		return err
 	}
 
-	r.settings.Logger.Info("Starting HTTP server", zap.String("endpoint", httpCfg.ServerConfig.Endpoint))
 	var hln net.Listener
 	if hln, err = httpCfg.ServerConfig.ToListener(ctx); err != nil {
 		return err
 	}
+	r.settings.Logger.Info("Starting HTTP server", zap.String("endpoint", hln.Addr().String()))
 
 	r.shutdownWG.Add(1)
 	go func() {


### PR DESCRIPTION
#### Description

Change otlpreceiver to log the listener addresses, rather than configured endpoints. This enables discovery of ephemeral ports through logs.

My goal is to enable more robust testing of the collector in a framework similar to https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/testbed/testbed

#### Link to tracking issue

Fixes #13654

#### Testing

Manually tested

#### Documentation

None