### PR TITLE
[exporter/otlp] Fix unix socket blocked with valid

### DIFF
--- a/.chloggen/fix_otlp-export-unixsocket.yaml
+++ b/.chloggen/fix_otlp-export-unixsocket.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporter/otlp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix unix socket blocked with valid
+
+# One or more tracking issues or pull requests related to the change
+issues: [#13642]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -101,7 +101,7 @@ func (v UnixValidator) Validate(ep string) error {
 	if strings.HasPrefix(ep, "unix://") {
 		path := strings.TrimPrefix(ep, "unix://")
 		if path == "" {
-			return fmt.Errorf("empty unix socket path")
+			return errors.New("empty unix socket path")
 		}
 		return nil
 	} else if strings.HasPrefix(ep, "unix:@") {

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -107,7 +107,7 @@ func (v UnixValidator) Validate(ep string) error {
 	} else if strings.HasPrefix(ep, "unix:@") {
 		path := strings.TrimPrefix(ep, "unix:@")
 		if path == "" {
-			return fmt.Errorf("empty abstract unix socket path")
+			return errors.New("empty abstract unix socket path")
 		}
 		return nil
 	}

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -5,6 +5,7 @@ package otlpexporter
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"path/filepath"
 	"runtime"
@@ -1039,4 +1040,79 @@ func TestSendProfilesWhenEndpointHasHttpScheme(t *testing.T) {
 			assert.EqualValues(t, 0, rcv.totalItems.Load())
 		})
 	}
+}
+
+func TestSendMetricsUnixSocket(t *testing.T) {
+	// create otlp socket
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "otlp_test.sock")
+
+	// listen unix socket
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err, "cannot start unix socket listener")
+	rcv := otlpMetricsReceiverOnGRPCServer(ln)
+	defer rcv.srv.GracefulStop()
+
+	// Start an OTLP exporter and point to the receiver.
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.QueueConfig.Enabled = false
+	cfg.ClientConfig = configgrpc.ClientConfig{
+		Endpoint: fmt.Sprintf("unix://%s", socketPath),
+		TLS:      configtls.ClientConfig{Insecure: true},
+	}
+
+	set := exportertest.NewNopSettings(factory.Type())
+	set.BuildInfo.Description = "Collector"
+	set.BuildInfo.Version = "1.2.3test"
+
+	logger, observed := observer.New(zap.DebugLevel)
+	set.Logger = zap.New(logger)
+
+	exp, err := factory.CreateMetrics(context.Background(), set, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+
+	defer func() {
+		assert.NoError(t, exp.Shutdown(context.Background()))
+	}()
+
+	host := componenttest.NewNopHost()
+	require.NoError(t, exp.Start(context.Background(), host))
+
+	assert.EqualValues(t, 0, rcv.requestCount.Load())
+
+	// send one metric
+	md := pmetric.NewMetrics()
+	require.NoError(t, exp.ConsumeMetrics(context.Background(), md))
+
+	assert.Eventually(t, func() bool {
+		return rcv.requestCount.Load() > 0
+	}, 10*time.Second, 5*time.Millisecond)
+
+	assert.EqualValues(t, 0, rcv.totalItems.Load())
+
+	// send two metric
+	md = testdata.GenerateMetrics(2)
+	require.NoError(t, exp.ConsumeMetrics(context.Background(), md))
+
+	assert.Eventually(t, func() bool {
+		return rcv.requestCount.Load() > 1
+	}, 10*time.Second, 5*time.Millisecond)
+
+	assert.EqualValues(t, 2, rcv.requestCount.Load())
+	assert.EqualValues(t, 4, rcv.totalItems.Load())
+	assert.Equal(t, md, rcv.getLastRequest())
+
+	// valid
+	rcv.setExportResponse(func() pmetricotlp.ExportResponse {
+		response := pmetricotlp.NewExportResponse()
+		ps := response.PartialSuccess()
+		ps.SetErrorMessage("Some data points were not ingested")
+		ps.SetRejectedDataPoints(1)
+		return response
+	})
+	require.NoError(t, exp.ConsumeMetrics(context.Background(), testdata.GenerateMetrics(2)))
+	assert.Len(t, observed.FilterLevelExact(zap.WarnLevel).All(), 1)
+	assert.Contains(t, observed.FilterLevelExact(zap.WarnLevel).All()[0].Message, "Partial success")
 }

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -603,7 +603,6 @@ func TestSendMetrics(t *testing.T) {
 			require.NoError(t, exp.ConsumeMetrics(context.Background(), md))
 			assert.Len(t, observed.FilterLevelExact(zap.WarnLevel).All(), 1)
 			assert.Contains(t, observed.FilterLevelExact(zap.WarnLevel).All()[0].Message, "Partial success")
-
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fixes OTLP exporter config validation for Unix socket endpoints. Splits validation for host/port and Unix socket, keeping backward compatibility.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13642

<!--Describe what testing was performed and which tests were added.-->
#### Testing
• Added tests for DNS, HTTP, HTTPS, Unix socket, and other schemes.
 • Updated sanitize endpoint test; behavior unchanged.
 • Unix socket test covered.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
