### PR TITLE
[chore] Move UnmarshalJSON to use the ProtoField to generate

### DIFF
--- a/internal/cmd/pdatagen/internal/pdata/message_field.go
+++ b/internal/cmd/pdatagen/internal/pdata/message_field.go
@@ -34,9 +34,6 @@ const messageSetTestTemplate = `orig.{{ .fieldOriginFullName }} = *GenTestOrig{{
 
 const messageCopyOrigTemplate = `CopyOrig{{ .fieldOriginName }}(&dest.{{ .fieldOriginFullName }}, &src.{{ .fieldOriginFullName }})`
 
-const messageUnmarshalJSONTemplate = `case "{{ lowerFirst .fieldOriginFullName }}"{{ if needSnake .fieldOriginFullName -}}, "{{ toSnake .fieldOriginFullName }}"{{- end }}:
-	UnmarshalJSONOrig{{ .fieldOriginName }}(&orig.{{ .fieldOriginFullName }}, iter)`
-
 type MessageField struct {
 	fieldName     string
 	protoID       uint32
@@ -75,9 +72,8 @@ func (mf *MessageField) GenerateMarshalJSON(*messageStruct) string {
 	return mf.toProtoField().GenMarshalJSON()
 }
 
-func (mf *MessageField) GenerateUnmarshalJSON(ms *messageStruct) string {
-	t := template.Parse("messageUnmarshalJSONTemplate", []byte(messageUnmarshalJSONTemplate))
-	return template.Execute(t, mf.templateFields(ms))
+func (mf *MessageField) GenerateUnmarshalJSON(*messageStruct) string {
+	return mf.toProtoField().GenUnmarshalJSON()
 }
 
 func (mf *MessageField) GenerateSizeProto(*messageStruct) string {

--- a/internal/cmd/pdatagen/internal/pdata/one_of_message_value.go
+++ b/internal/cmd/pdatagen/internal/pdata/one_of_message_value.go
@@ -62,11 +62,6 @@ const oneOfMessageCopyOrigTemplate = `	case *{{ .originStructType }}:
 const oneOfMessageTypeTemplate = `case *{{ .originStructType }}:
 	return {{ .typeName }}`
 
-const oneOfMessageUnmarshalJSONTemplate = `case "{{ lowerFirst .originFieldName }}"{{ if needSnake .originFieldName -}}, "{{ toSnake .originFieldName }}"{{- end }}:
-	val := &{{ .originFieldPackageName }}.{{ .fieldName }}{}
-	orig.{{ .originOneOfFieldName }} = &{{ .originStructType }}{{ "{" }}{{ .fieldName }}: val}
-	UnmarshalJSONOrig{{ .fieldOriginName }}(val, iter)`
-
 type OneOfMessageValue struct {
 	fieldName              string
 	protoID                uint32
@@ -116,8 +111,7 @@ func (omv *OneOfMessageValue) GenerateMarshalJSON(ms *messageStruct, of *OneOfFi
 }
 
 func (omv *OneOfMessageValue) GenerateUnmarshalJSON(ms *messageStruct, of *OneOfField) string {
-	t := template.Parse("oneOfMessageUnmarshalJSONTemplate", []byte(oneOfMessageUnmarshalJSONTemplate))
-	return template.Execute(t, omv.templateFields(ms, of))
+	return omv.toProtoField(ms, of, false).GenUnmarshalJSON()
 }
 
 func (omv *OneOfMessageValue) GenerateSizeProto(ms *messageStruct, of *OneOfField) string {

--- a/internal/cmd/pdatagen/internal/pdata/one_of_primitive_value.go
+++ b/internal/cmd/pdatagen/internal/pdata/one_of_primitive_value.go
@@ -57,11 +57,6 @@ const oneOfPrimitiveCopyOrigTemplate = `case *{{ .originStructType }}:
 const oneOfPrimitiveTypeTemplate = `case *{{ .originStructType }}:
 	return {{ .typeName }}`
 
-const oneOfPrimitiveUnmarshalJSONTemplate = `case "{{ lowerFirst .originFieldName }}"{{ if needSnake .originFieldName -}}, "{{ toSnake .originFieldName }}"{{- end }}:
-	orig.{{ .originOneOfFieldName }} = &{{ .originStructType }}{
-		{{ .originFieldName }}: iter.Read{{ upperFirst .returnType }}(),
-	}`
-
 type OneOfPrimitiveValue struct {
 	fieldName       string
 	protoID         uint32
@@ -111,8 +106,7 @@ func (opv *OneOfPrimitiveValue) GenerateMarshalJSON(ms *messageStruct, of *OneOf
 }
 
 func (opv *OneOfPrimitiveValue) GenerateUnmarshalJSON(ms *messageStruct, of *OneOfField) string {
-	t := template.Parse("oneOfPrimitiveUnmarshalJSONTemplate", []byte(oneOfPrimitiveUnmarshalJSONTemplate))
-	return template.Execute(t, opv.templateFields(ms, of))
+	return opv.toProtoField(ms, of, false).GenUnmarshalJSON()
 }
 
 func (opv *OneOfPrimitiveValue) GenerateSizeProto(ms *messageStruct, of *OneOfField) string {

--- a/internal/cmd/pdatagen/internal/pdata/optional_primitive_field.go
+++ b/internal/cmd/pdatagen/internal/pdata/optional_primitive_field.go
@@ -69,9 +69,6 @@ const optionalPrimitiveCopyOrigTemplate = `if src{{ .fieldName }}, ok := src.{{ 
 	dest.{{ .fieldName }}_ = nil
 }`
 
-const optionalPrimitiveUnmarshalJSONTemplate = `case "{{ lowerFirst .fieldName }}"{{ if needSnake .fieldName -}}, "{{ toSnake .fieldName }}"{{- end }}:
-		orig.{{ .fieldName }}_ = &{{ .originStructType }}{{ "{" }}{{ .fieldName }}: iter.Read{{ upperFirst .returnType }}()}`
-
 type OptionalPrimitiveField struct {
 	fieldName string
 	protoID   uint32
@@ -111,8 +108,7 @@ func (opv *OptionalPrimitiveField) GenerateMarshalJSON(ms *messageStruct) string
 }
 
 func (opv *OptionalPrimitiveField) GenerateUnmarshalJSON(ms *messageStruct) string {
-	t := template.Parse("optionalPrimitiveUnmarshalJSONTemplate", []byte(optionalPrimitiveUnmarshalJSONTemplate))
-	return template.Execute(t, opv.templateFields(ms))
+	return opv.toProtoField(ms, false).GenUnmarshalJSON()
 }
 
 func (opv *OptionalPrimitiveField) GenerateSizeProto(ms *messageStruct) string {

--- a/internal/cmd/pdatagen/internal/pdata/primitive_field.go
+++ b/internal/cmd/pdatagen/internal/pdata/primitive_field.go
@@ -51,9 +51,6 @@ const primitiveSetTestTemplate = `orig.{{ .originFieldName }} = {{ .testValue }}
 
 const primitiveCopyOrigTemplate = `dest.{{ .originFieldName }} = src.{{ .originFieldName }}`
 
-const primitiveUnmarshalJSONTemplate = `case "{{ lowerFirst .originFieldName }}"{{ if needSnake .originFieldName -}}, "{{ toSnake .originFieldName }}"{{- end }}:
-		orig.{{ .originFieldName }} = iter.Read{{ upperFirst .returnType }}()`
-
 type PrimitiveField struct {
 	fieldName string
 	protoType proto.Type
@@ -92,9 +89,8 @@ func (pf *PrimitiveField) GenerateMarshalJSON(*messageStruct) string {
 	return pf.toProtoField().GenMarshalJSON()
 }
 
-func (pf *PrimitiveField) GenerateUnmarshalJSON(ms *messageStruct) string {
-	t := template.Parse("primitiveUnmarshalJSONTemplate", []byte(primitiveUnmarshalJSONTemplate))
-	return template.Execute(t, pf.templateFields(ms))
+func (pf *PrimitiveField) GenerateUnmarshalJSON(*messageStruct) string {
+	return pf.toProtoField().GenUnmarshalJSON()
 }
 
 func (pf *PrimitiveField) GenerateSizeProto(*messageStruct) string {

--- a/internal/cmd/pdatagen/internal/pdata/slice_field.go
+++ b/internal/cmd/pdatagen/internal/pdata/slice_field.go
@@ -32,9 +32,6 @@ const sliceSetTestTemplate = `orig.{{ .originFieldName }} = GenerateOrigTest{{ .
 
 const sliceCopyOrigTemplate = `dest.{{ .originFieldName }} = CopyOrig{{ .elementOriginName }}Slice(dest.{{ .originFieldName }}, src.{{ .originFieldName }})`
 
-const sliceUnmarshalJSONTemplate = `case "{{ lowerFirst .originFieldName }}"{{ if needSnake .originFieldName -}}, "{{ toSnake .originFieldName }}"{{- end }}:
-	orig.{{ .originFieldName }} = UnmarshalJSONOrig{{ .elementOriginName }}Slice(iter)`
-
 type SliceField struct {
 	fieldName     string
 	protoType     proto.Type
@@ -81,9 +78,8 @@ func (sf *SliceField) GenerateMarshalJSON(*messageStruct) string {
 	return sf.toProtoField().GenMarshalJSON()
 }
 
-func (sf *SliceField) GenerateUnmarshalJSON(ms *messageStruct) string {
-	t := template.Parse("sliceUnmarshalJSONTemplate", []byte(sliceUnmarshalJSONTemplate))
-	return template.Execute(t, sf.templateFields(ms))
+func (sf *SliceField) GenerateUnmarshalJSON(*messageStruct) string {
+	return sf.toProtoField().GenUnmarshalJSON()
 }
 
 func (sf *SliceField) GenerateSizeProto(*messageStruct) string {

--- a/internal/cmd/pdatagen/internal/pdata/templates/message_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/message_internal.go.tmpl
@@ -61,7 +61,7 @@ func MarshalJSONOrig{{ .originName }}(orig *{{ .originFullName }}, dest *json.St
 
 // UnmarshalJSONOrig{{ .structName }} unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrig{{ .originName }}(orig *{{ .originFullName }}, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		{{ range .fields -}}
 		{{ .GenerateUnmarshalJSON $.messageStruct }}
@@ -69,8 +69,7 @@ func UnmarshalJSONOrig{{ .originName }}(orig *{{ .originFullName }}, iter *json.
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrig{{ .originName }}(orig *{{ .originFullName }}) int {

--- a/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice_internal.go.tmpl
@@ -41,23 +41,3 @@ func CopyOrig{{ .elementOriginName }}Slice(dst, src []{{ .itemType }}) []{{ .ite
 func GenerateOrigTest{{ .elementOriginName }}Slice() []{{ .itemType }} {
 	return []{{ .itemType }}{ {{ .testOrigVal }} }
 }
-
-// UnmarshalJSONOrig{{ .elementOriginName }}Slice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrig{{ .elementOriginName }}Slice(iter *json.Iterator) []{{ .itemType }}{
-	{{- if eq .itemType "byte" }}
-	buf := iter.ReadStringAsSlice()
-	orig := make([]byte, base64.StdEncoding.DecodedLen(len(buf)))
-	n, err := base64.StdEncoding.Decode(orig, buf)
-	if err != nil {
-		iter.ReportError("base64.Decode", err.Error())
-	}
-	orig = orig[:n]
-	{{- else }}
-	var orig []{{ .itemType }}
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, iter.Read{{ upperFirst .itemType }}())
-		return true
-	})
-	{{- end }}
-	return orig
-}

--- a/internal/cmd/pdatagen/internal/pdata/templates/slice_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/slice_internal.go.tmpl
@@ -87,14 +87,3 @@ func GenerateOrigTest{{ .elementOriginName }}Slice() []{{ if .elementNullable }}
     {{- end }}
 	return orig
 }
-
-// UnmarshalJSONOrig{{ .elementOriginName }}Slice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrig{{ .elementOriginName }}Slice(iter *json.Iterator) []{{ if .elementNullable }}*{{ end }}{{ .elementOriginFullName }} {
-	var orig []{{ if .elementNullable }}*{{ end }}{{ .elementOriginFullName }}
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, {{- if .elementNullable }}NewOrig{{ .elementOriginName }}(){{ else }}{{ .elementOriginFullName }}{}{{ end }})
-		UnmarshalJSONOrig{{ .elementOriginName }}({{ if not .elementNullable }}&{{ end }}orig[len(orig)-1], iter)
-		return true
-	})
-	return orig
-}

--- a/internal/cmd/pdatagen/internal/pdata/typed_field.go
+++ b/internal/cmd/pdatagen/internal/pdata/typed_field.go
@@ -33,15 +33,6 @@ const typedSetTestTemplate = `orig.{{ .originFieldName }} = {{ .testValue }}`
 
 const typedCopyOrigTemplate = `dest.{{ .originFieldName }} = src.{{ .originFieldName }}`
 
-const typedUnmarshalJSONTemplate = `case "{{ lowerFirst .originFieldName }}"{{ if needSnake .originFieldName -}}, "{{ toSnake .originFieldName }}"{{- end }}:
-		{{- if .isType }}
-		orig.{{ .originFieldName }}.UnmarshalJSONIter(iter)
-		{{- else if .isEnum }}
-		orig.{{ .originFieldName }} = {{ .rawType }}(iter.ReadEnumValue({{ .rawType }}_value))
-		{{- else }}	
-		orig.{{ .originFieldName }} = iter.Read{{ upperFirst .rawType }}()
-		{{- end }}`
-
 // TypedField is a field that has defined a custom type (e.g. "type Timestamp uint64")
 type TypedField struct {
 	fieldName       string
@@ -96,9 +87,8 @@ func (ptf *TypedField) GenerateMarshalJSON(*messageStruct) string {
 	return ptf.toProtoField().GenMarshalJSON()
 }
 
-func (ptf *TypedField) GenerateUnmarshalJSON(ms *messageStruct) string {
-	t := template.Parse("typedUnmarshalJSONTemplate", []byte(typedUnmarshalJSONTemplate))
-	return template.Execute(t, ptf.templateFields(ms))
+func (ptf *TypedField) GenerateUnmarshalJSON(*messageStruct) string {
+	return ptf.toProtoField().GenUnmarshalJSON()
 }
 
 func (ptf *TypedField) GenerateSizeProto(*messageStruct) string {
@@ -139,8 +129,6 @@ func (ptf *TypedField) templateFields(ms *messageStruct) map[string]any {
 		"lowerFieldName":  strings.ToLower(ptf.fieldName),
 		"testValue":       ptf.returnType.testVal,
 		"rawType":         pf.GoType(),
-		"isType":          ptf.returnType.protoType == proto.TypeMessage,
-		"isEnum":          ptf.returnType.protoType == proto.TypeEnum,
 		"originFieldName": ptf.getOriginFieldName(),
 	}
 }

--- a/internal/cmd/pdatagen/internal/proto/field.go
+++ b/internal/cmd/pdatagen/internal/proto/field.go
@@ -126,6 +126,7 @@ func (pf *Field) getTemplateFields() map[string]any {
 		"jsonTag":              genJSONTag(pf.Name),
 		"fieldName":            pf.Name,
 		"origName":             pf.messageName(),
+		"origFullName":         pf.MessageFullName,
 		"oneOfGroup":           pf.OneOfGroup,
 		"oneOfMessageFullName": pf.OneOfMessageFullName,
 		"repeated":             pf.Repeated,

--- a/internal/cmd/pdatagen/internal/proto/json_unmarshal.go
+++ b/internal/cmd/pdatagen/internal/proto/json_unmarshal.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package proto // import "go.opentelemetry.io/collector/internal/cmd/pdatagen/internal/proto"
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ettle/strcase"
+
+	"go.opentelemetry.io/collector/internal/cmd/pdatagen/internal/template"
+)
+
+const unmarshalJSONPrimitive = `	case {{ .allJSONTags }}:
+{{ if .repeated -}}
+	for iter.ReadArray() {
+		orig.{{ .fieldName }} = append(orig.{{ .fieldName }}, iter.Read{{ upperFirst .goType }}())
+	}
+{{ else if .nullable -}}
+	{
+		ofm := &{{ .oneOfMessageFullName }}{}
+		ofm.{{ .fieldName }} = iter.Read{{ upperFirst .goType }}()
+		orig.{{ .oneOfGroup }} = ofm
+	}
+{{ else -}}
+	orig.{{ .fieldName }} = iter.Read{{ upperFirst .goType }}()
+{{- end }}`
+
+const unmarshalJSONEnum = `	case {{ .allJSONTags }}:
+{{ if .repeated -}}
+	for iter.ReadArray() {
+		orig.{{ .fieldName }} = append(orig.{{ .fieldName }}, {{ .origFullName }}(iter.ReadEnumValue({{ .origFullName }}_value)))
+	}
+{{ else -}}
+	orig.{{ .fieldName }} = {{ .origFullName }}(iter.ReadEnumValue({{ .origFullName }}_value))
+{{- end }}`
+
+const unmarshalJSONMessage = `	case {{ .allJSONTags }}:
+{{ if .repeated -}}
+	for iter.ReadArray() {
+		orig.{{ .fieldName }} = append(orig.{{ .fieldName }}, {{ if .nullable }}NewOrig{{ .origName }}(){{ else }}{{ .defaultValue }}{{ end }})
+		UnmarshalJSONOrig{{ .origName }}({{ if not .nullable }}&{{ end }}orig.{{ .fieldName }}[len(orig.{{ .fieldName }}) - 1], iter)
+	}
+{{ else if ne .oneOfGroup "" -}}
+	{
+		ofm := &{{ .oneOfMessageFullName }}{}
+		ofm.{{ .fieldName }} = NewOrig{{ .origName }}()
+		UnmarshalJSONOrig{{ .origName }}(ofm.{{ .fieldName }}, iter)
+		orig.{{ .oneOfGroup }} = ofm
+	}
+{{ else -}}
+	UnmarshalJSONOrig{{ .origName }}({{ if not .nullable }}&{{ end }}orig.{{ .fieldName }}, iter)
+{{- end }}`
+
+const unmarshalJSONBytes = `	case {{ .allJSONTags }}:
+{{ if .repeated -}}
+	for iter.ReadArray() {
+		orig.{{ .fieldName }} = append(orig.{{ .fieldName }}, iter.ReadBytes())
+	}
+{{ else -}}
+	orig.{{ .fieldName }} = iter.ReadBytes()
+{{- end }}`
+
+func (pf *Field) GenUnmarshalJSON() string {
+	tf := pf.getTemplateFields()
+	tf["allJSONTags"] = allJSONTags(pf.Name)
+	switch pf.Type {
+	case TypeBytes:
+		return template.Execute(template.Parse("unmarshalJSONBytes", []byte(unmarshalJSONBytes)), tf)
+	case TypeMessage:
+		return template.Execute(template.Parse("unmarshalJSONMessage", []byte(unmarshalJSONMessage)), tf)
+	case TypeEnum:
+		return template.Execute(template.Parse("unmarshalJSONEnum", []byte(unmarshalJSONEnum)), tf)
+	case TypeDouble, TypeFloat,
+		TypeFixed64, TypeSFixed64, TypeFixed32, TypeSFixed32,
+		TypeInt32, TypeInt64, TypeUint32, TypeUint64,
+		TypeSInt32, TypeSInt64,
+		TypeBool, TypeString:
+		return template.Execute(template.Parse("unmarshalJSONPrimitive", []byte(unmarshalJSONPrimitive)), tf)
+	}
+	panic(fmt.Sprintf("unhandled case %T", pf.Type))
+}
+
+func allJSONTags(str string) string {
+	snake := strcase.ToSnake(str)
+	if !strings.EqualFold(str, snake) {
+		return `"` + lowerFirst(str) + `", "` + snake + `"`
+	}
+	return `"` + lowerFirst(str) + `"`
+}

--- a/pdata/internal/generated_wrapper_anyvalueslice.go
+++ b/pdata/internal/generated_wrapper_anyvalueslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 type Slice struct {
@@ -55,16 +54,5 @@ func GenerateOrigTestAnyValueSlice() []otlpcommon.AnyValue {
 	orig := make([]otlpcommon.AnyValue, 5)
 	orig[1] = *GenTestOrigAnyValue()
 	orig[3] = *GenTestOrigAnyValue()
-	return orig
-}
-
-// UnmarshalJSONOrigAnyValueSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigAnyValueSlice(iter *json.Iterator) []otlpcommon.AnyValue {
-	var orig []otlpcommon.AnyValue
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, otlpcommon.AnyValue{})
-		UnmarshalJSONOrigAnyValue(&orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_attributeunit.go
+++ b/pdata/internal/generated_wrapper_attributeunit.go
@@ -46,7 +46,7 @@ func MarshalJSONOrigAttributeUnit(orig *otlpprofiles.AttributeUnit, dest *json.S
 
 // UnmarshalJSONOrigAttributeUnit unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigAttributeUnit(orig *otlpprofiles.AttributeUnit, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "attributeKeyStrindex", "attribute_key_strindex":
 			orig.AttributeKeyStrindex = iter.ReadInt32()
@@ -55,8 +55,7 @@ func UnmarshalJSONOrigAttributeUnit(orig *otlpprofiles.AttributeUnit, iter *json
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigAttributeUnit(orig *otlpprofiles.AttributeUnit) int {

--- a/pdata/internal/generated_wrapper_attributeunitslice.go
+++ b/pdata/internal/generated_wrapper_attributeunitslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigAttributeUnitSlice(dest, src []*otlpprofiles.AttributeUnit) []*otlpprofiles.AttributeUnit {
@@ -47,16 +46,5 @@ func GenerateOrigTestAttributeUnitSlice() []*otlpprofiles.AttributeUnit {
 	orig[2] = NewOrigAttributeUnit()
 	orig[3] = GenTestOrigAttributeUnit()
 	orig[4] = NewOrigAttributeUnit()
-	return orig
-}
-
-// UnmarshalJSONOrigAttributeUnitSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigAttributeUnitSlice(iter *json.Iterator) []*otlpprofiles.AttributeUnit {
-	var orig []*otlpprofiles.AttributeUnit
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigAttributeUnit())
-		UnmarshalJSONOrigAttributeUnit(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_byteslice.go
+++ b/pdata/internal/generated_wrapper_byteslice.go
@@ -6,12 +6,6 @@
 
 package internal
 
-import (
-	"encoding/base64"
-
-	"go.opentelemetry.io/collector/pdata/internal/json"
-)
-
 type ByteSlice struct {
 	orig  *[]byte
 	state *State
@@ -40,16 +34,4 @@ func CopyOrigByteSlice(dst, src []byte) []byte {
 
 func GenerateOrigTestByteSlice() []byte {
 	return []byte{1, 2, 3}
-}
-
-// UnmarshalJSONOrigByteSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigByteSlice(iter *json.Iterator) []byte {
-	buf := iter.ReadStringAsSlice()
-	orig := make([]byte, base64.StdEncoding.DecodedLen(len(buf)))
-	n, err := base64.StdEncoding.Decode(orig, buf)
-	if err != nil {
-		iter.ReportError("base64.Decode", err.Error())
-	}
-	orig = orig[:n]
-	return orig
 }

--- a/pdata/internal/generated_wrapper_entityref.go
+++ b/pdata/internal/generated_wrapper_entityref.go
@@ -87,21 +87,26 @@ func MarshalJSONOrigEntityRef(orig *otlpcommon.EntityRef, dest *json.Stream) {
 
 // UnmarshalJSONOrigEntityRef unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigEntityRef(orig *otlpcommon.EntityRef, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		case "type":
 			orig.Type = iter.ReadString()
 		case "idKeys", "id_keys":
-			orig.IdKeys = UnmarshalJSONOrigStringSlice(iter)
+			for iter.ReadArray() {
+				orig.IdKeys = append(orig.IdKeys, iter.ReadString())
+			}
+
 		case "descriptionKeys", "description_keys":
-			orig.DescriptionKeys = UnmarshalJSONOrigStringSlice(iter)
+			for iter.ReadArray() {
+				orig.DescriptionKeys = append(orig.DescriptionKeys, iter.ReadString())
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigEntityRef(orig *otlpcommon.EntityRef) int {

--- a/pdata/internal/generated_wrapper_entityrefslice.go
+++ b/pdata/internal/generated_wrapper_entityrefslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 type EntityRefSlice struct {
@@ -69,16 +68,5 @@ func GenerateOrigTestEntityRefSlice() []*otlpcommon.EntityRef {
 	orig[2] = NewOrigEntityRef()
 	orig[3] = GenTestOrigEntityRef()
 	orig[4] = NewOrigEntityRef()
-	return orig
-}
-
-// UnmarshalJSONOrigEntityRefSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigEntityRefSlice(iter *json.Iterator) []*otlpcommon.EntityRef {
-	var orig []*otlpcommon.EntityRef
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigEntityRef())
-		UnmarshalJSONOrigEntityRef(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_exemplarslice.go
+++ b/pdata/internal/generated_wrapper_exemplarslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigExemplarSlice(dest, src []otlpmetrics.Exemplar) []otlpmetrics.Exemplar {
@@ -33,16 +32,5 @@ func GenerateOrigTestExemplarSlice() []otlpmetrics.Exemplar {
 	orig := make([]otlpmetrics.Exemplar, 5)
 	orig[1] = *GenTestOrigExemplar()
 	orig[3] = *GenTestOrigExemplar()
-	return orig
-}
-
-// UnmarshalJSONOrigExemplarSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigExemplarSlice(iter *json.Iterator) []otlpmetrics.Exemplar {
-	var orig []otlpmetrics.Exemplar
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, otlpmetrics.Exemplar{})
-		UnmarshalJSONOrigExemplar(&orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_exponentialhistogram.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogram.go
@@ -53,17 +53,20 @@ func MarshalJSONOrigExponentialHistogram(orig *otlpmetrics.ExponentialHistogram,
 
 // UnmarshalJSONOrigExponentialHistogram unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExponentialHistogram(orig *otlpmetrics.ExponentialHistogram, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "dataPoints", "data_points":
-			orig.DataPoints = UnmarshalJSONOrigExponentialHistogramDataPointSlice(iter)
+			for iter.ReadArray() {
+				orig.DataPoints = append(orig.DataPoints, NewOrigExponentialHistogramDataPoint())
+				UnmarshalJSONOrigExponentialHistogramDataPoint(orig.DataPoints[len(orig.DataPoints)-1], iter)
+			}
+
 		case "aggregationTemporality", "aggregation_temporality":
 			orig.AggregationTemporality = otlpmetrics.AggregationTemporality(iter.ReadEnumValue(otlpmetrics.AggregationTemporality_value))
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExponentialHistogram(orig *otlpmetrics.ExponentialHistogram) int {

--- a/pdata/internal/generated_wrapper_exponentialhistogramdatapoint.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogramdatapoint.go
@@ -156,10 +156,14 @@ func MarshalJSONOrigExponentialHistogramDataPoint(orig *otlpmetrics.ExponentialH
 
 // UnmarshalJSONOrigExponentialHistogramDataPoint unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExponentialHistogramDataPoint(orig *otlpmetrics.ExponentialHistogramDataPoint, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "attributes":
-			orig.Attributes = UnmarshalJSONOrigKeyValueSlice(iter)
+			for iter.ReadArray() {
+				orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
+				UnmarshalJSONOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], iter)
+			}
+
 		case "startTimeUnixNano", "start_time_unix_nano":
 			orig.StartTimeUnixNano = iter.ReadUint64()
 		case "timeUnixNano", "time_unix_nano":
@@ -167,7 +171,12 @@ func UnmarshalJSONOrigExponentialHistogramDataPoint(orig *otlpmetrics.Exponentia
 		case "count":
 			orig.Count = iter.ReadUint64()
 		case "sum":
-			orig.Sum_ = &otlpmetrics.ExponentialHistogramDataPoint_Sum{Sum: iter.ReadFloat64()}
+			{
+				ofm := &otlpmetrics.ExponentialHistogramDataPoint_Sum{}
+				ofm.Sum = iter.ReadFloat64()
+				orig.Sum_ = ofm
+			}
+
 		case "scale":
 			orig.Scale = iter.ReadInt32()
 		case "zeroCount", "zero_count":
@@ -179,18 +188,31 @@ func UnmarshalJSONOrigExponentialHistogramDataPoint(orig *otlpmetrics.Exponentia
 		case "flags":
 			orig.Flags = iter.ReadUint32()
 		case "exemplars":
-			orig.Exemplars = UnmarshalJSONOrigExemplarSlice(iter)
+			for iter.ReadArray() {
+				orig.Exemplars = append(orig.Exemplars, otlpmetrics.Exemplar{})
+				UnmarshalJSONOrigExemplar(&orig.Exemplars[len(orig.Exemplars)-1], iter)
+			}
+
 		case "min":
-			orig.Min_ = &otlpmetrics.ExponentialHistogramDataPoint_Min{Min: iter.ReadFloat64()}
+			{
+				ofm := &otlpmetrics.ExponentialHistogramDataPoint_Min{}
+				ofm.Min = iter.ReadFloat64()
+				orig.Min_ = ofm
+			}
+
 		case "max":
-			orig.Max_ = &otlpmetrics.ExponentialHistogramDataPoint_Max{Max: iter.ReadFloat64()}
+			{
+				ofm := &otlpmetrics.ExponentialHistogramDataPoint_Max{}
+				ofm.Max = iter.ReadFloat64()
+				orig.Max_ = ofm
+			}
+
 		case "zeroThreshold", "zero_threshold":
 			orig.ZeroThreshold = iter.ReadFloat64()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExponentialHistogramDataPoint(orig *otlpmetrics.ExponentialHistogramDataPoint) int {

--- a/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_buckets.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_buckets.go
@@ -52,17 +52,19 @@ func MarshalJSONOrigExponentialHistogramDataPoint_Buckets(orig *otlpmetrics.Expo
 
 // UnmarshalJSONOrigExponentialHistogramDataPointBuckets unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExponentialHistogramDataPoint_Buckets(orig *otlpmetrics.ExponentialHistogramDataPoint_Buckets, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "offset":
 			orig.Offset = iter.ReadInt32()
 		case "bucketCounts", "bucket_counts":
-			orig.BucketCounts = UnmarshalJSONOrigUint64Slice(iter)
+			for iter.ReadArray() {
+				orig.BucketCounts = append(orig.BucketCounts, iter.ReadUint64())
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExponentialHistogramDataPoint_Buckets(orig *otlpmetrics.ExponentialHistogramDataPoint_Buckets) int {

--- a/pdata/internal/generated_wrapper_exponentialhistogramdatapointslice.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogramdatapointslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigExponentialHistogramDataPointSlice(dest, src []*otlpmetrics.ExponentialHistogramDataPoint) []*otlpmetrics.ExponentialHistogramDataPoint {
@@ -47,16 +46,5 @@ func GenerateOrigTestExponentialHistogramDataPointSlice() []*otlpmetrics.Exponen
 	orig[2] = NewOrigExponentialHistogramDataPoint()
 	orig[3] = GenTestOrigExponentialHistogramDataPoint()
 	orig[4] = NewOrigExponentialHistogramDataPoint()
-	return orig
-}
-
-// UnmarshalJSONOrigExponentialHistogramDataPointSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigExponentialHistogramDataPointSlice(iter *json.Iterator) []*otlpmetrics.ExponentialHistogramDataPoint {
-	var orig []*otlpmetrics.ExponentialHistogramDataPoint
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigExponentialHistogramDataPoint())
-		UnmarshalJSONOrigExponentialHistogramDataPoint(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_exportlogspartialsuccess.go
+++ b/pdata/internal/generated_wrapper_exportlogspartialsuccess.go
@@ -46,7 +46,7 @@ func MarshalJSONOrigExportLogsPartialSuccess(orig *otlpcollectorlogs.ExportLogsP
 
 // UnmarshalJSONOrigExportPartialSuccess unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportLogsPartialSuccess(orig *otlpcollectorlogs.ExportLogsPartialSuccess, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "rejectedLogRecords", "rejected_log_records":
 			orig.RejectedLogRecords = iter.ReadInt64()
@@ -55,8 +55,7 @@ func UnmarshalJSONOrigExportLogsPartialSuccess(orig *otlpcollectorlogs.ExportLog
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportLogsPartialSuccess(orig *otlpcollectorlogs.ExportLogsPartialSuccess) int {

--- a/pdata/internal/generated_wrapper_exportlogsservicerequest.go
+++ b/pdata/internal/generated_wrapper_exportlogsservicerequest.go
@@ -63,15 +63,18 @@ func MarshalJSONOrigExportLogsServiceRequest(orig *otlpcollectorlogs.ExportLogsS
 
 // UnmarshalJSONOrigLogs unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportLogsServiceRequest(orig *otlpcollectorlogs.ExportLogsServiceRequest, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "resourceLogs", "resource_logs":
-			orig.ResourceLogs = UnmarshalJSONOrigResourceLogsSlice(iter)
+			for iter.ReadArray() {
+				orig.ResourceLogs = append(orig.ResourceLogs, NewOrigResourceLogs())
+				UnmarshalJSONOrigResourceLogs(orig.ResourceLogs[len(orig.ResourceLogs)-1], iter)
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportLogsServiceRequest(orig *otlpcollectorlogs.ExportLogsServiceRequest) int {

--- a/pdata/internal/generated_wrapper_exportlogsserviceresponse.go
+++ b/pdata/internal/generated_wrapper_exportlogsserviceresponse.go
@@ -38,15 +38,14 @@ func MarshalJSONOrigExportLogsServiceResponse(orig *otlpcollectorlogs.ExportLogs
 
 // UnmarshalJSONOrigExportResponse unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportLogsServiceResponse(orig *otlpcollectorlogs.ExportLogsServiceResponse, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "partialSuccess", "partial_success":
 			UnmarshalJSONOrigExportLogsPartialSuccess(&orig.PartialSuccess, iter)
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportLogsServiceResponse(orig *otlpcollectorlogs.ExportLogsServiceResponse) int {

--- a/pdata/internal/generated_wrapper_exportmetricspartialsuccess.go
+++ b/pdata/internal/generated_wrapper_exportmetricspartialsuccess.go
@@ -46,7 +46,7 @@ func MarshalJSONOrigExportMetricsPartialSuccess(orig *otlpcollectormetrics.Expor
 
 // UnmarshalJSONOrigExportPartialSuccess unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportMetricsPartialSuccess(orig *otlpcollectormetrics.ExportMetricsPartialSuccess, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "rejectedDataPoints", "rejected_data_points":
 			orig.RejectedDataPoints = iter.ReadInt64()
@@ -55,8 +55,7 @@ func UnmarshalJSONOrigExportMetricsPartialSuccess(orig *otlpcollectormetrics.Exp
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportMetricsPartialSuccess(orig *otlpcollectormetrics.ExportMetricsPartialSuccess) int {

--- a/pdata/internal/generated_wrapper_exportmetricsservicerequest.go
+++ b/pdata/internal/generated_wrapper_exportmetricsservicerequest.go
@@ -63,15 +63,18 @@ func MarshalJSONOrigExportMetricsServiceRequest(orig *otlpcollectormetrics.Expor
 
 // UnmarshalJSONOrigMetrics unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportMetricsServiceRequest(orig *otlpcollectormetrics.ExportMetricsServiceRequest, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "resourceMetrics", "resource_metrics":
-			orig.ResourceMetrics = UnmarshalJSONOrigResourceMetricsSlice(iter)
+			for iter.ReadArray() {
+				orig.ResourceMetrics = append(orig.ResourceMetrics, NewOrigResourceMetrics())
+				UnmarshalJSONOrigResourceMetrics(orig.ResourceMetrics[len(orig.ResourceMetrics)-1], iter)
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportMetricsServiceRequest(orig *otlpcollectormetrics.ExportMetricsServiceRequest) int {

--- a/pdata/internal/generated_wrapper_exportmetricsserviceresponse.go
+++ b/pdata/internal/generated_wrapper_exportmetricsserviceresponse.go
@@ -38,15 +38,14 @@ func MarshalJSONOrigExportMetricsServiceResponse(orig *otlpcollectormetrics.Expo
 
 // UnmarshalJSONOrigExportResponse unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportMetricsServiceResponse(orig *otlpcollectormetrics.ExportMetricsServiceResponse, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "partialSuccess", "partial_success":
 			UnmarshalJSONOrigExportMetricsPartialSuccess(&orig.PartialSuccess, iter)
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportMetricsServiceResponse(orig *otlpcollectormetrics.ExportMetricsServiceResponse) int {

--- a/pdata/internal/generated_wrapper_exportprofilespartialsuccess.go
+++ b/pdata/internal/generated_wrapper_exportprofilespartialsuccess.go
@@ -46,7 +46,7 @@ func MarshalJSONOrigExportProfilesPartialSuccess(orig *otlpcollectorprofiles.Exp
 
 // UnmarshalJSONOrigExportPartialSuccess unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportProfilesPartialSuccess(orig *otlpcollectorprofiles.ExportProfilesPartialSuccess, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "rejectedProfiles", "rejected_profiles":
 			orig.RejectedProfiles = iter.ReadInt64()
@@ -55,8 +55,7 @@ func UnmarshalJSONOrigExportProfilesPartialSuccess(orig *otlpcollectorprofiles.E
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportProfilesPartialSuccess(orig *otlpcollectorprofiles.ExportProfilesPartialSuccess) int {

--- a/pdata/internal/generated_wrapper_exportprofilesservicerequest.go
+++ b/pdata/internal/generated_wrapper_exportprofilesservicerequest.go
@@ -67,17 +67,20 @@ func MarshalJSONOrigExportProfilesServiceRequest(orig *otlpcollectorprofiles.Exp
 
 // UnmarshalJSONOrigProfiles unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportProfilesServiceRequest(orig *otlpcollectorprofiles.ExportProfilesServiceRequest, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "resourceProfiles", "resource_profiles":
-			orig.ResourceProfiles = UnmarshalJSONOrigResourceProfilesSlice(iter)
+			for iter.ReadArray() {
+				orig.ResourceProfiles = append(orig.ResourceProfiles, NewOrigResourceProfiles())
+				UnmarshalJSONOrigResourceProfiles(orig.ResourceProfiles[len(orig.ResourceProfiles)-1], iter)
+			}
+
 		case "dictionary":
 			UnmarshalJSONOrigProfilesDictionary(&orig.Dictionary, iter)
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportProfilesServiceRequest(orig *otlpcollectorprofiles.ExportProfilesServiceRequest) int {

--- a/pdata/internal/generated_wrapper_exportprofilesserviceresponse.go
+++ b/pdata/internal/generated_wrapper_exportprofilesserviceresponse.go
@@ -38,15 +38,14 @@ func MarshalJSONOrigExportProfilesServiceResponse(orig *otlpcollectorprofiles.Ex
 
 // UnmarshalJSONOrigExportResponse unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportProfilesServiceResponse(orig *otlpcollectorprofiles.ExportProfilesServiceResponse, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "partialSuccess", "partial_success":
 			UnmarshalJSONOrigExportProfilesPartialSuccess(&orig.PartialSuccess, iter)
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportProfilesServiceResponse(orig *otlpcollectorprofiles.ExportProfilesServiceResponse) int {

--- a/pdata/internal/generated_wrapper_exporttracepartialsuccess.go
+++ b/pdata/internal/generated_wrapper_exporttracepartialsuccess.go
@@ -46,7 +46,7 @@ func MarshalJSONOrigExportTracePartialSuccess(orig *otlpcollectortrace.ExportTra
 
 // UnmarshalJSONOrigExportPartialSuccess unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportTracePartialSuccess(orig *otlpcollectortrace.ExportTracePartialSuccess, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "rejectedSpans", "rejected_spans":
 			orig.RejectedSpans = iter.ReadInt64()
@@ -55,8 +55,7 @@ func UnmarshalJSONOrigExportTracePartialSuccess(orig *otlpcollectortrace.ExportT
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportTracePartialSuccess(orig *otlpcollectortrace.ExportTracePartialSuccess) int {

--- a/pdata/internal/generated_wrapper_exporttraceservicerequest.go
+++ b/pdata/internal/generated_wrapper_exporttraceservicerequest.go
@@ -63,15 +63,18 @@ func MarshalJSONOrigExportTraceServiceRequest(orig *otlpcollectortrace.ExportTra
 
 // UnmarshalJSONOrigTraces unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportTraceServiceRequest(orig *otlpcollectortrace.ExportTraceServiceRequest, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "resourceSpans", "resource_spans":
-			orig.ResourceSpans = UnmarshalJSONOrigResourceSpansSlice(iter)
+			for iter.ReadArray() {
+				orig.ResourceSpans = append(orig.ResourceSpans, NewOrigResourceSpans())
+				UnmarshalJSONOrigResourceSpans(orig.ResourceSpans[len(orig.ResourceSpans)-1], iter)
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportTraceServiceRequest(orig *otlpcollectortrace.ExportTraceServiceRequest) int {

--- a/pdata/internal/generated_wrapper_exporttraceserviceresponse.go
+++ b/pdata/internal/generated_wrapper_exporttraceserviceresponse.go
@@ -38,15 +38,14 @@ func MarshalJSONOrigExportTraceServiceResponse(orig *otlpcollectortrace.ExportTr
 
 // UnmarshalJSONOrigExportResponse unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigExportTraceServiceResponse(orig *otlpcollectortrace.ExportTraceServiceResponse, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "partialSuccess", "partial_success":
 			UnmarshalJSONOrigExportTracePartialSuccess(&orig.PartialSuccess, iter)
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigExportTraceServiceResponse(orig *otlpcollectortrace.ExportTraceServiceResponse) int {

--- a/pdata/internal/generated_wrapper_float64slice.go
+++ b/pdata/internal/generated_wrapper_float64slice.go
@@ -6,10 +6,6 @@
 
 package internal
 
-import (
-	"go.opentelemetry.io/collector/pdata/internal/json"
-)
-
 type Float64Slice struct {
 	orig  *[]float64
 	state *State
@@ -38,14 +34,4 @@ func CopyOrigFloat64Slice(dst, src []float64) []float64 {
 
 func GenerateOrigTestFloat64Slice() []float64 {
 	return []float64{1.1, 2.2, 3.3}
-}
-
-// UnmarshalJSONOrigFloat64Slice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigFloat64Slice(iter *json.Iterator) []float64 {
-	var orig []float64
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, iter.ReadFloat64())
-		return true
-	})
-	return orig
 }

--- a/pdata/internal/generated_wrapper_function.go
+++ b/pdata/internal/generated_wrapper_function.go
@@ -58,7 +58,7 @@ func MarshalJSONOrigFunction(orig *otlpprofiles.Function, dest *json.Stream) {
 
 // UnmarshalJSONOrigFunction unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigFunction(orig *otlpprofiles.Function, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "nameStrindex", "name_strindex":
 			orig.NameStrindex = iter.ReadInt32()
@@ -71,8 +71,7 @@ func UnmarshalJSONOrigFunction(orig *otlpprofiles.Function, iter *json.Iterator)
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigFunction(orig *otlpprofiles.Function) int {

--- a/pdata/internal/generated_wrapper_functionslice.go
+++ b/pdata/internal/generated_wrapper_functionslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigFunctionSlice(dest, src []*otlpprofiles.Function) []*otlpprofiles.Function {
@@ -47,16 +46,5 @@ func GenerateOrigTestFunctionSlice() []*otlpprofiles.Function {
 	orig[2] = NewOrigFunction()
 	orig[3] = GenTestOrigFunction()
 	orig[4] = NewOrigFunction()
-	return orig
-}
-
-// UnmarshalJSONOrigFunctionSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigFunctionSlice(iter *json.Iterator) []*otlpprofiles.Function {
-	var orig []*otlpprofiles.Function
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigFunction())
-		UnmarshalJSONOrigFunction(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_gauge.go
+++ b/pdata/internal/generated_wrapper_gauge.go
@@ -46,15 +46,18 @@ func MarshalJSONOrigGauge(orig *otlpmetrics.Gauge, dest *json.Stream) {
 
 // UnmarshalJSONOrigGauge unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigGauge(orig *otlpmetrics.Gauge, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "dataPoints", "data_points":
-			orig.DataPoints = UnmarshalJSONOrigNumberDataPointSlice(iter)
+			for iter.ReadArray() {
+				orig.DataPoints = append(orig.DataPoints, NewOrigNumberDataPoint())
+				UnmarshalJSONOrigNumberDataPoint(orig.DataPoints[len(orig.DataPoints)-1], iter)
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigGauge(orig *otlpmetrics.Gauge) int {

--- a/pdata/internal/generated_wrapper_histogram.go
+++ b/pdata/internal/generated_wrapper_histogram.go
@@ -53,17 +53,20 @@ func MarshalJSONOrigHistogram(orig *otlpmetrics.Histogram, dest *json.Stream) {
 
 // UnmarshalJSONOrigHistogram unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigHistogram(orig *otlpmetrics.Histogram, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "dataPoints", "data_points":
-			orig.DataPoints = UnmarshalJSONOrigHistogramDataPointSlice(iter)
+			for iter.ReadArray() {
+				orig.DataPoints = append(orig.DataPoints, NewOrigHistogramDataPoint())
+				UnmarshalJSONOrigHistogramDataPoint(orig.DataPoints[len(orig.DataPoints)-1], iter)
+			}
+
 		case "aggregationTemporality", "aggregation_temporality":
 			orig.AggregationTemporality = otlpmetrics.AggregationTemporality(iter.ReadEnumValue(otlpmetrics.AggregationTemporality_value))
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigHistogram(orig *otlpmetrics.Histogram) int {

--- a/pdata/internal/generated_wrapper_histogramdatapoint.go
+++ b/pdata/internal/generated_wrapper_histogramdatapoint.go
@@ -154,10 +154,14 @@ func MarshalJSONOrigHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint, des
 
 // UnmarshalJSONOrigHistogramDataPoint unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "attributes":
-			orig.Attributes = UnmarshalJSONOrigKeyValueSlice(iter)
+			for iter.ReadArray() {
+				orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
+				UnmarshalJSONOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], iter)
+			}
+
 		case "startTimeUnixNano", "start_time_unix_nano":
 			orig.StartTimeUnixNano = iter.ReadUint64()
 		case "timeUnixNano", "time_unix_nano":
@@ -165,24 +169,48 @@ func UnmarshalJSONOrigHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint, i
 		case "count":
 			orig.Count = iter.ReadUint64()
 		case "sum":
-			orig.Sum_ = &otlpmetrics.HistogramDataPoint_Sum{Sum: iter.ReadFloat64()}
+			{
+				ofm := &otlpmetrics.HistogramDataPoint_Sum{}
+				ofm.Sum = iter.ReadFloat64()
+				orig.Sum_ = ofm
+			}
+
 		case "bucketCounts", "bucket_counts":
-			orig.BucketCounts = UnmarshalJSONOrigUint64Slice(iter)
+			for iter.ReadArray() {
+				orig.BucketCounts = append(orig.BucketCounts, iter.ReadUint64())
+			}
+
 		case "explicitBounds", "explicit_bounds":
-			orig.ExplicitBounds = UnmarshalJSONOrigFloat64Slice(iter)
+			for iter.ReadArray() {
+				orig.ExplicitBounds = append(orig.ExplicitBounds, iter.ReadFloat64())
+			}
+
 		case "exemplars":
-			orig.Exemplars = UnmarshalJSONOrigExemplarSlice(iter)
+			for iter.ReadArray() {
+				orig.Exemplars = append(orig.Exemplars, otlpmetrics.Exemplar{})
+				UnmarshalJSONOrigExemplar(&orig.Exemplars[len(orig.Exemplars)-1], iter)
+			}
+
 		case "flags":
 			orig.Flags = iter.ReadUint32()
 		case "min":
-			orig.Min_ = &otlpmetrics.HistogramDataPoint_Min{Min: iter.ReadFloat64()}
+			{
+				ofm := &otlpmetrics.HistogramDataPoint_Min{}
+				ofm.Min = iter.ReadFloat64()
+				orig.Min_ = ofm
+			}
+
 		case "max":
-			orig.Max_ = &otlpmetrics.HistogramDataPoint_Max{Max: iter.ReadFloat64()}
+			{
+				ofm := &otlpmetrics.HistogramDataPoint_Max{}
+				ofm.Max = iter.ReadFloat64()
+				orig.Max_ = ofm
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint) int {

--- a/pdata/internal/generated_wrapper_histogramdatapointslice.go
+++ b/pdata/internal/generated_wrapper_histogramdatapointslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigHistogramDataPointSlice(dest, src []*otlpmetrics.HistogramDataPoint) []*otlpmetrics.HistogramDataPoint {
@@ -47,16 +46,5 @@ func GenerateOrigTestHistogramDataPointSlice() []*otlpmetrics.HistogramDataPoint
 	orig[2] = NewOrigHistogramDataPoint()
 	orig[3] = GenTestOrigHistogramDataPoint()
 	orig[4] = NewOrigHistogramDataPoint()
-	return orig
-}
-
-// UnmarshalJSONOrigHistogramDataPointSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigHistogramDataPointSlice(iter *json.Iterator) []*otlpmetrics.HistogramDataPoint {
-	var orig []*otlpmetrics.HistogramDataPoint
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigHistogramDataPoint())
-		UnmarshalJSONOrigHistogramDataPoint(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_instrumentationscope.go
+++ b/pdata/internal/generated_wrapper_instrumentationscope.go
@@ -81,21 +81,24 @@ func MarshalJSONOrigInstrumentationScope(orig *otlpcommon.InstrumentationScope, 
 
 // UnmarshalJSONOrigInstrumentationScope unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigInstrumentationScope(orig *otlpcommon.InstrumentationScope, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "name":
 			orig.Name = iter.ReadString()
 		case "version":
 			orig.Version = iter.ReadString()
 		case "attributes":
-			orig.Attributes = UnmarshalJSONOrigKeyValueSlice(iter)
+			for iter.ReadArray() {
+				orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
+				UnmarshalJSONOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], iter)
+			}
+
 		case "droppedAttributesCount", "dropped_attributes_count":
 			orig.DroppedAttributesCount = iter.ReadUint32()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigInstrumentationScope(orig *otlpcommon.InstrumentationScope) int {

--- a/pdata/internal/generated_wrapper_int32slice.go
+++ b/pdata/internal/generated_wrapper_int32slice.go
@@ -6,10 +6,6 @@
 
 package internal
 
-import (
-	"go.opentelemetry.io/collector/pdata/internal/json"
-)
-
 type Int32Slice struct {
 	orig  *[]int32
 	state *State
@@ -38,14 +34,4 @@ func CopyOrigInt32Slice(dst, src []int32) []int32 {
 
 func GenerateOrigTestInt32Slice() []int32 {
 	return []int32{1, 2, 3}
-}
-
-// UnmarshalJSONOrigInt32Slice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigInt32Slice(iter *json.Iterator) []int32 {
-	var orig []int32
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, iter.ReadInt32())
-		return true
-	})
-	return orig
 }

--- a/pdata/internal/generated_wrapper_int64slice.go
+++ b/pdata/internal/generated_wrapper_int64slice.go
@@ -6,10 +6,6 @@
 
 package internal
 
-import (
-	"go.opentelemetry.io/collector/pdata/internal/json"
-)
-
 type Int64Slice struct {
 	orig  *[]int64
 	state *State
@@ -38,14 +34,4 @@ func CopyOrigInt64Slice(dst, src []int64) []int64 {
 
 func GenerateOrigTestInt64Slice() []int64 {
 	return []int64{1, 2, 3}
-}
-
-// UnmarshalJSONOrigInt64Slice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigInt64Slice(iter *json.Iterator) []int64 {
-	var orig []int64
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, iter.ReadInt64())
-		return true
-	})
-	return orig
 }

--- a/pdata/internal/generated_wrapper_keyvalue.go
+++ b/pdata/internal/generated_wrapper_keyvalue.go
@@ -44,7 +44,7 @@ func MarshalJSONOrigKeyValue(orig *otlpcommon.KeyValue, dest *json.Stream) {
 
 // UnmarshalJSONOrigAttribute unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigKeyValue(orig *otlpcommon.KeyValue, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "key":
 			orig.Key = iter.ReadString()
@@ -53,8 +53,7 @@ func UnmarshalJSONOrigKeyValue(orig *otlpcommon.KeyValue, iter *json.Iterator) {
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigKeyValue(orig *otlpcommon.KeyValue) int {

--- a/pdata/internal/generated_wrapper_keyvalueslice.go
+++ b/pdata/internal/generated_wrapper_keyvalueslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigKeyValueSlice(dest, src []otlpcommon.KeyValue) []otlpcommon.KeyValue {
@@ -33,16 +32,5 @@ func GenerateOrigTestKeyValueSlice() []otlpcommon.KeyValue {
 	orig := make([]otlpcommon.KeyValue, 5)
 	orig[1] = *GenTestOrigKeyValue()
 	orig[3] = *GenTestOrigKeyValue()
-	return orig
-}
-
-// UnmarshalJSONOrigKeyValueSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigKeyValueSlice(iter *json.Iterator) []otlpcommon.KeyValue {
-	var orig []otlpcommon.KeyValue
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, otlpcommon.KeyValue{})
-		UnmarshalJSONOrigKeyValue(&orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_line.go
+++ b/pdata/internal/generated_wrapper_line.go
@@ -52,7 +52,7 @@ func MarshalJSONOrigLine(orig *otlpprofiles.Line, dest *json.Stream) {
 
 // UnmarshalJSONOrigLine unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigLine(orig *otlpprofiles.Line, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "functionIndex", "function_index":
 			orig.FunctionIndex = iter.ReadInt32()
@@ -63,8 +63,7 @@ func UnmarshalJSONOrigLine(orig *otlpprofiles.Line, iter *json.Iterator) {
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigLine(orig *otlpprofiles.Line) int {

--- a/pdata/internal/generated_wrapper_lineslice.go
+++ b/pdata/internal/generated_wrapper_lineslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigLineSlice(dest, src []*otlpprofiles.Line) []*otlpprofiles.Line {
@@ -47,16 +46,5 @@ func GenerateOrigTestLineSlice() []*otlpprofiles.Line {
 	orig[2] = NewOrigLine()
 	orig[3] = GenTestOrigLine()
 	orig[4] = NewOrigLine()
-	return orig
-}
-
-// UnmarshalJSONOrigLineSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigLineSlice(iter *json.Iterator) []*otlpprofiles.Line {
-	var orig []*otlpprofiles.Line
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigLine())
-		UnmarshalJSONOrigLine(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_link.go
+++ b/pdata/internal/generated_wrapper_link.go
@@ -47,17 +47,16 @@ func MarshalJSONOrigLink(orig *otlpprofiles.Link, dest *json.Stream) {
 
 // UnmarshalJSONOrigLink unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigLink(orig *otlpprofiles.Link, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "traceId", "trace_id":
-			orig.TraceId.UnmarshalJSONIter(iter)
+			UnmarshalJSONOrigTraceID(&orig.TraceId, iter)
 		case "spanId", "span_id":
-			orig.SpanId.UnmarshalJSONIter(iter)
+			UnmarshalJSONOrigSpanID(&orig.SpanId, iter)
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigLink(orig *otlpprofiles.Link) int {

--- a/pdata/internal/generated_wrapper_linkslice.go
+++ b/pdata/internal/generated_wrapper_linkslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigLinkSlice(dest, src []*otlpprofiles.Link) []*otlpprofiles.Link {
@@ -47,16 +46,5 @@ func GenerateOrigTestLinkSlice() []*otlpprofiles.Link {
 	orig[2] = NewOrigLink()
 	orig[3] = GenTestOrigLink()
 	orig[4] = NewOrigLink()
-	return orig
-}
-
-// UnmarshalJSONOrigLinkSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigLinkSlice(iter *json.Iterator) []*otlpprofiles.Link {
-	var orig []*otlpprofiles.Link
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigLink())
-		UnmarshalJSONOrigLink(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_location.go
+++ b/pdata/internal/generated_wrapper_location.go
@@ -85,23 +85,34 @@ func MarshalJSONOrigLocation(orig *otlpprofiles.Location, dest *json.Stream) {
 
 // UnmarshalJSONOrigLocation unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigLocation(orig *otlpprofiles.Location, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "mappingIndex", "mapping_index":
-			orig.MappingIndex_ = &otlpprofiles.Location_MappingIndex{MappingIndex: iter.ReadInt32()}
+			{
+				ofm := &otlpprofiles.Location_MappingIndex{}
+				ofm.MappingIndex = iter.ReadInt32()
+				orig.MappingIndex_ = ofm
+			}
+
 		case "address":
 			orig.Address = iter.ReadUint64()
 		case "line":
-			orig.Line = UnmarshalJSONOrigLineSlice(iter)
+			for iter.ReadArray() {
+				orig.Line = append(orig.Line, NewOrigLine())
+				UnmarshalJSONOrigLine(orig.Line[len(orig.Line)-1], iter)
+			}
+
 		case "isFolded", "is_folded":
 			orig.IsFolded = iter.ReadBool()
 		case "attributeIndices", "attribute_indices":
-			orig.AttributeIndices = UnmarshalJSONOrigInt32Slice(iter)
+			for iter.ReadArray() {
+				orig.AttributeIndices = append(orig.AttributeIndices, iter.ReadInt32())
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigLocation(orig *otlpprofiles.Location) int {

--- a/pdata/internal/generated_wrapper_locationslice.go
+++ b/pdata/internal/generated_wrapper_locationslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigLocationSlice(dest, src []*otlpprofiles.Location) []*otlpprofiles.Location {
@@ -47,16 +46,5 @@ func GenerateOrigTestLocationSlice() []*otlpprofiles.Location {
 	orig[2] = NewOrigLocation()
 	orig[3] = GenTestOrigLocation()
 	orig[4] = NewOrigLocation()
-	return orig
-}
-
-// UnmarshalJSONOrigLocationSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigLocationSlice(iter *json.Iterator) []*otlpprofiles.Location {
-	var orig []*otlpprofiles.Location
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigLocation())
-		UnmarshalJSONOrigLocation(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_logrecordslice.go
+++ b/pdata/internal/generated_wrapper_logrecordslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigLogRecordSlice(dest, src []*otlplogs.LogRecord) []*otlplogs.LogRecord {
@@ -47,16 +46,5 @@ func GenerateOrigTestLogRecordSlice() []*otlplogs.LogRecord {
 	orig[2] = NewOrigLogRecord()
 	orig[3] = GenTestOrigLogRecord()
 	orig[4] = NewOrigLogRecord()
-	return orig
-}
-
-// UnmarshalJSONOrigLogRecordSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigLogRecordSlice(iter *json.Iterator) []*otlplogs.LogRecord {
-	var orig []*otlplogs.LogRecord
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigLogRecord())
-		UnmarshalJSONOrigLogRecord(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_mapping.go
+++ b/pdata/internal/generated_wrapper_mapping.go
@@ -94,7 +94,7 @@ func MarshalJSONOrigMapping(orig *otlpprofiles.Mapping, dest *json.Stream) {
 
 // UnmarshalJSONOrigMapping unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigMapping(orig *otlpprofiles.Mapping, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "memoryStart", "memory_start":
 			orig.MemoryStart = iter.ReadUint64()
@@ -105,7 +105,10 @@ func UnmarshalJSONOrigMapping(orig *otlpprofiles.Mapping, iter *json.Iterator) {
 		case "filenameStrindex", "filename_strindex":
 			orig.FilenameStrindex = iter.ReadInt32()
 		case "attributeIndices", "attribute_indices":
-			orig.AttributeIndices = UnmarshalJSONOrigInt32Slice(iter)
+			for iter.ReadArray() {
+				orig.AttributeIndices = append(orig.AttributeIndices, iter.ReadInt32())
+			}
+
 		case "hasFunctions", "has_functions":
 			orig.HasFunctions = iter.ReadBool()
 		case "hasFilenames", "has_filenames":
@@ -117,8 +120,7 @@ func UnmarshalJSONOrigMapping(orig *otlpprofiles.Mapping, iter *json.Iterator) {
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigMapping(orig *otlpprofiles.Mapping) int {

--- a/pdata/internal/generated_wrapper_mappingslice.go
+++ b/pdata/internal/generated_wrapper_mappingslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigMappingSlice(dest, src []*otlpprofiles.Mapping) []*otlpprofiles.Mapping {
@@ -47,16 +46,5 @@ func GenerateOrigTestMappingSlice() []*otlpprofiles.Mapping {
 	orig[2] = NewOrigMapping()
 	orig[3] = GenTestOrigMapping()
 	orig[4] = NewOrigMapping()
-	return orig
-}
-
-// UnmarshalJSONOrigMappingSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigMappingSlice(iter *json.Iterator) []*otlpprofiles.Mapping {
-	var orig []*otlpprofiles.Mapping
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigMapping())
-		UnmarshalJSONOrigMapping(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_metricslice.go
+++ b/pdata/internal/generated_wrapper_metricslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigMetricSlice(dest, src []*otlpmetrics.Metric) []*otlpmetrics.Metric {
@@ -47,16 +46,5 @@ func GenerateOrigTestMetricSlice() []*otlpmetrics.Metric {
 	orig[2] = NewOrigMetric()
 	orig[3] = GenTestOrigMetric()
 	orig[4] = NewOrigMetric()
-	return orig
-}
-
-// UnmarshalJSONOrigMetricSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigMetricSlice(iter *json.Iterator) []*otlpmetrics.Metric {
-	var orig []*otlpmetrics.Metric
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigMetric())
-		UnmarshalJSONOrigMetric(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_numberdatapoint.go
+++ b/pdata/internal/generated_wrapper_numberdatapoint.go
@@ -94,32 +94,45 @@ func MarshalJSONOrigNumberDataPoint(orig *otlpmetrics.NumberDataPoint, dest *jso
 
 // UnmarshalJSONOrigNumberDataPoint unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigNumberDataPoint(orig *otlpmetrics.NumberDataPoint, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "attributes":
-			orig.Attributes = UnmarshalJSONOrigKeyValueSlice(iter)
+			for iter.ReadArray() {
+				orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
+				UnmarshalJSONOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], iter)
+			}
+
 		case "startTimeUnixNano", "start_time_unix_nano":
 			orig.StartTimeUnixNano = iter.ReadUint64()
 		case "timeUnixNano", "time_unix_nano":
 			orig.TimeUnixNano = iter.ReadUint64()
 
 		case "asDouble", "as_double":
-			orig.Value = &otlpmetrics.NumberDataPoint_AsDouble{
-				AsDouble: iter.ReadFloat64(),
+			{
+				ofm := &otlpmetrics.NumberDataPoint_AsDouble{}
+				ofm.AsDouble = iter.ReadFloat64()
+				orig.Value = ofm
 			}
+
 		case "asInt", "as_int":
-			orig.Value = &otlpmetrics.NumberDataPoint_AsInt{
-				AsInt: iter.ReadInt64(),
+			{
+				ofm := &otlpmetrics.NumberDataPoint_AsInt{}
+				ofm.AsInt = iter.ReadInt64()
+				orig.Value = ofm
 			}
+
 		case "exemplars":
-			orig.Exemplars = UnmarshalJSONOrigExemplarSlice(iter)
+			for iter.ReadArray() {
+				orig.Exemplars = append(orig.Exemplars, otlpmetrics.Exemplar{})
+				UnmarshalJSONOrigExemplar(&orig.Exemplars[len(orig.Exemplars)-1], iter)
+			}
+
 		case "flags":
 			orig.Flags = iter.ReadUint32()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigNumberDataPoint(orig *otlpmetrics.NumberDataPoint) int {

--- a/pdata/internal/generated_wrapper_numberdatapointslice.go
+++ b/pdata/internal/generated_wrapper_numberdatapointslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigNumberDataPointSlice(dest, src []*otlpmetrics.NumberDataPoint) []*otlpmetrics.NumberDataPoint {
@@ -47,16 +46,5 @@ func GenerateOrigTestNumberDataPointSlice() []*otlpmetrics.NumberDataPoint {
 	orig[2] = NewOrigNumberDataPoint()
 	orig[3] = GenTestOrigNumberDataPoint()
 	orig[4] = NewOrigNumberDataPoint()
-	return orig
-}
-
-// UnmarshalJSONOrigNumberDataPointSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigNumberDataPointSlice(iter *json.Iterator) []*otlpmetrics.NumberDataPoint {
-	var orig []*otlpmetrics.NumberDataPoint
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigNumberDataPoint())
-		UnmarshalJSONOrigNumberDataPoint(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_profile.go
+++ b/pdata/internal/generated_wrapper_profile.go
@@ -148,14 +148,25 @@ func MarshalJSONOrigProfile(orig *otlpprofiles.Profile, dest *json.Stream) {
 
 // UnmarshalJSONOrigProfile unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigProfile(orig *otlpprofiles.Profile, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "sampleType", "sample_type":
-			orig.SampleType = UnmarshalJSONOrigValueTypeSlice(iter)
+			for iter.ReadArray() {
+				orig.SampleType = append(orig.SampleType, NewOrigValueType())
+				UnmarshalJSONOrigValueType(orig.SampleType[len(orig.SampleType)-1], iter)
+			}
+
 		case "sample":
-			orig.Sample = UnmarshalJSONOrigSampleSlice(iter)
+			for iter.ReadArray() {
+				orig.Sample = append(orig.Sample, NewOrigSample())
+				UnmarshalJSONOrigSample(orig.Sample[len(orig.Sample)-1], iter)
+			}
+
 		case "locationIndices", "location_indices":
-			orig.LocationIndices = UnmarshalJSONOrigInt32Slice(iter)
+			for iter.ReadArray() {
+				orig.LocationIndices = append(orig.LocationIndices, iter.ReadInt32())
+			}
+
 		case "timeNanos", "time_nanos":
 			orig.TimeNanos = iter.ReadInt64()
 		case "durationNanos", "duration_nanos":
@@ -165,24 +176,29 @@ func UnmarshalJSONOrigProfile(orig *otlpprofiles.Profile, iter *json.Iterator) {
 		case "period":
 			orig.Period = iter.ReadInt64()
 		case "commentStrindices", "comment_strindices":
-			orig.CommentStrindices = UnmarshalJSONOrigInt32Slice(iter)
+			for iter.ReadArray() {
+				orig.CommentStrindices = append(orig.CommentStrindices, iter.ReadInt32())
+			}
+
 		case "defaultSampleTypeIndex", "default_sample_type_index":
 			orig.DefaultSampleTypeIndex = iter.ReadInt32()
 		case "profileId", "profile_id":
-			orig.ProfileId.UnmarshalJSONIter(iter)
+			UnmarshalJSONOrigProfileID(&orig.ProfileId, iter)
 		case "droppedAttributesCount", "dropped_attributes_count":
 			orig.DroppedAttributesCount = iter.ReadUint32()
 		case "originalPayloadFormat", "original_payload_format":
 			orig.OriginalPayloadFormat = iter.ReadString()
 		case "originalPayload", "original_payload":
-			orig.OriginalPayload = UnmarshalJSONOrigByteSlice(iter)
+			orig.OriginalPayload = iter.ReadBytes()
 		case "attributeIndices", "attribute_indices":
-			orig.AttributeIndices = UnmarshalJSONOrigInt32Slice(iter)
+			for iter.ReadArray() {
+				orig.AttributeIndices = append(orig.AttributeIndices, iter.ReadInt32())
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigProfile(orig *otlpprofiles.Profile) int {

--- a/pdata/internal/generated_wrapper_profilesdictionary.go
+++ b/pdata/internal/generated_wrapper_profilesdictionary.go
@@ -119,27 +119,53 @@ func MarshalJSONOrigProfilesDictionary(orig *otlpprofiles.ProfilesDictionary, de
 
 // UnmarshalJSONOrigProfilesDictionary unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigProfilesDictionary(orig *otlpprofiles.ProfilesDictionary, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "mappingTable", "mapping_table":
-			orig.MappingTable = UnmarshalJSONOrigMappingSlice(iter)
+			for iter.ReadArray() {
+				orig.MappingTable = append(orig.MappingTable, NewOrigMapping())
+				UnmarshalJSONOrigMapping(orig.MappingTable[len(orig.MappingTable)-1], iter)
+			}
+
 		case "locationTable", "location_table":
-			orig.LocationTable = UnmarshalJSONOrigLocationSlice(iter)
+			for iter.ReadArray() {
+				orig.LocationTable = append(orig.LocationTable, NewOrigLocation())
+				UnmarshalJSONOrigLocation(orig.LocationTable[len(orig.LocationTable)-1], iter)
+			}
+
 		case "functionTable", "function_table":
-			orig.FunctionTable = UnmarshalJSONOrigFunctionSlice(iter)
+			for iter.ReadArray() {
+				orig.FunctionTable = append(orig.FunctionTable, NewOrigFunction())
+				UnmarshalJSONOrigFunction(orig.FunctionTable[len(orig.FunctionTable)-1], iter)
+			}
+
 		case "linkTable", "link_table":
-			orig.LinkTable = UnmarshalJSONOrigLinkSlice(iter)
+			for iter.ReadArray() {
+				orig.LinkTable = append(orig.LinkTable, NewOrigLink())
+				UnmarshalJSONOrigLink(orig.LinkTable[len(orig.LinkTable)-1], iter)
+			}
+
 		case "stringTable", "string_table":
-			orig.StringTable = UnmarshalJSONOrigStringSlice(iter)
+			for iter.ReadArray() {
+				orig.StringTable = append(orig.StringTable, iter.ReadString())
+			}
+
 		case "attributeTable", "attribute_table":
-			orig.AttributeTable = UnmarshalJSONOrigKeyValueSlice(iter)
+			for iter.ReadArray() {
+				orig.AttributeTable = append(orig.AttributeTable, otlpcommon.KeyValue{})
+				UnmarshalJSONOrigKeyValue(&orig.AttributeTable[len(orig.AttributeTable)-1], iter)
+			}
+
 		case "attributeUnits", "attribute_units":
-			orig.AttributeUnits = UnmarshalJSONOrigAttributeUnitSlice(iter)
+			for iter.ReadArray() {
+				orig.AttributeUnits = append(orig.AttributeUnits, NewOrigAttributeUnit())
+				UnmarshalJSONOrigAttributeUnit(orig.AttributeUnits[len(orig.AttributeUnits)-1], iter)
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigProfilesDictionary(orig *otlpprofiles.ProfilesDictionary) int {

--- a/pdata/internal/generated_wrapper_profileslice.go
+++ b/pdata/internal/generated_wrapper_profileslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigProfileSlice(dest, src []*otlpprofiles.Profile) []*otlpprofiles.Profile {
@@ -47,16 +46,5 @@ func GenerateOrigTestProfileSlice() []*otlpprofiles.Profile {
 	orig[2] = NewOrigProfile()
 	orig[3] = GenTestOrigProfile()
 	orig[4] = NewOrigProfile()
-	return orig
-}
-
-// UnmarshalJSONOrigProfileSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigProfileSlice(iter *json.Iterator) []*otlpprofiles.Profile {
-	var orig []*otlpprofiles.Profile
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigProfile())
-		UnmarshalJSONOrigProfile(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_resource.go
+++ b/pdata/internal/generated_wrapper_resource.go
@@ -82,19 +82,26 @@ func MarshalJSONOrigResource(orig *otlpresource.Resource, dest *json.Stream) {
 
 // UnmarshalJSONOrigResource unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigResource(orig *otlpresource.Resource, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "attributes":
-			orig.Attributes = UnmarshalJSONOrigKeyValueSlice(iter)
+			for iter.ReadArray() {
+				orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
+				UnmarshalJSONOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], iter)
+			}
+
 		case "droppedAttributesCount", "dropped_attributes_count":
 			orig.DroppedAttributesCount = iter.ReadUint32()
 		case "entityRefs", "entity_refs":
-			orig.EntityRefs = UnmarshalJSONOrigEntityRefSlice(iter)
+			for iter.ReadArray() {
+				orig.EntityRefs = append(orig.EntityRefs, NewOrigEntityRef())
+				UnmarshalJSONOrigEntityRef(orig.EntityRefs[len(orig.EntityRefs)-1], iter)
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigResource(orig *otlpresource.Resource) int {

--- a/pdata/internal/generated_wrapper_resourcelogs.go
+++ b/pdata/internal/generated_wrapper_resourcelogs.go
@@ -56,19 +56,22 @@ func MarshalJSONOrigResourceLogs(orig *otlplogs.ResourceLogs, dest *json.Stream)
 
 // UnmarshalJSONOrigResourceLogs unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigResourceLogs(orig *otlplogs.ResourceLogs, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "resource":
 			UnmarshalJSONOrigResource(&orig.Resource, iter)
 		case "scopeLogs", "scope_logs":
-			orig.ScopeLogs = UnmarshalJSONOrigScopeLogsSlice(iter)
+			for iter.ReadArray() {
+				orig.ScopeLogs = append(orig.ScopeLogs, NewOrigScopeLogs())
+				UnmarshalJSONOrigScopeLogs(orig.ScopeLogs[len(orig.ScopeLogs)-1], iter)
+			}
+
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigResourceLogs(orig *otlplogs.ResourceLogs) int {

--- a/pdata/internal/generated_wrapper_resourcelogsslice.go
+++ b/pdata/internal/generated_wrapper_resourcelogsslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigResourceLogsSlice(dest, src []*otlplogs.ResourceLogs) []*otlplogs.ResourceLogs {
@@ -47,16 +46,5 @@ func GenerateOrigTestResourceLogsSlice() []*otlplogs.ResourceLogs {
 	orig[2] = NewOrigResourceLogs()
 	orig[3] = GenTestOrigResourceLogs()
 	orig[4] = NewOrigResourceLogs()
-	return orig
-}
-
-// UnmarshalJSONOrigResourceLogsSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigResourceLogsSlice(iter *json.Iterator) []*otlplogs.ResourceLogs {
-	var orig []*otlplogs.ResourceLogs
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigResourceLogs())
-		UnmarshalJSONOrigResourceLogs(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_resourcemetrics.go
+++ b/pdata/internal/generated_wrapper_resourcemetrics.go
@@ -56,19 +56,22 @@ func MarshalJSONOrigResourceMetrics(orig *otlpmetrics.ResourceMetrics, dest *jso
 
 // UnmarshalJSONOrigResourceMetrics unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigResourceMetrics(orig *otlpmetrics.ResourceMetrics, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "resource":
 			UnmarshalJSONOrigResource(&orig.Resource, iter)
 		case "scopeMetrics", "scope_metrics":
-			orig.ScopeMetrics = UnmarshalJSONOrigScopeMetricsSlice(iter)
+			for iter.ReadArray() {
+				orig.ScopeMetrics = append(orig.ScopeMetrics, NewOrigScopeMetrics())
+				UnmarshalJSONOrigScopeMetrics(orig.ScopeMetrics[len(orig.ScopeMetrics)-1], iter)
+			}
+
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigResourceMetrics(orig *otlpmetrics.ResourceMetrics) int {

--- a/pdata/internal/generated_wrapper_resourcemetricsslice.go
+++ b/pdata/internal/generated_wrapper_resourcemetricsslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigResourceMetricsSlice(dest, src []*otlpmetrics.ResourceMetrics) []*otlpmetrics.ResourceMetrics {
@@ -47,16 +46,5 @@ func GenerateOrigTestResourceMetricsSlice() []*otlpmetrics.ResourceMetrics {
 	orig[2] = NewOrigResourceMetrics()
 	orig[3] = GenTestOrigResourceMetrics()
 	orig[4] = NewOrigResourceMetrics()
-	return orig
-}
-
-// UnmarshalJSONOrigResourceMetricsSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigResourceMetricsSlice(iter *json.Iterator) []*otlpmetrics.ResourceMetrics {
-	var orig []*otlpmetrics.ResourceMetrics
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigResourceMetrics())
-		UnmarshalJSONOrigResourceMetrics(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_resourceprofiles.go
+++ b/pdata/internal/generated_wrapper_resourceprofiles.go
@@ -56,19 +56,22 @@ func MarshalJSONOrigResourceProfiles(orig *otlpprofiles.ResourceProfiles, dest *
 
 // UnmarshalJSONOrigResourceProfiles unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigResourceProfiles(orig *otlpprofiles.ResourceProfiles, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "resource":
 			UnmarshalJSONOrigResource(&orig.Resource, iter)
 		case "scopeProfiles", "scope_profiles":
-			orig.ScopeProfiles = UnmarshalJSONOrigScopeProfilesSlice(iter)
+			for iter.ReadArray() {
+				orig.ScopeProfiles = append(orig.ScopeProfiles, NewOrigScopeProfiles())
+				UnmarshalJSONOrigScopeProfiles(orig.ScopeProfiles[len(orig.ScopeProfiles)-1], iter)
+			}
+
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigResourceProfiles(orig *otlpprofiles.ResourceProfiles) int {

--- a/pdata/internal/generated_wrapper_resourceprofilesslice.go
+++ b/pdata/internal/generated_wrapper_resourceprofilesslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigResourceProfilesSlice(dest, src []*otlpprofiles.ResourceProfiles) []*otlpprofiles.ResourceProfiles {
@@ -47,16 +46,5 @@ func GenerateOrigTestResourceProfilesSlice() []*otlpprofiles.ResourceProfiles {
 	orig[2] = NewOrigResourceProfiles()
 	orig[3] = GenTestOrigResourceProfiles()
 	orig[4] = NewOrigResourceProfiles()
-	return orig
-}
-
-// UnmarshalJSONOrigResourceProfilesSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigResourceProfilesSlice(iter *json.Iterator) []*otlpprofiles.ResourceProfiles {
-	var orig []*otlpprofiles.ResourceProfiles
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigResourceProfiles())
-		UnmarshalJSONOrigResourceProfiles(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_resourcespans.go
+++ b/pdata/internal/generated_wrapper_resourcespans.go
@@ -56,19 +56,22 @@ func MarshalJSONOrigResourceSpans(orig *otlptrace.ResourceSpans, dest *json.Stre
 
 // UnmarshalJSONOrigResourceSpans unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigResourceSpans(orig *otlptrace.ResourceSpans, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "resource":
 			UnmarshalJSONOrigResource(&orig.Resource, iter)
 		case "scopeSpans", "scope_spans":
-			orig.ScopeSpans = UnmarshalJSONOrigScopeSpansSlice(iter)
+			for iter.ReadArray() {
+				orig.ScopeSpans = append(orig.ScopeSpans, NewOrigScopeSpans())
+				UnmarshalJSONOrigScopeSpans(orig.ScopeSpans[len(orig.ScopeSpans)-1], iter)
+			}
+
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigResourceSpans(orig *otlptrace.ResourceSpans) int {

--- a/pdata/internal/generated_wrapper_resourcespansslice.go
+++ b/pdata/internal/generated_wrapper_resourcespansslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigResourceSpansSlice(dest, src []*otlptrace.ResourceSpans) []*otlptrace.ResourceSpans {
@@ -47,16 +46,5 @@ func GenerateOrigTestResourceSpansSlice() []*otlptrace.ResourceSpans {
 	orig[2] = NewOrigResourceSpans()
 	orig[3] = GenTestOrigResourceSpans()
 	orig[4] = NewOrigResourceSpans()
-	return orig
-}
-
-// UnmarshalJSONOrigResourceSpansSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigResourceSpansSlice(iter *json.Iterator) []*otlptrace.ResourceSpans {
-	var orig []*otlptrace.ResourceSpans
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigResourceSpans())
-		UnmarshalJSONOrigResourceSpans(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_sample.go
+++ b/pdata/internal/generated_wrapper_sample.go
@@ -97,25 +97,38 @@ func MarshalJSONOrigSample(orig *otlpprofiles.Sample, dest *json.Stream) {
 
 // UnmarshalJSONOrigSample unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigSample(orig *otlpprofiles.Sample, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "locationsStartIndex", "locations_start_index":
 			orig.LocationsStartIndex = iter.ReadInt32()
 		case "locationsLength", "locations_length":
 			orig.LocationsLength = iter.ReadInt32()
 		case "value":
-			orig.Value = UnmarshalJSONOrigInt64Slice(iter)
+			for iter.ReadArray() {
+				orig.Value = append(orig.Value, iter.ReadInt64())
+			}
+
 		case "attributeIndices", "attribute_indices":
-			orig.AttributeIndices = UnmarshalJSONOrigInt32Slice(iter)
+			for iter.ReadArray() {
+				orig.AttributeIndices = append(orig.AttributeIndices, iter.ReadInt32())
+			}
+
 		case "linkIndex", "link_index":
-			orig.LinkIndex_ = &otlpprofiles.Sample_LinkIndex{LinkIndex: iter.ReadInt32()}
+			{
+				ofm := &otlpprofiles.Sample_LinkIndex{}
+				ofm.LinkIndex = iter.ReadInt32()
+				orig.LinkIndex_ = ofm
+			}
+
 		case "timestampsUnixNano", "timestamps_unix_nano":
-			orig.TimestampsUnixNano = UnmarshalJSONOrigUint64Slice(iter)
+			for iter.ReadArray() {
+				orig.TimestampsUnixNano = append(orig.TimestampsUnixNano, iter.ReadUint64())
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigSample(orig *otlpprofiles.Sample) int {

--- a/pdata/internal/generated_wrapper_sampleslice.go
+++ b/pdata/internal/generated_wrapper_sampleslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigSampleSlice(dest, src []*otlpprofiles.Sample) []*otlpprofiles.Sample {
@@ -47,16 +46,5 @@ func GenerateOrigTestSampleSlice() []*otlpprofiles.Sample {
 	orig[2] = NewOrigSample()
 	orig[3] = GenTestOrigSample()
 	orig[4] = NewOrigSample()
-	return orig
-}
-
-// UnmarshalJSONOrigSampleSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigSampleSlice(iter *json.Iterator) []*otlpprofiles.Sample {
-	var orig []*otlpprofiles.Sample
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigSample())
-		UnmarshalJSONOrigSample(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_scopelogs.go
+++ b/pdata/internal/generated_wrapper_scopelogs.go
@@ -56,19 +56,22 @@ func MarshalJSONOrigScopeLogs(orig *otlplogs.ScopeLogs, dest *json.Stream) {
 
 // UnmarshalJSONOrigScopeLogs unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigScopeLogs(orig *otlplogs.ScopeLogs, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "scope":
 			UnmarshalJSONOrigInstrumentationScope(&orig.Scope, iter)
 		case "logRecords", "log_records":
-			orig.LogRecords = UnmarshalJSONOrigLogRecordSlice(iter)
+			for iter.ReadArray() {
+				orig.LogRecords = append(orig.LogRecords, NewOrigLogRecord())
+				UnmarshalJSONOrigLogRecord(orig.LogRecords[len(orig.LogRecords)-1], iter)
+			}
+
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigScopeLogs(orig *otlplogs.ScopeLogs) int {

--- a/pdata/internal/generated_wrapper_scopelogsslice.go
+++ b/pdata/internal/generated_wrapper_scopelogsslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigScopeLogsSlice(dest, src []*otlplogs.ScopeLogs) []*otlplogs.ScopeLogs {
@@ -47,16 +46,5 @@ func GenerateOrigTestScopeLogsSlice() []*otlplogs.ScopeLogs {
 	orig[2] = NewOrigScopeLogs()
 	orig[3] = GenTestOrigScopeLogs()
 	orig[4] = NewOrigScopeLogs()
-	return orig
-}
-
-// UnmarshalJSONOrigScopeLogsSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigScopeLogsSlice(iter *json.Iterator) []*otlplogs.ScopeLogs {
-	var orig []*otlplogs.ScopeLogs
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigScopeLogs())
-		UnmarshalJSONOrigScopeLogs(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_scopemetrics.go
+++ b/pdata/internal/generated_wrapper_scopemetrics.go
@@ -56,19 +56,22 @@ func MarshalJSONOrigScopeMetrics(orig *otlpmetrics.ScopeMetrics, dest *json.Stre
 
 // UnmarshalJSONOrigScopeMetrics unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigScopeMetrics(orig *otlpmetrics.ScopeMetrics, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "scope":
 			UnmarshalJSONOrigInstrumentationScope(&orig.Scope, iter)
 		case "metrics":
-			orig.Metrics = UnmarshalJSONOrigMetricSlice(iter)
+			for iter.ReadArray() {
+				orig.Metrics = append(orig.Metrics, NewOrigMetric())
+				UnmarshalJSONOrigMetric(orig.Metrics[len(orig.Metrics)-1], iter)
+			}
+
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigScopeMetrics(orig *otlpmetrics.ScopeMetrics) int {

--- a/pdata/internal/generated_wrapper_scopemetricsslice.go
+++ b/pdata/internal/generated_wrapper_scopemetricsslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigScopeMetricsSlice(dest, src []*otlpmetrics.ScopeMetrics) []*otlpmetrics.ScopeMetrics {
@@ -47,16 +46,5 @@ func GenerateOrigTestScopeMetricsSlice() []*otlpmetrics.ScopeMetrics {
 	orig[2] = NewOrigScopeMetrics()
 	orig[3] = GenTestOrigScopeMetrics()
 	orig[4] = NewOrigScopeMetrics()
-	return orig
-}
-
-// UnmarshalJSONOrigScopeMetricsSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigScopeMetricsSlice(iter *json.Iterator) []*otlpmetrics.ScopeMetrics {
-	var orig []*otlpmetrics.ScopeMetrics
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigScopeMetrics())
-		UnmarshalJSONOrigScopeMetrics(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_scopeprofiles.go
+++ b/pdata/internal/generated_wrapper_scopeprofiles.go
@@ -56,19 +56,22 @@ func MarshalJSONOrigScopeProfiles(orig *otlpprofiles.ScopeProfiles, dest *json.S
 
 // UnmarshalJSONOrigScopeProfiles unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigScopeProfiles(orig *otlpprofiles.ScopeProfiles, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "scope":
 			UnmarshalJSONOrigInstrumentationScope(&orig.Scope, iter)
 		case "profiles":
-			orig.Profiles = UnmarshalJSONOrigProfileSlice(iter)
+			for iter.ReadArray() {
+				orig.Profiles = append(orig.Profiles, NewOrigProfile())
+				UnmarshalJSONOrigProfile(orig.Profiles[len(orig.Profiles)-1], iter)
+			}
+
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigScopeProfiles(orig *otlpprofiles.ScopeProfiles) int {

--- a/pdata/internal/generated_wrapper_scopeprofilesslice.go
+++ b/pdata/internal/generated_wrapper_scopeprofilesslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigScopeProfilesSlice(dest, src []*otlpprofiles.ScopeProfiles) []*otlpprofiles.ScopeProfiles {
@@ -47,16 +46,5 @@ func GenerateOrigTestScopeProfilesSlice() []*otlpprofiles.ScopeProfiles {
 	orig[2] = NewOrigScopeProfiles()
 	orig[3] = GenTestOrigScopeProfiles()
 	orig[4] = NewOrigScopeProfiles()
-	return orig
-}
-
-// UnmarshalJSONOrigScopeProfilesSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigScopeProfilesSlice(iter *json.Iterator) []*otlpprofiles.ScopeProfiles {
-	var orig []*otlpprofiles.ScopeProfiles
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigScopeProfiles())
-		UnmarshalJSONOrigScopeProfiles(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_scopespans.go
+++ b/pdata/internal/generated_wrapper_scopespans.go
@@ -56,19 +56,22 @@ func MarshalJSONOrigScopeSpans(orig *otlptrace.ScopeSpans, dest *json.Stream) {
 
 // UnmarshalJSONOrigScopeSpans unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigScopeSpans(orig *otlptrace.ScopeSpans, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "scope":
 			UnmarshalJSONOrigInstrumentationScope(&orig.Scope, iter)
 		case "spans":
-			orig.Spans = UnmarshalJSONOrigSpanSlice(iter)
+			for iter.ReadArray() {
+				orig.Spans = append(orig.Spans, NewOrigSpan())
+				UnmarshalJSONOrigSpan(orig.Spans[len(orig.Spans)-1], iter)
+			}
+
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigScopeSpans(orig *otlptrace.ScopeSpans) int {

--- a/pdata/internal/generated_wrapper_scopespansslice.go
+++ b/pdata/internal/generated_wrapper_scopespansslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigScopeSpansSlice(dest, src []*otlptrace.ScopeSpans) []*otlptrace.ScopeSpans {
@@ -47,16 +46,5 @@ func GenerateOrigTestScopeSpansSlice() []*otlptrace.ScopeSpans {
 	orig[2] = NewOrigScopeSpans()
 	orig[3] = GenTestOrigScopeSpans()
 	orig[4] = NewOrigScopeSpans()
-	return orig
-}
-
-// UnmarshalJSONOrigScopeSpansSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigScopeSpansSlice(iter *json.Iterator) []*otlptrace.ScopeSpans {
-	var orig []*otlptrace.ScopeSpans
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigScopeSpans())
-		UnmarshalJSONOrigScopeSpans(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_span_event.go
+++ b/pdata/internal/generated_wrapper_span_event.go
@@ -66,21 +66,24 @@ func MarshalJSONOrigSpan_Event(orig *otlptrace.Span_Event, dest *json.Stream) {
 
 // UnmarshalJSONOrigSpanEvent unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigSpan_Event(orig *otlptrace.Span_Event, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "timeUnixNano", "time_unix_nano":
 			orig.TimeUnixNano = iter.ReadUint64()
 		case "name":
 			orig.Name = iter.ReadString()
 		case "attributes":
-			orig.Attributes = UnmarshalJSONOrigKeyValueSlice(iter)
+			for iter.ReadArray() {
+				orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
+				UnmarshalJSONOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], iter)
+			}
+
 		case "droppedAttributesCount", "dropped_attributes_count":
 			orig.DroppedAttributesCount = iter.ReadUint32()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigSpan_Event(orig *otlptrace.Span_Event) int {

--- a/pdata/internal/generated_wrapper_span_eventslice.go
+++ b/pdata/internal/generated_wrapper_span_eventslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigSpan_EventSlice(dest, src []*otlptrace.Span_Event) []*otlptrace.Span_Event {
@@ -47,16 +46,5 @@ func GenerateOrigTestSpan_EventSlice() []*otlptrace.Span_Event {
 	orig[2] = NewOrigSpan_Event()
 	orig[3] = GenTestOrigSpan_Event()
 	orig[4] = NewOrigSpan_Event()
-	return orig
-}
-
-// UnmarshalJSONOrigSpan_EventSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigSpan_EventSlice(iter *json.Iterator) []*otlptrace.Span_Event {
-	var orig []*otlptrace.Span_Event
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigSpan_Event())
-		UnmarshalJSONOrigSpan_Event(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_span_link.go
+++ b/pdata/internal/generated_wrapper_span_link.go
@@ -79,16 +79,20 @@ func MarshalJSONOrigSpan_Link(orig *otlptrace.Span_Link, dest *json.Stream) {
 
 // UnmarshalJSONOrigSpanLink unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigSpan_Link(orig *otlptrace.Span_Link, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "traceId", "trace_id":
-			orig.TraceId.UnmarshalJSONIter(iter)
+			UnmarshalJSONOrigTraceID(&orig.TraceId, iter)
 		case "spanId", "span_id":
-			orig.SpanId.UnmarshalJSONIter(iter)
+			UnmarshalJSONOrigSpanID(&orig.SpanId, iter)
 		case "traceState", "trace_state":
-			UnmarshalJSONOrigTraceState(&orig.TraceState, iter)
+			orig.TraceState = iter.ReadString()
 		case "attributes":
-			orig.Attributes = UnmarshalJSONOrigKeyValueSlice(iter)
+			for iter.ReadArray() {
+				orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
+				UnmarshalJSONOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], iter)
+			}
+
 		case "droppedAttributesCount", "dropped_attributes_count":
 			orig.DroppedAttributesCount = iter.ReadUint32()
 		case "flags":
@@ -96,8 +100,7 @@ func UnmarshalJSONOrigSpan_Link(orig *otlptrace.Span_Link, iter *json.Iterator) 
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigSpan_Link(orig *otlptrace.Span_Link) int {

--- a/pdata/internal/generated_wrapper_span_linkslice.go
+++ b/pdata/internal/generated_wrapper_span_linkslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigSpan_LinkSlice(dest, src []*otlptrace.Span_Link) []*otlptrace.Span_Link {
@@ -47,16 +46,5 @@ func GenerateOrigTestSpan_LinkSlice() []*otlptrace.Span_Link {
 	orig[2] = NewOrigSpan_Link()
 	orig[3] = GenTestOrigSpan_Link()
 	orig[4] = NewOrigSpan_Link()
-	return orig
-}
-
-// UnmarshalJSONOrigSpan_LinkSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigSpan_LinkSlice(iter *json.Iterator) []*otlptrace.Span_Link {
-	var orig []*otlptrace.Span_Link
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigSpan_Link())
-		UnmarshalJSONOrigSpan_Link(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_spanslice.go
+++ b/pdata/internal/generated_wrapper_spanslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigSpanSlice(dest, src []*otlptrace.Span) []*otlptrace.Span {
@@ -47,16 +46,5 @@ func GenerateOrigTestSpanSlice() []*otlptrace.Span {
 	orig[2] = NewOrigSpan()
 	orig[3] = GenTestOrigSpan()
 	orig[4] = NewOrigSpan()
-	return orig
-}
-
-// UnmarshalJSONOrigSpanSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigSpanSlice(iter *json.Iterator) []*otlptrace.Span {
-	var orig []*otlptrace.Span
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigSpan())
-		UnmarshalJSONOrigSpan(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_status.go
+++ b/pdata/internal/generated_wrapper_status.go
@@ -47,7 +47,7 @@ func MarshalJSONOrigStatus(orig *otlptrace.Status, dest *json.Stream) {
 
 // UnmarshalJSONOrigStatus unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigStatus(orig *otlptrace.Status, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "message":
 			orig.Message = iter.ReadString()
@@ -56,8 +56,7 @@ func UnmarshalJSONOrigStatus(orig *otlptrace.Status, iter *json.Iterator) {
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigStatus(orig *otlptrace.Status) int {

--- a/pdata/internal/generated_wrapper_stringslice.go
+++ b/pdata/internal/generated_wrapper_stringslice.go
@@ -6,10 +6,6 @@
 
 package internal
 
-import (
-	"go.opentelemetry.io/collector/pdata/internal/json"
-)
-
 type StringSlice struct {
 	orig  *[]string
 	state *State
@@ -38,14 +34,4 @@ func CopyOrigStringSlice(dst, src []string) []string {
 
 func GenerateOrigTestStringSlice() []string {
 	return []string{"a", "b", "c"}
-}
-
-// UnmarshalJSONOrigStringSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigStringSlice(iter *json.Iterator) []string {
-	var orig []string
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, iter.ReadString())
-		return true
-	})
-	return orig
 }

--- a/pdata/internal/generated_wrapper_sum.go
+++ b/pdata/internal/generated_wrapper_sum.go
@@ -59,10 +59,14 @@ func MarshalJSONOrigSum(orig *otlpmetrics.Sum, dest *json.Stream) {
 
 // UnmarshalJSONOrigSum unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigSum(orig *otlpmetrics.Sum, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "dataPoints", "data_points":
-			orig.DataPoints = UnmarshalJSONOrigNumberDataPointSlice(iter)
+			for iter.ReadArray() {
+				orig.DataPoints = append(orig.DataPoints, NewOrigNumberDataPoint())
+				UnmarshalJSONOrigNumberDataPoint(orig.DataPoints[len(orig.DataPoints)-1], iter)
+			}
+
 		case "aggregationTemporality", "aggregation_temporality":
 			orig.AggregationTemporality = otlpmetrics.AggregationTemporality(iter.ReadEnumValue(otlpmetrics.AggregationTemporality_value))
 		case "isMonotonic", "is_monotonic":
@@ -70,8 +74,7 @@ func UnmarshalJSONOrigSum(orig *otlpmetrics.Sum, iter *json.Iterator) {
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigSum(orig *otlpmetrics.Sum) int {

--- a/pdata/internal/generated_wrapper_summary.go
+++ b/pdata/internal/generated_wrapper_summary.go
@@ -46,15 +46,18 @@ func MarshalJSONOrigSummary(orig *otlpmetrics.Summary, dest *json.Stream) {
 
 // UnmarshalJSONOrigSummary unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigSummary(orig *otlpmetrics.Summary, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "dataPoints", "data_points":
-			orig.DataPoints = UnmarshalJSONOrigSummaryDataPointSlice(iter)
+			for iter.ReadArray() {
+				orig.DataPoints = append(orig.DataPoints, NewOrigSummaryDataPoint())
+				UnmarshalJSONOrigSummaryDataPoint(orig.DataPoints[len(orig.DataPoints)-1], iter)
+			}
+
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigSummary(orig *otlpmetrics.Summary) int {

--- a/pdata/internal/generated_wrapper_summarydatapoint.go
+++ b/pdata/internal/generated_wrapper_summarydatapoint.go
@@ -91,10 +91,14 @@ func MarshalJSONOrigSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint, dest *j
 
 // UnmarshalJSONOrigSummaryDataPoint unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "attributes":
-			orig.Attributes = UnmarshalJSONOrigKeyValueSlice(iter)
+			for iter.ReadArray() {
+				orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
+				UnmarshalJSONOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], iter)
+			}
+
 		case "startTimeUnixNano", "start_time_unix_nano":
 			orig.StartTimeUnixNano = iter.ReadUint64()
 		case "timeUnixNano", "time_unix_nano":
@@ -104,14 +108,17 @@ func UnmarshalJSONOrigSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint, iter 
 		case "sum":
 			orig.Sum = iter.ReadFloat64()
 		case "quantileValues", "quantile_values":
-			orig.QuantileValues = UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantileSlice(iter)
+			for iter.ReadArray() {
+				orig.QuantileValues = append(orig.QuantileValues, NewOrigSummaryDataPoint_ValueAtQuantile())
+				UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(orig.QuantileValues[len(orig.QuantileValues)-1], iter)
+			}
+
 		case "flags":
 			orig.Flags = iter.ReadUint32()
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint) int {

--- a/pdata/internal/generated_wrapper_summarydatapoint_valueatquantile.go
+++ b/pdata/internal/generated_wrapper_summarydatapoint_valueatquantile.go
@@ -48,7 +48,7 @@ func MarshalJSONOrigSummaryDataPoint_ValueAtQuantile(orig *otlpmetrics.SummaryDa
 
 // UnmarshalJSONOrigSummaryDataPointValueAtQuantile unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "quantile":
 			orig.Quantile = iter.ReadFloat64()
@@ -57,8 +57,7 @@ func UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(orig *otlpmetrics.Summary
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigSummaryDataPoint_ValueAtQuantile(orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile) int {

--- a/pdata/internal/generated_wrapper_summarydatapoint_valueatquantileslice.go
+++ b/pdata/internal/generated_wrapper_summarydatapoint_valueatquantileslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigSummaryDataPoint_ValueAtQuantileSlice(dest, src []*otlpmetrics.SummaryDataPoint_ValueAtQuantile) []*otlpmetrics.SummaryDataPoint_ValueAtQuantile {
@@ -47,16 +46,5 @@ func GenerateOrigTestSummaryDataPoint_ValueAtQuantileSlice() []*otlpmetrics.Summ
 	orig[2] = NewOrigSummaryDataPoint_ValueAtQuantile()
 	orig[3] = GenTestOrigSummaryDataPoint_ValueAtQuantile()
 	orig[4] = NewOrigSummaryDataPoint_ValueAtQuantile()
-	return orig
-}
-
-// UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantileSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantileSlice(iter *json.Iterator) []*otlpmetrics.SummaryDataPoint_ValueAtQuantile {
-	var orig []*otlpmetrics.SummaryDataPoint_ValueAtQuantile
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigSummaryDataPoint_ValueAtQuantile())
-		UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_summarydatapointslice.go
+++ b/pdata/internal/generated_wrapper_summarydatapointslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigSummaryDataPointSlice(dest, src []*otlpmetrics.SummaryDataPoint) []*otlpmetrics.SummaryDataPoint {
@@ -47,16 +46,5 @@ func GenerateOrigTestSummaryDataPointSlice() []*otlpmetrics.SummaryDataPoint {
 	orig[2] = NewOrigSummaryDataPoint()
 	orig[3] = GenTestOrigSummaryDataPoint()
 	orig[4] = NewOrigSummaryDataPoint()
-	return orig
-}
-
-// UnmarshalJSONOrigSummaryDataPointSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigSummaryDataPointSlice(iter *json.Iterator) []*otlpmetrics.SummaryDataPoint {
-	var orig []*otlpmetrics.SummaryDataPoint
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigSummaryDataPoint())
-		UnmarshalJSONOrigSummaryDataPoint(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/generated_wrapper_uint64slice.go
+++ b/pdata/internal/generated_wrapper_uint64slice.go
@@ -6,10 +6,6 @@
 
 package internal
 
-import (
-	"go.opentelemetry.io/collector/pdata/internal/json"
-)
-
 type UInt64Slice struct {
 	orig  *[]uint64
 	state *State
@@ -38,14 +34,4 @@ func CopyOrigUint64Slice(dst, src []uint64) []uint64 {
 
 func GenerateOrigTestUint64Slice() []uint64 {
 	return []uint64{1, 2, 3}
-}
-
-// UnmarshalJSONOrigUint64Slice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigUint64Slice(iter *json.Iterator) []uint64 {
-	var orig []uint64
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, iter.ReadUint64())
-		return true
-	})
-	return orig
 }

--- a/pdata/internal/generated_wrapper_valuetype.go
+++ b/pdata/internal/generated_wrapper_valuetype.go
@@ -53,7 +53,7 @@ func MarshalJSONOrigValueType(orig *otlpprofiles.ValueType, dest *json.Stream) {
 
 // UnmarshalJSONOrigValueType unmarshals all properties from the current struct from the source iterator.
 func UnmarshalJSONOrigValueType(orig *otlpprofiles.ValueType, iter *json.Iterator) {
-	iter.ReadObjectCB(func(iter *json.Iterator, f string) bool {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "typeStrindex", "type_strindex":
 			orig.TypeStrindex = iter.ReadInt32()
@@ -64,8 +64,7 @@ func UnmarshalJSONOrigValueType(orig *otlpprofiles.ValueType, iter *json.Iterato
 		default:
 			iter.Skip()
 		}
-		return true
-	})
+	}
 }
 
 func SizeProtoOrigValueType(orig *otlpprofiles.ValueType) int {

--- a/pdata/internal/generated_wrapper_valuetypeslice.go
+++ b/pdata/internal/generated_wrapper_valuetypeslice.go
@@ -8,7 +8,6 @@ package internal
 
 import (
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
-	"go.opentelemetry.io/collector/pdata/internal/json"
 )
 
 func CopyOrigValueTypeSlice(dest, src []*otlpprofiles.ValueType) []*otlpprofiles.ValueType {
@@ -47,16 +46,5 @@ func GenerateOrigTestValueTypeSlice() []*otlpprofiles.ValueType {
 	orig[2] = NewOrigValueType()
 	orig[3] = GenTestOrigValueType()
 	orig[4] = NewOrigValueType()
-	return orig
-}
-
-// UnmarshalJSONOrigValueTypeSlice unmarshals all properties from the current struct from the source iterator.
-func UnmarshalJSONOrigValueTypeSlice(iter *json.Iterator) []*otlpprofiles.ValueType {
-	var orig []*otlpprofiles.ValueType
-	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigValueType())
-		UnmarshalJSONOrigValueType(orig[len(orig)-1], iter)
-		return true
-	})
 	return orig
 }

--- a/pdata/internal/ids.go
+++ b/pdata/internal/ids.go
@@ -35,6 +35,18 @@ func MarshalJSONOrigProfileID(id *data.ProfileID, dest *json.Stream) {
 	id.MarshalJSONStream(dest)
 }
 
+func UnmarshalJSONOrigTraceID(id *data.TraceID, iter *json.Iterator) {
+	id.UnmarshalJSONIter(iter)
+}
+
+func UnmarshalJSONOrigSpanID(id *data.SpanID, iter *json.Iterator) {
+	id.UnmarshalJSONIter(iter)
+}
+
+func UnmarshalJSONOrigProfileID(id *data.ProfileID, iter *json.Iterator) {
+	id.UnmarshalJSONIter(iter)
+}
+
 func SizeProtoOrigTraceID(id *data.TraceID) int {
 	return id.Size()
 }

--- a/pdata/internal/json/iterator.go
+++ b/pdata/internal/json/iterator.go
@@ -3,6 +3,7 @@
 
 package json // import "go.opentelemetry.io/collector/pdata/internal/json"
 import (
+	"encoding/base64"
 	"strconv"
 
 	jsoniter "github.com/json-iterator/go"
@@ -142,6 +143,17 @@ func (iter *Iterator) ReadString() string {
 	return iter.delegate.ReadString()
 }
 
+// ReadBytes read base64 encoded bytes from iterator.
+func (iter *Iterator) ReadBytes() []byte {
+	buf := iter.ReadStringAsSlice()
+	orig := make([]byte, base64.StdEncoding.DecodedLen(len(buf)))
+	n, err := base64.StdEncoding.Decode(orig, buf)
+	if err != nil {
+		iter.ReportError("base64.Decode", err.Error())
+	}
+	return orig[:n]
+}
+
 // ReadStringAsSlice read string from iterator without copying into string form.
 // The []byte cannot be kept, as it will change after next iterator call.
 func (iter *Iterator) ReadStringAsSlice() []byte {
@@ -163,24 +175,15 @@ func (iter *Iterator) Skip() {
 	iter.delegate.Skip()
 }
 
-// ReadArrayCB read array with callback
-func (iter *Iterator) ReadArrayCB(fn func(iter *Iterator) bool) {
-	iter.delegate.ReadArrayCB(func(iterator *jsoniter.Iterator) bool {
-		newIter := Iterator{
-			delegate: iterator,
-		}
-		return fn(&newIter)
-	})
+// ReadArray read array element, returns true if the array has more element to read.
+func (iter *Iterator) ReadArray() bool {
+	return iter.delegate.ReadArray()
 }
 
-// ReadObjectCB read object with callback, the key is ascii only and field name not copied
-func (iter *Iterator) ReadObjectCB(fn func(iter *Iterator, f string) bool) {
-	iter.delegate.ReadObjectCB(func(iterator *jsoniter.Iterator, f string) bool {
-		newIter := Iterator{
-			delegate: iterator,
-		}
-		return fn(&newIter, f)
-	})
+// ReadObject read one field from object.
+// If object ended, returns empty string. Otherwise, returns the field name.
+func (iter *Iterator) ReadObject() string {
+	return iter.delegate.ReadObject()
 }
 
 // ReadEnumValue returns the enum integer value representation. Accepts both enum names and enum integer values.

--- a/pdata/internal/json/stream_test.go
+++ b/pdata/internal/json/stream_test.go
@@ -79,9 +79,16 @@ func TestMarshalFloat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := BorrowStream(nil)
+			defer ReturnStream(s)
 			s.WriteFloat64(tt.inputFloat)
 			require.Equal(t, tt.expected, string(s.Buffer()))
-			ReturnStream(s)
 		})
 	}
+}
+
+func TestWriteBytes(t *testing.T) {
+	s := BorrowStream(nil)
+	defer ReturnStream(s)
+	s.WriteBytes([]byte("test"))
+	require.Equal(t, `"dGVzdA=="`, string(s.Buffer()))
 }


### PR DESCRIPTION
Also, this PR improves JSON unmarshal logic by avoiding stack calls caused by using the Read[Array|Object]CB and replace with simple non-recursive iterations.