### PR TITLE
[chore] Remove internal.NewOrig* that returns directly the value

### DIFF
--- a/internal/cmd/pdatagen/internal/pdata/templates/message.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/message.go.tmpl
@@ -41,7 +41,7 @@ func new{{ .structName }}(orig *{{ .originFullName }}, state *internal.State) {{
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func New{{ .structName }}() {{ .structName }} {
-	return new{{ .structName }}(internal.NewOrigPtr{{ .originName }}(), internal.NewState())
+	return new{{ .structName }}(internal.NewOrig{{ .originName }}(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/internal/cmd/pdatagen/internal/pdata/templates/message_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/message_internal.go.tmpl
@@ -32,11 +32,7 @@ func New{{ .structName }}(orig *{{ .originFullName }}, state *State) {{ .structN
 
 {{ end }}
 
-func NewOrig{{ .originName }}() {{ .originFullName }} {
-	return {{ .originFullName }}{}
-}
-
-func NewOrigPtr{{ .originName }}() *{{ .originFullName }} {
+func NewOrig{{ .originName }}() *{{ .originFullName }} {
     return &{{ .originFullName }}{}
 }
 
@@ -47,7 +43,7 @@ func CopyOrig{{ .originName }}(dest, src *{{ .originFullName }}) {
 }
 
 func GenTestOrig{{ .originName }}() *{{ .originFullName }} {
-	orig := NewOrigPtr{{ .originName }}()
+	orig := NewOrig{{ .originName }}()
 	{{- range .fields }}
 	{{ .GenerateTestValue $.messageStruct }}
 	{{- end }}

--- a/internal/cmd/pdatagen/internal/pdata/templates/message_internal_test.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/message_internal_test.go.tmpl
@@ -10,14 +10,13 @@ import (
 	{{ range $index, $element := .testImports -}}
 	{{ $element }}
 	{{ end }}
-    "strconv"
 )
 
 func TestCopyOrig{{ .originName }}(t *testing.T) {
-	src := NewOrigPtr{{ .originName }}()
-	dest := NewOrigPtr{{ .originName }}()
+	src := NewOrig{{ .originName }}()
+	dest := NewOrig{{ .originName }}()
 	CopyOrig{{ .originName }}(dest, src)
-	assert.Equal(t, NewOrigPtr{{ .originName }}(), dest)
+	assert.Equal(t, NewOrig{{ .originName }}(), dest)
     *src = *GenTestOrig{{ .originName }}()
 	CopyOrig{{ .originName }}(dest, src)
 	assert.Equal(t, src, dest)
@@ -26,10 +25,10 @@ func TestCopyOrig{{ .originName }}(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrig{{ .originName }}Unknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtr{{ .originName }}()
+	dest := NewOrig{{ .originName }}()
 	UnmarshalJSONOrig{{ .originName }}(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtr{{ .originName }}(), dest)
+	assert.Equal(t, NewOrig{{ .originName }}(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrig{{ .originName }}(t *testing.T) {
@@ -42,7 +41,7 @@ func TestMarshalAndUnmarshalJSONOrig{{ .originName }}(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtr{{ .originName }}()
+			dest := NewOrig{{ .originName }}()
 			UnmarshalJSONOrig{{ .originName }}(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -54,17 +53,17 @@ func TestMarshalAndUnmarshalJSONOrig{{ .originName }}(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrig{{ .originName }}Failing(t *testing.T) {
     for name, buf := range genTestFailingUnmarshalProtoValues{{ .originName }}() {
         t.Run(name, func(t *testing.T) {
-            dest := NewOrigPtr{{ .originName }}()
+            dest := NewOrig{{ .originName }}()
             require.Error(t, UnmarshalProtoOrig{{ .originName }}(dest, buf))
         })
     }
 }
 
 func TestMarshalAndUnmarshalProtoOrig{{ .originName }}Unknown(t *testing.T) {
-	dest := NewOrigPtr{{ .originName }}()
+	dest := NewOrig{{ .originName }}()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrig{{ .originName }}(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtr{{ .originName }}(), dest)
+	assert.Equal(t, NewOrig{{ .originName }}(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrig{{ .originName }}(t *testing.T) {
@@ -74,7 +73,7 @@ func TestMarshalAndUnmarshalProtoOrig{{ .originName }}(t *testing.T) {
 			gotSize := MarshalProtoOrig{{ .originName }}(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtr{{ .originName }}()
+			dest := NewOrig{{ .originName }}()
 			require.NoError(t, UnmarshalProtoOrig{{ .originName }}(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -94,7 +93,7 @@ func TestMarshalAndUnmarshalProtoViaProtobuf{{ .originName }}(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtr{{ .originName }}()
+			dest := NewOrig{{ .originName }}()
 			require.NoError(t, UnmarshalProtoOrig{{ .originName }}(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -110,7 +109,7 @@ func genTestFailingUnmarshalProtoValues{{ .originName }}() map[string][]byte {
 
 func genTestEncodingValues{{ .originName }}() map[string]*{{ .originFullName }} {
 	return map[string]*{{ .originFullName }}{
-		"empty": NewOrigPtr{{ .originName }}(),
+		"empty": NewOrig{{ .originName }}(),
 		{{- range .fields }}{{ .GenerateTestEncodingValues $.messageStruct }}{{- end }}
 	}
 }

--- a/internal/cmd/pdatagen/internal/pdata/templates/message_test.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/message_test.go.tmpl
@@ -22,8 +22,8 @@ func Test{{ .structName }}_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTest{{ .structName }}(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(new{{ .structName }}(internal.NewOrigPtr{{ .originName }}(), sharedState)) })
-	assert.Panics(t, func() { new{{ .structName }}(internal.NewOrigPtr{{ .originName }}(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(new{{ .structName }}(internal.NewOrig{{ .originName }}(), sharedState)) })
+	assert.Panics(t, func() { new{{ .structName }}(internal.NewOrig{{ .originName }}(), sharedState).MoveTo(dest) })
 }
 
 func Test{{ .structName }}_CopyTo(t *testing.T) {
@@ -36,7 +36,7 @@ func Test{{ .structName }}_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(new{{ .structName }}(internal.NewOrigPtr{{ .originName }}(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(new{{ .structName }}(internal.NewOrig{{ .originName }}(), sharedState)) })
 }
 
 {{ range .fields }}

--- a/internal/cmd/pdatagen/internal/pdata/templates/slice.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/slice.go.tmpl
@@ -103,7 +103,7 @@ func (es {{ .structName }}) EnsureCapacity(newCap int) {
 // It returns the newly added {{ .elementName }}.
 func (es {{ .structName }}) AppendEmpty() {{ .elementName }} {
 	es.{{ .stateAccessor }}.AssertMutable()
-	*es.{{ .origAccessor }} = append(*es.{{ .origAccessor }}, {{- if .elementNullable }}internal.NewOrigPtr{{ .elementOriginName }}(){{ else }}{{ .elementOriginFullName }}{}{{ end }})
+	*es.{{ .origAccessor }} = append(*es.{{ .origAccessor }}, {{- if .elementNullable }}internal.NewOrig{{ .elementOriginName }}(){{ else }}{{ .elementOriginFullName }}{}{{ end }})
 	return es.At(es.Len() - 1)
 }
 

--- a/internal/cmd/pdatagen/internal/pdata/templates/slice_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/slice_internal.go.tmpl
@@ -45,7 +45,7 @@ func CopyOrig{{ .elementOriginName }}Slice(dest, src []{{ if .elementNullable }}
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtr{{ .elementOriginName }}()
+			newDest[i] = NewOrig{{ .elementOriginName }}()
 		}{{ else -}}
 		newDest = make([]{{ .elementOriginFullName }}, len(src))
         {{- end }}
@@ -60,7 +60,7 @@ func CopyOrig{{ .elementOriginName }}Slice(dest, src []{{ if .elementNullable }}
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtr{{ .elementOriginName }}()
+			newDest[i] = NewOrig{{ .elementOriginName }}()
 		}{{ else -}}
 		for i := len(src); i < len(dest); i++ {
 			dest[i].Reset()
@@ -76,11 +76,11 @@ func CopyOrig{{ .elementOriginName }}Slice(dest, src []{{ if .elementNullable }}
 func GenerateOrigTest{{ .elementOriginName }}Slice() []{{ if .elementNullable }}*{{ end }}{{ .elementOriginFullName }} {
     {{ if .elementNullable -}}
     orig := make([]*{{ .elementOriginFullName }}, 5)
-	orig[0] = NewOrigPtr{{ .elementOriginName }}()
+	orig[0] = NewOrig{{ .elementOriginName }}()
 	orig[1] = GenTestOrig{{ .elementOriginName }}()
-    orig[2] = NewOrigPtr{{ .elementOriginName }}()
+    orig[2] = NewOrig{{ .elementOriginName }}()
 	orig[3] = GenTestOrig{{ .elementOriginName }}()
-    orig[4] = NewOrigPtr{{ .elementOriginName }}(){{ else -}}
+    orig[4] = NewOrig{{ .elementOriginName }}(){{ else -}}
     orig := make([]{{ .elementOriginFullName }}, 5)
     orig[1] = *GenTestOrig{{ .elementOriginName }}()
     orig[3] = *GenTestOrig{{ .elementOriginName }}()
@@ -92,7 +92,7 @@ func GenerateOrigTest{{ .elementOriginName }}Slice() []{{ if .elementNullable }}
 func UnmarshalJSONOrig{{ .elementOriginName }}Slice(iter *json.Iterator) []{{ if .elementNullable }}*{{ end }}{{ .elementOriginFullName }} {
 	var orig []{{ if .elementNullable }}*{{ end }}{{ .elementOriginFullName }}
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, {{- if .elementNullable }}NewOrigPtr{{ .elementOriginName }}(){{ else }}{{ .elementOriginFullName }}{}{{ end }})
+		orig = append(orig, {{- if .elementNullable }}NewOrig{{ .elementOriginName }}(){{ else }}{{ .elementOriginFullName }}{}{{ end }})
 		UnmarshalJSONOrig{{ .elementOriginName }}({{ if not .elementNullable }}&{{ end }}orig[len(orig)-1], iter)
 		return true
 	})

--- a/internal/cmd/pdatagen/internal/proto/proto_unmarshal.go
+++ b/internal/cmd/pdatagen/internal/proto/proto_unmarshal.go
@@ -233,20 +233,20 @@ const unmarshalProtoMessage = `
 		startPos := pos - length
 {{ if ne .oneOfGroup "" -}}
 		ofv := &{{ .oneOfMessageFullName }}{}
-		ofv.{{ .fieldName }} = NewOrigPtr{{ .origName }}()
+		ofv.{{ .fieldName }} = NewOrig{{ .origName }}()
 		err = UnmarshalProtoOrig{{ .origName }}(ofv.{{ .fieldName }}, buf[startPos:pos])
 		if err != nil {
 			return err
 		}
 		orig.{{ .oneOfGroup }} = ofv
 {{- else if .repeated -}}
-		orig.{{ .fieldName }} = append(orig.{{ .fieldName }}, NewOrig{{ if .nullable }}Ptr{{ end }}{{ .origName }}())
+		orig.{{ .fieldName }} = append(orig.{{ .fieldName }}, {{ if .nullable }}NewOrig{{ .origName }}(){{ else }}{{ .defaultValue }}{{ end }})
 		err = UnmarshalProtoOrig{{ .origName }}({{ if not .nullable }}&{{ end }}orig.{{ .fieldName }}[len(orig.{{ .fieldName }})-1], buf[startPos:pos])
 		if err != nil {
 			return err
 		}
 {{- else }}
-		{{ if .nullable }}orig.{{ .fieldName }} = NewOrigPtr{{ .origName }}(){{ end }}
+		{{ if .nullable }}orig.{{ .fieldName }} = NewOrig{{ .origName }}(){{ end }}
 		err = UnmarshalProtoOrig{{ .origName }}({{ if not .nullable }}&{{ end }}orig.{{ .fieldName }}, buf[startPos:pos]) 
 		if err != nil {
 			return err

--- a/pdata/internal/generated_wrapper_attributeunit.go
+++ b/pdata/internal/generated_wrapper_attributeunit.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigAttributeUnit() otlpprofiles.AttributeUnit {
-	return otlpprofiles.AttributeUnit{}
-}
-
-func NewOrigPtrAttributeUnit() *otlpprofiles.AttributeUnit {
+func NewOrigAttributeUnit() *otlpprofiles.AttributeUnit {
 	return &otlpprofiles.AttributeUnit{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigAttributeUnit(dest, src *otlpprofiles.AttributeUnit) {
 }
 
 func GenTestOrigAttributeUnit() *otlpprofiles.AttributeUnit {
-	orig := NewOrigPtrAttributeUnit()
+	orig := NewOrigAttributeUnit()
 	orig.AttributeKeyStrindex = int32(13)
 	orig.UnitStrindex = int32(13)
 	return orig

--- a/pdata/internal/generated_wrapper_attributeunit_test.go
+++ b/pdata/internal/generated_wrapper_attributeunit_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigAttributeUnit(t *testing.T) {
-	src := NewOrigPtrAttributeUnit()
-	dest := NewOrigPtrAttributeUnit()
+	src := NewOrigAttributeUnit()
+	dest := NewOrigAttributeUnit()
 	CopyOrigAttributeUnit(dest, src)
-	assert.Equal(t, NewOrigPtrAttributeUnit(), dest)
+	assert.Equal(t, NewOrigAttributeUnit(), dest)
 	*src = *GenTestOrigAttributeUnit()
 	CopyOrigAttributeUnit(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigAttributeUnit(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigAttributeUnitUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrAttributeUnit()
+	dest := NewOrigAttributeUnit()
 	UnmarshalJSONOrigAttributeUnit(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrAttributeUnit(), dest)
+	assert.Equal(t, NewOrigAttributeUnit(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigAttributeUnit(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigAttributeUnit(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrAttributeUnit()
+			dest := NewOrigAttributeUnit()
 			UnmarshalJSONOrigAttributeUnit(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigAttributeUnit(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigAttributeUnitFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesAttributeUnit() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrAttributeUnit()
+			dest := NewOrigAttributeUnit()
 			require.Error(t, UnmarshalProtoOrigAttributeUnit(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigAttributeUnitUnknown(t *testing.T) {
-	dest := NewOrigPtrAttributeUnit()
+	dest := NewOrigAttributeUnit()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigAttributeUnit(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrAttributeUnit(), dest)
+	assert.Equal(t, NewOrigAttributeUnit(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigAttributeUnit(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigAttributeUnit(t *testing.T) {
 			gotSize := MarshalProtoOrigAttributeUnit(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrAttributeUnit()
+			dest := NewOrigAttributeUnit()
 			require.NoError(t, UnmarshalProtoOrigAttributeUnit(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufAttributeUnit(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrAttributeUnit()
+			dest := NewOrigAttributeUnit()
 			require.NoError(t, UnmarshalProtoOrigAttributeUnit(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesAttributeUnit() map[string][]byte {
 
 func genTestEncodingValuesAttributeUnit() map[string]*otlpprofiles.AttributeUnit {
 	return map[string]*otlpprofiles.AttributeUnit{
-		"empty":                     NewOrigPtrAttributeUnit(),
+		"empty":                     NewOrigAttributeUnit(),
 		"AttributeKeyStrindex/test": {AttributeKeyStrindex: int32(13)},
 		"UnitStrindex/test":         {UnitStrindex: int32(13)},
 	}

--- a/pdata/internal/generated_wrapper_attributeunitslice.go
+++ b/pdata/internal/generated_wrapper_attributeunitslice.go
@@ -19,7 +19,7 @@ func CopyOrigAttributeUnitSlice(dest, src []*otlpprofiles.AttributeUnit) []*otlp
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrAttributeUnit()
+			newDest[i] = NewOrigAttributeUnit()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigAttributeUnitSlice(dest, src []*otlpprofiles.AttributeUnit) []*otlp
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrAttributeUnit()
+			newDest[i] = NewOrigAttributeUnit()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigAttributeUnitSlice(dest, src []*otlpprofiles.AttributeUnit) []*otlp
 
 func GenerateOrigTestAttributeUnitSlice() []*otlpprofiles.AttributeUnit {
 	orig := make([]*otlpprofiles.AttributeUnit, 5)
-	orig[0] = NewOrigPtrAttributeUnit()
+	orig[0] = NewOrigAttributeUnit()
 	orig[1] = GenTestOrigAttributeUnit()
-	orig[2] = NewOrigPtrAttributeUnit()
+	orig[2] = NewOrigAttributeUnit()
 	orig[3] = GenTestOrigAttributeUnit()
-	orig[4] = NewOrigPtrAttributeUnit()
+	orig[4] = NewOrigAttributeUnit()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestAttributeUnitSlice() []*otlpprofiles.AttributeUnit {
 func UnmarshalJSONOrigAttributeUnitSlice(iter *json.Iterator) []*otlpprofiles.AttributeUnit {
 	var orig []*otlpprofiles.AttributeUnit
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrAttributeUnit())
+		orig = append(orig, NewOrigAttributeUnit())
 		UnmarshalJSONOrigAttributeUnit(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_entityref.go
+++ b/pdata/internal/generated_wrapper_entityref.go
@@ -31,11 +31,7 @@ func NewEntityRef(orig *otlpcommon.EntityRef, state *State) EntityRef {
 	return EntityRef{orig: orig, state: state}
 }
 
-func NewOrigEntityRef() otlpcommon.EntityRef {
-	return otlpcommon.EntityRef{}
-}
-
-func NewOrigPtrEntityRef() *otlpcommon.EntityRef {
+func NewOrigEntityRef() *otlpcommon.EntityRef {
 	return &otlpcommon.EntityRef{}
 }
 
@@ -47,7 +43,7 @@ func CopyOrigEntityRef(dest, src *otlpcommon.EntityRef) {
 }
 
 func GenTestOrigEntityRef() *otlpcommon.EntityRef {
-	orig := NewOrigPtrEntityRef()
+	orig := NewOrigEntityRef()
 	orig.SchemaUrl = "test_schemaurl"
 	orig.Type = "test_type"
 	orig.IdKeys = GenerateOrigTestStringSlice()

--- a/pdata/internal/generated_wrapper_entityref_test.go
+++ b/pdata/internal/generated_wrapper_entityref_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigEntityRef(t *testing.T) {
-	src := NewOrigPtrEntityRef()
-	dest := NewOrigPtrEntityRef()
+	src := NewOrigEntityRef()
+	dest := NewOrigEntityRef()
 	CopyOrigEntityRef(dest, src)
-	assert.Equal(t, NewOrigPtrEntityRef(), dest)
+	assert.Equal(t, NewOrigEntityRef(), dest)
 	*src = *GenTestOrigEntityRef()
 	CopyOrigEntityRef(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigEntityRef(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigEntityRefUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrEntityRef()
+	dest := NewOrigEntityRef()
 	UnmarshalJSONOrigEntityRef(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrEntityRef(), dest)
+	assert.Equal(t, NewOrigEntityRef(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigEntityRef(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigEntityRef(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrEntityRef()
+			dest := NewOrigEntityRef()
 			UnmarshalJSONOrigEntityRef(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigEntityRef(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigEntityRefFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesEntityRef() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrEntityRef()
+			dest := NewOrigEntityRef()
 			require.Error(t, UnmarshalProtoOrigEntityRef(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigEntityRefUnknown(t *testing.T) {
-	dest := NewOrigPtrEntityRef()
+	dest := NewOrigEntityRef()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigEntityRef(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrEntityRef(), dest)
+	assert.Equal(t, NewOrigEntityRef(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigEntityRef(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigEntityRef(t *testing.T) {
 			gotSize := MarshalProtoOrigEntityRef(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrEntityRef()
+			dest := NewOrigEntityRef()
 			require.NoError(t, UnmarshalProtoOrigEntityRef(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufEntityRef(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrEntityRef()
+			dest := NewOrigEntityRef()
 			require.NoError(t, UnmarshalProtoOrigEntityRef(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -122,7 +122,7 @@ func genTestFailingUnmarshalProtoValuesEntityRef() map[string][]byte {
 
 func genTestEncodingValuesEntityRef() map[string]*otlpcommon.EntityRef {
 	return map[string]*otlpcommon.EntityRef{
-		"empty":                            NewOrigPtrEntityRef(),
+		"empty":                            NewOrigEntityRef(),
 		"SchemaUrl/test":                   {SchemaUrl: "test_schemaurl"},
 		"Type/test":                        {Type: "test_type"},
 		"IdKeys/default_and_test":          {IdKeys: []string{"", "test_idkeys"}},

--- a/pdata/internal/generated_wrapper_entityrefslice.go
+++ b/pdata/internal/generated_wrapper_entityrefslice.go
@@ -41,7 +41,7 @@ func CopyOrigEntityRefSlice(dest, src []*otlpcommon.EntityRef) []*otlpcommon.Ent
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrEntityRef()
+			newDest[i] = NewOrigEntityRef()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -53,7 +53,7 @@ func CopyOrigEntityRefSlice(dest, src []*otlpcommon.EntityRef) []*otlpcommon.Ent
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrEntityRef()
+			newDest[i] = NewOrigEntityRef()
 		}
 	}
 	for i := range src {
@@ -64,11 +64,11 @@ func CopyOrigEntityRefSlice(dest, src []*otlpcommon.EntityRef) []*otlpcommon.Ent
 
 func GenerateOrigTestEntityRefSlice() []*otlpcommon.EntityRef {
 	orig := make([]*otlpcommon.EntityRef, 5)
-	orig[0] = NewOrigPtrEntityRef()
+	orig[0] = NewOrigEntityRef()
 	orig[1] = GenTestOrigEntityRef()
-	orig[2] = NewOrigPtrEntityRef()
+	orig[2] = NewOrigEntityRef()
 	orig[3] = GenTestOrigEntityRef()
-	orig[4] = NewOrigPtrEntityRef()
+	orig[4] = NewOrigEntityRef()
 	return orig
 }
 
@@ -76,7 +76,7 @@ func GenerateOrigTestEntityRefSlice() []*otlpcommon.EntityRef {
 func UnmarshalJSONOrigEntityRefSlice(iter *json.Iterator) []*otlpcommon.EntityRef {
 	var orig []*otlpcommon.EntityRef
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrEntityRef())
+		orig = append(orig, NewOrigEntityRef())
 		UnmarshalJSONOrigEntityRef(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_exemplar.go
+++ b/pdata/internal/generated_wrapper_exemplar.go
@@ -12,16 +12,13 @@ import (
 	"math"
 
 	"go.opentelemetry.io/collector/pdata/internal/data"
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExemplar() otlpmetrics.Exemplar {
-	return otlpmetrics.Exemplar{}
-}
-
-func NewOrigPtrExemplar() *otlpmetrics.Exemplar {
+func NewOrigExemplar() *otlpmetrics.Exemplar {
 	return &otlpmetrics.Exemplar{}
 }
 
@@ -39,7 +36,7 @@ func CopyOrigExemplar(dest, src *otlpmetrics.Exemplar) {
 }
 
 func GenTestOrigExemplar() *otlpmetrics.Exemplar {
-	orig := NewOrigPtrExemplar()
+	orig := NewOrigExemplar()
 	orig.FilteredAttributes = GenerateOrigTestKeyValueSlice()
 	orig.TimeUnixNano = 1234567890
 	orig.Value = &otlpmetrics.Exemplar_AsInt{AsInt: int64(13)}
@@ -208,7 +205,7 @@ func UnmarshalProtoOrigExemplar(orig *otlpmetrics.Exemplar, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.FilteredAttributes = append(orig.FilteredAttributes, NewOrigKeyValue())
+			orig.FilteredAttributes = append(orig.FilteredAttributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.FilteredAttributes[len(orig.FilteredAttributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_exemplar_test.go
+++ b/pdata/internal/generated_wrapper_exemplar_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigExemplar(t *testing.T) {
-	src := NewOrigPtrExemplar()
-	dest := NewOrigPtrExemplar()
+	src := NewOrigExemplar()
+	dest := NewOrigExemplar()
 	CopyOrigExemplar(dest, src)
-	assert.Equal(t, NewOrigPtrExemplar(), dest)
+	assert.Equal(t, NewOrigExemplar(), dest)
 	*src = *GenTestOrigExemplar()
 	CopyOrigExemplar(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigExemplar(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExemplarUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExemplar()
+	dest := NewOrigExemplar()
 	UnmarshalJSONOrigExemplar(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExemplar(), dest)
+	assert.Equal(t, NewOrigExemplar(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExemplar(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigExemplar(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExemplar()
+			dest := NewOrigExemplar()
 			UnmarshalJSONOrigExemplar(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigExemplar(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExemplarFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExemplar() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExemplar()
+			dest := NewOrigExemplar()
 			require.Error(t, UnmarshalProtoOrigExemplar(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExemplarUnknown(t *testing.T) {
-	dest := NewOrigPtrExemplar()
+	dest := NewOrigExemplar()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExemplar(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExemplar(), dest)
+	assert.Equal(t, NewOrigExemplar(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExemplar(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigExemplar(t *testing.T) {
 			gotSize := MarshalProtoOrigExemplar(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExemplar()
+			dest := NewOrigExemplar()
 			require.NoError(t, UnmarshalProtoOrigExemplar(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExemplar(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExemplar()
+			dest := NewOrigExemplar()
 			require.NoError(t, UnmarshalProtoOrigExemplar(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -129,7 +129,7 @@ func genTestFailingUnmarshalProtoValuesExemplar() map[string][]byte {
 
 func genTestEncodingValuesExemplar() map[string]*otlpmetrics.Exemplar {
 	return map[string]*otlpmetrics.Exemplar{
-		"empty":                               NewOrigPtrExemplar(),
+		"empty":                               NewOrigExemplar(),
 		"FilteredAttributes/default_and_test": {FilteredAttributes: []otlpcommon.KeyValue{{}, *GenTestOrigKeyValue()}},
 		"TimeUnixNano/test":                   {TimeUnixNano: uint64(13)},
 		"AsDouble/default":                    {Value: &otlpmetrics.Exemplar_AsDouble{AsDouble: float64(0)}},

--- a/pdata/internal/generated_wrapper_exponentialhistogram.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogram.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExponentialHistogram() otlpmetrics.ExponentialHistogram {
-	return otlpmetrics.ExponentialHistogram{}
-}
-
-func NewOrigPtrExponentialHistogram() *otlpmetrics.ExponentialHistogram {
+func NewOrigExponentialHistogram() *otlpmetrics.ExponentialHistogram {
 	return &otlpmetrics.ExponentialHistogram{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigExponentialHistogram(dest, src *otlpmetrics.ExponentialHistogram) {
 }
 
 func GenTestOrigExponentialHistogram() *otlpmetrics.ExponentialHistogram {
-	orig := NewOrigPtrExponentialHistogram()
+	orig := NewOrigExponentialHistogram()
 	orig.DataPoints = GenerateOrigTestExponentialHistogramDataPointSlice()
 	orig.AggregationTemporality = otlpmetrics.AggregationTemporality(1)
 	return orig
@@ -128,7 +124,7 @@ func UnmarshalProtoOrigExponentialHistogram(orig *otlpmetrics.ExponentialHistogr
 				return err
 			}
 			startPos := pos - length
-			orig.DataPoints = append(orig.DataPoints, NewOrigPtrExponentialHistogramDataPoint())
+			orig.DataPoints = append(orig.DataPoints, NewOrigExponentialHistogramDataPoint())
 			err = UnmarshalProtoOrigExponentialHistogramDataPoint(orig.DataPoints[len(orig.DataPoints)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_exponentialhistogram_test.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogram_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExponentialHistogram(t *testing.T) {
-	src := NewOrigPtrExponentialHistogram()
-	dest := NewOrigPtrExponentialHistogram()
+	src := NewOrigExponentialHistogram()
+	dest := NewOrigExponentialHistogram()
 	CopyOrigExponentialHistogram(dest, src)
-	assert.Equal(t, NewOrigPtrExponentialHistogram(), dest)
+	assert.Equal(t, NewOrigExponentialHistogram(), dest)
 	*src = *GenTestOrigExponentialHistogram()
 	CopyOrigExponentialHistogram(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExponentialHistogram(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExponentialHistogramUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExponentialHistogram()
+	dest := NewOrigExponentialHistogram()
 	UnmarshalJSONOrigExponentialHistogram(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExponentialHistogram(), dest)
+	assert.Equal(t, NewOrigExponentialHistogram(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExponentialHistogram(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExponentialHistogram(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExponentialHistogram()
+			dest := NewOrigExponentialHistogram()
 			UnmarshalJSONOrigExponentialHistogram(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExponentialHistogram(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExponentialHistogramFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExponentialHistogram() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExponentialHistogram()
+			dest := NewOrigExponentialHistogram()
 			require.Error(t, UnmarshalProtoOrigExponentialHistogram(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExponentialHistogramUnknown(t *testing.T) {
-	dest := NewOrigPtrExponentialHistogram()
+	dest := NewOrigExponentialHistogram()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExponentialHistogram(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExponentialHistogram(), dest)
+	assert.Equal(t, NewOrigExponentialHistogram(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExponentialHistogram(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExponentialHistogram(t *testing.T) {
 			gotSize := MarshalProtoOrigExponentialHistogram(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExponentialHistogram()
+			dest := NewOrigExponentialHistogram()
 			require.NoError(t, UnmarshalProtoOrigExponentialHistogram(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExponentialHistogram(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExponentialHistogram()
+			dest := NewOrigExponentialHistogram()
 			require.NoError(t, UnmarshalProtoOrigExponentialHistogram(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesExponentialHistogram() map[string][]byte 
 
 func genTestEncodingValuesExponentialHistogram() map[string]*otlpmetrics.ExponentialHistogram {
 	return map[string]*otlpmetrics.ExponentialHistogram{
-		"empty":                       NewOrigPtrExponentialHistogram(),
+		"empty":                       NewOrigExponentialHistogram(),
 		"DataPoints/default_and_test": {DataPoints: []*otlpmetrics.ExponentialHistogramDataPoint{{}, GenTestOrigExponentialHistogramDataPoint()}},
 		"AggregationTemporality/test": {AggregationTemporality: otlpmetrics.AggregationTemporality(13)},
 	}

--- a/pdata/internal/generated_wrapper_exponentialhistogramdatapoint.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogramdatapoint.go
@@ -11,16 +11,13 @@ import (
 	"fmt"
 	"math"
 
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExponentialHistogramDataPoint() otlpmetrics.ExponentialHistogramDataPoint {
-	return otlpmetrics.ExponentialHistogramDataPoint{}
-}
-
-func NewOrigPtrExponentialHistogramDataPoint() *otlpmetrics.ExponentialHistogramDataPoint {
+func NewOrigExponentialHistogramDataPoint() *otlpmetrics.ExponentialHistogramDataPoint {
 	return &otlpmetrics.ExponentialHistogramDataPoint{}
 }
 
@@ -69,7 +66,7 @@ func CopyOrigExponentialHistogramDataPoint(dest, src *otlpmetrics.ExponentialHis
 }
 
 func GenTestOrigExponentialHistogramDataPoint() *otlpmetrics.ExponentialHistogramDataPoint {
-	orig := NewOrigPtrExponentialHistogramDataPoint()
+	orig := NewOrigExponentialHistogramDataPoint()
 	orig.Attributes = GenerateOrigTestKeyValueSlice()
 	orig.StartTimeUnixNano = 1234567890
 	orig.TimeUnixNano = 1234567890
@@ -365,7 +362,7 @@ func UnmarshalProtoOrigExponentialHistogramDataPoint(orig *otlpmetrics.Exponenti
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -498,7 +495,7 @@ func UnmarshalProtoOrigExponentialHistogramDataPoint(orig *otlpmetrics.Exponenti
 				return err
 			}
 			startPos := pos - length
-			orig.Exemplars = append(orig.Exemplars, NewOrigExemplar())
+			orig.Exemplars = append(orig.Exemplars, otlpmetrics.Exemplar{})
 			err = UnmarshalProtoOrigExemplar(&orig.Exemplars[len(orig.Exemplars)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_buckets.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_buckets.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExponentialHistogramDataPoint_Buckets() otlpmetrics.ExponentialHistogramDataPoint_Buckets {
-	return otlpmetrics.ExponentialHistogramDataPoint_Buckets{}
-}
-
-func NewOrigPtrExponentialHistogramDataPoint_Buckets() *otlpmetrics.ExponentialHistogramDataPoint_Buckets {
+func NewOrigExponentialHistogramDataPoint_Buckets() *otlpmetrics.ExponentialHistogramDataPoint_Buckets {
 	return &otlpmetrics.ExponentialHistogramDataPoint_Buckets{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigExponentialHistogramDataPoint_Buckets(dest, src *otlpmetrics.Expone
 }
 
 func GenTestOrigExponentialHistogramDataPoint_Buckets() *otlpmetrics.ExponentialHistogramDataPoint_Buckets {
-	orig := NewOrigPtrExponentialHistogramDataPoint_Buckets()
+	orig := NewOrigExponentialHistogramDataPoint_Buckets()
 	orig.Offset = int32(13)
 	orig.BucketCounts = GenerateOrigTestUint64Slice()
 	return orig

--- a/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_buckets_test.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_buckets_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExponentialHistogramDataPoint_Buckets(t *testing.T) {
-	src := NewOrigPtrExponentialHistogramDataPoint_Buckets()
-	dest := NewOrigPtrExponentialHistogramDataPoint_Buckets()
+	src := NewOrigExponentialHistogramDataPoint_Buckets()
+	dest := NewOrigExponentialHistogramDataPoint_Buckets()
 	CopyOrigExponentialHistogramDataPoint_Buckets(dest, src)
-	assert.Equal(t, NewOrigPtrExponentialHistogramDataPoint_Buckets(), dest)
+	assert.Equal(t, NewOrigExponentialHistogramDataPoint_Buckets(), dest)
 	*src = *GenTestOrigExponentialHistogramDataPoint_Buckets()
 	CopyOrigExponentialHistogramDataPoint_Buckets(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExponentialHistogramDataPoint_Buckets(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExponentialHistogramDataPoint_BucketsUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExponentialHistogramDataPoint_Buckets()
+	dest := NewOrigExponentialHistogramDataPoint_Buckets()
 	UnmarshalJSONOrigExponentialHistogramDataPoint_Buckets(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExponentialHistogramDataPoint_Buckets(), dest)
+	assert.Equal(t, NewOrigExponentialHistogramDataPoint_Buckets(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExponentialHistogramDataPoint_Buckets(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExponentialHistogramDataPoint_Buckets(t *tes
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExponentialHistogramDataPoint_Buckets()
+			dest := NewOrigExponentialHistogramDataPoint_Buckets()
 			UnmarshalJSONOrigExponentialHistogramDataPoint_Buckets(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExponentialHistogramDataPoint_Buckets(t *tes
 func TestMarshalAndUnmarshalProtoOrigExponentialHistogramDataPoint_BucketsFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExponentialHistogramDataPoint_Buckets() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExponentialHistogramDataPoint_Buckets()
+			dest := NewOrigExponentialHistogramDataPoint_Buckets()
 			require.Error(t, UnmarshalProtoOrigExponentialHistogramDataPoint_Buckets(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExponentialHistogramDataPoint_BucketsUnknown(t *testing.T) {
-	dest := NewOrigPtrExponentialHistogramDataPoint_Buckets()
+	dest := NewOrigExponentialHistogramDataPoint_Buckets()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExponentialHistogramDataPoint_Buckets(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExponentialHistogramDataPoint_Buckets(), dest)
+	assert.Equal(t, NewOrigExponentialHistogramDataPoint_Buckets(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExponentialHistogramDataPoint_Buckets(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExponentialHistogramDataPoint_Buckets(t *te
 			gotSize := MarshalProtoOrigExponentialHistogramDataPoint_Buckets(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExponentialHistogramDataPoint_Buckets()
+			dest := NewOrigExponentialHistogramDataPoint_Buckets()
 			require.NoError(t, UnmarshalProtoOrigExponentialHistogramDataPoint_Buckets(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExponentialHistogramDataPoint_Bucket
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExponentialHistogramDataPoint_Buckets()
+			dest := NewOrigExponentialHistogramDataPoint_Buckets()
 			require.NoError(t, UnmarshalProtoOrigExponentialHistogramDataPoint_Buckets(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesExponentialHistogramDataPoint_Buckets() m
 
 func genTestEncodingValuesExponentialHistogramDataPoint_Buckets() map[string]*otlpmetrics.ExponentialHistogramDataPoint_Buckets {
 	return map[string]*otlpmetrics.ExponentialHistogramDataPoint_Buckets{
-		"empty":                         NewOrigPtrExponentialHistogramDataPoint_Buckets(),
+		"empty":                         NewOrigExponentialHistogramDataPoint_Buckets(),
 		"Offset/test":                   {Offset: int32(13)},
 		"BucketCounts/default_and_test": {BucketCounts: []uint64{uint64(0), uint64(13)}},
 	}

--- a/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_test.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigExponentialHistogramDataPoint(t *testing.T) {
-	src := NewOrigPtrExponentialHistogramDataPoint()
-	dest := NewOrigPtrExponentialHistogramDataPoint()
+	src := NewOrigExponentialHistogramDataPoint()
+	dest := NewOrigExponentialHistogramDataPoint()
 	CopyOrigExponentialHistogramDataPoint(dest, src)
-	assert.Equal(t, NewOrigPtrExponentialHistogramDataPoint(), dest)
+	assert.Equal(t, NewOrigExponentialHistogramDataPoint(), dest)
 	*src = *GenTestOrigExponentialHistogramDataPoint()
 	CopyOrigExponentialHistogramDataPoint(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigExponentialHistogramDataPoint(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExponentialHistogramDataPointUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExponentialHistogramDataPoint()
+	dest := NewOrigExponentialHistogramDataPoint()
 	UnmarshalJSONOrigExponentialHistogramDataPoint(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExponentialHistogramDataPoint(), dest)
+	assert.Equal(t, NewOrigExponentialHistogramDataPoint(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExponentialHistogramDataPoint(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigExponentialHistogramDataPoint(t *testing.T) 
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExponentialHistogramDataPoint()
+			dest := NewOrigExponentialHistogramDataPoint()
 			UnmarshalJSONOrigExponentialHistogramDataPoint(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigExponentialHistogramDataPoint(t *testing.T) 
 func TestMarshalAndUnmarshalProtoOrigExponentialHistogramDataPointFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExponentialHistogramDataPoint() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExponentialHistogramDataPoint()
+			dest := NewOrigExponentialHistogramDataPoint()
 			require.Error(t, UnmarshalProtoOrigExponentialHistogramDataPoint(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExponentialHistogramDataPointUnknown(t *testing.T) {
-	dest := NewOrigPtrExponentialHistogramDataPoint()
+	dest := NewOrigExponentialHistogramDataPoint()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExponentialHistogramDataPoint(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExponentialHistogramDataPoint(), dest)
+	assert.Equal(t, NewOrigExponentialHistogramDataPoint(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExponentialHistogramDataPoint(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigExponentialHistogramDataPoint(t *testing.T)
 			gotSize := MarshalProtoOrigExponentialHistogramDataPoint(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExponentialHistogramDataPoint()
+			dest := NewOrigExponentialHistogramDataPoint()
 			require.NoError(t, UnmarshalProtoOrigExponentialHistogramDataPoint(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExponentialHistogramDataPoint(t *tes
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExponentialHistogramDataPoint()
+			dest := NewOrigExponentialHistogramDataPoint()
 			require.NoError(t, UnmarshalProtoOrigExponentialHistogramDataPoint(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -143,7 +143,7 @@ func genTestFailingUnmarshalProtoValuesExponentialHistogramDataPoint() map[strin
 
 func genTestEncodingValuesExponentialHistogramDataPoint() map[string]*otlpmetrics.ExponentialHistogramDataPoint {
 	return map[string]*otlpmetrics.ExponentialHistogramDataPoint{
-		"empty":                       NewOrigPtrExponentialHistogramDataPoint(),
+		"empty":                       NewOrigExponentialHistogramDataPoint(),
 		"Attributes/default_and_test": {Attributes: []otlpcommon.KeyValue{{}, *GenTestOrigKeyValue()}},
 		"StartTimeUnixNano/test":      {StartTimeUnixNano: uint64(13)},
 		"TimeUnixNano/test":           {TimeUnixNano: uint64(13)},

--- a/pdata/internal/generated_wrapper_exponentialhistogramdatapointslice.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogramdatapointslice.go
@@ -19,7 +19,7 @@ func CopyOrigExponentialHistogramDataPointSlice(dest, src []*otlpmetrics.Exponen
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrExponentialHistogramDataPoint()
+			newDest[i] = NewOrigExponentialHistogramDataPoint()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigExponentialHistogramDataPointSlice(dest, src []*otlpmetrics.Exponen
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrExponentialHistogramDataPoint()
+			newDest[i] = NewOrigExponentialHistogramDataPoint()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigExponentialHistogramDataPointSlice(dest, src []*otlpmetrics.Exponen
 
 func GenerateOrigTestExponentialHistogramDataPointSlice() []*otlpmetrics.ExponentialHistogramDataPoint {
 	orig := make([]*otlpmetrics.ExponentialHistogramDataPoint, 5)
-	orig[0] = NewOrigPtrExponentialHistogramDataPoint()
+	orig[0] = NewOrigExponentialHistogramDataPoint()
 	orig[1] = GenTestOrigExponentialHistogramDataPoint()
-	orig[2] = NewOrigPtrExponentialHistogramDataPoint()
+	orig[2] = NewOrigExponentialHistogramDataPoint()
 	orig[3] = GenTestOrigExponentialHistogramDataPoint()
-	orig[4] = NewOrigPtrExponentialHistogramDataPoint()
+	orig[4] = NewOrigExponentialHistogramDataPoint()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestExponentialHistogramDataPointSlice() []*otlpmetrics.Exponen
 func UnmarshalJSONOrigExponentialHistogramDataPointSlice(iter *json.Iterator) []*otlpmetrics.ExponentialHistogramDataPoint {
 	var orig []*otlpmetrics.ExponentialHistogramDataPoint
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrExponentialHistogramDataPoint())
+		orig = append(orig, NewOrigExponentialHistogramDataPoint())
 		UnmarshalJSONOrigExponentialHistogramDataPoint(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_exportlogspartialsuccess.go
+++ b/pdata/internal/generated_wrapper_exportlogspartialsuccess.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExportLogsPartialSuccess() otlpcollectorlogs.ExportLogsPartialSuccess {
-	return otlpcollectorlogs.ExportLogsPartialSuccess{}
-}
-
-func NewOrigPtrExportLogsPartialSuccess() *otlpcollectorlogs.ExportLogsPartialSuccess {
+func NewOrigExportLogsPartialSuccess() *otlpcollectorlogs.ExportLogsPartialSuccess {
 	return &otlpcollectorlogs.ExportLogsPartialSuccess{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigExportLogsPartialSuccess(dest, src *otlpcollectorlogs.ExportLogsPar
 }
 
 func GenTestOrigExportLogsPartialSuccess() *otlpcollectorlogs.ExportLogsPartialSuccess {
-	orig := NewOrigPtrExportLogsPartialSuccess()
+	orig := NewOrigExportLogsPartialSuccess()
 	orig.RejectedLogRecords = int64(13)
 	orig.ErrorMessage = "test_errormessage"
 	return orig

--- a/pdata/internal/generated_wrapper_exportlogspartialsuccess_test.go
+++ b/pdata/internal/generated_wrapper_exportlogspartialsuccess_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExportLogsPartialSuccess(t *testing.T) {
-	src := NewOrigPtrExportLogsPartialSuccess()
-	dest := NewOrigPtrExportLogsPartialSuccess()
+	src := NewOrigExportLogsPartialSuccess()
+	dest := NewOrigExportLogsPartialSuccess()
 	CopyOrigExportLogsPartialSuccess(dest, src)
-	assert.Equal(t, NewOrigPtrExportLogsPartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportLogsPartialSuccess(), dest)
 	*src = *GenTestOrigExportLogsPartialSuccess()
 	CopyOrigExportLogsPartialSuccess(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExportLogsPartialSuccess(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportLogsPartialSuccessUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportLogsPartialSuccess()
+	dest := NewOrigExportLogsPartialSuccess()
 	UnmarshalJSONOrigExportLogsPartialSuccess(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportLogsPartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportLogsPartialSuccess(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportLogsPartialSuccess(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExportLogsPartialSuccess(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportLogsPartialSuccess()
+			dest := NewOrigExportLogsPartialSuccess()
 			UnmarshalJSONOrigExportLogsPartialSuccess(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExportLogsPartialSuccess(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportLogsPartialSuccessFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportLogsPartialSuccess() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportLogsPartialSuccess()
+			dest := NewOrigExportLogsPartialSuccess()
 			require.Error(t, UnmarshalProtoOrigExportLogsPartialSuccess(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportLogsPartialSuccessUnknown(t *testing.T) {
-	dest := NewOrigPtrExportLogsPartialSuccess()
+	dest := NewOrigExportLogsPartialSuccess()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportLogsPartialSuccess(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportLogsPartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportLogsPartialSuccess(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportLogsPartialSuccess(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExportLogsPartialSuccess(t *testing.T) {
 			gotSize := MarshalProtoOrigExportLogsPartialSuccess(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportLogsPartialSuccess()
+			dest := NewOrigExportLogsPartialSuccess()
 			require.NoError(t, UnmarshalProtoOrigExportLogsPartialSuccess(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportLogsPartialSuccess(t *testing.
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportLogsPartialSuccess()
+			dest := NewOrigExportLogsPartialSuccess()
 			require.NoError(t, UnmarshalProtoOrigExportLogsPartialSuccess(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesExportLogsPartialSuccess() map[string][]b
 
 func genTestEncodingValuesExportLogsPartialSuccess() map[string]*otlpcollectorlogs.ExportLogsPartialSuccess {
 	return map[string]*otlpcollectorlogs.ExportLogsPartialSuccess{
-		"empty":                   NewOrigPtrExportLogsPartialSuccess(),
+		"empty":                   NewOrigExportLogsPartialSuccess(),
 		"RejectedLogRecords/test": {RejectedLogRecords: int64(13)},
 		"ErrorMessage/test":       {ErrorMessage: "test_errormessage"},
 	}

--- a/pdata/internal/generated_wrapper_exportlogsservicerequest.go
+++ b/pdata/internal/generated_wrapper_exportlogsservicerequest.go
@@ -31,11 +31,7 @@ func NewLogs(orig *otlpcollectorlogs.ExportLogsServiceRequest, state *State) Log
 	return Logs{orig: orig, state: state}
 }
 
-func NewOrigExportLogsServiceRequest() otlpcollectorlogs.ExportLogsServiceRequest {
-	return otlpcollectorlogs.ExportLogsServiceRequest{}
-}
-
-func NewOrigPtrExportLogsServiceRequest() *otlpcollectorlogs.ExportLogsServiceRequest {
+func NewOrigExportLogsServiceRequest() *otlpcollectorlogs.ExportLogsServiceRequest {
 	return &otlpcollectorlogs.ExportLogsServiceRequest{}
 }
 
@@ -44,7 +40,7 @@ func CopyOrigExportLogsServiceRequest(dest, src *otlpcollectorlogs.ExportLogsSer
 }
 
 func GenTestOrigExportLogsServiceRequest() *otlpcollectorlogs.ExportLogsServiceRequest {
-	orig := NewOrigPtrExportLogsServiceRequest()
+	orig := NewOrigExportLogsServiceRequest()
 	orig.ResourceLogs = GenerateOrigTestResourceLogsSlice()
 	return orig
 }
@@ -128,7 +124,7 @@ func UnmarshalProtoOrigExportLogsServiceRequest(orig *otlpcollectorlogs.ExportLo
 				return err
 			}
 			startPos := pos - length
-			orig.ResourceLogs = append(orig.ResourceLogs, NewOrigPtrResourceLogs())
+			orig.ResourceLogs = append(orig.ResourceLogs, NewOrigResourceLogs())
 			err = UnmarshalProtoOrigResourceLogs(orig.ResourceLogs[len(orig.ResourceLogs)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_exportlogsservicerequest_test.go
+++ b/pdata/internal/generated_wrapper_exportlogsservicerequest_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigExportLogsServiceRequest(t *testing.T) {
-	src := NewOrigPtrExportLogsServiceRequest()
-	dest := NewOrigPtrExportLogsServiceRequest()
+	src := NewOrigExportLogsServiceRequest()
+	dest := NewOrigExportLogsServiceRequest()
 	CopyOrigExportLogsServiceRequest(dest, src)
-	assert.Equal(t, NewOrigPtrExportLogsServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportLogsServiceRequest(), dest)
 	*src = *GenTestOrigExportLogsServiceRequest()
 	CopyOrigExportLogsServiceRequest(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigExportLogsServiceRequest(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportLogsServiceRequestUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportLogsServiceRequest()
+	dest := NewOrigExportLogsServiceRequest()
 	UnmarshalJSONOrigExportLogsServiceRequest(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportLogsServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportLogsServiceRequest(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportLogsServiceRequest(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigExportLogsServiceRequest(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportLogsServiceRequest()
+			dest := NewOrigExportLogsServiceRequest()
 			UnmarshalJSONOrigExportLogsServiceRequest(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigExportLogsServiceRequest(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportLogsServiceRequestFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportLogsServiceRequest() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportLogsServiceRequest()
+			dest := NewOrigExportLogsServiceRequest()
 			require.Error(t, UnmarshalProtoOrigExportLogsServiceRequest(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportLogsServiceRequestUnknown(t *testing.T) {
-	dest := NewOrigPtrExportLogsServiceRequest()
+	dest := NewOrigExportLogsServiceRequest()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportLogsServiceRequest(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportLogsServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportLogsServiceRequest(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportLogsServiceRequest(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigExportLogsServiceRequest(t *testing.T) {
 			gotSize := MarshalProtoOrigExportLogsServiceRequest(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportLogsServiceRequest()
+			dest := NewOrigExportLogsServiceRequest()
 			require.NoError(t, UnmarshalProtoOrigExportLogsServiceRequest(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportLogsServiceRequest(t *testing.
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportLogsServiceRequest()
+			dest := NewOrigExportLogsServiceRequest()
 			require.NoError(t, UnmarshalProtoOrigExportLogsServiceRequest(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -117,7 +117,7 @@ func genTestFailingUnmarshalProtoValuesExportLogsServiceRequest() map[string][]b
 
 func genTestEncodingValuesExportLogsServiceRequest() map[string]*otlpcollectorlogs.ExportLogsServiceRequest {
 	return map[string]*otlpcollectorlogs.ExportLogsServiceRequest{
-		"empty":                         NewOrigPtrExportLogsServiceRequest(),
+		"empty":                         NewOrigExportLogsServiceRequest(),
 		"ResourceLogs/default_and_test": {ResourceLogs: []*otlplogs.ResourceLogs{{}, GenTestOrigResourceLogs()}},
 	}
 }

--- a/pdata/internal/generated_wrapper_exportlogsserviceresponse.go
+++ b/pdata/internal/generated_wrapper_exportlogsserviceresponse.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExportLogsServiceResponse() otlpcollectorlogs.ExportLogsServiceResponse {
-	return otlpcollectorlogs.ExportLogsServiceResponse{}
-}
-
-func NewOrigPtrExportLogsServiceResponse() *otlpcollectorlogs.ExportLogsServiceResponse {
+func NewOrigExportLogsServiceResponse() *otlpcollectorlogs.ExportLogsServiceResponse {
 	return &otlpcollectorlogs.ExportLogsServiceResponse{}
 }
 
@@ -27,7 +23,7 @@ func CopyOrigExportLogsServiceResponse(dest, src *otlpcollectorlogs.ExportLogsSe
 }
 
 func GenTestOrigExportLogsServiceResponse() *otlpcollectorlogs.ExportLogsServiceResponse {
-	orig := NewOrigPtrExportLogsServiceResponse()
+	orig := NewOrigExportLogsServiceResponse()
 	orig.PartialSuccess = *GenTestOrigExportLogsPartialSuccess()
 	return orig
 }

--- a/pdata/internal/generated_wrapper_exportlogsserviceresponse_test.go
+++ b/pdata/internal/generated_wrapper_exportlogsserviceresponse_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExportLogsServiceResponse(t *testing.T) {
-	src := NewOrigPtrExportLogsServiceResponse()
-	dest := NewOrigPtrExportLogsServiceResponse()
+	src := NewOrigExportLogsServiceResponse()
+	dest := NewOrigExportLogsServiceResponse()
 	CopyOrigExportLogsServiceResponse(dest, src)
-	assert.Equal(t, NewOrigPtrExportLogsServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportLogsServiceResponse(), dest)
 	*src = *GenTestOrigExportLogsServiceResponse()
 	CopyOrigExportLogsServiceResponse(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExportLogsServiceResponse(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportLogsServiceResponseUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportLogsServiceResponse()
+	dest := NewOrigExportLogsServiceResponse()
 	UnmarshalJSONOrigExportLogsServiceResponse(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportLogsServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportLogsServiceResponse(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportLogsServiceResponse(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExportLogsServiceResponse(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportLogsServiceResponse()
+			dest := NewOrigExportLogsServiceResponse()
 			UnmarshalJSONOrigExportLogsServiceResponse(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExportLogsServiceResponse(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportLogsServiceResponseFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportLogsServiceResponse() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportLogsServiceResponse()
+			dest := NewOrigExportLogsServiceResponse()
 			require.Error(t, UnmarshalProtoOrigExportLogsServiceResponse(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportLogsServiceResponseUnknown(t *testing.T) {
-	dest := NewOrigPtrExportLogsServiceResponse()
+	dest := NewOrigExportLogsServiceResponse()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportLogsServiceResponse(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportLogsServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportLogsServiceResponse(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportLogsServiceResponse(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExportLogsServiceResponse(t *testing.T) {
 			gotSize := MarshalProtoOrigExportLogsServiceResponse(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportLogsServiceResponse()
+			dest := NewOrigExportLogsServiceResponse()
 			require.NoError(t, UnmarshalProtoOrigExportLogsServiceResponse(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportLogsServiceResponse(t *testing
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportLogsServiceResponse()
+			dest := NewOrigExportLogsServiceResponse()
 			require.NoError(t, UnmarshalProtoOrigExportLogsServiceResponse(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -116,7 +116,7 @@ func genTestFailingUnmarshalProtoValuesExportLogsServiceResponse() map[string][]
 
 func genTestEncodingValuesExportLogsServiceResponse() map[string]*otlpcollectorlogs.ExportLogsServiceResponse {
 	return map[string]*otlpcollectorlogs.ExportLogsServiceResponse{
-		"empty":               NewOrigPtrExportLogsServiceResponse(),
+		"empty":               NewOrigExportLogsServiceResponse(),
 		"PartialSuccess/test": {PartialSuccess: *GenTestOrigExportLogsPartialSuccess()},
 	}
 }

--- a/pdata/internal/generated_wrapper_exportmetricspartialsuccess.go
+++ b/pdata/internal/generated_wrapper_exportmetricspartialsuccess.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExportMetricsPartialSuccess() otlpcollectormetrics.ExportMetricsPartialSuccess {
-	return otlpcollectormetrics.ExportMetricsPartialSuccess{}
-}
-
-func NewOrigPtrExportMetricsPartialSuccess() *otlpcollectormetrics.ExportMetricsPartialSuccess {
+func NewOrigExportMetricsPartialSuccess() *otlpcollectormetrics.ExportMetricsPartialSuccess {
 	return &otlpcollectormetrics.ExportMetricsPartialSuccess{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigExportMetricsPartialSuccess(dest, src *otlpcollectormetrics.ExportM
 }
 
 func GenTestOrigExportMetricsPartialSuccess() *otlpcollectormetrics.ExportMetricsPartialSuccess {
-	orig := NewOrigPtrExportMetricsPartialSuccess()
+	orig := NewOrigExportMetricsPartialSuccess()
 	orig.RejectedDataPoints = int64(13)
 	orig.ErrorMessage = "test_errormessage"
 	return orig

--- a/pdata/internal/generated_wrapper_exportmetricspartialsuccess_test.go
+++ b/pdata/internal/generated_wrapper_exportmetricspartialsuccess_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExportMetricsPartialSuccess(t *testing.T) {
-	src := NewOrigPtrExportMetricsPartialSuccess()
-	dest := NewOrigPtrExportMetricsPartialSuccess()
+	src := NewOrigExportMetricsPartialSuccess()
+	dest := NewOrigExportMetricsPartialSuccess()
 	CopyOrigExportMetricsPartialSuccess(dest, src)
-	assert.Equal(t, NewOrigPtrExportMetricsPartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportMetricsPartialSuccess(), dest)
 	*src = *GenTestOrigExportMetricsPartialSuccess()
 	CopyOrigExportMetricsPartialSuccess(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExportMetricsPartialSuccess(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportMetricsPartialSuccessUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportMetricsPartialSuccess()
+	dest := NewOrigExportMetricsPartialSuccess()
 	UnmarshalJSONOrigExportMetricsPartialSuccess(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportMetricsPartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportMetricsPartialSuccess(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportMetricsPartialSuccess(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExportMetricsPartialSuccess(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportMetricsPartialSuccess()
+			dest := NewOrigExportMetricsPartialSuccess()
 			UnmarshalJSONOrigExportMetricsPartialSuccess(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExportMetricsPartialSuccess(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportMetricsPartialSuccessFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportMetricsPartialSuccess() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportMetricsPartialSuccess()
+			dest := NewOrigExportMetricsPartialSuccess()
 			require.Error(t, UnmarshalProtoOrigExportMetricsPartialSuccess(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportMetricsPartialSuccessUnknown(t *testing.T) {
-	dest := NewOrigPtrExportMetricsPartialSuccess()
+	dest := NewOrigExportMetricsPartialSuccess()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportMetricsPartialSuccess(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportMetricsPartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportMetricsPartialSuccess(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportMetricsPartialSuccess(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExportMetricsPartialSuccess(t *testing.T) {
 			gotSize := MarshalProtoOrigExportMetricsPartialSuccess(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportMetricsPartialSuccess()
+			dest := NewOrigExportMetricsPartialSuccess()
 			require.NoError(t, UnmarshalProtoOrigExportMetricsPartialSuccess(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportMetricsPartialSuccess(t *testi
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportMetricsPartialSuccess()
+			dest := NewOrigExportMetricsPartialSuccess()
 			require.NoError(t, UnmarshalProtoOrigExportMetricsPartialSuccess(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesExportMetricsPartialSuccess() map[string]
 
 func genTestEncodingValuesExportMetricsPartialSuccess() map[string]*otlpcollectormetrics.ExportMetricsPartialSuccess {
 	return map[string]*otlpcollectormetrics.ExportMetricsPartialSuccess{
-		"empty":                   NewOrigPtrExportMetricsPartialSuccess(),
+		"empty":                   NewOrigExportMetricsPartialSuccess(),
 		"RejectedDataPoints/test": {RejectedDataPoints: int64(13)},
 		"ErrorMessage/test":       {ErrorMessage: "test_errormessage"},
 	}

--- a/pdata/internal/generated_wrapper_exportmetricsservicerequest.go
+++ b/pdata/internal/generated_wrapper_exportmetricsservicerequest.go
@@ -31,11 +31,7 @@ func NewMetrics(orig *otlpcollectormetrics.ExportMetricsServiceRequest, state *S
 	return Metrics{orig: orig, state: state}
 }
 
-func NewOrigExportMetricsServiceRequest() otlpcollectormetrics.ExportMetricsServiceRequest {
-	return otlpcollectormetrics.ExportMetricsServiceRequest{}
-}
-
-func NewOrigPtrExportMetricsServiceRequest() *otlpcollectormetrics.ExportMetricsServiceRequest {
+func NewOrigExportMetricsServiceRequest() *otlpcollectormetrics.ExportMetricsServiceRequest {
 	return &otlpcollectormetrics.ExportMetricsServiceRequest{}
 }
 
@@ -44,7 +40,7 @@ func CopyOrigExportMetricsServiceRequest(dest, src *otlpcollectormetrics.ExportM
 }
 
 func GenTestOrigExportMetricsServiceRequest() *otlpcollectormetrics.ExportMetricsServiceRequest {
-	orig := NewOrigPtrExportMetricsServiceRequest()
+	orig := NewOrigExportMetricsServiceRequest()
 	orig.ResourceMetrics = GenerateOrigTestResourceMetricsSlice()
 	return orig
 }
@@ -128,7 +124,7 @@ func UnmarshalProtoOrigExportMetricsServiceRequest(orig *otlpcollectormetrics.Ex
 				return err
 			}
 			startPos := pos - length
-			orig.ResourceMetrics = append(orig.ResourceMetrics, NewOrigPtrResourceMetrics())
+			orig.ResourceMetrics = append(orig.ResourceMetrics, NewOrigResourceMetrics())
 			err = UnmarshalProtoOrigResourceMetrics(orig.ResourceMetrics[len(orig.ResourceMetrics)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_exportmetricsservicerequest_test.go
+++ b/pdata/internal/generated_wrapper_exportmetricsservicerequest_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigExportMetricsServiceRequest(t *testing.T) {
-	src := NewOrigPtrExportMetricsServiceRequest()
-	dest := NewOrigPtrExportMetricsServiceRequest()
+	src := NewOrigExportMetricsServiceRequest()
+	dest := NewOrigExportMetricsServiceRequest()
 	CopyOrigExportMetricsServiceRequest(dest, src)
-	assert.Equal(t, NewOrigPtrExportMetricsServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportMetricsServiceRequest(), dest)
 	*src = *GenTestOrigExportMetricsServiceRequest()
 	CopyOrigExportMetricsServiceRequest(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigExportMetricsServiceRequest(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportMetricsServiceRequestUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportMetricsServiceRequest()
+	dest := NewOrigExportMetricsServiceRequest()
 	UnmarshalJSONOrigExportMetricsServiceRequest(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportMetricsServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportMetricsServiceRequest(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportMetricsServiceRequest(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigExportMetricsServiceRequest(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportMetricsServiceRequest()
+			dest := NewOrigExportMetricsServiceRequest()
 			UnmarshalJSONOrigExportMetricsServiceRequest(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigExportMetricsServiceRequest(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportMetricsServiceRequestFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportMetricsServiceRequest() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportMetricsServiceRequest()
+			dest := NewOrigExportMetricsServiceRequest()
 			require.Error(t, UnmarshalProtoOrigExportMetricsServiceRequest(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportMetricsServiceRequestUnknown(t *testing.T) {
-	dest := NewOrigPtrExportMetricsServiceRequest()
+	dest := NewOrigExportMetricsServiceRequest()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportMetricsServiceRequest(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportMetricsServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportMetricsServiceRequest(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportMetricsServiceRequest(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigExportMetricsServiceRequest(t *testing.T) {
 			gotSize := MarshalProtoOrigExportMetricsServiceRequest(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportMetricsServiceRequest()
+			dest := NewOrigExportMetricsServiceRequest()
 			require.NoError(t, UnmarshalProtoOrigExportMetricsServiceRequest(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportMetricsServiceRequest(t *testi
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportMetricsServiceRequest()
+			dest := NewOrigExportMetricsServiceRequest()
 			require.NoError(t, UnmarshalProtoOrigExportMetricsServiceRequest(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -117,7 +117,7 @@ func genTestFailingUnmarshalProtoValuesExportMetricsServiceRequest() map[string]
 
 func genTestEncodingValuesExportMetricsServiceRequest() map[string]*otlpcollectormetrics.ExportMetricsServiceRequest {
 	return map[string]*otlpcollectormetrics.ExportMetricsServiceRequest{
-		"empty":                            NewOrigPtrExportMetricsServiceRequest(),
+		"empty":                            NewOrigExportMetricsServiceRequest(),
 		"ResourceMetrics/default_and_test": {ResourceMetrics: []*otlpmetrics.ResourceMetrics{{}, GenTestOrigResourceMetrics()}},
 	}
 }

--- a/pdata/internal/generated_wrapper_exportmetricsserviceresponse.go
+++ b/pdata/internal/generated_wrapper_exportmetricsserviceresponse.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExportMetricsServiceResponse() otlpcollectormetrics.ExportMetricsServiceResponse {
-	return otlpcollectormetrics.ExportMetricsServiceResponse{}
-}
-
-func NewOrigPtrExportMetricsServiceResponse() *otlpcollectormetrics.ExportMetricsServiceResponse {
+func NewOrigExportMetricsServiceResponse() *otlpcollectormetrics.ExportMetricsServiceResponse {
 	return &otlpcollectormetrics.ExportMetricsServiceResponse{}
 }
 
@@ -27,7 +23,7 @@ func CopyOrigExportMetricsServiceResponse(dest, src *otlpcollectormetrics.Export
 }
 
 func GenTestOrigExportMetricsServiceResponse() *otlpcollectormetrics.ExportMetricsServiceResponse {
-	orig := NewOrigPtrExportMetricsServiceResponse()
+	orig := NewOrigExportMetricsServiceResponse()
 	orig.PartialSuccess = *GenTestOrigExportMetricsPartialSuccess()
 	return orig
 }

--- a/pdata/internal/generated_wrapper_exportmetricsserviceresponse_test.go
+++ b/pdata/internal/generated_wrapper_exportmetricsserviceresponse_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExportMetricsServiceResponse(t *testing.T) {
-	src := NewOrigPtrExportMetricsServiceResponse()
-	dest := NewOrigPtrExportMetricsServiceResponse()
+	src := NewOrigExportMetricsServiceResponse()
+	dest := NewOrigExportMetricsServiceResponse()
 	CopyOrigExportMetricsServiceResponse(dest, src)
-	assert.Equal(t, NewOrigPtrExportMetricsServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportMetricsServiceResponse(), dest)
 	*src = *GenTestOrigExportMetricsServiceResponse()
 	CopyOrigExportMetricsServiceResponse(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExportMetricsServiceResponse(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportMetricsServiceResponseUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportMetricsServiceResponse()
+	dest := NewOrigExportMetricsServiceResponse()
 	UnmarshalJSONOrigExportMetricsServiceResponse(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportMetricsServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportMetricsServiceResponse(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportMetricsServiceResponse(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExportMetricsServiceResponse(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportMetricsServiceResponse()
+			dest := NewOrigExportMetricsServiceResponse()
 			UnmarshalJSONOrigExportMetricsServiceResponse(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExportMetricsServiceResponse(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportMetricsServiceResponseFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportMetricsServiceResponse() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportMetricsServiceResponse()
+			dest := NewOrigExportMetricsServiceResponse()
 			require.Error(t, UnmarshalProtoOrigExportMetricsServiceResponse(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportMetricsServiceResponseUnknown(t *testing.T) {
-	dest := NewOrigPtrExportMetricsServiceResponse()
+	dest := NewOrigExportMetricsServiceResponse()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportMetricsServiceResponse(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportMetricsServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportMetricsServiceResponse(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportMetricsServiceResponse(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExportMetricsServiceResponse(t *testing.T) 
 			gotSize := MarshalProtoOrigExportMetricsServiceResponse(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportMetricsServiceResponse()
+			dest := NewOrigExportMetricsServiceResponse()
 			require.NoError(t, UnmarshalProtoOrigExportMetricsServiceResponse(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportMetricsServiceResponse(t *test
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportMetricsServiceResponse()
+			dest := NewOrigExportMetricsServiceResponse()
 			require.NoError(t, UnmarshalProtoOrigExportMetricsServiceResponse(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -116,7 +116,7 @@ func genTestFailingUnmarshalProtoValuesExportMetricsServiceResponse() map[string
 
 func genTestEncodingValuesExportMetricsServiceResponse() map[string]*otlpcollectormetrics.ExportMetricsServiceResponse {
 	return map[string]*otlpcollectormetrics.ExportMetricsServiceResponse{
-		"empty":               NewOrigPtrExportMetricsServiceResponse(),
+		"empty":               NewOrigExportMetricsServiceResponse(),
 		"PartialSuccess/test": {PartialSuccess: *GenTestOrigExportMetricsPartialSuccess()},
 	}
 }

--- a/pdata/internal/generated_wrapper_exportprofilespartialsuccess.go
+++ b/pdata/internal/generated_wrapper_exportprofilespartialsuccess.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExportProfilesPartialSuccess() otlpcollectorprofiles.ExportProfilesPartialSuccess {
-	return otlpcollectorprofiles.ExportProfilesPartialSuccess{}
-}
-
-func NewOrigPtrExportProfilesPartialSuccess() *otlpcollectorprofiles.ExportProfilesPartialSuccess {
+func NewOrigExportProfilesPartialSuccess() *otlpcollectorprofiles.ExportProfilesPartialSuccess {
 	return &otlpcollectorprofiles.ExportProfilesPartialSuccess{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigExportProfilesPartialSuccess(dest, src *otlpcollectorprofiles.Expor
 }
 
 func GenTestOrigExportProfilesPartialSuccess() *otlpcollectorprofiles.ExportProfilesPartialSuccess {
-	orig := NewOrigPtrExportProfilesPartialSuccess()
+	orig := NewOrigExportProfilesPartialSuccess()
 	orig.RejectedProfiles = int64(13)
 	orig.ErrorMessage = "test_errormessage"
 	return orig

--- a/pdata/internal/generated_wrapper_exportprofilespartialsuccess_test.go
+++ b/pdata/internal/generated_wrapper_exportprofilespartialsuccess_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExportProfilesPartialSuccess(t *testing.T) {
-	src := NewOrigPtrExportProfilesPartialSuccess()
-	dest := NewOrigPtrExportProfilesPartialSuccess()
+	src := NewOrigExportProfilesPartialSuccess()
+	dest := NewOrigExportProfilesPartialSuccess()
 	CopyOrigExportProfilesPartialSuccess(dest, src)
-	assert.Equal(t, NewOrigPtrExportProfilesPartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportProfilesPartialSuccess(), dest)
 	*src = *GenTestOrigExportProfilesPartialSuccess()
 	CopyOrigExportProfilesPartialSuccess(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExportProfilesPartialSuccess(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportProfilesPartialSuccessUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportProfilesPartialSuccess()
+	dest := NewOrigExportProfilesPartialSuccess()
 	UnmarshalJSONOrigExportProfilesPartialSuccess(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportProfilesPartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportProfilesPartialSuccess(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportProfilesPartialSuccess(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExportProfilesPartialSuccess(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportProfilesPartialSuccess()
+			dest := NewOrigExportProfilesPartialSuccess()
 			UnmarshalJSONOrigExportProfilesPartialSuccess(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExportProfilesPartialSuccess(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportProfilesPartialSuccessFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportProfilesPartialSuccess() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportProfilesPartialSuccess()
+			dest := NewOrigExportProfilesPartialSuccess()
 			require.Error(t, UnmarshalProtoOrigExportProfilesPartialSuccess(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportProfilesPartialSuccessUnknown(t *testing.T) {
-	dest := NewOrigPtrExportProfilesPartialSuccess()
+	dest := NewOrigExportProfilesPartialSuccess()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportProfilesPartialSuccess(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportProfilesPartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportProfilesPartialSuccess(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportProfilesPartialSuccess(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExportProfilesPartialSuccess(t *testing.T) 
 			gotSize := MarshalProtoOrigExportProfilesPartialSuccess(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportProfilesPartialSuccess()
+			dest := NewOrigExportProfilesPartialSuccess()
 			require.NoError(t, UnmarshalProtoOrigExportProfilesPartialSuccess(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportProfilesPartialSuccess(t *test
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportProfilesPartialSuccess()
+			dest := NewOrigExportProfilesPartialSuccess()
 			require.NoError(t, UnmarshalProtoOrigExportProfilesPartialSuccess(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesExportProfilesPartialSuccess() map[string
 
 func genTestEncodingValuesExportProfilesPartialSuccess() map[string]*otlpcollectorprofiles.ExportProfilesPartialSuccess {
 	return map[string]*otlpcollectorprofiles.ExportProfilesPartialSuccess{
-		"empty":                 NewOrigPtrExportProfilesPartialSuccess(),
+		"empty":                 NewOrigExportProfilesPartialSuccess(),
 		"RejectedProfiles/test": {RejectedProfiles: int64(13)},
 		"ErrorMessage/test":     {ErrorMessage: "test_errormessage"},
 	}

--- a/pdata/internal/generated_wrapper_exportprofilesservicerequest.go
+++ b/pdata/internal/generated_wrapper_exportprofilesservicerequest.go
@@ -31,11 +31,7 @@ func NewProfiles(orig *otlpcollectorprofiles.ExportProfilesServiceRequest, state
 	return Profiles{orig: orig, state: state}
 }
 
-func NewOrigExportProfilesServiceRequest() otlpcollectorprofiles.ExportProfilesServiceRequest {
-	return otlpcollectorprofiles.ExportProfilesServiceRequest{}
-}
-
-func NewOrigPtrExportProfilesServiceRequest() *otlpcollectorprofiles.ExportProfilesServiceRequest {
+func NewOrigExportProfilesServiceRequest() *otlpcollectorprofiles.ExportProfilesServiceRequest {
 	return &otlpcollectorprofiles.ExportProfilesServiceRequest{}
 }
 
@@ -45,7 +41,7 @@ func CopyOrigExportProfilesServiceRequest(dest, src *otlpcollectorprofiles.Expor
 }
 
 func GenTestOrigExportProfilesServiceRequest() *otlpcollectorprofiles.ExportProfilesServiceRequest {
-	orig := NewOrigPtrExportProfilesServiceRequest()
+	orig := NewOrigExportProfilesServiceRequest()
 	orig.ResourceProfiles = GenerateOrigTestResourceProfilesSlice()
 	orig.Dictionary = *GenTestOrigProfilesDictionary()
 	return orig
@@ -143,7 +139,7 @@ func UnmarshalProtoOrigExportProfilesServiceRequest(orig *otlpcollectorprofiles.
 				return err
 			}
 			startPos := pos - length
-			orig.ResourceProfiles = append(orig.ResourceProfiles, NewOrigPtrResourceProfiles())
+			orig.ResourceProfiles = append(orig.ResourceProfiles, NewOrigResourceProfiles())
 			err = UnmarshalProtoOrigResourceProfiles(orig.ResourceProfiles[len(orig.ResourceProfiles)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_exportprofilesservicerequest_test.go
+++ b/pdata/internal/generated_wrapper_exportprofilesservicerequest_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigExportProfilesServiceRequest(t *testing.T) {
-	src := NewOrigPtrExportProfilesServiceRequest()
-	dest := NewOrigPtrExportProfilesServiceRequest()
+	src := NewOrigExportProfilesServiceRequest()
+	dest := NewOrigExportProfilesServiceRequest()
 	CopyOrigExportProfilesServiceRequest(dest, src)
-	assert.Equal(t, NewOrigPtrExportProfilesServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportProfilesServiceRequest(), dest)
 	*src = *GenTestOrigExportProfilesServiceRequest()
 	CopyOrigExportProfilesServiceRequest(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigExportProfilesServiceRequest(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportProfilesServiceRequestUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportProfilesServiceRequest()
+	dest := NewOrigExportProfilesServiceRequest()
 	UnmarshalJSONOrigExportProfilesServiceRequest(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportProfilesServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportProfilesServiceRequest(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportProfilesServiceRequest(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigExportProfilesServiceRequest(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportProfilesServiceRequest()
+			dest := NewOrigExportProfilesServiceRequest()
 			UnmarshalJSONOrigExportProfilesServiceRequest(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigExportProfilesServiceRequest(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportProfilesServiceRequestFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportProfilesServiceRequest() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportProfilesServiceRequest()
+			dest := NewOrigExportProfilesServiceRequest()
 			require.Error(t, UnmarshalProtoOrigExportProfilesServiceRequest(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportProfilesServiceRequestUnknown(t *testing.T) {
-	dest := NewOrigPtrExportProfilesServiceRequest()
+	dest := NewOrigExportProfilesServiceRequest()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportProfilesServiceRequest(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportProfilesServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportProfilesServiceRequest(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportProfilesServiceRequest(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigExportProfilesServiceRequest(t *testing.T) 
 			gotSize := MarshalProtoOrigExportProfilesServiceRequest(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportProfilesServiceRequest()
+			dest := NewOrigExportProfilesServiceRequest()
 			require.NoError(t, UnmarshalProtoOrigExportProfilesServiceRequest(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportProfilesServiceRequest(t *test
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportProfilesServiceRequest()
+			dest := NewOrigExportProfilesServiceRequest()
 			require.NoError(t, UnmarshalProtoOrigExportProfilesServiceRequest(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -119,7 +119,7 @@ func genTestFailingUnmarshalProtoValuesExportProfilesServiceRequest() map[string
 
 func genTestEncodingValuesExportProfilesServiceRequest() map[string]*otlpcollectorprofiles.ExportProfilesServiceRequest {
 	return map[string]*otlpcollectorprofiles.ExportProfilesServiceRequest{
-		"empty":                             NewOrigPtrExportProfilesServiceRequest(),
+		"empty":                             NewOrigExportProfilesServiceRequest(),
 		"ResourceProfiles/default_and_test": {ResourceProfiles: []*otlpprofiles.ResourceProfiles{{}, GenTestOrigResourceProfiles()}},
 		"Dictionary/test":                   {Dictionary: *GenTestOrigProfilesDictionary()},
 	}

--- a/pdata/internal/generated_wrapper_exportprofilesserviceresponse.go
+++ b/pdata/internal/generated_wrapper_exportprofilesserviceresponse.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExportProfilesServiceResponse() otlpcollectorprofiles.ExportProfilesServiceResponse {
-	return otlpcollectorprofiles.ExportProfilesServiceResponse{}
-}
-
-func NewOrigPtrExportProfilesServiceResponse() *otlpcollectorprofiles.ExportProfilesServiceResponse {
+func NewOrigExportProfilesServiceResponse() *otlpcollectorprofiles.ExportProfilesServiceResponse {
 	return &otlpcollectorprofiles.ExportProfilesServiceResponse{}
 }
 
@@ -27,7 +23,7 @@ func CopyOrigExportProfilesServiceResponse(dest, src *otlpcollectorprofiles.Expo
 }
 
 func GenTestOrigExportProfilesServiceResponse() *otlpcollectorprofiles.ExportProfilesServiceResponse {
-	orig := NewOrigPtrExportProfilesServiceResponse()
+	orig := NewOrigExportProfilesServiceResponse()
 	orig.PartialSuccess = *GenTestOrigExportProfilesPartialSuccess()
 	return orig
 }

--- a/pdata/internal/generated_wrapper_exportprofilesserviceresponse_test.go
+++ b/pdata/internal/generated_wrapper_exportprofilesserviceresponse_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExportProfilesServiceResponse(t *testing.T) {
-	src := NewOrigPtrExportProfilesServiceResponse()
-	dest := NewOrigPtrExportProfilesServiceResponse()
+	src := NewOrigExportProfilesServiceResponse()
+	dest := NewOrigExportProfilesServiceResponse()
 	CopyOrigExportProfilesServiceResponse(dest, src)
-	assert.Equal(t, NewOrigPtrExportProfilesServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportProfilesServiceResponse(), dest)
 	*src = *GenTestOrigExportProfilesServiceResponse()
 	CopyOrigExportProfilesServiceResponse(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExportProfilesServiceResponse(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportProfilesServiceResponseUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportProfilesServiceResponse()
+	dest := NewOrigExportProfilesServiceResponse()
 	UnmarshalJSONOrigExportProfilesServiceResponse(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportProfilesServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportProfilesServiceResponse(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportProfilesServiceResponse(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExportProfilesServiceResponse(t *testing.T) 
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportProfilesServiceResponse()
+			dest := NewOrigExportProfilesServiceResponse()
 			UnmarshalJSONOrigExportProfilesServiceResponse(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExportProfilesServiceResponse(t *testing.T) 
 func TestMarshalAndUnmarshalProtoOrigExportProfilesServiceResponseFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportProfilesServiceResponse() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportProfilesServiceResponse()
+			dest := NewOrigExportProfilesServiceResponse()
 			require.Error(t, UnmarshalProtoOrigExportProfilesServiceResponse(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportProfilesServiceResponseUnknown(t *testing.T) {
-	dest := NewOrigPtrExportProfilesServiceResponse()
+	dest := NewOrigExportProfilesServiceResponse()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportProfilesServiceResponse(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportProfilesServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportProfilesServiceResponse(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportProfilesServiceResponse(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExportProfilesServiceResponse(t *testing.T)
 			gotSize := MarshalProtoOrigExportProfilesServiceResponse(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportProfilesServiceResponse()
+			dest := NewOrigExportProfilesServiceResponse()
 			require.NoError(t, UnmarshalProtoOrigExportProfilesServiceResponse(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportProfilesServiceResponse(t *tes
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportProfilesServiceResponse()
+			dest := NewOrigExportProfilesServiceResponse()
 			require.NoError(t, UnmarshalProtoOrigExportProfilesServiceResponse(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -116,7 +116,7 @@ func genTestFailingUnmarshalProtoValuesExportProfilesServiceResponse() map[strin
 
 func genTestEncodingValuesExportProfilesServiceResponse() map[string]*otlpcollectorprofiles.ExportProfilesServiceResponse {
 	return map[string]*otlpcollectorprofiles.ExportProfilesServiceResponse{
-		"empty":               NewOrigPtrExportProfilesServiceResponse(),
+		"empty":               NewOrigExportProfilesServiceResponse(),
 		"PartialSuccess/test": {PartialSuccess: *GenTestOrigExportProfilesPartialSuccess()},
 	}
 }

--- a/pdata/internal/generated_wrapper_exporttracepartialsuccess.go
+++ b/pdata/internal/generated_wrapper_exporttracepartialsuccess.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExportTracePartialSuccess() otlpcollectortrace.ExportTracePartialSuccess {
-	return otlpcollectortrace.ExportTracePartialSuccess{}
-}
-
-func NewOrigPtrExportTracePartialSuccess() *otlpcollectortrace.ExportTracePartialSuccess {
+func NewOrigExportTracePartialSuccess() *otlpcollectortrace.ExportTracePartialSuccess {
 	return &otlpcollectortrace.ExportTracePartialSuccess{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigExportTracePartialSuccess(dest, src *otlpcollectortrace.ExportTrace
 }
 
 func GenTestOrigExportTracePartialSuccess() *otlpcollectortrace.ExportTracePartialSuccess {
-	orig := NewOrigPtrExportTracePartialSuccess()
+	orig := NewOrigExportTracePartialSuccess()
 	orig.RejectedSpans = int64(13)
 	orig.ErrorMessage = "test_errormessage"
 	return orig

--- a/pdata/internal/generated_wrapper_exporttracepartialsuccess_test.go
+++ b/pdata/internal/generated_wrapper_exporttracepartialsuccess_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExportTracePartialSuccess(t *testing.T) {
-	src := NewOrigPtrExportTracePartialSuccess()
-	dest := NewOrigPtrExportTracePartialSuccess()
+	src := NewOrigExportTracePartialSuccess()
+	dest := NewOrigExportTracePartialSuccess()
 	CopyOrigExportTracePartialSuccess(dest, src)
-	assert.Equal(t, NewOrigPtrExportTracePartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportTracePartialSuccess(), dest)
 	*src = *GenTestOrigExportTracePartialSuccess()
 	CopyOrigExportTracePartialSuccess(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExportTracePartialSuccess(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportTracePartialSuccessUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportTracePartialSuccess()
+	dest := NewOrigExportTracePartialSuccess()
 	UnmarshalJSONOrigExportTracePartialSuccess(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportTracePartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportTracePartialSuccess(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportTracePartialSuccess(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExportTracePartialSuccess(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportTracePartialSuccess()
+			dest := NewOrigExportTracePartialSuccess()
 			UnmarshalJSONOrigExportTracePartialSuccess(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExportTracePartialSuccess(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportTracePartialSuccessFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportTracePartialSuccess() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportTracePartialSuccess()
+			dest := NewOrigExportTracePartialSuccess()
 			require.Error(t, UnmarshalProtoOrigExportTracePartialSuccess(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportTracePartialSuccessUnknown(t *testing.T) {
-	dest := NewOrigPtrExportTracePartialSuccess()
+	dest := NewOrigExportTracePartialSuccess()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportTracePartialSuccess(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportTracePartialSuccess(), dest)
+	assert.Equal(t, NewOrigExportTracePartialSuccess(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportTracePartialSuccess(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExportTracePartialSuccess(t *testing.T) {
 			gotSize := MarshalProtoOrigExportTracePartialSuccess(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportTracePartialSuccess()
+			dest := NewOrigExportTracePartialSuccess()
 			require.NoError(t, UnmarshalProtoOrigExportTracePartialSuccess(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportTracePartialSuccess(t *testing
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportTracePartialSuccess()
+			dest := NewOrigExportTracePartialSuccess()
 			require.NoError(t, UnmarshalProtoOrigExportTracePartialSuccess(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesExportTracePartialSuccess() map[string][]
 
 func genTestEncodingValuesExportTracePartialSuccess() map[string]*otlpcollectortrace.ExportTracePartialSuccess {
 	return map[string]*otlpcollectortrace.ExportTracePartialSuccess{
-		"empty":              NewOrigPtrExportTracePartialSuccess(),
+		"empty":              NewOrigExportTracePartialSuccess(),
 		"RejectedSpans/test": {RejectedSpans: int64(13)},
 		"ErrorMessage/test":  {ErrorMessage: "test_errormessage"},
 	}

--- a/pdata/internal/generated_wrapper_exporttraceservicerequest.go
+++ b/pdata/internal/generated_wrapper_exporttraceservicerequest.go
@@ -31,11 +31,7 @@ func NewTraces(orig *otlpcollectortrace.ExportTraceServiceRequest, state *State)
 	return Traces{orig: orig, state: state}
 }
 
-func NewOrigExportTraceServiceRequest() otlpcollectortrace.ExportTraceServiceRequest {
-	return otlpcollectortrace.ExportTraceServiceRequest{}
-}
-
-func NewOrigPtrExportTraceServiceRequest() *otlpcollectortrace.ExportTraceServiceRequest {
+func NewOrigExportTraceServiceRequest() *otlpcollectortrace.ExportTraceServiceRequest {
 	return &otlpcollectortrace.ExportTraceServiceRequest{}
 }
 
@@ -44,7 +40,7 @@ func CopyOrigExportTraceServiceRequest(dest, src *otlpcollectortrace.ExportTrace
 }
 
 func GenTestOrigExportTraceServiceRequest() *otlpcollectortrace.ExportTraceServiceRequest {
-	orig := NewOrigPtrExportTraceServiceRequest()
+	orig := NewOrigExportTraceServiceRequest()
 	orig.ResourceSpans = GenerateOrigTestResourceSpansSlice()
 	return orig
 }
@@ -128,7 +124,7 @@ func UnmarshalProtoOrigExportTraceServiceRequest(orig *otlpcollectortrace.Export
 				return err
 			}
 			startPos := pos - length
-			orig.ResourceSpans = append(orig.ResourceSpans, NewOrigPtrResourceSpans())
+			orig.ResourceSpans = append(orig.ResourceSpans, NewOrigResourceSpans())
 			err = UnmarshalProtoOrigResourceSpans(orig.ResourceSpans[len(orig.ResourceSpans)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_exporttraceservicerequest_test.go
+++ b/pdata/internal/generated_wrapper_exporttraceservicerequest_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigExportTraceServiceRequest(t *testing.T) {
-	src := NewOrigPtrExportTraceServiceRequest()
-	dest := NewOrigPtrExportTraceServiceRequest()
+	src := NewOrigExportTraceServiceRequest()
+	dest := NewOrigExportTraceServiceRequest()
 	CopyOrigExportTraceServiceRequest(dest, src)
-	assert.Equal(t, NewOrigPtrExportTraceServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportTraceServiceRequest(), dest)
 	*src = *GenTestOrigExportTraceServiceRequest()
 	CopyOrigExportTraceServiceRequest(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigExportTraceServiceRequest(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportTraceServiceRequestUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportTraceServiceRequest()
+	dest := NewOrigExportTraceServiceRequest()
 	UnmarshalJSONOrigExportTraceServiceRequest(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportTraceServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportTraceServiceRequest(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportTraceServiceRequest(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigExportTraceServiceRequest(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportTraceServiceRequest()
+			dest := NewOrigExportTraceServiceRequest()
 			UnmarshalJSONOrigExportTraceServiceRequest(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigExportTraceServiceRequest(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportTraceServiceRequestFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportTraceServiceRequest() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportTraceServiceRequest()
+			dest := NewOrigExportTraceServiceRequest()
 			require.Error(t, UnmarshalProtoOrigExportTraceServiceRequest(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportTraceServiceRequestUnknown(t *testing.T) {
-	dest := NewOrigPtrExportTraceServiceRequest()
+	dest := NewOrigExportTraceServiceRequest()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportTraceServiceRequest(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportTraceServiceRequest(), dest)
+	assert.Equal(t, NewOrigExportTraceServiceRequest(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportTraceServiceRequest(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigExportTraceServiceRequest(t *testing.T) {
 			gotSize := MarshalProtoOrigExportTraceServiceRequest(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportTraceServiceRequest()
+			dest := NewOrigExportTraceServiceRequest()
 			require.NoError(t, UnmarshalProtoOrigExportTraceServiceRequest(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportTraceServiceRequest(t *testing
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportTraceServiceRequest()
+			dest := NewOrigExportTraceServiceRequest()
 			require.NoError(t, UnmarshalProtoOrigExportTraceServiceRequest(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -117,7 +117,7 @@ func genTestFailingUnmarshalProtoValuesExportTraceServiceRequest() map[string][]
 
 func genTestEncodingValuesExportTraceServiceRequest() map[string]*otlpcollectortrace.ExportTraceServiceRequest {
 	return map[string]*otlpcollectortrace.ExportTraceServiceRequest{
-		"empty":                          NewOrigPtrExportTraceServiceRequest(),
+		"empty":                          NewOrigExportTraceServiceRequest(),
 		"ResourceSpans/default_and_test": {ResourceSpans: []*otlptrace.ResourceSpans{{}, GenTestOrigResourceSpans()}},
 	}
 }

--- a/pdata/internal/generated_wrapper_exporttraceserviceresponse.go
+++ b/pdata/internal/generated_wrapper_exporttraceserviceresponse.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigExportTraceServiceResponse() otlpcollectortrace.ExportTraceServiceResponse {
-	return otlpcollectortrace.ExportTraceServiceResponse{}
-}
-
-func NewOrigPtrExportTraceServiceResponse() *otlpcollectortrace.ExportTraceServiceResponse {
+func NewOrigExportTraceServiceResponse() *otlpcollectortrace.ExportTraceServiceResponse {
 	return &otlpcollectortrace.ExportTraceServiceResponse{}
 }
 
@@ -27,7 +23,7 @@ func CopyOrigExportTraceServiceResponse(dest, src *otlpcollectortrace.ExportTrac
 }
 
 func GenTestOrigExportTraceServiceResponse() *otlpcollectortrace.ExportTraceServiceResponse {
-	orig := NewOrigPtrExportTraceServiceResponse()
+	orig := NewOrigExportTraceServiceResponse()
 	orig.PartialSuccess = *GenTestOrigExportTracePartialSuccess()
 	return orig
 }

--- a/pdata/internal/generated_wrapper_exporttraceserviceresponse_test.go
+++ b/pdata/internal/generated_wrapper_exporttraceserviceresponse_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigExportTraceServiceResponse(t *testing.T) {
-	src := NewOrigPtrExportTraceServiceResponse()
-	dest := NewOrigPtrExportTraceServiceResponse()
+	src := NewOrigExportTraceServiceResponse()
+	dest := NewOrigExportTraceServiceResponse()
 	CopyOrigExportTraceServiceResponse(dest, src)
-	assert.Equal(t, NewOrigPtrExportTraceServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportTraceServiceResponse(), dest)
 	*src = *GenTestOrigExportTraceServiceResponse()
 	CopyOrigExportTraceServiceResponse(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigExportTraceServiceResponse(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigExportTraceServiceResponseUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrExportTraceServiceResponse()
+	dest := NewOrigExportTraceServiceResponse()
 	UnmarshalJSONOrigExportTraceServiceResponse(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrExportTraceServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportTraceServiceResponse(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigExportTraceServiceResponse(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigExportTraceServiceResponse(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrExportTraceServiceResponse()
+			dest := NewOrigExportTraceServiceResponse()
 			UnmarshalJSONOrigExportTraceServiceResponse(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigExportTraceServiceResponse(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigExportTraceServiceResponseFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesExportTraceServiceResponse() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrExportTraceServiceResponse()
+			dest := NewOrigExportTraceServiceResponse()
 			require.Error(t, UnmarshalProtoOrigExportTraceServiceResponse(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportTraceServiceResponseUnknown(t *testing.T) {
-	dest := NewOrigPtrExportTraceServiceResponse()
+	dest := NewOrigExportTraceServiceResponse()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigExportTraceServiceResponse(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrExportTraceServiceResponse(), dest)
+	assert.Equal(t, NewOrigExportTraceServiceResponse(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigExportTraceServiceResponse(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigExportTraceServiceResponse(t *testing.T) {
 			gotSize := MarshalProtoOrigExportTraceServiceResponse(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrExportTraceServiceResponse()
+			dest := NewOrigExportTraceServiceResponse()
 			require.NoError(t, UnmarshalProtoOrigExportTraceServiceResponse(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufExportTraceServiceResponse(t *testin
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrExportTraceServiceResponse()
+			dest := NewOrigExportTraceServiceResponse()
 			require.NoError(t, UnmarshalProtoOrigExportTraceServiceResponse(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -116,7 +116,7 @@ func genTestFailingUnmarshalProtoValuesExportTraceServiceResponse() map[string][
 
 func genTestEncodingValuesExportTraceServiceResponse() map[string]*otlpcollectortrace.ExportTraceServiceResponse {
 	return map[string]*otlpcollectortrace.ExportTraceServiceResponse{
-		"empty":               NewOrigPtrExportTraceServiceResponse(),
+		"empty":               NewOrigExportTraceServiceResponse(),
 		"PartialSuccess/test": {PartialSuccess: *GenTestOrigExportTracePartialSuccess()},
 	}
 }

--- a/pdata/internal/generated_wrapper_function.go
+++ b/pdata/internal/generated_wrapper_function.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigFunction() otlpprofiles.Function {
-	return otlpprofiles.Function{}
-}
-
-func NewOrigPtrFunction() *otlpprofiles.Function {
+func NewOrigFunction() *otlpprofiles.Function {
 	return &otlpprofiles.Function{}
 }
 
@@ -30,7 +26,7 @@ func CopyOrigFunction(dest, src *otlpprofiles.Function) {
 }
 
 func GenTestOrigFunction() *otlpprofiles.Function {
-	orig := NewOrigPtrFunction()
+	orig := NewOrigFunction()
 	orig.NameStrindex = int32(13)
 	orig.SystemNameStrindex = int32(13)
 	orig.FilenameStrindex = int32(13)

--- a/pdata/internal/generated_wrapper_function_test.go
+++ b/pdata/internal/generated_wrapper_function_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigFunction(t *testing.T) {
-	src := NewOrigPtrFunction()
-	dest := NewOrigPtrFunction()
+	src := NewOrigFunction()
+	dest := NewOrigFunction()
 	CopyOrigFunction(dest, src)
-	assert.Equal(t, NewOrigPtrFunction(), dest)
+	assert.Equal(t, NewOrigFunction(), dest)
 	*src = *GenTestOrigFunction()
 	CopyOrigFunction(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigFunction(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigFunctionUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrFunction()
+	dest := NewOrigFunction()
 	UnmarshalJSONOrigFunction(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrFunction(), dest)
+	assert.Equal(t, NewOrigFunction(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigFunction(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigFunction(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrFunction()
+			dest := NewOrigFunction()
 			UnmarshalJSONOrigFunction(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigFunction(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigFunctionFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesFunction() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrFunction()
+			dest := NewOrigFunction()
 			require.Error(t, UnmarshalProtoOrigFunction(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigFunctionUnknown(t *testing.T) {
-	dest := NewOrigPtrFunction()
+	dest := NewOrigFunction()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigFunction(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrFunction(), dest)
+	assert.Equal(t, NewOrigFunction(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigFunction(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigFunction(t *testing.T) {
 			gotSize := MarshalProtoOrigFunction(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrFunction()
+			dest := NewOrigFunction()
 			require.NoError(t, UnmarshalProtoOrigFunction(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufFunction(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrFunction()
+			dest := NewOrigFunction()
 			require.NoError(t, UnmarshalProtoOrigFunction(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -122,7 +122,7 @@ func genTestFailingUnmarshalProtoValuesFunction() map[string][]byte {
 
 func genTestEncodingValuesFunction() map[string]*otlpprofiles.Function {
 	return map[string]*otlpprofiles.Function{
-		"empty":                   NewOrigPtrFunction(),
+		"empty":                   NewOrigFunction(),
 		"NameStrindex/test":       {NameStrindex: int32(13)},
 		"SystemNameStrindex/test": {SystemNameStrindex: int32(13)},
 		"FilenameStrindex/test":   {FilenameStrindex: int32(13)},

--- a/pdata/internal/generated_wrapper_functionslice.go
+++ b/pdata/internal/generated_wrapper_functionslice.go
@@ -19,7 +19,7 @@ func CopyOrigFunctionSlice(dest, src []*otlpprofiles.Function) []*otlpprofiles.F
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrFunction()
+			newDest[i] = NewOrigFunction()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigFunctionSlice(dest, src []*otlpprofiles.Function) []*otlpprofiles.F
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrFunction()
+			newDest[i] = NewOrigFunction()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigFunctionSlice(dest, src []*otlpprofiles.Function) []*otlpprofiles.F
 
 func GenerateOrigTestFunctionSlice() []*otlpprofiles.Function {
 	orig := make([]*otlpprofiles.Function, 5)
-	orig[0] = NewOrigPtrFunction()
+	orig[0] = NewOrigFunction()
 	orig[1] = GenTestOrigFunction()
-	orig[2] = NewOrigPtrFunction()
+	orig[2] = NewOrigFunction()
 	orig[3] = GenTestOrigFunction()
-	orig[4] = NewOrigPtrFunction()
+	orig[4] = NewOrigFunction()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestFunctionSlice() []*otlpprofiles.Function {
 func UnmarshalJSONOrigFunctionSlice(iter *json.Iterator) []*otlpprofiles.Function {
 	var orig []*otlpprofiles.Function
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrFunction())
+		orig = append(orig, NewOrigFunction())
 		UnmarshalJSONOrigFunction(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_gauge.go
+++ b/pdata/internal/generated_wrapper_gauge.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigGauge() otlpmetrics.Gauge {
-	return otlpmetrics.Gauge{}
-}
-
-func NewOrigPtrGauge() *otlpmetrics.Gauge {
+func NewOrigGauge() *otlpmetrics.Gauge {
 	return &otlpmetrics.Gauge{}
 }
 
@@ -27,7 +23,7 @@ func CopyOrigGauge(dest, src *otlpmetrics.Gauge) {
 }
 
 func GenTestOrigGauge() *otlpmetrics.Gauge {
-	orig := NewOrigPtrGauge()
+	orig := NewOrigGauge()
 	orig.DataPoints = GenerateOrigTestNumberDataPointSlice()
 	return orig
 }
@@ -111,7 +107,7 @@ func UnmarshalProtoOrigGauge(orig *otlpmetrics.Gauge, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.DataPoints = append(orig.DataPoints, NewOrigPtrNumberDataPoint())
+			orig.DataPoints = append(orig.DataPoints, NewOrigNumberDataPoint())
 			err = UnmarshalProtoOrigNumberDataPoint(orig.DataPoints[len(orig.DataPoints)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_gauge_test.go
+++ b/pdata/internal/generated_wrapper_gauge_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigGauge(t *testing.T) {
-	src := NewOrigPtrGauge()
-	dest := NewOrigPtrGauge()
+	src := NewOrigGauge()
+	dest := NewOrigGauge()
 	CopyOrigGauge(dest, src)
-	assert.Equal(t, NewOrigPtrGauge(), dest)
+	assert.Equal(t, NewOrigGauge(), dest)
 	*src = *GenTestOrigGauge()
 	CopyOrigGauge(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigGauge(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigGaugeUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrGauge()
+	dest := NewOrigGauge()
 	UnmarshalJSONOrigGauge(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrGauge(), dest)
+	assert.Equal(t, NewOrigGauge(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigGauge(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigGauge(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrGauge()
+			dest := NewOrigGauge()
 			UnmarshalJSONOrigGauge(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigGauge(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigGaugeFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesGauge() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrGauge()
+			dest := NewOrigGauge()
 			require.Error(t, UnmarshalProtoOrigGauge(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigGaugeUnknown(t *testing.T) {
-	dest := NewOrigPtrGauge()
+	dest := NewOrigGauge()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigGauge(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrGauge(), dest)
+	assert.Equal(t, NewOrigGauge(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigGauge(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigGauge(t *testing.T) {
 			gotSize := MarshalProtoOrigGauge(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrGauge()
+			dest := NewOrigGauge()
 			require.NoError(t, UnmarshalProtoOrigGauge(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufGauge(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrGauge()
+			dest := NewOrigGauge()
 			require.NoError(t, UnmarshalProtoOrigGauge(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -116,7 +116,7 @@ func genTestFailingUnmarshalProtoValuesGauge() map[string][]byte {
 
 func genTestEncodingValuesGauge() map[string]*otlpmetrics.Gauge {
 	return map[string]*otlpmetrics.Gauge{
-		"empty":                       NewOrigPtrGauge(),
+		"empty":                       NewOrigGauge(),
 		"DataPoints/default_and_test": {DataPoints: []*otlpmetrics.NumberDataPoint{{}, GenTestOrigNumberDataPoint()}},
 	}
 }

--- a/pdata/internal/generated_wrapper_histogram.go
+++ b/pdata/internal/generated_wrapper_histogram.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigHistogram() otlpmetrics.Histogram {
-	return otlpmetrics.Histogram{}
-}
-
-func NewOrigPtrHistogram() *otlpmetrics.Histogram {
+func NewOrigHistogram() *otlpmetrics.Histogram {
 	return &otlpmetrics.Histogram{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigHistogram(dest, src *otlpmetrics.Histogram) {
 }
 
 func GenTestOrigHistogram() *otlpmetrics.Histogram {
-	orig := NewOrigPtrHistogram()
+	orig := NewOrigHistogram()
 	orig.DataPoints = GenerateOrigTestHistogramDataPointSlice()
 	orig.AggregationTemporality = otlpmetrics.AggregationTemporality(1)
 	return orig
@@ -128,7 +124,7 @@ func UnmarshalProtoOrigHistogram(orig *otlpmetrics.Histogram, buf []byte) error 
 				return err
 			}
 			startPos := pos - length
-			orig.DataPoints = append(orig.DataPoints, NewOrigPtrHistogramDataPoint())
+			orig.DataPoints = append(orig.DataPoints, NewOrigHistogramDataPoint())
 			err = UnmarshalProtoOrigHistogramDataPoint(orig.DataPoints[len(orig.DataPoints)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_histogram_test.go
+++ b/pdata/internal/generated_wrapper_histogram_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigHistogram(t *testing.T) {
-	src := NewOrigPtrHistogram()
-	dest := NewOrigPtrHistogram()
+	src := NewOrigHistogram()
+	dest := NewOrigHistogram()
 	CopyOrigHistogram(dest, src)
-	assert.Equal(t, NewOrigPtrHistogram(), dest)
+	assert.Equal(t, NewOrigHistogram(), dest)
 	*src = *GenTestOrigHistogram()
 	CopyOrigHistogram(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigHistogram(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigHistogramUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrHistogram()
+	dest := NewOrigHistogram()
 	UnmarshalJSONOrigHistogram(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrHistogram(), dest)
+	assert.Equal(t, NewOrigHistogram(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigHistogram(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigHistogram(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrHistogram()
+			dest := NewOrigHistogram()
 			UnmarshalJSONOrigHistogram(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigHistogram(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigHistogramFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesHistogram() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrHistogram()
+			dest := NewOrigHistogram()
 			require.Error(t, UnmarshalProtoOrigHistogram(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigHistogramUnknown(t *testing.T) {
-	dest := NewOrigPtrHistogram()
+	dest := NewOrigHistogram()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigHistogram(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrHistogram(), dest)
+	assert.Equal(t, NewOrigHistogram(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigHistogram(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigHistogram(t *testing.T) {
 			gotSize := MarshalProtoOrigHistogram(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrHistogram()
+			dest := NewOrigHistogram()
 			require.NoError(t, UnmarshalProtoOrigHistogram(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufHistogram(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrHistogram()
+			dest := NewOrigHistogram()
 			require.NoError(t, UnmarshalProtoOrigHistogram(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesHistogram() map[string][]byte {
 
 func genTestEncodingValuesHistogram() map[string]*otlpmetrics.Histogram {
 	return map[string]*otlpmetrics.Histogram{
-		"empty":                       NewOrigPtrHistogram(),
+		"empty":                       NewOrigHistogram(),
 		"DataPoints/default_and_test": {DataPoints: []*otlpmetrics.HistogramDataPoint{{}, GenTestOrigHistogramDataPoint()}},
 		"AggregationTemporality/test": {AggregationTemporality: otlpmetrics.AggregationTemporality(13)},
 	}

--- a/pdata/internal/generated_wrapper_histogramdatapoint.go
+++ b/pdata/internal/generated_wrapper_histogramdatapoint.go
@@ -11,16 +11,13 @@ import (
 	"fmt"
 	"math"
 
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigHistogramDataPoint() otlpmetrics.HistogramDataPoint {
-	return otlpmetrics.HistogramDataPoint{}
-}
-
-func NewOrigPtrHistogramDataPoint() *otlpmetrics.HistogramDataPoint {
+func NewOrigHistogramDataPoint() *otlpmetrics.HistogramDataPoint {
 	return &otlpmetrics.HistogramDataPoint{}
 }
 
@@ -66,7 +63,7 @@ func CopyOrigHistogramDataPoint(dest, src *otlpmetrics.HistogramDataPoint) {
 }
 
 func GenTestOrigHistogramDataPoint() *otlpmetrics.HistogramDataPoint {
-	orig := NewOrigPtrHistogramDataPoint()
+	orig := NewOrigHistogramDataPoint()
 	orig.Attributes = GenerateOrigTestKeyValueSlice()
 	orig.StartTimeUnixNano = 1234567890
 	orig.TimeUnixNano = 1234567890
@@ -344,7 +341,7 @@ func UnmarshalProtoOrigHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint, 
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -455,7 +452,7 @@ func UnmarshalProtoOrigHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint, 
 				return err
 			}
 			startPos := pos - length
-			orig.Exemplars = append(orig.Exemplars, NewOrigExemplar())
+			orig.Exemplars = append(orig.Exemplars, otlpmetrics.Exemplar{})
 			err = UnmarshalProtoOrigExemplar(&orig.Exemplars[len(orig.Exemplars)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_histogramdatapoint_test.go
+++ b/pdata/internal/generated_wrapper_histogramdatapoint_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigHistogramDataPoint(t *testing.T) {
-	src := NewOrigPtrHistogramDataPoint()
-	dest := NewOrigPtrHistogramDataPoint()
+	src := NewOrigHistogramDataPoint()
+	dest := NewOrigHistogramDataPoint()
 	CopyOrigHistogramDataPoint(dest, src)
-	assert.Equal(t, NewOrigPtrHistogramDataPoint(), dest)
+	assert.Equal(t, NewOrigHistogramDataPoint(), dest)
 	*src = *GenTestOrigHistogramDataPoint()
 	CopyOrigHistogramDataPoint(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigHistogramDataPoint(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigHistogramDataPointUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrHistogramDataPoint()
+	dest := NewOrigHistogramDataPoint()
 	UnmarshalJSONOrigHistogramDataPoint(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrHistogramDataPoint(), dest)
+	assert.Equal(t, NewOrigHistogramDataPoint(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigHistogramDataPoint(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigHistogramDataPoint(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrHistogramDataPoint()
+			dest := NewOrigHistogramDataPoint()
 			UnmarshalJSONOrigHistogramDataPoint(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigHistogramDataPoint(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigHistogramDataPointFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesHistogramDataPoint() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrHistogramDataPoint()
+			dest := NewOrigHistogramDataPoint()
 			require.Error(t, UnmarshalProtoOrigHistogramDataPoint(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigHistogramDataPointUnknown(t *testing.T) {
-	dest := NewOrigPtrHistogramDataPoint()
+	dest := NewOrigHistogramDataPoint()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigHistogramDataPoint(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrHistogramDataPoint(), dest)
+	assert.Equal(t, NewOrigHistogramDataPoint(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigHistogramDataPoint(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigHistogramDataPoint(t *testing.T) {
 			gotSize := MarshalProtoOrigHistogramDataPoint(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrHistogramDataPoint()
+			dest := NewOrigHistogramDataPoint()
 			require.NoError(t, UnmarshalProtoOrigHistogramDataPoint(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufHistogramDataPoint(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrHistogramDataPoint()
+			dest := NewOrigHistogramDataPoint()
 			require.NoError(t, UnmarshalProtoOrigHistogramDataPoint(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -137,7 +137,7 @@ func genTestFailingUnmarshalProtoValuesHistogramDataPoint() map[string][]byte {
 
 func genTestEncodingValuesHistogramDataPoint() map[string]*otlpmetrics.HistogramDataPoint {
 	return map[string]*otlpmetrics.HistogramDataPoint{
-		"empty":                       NewOrigPtrHistogramDataPoint(),
+		"empty":                       NewOrigHistogramDataPoint(),
 		"Attributes/default_and_test": {Attributes: []otlpcommon.KeyValue{{}, *GenTestOrigKeyValue()}},
 		"StartTimeUnixNano/test":      {StartTimeUnixNano: uint64(13)},
 		"TimeUnixNano/test":           {TimeUnixNano: uint64(13)},

--- a/pdata/internal/generated_wrapper_histogramdatapointslice.go
+++ b/pdata/internal/generated_wrapper_histogramdatapointslice.go
@@ -19,7 +19,7 @@ func CopyOrigHistogramDataPointSlice(dest, src []*otlpmetrics.HistogramDataPoint
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrHistogramDataPoint()
+			newDest[i] = NewOrigHistogramDataPoint()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigHistogramDataPointSlice(dest, src []*otlpmetrics.HistogramDataPoint
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrHistogramDataPoint()
+			newDest[i] = NewOrigHistogramDataPoint()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigHistogramDataPointSlice(dest, src []*otlpmetrics.HistogramDataPoint
 
 func GenerateOrigTestHistogramDataPointSlice() []*otlpmetrics.HistogramDataPoint {
 	orig := make([]*otlpmetrics.HistogramDataPoint, 5)
-	orig[0] = NewOrigPtrHistogramDataPoint()
+	orig[0] = NewOrigHistogramDataPoint()
 	orig[1] = GenTestOrigHistogramDataPoint()
-	orig[2] = NewOrigPtrHistogramDataPoint()
+	orig[2] = NewOrigHistogramDataPoint()
 	orig[3] = GenTestOrigHistogramDataPoint()
-	orig[4] = NewOrigPtrHistogramDataPoint()
+	orig[4] = NewOrigHistogramDataPoint()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestHistogramDataPointSlice() []*otlpmetrics.HistogramDataPoint
 func UnmarshalJSONOrigHistogramDataPointSlice(iter *json.Iterator) []*otlpmetrics.HistogramDataPoint {
 	var orig []*otlpmetrics.HistogramDataPoint
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrHistogramDataPoint())
+		orig = append(orig, NewOrigHistogramDataPoint())
 		UnmarshalJSONOrigHistogramDataPoint(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_instrumentationscope.go
+++ b/pdata/internal/generated_wrapper_instrumentationscope.go
@@ -31,11 +31,7 @@ func NewInstrumentationScope(orig *otlpcommon.InstrumentationScope, state *State
 	return InstrumentationScope{orig: orig, state: state}
 }
 
-func NewOrigInstrumentationScope() otlpcommon.InstrumentationScope {
-	return otlpcommon.InstrumentationScope{}
-}
-
-func NewOrigPtrInstrumentationScope() *otlpcommon.InstrumentationScope {
+func NewOrigInstrumentationScope() *otlpcommon.InstrumentationScope {
 	return &otlpcommon.InstrumentationScope{}
 }
 
@@ -47,7 +43,7 @@ func CopyOrigInstrumentationScope(dest, src *otlpcommon.InstrumentationScope) {
 }
 
 func GenTestOrigInstrumentationScope() *otlpcommon.InstrumentationScope {
-	orig := NewOrigPtrInstrumentationScope()
+	orig := NewOrigInstrumentationScope()
 	orig.Name = "test_name"
 	orig.Version = "test_version"
 	orig.Attributes = GenerateOrigTestKeyValueSlice()
@@ -208,7 +204,7 @@ func UnmarshalProtoOrigInstrumentationScope(orig *otlpcommon.InstrumentationScop
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_instrumentationscope_test.go
+++ b/pdata/internal/generated_wrapper_instrumentationscope_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigInstrumentationScope(t *testing.T) {
-	src := NewOrigPtrInstrumentationScope()
-	dest := NewOrigPtrInstrumentationScope()
+	src := NewOrigInstrumentationScope()
+	dest := NewOrigInstrumentationScope()
 	CopyOrigInstrumentationScope(dest, src)
-	assert.Equal(t, NewOrigPtrInstrumentationScope(), dest)
+	assert.Equal(t, NewOrigInstrumentationScope(), dest)
 	*src = *GenTestOrigInstrumentationScope()
 	CopyOrigInstrumentationScope(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigInstrumentationScope(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigInstrumentationScopeUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrInstrumentationScope()
+	dest := NewOrigInstrumentationScope()
 	UnmarshalJSONOrigInstrumentationScope(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrInstrumentationScope(), dest)
+	assert.Equal(t, NewOrigInstrumentationScope(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigInstrumentationScope(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigInstrumentationScope(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrInstrumentationScope()
+			dest := NewOrigInstrumentationScope()
 			UnmarshalJSONOrigInstrumentationScope(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigInstrumentationScope(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigInstrumentationScopeFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesInstrumentationScope() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrInstrumentationScope()
+			dest := NewOrigInstrumentationScope()
 			require.Error(t, UnmarshalProtoOrigInstrumentationScope(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigInstrumentationScopeUnknown(t *testing.T) {
-	dest := NewOrigPtrInstrumentationScope()
+	dest := NewOrigInstrumentationScope()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigInstrumentationScope(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrInstrumentationScope(), dest)
+	assert.Equal(t, NewOrigInstrumentationScope(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigInstrumentationScope(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigInstrumentationScope(t *testing.T) {
 			gotSize := MarshalProtoOrigInstrumentationScope(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrInstrumentationScope()
+			dest := NewOrigInstrumentationScope()
 			require.NoError(t, UnmarshalProtoOrigInstrumentationScope(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufInstrumentationScope(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrInstrumentationScope()
+			dest := NewOrigInstrumentationScope()
 			require.NoError(t, UnmarshalProtoOrigInstrumentationScope(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -122,7 +122,7 @@ func genTestFailingUnmarshalProtoValuesInstrumentationScope() map[string][]byte 
 
 func genTestEncodingValuesInstrumentationScope() map[string]*otlpcommon.InstrumentationScope {
 	return map[string]*otlpcommon.InstrumentationScope{
-		"empty":                       NewOrigPtrInstrumentationScope(),
+		"empty":                       NewOrigInstrumentationScope(),
 		"Name/test":                   {Name: "test_name"},
 		"Version/test":                {Version: "test_version"},
 		"Attributes/default_and_test": {Attributes: []otlpcommon.KeyValue{{}, *GenTestOrigKeyValue()}},

--- a/pdata/internal/generated_wrapper_keyvalue.go
+++ b/pdata/internal/generated_wrapper_keyvalue.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigKeyValue() otlpcommon.KeyValue {
-	return otlpcommon.KeyValue{}
-}
-
-func NewOrigPtrKeyValue() *otlpcommon.KeyValue {
+func NewOrigKeyValue() *otlpcommon.KeyValue {
 	return &otlpcommon.KeyValue{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigKeyValue(dest, src *otlpcommon.KeyValue) {
 }
 
 func GenTestOrigKeyValue() *otlpcommon.KeyValue {
-	orig := NewOrigPtrKeyValue()
+	orig := NewOrigKeyValue()
 	orig.Key = "test_key"
 	orig.Value = *GenTestOrigAnyValue()
 	return orig

--- a/pdata/internal/generated_wrapper_keyvalue_test.go
+++ b/pdata/internal/generated_wrapper_keyvalue_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigKeyValue(t *testing.T) {
-	src := NewOrigPtrKeyValue()
-	dest := NewOrigPtrKeyValue()
+	src := NewOrigKeyValue()
+	dest := NewOrigKeyValue()
 	CopyOrigKeyValue(dest, src)
-	assert.Equal(t, NewOrigPtrKeyValue(), dest)
+	assert.Equal(t, NewOrigKeyValue(), dest)
 	*src = *GenTestOrigKeyValue()
 	CopyOrigKeyValue(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigKeyValue(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigKeyValueUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrKeyValue()
+	dest := NewOrigKeyValue()
 	UnmarshalJSONOrigKeyValue(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrKeyValue(), dest)
+	assert.Equal(t, NewOrigKeyValue(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigKeyValue(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigKeyValue(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrKeyValue()
+			dest := NewOrigKeyValue()
 			UnmarshalJSONOrigKeyValue(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigKeyValue(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigKeyValueFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesKeyValue() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrKeyValue()
+			dest := NewOrigKeyValue()
 			require.Error(t, UnmarshalProtoOrigKeyValue(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigKeyValueUnknown(t *testing.T) {
-	dest := NewOrigPtrKeyValue()
+	dest := NewOrigKeyValue()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigKeyValue(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrKeyValue(), dest)
+	assert.Equal(t, NewOrigKeyValue(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigKeyValue(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigKeyValue(t *testing.T) {
 			gotSize := MarshalProtoOrigKeyValue(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrKeyValue()
+			dest := NewOrigKeyValue()
 			require.NoError(t, UnmarshalProtoOrigKeyValue(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufKeyValue(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrKeyValue()
+			dest := NewOrigKeyValue()
 			require.NoError(t, UnmarshalProtoOrigKeyValue(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesKeyValue() map[string][]byte {
 
 func genTestEncodingValuesKeyValue() map[string]*otlpcommon.KeyValue {
 	return map[string]*otlpcommon.KeyValue{
-		"empty":      NewOrigPtrKeyValue(),
+		"empty":      NewOrigKeyValue(),
 		"Key/test":   {Key: "test_key"},
 		"Value/test": {Value: *GenTestOrigAnyValue()},
 	}

--- a/pdata/internal/generated_wrapper_line.go
+++ b/pdata/internal/generated_wrapper_line.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigLine() otlpprofiles.Line {
-	return otlpprofiles.Line{}
-}
-
-func NewOrigPtrLine() *otlpprofiles.Line {
+func NewOrigLine() *otlpprofiles.Line {
 	return &otlpprofiles.Line{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigLine(dest, src *otlpprofiles.Line) {
 }
 
 func GenTestOrigLine() *otlpprofiles.Line {
-	orig := NewOrigPtrLine()
+	orig := NewOrigLine()
 	orig.FunctionIndex = int32(13)
 	orig.Line = int64(13)
 	orig.Column = int64(13)

--- a/pdata/internal/generated_wrapper_line_test.go
+++ b/pdata/internal/generated_wrapper_line_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigLine(t *testing.T) {
-	src := NewOrigPtrLine()
-	dest := NewOrigPtrLine()
+	src := NewOrigLine()
+	dest := NewOrigLine()
 	CopyOrigLine(dest, src)
-	assert.Equal(t, NewOrigPtrLine(), dest)
+	assert.Equal(t, NewOrigLine(), dest)
 	*src = *GenTestOrigLine()
 	CopyOrigLine(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigLine(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigLineUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrLine()
+	dest := NewOrigLine()
 	UnmarshalJSONOrigLine(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrLine(), dest)
+	assert.Equal(t, NewOrigLine(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigLine(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigLine(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrLine()
+			dest := NewOrigLine()
 			UnmarshalJSONOrigLine(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigLine(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigLineFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesLine() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrLine()
+			dest := NewOrigLine()
 			require.Error(t, UnmarshalProtoOrigLine(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigLineUnknown(t *testing.T) {
-	dest := NewOrigPtrLine()
+	dest := NewOrigLine()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigLine(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrLine(), dest)
+	assert.Equal(t, NewOrigLine(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigLine(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigLine(t *testing.T) {
 			gotSize := MarshalProtoOrigLine(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrLine()
+			dest := NewOrigLine()
 			require.NoError(t, UnmarshalProtoOrigLine(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufLine(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrLine()
+			dest := NewOrigLine()
 			require.NoError(t, UnmarshalProtoOrigLine(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesLine() map[string][]byte {
 
 func genTestEncodingValuesLine() map[string]*otlpprofiles.Line {
 	return map[string]*otlpprofiles.Line{
-		"empty":              NewOrigPtrLine(),
+		"empty":              NewOrigLine(),
 		"FunctionIndex/test": {FunctionIndex: int32(13)},
 		"Line/test":          {Line: int64(13)},
 		"Column/test":        {Column: int64(13)},

--- a/pdata/internal/generated_wrapper_lineslice.go
+++ b/pdata/internal/generated_wrapper_lineslice.go
@@ -19,7 +19,7 @@ func CopyOrigLineSlice(dest, src []*otlpprofiles.Line) []*otlpprofiles.Line {
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrLine()
+			newDest[i] = NewOrigLine()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigLineSlice(dest, src []*otlpprofiles.Line) []*otlpprofiles.Line {
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrLine()
+			newDest[i] = NewOrigLine()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigLineSlice(dest, src []*otlpprofiles.Line) []*otlpprofiles.Line {
 
 func GenerateOrigTestLineSlice() []*otlpprofiles.Line {
 	orig := make([]*otlpprofiles.Line, 5)
-	orig[0] = NewOrigPtrLine()
+	orig[0] = NewOrigLine()
 	orig[1] = GenTestOrigLine()
-	orig[2] = NewOrigPtrLine()
+	orig[2] = NewOrigLine()
 	orig[3] = GenTestOrigLine()
-	orig[4] = NewOrigPtrLine()
+	orig[4] = NewOrigLine()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestLineSlice() []*otlpprofiles.Line {
 func UnmarshalJSONOrigLineSlice(iter *json.Iterator) []*otlpprofiles.Line {
 	var orig []*otlpprofiles.Line
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrLine())
+		orig = append(orig, NewOrigLine())
 		UnmarshalJSONOrigLine(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_link.go
+++ b/pdata/internal/generated_wrapper_link.go
@@ -15,11 +15,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigLink() otlpprofiles.Link {
-	return otlpprofiles.Link{}
-}
-
-func NewOrigPtrLink() *otlpprofiles.Link {
+func NewOrigLink() *otlpprofiles.Link {
 	return &otlpprofiles.Link{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigLink(dest, src *otlpprofiles.Link) {
 }
 
 func GenTestOrigLink() *otlpprofiles.Link {
-	orig := NewOrigPtrLink()
+	orig := NewOrigLink()
 	orig.TraceId = data.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
 	orig.SpanId = data.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1})
 	return orig

--- a/pdata/internal/generated_wrapper_link_test.go
+++ b/pdata/internal/generated_wrapper_link_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigLink(t *testing.T) {
-	src := NewOrigPtrLink()
-	dest := NewOrigPtrLink()
+	src := NewOrigLink()
+	dest := NewOrigLink()
 	CopyOrigLink(dest, src)
-	assert.Equal(t, NewOrigPtrLink(), dest)
+	assert.Equal(t, NewOrigLink(), dest)
 	*src = *GenTestOrigLink()
 	CopyOrigLink(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigLink(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigLinkUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrLink()
+	dest := NewOrigLink()
 	UnmarshalJSONOrigLink(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrLink(), dest)
+	assert.Equal(t, NewOrigLink(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigLink(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigLink(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrLink()
+			dest := NewOrigLink()
 			UnmarshalJSONOrigLink(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigLink(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigLinkFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesLink() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrLink()
+			dest := NewOrigLink()
 			require.Error(t, UnmarshalProtoOrigLink(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigLinkUnknown(t *testing.T) {
-	dest := NewOrigPtrLink()
+	dest := NewOrigLink()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigLink(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrLink(), dest)
+	assert.Equal(t, NewOrigLink(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigLink(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigLink(t *testing.T) {
 			gotSize := MarshalProtoOrigLink(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrLink()
+			dest := NewOrigLink()
 			require.NoError(t, UnmarshalProtoOrigLink(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufLink(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrLink()
+			dest := NewOrigLink()
 			require.NoError(t, UnmarshalProtoOrigLink(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesLink() map[string][]byte {
 
 func genTestEncodingValuesLink() map[string]*otlpprofiles.Link {
 	return map[string]*otlpprofiles.Link{
-		"empty":        NewOrigPtrLink(),
+		"empty":        NewOrigLink(),
 		"TraceId/test": {TraceId: *GenTestOrigTraceID()},
 		"SpanId/test":  {SpanId: *GenTestOrigSpanID()},
 	}

--- a/pdata/internal/generated_wrapper_linkslice.go
+++ b/pdata/internal/generated_wrapper_linkslice.go
@@ -19,7 +19,7 @@ func CopyOrigLinkSlice(dest, src []*otlpprofiles.Link) []*otlpprofiles.Link {
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrLink()
+			newDest[i] = NewOrigLink()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigLinkSlice(dest, src []*otlpprofiles.Link) []*otlpprofiles.Link {
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrLink()
+			newDest[i] = NewOrigLink()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigLinkSlice(dest, src []*otlpprofiles.Link) []*otlpprofiles.Link {
 
 func GenerateOrigTestLinkSlice() []*otlpprofiles.Link {
 	orig := make([]*otlpprofiles.Link, 5)
-	orig[0] = NewOrigPtrLink()
+	orig[0] = NewOrigLink()
 	orig[1] = GenTestOrigLink()
-	orig[2] = NewOrigPtrLink()
+	orig[2] = NewOrigLink()
 	orig[3] = GenTestOrigLink()
-	orig[4] = NewOrigPtrLink()
+	orig[4] = NewOrigLink()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestLinkSlice() []*otlpprofiles.Link {
 func UnmarshalJSONOrigLinkSlice(iter *json.Iterator) []*otlpprofiles.Link {
 	var orig []*otlpprofiles.Link
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrLink())
+		orig = append(orig, NewOrigLink())
 		UnmarshalJSONOrigLink(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_location.go
+++ b/pdata/internal/generated_wrapper_location.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigLocation() otlpprofiles.Location {
-	return otlpprofiles.Location{}
-}
-
-func NewOrigPtrLocation() *otlpprofiles.Location {
+func NewOrigLocation() *otlpprofiles.Location {
 	return &otlpprofiles.Location{}
 }
 
@@ -40,7 +36,7 @@ func CopyOrigLocation(dest, src *otlpprofiles.Location) {
 }
 
 func GenTestOrigLocation() *otlpprofiles.Location {
-	orig := NewOrigPtrLocation()
+	orig := NewOrigLocation()
 	orig.MappingIndex_ = &otlpprofiles.Location_MappingIndex{MappingIndex: int32(13)}
 	orig.Address = uint64(13)
 	orig.Line = GenerateOrigTestLineSlice()
@@ -230,7 +226,7 @@ func UnmarshalProtoOrigLocation(orig *otlpprofiles.Location, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.Line = append(orig.Line, NewOrigPtrLine())
+			orig.Line = append(orig.Line, NewOrigLine())
 			err = UnmarshalProtoOrigLine(orig.Line[len(orig.Line)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_location_test.go
+++ b/pdata/internal/generated_wrapper_location_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigLocation(t *testing.T) {
-	src := NewOrigPtrLocation()
-	dest := NewOrigPtrLocation()
+	src := NewOrigLocation()
+	dest := NewOrigLocation()
 	CopyOrigLocation(dest, src)
-	assert.Equal(t, NewOrigPtrLocation(), dest)
+	assert.Equal(t, NewOrigLocation(), dest)
 	*src = *GenTestOrigLocation()
 	CopyOrigLocation(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigLocation(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigLocationUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrLocation()
+	dest := NewOrigLocation()
 	UnmarshalJSONOrigLocation(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrLocation(), dest)
+	assert.Equal(t, NewOrigLocation(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigLocation(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigLocation(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrLocation()
+			dest := NewOrigLocation()
 			UnmarshalJSONOrigLocation(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigLocation(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigLocationFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesLocation() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrLocation()
+			dest := NewOrigLocation()
 			require.Error(t, UnmarshalProtoOrigLocation(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigLocationUnknown(t *testing.T) {
-	dest := NewOrigPtrLocation()
+	dest := NewOrigLocation()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigLocation(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrLocation(), dest)
+	assert.Equal(t, NewOrigLocation(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigLocation(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigLocation(t *testing.T) {
 			gotSize := MarshalProtoOrigLocation(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrLocation()
+			dest := NewOrigLocation()
 			require.NoError(t, UnmarshalProtoOrigLocation(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufLocation(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrLocation()
+			dest := NewOrigLocation()
 			require.NoError(t, UnmarshalProtoOrigLocation(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -124,7 +124,7 @@ func genTestFailingUnmarshalProtoValuesLocation() map[string][]byte {
 
 func genTestEncodingValuesLocation() map[string]*otlpprofiles.Location {
 	return map[string]*otlpprofiles.Location{
-		"empty": NewOrigPtrLocation(), "MappingIndex/default": {MappingIndex_: &otlpprofiles.Location_MappingIndex{MappingIndex: int32(0)}},
+		"empty": NewOrigLocation(), "MappingIndex/default": {MappingIndex_: &otlpprofiles.Location_MappingIndex{MappingIndex: int32(0)}},
 		"MappingIndex/test":                 {MappingIndex_: &otlpprofiles.Location_MappingIndex{MappingIndex: int32(13)}},
 		"Address/test":                      {Address: uint64(13)},
 		"Line/default_and_test":             {Line: []*otlpprofiles.Line{{}, GenTestOrigLine()}},

--- a/pdata/internal/generated_wrapper_locationslice.go
+++ b/pdata/internal/generated_wrapper_locationslice.go
@@ -19,7 +19,7 @@ func CopyOrigLocationSlice(dest, src []*otlpprofiles.Location) []*otlpprofiles.L
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrLocation()
+			newDest[i] = NewOrigLocation()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigLocationSlice(dest, src []*otlpprofiles.Location) []*otlpprofiles.L
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrLocation()
+			newDest[i] = NewOrigLocation()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigLocationSlice(dest, src []*otlpprofiles.Location) []*otlpprofiles.L
 
 func GenerateOrigTestLocationSlice() []*otlpprofiles.Location {
 	orig := make([]*otlpprofiles.Location, 5)
-	orig[0] = NewOrigPtrLocation()
+	orig[0] = NewOrigLocation()
 	orig[1] = GenTestOrigLocation()
-	orig[2] = NewOrigPtrLocation()
+	orig[2] = NewOrigLocation()
 	orig[3] = GenTestOrigLocation()
-	orig[4] = NewOrigPtrLocation()
+	orig[4] = NewOrigLocation()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestLocationSlice() []*otlpprofiles.Location {
 func UnmarshalJSONOrigLocationSlice(iter *json.Iterator) []*otlpprofiles.Location {
 	var orig []*otlpprofiles.Location
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrLocation())
+		orig = append(orig, NewOrigLocation())
 		UnmarshalJSONOrigLocation(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_logrecord.go
+++ b/pdata/internal/generated_wrapper_logrecord.go
@@ -11,16 +11,13 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/internal/data"
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigLogRecord() otlplogs.LogRecord {
-	return otlplogs.LogRecord{}
-}
-
-func NewOrigPtrLogRecord() *otlplogs.LogRecord {
+func NewOrigLogRecord() *otlplogs.LogRecord {
 	return &otlplogs.LogRecord{}
 }
 
@@ -39,7 +36,7 @@ func CopyOrigLogRecord(dest, src *otlplogs.LogRecord) {
 }
 
 func GenTestOrigLogRecord() *otlplogs.LogRecord {
-	orig := NewOrigPtrLogRecord()
+	orig := NewOrigLogRecord()
 	orig.TimeUnixNano = 1234567890
 	orig.ObservedTimeUnixNano = 1234567890
 	orig.SeverityNumber = otlplogs.SeverityNumber(5)
@@ -349,7 +346,7 @@ func UnmarshalProtoOrigLogRecord(orig *otlplogs.LogRecord, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_logrecord_test.go
+++ b/pdata/internal/generated_wrapper_logrecord_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigLogRecord(t *testing.T) {
-	src := NewOrigPtrLogRecord()
-	dest := NewOrigPtrLogRecord()
+	src := NewOrigLogRecord()
+	dest := NewOrigLogRecord()
 	CopyOrigLogRecord(dest, src)
-	assert.Equal(t, NewOrigPtrLogRecord(), dest)
+	assert.Equal(t, NewOrigLogRecord(), dest)
 	*src = *GenTestOrigLogRecord()
 	CopyOrigLogRecord(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigLogRecord(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigLogRecordUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrLogRecord()
+	dest := NewOrigLogRecord()
 	UnmarshalJSONOrigLogRecord(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrLogRecord(), dest)
+	assert.Equal(t, NewOrigLogRecord(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigLogRecord(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigLogRecord(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrLogRecord()
+			dest := NewOrigLogRecord()
 			UnmarshalJSONOrigLogRecord(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigLogRecord(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigLogRecordFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesLogRecord() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrLogRecord()
+			dest := NewOrigLogRecord()
 			require.Error(t, UnmarshalProtoOrigLogRecord(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigLogRecordUnknown(t *testing.T) {
-	dest := NewOrigPtrLogRecord()
+	dest := NewOrigLogRecord()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigLogRecord(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrLogRecord(), dest)
+	assert.Equal(t, NewOrigLogRecord(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigLogRecord(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigLogRecord(t *testing.T) {
 			gotSize := MarshalProtoOrigLogRecord(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrLogRecord()
+			dest := NewOrigLogRecord()
 			require.NoError(t, UnmarshalProtoOrigLogRecord(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufLogRecord(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrLogRecord()
+			dest := NewOrigLogRecord()
 			require.NoError(t, UnmarshalProtoOrigLogRecord(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -137,7 +137,7 @@ func genTestFailingUnmarshalProtoValuesLogRecord() map[string][]byte {
 
 func genTestEncodingValuesLogRecord() map[string]*otlplogs.LogRecord {
 	return map[string]*otlplogs.LogRecord{
-		"empty":                       NewOrigPtrLogRecord(),
+		"empty":                       NewOrigLogRecord(),
 		"TimeUnixNano/test":           {TimeUnixNano: uint64(13)},
 		"ObservedTimeUnixNano/test":   {ObservedTimeUnixNano: uint64(13)},
 		"SeverityNumber/test":         {SeverityNumber: otlplogs.SeverityNumber(13)},

--- a/pdata/internal/generated_wrapper_logrecordslice.go
+++ b/pdata/internal/generated_wrapper_logrecordslice.go
@@ -19,7 +19,7 @@ func CopyOrigLogRecordSlice(dest, src []*otlplogs.LogRecord) []*otlplogs.LogReco
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrLogRecord()
+			newDest[i] = NewOrigLogRecord()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigLogRecordSlice(dest, src []*otlplogs.LogRecord) []*otlplogs.LogReco
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrLogRecord()
+			newDest[i] = NewOrigLogRecord()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigLogRecordSlice(dest, src []*otlplogs.LogRecord) []*otlplogs.LogReco
 
 func GenerateOrigTestLogRecordSlice() []*otlplogs.LogRecord {
 	orig := make([]*otlplogs.LogRecord, 5)
-	orig[0] = NewOrigPtrLogRecord()
+	orig[0] = NewOrigLogRecord()
 	orig[1] = GenTestOrigLogRecord()
-	orig[2] = NewOrigPtrLogRecord()
+	orig[2] = NewOrigLogRecord()
 	orig[3] = GenTestOrigLogRecord()
-	orig[4] = NewOrigPtrLogRecord()
+	orig[4] = NewOrigLogRecord()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestLogRecordSlice() []*otlplogs.LogRecord {
 func UnmarshalJSONOrigLogRecordSlice(iter *json.Iterator) []*otlplogs.LogRecord {
 	var orig []*otlplogs.LogRecord
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrLogRecord())
+		orig = append(orig, NewOrigLogRecord())
 		UnmarshalJSONOrigLogRecord(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_mapping.go
+++ b/pdata/internal/generated_wrapper_mapping.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigMapping() otlpprofiles.Mapping {
-	return otlpprofiles.Mapping{}
-}
-
-func NewOrigPtrMapping() *otlpprofiles.Mapping {
+func NewOrigMapping() *otlpprofiles.Mapping {
 	return &otlpprofiles.Mapping{}
 }
 
@@ -35,7 +31,7 @@ func CopyOrigMapping(dest, src *otlpprofiles.Mapping) {
 }
 
 func GenTestOrigMapping() *otlpprofiles.Mapping {
-	orig := NewOrigPtrMapping()
+	orig := NewOrigMapping()
 	orig.MemoryStart = uint64(13)
 	orig.MemoryLimit = uint64(13)
 	orig.FileOffset = uint64(13)

--- a/pdata/internal/generated_wrapper_mapping_test.go
+++ b/pdata/internal/generated_wrapper_mapping_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigMapping(t *testing.T) {
-	src := NewOrigPtrMapping()
-	dest := NewOrigPtrMapping()
+	src := NewOrigMapping()
+	dest := NewOrigMapping()
 	CopyOrigMapping(dest, src)
-	assert.Equal(t, NewOrigPtrMapping(), dest)
+	assert.Equal(t, NewOrigMapping(), dest)
 	*src = *GenTestOrigMapping()
 	CopyOrigMapping(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigMapping(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigMappingUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrMapping()
+	dest := NewOrigMapping()
 	UnmarshalJSONOrigMapping(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrMapping(), dest)
+	assert.Equal(t, NewOrigMapping(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigMapping(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigMapping(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrMapping()
+			dest := NewOrigMapping()
 			UnmarshalJSONOrigMapping(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigMapping(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigMappingFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesMapping() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrMapping()
+			dest := NewOrigMapping()
 			require.Error(t, UnmarshalProtoOrigMapping(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigMappingUnknown(t *testing.T) {
-	dest := NewOrigPtrMapping()
+	dest := NewOrigMapping()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigMapping(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrMapping(), dest)
+	assert.Equal(t, NewOrigMapping(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigMapping(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigMapping(t *testing.T) {
 			gotSize := MarshalProtoOrigMapping(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrMapping()
+			dest := NewOrigMapping()
 			require.NoError(t, UnmarshalProtoOrigMapping(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufMapping(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrMapping()
+			dest := NewOrigMapping()
 			require.NoError(t, UnmarshalProtoOrigMapping(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -132,7 +132,7 @@ func genTestFailingUnmarshalProtoValuesMapping() map[string][]byte {
 
 func genTestEncodingValuesMapping() map[string]*otlpprofiles.Mapping {
 	return map[string]*otlpprofiles.Mapping{
-		"empty":                             NewOrigPtrMapping(),
+		"empty":                             NewOrigMapping(),
 		"MemoryStart/test":                  {MemoryStart: uint64(13)},
 		"MemoryLimit/test":                  {MemoryLimit: uint64(13)},
 		"FileOffset/test":                   {FileOffset: uint64(13)},

--- a/pdata/internal/generated_wrapper_mappingslice.go
+++ b/pdata/internal/generated_wrapper_mappingslice.go
@@ -19,7 +19,7 @@ func CopyOrigMappingSlice(dest, src []*otlpprofiles.Mapping) []*otlpprofiles.Map
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrMapping()
+			newDest[i] = NewOrigMapping()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigMappingSlice(dest, src []*otlpprofiles.Mapping) []*otlpprofiles.Map
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrMapping()
+			newDest[i] = NewOrigMapping()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigMappingSlice(dest, src []*otlpprofiles.Mapping) []*otlpprofiles.Map
 
 func GenerateOrigTestMappingSlice() []*otlpprofiles.Mapping {
 	orig := make([]*otlpprofiles.Mapping, 5)
-	orig[0] = NewOrigPtrMapping()
+	orig[0] = NewOrigMapping()
 	orig[1] = GenTestOrigMapping()
-	orig[2] = NewOrigPtrMapping()
+	orig[2] = NewOrigMapping()
 	orig[3] = GenTestOrigMapping()
-	orig[4] = NewOrigPtrMapping()
+	orig[4] = NewOrigMapping()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestMappingSlice() []*otlpprofiles.Mapping {
 func UnmarshalJSONOrigMappingSlice(iter *json.Iterator) []*otlpprofiles.Mapping {
 	var orig []*otlpprofiles.Mapping
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrMapping())
+		orig = append(orig, NewOrigMapping())
 		UnmarshalJSONOrigMapping(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_metric.go
+++ b/pdata/internal/generated_wrapper_metric.go
@@ -9,16 +9,13 @@ package internal
 import (
 	"fmt"
 
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigMetric() otlpmetrics.Metric {
-	return otlpmetrics.Metric{}
-}
-
-func NewOrigPtrMetric() *otlpmetrics.Metric {
+func NewOrigMetric() *otlpmetrics.Metric {
 	return &otlpmetrics.Metric{}
 }
 
@@ -62,7 +59,7 @@ func CopyOrigMetric(dest, src *otlpmetrics.Metric) {
 }
 
 func GenTestOrigMetric() *otlpmetrics.Metric {
-	orig := NewOrigPtrMetric()
+	orig := NewOrigMetric()
 	orig.Name = "test_name"
 	orig.Description = "test_description"
 	orig.Unit = "test_unit"
@@ -348,7 +345,7 @@ func UnmarshalProtoOrigMetric(orig *otlpmetrics.Metric, buf []byte) error {
 			}
 			startPos := pos - length
 			ofv := &otlpmetrics.Metric_Gauge{}
-			ofv.Gauge = NewOrigPtrGauge()
+			ofv.Gauge = NewOrigGauge()
 			err = UnmarshalProtoOrigGauge(ofv.Gauge, buf[startPos:pos])
 			if err != nil {
 				return err
@@ -366,7 +363,7 @@ func UnmarshalProtoOrigMetric(orig *otlpmetrics.Metric, buf []byte) error {
 			}
 			startPos := pos - length
 			ofv := &otlpmetrics.Metric_Sum{}
-			ofv.Sum = NewOrigPtrSum()
+			ofv.Sum = NewOrigSum()
 			err = UnmarshalProtoOrigSum(ofv.Sum, buf[startPos:pos])
 			if err != nil {
 				return err
@@ -384,7 +381,7 @@ func UnmarshalProtoOrigMetric(orig *otlpmetrics.Metric, buf []byte) error {
 			}
 			startPos := pos - length
 			ofv := &otlpmetrics.Metric_Histogram{}
-			ofv.Histogram = NewOrigPtrHistogram()
+			ofv.Histogram = NewOrigHistogram()
 			err = UnmarshalProtoOrigHistogram(ofv.Histogram, buf[startPos:pos])
 			if err != nil {
 				return err
@@ -402,7 +399,7 @@ func UnmarshalProtoOrigMetric(orig *otlpmetrics.Metric, buf []byte) error {
 			}
 			startPos := pos - length
 			ofv := &otlpmetrics.Metric_ExponentialHistogram{}
-			ofv.ExponentialHistogram = NewOrigPtrExponentialHistogram()
+			ofv.ExponentialHistogram = NewOrigExponentialHistogram()
 			err = UnmarshalProtoOrigExponentialHistogram(ofv.ExponentialHistogram, buf[startPos:pos])
 			if err != nil {
 				return err
@@ -420,7 +417,7 @@ func UnmarshalProtoOrigMetric(orig *otlpmetrics.Metric, buf []byte) error {
 			}
 			startPos := pos - length
 			ofv := &otlpmetrics.Metric_Summary{}
-			ofv.Summary = NewOrigPtrSummary()
+			ofv.Summary = NewOrigSummary()
 			err = UnmarshalProtoOrigSummary(ofv.Summary, buf[startPos:pos])
 			if err != nil {
 				return err
@@ -437,7 +434,7 @@ func UnmarshalProtoOrigMetric(orig *otlpmetrics.Metric, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.Metadata = append(orig.Metadata, NewOrigKeyValue())
+			orig.Metadata = append(orig.Metadata, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Metadata[len(orig.Metadata)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_metric_test.go
+++ b/pdata/internal/generated_wrapper_metric_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigMetric(t *testing.T) {
-	src := NewOrigPtrMetric()
-	dest := NewOrigPtrMetric()
+	src := NewOrigMetric()
+	dest := NewOrigMetric()
 	CopyOrigMetric(dest, src)
-	assert.Equal(t, NewOrigPtrMetric(), dest)
+	assert.Equal(t, NewOrigMetric(), dest)
 	*src = *GenTestOrigMetric()
 	CopyOrigMetric(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigMetric(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigMetricUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrMetric()
+	dest := NewOrigMetric()
 	UnmarshalJSONOrigMetric(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrMetric(), dest)
+	assert.Equal(t, NewOrigMetric(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigMetric(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigMetric(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrMetric()
+			dest := NewOrigMetric()
 			UnmarshalJSONOrigMetric(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigMetric(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigMetricFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesMetric() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrMetric()
+			dest := NewOrigMetric()
 			require.Error(t, UnmarshalProtoOrigMetric(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigMetricUnknown(t *testing.T) {
-	dest := NewOrigPtrMetric()
+	dest := NewOrigMetric()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigMetric(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrMetric(), dest)
+	assert.Equal(t, NewOrigMetric(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigMetric(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigMetric(t *testing.T) {
 			gotSize := MarshalProtoOrigMetric(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrMetric()
+			dest := NewOrigMetric()
 			require.NoError(t, UnmarshalProtoOrigMetric(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufMetric(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrMetric()
+			dest := NewOrigMetric()
 			require.NoError(t, UnmarshalProtoOrigMetric(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -138,7 +138,7 @@ func genTestFailingUnmarshalProtoValuesMetric() map[string][]byte {
 
 func genTestEncodingValuesMetric() map[string]*otlpmetrics.Metric {
 	return map[string]*otlpmetrics.Metric{
-		"empty":                        NewOrigPtrMetric(),
+		"empty":                        NewOrigMetric(),
 		"Name/test":                    {Name: "test_name"},
 		"Description/test":             {Description: "test_description"},
 		"Unit/test":                    {Unit: "test_unit"},

--- a/pdata/internal/generated_wrapper_metricslice.go
+++ b/pdata/internal/generated_wrapper_metricslice.go
@@ -19,7 +19,7 @@ func CopyOrigMetricSlice(dest, src []*otlpmetrics.Metric) []*otlpmetrics.Metric 
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrMetric()
+			newDest[i] = NewOrigMetric()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigMetricSlice(dest, src []*otlpmetrics.Metric) []*otlpmetrics.Metric 
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrMetric()
+			newDest[i] = NewOrigMetric()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigMetricSlice(dest, src []*otlpmetrics.Metric) []*otlpmetrics.Metric 
 
 func GenerateOrigTestMetricSlice() []*otlpmetrics.Metric {
 	orig := make([]*otlpmetrics.Metric, 5)
-	orig[0] = NewOrigPtrMetric()
+	orig[0] = NewOrigMetric()
 	orig[1] = GenTestOrigMetric()
-	orig[2] = NewOrigPtrMetric()
+	orig[2] = NewOrigMetric()
 	orig[3] = GenTestOrigMetric()
-	orig[4] = NewOrigPtrMetric()
+	orig[4] = NewOrigMetric()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestMetricSlice() []*otlpmetrics.Metric {
 func UnmarshalJSONOrigMetricSlice(iter *json.Iterator) []*otlpmetrics.Metric {
 	var orig []*otlpmetrics.Metric
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrMetric())
+		orig = append(orig, NewOrigMetric())
 		UnmarshalJSONOrigMetric(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_numberdatapoint.go
+++ b/pdata/internal/generated_wrapper_numberdatapoint.go
@@ -11,16 +11,13 @@ import (
 	"fmt"
 	"math"
 
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigNumberDataPoint() otlpmetrics.NumberDataPoint {
-	return otlpmetrics.NumberDataPoint{}
-}
-
-func NewOrigPtrNumberDataPoint() *otlpmetrics.NumberDataPoint {
+func NewOrigNumberDataPoint() *otlpmetrics.NumberDataPoint {
 	return &otlpmetrics.NumberDataPoint{}
 }
 
@@ -39,7 +36,7 @@ func CopyOrigNumberDataPoint(dest, src *otlpmetrics.NumberDataPoint) {
 }
 
 func GenTestOrigNumberDataPoint() *otlpmetrics.NumberDataPoint {
-	orig := NewOrigPtrNumberDataPoint()
+	orig := NewOrigNumberDataPoint()
 	orig.Attributes = GenerateOrigTestKeyValueSlice()
 	orig.StartTimeUnixNano = 1234567890
 	orig.TimeUnixNano = 1234567890
@@ -232,7 +229,7 @@ func UnmarshalProtoOrigNumberDataPoint(orig *otlpmetrics.NumberDataPoint, buf []
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -298,7 +295,7 @@ func UnmarshalProtoOrigNumberDataPoint(orig *otlpmetrics.NumberDataPoint, buf []
 				return err
 			}
 			startPos := pos - length
-			orig.Exemplars = append(orig.Exemplars, NewOrigExemplar())
+			orig.Exemplars = append(orig.Exemplars, otlpmetrics.Exemplar{})
 			err = UnmarshalProtoOrigExemplar(&orig.Exemplars[len(orig.Exemplars)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_numberdatapoint_test.go
+++ b/pdata/internal/generated_wrapper_numberdatapoint_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigNumberDataPoint(t *testing.T) {
-	src := NewOrigPtrNumberDataPoint()
-	dest := NewOrigPtrNumberDataPoint()
+	src := NewOrigNumberDataPoint()
+	dest := NewOrigNumberDataPoint()
 	CopyOrigNumberDataPoint(dest, src)
-	assert.Equal(t, NewOrigPtrNumberDataPoint(), dest)
+	assert.Equal(t, NewOrigNumberDataPoint(), dest)
 	*src = *GenTestOrigNumberDataPoint()
 	CopyOrigNumberDataPoint(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigNumberDataPoint(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigNumberDataPointUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrNumberDataPoint()
+	dest := NewOrigNumberDataPoint()
 	UnmarshalJSONOrigNumberDataPoint(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrNumberDataPoint(), dest)
+	assert.Equal(t, NewOrigNumberDataPoint(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigNumberDataPoint(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigNumberDataPoint(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrNumberDataPoint()
+			dest := NewOrigNumberDataPoint()
 			UnmarshalJSONOrigNumberDataPoint(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigNumberDataPoint(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigNumberDataPointFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesNumberDataPoint() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrNumberDataPoint()
+			dest := NewOrigNumberDataPoint()
 			require.Error(t, UnmarshalProtoOrigNumberDataPoint(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigNumberDataPointUnknown(t *testing.T) {
-	dest := NewOrigPtrNumberDataPoint()
+	dest := NewOrigNumberDataPoint()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigNumberDataPoint(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrNumberDataPoint(), dest)
+	assert.Equal(t, NewOrigNumberDataPoint(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigNumberDataPoint(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigNumberDataPoint(t *testing.T) {
 			gotSize := MarshalProtoOrigNumberDataPoint(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrNumberDataPoint()
+			dest := NewOrigNumberDataPoint()
 			require.NoError(t, UnmarshalProtoOrigNumberDataPoint(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufNumberDataPoint(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrNumberDataPoint()
+			dest := NewOrigNumberDataPoint()
 			require.NoError(t, UnmarshalProtoOrigNumberDataPoint(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -131,7 +131,7 @@ func genTestFailingUnmarshalProtoValuesNumberDataPoint() map[string][]byte {
 
 func genTestEncodingValuesNumberDataPoint() map[string]*otlpmetrics.NumberDataPoint {
 	return map[string]*otlpmetrics.NumberDataPoint{
-		"empty":                       NewOrigPtrNumberDataPoint(),
+		"empty":                       NewOrigNumberDataPoint(),
 		"Attributes/default_and_test": {Attributes: []otlpcommon.KeyValue{{}, *GenTestOrigKeyValue()}},
 		"StartTimeUnixNano/test":      {StartTimeUnixNano: uint64(13)},
 		"TimeUnixNano/test":           {TimeUnixNano: uint64(13)},

--- a/pdata/internal/generated_wrapper_numberdatapointslice.go
+++ b/pdata/internal/generated_wrapper_numberdatapointslice.go
@@ -19,7 +19,7 @@ func CopyOrigNumberDataPointSlice(dest, src []*otlpmetrics.NumberDataPoint) []*o
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrNumberDataPoint()
+			newDest[i] = NewOrigNumberDataPoint()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigNumberDataPointSlice(dest, src []*otlpmetrics.NumberDataPoint) []*o
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrNumberDataPoint()
+			newDest[i] = NewOrigNumberDataPoint()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigNumberDataPointSlice(dest, src []*otlpmetrics.NumberDataPoint) []*o
 
 func GenerateOrigTestNumberDataPointSlice() []*otlpmetrics.NumberDataPoint {
 	orig := make([]*otlpmetrics.NumberDataPoint, 5)
-	orig[0] = NewOrigPtrNumberDataPoint()
+	orig[0] = NewOrigNumberDataPoint()
 	orig[1] = GenTestOrigNumberDataPoint()
-	orig[2] = NewOrigPtrNumberDataPoint()
+	orig[2] = NewOrigNumberDataPoint()
 	orig[3] = GenTestOrigNumberDataPoint()
-	orig[4] = NewOrigPtrNumberDataPoint()
+	orig[4] = NewOrigNumberDataPoint()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestNumberDataPointSlice() []*otlpmetrics.NumberDataPoint {
 func UnmarshalJSONOrigNumberDataPointSlice(iter *json.Iterator) []*otlpmetrics.NumberDataPoint {
 	var orig []*otlpmetrics.NumberDataPoint
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrNumberDataPoint())
+		orig = append(orig, NewOrigNumberDataPoint())
 		UnmarshalJSONOrigNumberDataPoint(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_profile.go
+++ b/pdata/internal/generated_wrapper_profile.go
@@ -15,11 +15,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigProfile() otlpprofiles.Profile {
-	return otlpprofiles.Profile{}
-}
-
-func NewOrigPtrProfile() *otlpprofiles.Profile {
+func NewOrigProfile() *otlpprofiles.Profile {
 	return &otlpprofiles.Profile{}
 }
 
@@ -41,7 +37,7 @@ func CopyOrigProfile(dest, src *otlpprofiles.Profile) {
 }
 
 func GenTestOrigProfile() *otlpprofiles.Profile {
-	orig := NewOrigPtrProfile()
+	orig := NewOrigProfile()
 	orig.SampleType = GenerateOrigTestValueTypeSlice()
 	orig.Sample = GenerateOrigTestSampleSlice()
 	orig.LocationIndices = GenerateOrigTestInt32Slice()
@@ -383,7 +379,7 @@ func UnmarshalProtoOrigProfile(orig *otlpprofiles.Profile, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.SampleType = append(orig.SampleType, NewOrigPtrValueType())
+			orig.SampleType = append(orig.SampleType, NewOrigValueType())
 			err = UnmarshalProtoOrigValueType(orig.SampleType[len(orig.SampleType)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -399,7 +395,7 @@ func UnmarshalProtoOrigProfile(orig *otlpprofiles.Profile, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.Sample = append(orig.Sample, NewOrigPtrSample())
+			orig.Sample = append(orig.Sample, NewOrigSample())
 			err = UnmarshalProtoOrigSample(orig.Sample[len(orig.Sample)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_profile_test.go
+++ b/pdata/internal/generated_wrapper_profile_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigProfile(t *testing.T) {
-	src := NewOrigPtrProfile()
-	dest := NewOrigPtrProfile()
+	src := NewOrigProfile()
+	dest := NewOrigProfile()
 	CopyOrigProfile(dest, src)
-	assert.Equal(t, NewOrigPtrProfile(), dest)
+	assert.Equal(t, NewOrigProfile(), dest)
 	*src = *GenTestOrigProfile()
 	CopyOrigProfile(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigProfile(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigProfileUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrProfile()
+	dest := NewOrigProfile()
 	UnmarshalJSONOrigProfile(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrProfile(), dest)
+	assert.Equal(t, NewOrigProfile(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigProfile(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigProfile(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrProfile()
+			dest := NewOrigProfile()
 			UnmarshalJSONOrigProfile(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigProfile(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigProfileFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesProfile() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrProfile()
+			dest := NewOrigProfile()
 			require.Error(t, UnmarshalProtoOrigProfile(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigProfileUnknown(t *testing.T) {
-	dest := NewOrigPtrProfile()
+	dest := NewOrigProfile()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigProfile(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrProfile(), dest)
+	assert.Equal(t, NewOrigProfile(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigProfile(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigProfile(t *testing.T) {
 			gotSize := MarshalProtoOrigProfile(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrProfile()
+			dest := NewOrigProfile()
 			require.NoError(t, UnmarshalProtoOrigProfile(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufProfile(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrProfile()
+			dest := NewOrigProfile()
 			require.NoError(t, UnmarshalProtoOrigProfile(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -142,7 +142,7 @@ func genTestFailingUnmarshalProtoValuesProfile() map[string][]byte {
 
 func genTestEncodingValuesProfile() map[string]*otlpprofiles.Profile {
 	return map[string]*otlpprofiles.Profile{
-		"empty":                              NewOrigPtrProfile(),
+		"empty":                              NewOrigProfile(),
 		"SampleType/default_and_test":        {SampleType: []*otlpprofiles.ValueType{{}, GenTestOrigValueType()}},
 		"Sample/default_and_test":            {Sample: []*otlpprofiles.Sample{{}, GenTestOrigSample()}},
 		"LocationIndices/default_and_test":   {LocationIndices: []int32{int32(0), int32(13)}},

--- a/pdata/internal/generated_wrapper_profilesdictionary.go
+++ b/pdata/internal/generated_wrapper_profilesdictionary.go
@@ -9,16 +9,13 @@ package internal
 import (
 	"fmt"
 
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlpprofiles "go.opentelemetry.io/collector/pdata/internal/data/protogen/profiles/v1development"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigProfilesDictionary() otlpprofiles.ProfilesDictionary {
-	return otlpprofiles.ProfilesDictionary{}
-}
-
-func NewOrigPtrProfilesDictionary() *otlpprofiles.ProfilesDictionary {
+func NewOrigProfilesDictionary() *otlpprofiles.ProfilesDictionary {
 	return &otlpprofiles.ProfilesDictionary{}
 }
 
@@ -33,7 +30,7 @@ func CopyOrigProfilesDictionary(dest, src *otlpprofiles.ProfilesDictionary) {
 }
 
 func GenTestOrigProfilesDictionary() *otlpprofiles.ProfilesDictionary {
-	orig := NewOrigPtrProfilesDictionary()
+	orig := NewOrigProfilesDictionary()
 	orig.MappingTable = GenerateOrigTestMappingSlice()
 	orig.LocationTable = GenerateOrigTestLocationSlice()
 	orig.FunctionTable = GenerateOrigTestFunctionSlice()
@@ -262,7 +259,7 @@ func UnmarshalProtoOrigProfilesDictionary(orig *otlpprofiles.ProfilesDictionary,
 				return err
 			}
 			startPos := pos - length
-			orig.MappingTable = append(orig.MappingTable, NewOrigPtrMapping())
+			orig.MappingTable = append(orig.MappingTable, NewOrigMapping())
 			err = UnmarshalProtoOrigMapping(orig.MappingTable[len(orig.MappingTable)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -278,7 +275,7 @@ func UnmarshalProtoOrigProfilesDictionary(orig *otlpprofiles.ProfilesDictionary,
 				return err
 			}
 			startPos := pos - length
-			orig.LocationTable = append(orig.LocationTable, NewOrigPtrLocation())
+			orig.LocationTable = append(orig.LocationTable, NewOrigLocation())
 			err = UnmarshalProtoOrigLocation(orig.LocationTable[len(orig.LocationTable)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -294,7 +291,7 @@ func UnmarshalProtoOrigProfilesDictionary(orig *otlpprofiles.ProfilesDictionary,
 				return err
 			}
 			startPos := pos - length
-			orig.FunctionTable = append(orig.FunctionTable, NewOrigPtrFunction())
+			orig.FunctionTable = append(orig.FunctionTable, NewOrigFunction())
 			err = UnmarshalProtoOrigFunction(orig.FunctionTable[len(orig.FunctionTable)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -310,7 +307,7 @@ func UnmarshalProtoOrigProfilesDictionary(orig *otlpprofiles.ProfilesDictionary,
 				return err
 			}
 			startPos := pos - length
-			orig.LinkTable = append(orig.LinkTable, NewOrigPtrLink())
+			orig.LinkTable = append(orig.LinkTable, NewOrigLink())
 			err = UnmarshalProtoOrigLink(orig.LinkTable[len(orig.LinkTable)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -338,7 +335,7 @@ func UnmarshalProtoOrigProfilesDictionary(orig *otlpprofiles.ProfilesDictionary,
 				return err
 			}
 			startPos := pos - length
-			orig.AttributeTable = append(orig.AttributeTable, NewOrigKeyValue())
+			orig.AttributeTable = append(orig.AttributeTable, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.AttributeTable[len(orig.AttributeTable)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -354,7 +351,7 @@ func UnmarshalProtoOrigProfilesDictionary(orig *otlpprofiles.ProfilesDictionary,
 				return err
 			}
 			startPos := pos - length
-			orig.AttributeUnits = append(orig.AttributeUnits, NewOrigPtrAttributeUnit())
+			orig.AttributeUnits = append(orig.AttributeUnits, NewOrigAttributeUnit())
 			err = UnmarshalProtoOrigAttributeUnit(orig.AttributeUnits[len(orig.AttributeUnits)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_profilesdictionary_test.go
+++ b/pdata/internal/generated_wrapper_profilesdictionary_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigProfilesDictionary(t *testing.T) {
-	src := NewOrigPtrProfilesDictionary()
-	dest := NewOrigPtrProfilesDictionary()
+	src := NewOrigProfilesDictionary()
+	dest := NewOrigProfilesDictionary()
 	CopyOrigProfilesDictionary(dest, src)
-	assert.Equal(t, NewOrigPtrProfilesDictionary(), dest)
+	assert.Equal(t, NewOrigProfilesDictionary(), dest)
 	*src = *GenTestOrigProfilesDictionary()
 	CopyOrigProfilesDictionary(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigProfilesDictionary(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigProfilesDictionaryUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrProfilesDictionary()
+	dest := NewOrigProfilesDictionary()
 	UnmarshalJSONOrigProfilesDictionary(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrProfilesDictionary(), dest)
+	assert.Equal(t, NewOrigProfilesDictionary(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigProfilesDictionary(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigProfilesDictionary(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrProfilesDictionary()
+			dest := NewOrigProfilesDictionary()
 			UnmarshalJSONOrigProfilesDictionary(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigProfilesDictionary(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigProfilesDictionaryFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesProfilesDictionary() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrProfilesDictionary()
+			dest := NewOrigProfilesDictionary()
 			require.Error(t, UnmarshalProtoOrigProfilesDictionary(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigProfilesDictionaryUnknown(t *testing.T) {
-	dest := NewOrigPtrProfilesDictionary()
+	dest := NewOrigProfilesDictionary()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigProfilesDictionary(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrProfilesDictionary(), dest)
+	assert.Equal(t, NewOrigProfilesDictionary(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigProfilesDictionary(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigProfilesDictionary(t *testing.T) {
 			gotSize := MarshalProtoOrigProfilesDictionary(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrProfilesDictionary()
+			dest := NewOrigProfilesDictionary()
 			require.NoError(t, UnmarshalProtoOrigProfilesDictionary(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufProfilesDictionary(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrProfilesDictionary()
+			dest := NewOrigProfilesDictionary()
 			require.NoError(t, UnmarshalProtoOrigProfilesDictionary(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -129,7 +129,7 @@ func genTestFailingUnmarshalProtoValuesProfilesDictionary() map[string][]byte {
 
 func genTestEncodingValuesProfilesDictionary() map[string]*otlpprofiles.ProfilesDictionary {
 	return map[string]*otlpprofiles.ProfilesDictionary{
-		"empty":                           NewOrigPtrProfilesDictionary(),
+		"empty":                           NewOrigProfilesDictionary(),
 		"MappingTable/default_and_test":   {MappingTable: []*otlpprofiles.Mapping{{}, GenTestOrigMapping()}},
 		"LocationTable/default_and_test":  {LocationTable: []*otlpprofiles.Location{{}, GenTestOrigLocation()}},
 		"FunctionTable/default_and_test":  {FunctionTable: []*otlpprofiles.Function{{}, GenTestOrigFunction()}},

--- a/pdata/internal/generated_wrapper_profileslice.go
+++ b/pdata/internal/generated_wrapper_profileslice.go
@@ -19,7 +19,7 @@ func CopyOrigProfileSlice(dest, src []*otlpprofiles.Profile) []*otlpprofiles.Pro
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrProfile()
+			newDest[i] = NewOrigProfile()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigProfileSlice(dest, src []*otlpprofiles.Profile) []*otlpprofiles.Pro
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrProfile()
+			newDest[i] = NewOrigProfile()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigProfileSlice(dest, src []*otlpprofiles.Profile) []*otlpprofiles.Pro
 
 func GenerateOrigTestProfileSlice() []*otlpprofiles.Profile {
 	orig := make([]*otlpprofiles.Profile, 5)
-	orig[0] = NewOrigPtrProfile()
+	orig[0] = NewOrigProfile()
 	orig[1] = GenTestOrigProfile()
-	orig[2] = NewOrigPtrProfile()
+	orig[2] = NewOrigProfile()
 	orig[3] = GenTestOrigProfile()
-	orig[4] = NewOrigPtrProfile()
+	orig[4] = NewOrigProfile()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestProfileSlice() []*otlpprofiles.Profile {
 func UnmarshalJSONOrigProfileSlice(iter *json.Iterator) []*otlpprofiles.Profile {
 	var orig []*otlpprofiles.Profile
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrProfile())
+		orig = append(orig, NewOrigProfile())
 		UnmarshalJSONOrigProfile(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_resource.go
+++ b/pdata/internal/generated_wrapper_resource.go
@@ -9,6 +9,7 @@ package internal
 import (
 	"fmt"
 
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlpresource "go.opentelemetry.io/collector/pdata/internal/data/protogen/resource/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
@@ -31,11 +32,7 @@ func NewResource(orig *otlpresource.Resource, state *State) Resource {
 	return Resource{orig: orig, state: state}
 }
 
-func NewOrigResource() otlpresource.Resource {
-	return otlpresource.Resource{}
-}
-
-func NewOrigPtrResource() *otlpresource.Resource {
+func NewOrigResource() *otlpresource.Resource {
 	return &otlpresource.Resource{}
 }
 
@@ -46,7 +43,7 @@ func CopyOrigResource(dest, src *otlpresource.Resource) {
 }
 
 func GenTestOrigResource() *otlpresource.Resource {
-	orig := NewOrigPtrResource()
+	orig := NewOrigResource()
 	orig.Attributes = GenerateOrigTestKeyValueSlice()
 	orig.DroppedAttributesCount = uint32(13)
 	orig.EntityRefs = GenerateOrigTestEntityRefSlice()
@@ -169,7 +166,7 @@ func UnmarshalProtoOrigResource(orig *otlpresource.Resource, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -197,7 +194,7 @@ func UnmarshalProtoOrigResource(orig *otlpresource.Resource, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.EntityRefs = append(orig.EntityRefs, NewOrigPtrEntityRef())
+			orig.EntityRefs = append(orig.EntityRefs, NewOrigEntityRef())
 			err = UnmarshalProtoOrigEntityRef(orig.EntityRefs[len(orig.EntityRefs)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_resource_test.go
+++ b/pdata/internal/generated_wrapper_resource_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigResource(t *testing.T) {
-	src := NewOrigPtrResource()
-	dest := NewOrigPtrResource()
+	src := NewOrigResource()
+	dest := NewOrigResource()
 	CopyOrigResource(dest, src)
-	assert.Equal(t, NewOrigPtrResource(), dest)
+	assert.Equal(t, NewOrigResource(), dest)
 	*src = *GenTestOrigResource()
 	CopyOrigResource(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigResource(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigResourceUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrResource()
+	dest := NewOrigResource()
 	UnmarshalJSONOrigResource(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrResource(), dest)
+	assert.Equal(t, NewOrigResource(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigResource(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigResource(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrResource()
+			dest := NewOrigResource()
 			UnmarshalJSONOrigResource(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigResource(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigResourceFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesResource() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrResource()
+			dest := NewOrigResource()
 			require.Error(t, UnmarshalProtoOrigResource(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigResourceUnknown(t *testing.T) {
-	dest := NewOrigPtrResource()
+	dest := NewOrigResource()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigResource(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrResource(), dest)
+	assert.Equal(t, NewOrigResource(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigResource(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigResource(t *testing.T) {
 			gotSize := MarshalProtoOrigResource(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrResource()
+			dest := NewOrigResource()
 			require.NoError(t, UnmarshalProtoOrigResource(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufResource(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrResource()
+			dest := NewOrigResource()
 			require.NoError(t, UnmarshalProtoOrigResource(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -121,7 +121,7 @@ func genTestFailingUnmarshalProtoValuesResource() map[string][]byte {
 
 func genTestEncodingValuesResource() map[string]*otlpresource.Resource {
 	return map[string]*otlpresource.Resource{
-		"empty":                       NewOrigPtrResource(),
+		"empty":                       NewOrigResource(),
 		"Attributes/default_and_test": {Attributes: []otlpcommon.KeyValue{{}, *GenTestOrigKeyValue()}},
 		"DroppedAttributesCount/test": {DroppedAttributesCount: uint32(13)},
 		"EntityRefs/default_and_test": {EntityRefs: []*otlpcommon.EntityRef{{}, GenTestOrigEntityRef()}},

--- a/pdata/internal/generated_wrapper_resourcelogs.go
+++ b/pdata/internal/generated_wrapper_resourcelogs.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigResourceLogs() otlplogs.ResourceLogs {
-	return otlplogs.ResourceLogs{}
-}
-
-func NewOrigPtrResourceLogs() *otlplogs.ResourceLogs {
+func NewOrigResourceLogs() *otlplogs.ResourceLogs {
 	return &otlplogs.ResourceLogs{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigResourceLogs(dest, src *otlplogs.ResourceLogs) {
 }
 
 func GenTestOrigResourceLogs() *otlplogs.ResourceLogs {
-	orig := NewOrigPtrResourceLogs()
+	orig := NewOrigResourceLogs()
 	orig.Resource = *GenTestOrigResource()
 	orig.ScopeLogs = GenerateOrigTestScopeLogsSlice()
 	orig.SchemaUrl = "test_schemaurl"
@@ -162,7 +158,7 @@ func UnmarshalProtoOrigResourceLogs(orig *otlplogs.ResourceLogs, buf []byte) err
 				return err
 			}
 			startPos := pos - length
-			orig.ScopeLogs = append(orig.ScopeLogs, NewOrigPtrScopeLogs())
+			orig.ScopeLogs = append(orig.ScopeLogs, NewOrigScopeLogs())
 			err = UnmarshalProtoOrigScopeLogs(orig.ScopeLogs[len(orig.ScopeLogs)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_resourcelogs_test.go
+++ b/pdata/internal/generated_wrapper_resourcelogs_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigResourceLogs(t *testing.T) {
-	src := NewOrigPtrResourceLogs()
-	dest := NewOrigPtrResourceLogs()
+	src := NewOrigResourceLogs()
+	dest := NewOrigResourceLogs()
 	CopyOrigResourceLogs(dest, src)
-	assert.Equal(t, NewOrigPtrResourceLogs(), dest)
+	assert.Equal(t, NewOrigResourceLogs(), dest)
 	*src = *GenTestOrigResourceLogs()
 	CopyOrigResourceLogs(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigResourceLogs(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigResourceLogsUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrResourceLogs()
+	dest := NewOrigResourceLogs()
 	UnmarshalJSONOrigResourceLogs(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrResourceLogs(), dest)
+	assert.Equal(t, NewOrigResourceLogs(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigResourceLogs(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigResourceLogs(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrResourceLogs()
+			dest := NewOrigResourceLogs()
 			UnmarshalJSONOrigResourceLogs(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigResourceLogs(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigResourceLogsFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesResourceLogs() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrResourceLogs()
+			dest := NewOrigResourceLogs()
 			require.Error(t, UnmarshalProtoOrigResourceLogs(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigResourceLogsUnknown(t *testing.T) {
-	dest := NewOrigPtrResourceLogs()
+	dest := NewOrigResourceLogs()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigResourceLogs(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrResourceLogs(), dest)
+	assert.Equal(t, NewOrigResourceLogs(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigResourceLogs(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigResourceLogs(t *testing.T) {
 			gotSize := MarshalProtoOrigResourceLogs(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrResourceLogs()
+			dest := NewOrigResourceLogs()
 			require.NoError(t, UnmarshalProtoOrigResourceLogs(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufResourceLogs(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrResourceLogs()
+			dest := NewOrigResourceLogs()
 			require.NoError(t, UnmarshalProtoOrigResourceLogs(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesResourceLogs() map[string][]byte {
 
 func genTestEncodingValuesResourceLogs() map[string]*otlplogs.ResourceLogs {
 	return map[string]*otlplogs.ResourceLogs{
-		"empty":                      NewOrigPtrResourceLogs(),
+		"empty":                      NewOrigResourceLogs(),
 		"Resource/test":              {Resource: *GenTestOrigResource()},
 		"ScopeLogs/default_and_test": {ScopeLogs: []*otlplogs.ScopeLogs{{}, GenTestOrigScopeLogs()}},
 		"SchemaUrl/test":             {SchemaUrl: "test_schemaurl"},

--- a/pdata/internal/generated_wrapper_resourcelogsslice.go
+++ b/pdata/internal/generated_wrapper_resourcelogsslice.go
@@ -19,7 +19,7 @@ func CopyOrigResourceLogsSlice(dest, src []*otlplogs.ResourceLogs) []*otlplogs.R
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrResourceLogs()
+			newDest[i] = NewOrigResourceLogs()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigResourceLogsSlice(dest, src []*otlplogs.ResourceLogs) []*otlplogs.R
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrResourceLogs()
+			newDest[i] = NewOrigResourceLogs()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigResourceLogsSlice(dest, src []*otlplogs.ResourceLogs) []*otlplogs.R
 
 func GenerateOrigTestResourceLogsSlice() []*otlplogs.ResourceLogs {
 	orig := make([]*otlplogs.ResourceLogs, 5)
-	orig[0] = NewOrigPtrResourceLogs()
+	orig[0] = NewOrigResourceLogs()
 	orig[1] = GenTestOrigResourceLogs()
-	orig[2] = NewOrigPtrResourceLogs()
+	orig[2] = NewOrigResourceLogs()
 	orig[3] = GenTestOrigResourceLogs()
-	orig[4] = NewOrigPtrResourceLogs()
+	orig[4] = NewOrigResourceLogs()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestResourceLogsSlice() []*otlplogs.ResourceLogs {
 func UnmarshalJSONOrigResourceLogsSlice(iter *json.Iterator) []*otlplogs.ResourceLogs {
 	var orig []*otlplogs.ResourceLogs
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrResourceLogs())
+		orig = append(orig, NewOrigResourceLogs())
 		UnmarshalJSONOrigResourceLogs(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_resourcemetrics.go
+++ b/pdata/internal/generated_wrapper_resourcemetrics.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigResourceMetrics() otlpmetrics.ResourceMetrics {
-	return otlpmetrics.ResourceMetrics{}
-}
-
-func NewOrigPtrResourceMetrics() *otlpmetrics.ResourceMetrics {
+func NewOrigResourceMetrics() *otlpmetrics.ResourceMetrics {
 	return &otlpmetrics.ResourceMetrics{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigResourceMetrics(dest, src *otlpmetrics.ResourceMetrics) {
 }
 
 func GenTestOrigResourceMetrics() *otlpmetrics.ResourceMetrics {
-	orig := NewOrigPtrResourceMetrics()
+	orig := NewOrigResourceMetrics()
 	orig.Resource = *GenTestOrigResource()
 	orig.ScopeMetrics = GenerateOrigTestScopeMetricsSlice()
 	orig.SchemaUrl = "test_schemaurl"
@@ -162,7 +158,7 @@ func UnmarshalProtoOrigResourceMetrics(orig *otlpmetrics.ResourceMetrics, buf []
 				return err
 			}
 			startPos := pos - length
-			orig.ScopeMetrics = append(orig.ScopeMetrics, NewOrigPtrScopeMetrics())
+			orig.ScopeMetrics = append(orig.ScopeMetrics, NewOrigScopeMetrics())
 			err = UnmarshalProtoOrigScopeMetrics(orig.ScopeMetrics[len(orig.ScopeMetrics)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_resourcemetrics_test.go
+++ b/pdata/internal/generated_wrapper_resourcemetrics_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigResourceMetrics(t *testing.T) {
-	src := NewOrigPtrResourceMetrics()
-	dest := NewOrigPtrResourceMetrics()
+	src := NewOrigResourceMetrics()
+	dest := NewOrigResourceMetrics()
 	CopyOrigResourceMetrics(dest, src)
-	assert.Equal(t, NewOrigPtrResourceMetrics(), dest)
+	assert.Equal(t, NewOrigResourceMetrics(), dest)
 	*src = *GenTestOrigResourceMetrics()
 	CopyOrigResourceMetrics(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigResourceMetrics(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigResourceMetricsUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrResourceMetrics()
+	dest := NewOrigResourceMetrics()
 	UnmarshalJSONOrigResourceMetrics(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrResourceMetrics(), dest)
+	assert.Equal(t, NewOrigResourceMetrics(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigResourceMetrics(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigResourceMetrics(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrResourceMetrics()
+			dest := NewOrigResourceMetrics()
 			UnmarshalJSONOrigResourceMetrics(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigResourceMetrics(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigResourceMetricsFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesResourceMetrics() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrResourceMetrics()
+			dest := NewOrigResourceMetrics()
 			require.Error(t, UnmarshalProtoOrigResourceMetrics(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigResourceMetricsUnknown(t *testing.T) {
-	dest := NewOrigPtrResourceMetrics()
+	dest := NewOrigResourceMetrics()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigResourceMetrics(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrResourceMetrics(), dest)
+	assert.Equal(t, NewOrigResourceMetrics(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigResourceMetrics(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigResourceMetrics(t *testing.T) {
 			gotSize := MarshalProtoOrigResourceMetrics(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrResourceMetrics()
+			dest := NewOrigResourceMetrics()
 			require.NoError(t, UnmarshalProtoOrigResourceMetrics(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufResourceMetrics(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrResourceMetrics()
+			dest := NewOrigResourceMetrics()
 			require.NoError(t, UnmarshalProtoOrigResourceMetrics(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesResourceMetrics() map[string][]byte {
 
 func genTestEncodingValuesResourceMetrics() map[string]*otlpmetrics.ResourceMetrics {
 	return map[string]*otlpmetrics.ResourceMetrics{
-		"empty":                         NewOrigPtrResourceMetrics(),
+		"empty":                         NewOrigResourceMetrics(),
 		"Resource/test":                 {Resource: *GenTestOrigResource()},
 		"ScopeMetrics/default_and_test": {ScopeMetrics: []*otlpmetrics.ScopeMetrics{{}, GenTestOrigScopeMetrics()}},
 		"SchemaUrl/test":                {SchemaUrl: "test_schemaurl"},

--- a/pdata/internal/generated_wrapper_resourcemetricsslice.go
+++ b/pdata/internal/generated_wrapper_resourcemetricsslice.go
@@ -19,7 +19,7 @@ func CopyOrigResourceMetricsSlice(dest, src []*otlpmetrics.ResourceMetrics) []*o
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrResourceMetrics()
+			newDest[i] = NewOrigResourceMetrics()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigResourceMetricsSlice(dest, src []*otlpmetrics.ResourceMetrics) []*o
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrResourceMetrics()
+			newDest[i] = NewOrigResourceMetrics()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigResourceMetricsSlice(dest, src []*otlpmetrics.ResourceMetrics) []*o
 
 func GenerateOrigTestResourceMetricsSlice() []*otlpmetrics.ResourceMetrics {
 	orig := make([]*otlpmetrics.ResourceMetrics, 5)
-	orig[0] = NewOrigPtrResourceMetrics()
+	orig[0] = NewOrigResourceMetrics()
 	orig[1] = GenTestOrigResourceMetrics()
-	orig[2] = NewOrigPtrResourceMetrics()
+	orig[2] = NewOrigResourceMetrics()
 	orig[3] = GenTestOrigResourceMetrics()
-	orig[4] = NewOrigPtrResourceMetrics()
+	orig[4] = NewOrigResourceMetrics()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestResourceMetricsSlice() []*otlpmetrics.ResourceMetrics {
 func UnmarshalJSONOrigResourceMetricsSlice(iter *json.Iterator) []*otlpmetrics.ResourceMetrics {
 	var orig []*otlpmetrics.ResourceMetrics
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrResourceMetrics())
+		orig = append(orig, NewOrigResourceMetrics())
 		UnmarshalJSONOrigResourceMetrics(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_resourceprofiles.go
+++ b/pdata/internal/generated_wrapper_resourceprofiles.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigResourceProfiles() otlpprofiles.ResourceProfiles {
-	return otlpprofiles.ResourceProfiles{}
-}
-
-func NewOrigPtrResourceProfiles() *otlpprofiles.ResourceProfiles {
+func NewOrigResourceProfiles() *otlpprofiles.ResourceProfiles {
 	return &otlpprofiles.ResourceProfiles{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigResourceProfiles(dest, src *otlpprofiles.ResourceProfiles) {
 }
 
 func GenTestOrigResourceProfiles() *otlpprofiles.ResourceProfiles {
-	orig := NewOrigPtrResourceProfiles()
+	orig := NewOrigResourceProfiles()
 	orig.Resource = *GenTestOrigResource()
 	orig.ScopeProfiles = GenerateOrigTestScopeProfilesSlice()
 	orig.SchemaUrl = "test_schemaurl"
@@ -162,7 +158,7 @@ func UnmarshalProtoOrigResourceProfiles(orig *otlpprofiles.ResourceProfiles, buf
 				return err
 			}
 			startPos := pos - length
-			orig.ScopeProfiles = append(orig.ScopeProfiles, NewOrigPtrScopeProfiles())
+			orig.ScopeProfiles = append(orig.ScopeProfiles, NewOrigScopeProfiles())
 			err = UnmarshalProtoOrigScopeProfiles(orig.ScopeProfiles[len(orig.ScopeProfiles)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_resourceprofiles_test.go
+++ b/pdata/internal/generated_wrapper_resourceprofiles_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigResourceProfiles(t *testing.T) {
-	src := NewOrigPtrResourceProfiles()
-	dest := NewOrigPtrResourceProfiles()
+	src := NewOrigResourceProfiles()
+	dest := NewOrigResourceProfiles()
 	CopyOrigResourceProfiles(dest, src)
-	assert.Equal(t, NewOrigPtrResourceProfiles(), dest)
+	assert.Equal(t, NewOrigResourceProfiles(), dest)
 	*src = *GenTestOrigResourceProfiles()
 	CopyOrigResourceProfiles(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigResourceProfiles(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigResourceProfilesUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrResourceProfiles()
+	dest := NewOrigResourceProfiles()
 	UnmarshalJSONOrigResourceProfiles(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrResourceProfiles(), dest)
+	assert.Equal(t, NewOrigResourceProfiles(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigResourceProfiles(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigResourceProfiles(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrResourceProfiles()
+			dest := NewOrigResourceProfiles()
 			UnmarshalJSONOrigResourceProfiles(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigResourceProfiles(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigResourceProfilesFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesResourceProfiles() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrResourceProfiles()
+			dest := NewOrigResourceProfiles()
 			require.Error(t, UnmarshalProtoOrigResourceProfiles(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigResourceProfilesUnknown(t *testing.T) {
-	dest := NewOrigPtrResourceProfiles()
+	dest := NewOrigResourceProfiles()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigResourceProfiles(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrResourceProfiles(), dest)
+	assert.Equal(t, NewOrigResourceProfiles(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigResourceProfiles(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigResourceProfiles(t *testing.T) {
 			gotSize := MarshalProtoOrigResourceProfiles(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrResourceProfiles()
+			dest := NewOrigResourceProfiles()
 			require.NoError(t, UnmarshalProtoOrigResourceProfiles(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufResourceProfiles(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrResourceProfiles()
+			dest := NewOrigResourceProfiles()
 			require.NoError(t, UnmarshalProtoOrigResourceProfiles(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesResourceProfiles() map[string][]byte {
 
 func genTestEncodingValuesResourceProfiles() map[string]*otlpprofiles.ResourceProfiles {
 	return map[string]*otlpprofiles.ResourceProfiles{
-		"empty":                          NewOrigPtrResourceProfiles(),
+		"empty":                          NewOrigResourceProfiles(),
 		"Resource/test":                  {Resource: *GenTestOrigResource()},
 		"ScopeProfiles/default_and_test": {ScopeProfiles: []*otlpprofiles.ScopeProfiles{{}, GenTestOrigScopeProfiles()}},
 		"SchemaUrl/test":                 {SchemaUrl: "test_schemaurl"},

--- a/pdata/internal/generated_wrapper_resourceprofilesslice.go
+++ b/pdata/internal/generated_wrapper_resourceprofilesslice.go
@@ -19,7 +19,7 @@ func CopyOrigResourceProfilesSlice(dest, src []*otlpprofiles.ResourceProfiles) [
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrResourceProfiles()
+			newDest[i] = NewOrigResourceProfiles()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigResourceProfilesSlice(dest, src []*otlpprofiles.ResourceProfiles) [
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrResourceProfiles()
+			newDest[i] = NewOrigResourceProfiles()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigResourceProfilesSlice(dest, src []*otlpprofiles.ResourceProfiles) [
 
 func GenerateOrigTestResourceProfilesSlice() []*otlpprofiles.ResourceProfiles {
 	orig := make([]*otlpprofiles.ResourceProfiles, 5)
-	orig[0] = NewOrigPtrResourceProfiles()
+	orig[0] = NewOrigResourceProfiles()
 	orig[1] = GenTestOrigResourceProfiles()
-	orig[2] = NewOrigPtrResourceProfiles()
+	orig[2] = NewOrigResourceProfiles()
 	orig[3] = GenTestOrigResourceProfiles()
-	orig[4] = NewOrigPtrResourceProfiles()
+	orig[4] = NewOrigResourceProfiles()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestResourceProfilesSlice() []*otlpprofiles.ResourceProfiles {
 func UnmarshalJSONOrigResourceProfilesSlice(iter *json.Iterator) []*otlpprofiles.ResourceProfiles {
 	var orig []*otlpprofiles.ResourceProfiles
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrResourceProfiles())
+		orig = append(orig, NewOrigResourceProfiles())
 		UnmarshalJSONOrigResourceProfiles(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_resourcespans.go
+++ b/pdata/internal/generated_wrapper_resourcespans.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigResourceSpans() otlptrace.ResourceSpans {
-	return otlptrace.ResourceSpans{}
-}
-
-func NewOrigPtrResourceSpans() *otlptrace.ResourceSpans {
+func NewOrigResourceSpans() *otlptrace.ResourceSpans {
 	return &otlptrace.ResourceSpans{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigResourceSpans(dest, src *otlptrace.ResourceSpans) {
 }
 
 func GenTestOrigResourceSpans() *otlptrace.ResourceSpans {
-	orig := NewOrigPtrResourceSpans()
+	orig := NewOrigResourceSpans()
 	orig.Resource = *GenTestOrigResource()
 	orig.ScopeSpans = GenerateOrigTestScopeSpansSlice()
 	orig.SchemaUrl = "test_schemaurl"
@@ -162,7 +158,7 @@ func UnmarshalProtoOrigResourceSpans(orig *otlptrace.ResourceSpans, buf []byte) 
 				return err
 			}
 			startPos := pos - length
-			orig.ScopeSpans = append(orig.ScopeSpans, NewOrigPtrScopeSpans())
+			orig.ScopeSpans = append(orig.ScopeSpans, NewOrigScopeSpans())
 			err = UnmarshalProtoOrigScopeSpans(orig.ScopeSpans[len(orig.ScopeSpans)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_resourcespans_test.go
+++ b/pdata/internal/generated_wrapper_resourcespans_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigResourceSpans(t *testing.T) {
-	src := NewOrigPtrResourceSpans()
-	dest := NewOrigPtrResourceSpans()
+	src := NewOrigResourceSpans()
+	dest := NewOrigResourceSpans()
 	CopyOrigResourceSpans(dest, src)
-	assert.Equal(t, NewOrigPtrResourceSpans(), dest)
+	assert.Equal(t, NewOrigResourceSpans(), dest)
 	*src = *GenTestOrigResourceSpans()
 	CopyOrigResourceSpans(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigResourceSpans(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigResourceSpansUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrResourceSpans()
+	dest := NewOrigResourceSpans()
 	UnmarshalJSONOrigResourceSpans(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrResourceSpans(), dest)
+	assert.Equal(t, NewOrigResourceSpans(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigResourceSpans(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigResourceSpans(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrResourceSpans()
+			dest := NewOrigResourceSpans()
 			UnmarshalJSONOrigResourceSpans(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigResourceSpans(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigResourceSpansFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesResourceSpans() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrResourceSpans()
+			dest := NewOrigResourceSpans()
 			require.Error(t, UnmarshalProtoOrigResourceSpans(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigResourceSpansUnknown(t *testing.T) {
-	dest := NewOrigPtrResourceSpans()
+	dest := NewOrigResourceSpans()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigResourceSpans(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrResourceSpans(), dest)
+	assert.Equal(t, NewOrigResourceSpans(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigResourceSpans(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigResourceSpans(t *testing.T) {
 			gotSize := MarshalProtoOrigResourceSpans(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrResourceSpans()
+			dest := NewOrigResourceSpans()
 			require.NoError(t, UnmarshalProtoOrigResourceSpans(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufResourceSpans(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrResourceSpans()
+			dest := NewOrigResourceSpans()
 			require.NoError(t, UnmarshalProtoOrigResourceSpans(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesResourceSpans() map[string][]byte {
 
 func genTestEncodingValuesResourceSpans() map[string]*otlptrace.ResourceSpans {
 	return map[string]*otlptrace.ResourceSpans{
-		"empty":                       NewOrigPtrResourceSpans(),
+		"empty":                       NewOrigResourceSpans(),
 		"Resource/test":               {Resource: *GenTestOrigResource()},
 		"ScopeSpans/default_and_test": {ScopeSpans: []*otlptrace.ScopeSpans{{}, GenTestOrigScopeSpans()}},
 		"SchemaUrl/test":              {SchemaUrl: "test_schemaurl"},

--- a/pdata/internal/generated_wrapper_resourcespansslice.go
+++ b/pdata/internal/generated_wrapper_resourcespansslice.go
@@ -19,7 +19,7 @@ func CopyOrigResourceSpansSlice(dest, src []*otlptrace.ResourceSpans) []*otlptra
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrResourceSpans()
+			newDest[i] = NewOrigResourceSpans()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigResourceSpansSlice(dest, src []*otlptrace.ResourceSpans) []*otlptra
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrResourceSpans()
+			newDest[i] = NewOrigResourceSpans()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigResourceSpansSlice(dest, src []*otlptrace.ResourceSpans) []*otlptra
 
 func GenerateOrigTestResourceSpansSlice() []*otlptrace.ResourceSpans {
 	orig := make([]*otlptrace.ResourceSpans, 5)
-	orig[0] = NewOrigPtrResourceSpans()
+	orig[0] = NewOrigResourceSpans()
 	orig[1] = GenTestOrigResourceSpans()
-	orig[2] = NewOrigPtrResourceSpans()
+	orig[2] = NewOrigResourceSpans()
 	orig[3] = GenTestOrigResourceSpans()
-	orig[4] = NewOrigPtrResourceSpans()
+	orig[4] = NewOrigResourceSpans()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestResourceSpansSlice() []*otlptrace.ResourceSpans {
 func UnmarshalJSONOrigResourceSpansSlice(iter *json.Iterator) []*otlptrace.ResourceSpans {
 	var orig []*otlptrace.ResourceSpans
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrResourceSpans())
+		orig = append(orig, NewOrigResourceSpans())
 		UnmarshalJSONOrigResourceSpans(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_sample.go
+++ b/pdata/internal/generated_wrapper_sample.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigSample() otlpprofiles.Sample {
-	return otlpprofiles.Sample{}
-}
-
-func NewOrigPtrSample() *otlpprofiles.Sample {
+func NewOrigSample() *otlpprofiles.Sample {
 	return &otlpprofiles.Sample{}
 }
 
@@ -41,7 +37,7 @@ func CopyOrigSample(dest, src *otlpprofiles.Sample) {
 }
 
 func GenTestOrigSample() *otlpprofiles.Sample {
-	orig := NewOrigPtrSample()
+	orig := NewOrigSample()
 	orig.LocationsStartIndex = int32(13)
 	orig.LocationsLength = int32(13)
 	orig.Value = GenerateOrigTestInt64Slice()

--- a/pdata/internal/generated_wrapper_sample_test.go
+++ b/pdata/internal/generated_wrapper_sample_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigSample(t *testing.T) {
-	src := NewOrigPtrSample()
-	dest := NewOrigPtrSample()
+	src := NewOrigSample()
+	dest := NewOrigSample()
 	CopyOrigSample(dest, src)
-	assert.Equal(t, NewOrigPtrSample(), dest)
+	assert.Equal(t, NewOrigSample(), dest)
 	*src = *GenTestOrigSample()
 	CopyOrigSample(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigSample(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigSampleUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrSample()
+	dest := NewOrigSample()
 	UnmarshalJSONOrigSample(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrSample(), dest)
+	assert.Equal(t, NewOrigSample(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigSample(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigSample(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrSample()
+			dest := NewOrigSample()
 			UnmarshalJSONOrigSample(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigSample(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigSampleFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesSample() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrSample()
+			dest := NewOrigSample()
 			require.Error(t, UnmarshalProtoOrigSample(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigSampleUnknown(t *testing.T) {
-	dest := NewOrigPtrSample()
+	dest := NewOrigSample()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigSample(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrSample(), dest)
+	assert.Equal(t, NewOrigSample(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigSample(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigSample(t *testing.T) {
 			gotSize := MarshalProtoOrigSample(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrSample()
+			dest := NewOrigSample()
 			require.NoError(t, UnmarshalProtoOrigSample(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufSample(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrSample()
+			dest := NewOrigSample()
 			require.NoError(t, UnmarshalProtoOrigSample(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -126,7 +126,7 @@ func genTestFailingUnmarshalProtoValuesSample() map[string][]byte {
 
 func genTestEncodingValuesSample() map[string]*otlpprofiles.Sample {
 	return map[string]*otlpprofiles.Sample{
-		"empty":                             NewOrigPtrSample(),
+		"empty":                             NewOrigSample(),
 		"LocationsStartIndex/test":          {LocationsStartIndex: int32(13)},
 		"LocationsLength/test":              {LocationsLength: int32(13)},
 		"Value/default_and_test":            {Value: []int64{int64(0), int64(13)}},

--- a/pdata/internal/generated_wrapper_sampleslice.go
+++ b/pdata/internal/generated_wrapper_sampleslice.go
@@ -19,7 +19,7 @@ func CopyOrigSampleSlice(dest, src []*otlpprofiles.Sample) []*otlpprofiles.Sampl
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSample()
+			newDest[i] = NewOrigSample()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigSampleSlice(dest, src []*otlpprofiles.Sample) []*otlpprofiles.Sampl
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSample()
+			newDest[i] = NewOrigSample()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigSampleSlice(dest, src []*otlpprofiles.Sample) []*otlpprofiles.Sampl
 
 func GenerateOrigTestSampleSlice() []*otlpprofiles.Sample {
 	orig := make([]*otlpprofiles.Sample, 5)
-	orig[0] = NewOrigPtrSample()
+	orig[0] = NewOrigSample()
 	orig[1] = GenTestOrigSample()
-	orig[2] = NewOrigPtrSample()
+	orig[2] = NewOrigSample()
 	orig[3] = GenTestOrigSample()
-	orig[4] = NewOrigPtrSample()
+	orig[4] = NewOrigSample()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestSampleSlice() []*otlpprofiles.Sample {
 func UnmarshalJSONOrigSampleSlice(iter *json.Iterator) []*otlpprofiles.Sample {
 	var orig []*otlpprofiles.Sample
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrSample())
+		orig = append(orig, NewOrigSample())
 		UnmarshalJSONOrigSample(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_scopelogs.go
+++ b/pdata/internal/generated_wrapper_scopelogs.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigScopeLogs() otlplogs.ScopeLogs {
-	return otlplogs.ScopeLogs{}
-}
-
-func NewOrigPtrScopeLogs() *otlplogs.ScopeLogs {
+func NewOrigScopeLogs() *otlplogs.ScopeLogs {
 	return &otlplogs.ScopeLogs{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigScopeLogs(dest, src *otlplogs.ScopeLogs) {
 }
 
 func GenTestOrigScopeLogs() *otlplogs.ScopeLogs {
-	orig := NewOrigPtrScopeLogs()
+	orig := NewOrigScopeLogs()
 	orig.Scope = *GenTestOrigInstrumentationScope()
 	orig.LogRecords = GenerateOrigTestLogRecordSlice()
 	orig.SchemaUrl = "test_schemaurl"
@@ -162,7 +158,7 @@ func UnmarshalProtoOrigScopeLogs(orig *otlplogs.ScopeLogs, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.LogRecords = append(orig.LogRecords, NewOrigPtrLogRecord())
+			orig.LogRecords = append(orig.LogRecords, NewOrigLogRecord())
 			err = UnmarshalProtoOrigLogRecord(orig.LogRecords[len(orig.LogRecords)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_scopelogs_test.go
+++ b/pdata/internal/generated_wrapper_scopelogs_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigScopeLogs(t *testing.T) {
-	src := NewOrigPtrScopeLogs()
-	dest := NewOrigPtrScopeLogs()
+	src := NewOrigScopeLogs()
+	dest := NewOrigScopeLogs()
 	CopyOrigScopeLogs(dest, src)
-	assert.Equal(t, NewOrigPtrScopeLogs(), dest)
+	assert.Equal(t, NewOrigScopeLogs(), dest)
 	*src = *GenTestOrigScopeLogs()
 	CopyOrigScopeLogs(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigScopeLogs(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigScopeLogsUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrScopeLogs()
+	dest := NewOrigScopeLogs()
 	UnmarshalJSONOrigScopeLogs(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrScopeLogs(), dest)
+	assert.Equal(t, NewOrigScopeLogs(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigScopeLogs(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigScopeLogs(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrScopeLogs()
+			dest := NewOrigScopeLogs()
 			UnmarshalJSONOrigScopeLogs(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigScopeLogs(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigScopeLogsFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesScopeLogs() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrScopeLogs()
+			dest := NewOrigScopeLogs()
 			require.Error(t, UnmarshalProtoOrigScopeLogs(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigScopeLogsUnknown(t *testing.T) {
-	dest := NewOrigPtrScopeLogs()
+	dest := NewOrigScopeLogs()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigScopeLogs(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrScopeLogs(), dest)
+	assert.Equal(t, NewOrigScopeLogs(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigScopeLogs(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigScopeLogs(t *testing.T) {
 			gotSize := MarshalProtoOrigScopeLogs(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrScopeLogs()
+			dest := NewOrigScopeLogs()
 			require.NoError(t, UnmarshalProtoOrigScopeLogs(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufScopeLogs(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrScopeLogs()
+			dest := NewOrigScopeLogs()
 			require.NoError(t, UnmarshalProtoOrigScopeLogs(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesScopeLogs() map[string][]byte {
 
 func genTestEncodingValuesScopeLogs() map[string]*otlplogs.ScopeLogs {
 	return map[string]*otlplogs.ScopeLogs{
-		"empty":                       NewOrigPtrScopeLogs(),
+		"empty":                       NewOrigScopeLogs(),
 		"Scope/test":                  {Scope: *GenTestOrigInstrumentationScope()},
 		"LogRecords/default_and_test": {LogRecords: []*otlplogs.LogRecord{{}, GenTestOrigLogRecord()}},
 		"SchemaUrl/test":              {SchemaUrl: "test_schemaurl"},

--- a/pdata/internal/generated_wrapper_scopelogsslice.go
+++ b/pdata/internal/generated_wrapper_scopelogsslice.go
@@ -19,7 +19,7 @@ func CopyOrigScopeLogsSlice(dest, src []*otlplogs.ScopeLogs) []*otlplogs.ScopeLo
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrScopeLogs()
+			newDest[i] = NewOrigScopeLogs()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigScopeLogsSlice(dest, src []*otlplogs.ScopeLogs) []*otlplogs.ScopeLo
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrScopeLogs()
+			newDest[i] = NewOrigScopeLogs()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigScopeLogsSlice(dest, src []*otlplogs.ScopeLogs) []*otlplogs.ScopeLo
 
 func GenerateOrigTestScopeLogsSlice() []*otlplogs.ScopeLogs {
 	orig := make([]*otlplogs.ScopeLogs, 5)
-	orig[0] = NewOrigPtrScopeLogs()
+	orig[0] = NewOrigScopeLogs()
 	orig[1] = GenTestOrigScopeLogs()
-	orig[2] = NewOrigPtrScopeLogs()
+	orig[2] = NewOrigScopeLogs()
 	orig[3] = GenTestOrigScopeLogs()
-	orig[4] = NewOrigPtrScopeLogs()
+	orig[4] = NewOrigScopeLogs()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestScopeLogsSlice() []*otlplogs.ScopeLogs {
 func UnmarshalJSONOrigScopeLogsSlice(iter *json.Iterator) []*otlplogs.ScopeLogs {
 	var orig []*otlplogs.ScopeLogs
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrScopeLogs())
+		orig = append(orig, NewOrigScopeLogs())
 		UnmarshalJSONOrigScopeLogs(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_scopemetrics.go
+++ b/pdata/internal/generated_wrapper_scopemetrics.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigScopeMetrics() otlpmetrics.ScopeMetrics {
-	return otlpmetrics.ScopeMetrics{}
-}
-
-func NewOrigPtrScopeMetrics() *otlpmetrics.ScopeMetrics {
+func NewOrigScopeMetrics() *otlpmetrics.ScopeMetrics {
 	return &otlpmetrics.ScopeMetrics{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigScopeMetrics(dest, src *otlpmetrics.ScopeMetrics) {
 }
 
 func GenTestOrigScopeMetrics() *otlpmetrics.ScopeMetrics {
-	orig := NewOrigPtrScopeMetrics()
+	orig := NewOrigScopeMetrics()
 	orig.Scope = *GenTestOrigInstrumentationScope()
 	orig.Metrics = GenerateOrigTestMetricSlice()
 	orig.SchemaUrl = "test_schemaurl"
@@ -162,7 +158,7 @@ func UnmarshalProtoOrigScopeMetrics(orig *otlpmetrics.ScopeMetrics, buf []byte) 
 				return err
 			}
 			startPos := pos - length
-			orig.Metrics = append(orig.Metrics, NewOrigPtrMetric())
+			orig.Metrics = append(orig.Metrics, NewOrigMetric())
 			err = UnmarshalProtoOrigMetric(orig.Metrics[len(orig.Metrics)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_scopemetrics_test.go
+++ b/pdata/internal/generated_wrapper_scopemetrics_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigScopeMetrics(t *testing.T) {
-	src := NewOrigPtrScopeMetrics()
-	dest := NewOrigPtrScopeMetrics()
+	src := NewOrigScopeMetrics()
+	dest := NewOrigScopeMetrics()
 	CopyOrigScopeMetrics(dest, src)
-	assert.Equal(t, NewOrigPtrScopeMetrics(), dest)
+	assert.Equal(t, NewOrigScopeMetrics(), dest)
 	*src = *GenTestOrigScopeMetrics()
 	CopyOrigScopeMetrics(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigScopeMetrics(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigScopeMetricsUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrScopeMetrics()
+	dest := NewOrigScopeMetrics()
 	UnmarshalJSONOrigScopeMetrics(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrScopeMetrics(), dest)
+	assert.Equal(t, NewOrigScopeMetrics(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigScopeMetrics(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigScopeMetrics(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrScopeMetrics()
+			dest := NewOrigScopeMetrics()
 			UnmarshalJSONOrigScopeMetrics(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigScopeMetrics(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigScopeMetricsFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesScopeMetrics() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrScopeMetrics()
+			dest := NewOrigScopeMetrics()
 			require.Error(t, UnmarshalProtoOrigScopeMetrics(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigScopeMetricsUnknown(t *testing.T) {
-	dest := NewOrigPtrScopeMetrics()
+	dest := NewOrigScopeMetrics()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigScopeMetrics(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrScopeMetrics(), dest)
+	assert.Equal(t, NewOrigScopeMetrics(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigScopeMetrics(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigScopeMetrics(t *testing.T) {
 			gotSize := MarshalProtoOrigScopeMetrics(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrScopeMetrics()
+			dest := NewOrigScopeMetrics()
 			require.NoError(t, UnmarshalProtoOrigScopeMetrics(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufScopeMetrics(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrScopeMetrics()
+			dest := NewOrigScopeMetrics()
 			require.NoError(t, UnmarshalProtoOrigScopeMetrics(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesScopeMetrics() map[string][]byte {
 
 func genTestEncodingValuesScopeMetrics() map[string]*otlpmetrics.ScopeMetrics {
 	return map[string]*otlpmetrics.ScopeMetrics{
-		"empty":                    NewOrigPtrScopeMetrics(),
+		"empty":                    NewOrigScopeMetrics(),
 		"Scope/test":               {Scope: *GenTestOrigInstrumentationScope()},
 		"Metrics/default_and_test": {Metrics: []*otlpmetrics.Metric{{}, GenTestOrigMetric()}},
 		"SchemaUrl/test":           {SchemaUrl: "test_schemaurl"},

--- a/pdata/internal/generated_wrapper_scopemetricsslice.go
+++ b/pdata/internal/generated_wrapper_scopemetricsslice.go
@@ -19,7 +19,7 @@ func CopyOrigScopeMetricsSlice(dest, src []*otlpmetrics.ScopeMetrics) []*otlpmet
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrScopeMetrics()
+			newDest[i] = NewOrigScopeMetrics()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigScopeMetricsSlice(dest, src []*otlpmetrics.ScopeMetrics) []*otlpmet
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrScopeMetrics()
+			newDest[i] = NewOrigScopeMetrics()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigScopeMetricsSlice(dest, src []*otlpmetrics.ScopeMetrics) []*otlpmet
 
 func GenerateOrigTestScopeMetricsSlice() []*otlpmetrics.ScopeMetrics {
 	orig := make([]*otlpmetrics.ScopeMetrics, 5)
-	orig[0] = NewOrigPtrScopeMetrics()
+	orig[0] = NewOrigScopeMetrics()
 	orig[1] = GenTestOrigScopeMetrics()
-	orig[2] = NewOrigPtrScopeMetrics()
+	orig[2] = NewOrigScopeMetrics()
 	orig[3] = GenTestOrigScopeMetrics()
-	orig[4] = NewOrigPtrScopeMetrics()
+	orig[4] = NewOrigScopeMetrics()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestScopeMetricsSlice() []*otlpmetrics.ScopeMetrics {
 func UnmarshalJSONOrigScopeMetricsSlice(iter *json.Iterator) []*otlpmetrics.ScopeMetrics {
 	var orig []*otlpmetrics.ScopeMetrics
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrScopeMetrics())
+		orig = append(orig, NewOrigScopeMetrics())
 		UnmarshalJSONOrigScopeMetrics(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_scopeprofiles.go
+++ b/pdata/internal/generated_wrapper_scopeprofiles.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigScopeProfiles() otlpprofiles.ScopeProfiles {
-	return otlpprofiles.ScopeProfiles{}
-}
-
-func NewOrigPtrScopeProfiles() *otlpprofiles.ScopeProfiles {
+func NewOrigScopeProfiles() *otlpprofiles.ScopeProfiles {
 	return &otlpprofiles.ScopeProfiles{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigScopeProfiles(dest, src *otlpprofiles.ScopeProfiles) {
 }
 
 func GenTestOrigScopeProfiles() *otlpprofiles.ScopeProfiles {
-	orig := NewOrigPtrScopeProfiles()
+	orig := NewOrigScopeProfiles()
 	orig.Scope = *GenTestOrigInstrumentationScope()
 	orig.Profiles = GenerateOrigTestProfileSlice()
 	orig.SchemaUrl = "test_schemaurl"
@@ -162,7 +158,7 @@ func UnmarshalProtoOrigScopeProfiles(orig *otlpprofiles.ScopeProfiles, buf []byt
 				return err
 			}
 			startPos := pos - length
-			orig.Profiles = append(orig.Profiles, NewOrigPtrProfile())
+			orig.Profiles = append(orig.Profiles, NewOrigProfile())
 			err = UnmarshalProtoOrigProfile(orig.Profiles[len(orig.Profiles)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_scopeprofiles_test.go
+++ b/pdata/internal/generated_wrapper_scopeprofiles_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigScopeProfiles(t *testing.T) {
-	src := NewOrigPtrScopeProfiles()
-	dest := NewOrigPtrScopeProfiles()
+	src := NewOrigScopeProfiles()
+	dest := NewOrigScopeProfiles()
 	CopyOrigScopeProfiles(dest, src)
-	assert.Equal(t, NewOrigPtrScopeProfiles(), dest)
+	assert.Equal(t, NewOrigScopeProfiles(), dest)
 	*src = *GenTestOrigScopeProfiles()
 	CopyOrigScopeProfiles(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigScopeProfiles(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigScopeProfilesUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrScopeProfiles()
+	dest := NewOrigScopeProfiles()
 	UnmarshalJSONOrigScopeProfiles(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrScopeProfiles(), dest)
+	assert.Equal(t, NewOrigScopeProfiles(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigScopeProfiles(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigScopeProfiles(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrScopeProfiles()
+			dest := NewOrigScopeProfiles()
 			UnmarshalJSONOrigScopeProfiles(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigScopeProfiles(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigScopeProfilesFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesScopeProfiles() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrScopeProfiles()
+			dest := NewOrigScopeProfiles()
 			require.Error(t, UnmarshalProtoOrigScopeProfiles(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigScopeProfilesUnknown(t *testing.T) {
-	dest := NewOrigPtrScopeProfiles()
+	dest := NewOrigScopeProfiles()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigScopeProfiles(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrScopeProfiles(), dest)
+	assert.Equal(t, NewOrigScopeProfiles(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigScopeProfiles(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigScopeProfiles(t *testing.T) {
 			gotSize := MarshalProtoOrigScopeProfiles(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrScopeProfiles()
+			dest := NewOrigScopeProfiles()
 			require.NoError(t, UnmarshalProtoOrigScopeProfiles(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufScopeProfiles(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrScopeProfiles()
+			dest := NewOrigScopeProfiles()
 			require.NoError(t, UnmarshalProtoOrigScopeProfiles(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesScopeProfiles() map[string][]byte {
 
 func genTestEncodingValuesScopeProfiles() map[string]*otlpprofiles.ScopeProfiles {
 	return map[string]*otlpprofiles.ScopeProfiles{
-		"empty":                     NewOrigPtrScopeProfiles(),
+		"empty":                     NewOrigScopeProfiles(),
 		"Scope/test":                {Scope: *GenTestOrigInstrumentationScope()},
 		"Profiles/default_and_test": {Profiles: []*otlpprofiles.Profile{{}, GenTestOrigProfile()}},
 		"SchemaUrl/test":            {SchemaUrl: "test_schemaurl"},

--- a/pdata/internal/generated_wrapper_scopeprofilesslice.go
+++ b/pdata/internal/generated_wrapper_scopeprofilesslice.go
@@ -19,7 +19,7 @@ func CopyOrigScopeProfilesSlice(dest, src []*otlpprofiles.ScopeProfiles) []*otlp
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrScopeProfiles()
+			newDest[i] = NewOrigScopeProfiles()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigScopeProfilesSlice(dest, src []*otlpprofiles.ScopeProfiles) []*otlp
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrScopeProfiles()
+			newDest[i] = NewOrigScopeProfiles()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigScopeProfilesSlice(dest, src []*otlpprofiles.ScopeProfiles) []*otlp
 
 func GenerateOrigTestScopeProfilesSlice() []*otlpprofiles.ScopeProfiles {
 	orig := make([]*otlpprofiles.ScopeProfiles, 5)
-	orig[0] = NewOrigPtrScopeProfiles()
+	orig[0] = NewOrigScopeProfiles()
 	orig[1] = GenTestOrigScopeProfiles()
-	orig[2] = NewOrigPtrScopeProfiles()
+	orig[2] = NewOrigScopeProfiles()
 	orig[3] = GenTestOrigScopeProfiles()
-	orig[4] = NewOrigPtrScopeProfiles()
+	orig[4] = NewOrigScopeProfiles()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestScopeProfilesSlice() []*otlpprofiles.ScopeProfiles {
 func UnmarshalJSONOrigScopeProfilesSlice(iter *json.Iterator) []*otlpprofiles.ScopeProfiles {
 	var orig []*otlpprofiles.ScopeProfiles
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrScopeProfiles())
+		orig = append(orig, NewOrigScopeProfiles())
 		UnmarshalJSONOrigScopeProfiles(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_scopespans.go
+++ b/pdata/internal/generated_wrapper_scopespans.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigScopeSpans() otlptrace.ScopeSpans {
-	return otlptrace.ScopeSpans{}
-}
-
-func NewOrigPtrScopeSpans() *otlptrace.ScopeSpans {
+func NewOrigScopeSpans() *otlptrace.ScopeSpans {
 	return &otlptrace.ScopeSpans{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigScopeSpans(dest, src *otlptrace.ScopeSpans) {
 }
 
 func GenTestOrigScopeSpans() *otlptrace.ScopeSpans {
-	orig := NewOrigPtrScopeSpans()
+	orig := NewOrigScopeSpans()
 	orig.Scope = *GenTestOrigInstrumentationScope()
 	orig.Spans = GenerateOrigTestSpanSlice()
 	orig.SchemaUrl = "test_schemaurl"
@@ -162,7 +158,7 @@ func UnmarshalProtoOrigScopeSpans(orig *otlptrace.ScopeSpans, buf []byte) error 
 				return err
 			}
 			startPos := pos - length
-			orig.Spans = append(orig.Spans, NewOrigPtrSpan())
+			orig.Spans = append(orig.Spans, NewOrigSpan())
 			err = UnmarshalProtoOrigSpan(orig.Spans[len(orig.Spans)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_scopespans_test.go
+++ b/pdata/internal/generated_wrapper_scopespans_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigScopeSpans(t *testing.T) {
-	src := NewOrigPtrScopeSpans()
-	dest := NewOrigPtrScopeSpans()
+	src := NewOrigScopeSpans()
+	dest := NewOrigScopeSpans()
 	CopyOrigScopeSpans(dest, src)
-	assert.Equal(t, NewOrigPtrScopeSpans(), dest)
+	assert.Equal(t, NewOrigScopeSpans(), dest)
 	*src = *GenTestOrigScopeSpans()
 	CopyOrigScopeSpans(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigScopeSpans(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigScopeSpansUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrScopeSpans()
+	dest := NewOrigScopeSpans()
 	UnmarshalJSONOrigScopeSpans(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrScopeSpans(), dest)
+	assert.Equal(t, NewOrigScopeSpans(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigScopeSpans(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigScopeSpans(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrScopeSpans()
+			dest := NewOrigScopeSpans()
 			UnmarshalJSONOrigScopeSpans(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigScopeSpans(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigScopeSpansFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesScopeSpans() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrScopeSpans()
+			dest := NewOrigScopeSpans()
 			require.Error(t, UnmarshalProtoOrigScopeSpans(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigScopeSpansUnknown(t *testing.T) {
-	dest := NewOrigPtrScopeSpans()
+	dest := NewOrigScopeSpans()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigScopeSpans(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrScopeSpans(), dest)
+	assert.Equal(t, NewOrigScopeSpans(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigScopeSpans(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigScopeSpans(t *testing.T) {
 			gotSize := MarshalProtoOrigScopeSpans(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrScopeSpans()
+			dest := NewOrigScopeSpans()
 			require.NoError(t, UnmarshalProtoOrigScopeSpans(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufScopeSpans(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrScopeSpans()
+			dest := NewOrigScopeSpans()
 			require.NoError(t, UnmarshalProtoOrigScopeSpans(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesScopeSpans() map[string][]byte {
 
 func genTestEncodingValuesScopeSpans() map[string]*otlptrace.ScopeSpans {
 	return map[string]*otlptrace.ScopeSpans{
-		"empty":                  NewOrigPtrScopeSpans(),
+		"empty":                  NewOrigScopeSpans(),
 		"Scope/test":             {Scope: *GenTestOrigInstrumentationScope()},
 		"Spans/default_and_test": {Spans: []*otlptrace.Span{{}, GenTestOrigSpan()}},
 		"SchemaUrl/test":         {SchemaUrl: "test_schemaurl"},

--- a/pdata/internal/generated_wrapper_scopespansslice.go
+++ b/pdata/internal/generated_wrapper_scopespansslice.go
@@ -19,7 +19,7 @@ func CopyOrigScopeSpansSlice(dest, src []*otlptrace.ScopeSpans) []*otlptrace.Sco
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrScopeSpans()
+			newDest[i] = NewOrigScopeSpans()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigScopeSpansSlice(dest, src []*otlptrace.ScopeSpans) []*otlptrace.Sco
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrScopeSpans()
+			newDest[i] = NewOrigScopeSpans()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigScopeSpansSlice(dest, src []*otlptrace.ScopeSpans) []*otlptrace.Sco
 
 func GenerateOrigTestScopeSpansSlice() []*otlptrace.ScopeSpans {
 	orig := make([]*otlptrace.ScopeSpans, 5)
-	orig[0] = NewOrigPtrScopeSpans()
+	orig[0] = NewOrigScopeSpans()
 	orig[1] = GenTestOrigScopeSpans()
-	orig[2] = NewOrigPtrScopeSpans()
+	orig[2] = NewOrigScopeSpans()
 	orig[3] = GenTestOrigScopeSpans()
-	orig[4] = NewOrigPtrScopeSpans()
+	orig[4] = NewOrigScopeSpans()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestScopeSpansSlice() []*otlptrace.ScopeSpans {
 func UnmarshalJSONOrigScopeSpansSlice(iter *json.Iterator) []*otlptrace.ScopeSpans {
 	var orig []*otlptrace.ScopeSpans
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrScopeSpans())
+		orig = append(orig, NewOrigScopeSpans())
 		UnmarshalJSONOrigScopeSpans(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_span.go
+++ b/pdata/internal/generated_wrapper_span.go
@@ -11,16 +11,13 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/internal/data"
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigSpan() otlptrace.Span {
-	return otlptrace.Span{}
-}
-
-func NewOrigPtrSpan() *otlptrace.Span {
+func NewOrigSpan() *otlptrace.Span {
 	return &otlptrace.Span{}
 }
 
@@ -44,7 +41,7 @@ func CopyOrigSpan(dest, src *otlptrace.Span) {
 }
 
 func GenTestOrigSpan() *otlptrace.Span {
-	orig := NewOrigPtrSpan()
+	orig := NewOrigSpan()
 	orig.TraceId = data.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
 	orig.SpanId = data.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1})
 	orig.TraceState = *GenTestOrigTraceState()
@@ -506,7 +503,7 @@ func UnmarshalProtoOrigSpan(orig *otlptrace.Span, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -534,7 +531,7 @@ func UnmarshalProtoOrigSpan(orig *otlptrace.Span, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.Events = append(orig.Events, NewOrigPtrSpan_Event())
+			orig.Events = append(orig.Events, NewOrigSpan_Event())
 			err = UnmarshalProtoOrigSpan_Event(orig.Events[len(orig.Events)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -562,7 +559,7 @@ func UnmarshalProtoOrigSpan(orig *otlptrace.Span, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.Links = append(orig.Links, NewOrigPtrSpan_Link())
+			orig.Links = append(orig.Links, NewOrigSpan_Link())
 			err = UnmarshalProtoOrigSpan_Link(orig.Links[len(orig.Links)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_span_event.go
+++ b/pdata/internal/generated_wrapper_span_event.go
@@ -10,16 +10,13 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigSpan_Event() otlptrace.Span_Event {
-	return otlptrace.Span_Event{}
-}
-
-func NewOrigPtrSpan_Event() *otlptrace.Span_Event {
+func NewOrigSpan_Event() *otlptrace.Span_Event {
 	return &otlptrace.Span_Event{}
 }
 
@@ -31,7 +28,7 @@ func CopyOrigSpan_Event(dest, src *otlptrace.Span_Event) {
 }
 
 func GenTestOrigSpan_Event() *otlptrace.Span_Event {
-	orig := NewOrigPtrSpan_Event()
+	orig := NewOrigSpan_Event()
 	orig.TimeUnixNano = 1234567890
 	orig.Name = "test_name"
 	orig.Attributes = GenerateOrigTestKeyValueSlice()
@@ -189,7 +186,7 @@ func UnmarshalProtoOrigSpan_Event(orig *otlptrace.Span_Event, buf []byte) error 
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_span_event_test.go
+++ b/pdata/internal/generated_wrapper_span_event_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigSpan_Event(t *testing.T) {
-	src := NewOrigPtrSpan_Event()
-	dest := NewOrigPtrSpan_Event()
+	src := NewOrigSpan_Event()
+	dest := NewOrigSpan_Event()
 	CopyOrigSpan_Event(dest, src)
-	assert.Equal(t, NewOrigPtrSpan_Event(), dest)
+	assert.Equal(t, NewOrigSpan_Event(), dest)
 	*src = *GenTestOrigSpan_Event()
 	CopyOrigSpan_Event(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigSpan_Event(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigSpan_EventUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrSpan_Event()
+	dest := NewOrigSpan_Event()
 	UnmarshalJSONOrigSpan_Event(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrSpan_Event(), dest)
+	assert.Equal(t, NewOrigSpan_Event(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigSpan_Event(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigSpan_Event(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrSpan_Event()
+			dest := NewOrigSpan_Event()
 			UnmarshalJSONOrigSpan_Event(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigSpan_Event(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigSpan_EventFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesSpan_Event() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrSpan_Event()
+			dest := NewOrigSpan_Event()
 			require.Error(t, UnmarshalProtoOrigSpan_Event(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigSpan_EventUnknown(t *testing.T) {
-	dest := NewOrigPtrSpan_Event()
+	dest := NewOrigSpan_Event()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigSpan_Event(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrSpan_Event(), dest)
+	assert.Equal(t, NewOrigSpan_Event(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigSpan_Event(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigSpan_Event(t *testing.T) {
 			gotSize := MarshalProtoOrigSpan_Event(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrSpan_Event()
+			dest := NewOrigSpan_Event()
 			require.NoError(t, UnmarshalProtoOrigSpan_Event(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufSpan_Event(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrSpan_Event()
+			dest := NewOrigSpan_Event()
 			require.NoError(t, UnmarshalProtoOrigSpan_Event(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -123,7 +123,7 @@ func genTestFailingUnmarshalProtoValuesSpan_Event() map[string][]byte {
 
 func genTestEncodingValuesSpan_Event() map[string]*otlptrace.Span_Event {
 	return map[string]*otlptrace.Span_Event{
-		"empty":                       NewOrigPtrSpan_Event(),
+		"empty":                       NewOrigSpan_Event(),
 		"TimeUnixNano/test":           {TimeUnixNano: uint64(13)},
 		"Name/test":                   {Name: "test_name"},
 		"Attributes/default_and_test": {Attributes: []otlpcommon.KeyValue{{}, *GenTestOrigKeyValue()}},

--- a/pdata/internal/generated_wrapper_span_eventslice.go
+++ b/pdata/internal/generated_wrapper_span_eventslice.go
@@ -19,7 +19,7 @@ func CopyOrigSpan_EventSlice(dest, src []*otlptrace.Span_Event) []*otlptrace.Spa
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSpan_Event()
+			newDest[i] = NewOrigSpan_Event()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigSpan_EventSlice(dest, src []*otlptrace.Span_Event) []*otlptrace.Spa
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSpan_Event()
+			newDest[i] = NewOrigSpan_Event()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigSpan_EventSlice(dest, src []*otlptrace.Span_Event) []*otlptrace.Spa
 
 func GenerateOrigTestSpan_EventSlice() []*otlptrace.Span_Event {
 	orig := make([]*otlptrace.Span_Event, 5)
-	orig[0] = NewOrigPtrSpan_Event()
+	orig[0] = NewOrigSpan_Event()
 	orig[1] = GenTestOrigSpan_Event()
-	orig[2] = NewOrigPtrSpan_Event()
+	orig[2] = NewOrigSpan_Event()
 	orig[3] = GenTestOrigSpan_Event()
-	orig[4] = NewOrigPtrSpan_Event()
+	orig[4] = NewOrigSpan_Event()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestSpan_EventSlice() []*otlptrace.Span_Event {
 func UnmarshalJSONOrigSpan_EventSlice(iter *json.Iterator) []*otlptrace.Span_Event {
 	var orig []*otlptrace.Span_Event
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrSpan_Event())
+		orig = append(orig, NewOrigSpan_Event())
 		UnmarshalJSONOrigSpan_Event(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_span_link.go
+++ b/pdata/internal/generated_wrapper_span_link.go
@@ -11,16 +11,13 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/internal/data"
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigSpan_Link() otlptrace.Span_Link {
-	return otlptrace.Span_Link{}
-}
-
-func NewOrigPtrSpan_Link() *otlptrace.Span_Link {
+func NewOrigSpan_Link() *otlptrace.Span_Link {
 	return &otlptrace.Span_Link{}
 }
 
@@ -34,7 +31,7 @@ func CopyOrigSpan_Link(dest, src *otlptrace.Span_Link) {
 }
 
 func GenTestOrigSpan_Link() *otlptrace.Span_Link {
-	orig := NewOrigPtrSpan_Link()
+	orig := NewOrigSpan_Link()
 	orig.TraceId = data.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
 	orig.SpanId = data.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1})
 	orig.TraceState = *GenTestOrigTraceState()
@@ -243,7 +240,7 @@ func UnmarshalProtoOrigSpan_Link(orig *otlptrace.Span_Link, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_span_link_test.go
+++ b/pdata/internal/generated_wrapper_span_link_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigSpan_Link(t *testing.T) {
-	src := NewOrigPtrSpan_Link()
-	dest := NewOrigPtrSpan_Link()
+	src := NewOrigSpan_Link()
+	dest := NewOrigSpan_Link()
 	CopyOrigSpan_Link(dest, src)
-	assert.Equal(t, NewOrigPtrSpan_Link(), dest)
+	assert.Equal(t, NewOrigSpan_Link(), dest)
 	*src = *GenTestOrigSpan_Link()
 	CopyOrigSpan_Link(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigSpan_Link(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigSpan_LinkUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrSpan_Link()
+	dest := NewOrigSpan_Link()
 	UnmarshalJSONOrigSpan_Link(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrSpan_Link(), dest)
+	assert.Equal(t, NewOrigSpan_Link(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigSpan_Link(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigSpan_Link(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrSpan_Link()
+			dest := NewOrigSpan_Link()
 			UnmarshalJSONOrigSpan_Link(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigSpan_Link(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigSpan_LinkFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesSpan_Link() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrSpan_Link()
+			dest := NewOrigSpan_Link()
 			require.Error(t, UnmarshalProtoOrigSpan_Link(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigSpan_LinkUnknown(t *testing.T) {
-	dest := NewOrigPtrSpan_Link()
+	dest := NewOrigSpan_Link()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigSpan_Link(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrSpan_Link(), dest)
+	assert.Equal(t, NewOrigSpan_Link(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigSpan_Link(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigSpan_Link(t *testing.T) {
 			gotSize := MarshalProtoOrigSpan_Link(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrSpan_Link()
+			dest := NewOrigSpan_Link()
 			require.NoError(t, UnmarshalProtoOrigSpan_Link(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufSpan_Link(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrSpan_Link()
+			dest := NewOrigSpan_Link()
 			require.NoError(t, UnmarshalProtoOrigSpan_Link(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -127,7 +127,7 @@ func genTestFailingUnmarshalProtoValuesSpan_Link() map[string][]byte {
 
 func genTestEncodingValuesSpan_Link() map[string]*otlptrace.Span_Link {
 	return map[string]*otlptrace.Span_Link{
-		"empty":                       NewOrigPtrSpan_Link(),
+		"empty":                       NewOrigSpan_Link(),
 		"TraceId/test":                {TraceId: *GenTestOrigTraceID()},
 		"SpanId/test":                 {SpanId: *GenTestOrigSpanID()},
 		"TraceState/test":             {TraceState: "test_tracestate"},

--- a/pdata/internal/generated_wrapper_span_linkslice.go
+++ b/pdata/internal/generated_wrapper_span_linkslice.go
@@ -19,7 +19,7 @@ func CopyOrigSpan_LinkSlice(dest, src []*otlptrace.Span_Link) []*otlptrace.Span_
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSpan_Link()
+			newDest[i] = NewOrigSpan_Link()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigSpan_LinkSlice(dest, src []*otlptrace.Span_Link) []*otlptrace.Span_
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSpan_Link()
+			newDest[i] = NewOrigSpan_Link()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigSpan_LinkSlice(dest, src []*otlptrace.Span_Link) []*otlptrace.Span_
 
 func GenerateOrigTestSpan_LinkSlice() []*otlptrace.Span_Link {
 	orig := make([]*otlptrace.Span_Link, 5)
-	orig[0] = NewOrigPtrSpan_Link()
+	orig[0] = NewOrigSpan_Link()
 	orig[1] = GenTestOrigSpan_Link()
-	orig[2] = NewOrigPtrSpan_Link()
+	orig[2] = NewOrigSpan_Link()
 	orig[3] = GenTestOrigSpan_Link()
-	orig[4] = NewOrigPtrSpan_Link()
+	orig[4] = NewOrigSpan_Link()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestSpan_LinkSlice() []*otlptrace.Span_Link {
 func UnmarshalJSONOrigSpan_LinkSlice(iter *json.Iterator) []*otlptrace.Span_Link {
 	var orig []*otlptrace.Span_Link
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrSpan_Link())
+		orig = append(orig, NewOrigSpan_Link())
 		UnmarshalJSONOrigSpan_Link(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_span_test.go
+++ b/pdata/internal/generated_wrapper_span_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigSpan(t *testing.T) {
-	src := NewOrigPtrSpan()
-	dest := NewOrigPtrSpan()
+	src := NewOrigSpan()
+	dest := NewOrigSpan()
 	CopyOrigSpan(dest, src)
-	assert.Equal(t, NewOrigPtrSpan(), dest)
+	assert.Equal(t, NewOrigSpan(), dest)
 	*src = *GenTestOrigSpan()
 	CopyOrigSpan(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigSpan(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigSpanUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrSpan()
+	dest := NewOrigSpan()
 	UnmarshalJSONOrigSpan(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrSpan(), dest)
+	assert.Equal(t, NewOrigSpan(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigSpan(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigSpan(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrSpan()
+			dest := NewOrigSpan()
 			UnmarshalJSONOrigSpan(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigSpan(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigSpanFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesSpan() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrSpan()
+			dest := NewOrigSpan()
 			require.Error(t, UnmarshalProtoOrigSpan(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigSpanUnknown(t *testing.T) {
-	dest := NewOrigPtrSpan()
+	dest := NewOrigSpan()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigSpan(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrSpan(), dest)
+	assert.Equal(t, NewOrigSpan(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigSpan(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigSpan(t *testing.T) {
 			gotSize := MarshalProtoOrigSpan(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrSpan()
+			dest := NewOrigSpan()
 			require.NoError(t, UnmarshalProtoOrigSpan(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufSpan(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrSpan()
+			dest := NewOrigSpan()
 			require.NoError(t, UnmarshalProtoOrigSpan(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -147,7 +147,7 @@ func genTestFailingUnmarshalProtoValuesSpan() map[string][]byte {
 
 func genTestEncodingValuesSpan() map[string]*otlptrace.Span {
 	return map[string]*otlptrace.Span{
-		"empty":                       NewOrigPtrSpan(),
+		"empty":                       NewOrigSpan(),
 		"TraceId/test":                {TraceId: *GenTestOrigTraceID()},
 		"SpanId/test":                 {SpanId: *GenTestOrigSpanID()},
 		"TraceState/test":             {TraceState: "test_tracestate"},

--- a/pdata/internal/generated_wrapper_spanslice.go
+++ b/pdata/internal/generated_wrapper_spanslice.go
@@ -19,7 +19,7 @@ func CopyOrigSpanSlice(dest, src []*otlptrace.Span) []*otlptrace.Span {
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSpan()
+			newDest[i] = NewOrigSpan()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigSpanSlice(dest, src []*otlptrace.Span) []*otlptrace.Span {
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSpan()
+			newDest[i] = NewOrigSpan()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigSpanSlice(dest, src []*otlptrace.Span) []*otlptrace.Span {
 
 func GenerateOrigTestSpanSlice() []*otlptrace.Span {
 	orig := make([]*otlptrace.Span, 5)
-	orig[0] = NewOrigPtrSpan()
+	orig[0] = NewOrigSpan()
 	orig[1] = GenTestOrigSpan()
-	orig[2] = NewOrigPtrSpan()
+	orig[2] = NewOrigSpan()
 	orig[3] = GenTestOrigSpan()
-	orig[4] = NewOrigPtrSpan()
+	orig[4] = NewOrigSpan()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestSpanSlice() []*otlptrace.Span {
 func UnmarshalJSONOrigSpanSlice(iter *json.Iterator) []*otlptrace.Span {
 	var orig []*otlptrace.Span
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrSpan())
+		orig = append(orig, NewOrigSpan())
 		UnmarshalJSONOrigSpan(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_status.go
+++ b/pdata/internal/generated_wrapper_status.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigStatus() otlptrace.Status {
-	return otlptrace.Status{}
-}
-
-func NewOrigPtrStatus() *otlptrace.Status {
+func NewOrigStatus() *otlptrace.Status {
 	return &otlptrace.Status{}
 }
 
@@ -28,7 +24,7 @@ func CopyOrigStatus(dest, src *otlptrace.Status) {
 }
 
 func GenTestOrigStatus() *otlptrace.Status {
-	orig := NewOrigPtrStatus()
+	orig := NewOrigStatus()
 	orig.Message = "test_message"
 	orig.Code = otlptrace.Status_StatusCode(1)
 	return orig

--- a/pdata/internal/generated_wrapper_status_test.go
+++ b/pdata/internal/generated_wrapper_status_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigStatus(t *testing.T) {
-	src := NewOrigPtrStatus()
-	dest := NewOrigPtrStatus()
+	src := NewOrigStatus()
+	dest := NewOrigStatus()
 	CopyOrigStatus(dest, src)
-	assert.Equal(t, NewOrigPtrStatus(), dest)
+	assert.Equal(t, NewOrigStatus(), dest)
 	*src = *GenTestOrigStatus()
 	CopyOrigStatus(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigStatus(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigStatusUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrStatus()
+	dest := NewOrigStatus()
 	UnmarshalJSONOrigStatus(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrStatus(), dest)
+	assert.Equal(t, NewOrigStatus(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigStatus(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigStatus(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrStatus()
+			dest := NewOrigStatus()
 			UnmarshalJSONOrigStatus(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigStatus(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigStatusFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesStatus() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrStatus()
+			dest := NewOrigStatus()
 			require.Error(t, UnmarshalProtoOrigStatus(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigStatusUnknown(t *testing.T) {
-	dest := NewOrigPtrStatus()
+	dest := NewOrigStatus()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigStatus(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrStatus(), dest)
+	assert.Equal(t, NewOrigStatus(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigStatus(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigStatus(t *testing.T) {
 			gotSize := MarshalProtoOrigStatus(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrStatus()
+			dest := NewOrigStatus()
 			require.NoError(t, UnmarshalProtoOrigStatus(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufStatus(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrStatus()
+			dest := NewOrigStatus()
 			require.NoError(t, UnmarshalProtoOrigStatus(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesStatus() map[string][]byte {
 
 func genTestEncodingValuesStatus() map[string]*otlptrace.Status {
 	return map[string]*otlptrace.Status{
-		"empty":        NewOrigPtrStatus(),
+		"empty":        NewOrigStatus(),
 		"Message/test": {Message: "test_message"},
 		"Code/test":    {Code: otlptrace.Status_StatusCode(13)},
 	}

--- a/pdata/internal/generated_wrapper_sum.go
+++ b/pdata/internal/generated_wrapper_sum.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigSum() otlpmetrics.Sum {
-	return otlpmetrics.Sum{}
-}
-
-func NewOrigPtrSum() *otlpmetrics.Sum {
+func NewOrigSum() *otlpmetrics.Sum {
 	return &otlpmetrics.Sum{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigSum(dest, src *otlpmetrics.Sum) {
 }
 
 func GenTestOrigSum() *otlpmetrics.Sum {
-	orig := NewOrigPtrSum()
+	orig := NewOrigSum()
 	orig.DataPoints = GenerateOrigTestNumberDataPointSlice()
 	orig.AggregationTemporality = otlpmetrics.AggregationTemporality(1)
 	orig.IsMonotonic = true
@@ -149,7 +145,7 @@ func UnmarshalProtoOrigSum(orig *otlpmetrics.Sum, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.DataPoints = append(orig.DataPoints, NewOrigPtrNumberDataPoint())
+			orig.DataPoints = append(orig.DataPoints, NewOrigNumberDataPoint())
 			err = UnmarshalProtoOrigNumberDataPoint(orig.DataPoints[len(orig.DataPoints)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_sum_test.go
+++ b/pdata/internal/generated_wrapper_sum_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigSum(t *testing.T) {
-	src := NewOrigPtrSum()
-	dest := NewOrigPtrSum()
+	src := NewOrigSum()
+	dest := NewOrigSum()
 	CopyOrigSum(dest, src)
-	assert.Equal(t, NewOrigPtrSum(), dest)
+	assert.Equal(t, NewOrigSum(), dest)
 	*src = *GenTestOrigSum()
 	CopyOrigSum(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigSum(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigSumUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrSum()
+	dest := NewOrigSum()
 	UnmarshalJSONOrigSum(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrSum(), dest)
+	assert.Equal(t, NewOrigSum(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigSum(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigSum(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrSum()
+			dest := NewOrigSum()
 			UnmarshalJSONOrigSum(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigSum(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigSumFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesSum() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrSum()
+			dest := NewOrigSum()
 			require.Error(t, UnmarshalProtoOrigSum(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigSumUnknown(t *testing.T) {
-	dest := NewOrigPtrSum()
+	dest := NewOrigSum()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigSum(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrSum(), dest)
+	assert.Equal(t, NewOrigSum(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigSum(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigSum(t *testing.T) {
 			gotSize := MarshalProtoOrigSum(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrSum()
+			dest := NewOrigSum()
 			require.NoError(t, UnmarshalProtoOrigSum(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufSum(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrSum()
+			dest := NewOrigSum()
 			require.NoError(t, UnmarshalProtoOrigSum(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesSum() map[string][]byte {
 
 func genTestEncodingValuesSum() map[string]*otlpmetrics.Sum {
 	return map[string]*otlpmetrics.Sum{
-		"empty":                       NewOrigPtrSum(),
+		"empty":                       NewOrigSum(),
 		"DataPoints/default_and_test": {DataPoints: []*otlpmetrics.NumberDataPoint{{}, GenTestOrigNumberDataPoint()}},
 		"AggregationTemporality/test": {AggregationTemporality: otlpmetrics.AggregationTemporality(13)},
 		"IsMonotonic/test":            {IsMonotonic: true},

--- a/pdata/internal/generated_wrapper_summary.go
+++ b/pdata/internal/generated_wrapper_summary.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigSummary() otlpmetrics.Summary {
-	return otlpmetrics.Summary{}
-}
-
-func NewOrigPtrSummary() *otlpmetrics.Summary {
+func NewOrigSummary() *otlpmetrics.Summary {
 	return &otlpmetrics.Summary{}
 }
 
@@ -27,7 +23,7 @@ func CopyOrigSummary(dest, src *otlpmetrics.Summary) {
 }
 
 func GenTestOrigSummary() *otlpmetrics.Summary {
-	orig := NewOrigPtrSummary()
+	orig := NewOrigSummary()
 	orig.DataPoints = GenerateOrigTestSummaryDataPointSlice()
 	return orig
 }
@@ -111,7 +107,7 @@ func UnmarshalProtoOrigSummary(orig *otlpmetrics.Summary, buf []byte) error {
 				return err
 			}
 			startPos := pos - length
-			orig.DataPoints = append(orig.DataPoints, NewOrigPtrSummaryDataPoint())
+			orig.DataPoints = append(orig.DataPoints, NewOrigSummaryDataPoint())
 			err = UnmarshalProtoOrigSummaryDataPoint(orig.DataPoints[len(orig.DataPoints)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_summary_test.go
+++ b/pdata/internal/generated_wrapper_summary_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigSummary(t *testing.T) {
-	src := NewOrigPtrSummary()
-	dest := NewOrigPtrSummary()
+	src := NewOrigSummary()
+	dest := NewOrigSummary()
 	CopyOrigSummary(dest, src)
-	assert.Equal(t, NewOrigPtrSummary(), dest)
+	assert.Equal(t, NewOrigSummary(), dest)
 	*src = *GenTestOrigSummary()
 	CopyOrigSummary(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigSummary(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigSummaryUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrSummary()
+	dest := NewOrigSummary()
 	UnmarshalJSONOrigSummary(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrSummary(), dest)
+	assert.Equal(t, NewOrigSummary(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigSummary(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigSummary(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrSummary()
+			dest := NewOrigSummary()
 			UnmarshalJSONOrigSummary(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigSummary(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigSummaryFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesSummary() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrSummary()
+			dest := NewOrigSummary()
 			require.Error(t, UnmarshalProtoOrigSummary(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigSummaryUnknown(t *testing.T) {
-	dest := NewOrigPtrSummary()
+	dest := NewOrigSummary()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigSummary(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrSummary(), dest)
+	assert.Equal(t, NewOrigSummary(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigSummary(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigSummary(t *testing.T) {
 			gotSize := MarshalProtoOrigSummary(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrSummary()
+			dest := NewOrigSummary()
 			require.NoError(t, UnmarshalProtoOrigSummary(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufSummary(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrSummary()
+			dest := NewOrigSummary()
 			require.NoError(t, UnmarshalProtoOrigSummary(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -116,7 +116,7 @@ func genTestFailingUnmarshalProtoValuesSummary() map[string][]byte {
 
 func genTestEncodingValuesSummary() map[string]*otlpmetrics.Summary {
 	return map[string]*otlpmetrics.Summary{
-		"empty":                       NewOrigPtrSummary(),
+		"empty":                       NewOrigSummary(),
 		"DataPoints/default_and_test": {DataPoints: []*otlpmetrics.SummaryDataPoint{{}, GenTestOrigSummaryDataPoint()}},
 	}
 }

--- a/pdata/internal/generated_wrapper_summarydatapoint.go
+++ b/pdata/internal/generated_wrapper_summarydatapoint.go
@@ -11,16 +11,13 @@ import (
 	"fmt"
 	"math"
 
+	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigSummaryDataPoint() otlpmetrics.SummaryDataPoint {
-	return otlpmetrics.SummaryDataPoint{}
-}
-
-func NewOrigPtrSummaryDataPoint() *otlpmetrics.SummaryDataPoint {
+func NewOrigSummaryDataPoint() *otlpmetrics.SummaryDataPoint {
 	return &otlpmetrics.SummaryDataPoint{}
 }
 
@@ -35,7 +32,7 @@ func CopyOrigSummaryDataPoint(dest, src *otlpmetrics.SummaryDataPoint) {
 }
 
 func GenTestOrigSummaryDataPoint() *otlpmetrics.SummaryDataPoint {
-	orig := NewOrigPtrSummaryDataPoint()
+	orig := NewOrigSummaryDataPoint()
 	orig.Attributes = GenerateOrigTestKeyValueSlice()
 	orig.StartTimeUnixNano = 1234567890
 	orig.TimeUnixNano = 1234567890
@@ -222,7 +219,7 @@ func UnmarshalProtoOrigSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint, buf 
 				return err
 			}
 			startPos := pos - length
-			orig.Attributes = append(orig.Attributes, NewOrigKeyValue())
+			orig.Attributes = append(orig.Attributes, otlpcommon.KeyValue{})
 			err = UnmarshalProtoOrigKeyValue(&orig.Attributes[len(orig.Attributes)-1], buf[startPos:pos])
 			if err != nil {
 				return err
@@ -286,7 +283,7 @@ func UnmarshalProtoOrigSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint, buf 
 				return err
 			}
 			startPos := pos - length
-			orig.QuantileValues = append(orig.QuantileValues, NewOrigPtrSummaryDataPoint_ValueAtQuantile())
+			orig.QuantileValues = append(orig.QuantileValues, NewOrigSummaryDataPoint_ValueAtQuantile())
 			err = UnmarshalProtoOrigSummaryDataPoint_ValueAtQuantile(orig.QuantileValues[len(orig.QuantileValues)-1], buf[startPos:pos])
 			if err != nil {
 				return err

--- a/pdata/internal/generated_wrapper_summarydatapoint_test.go
+++ b/pdata/internal/generated_wrapper_summarydatapoint_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestCopyOrigSummaryDataPoint(t *testing.T) {
-	src := NewOrigPtrSummaryDataPoint()
-	dest := NewOrigPtrSummaryDataPoint()
+	src := NewOrigSummaryDataPoint()
+	dest := NewOrigSummaryDataPoint()
 	CopyOrigSummaryDataPoint(dest, src)
-	assert.Equal(t, NewOrigPtrSummaryDataPoint(), dest)
+	assert.Equal(t, NewOrigSummaryDataPoint(), dest)
 	*src = *GenTestOrigSummaryDataPoint()
 	CopyOrigSummaryDataPoint(dest, src)
 	assert.Equal(t, src, dest)
@@ -32,10 +32,10 @@ func TestCopyOrigSummaryDataPoint(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigSummaryDataPointUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrSummaryDataPoint()
+	dest := NewOrigSummaryDataPoint()
 	UnmarshalJSONOrigSummaryDataPoint(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrSummaryDataPoint(), dest)
+	assert.Equal(t, NewOrigSummaryDataPoint(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigSummaryDataPoint(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMarshalAndUnmarshalJSONOrigSummaryDataPoint(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrSummaryDataPoint()
+			dest := NewOrigSummaryDataPoint()
 			UnmarshalJSONOrigSummaryDataPoint(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -60,17 +60,17 @@ func TestMarshalAndUnmarshalJSONOrigSummaryDataPoint(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigSummaryDataPointFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesSummaryDataPoint() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrSummaryDataPoint()
+			dest := NewOrigSummaryDataPoint()
 			require.Error(t, UnmarshalProtoOrigSummaryDataPoint(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigSummaryDataPointUnknown(t *testing.T) {
-	dest := NewOrigPtrSummaryDataPoint()
+	dest := NewOrigSummaryDataPoint()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigSummaryDataPoint(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrSummaryDataPoint(), dest)
+	assert.Equal(t, NewOrigSummaryDataPoint(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigSummaryDataPoint(t *testing.T) {
@@ -80,7 +80,7 @@ func TestMarshalAndUnmarshalProtoOrigSummaryDataPoint(t *testing.T) {
 			gotSize := MarshalProtoOrigSummaryDataPoint(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrSummaryDataPoint()
+			dest := NewOrigSummaryDataPoint()
 			require.NoError(t, UnmarshalProtoOrigSummaryDataPoint(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -100,7 +100,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufSummaryDataPoint(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrSummaryDataPoint()
+			dest := NewOrigSummaryDataPoint()
 			require.NoError(t, UnmarshalProtoOrigSummaryDataPoint(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -129,7 +129,7 @@ func genTestFailingUnmarshalProtoValuesSummaryDataPoint() map[string][]byte {
 
 func genTestEncodingValuesSummaryDataPoint() map[string]*otlpmetrics.SummaryDataPoint {
 	return map[string]*otlpmetrics.SummaryDataPoint{
-		"empty":                           NewOrigPtrSummaryDataPoint(),
+		"empty":                           NewOrigSummaryDataPoint(),
 		"Attributes/default_and_test":     {Attributes: []otlpcommon.KeyValue{{}, *GenTestOrigKeyValue()}},
 		"StartTimeUnixNano/test":          {StartTimeUnixNano: uint64(13)},
 		"TimeUnixNano/test":               {TimeUnixNano: uint64(13)},

--- a/pdata/internal/generated_wrapper_summarydatapoint_valueatquantile.go
+++ b/pdata/internal/generated_wrapper_summarydatapoint_valueatquantile.go
@@ -16,11 +16,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigSummaryDataPoint_ValueAtQuantile() otlpmetrics.SummaryDataPoint_ValueAtQuantile {
-	return otlpmetrics.SummaryDataPoint_ValueAtQuantile{}
-}
-
-func NewOrigPtrSummaryDataPoint_ValueAtQuantile() *otlpmetrics.SummaryDataPoint_ValueAtQuantile {
+func NewOrigSummaryDataPoint_ValueAtQuantile() *otlpmetrics.SummaryDataPoint_ValueAtQuantile {
 	return &otlpmetrics.SummaryDataPoint_ValueAtQuantile{}
 }
 
@@ -30,7 +26,7 @@ func CopyOrigSummaryDataPoint_ValueAtQuantile(dest, src *otlpmetrics.SummaryData
 }
 
 func GenTestOrigSummaryDataPoint_ValueAtQuantile() *otlpmetrics.SummaryDataPoint_ValueAtQuantile {
-	orig := NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+	orig := NewOrigSummaryDataPoint_ValueAtQuantile()
 	orig.Quantile = float64(3.1415926)
 	orig.Value = float64(3.1415926)
 	return orig

--- a/pdata/internal/generated_wrapper_summarydatapoint_valueatquantile_test.go
+++ b/pdata/internal/generated_wrapper_summarydatapoint_valueatquantile_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigSummaryDataPoint_ValueAtQuantile(t *testing.T) {
-	src := NewOrigPtrSummaryDataPoint_ValueAtQuantile()
-	dest := NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+	src := NewOrigSummaryDataPoint_ValueAtQuantile()
+	dest := NewOrigSummaryDataPoint_ValueAtQuantile()
 	CopyOrigSummaryDataPoint_ValueAtQuantile(dest, src)
-	assert.Equal(t, NewOrigPtrSummaryDataPoint_ValueAtQuantile(), dest)
+	assert.Equal(t, NewOrigSummaryDataPoint_ValueAtQuantile(), dest)
 	*src = *GenTestOrigSummaryDataPoint_ValueAtQuantile()
 	CopyOrigSummaryDataPoint_ValueAtQuantile(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigSummaryDataPoint_ValueAtQuantile(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigSummaryDataPoint_ValueAtQuantileUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+	dest := NewOrigSummaryDataPoint_ValueAtQuantile()
 	UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrSummaryDataPoint_ValueAtQuantile(), dest)
+	assert.Equal(t, NewOrigSummaryDataPoint_ValueAtQuantile(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(t *testing.
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+			dest := NewOrigSummaryDataPoint_ValueAtQuantile()
 			UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(t *testing.
 func TestMarshalAndUnmarshalProtoOrigSummaryDataPoint_ValueAtQuantileFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesSummaryDataPoint_ValueAtQuantile() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+			dest := NewOrigSummaryDataPoint_ValueAtQuantile()
 			require.Error(t, UnmarshalProtoOrigSummaryDataPoint_ValueAtQuantile(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigSummaryDataPoint_ValueAtQuantileUnknown(t *testing.T) {
-	dest := NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+	dest := NewOrigSummaryDataPoint_ValueAtQuantile()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigSummaryDataPoint_ValueAtQuantile(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrSummaryDataPoint_ValueAtQuantile(), dest)
+	assert.Equal(t, NewOrigSummaryDataPoint_ValueAtQuantile(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigSummaryDataPoint_ValueAtQuantile(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigSummaryDataPoint_ValueAtQuantile(t *testing
 			gotSize := MarshalProtoOrigSummaryDataPoint_ValueAtQuantile(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+			dest := NewOrigSummaryDataPoint_ValueAtQuantile()
 			require.NoError(t, UnmarshalProtoOrigSummaryDataPoint_ValueAtQuantile(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufSummaryDataPoint_ValueAtQuantile(t *
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+			dest := NewOrigSummaryDataPoint_ValueAtQuantile()
 			require.NoError(t, UnmarshalProtoOrigSummaryDataPoint_ValueAtQuantile(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -118,7 +118,7 @@ func genTestFailingUnmarshalProtoValuesSummaryDataPoint_ValueAtQuantile() map[st
 
 func genTestEncodingValuesSummaryDataPoint_ValueAtQuantile() map[string]*otlpmetrics.SummaryDataPoint_ValueAtQuantile {
 	return map[string]*otlpmetrics.SummaryDataPoint_ValueAtQuantile{
-		"empty":         NewOrigPtrSummaryDataPoint_ValueAtQuantile(),
+		"empty":         NewOrigSummaryDataPoint_ValueAtQuantile(),
 		"Quantile/test": {Quantile: float64(3.1415926)},
 		"Value/test":    {Value: float64(3.1415926)},
 	}

--- a/pdata/internal/generated_wrapper_summarydatapoint_valueatquantileslice.go
+++ b/pdata/internal/generated_wrapper_summarydatapoint_valueatquantileslice.go
@@ -19,7 +19,7 @@ func CopyOrigSummaryDataPoint_ValueAtQuantileSlice(dest, src []*otlpmetrics.Summ
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+			newDest[i] = NewOrigSummaryDataPoint_ValueAtQuantile()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigSummaryDataPoint_ValueAtQuantileSlice(dest, src []*otlpmetrics.Summ
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+			newDest[i] = NewOrigSummaryDataPoint_ValueAtQuantile()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigSummaryDataPoint_ValueAtQuantileSlice(dest, src []*otlpmetrics.Summ
 
 func GenerateOrigTestSummaryDataPoint_ValueAtQuantileSlice() []*otlpmetrics.SummaryDataPoint_ValueAtQuantile {
 	orig := make([]*otlpmetrics.SummaryDataPoint_ValueAtQuantile, 5)
-	orig[0] = NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+	orig[0] = NewOrigSummaryDataPoint_ValueAtQuantile()
 	orig[1] = GenTestOrigSummaryDataPoint_ValueAtQuantile()
-	orig[2] = NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+	orig[2] = NewOrigSummaryDataPoint_ValueAtQuantile()
 	orig[3] = GenTestOrigSummaryDataPoint_ValueAtQuantile()
-	orig[4] = NewOrigPtrSummaryDataPoint_ValueAtQuantile()
+	orig[4] = NewOrigSummaryDataPoint_ValueAtQuantile()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestSummaryDataPoint_ValueAtQuantileSlice() []*otlpmetrics.Summ
 func UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantileSlice(iter *json.Iterator) []*otlpmetrics.SummaryDataPoint_ValueAtQuantile {
 	var orig []*otlpmetrics.SummaryDataPoint_ValueAtQuantile
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrSummaryDataPoint_ValueAtQuantile())
+		orig = append(orig, NewOrigSummaryDataPoint_ValueAtQuantile())
 		UnmarshalJSONOrigSummaryDataPoint_ValueAtQuantile(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_summarydatapointslice.go
+++ b/pdata/internal/generated_wrapper_summarydatapointslice.go
@@ -19,7 +19,7 @@ func CopyOrigSummaryDataPointSlice(dest, src []*otlpmetrics.SummaryDataPoint) []
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSummaryDataPoint()
+			newDest[i] = NewOrigSummaryDataPoint()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigSummaryDataPointSlice(dest, src []*otlpmetrics.SummaryDataPoint) []
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrSummaryDataPoint()
+			newDest[i] = NewOrigSummaryDataPoint()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigSummaryDataPointSlice(dest, src []*otlpmetrics.SummaryDataPoint) []
 
 func GenerateOrigTestSummaryDataPointSlice() []*otlpmetrics.SummaryDataPoint {
 	orig := make([]*otlpmetrics.SummaryDataPoint, 5)
-	orig[0] = NewOrigPtrSummaryDataPoint()
+	orig[0] = NewOrigSummaryDataPoint()
 	orig[1] = GenTestOrigSummaryDataPoint()
-	orig[2] = NewOrigPtrSummaryDataPoint()
+	orig[2] = NewOrigSummaryDataPoint()
 	orig[3] = GenTestOrigSummaryDataPoint()
-	orig[4] = NewOrigPtrSummaryDataPoint()
+	orig[4] = NewOrigSummaryDataPoint()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestSummaryDataPointSlice() []*otlpmetrics.SummaryDataPoint {
 func UnmarshalJSONOrigSummaryDataPointSlice(iter *json.Iterator) []*otlpmetrics.SummaryDataPoint {
 	var orig []*otlpmetrics.SummaryDataPoint
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrSummaryDataPoint())
+		orig = append(orig, NewOrigSummaryDataPoint())
 		UnmarshalJSONOrigSummaryDataPoint(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/internal/generated_wrapper_valuetype.go
+++ b/pdata/internal/generated_wrapper_valuetype.go
@@ -14,11 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func NewOrigValueType() otlpprofiles.ValueType {
-	return otlpprofiles.ValueType{}
-}
-
-func NewOrigPtrValueType() *otlpprofiles.ValueType {
+func NewOrigValueType() *otlpprofiles.ValueType {
 	return &otlpprofiles.ValueType{}
 }
 
@@ -29,7 +25,7 @@ func CopyOrigValueType(dest, src *otlpprofiles.ValueType) {
 }
 
 func GenTestOrigValueType() *otlpprofiles.ValueType {
-	orig := NewOrigPtrValueType()
+	orig := NewOrigValueType()
 	orig.TypeStrindex = int32(13)
 	orig.UnitStrindex = int32(13)
 	orig.AggregationTemporality = otlpprofiles.AggregationTemporality(1)

--- a/pdata/internal/generated_wrapper_valuetype_test.go
+++ b/pdata/internal/generated_wrapper_valuetype_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func TestCopyOrigValueType(t *testing.T) {
-	src := NewOrigPtrValueType()
-	dest := NewOrigPtrValueType()
+	src := NewOrigValueType()
+	dest := NewOrigValueType()
 	CopyOrigValueType(dest, src)
-	assert.Equal(t, NewOrigPtrValueType(), dest)
+	assert.Equal(t, NewOrigValueType(), dest)
 	*src = *GenTestOrigValueType()
 	CopyOrigValueType(dest, src)
 	assert.Equal(t, src, dest)
@@ -31,10 +31,10 @@ func TestCopyOrigValueType(t *testing.T) {
 func TestMarshalAndUnmarshalJSONOrigValueTypeUnknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
-	dest := NewOrigPtrValueType()
+	dest := NewOrigValueType()
 	UnmarshalJSONOrigValueType(dest, iter)
 	require.NoError(t, iter.Error())
-	assert.Equal(t, NewOrigPtrValueType(), dest)
+	assert.Equal(t, NewOrigValueType(), dest)
 }
 
 func TestMarshalAndUnmarshalJSONOrigValueType(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMarshalAndUnmarshalJSONOrigValueType(t *testing.T) {
 
 			iter := json.BorrowIterator(stream.Buffer())
 			defer json.ReturnIterator(iter)
-			dest := NewOrigPtrValueType()
+			dest := NewOrigValueType()
 			UnmarshalJSONOrigValueType(dest, iter)
 			require.NoError(t, iter.Error())
 
@@ -59,17 +59,17 @@ func TestMarshalAndUnmarshalJSONOrigValueType(t *testing.T) {
 func TestMarshalAndUnmarshalProtoOrigValueTypeFailing(t *testing.T) {
 	for name, buf := range genTestFailingUnmarshalProtoValuesValueType() {
 		t.Run(name, func(t *testing.T) {
-			dest := NewOrigPtrValueType()
+			dest := NewOrigValueType()
 			require.Error(t, UnmarshalProtoOrigValueType(dest, buf))
 		})
 	}
 }
 
 func TestMarshalAndUnmarshalProtoOrigValueTypeUnknown(t *testing.T) {
-	dest := NewOrigPtrValueType()
+	dest := NewOrigValueType()
 	// message Test { required int64 field = 1313; } encoding { "field": "1234" }
 	require.NoError(t, UnmarshalProtoOrigValueType(dest, []byte{0x88, 0x52, 0xD2, 0x09}))
-	assert.Equal(t, NewOrigPtrValueType(), dest)
+	assert.Equal(t, NewOrigValueType(), dest)
 }
 
 func TestMarshalAndUnmarshalProtoOrigValueType(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarshalAndUnmarshalProtoOrigValueType(t *testing.T) {
 			gotSize := MarshalProtoOrigValueType(src, buf)
 			assert.Equal(t, len(buf), gotSize)
 
-			dest := NewOrigPtrValueType()
+			dest := NewOrigValueType()
 			require.NoError(t, UnmarshalProtoOrigValueType(dest, buf))
 			assert.Equal(t, src, dest)
 		})
@@ -99,7 +99,7 @@ func TestMarshalAndUnmarshalProtoViaProtobufValueType(t *testing.T) {
 			goBuf, err := proto.Marshal(goDest)
 			require.NoError(t, err)
 
-			dest := NewOrigPtrValueType()
+			dest := NewOrigValueType()
 			require.NoError(t, UnmarshalProtoOrigValueType(dest, goBuf))
 			assert.Equal(t, src, dest)
 		})
@@ -120,7 +120,7 @@ func genTestFailingUnmarshalProtoValuesValueType() map[string][]byte {
 
 func genTestEncodingValuesValueType() map[string]*otlpprofiles.ValueType {
 	return map[string]*otlpprofiles.ValueType{
-		"empty":                       NewOrigPtrValueType(),
+		"empty":                       NewOrigValueType(),
 		"TypeStrindex/test":           {TypeStrindex: int32(13)},
 		"UnitStrindex/test":           {UnitStrindex: int32(13)},
 		"AggregationTemporality/test": {AggregationTemporality: otlpprofiles.AggregationTemporality(13)},

--- a/pdata/internal/generated_wrapper_valuetypeslice.go
+++ b/pdata/internal/generated_wrapper_valuetypeslice.go
@@ -19,7 +19,7 @@ func CopyOrigValueTypeSlice(dest, src []*otlpprofiles.ValueType) []*otlpprofiles
 		copy(newDest, dest)
 		// Add new pointers for missing elements from len(dest) to len(srt).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrValueType()
+			newDest[i] = NewOrigValueType()
 		}
 	} else {
 		newDest = dest[:len(src)]
@@ -31,7 +31,7 @@ func CopyOrigValueTypeSlice(dest, src []*otlpprofiles.ValueType) []*otlpprofiles
 		// Add new pointers for missing elements.
 		// This can happen when len(dest) < len(src) < cap(dest).
 		for i := len(dest); i < len(src); i++ {
-			newDest[i] = NewOrigPtrValueType()
+			newDest[i] = NewOrigValueType()
 		}
 	}
 	for i := range src {
@@ -42,11 +42,11 @@ func CopyOrigValueTypeSlice(dest, src []*otlpprofiles.ValueType) []*otlpprofiles
 
 func GenerateOrigTestValueTypeSlice() []*otlpprofiles.ValueType {
 	orig := make([]*otlpprofiles.ValueType, 5)
-	orig[0] = NewOrigPtrValueType()
+	orig[0] = NewOrigValueType()
 	orig[1] = GenTestOrigValueType()
-	orig[2] = NewOrigPtrValueType()
+	orig[2] = NewOrigValueType()
 	orig[3] = GenTestOrigValueType()
-	orig[4] = NewOrigPtrValueType()
+	orig[4] = NewOrigValueType()
 	return orig
 }
 
@@ -54,7 +54,7 @@ func GenerateOrigTestValueTypeSlice() []*otlpprofiles.ValueType {
 func UnmarshalJSONOrigValueTypeSlice(iter *json.Iterator) []*otlpprofiles.ValueType {
 	var orig []*otlpprofiles.ValueType
 	iter.ReadArrayCB(func(iter *json.Iterator) bool {
-		orig = append(orig, NewOrigPtrValueType())
+		orig = append(orig, NewOrigValueType())
 		UnmarshalJSONOrigValueType(orig[len(orig)-1], iter)
 		return true
 	})

--- a/pdata/pcommon/generated_instrumentationscope.go
+++ b/pdata/pcommon/generated_instrumentationscope.go
@@ -29,7 +29,7 @@ func newInstrumentationScope(orig *otlpcommon.InstrumentationScope, state *inter
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewInstrumentationScope() InstrumentationScope {
-	return newInstrumentationScope(internal.NewOrigPtrInstrumentationScope(), internal.NewState())
+	return newInstrumentationScope(internal.NewOrigInstrumentationScope(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pcommon/generated_instrumentationscope_test.go
+++ b/pdata/pcommon/generated_instrumentationscope_test.go
@@ -25,8 +25,8 @@ func TestInstrumentationScope_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestInstrumentationScope(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newInstrumentationScope(internal.NewOrigPtrInstrumentationScope(), sharedState)) })
-	assert.Panics(t, func() { newInstrumentationScope(internal.NewOrigPtrInstrumentationScope(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newInstrumentationScope(internal.NewOrigInstrumentationScope(), sharedState)) })
+	assert.Panics(t, func() { newInstrumentationScope(internal.NewOrigInstrumentationScope(), sharedState).MoveTo(dest) })
 }
 
 func TestInstrumentationScope_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestInstrumentationScope_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newInstrumentationScope(internal.NewOrigPtrInstrumentationScope(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newInstrumentationScope(internal.NewOrigInstrumentationScope(), sharedState)) })
 }
 
 func TestInstrumentationScope_Name(t *testing.T) {

--- a/pdata/pcommon/generated_resource.go
+++ b/pdata/pcommon/generated_resource.go
@@ -29,7 +29,7 @@ func newResource(orig *otlpresource.Resource, state *internal.State) Resource {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResource() Resource {
-	return newResource(internal.NewOrigPtrResource(), internal.NewState())
+	return newResource(internal.NewOrigResource(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pcommon/generated_resource_test.go
+++ b/pdata/pcommon/generated_resource_test.go
@@ -25,8 +25,8 @@ func TestResource_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResource(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newResource(internal.NewOrigPtrResource(), sharedState)) })
-	assert.Panics(t, func() { newResource(internal.NewOrigPtrResource(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newResource(internal.NewOrigResource(), sharedState)) })
+	assert.Panics(t, func() { newResource(internal.NewOrigResource(), sharedState).MoveTo(dest) })
 }
 
 func TestResource_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestResource_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newResource(internal.NewOrigPtrResource(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newResource(internal.NewOrigResource(), sharedState)) })
 }
 
 func TestResource_Attributes(t *testing.T) {

--- a/pdata/plog/generated_logrecord.go
+++ b/pdata/plog/generated_logrecord.go
@@ -34,7 +34,7 @@ func newLogRecord(orig *otlplogs.LogRecord, state *internal.State) LogRecord {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLogRecord() LogRecord {
-	return newLogRecord(internal.NewOrigPtrLogRecord(), internal.NewState())
+	return newLogRecord(internal.NewOrigLogRecord(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/generated_logrecord_test.go
+++ b/pdata/plog/generated_logrecord_test.go
@@ -27,8 +27,8 @@ func TestLogRecord_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLogRecord(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newLogRecord(internal.NewOrigPtrLogRecord(), sharedState)) })
-	assert.Panics(t, func() { newLogRecord(internal.NewOrigPtrLogRecord(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newLogRecord(internal.NewOrigLogRecord(), sharedState)) })
+	assert.Panics(t, func() { newLogRecord(internal.NewOrigLogRecord(), sharedState).MoveTo(dest) })
 }
 
 func TestLogRecord_CopyTo(t *testing.T) {
@@ -41,7 +41,7 @@ func TestLogRecord_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newLogRecord(internal.NewOrigPtrLogRecord(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newLogRecord(internal.NewOrigLogRecord(), sharedState)) })
 }
 
 func TestLogRecord_Timestamp(t *testing.T) {

--- a/pdata/plog/generated_logrecordslice.go
+++ b/pdata/plog/generated_logrecordslice.go
@@ -99,7 +99,7 @@ func (es LogRecordSlice) EnsureCapacity(newCap int) {
 // It returns the newly added LogRecord.
 func (es LogRecordSlice) AppendEmpty() LogRecord {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrLogRecord())
+	*es.orig = append(*es.orig, internal.NewOrigLogRecord())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/plog/generated_logs.go
+++ b/pdata/plog/generated_logs.go
@@ -30,7 +30,7 @@ func newLogs(orig *otlpcollectorlogs.ExportLogsServiceRequest, state *internal.S
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLogs() Logs {
-	return newLogs(internal.NewOrigPtrExportLogsServiceRequest(), internal.NewState())
+	return newLogs(internal.NewOrigExportLogsServiceRequest(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/generated_logs_test.go
+++ b/pdata/plog/generated_logs_test.go
@@ -24,8 +24,8 @@ func TestLogs_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLogs(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newLogs(internal.NewOrigPtrExportLogsServiceRequest(), sharedState)) })
-	assert.Panics(t, func() { newLogs(internal.NewOrigPtrExportLogsServiceRequest(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newLogs(internal.NewOrigExportLogsServiceRequest(), sharedState)) })
+	assert.Panics(t, func() { newLogs(internal.NewOrigExportLogsServiceRequest(), sharedState).MoveTo(dest) })
 }
 
 func TestLogs_CopyTo(t *testing.T) {
@@ -38,7 +38,7 @@ func TestLogs_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newLogs(internal.NewOrigPtrExportLogsServiceRequest(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newLogs(internal.NewOrigExportLogsServiceRequest(), sharedState)) })
 }
 
 func TestLogs_ResourceLogs(t *testing.T) {

--- a/pdata/plog/generated_resourcelogs.go
+++ b/pdata/plog/generated_resourcelogs.go
@@ -33,7 +33,7 @@ func newResourceLogs(orig *otlplogs.ResourceLogs, state *internal.State) Resourc
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResourceLogs() ResourceLogs {
-	return newResourceLogs(internal.NewOrigPtrResourceLogs(), internal.NewState())
+	return newResourceLogs(internal.NewOrigResourceLogs(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/generated_resourcelogs_test.go
+++ b/pdata/plog/generated_resourcelogs_test.go
@@ -26,8 +26,8 @@ func TestResourceLogs_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResourceLogs(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newResourceLogs(internal.NewOrigPtrResourceLogs(), sharedState)) })
-	assert.Panics(t, func() { newResourceLogs(internal.NewOrigPtrResourceLogs(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newResourceLogs(internal.NewOrigResourceLogs(), sharedState)) })
+	assert.Panics(t, func() { newResourceLogs(internal.NewOrigResourceLogs(), sharedState).MoveTo(dest) })
 }
 
 func TestResourceLogs_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestResourceLogs_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newResourceLogs(internal.NewOrigPtrResourceLogs(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newResourceLogs(internal.NewOrigResourceLogs(), sharedState)) })
 }
 
 func TestResourceLogs_Resource(t *testing.T) {

--- a/pdata/plog/generated_resourcelogsslice.go
+++ b/pdata/plog/generated_resourcelogsslice.go
@@ -99,7 +99,7 @@ func (es ResourceLogsSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ResourceLogs.
 func (es ResourceLogsSlice) AppendEmpty() ResourceLogs {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrResourceLogs())
+	*es.orig = append(*es.orig, internal.NewOrigResourceLogs())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/plog/generated_scopelogs.go
+++ b/pdata/plog/generated_scopelogs.go
@@ -33,7 +33,7 @@ func newScopeLogs(orig *otlplogs.ScopeLogs, state *internal.State) ScopeLogs {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewScopeLogs() ScopeLogs {
-	return newScopeLogs(internal.NewOrigPtrScopeLogs(), internal.NewState())
+	return newScopeLogs(internal.NewOrigScopeLogs(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/generated_scopelogs_test.go
+++ b/pdata/plog/generated_scopelogs_test.go
@@ -26,8 +26,8 @@ func TestScopeLogs_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestScopeLogs(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newScopeLogs(internal.NewOrigPtrScopeLogs(), sharedState)) })
-	assert.Panics(t, func() { newScopeLogs(internal.NewOrigPtrScopeLogs(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newScopeLogs(internal.NewOrigScopeLogs(), sharedState)) })
+	assert.Panics(t, func() { newScopeLogs(internal.NewOrigScopeLogs(), sharedState).MoveTo(dest) })
 }
 
 func TestScopeLogs_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestScopeLogs_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newScopeLogs(internal.NewOrigPtrScopeLogs(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newScopeLogs(internal.NewOrigScopeLogs(), sharedState)) })
 }
 
 func TestScopeLogs_Scope(t *testing.T) {

--- a/pdata/plog/generated_scopelogsslice.go
+++ b/pdata/plog/generated_scopelogsslice.go
@@ -99,7 +99,7 @@ func (es ScopeLogsSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ScopeLogs.
 func (es ScopeLogsSlice) AppendEmpty() ScopeLogs {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrScopeLogs())
+	*es.orig = append(*es.orig, internal.NewOrigScopeLogs())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/plog/plogotlp/generated_exportpartialsuccess.go
+++ b/pdata/plog/plogotlp/generated_exportpartialsuccess.go
@@ -32,7 +32,7 @@ func newExportPartialSuccess(orig *otlpcollectorlogs.ExportLogsPartialSuccess, s
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportPartialSuccess() ExportPartialSuccess {
-	return newExportPartialSuccess(internal.NewOrigPtrExportLogsPartialSuccess(), internal.NewState())
+	return newExportPartialSuccess(internal.NewOrigExportLogsPartialSuccess(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/plogotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/plog/plogotlp/generated_exportpartialsuccess_test.go
@@ -25,10 +25,8 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newExportPartialSuccess(internal.NewOrigPtrExportLogsPartialSuccess(), sharedState)) })
-	assert.Panics(t, func() {
-		newExportPartialSuccess(internal.NewOrigPtrExportLogsPartialSuccess(), sharedState).MoveTo(dest)
-	})
+	assert.Panics(t, func() { ms.MoveTo(newExportPartialSuccess(internal.NewOrigExportLogsPartialSuccess(), sharedState)) })
+	assert.Panics(t, func() { newExportPartialSuccess(internal.NewOrigExportLogsPartialSuccess(), sharedState).MoveTo(dest) })
 }
 
 func TestExportPartialSuccess_CopyTo(t *testing.T) {
@@ -41,7 +39,7 @@ func TestExportPartialSuccess_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newExportPartialSuccess(internal.NewOrigPtrExportLogsPartialSuccess(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newExportPartialSuccess(internal.NewOrigExportLogsPartialSuccess(), sharedState)) })
 }
 
 func TestExportPartialSuccess_RejectedLogRecords(t *testing.T) {

--- a/pdata/plog/plogotlp/generated_exportresponse.go
+++ b/pdata/plog/plogotlp/generated_exportresponse.go
@@ -32,7 +32,7 @@ func newExportResponse(orig *otlpcollectorlogs.ExportLogsServiceResponse, state 
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportResponse() ExportResponse {
-	return newExportResponse(internal.NewOrigPtrExportLogsServiceResponse(), internal.NewState())
+	return newExportResponse(internal.NewOrigExportLogsServiceResponse(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/plog/plogotlp/generated_exportresponse_test.go
+++ b/pdata/plog/plogotlp/generated_exportresponse_test.go
@@ -24,8 +24,8 @@ func TestExportResponse_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportResponse(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newExportResponse(internal.NewOrigPtrExportLogsServiceResponse(), sharedState)) })
-	assert.Panics(t, func() { newExportResponse(internal.NewOrigPtrExportLogsServiceResponse(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newExportResponse(internal.NewOrigExportLogsServiceResponse(), sharedState)) })
+	assert.Panics(t, func() { newExportResponse(internal.NewOrigExportLogsServiceResponse(), sharedState).MoveTo(dest) })
 }
 
 func TestExportResponse_CopyTo(t *testing.T) {
@@ -38,7 +38,7 @@ func TestExportResponse_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newExportResponse(internal.NewOrigPtrExportLogsServiceResponse(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newExportResponse(internal.NewOrigExportLogsServiceResponse(), sharedState)) })
 }
 
 func TestExportResponse_PartialSuccess(t *testing.T) {

--- a/pdata/pmetric/generated_exemplar.go
+++ b/pdata/pmetric/generated_exemplar.go
@@ -37,7 +37,7 @@ func newExemplar(orig *otlpmetrics.Exemplar, state *internal.State) Exemplar {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExemplar() Exemplar {
-	return newExemplar(internal.NewOrigPtrExemplar(), internal.NewState())
+	return newExemplar(internal.NewOrigExemplar(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_exemplar_test.go
+++ b/pdata/pmetric/generated_exemplar_test.go
@@ -27,8 +27,8 @@ func TestExemplar_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExemplar(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newExemplar(internal.NewOrigPtrExemplar(), sharedState)) })
-	assert.Panics(t, func() { newExemplar(internal.NewOrigPtrExemplar(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newExemplar(internal.NewOrigExemplar(), sharedState)) })
+	assert.Panics(t, func() { newExemplar(internal.NewOrigExemplar(), sharedState).MoveTo(dest) })
 }
 
 func TestExemplar_CopyTo(t *testing.T) {
@@ -41,7 +41,7 @@ func TestExemplar_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newExemplar(internal.NewOrigPtrExemplar(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newExemplar(internal.NewOrigExemplar(), sharedState)) })
 }
 
 func TestExemplar_FilteredAttributes(t *testing.T) {

--- a/pdata/pmetric/generated_exponentialhistogram.go
+++ b/pdata/pmetric/generated_exponentialhistogram.go
@@ -33,7 +33,7 @@ func newExponentialHistogram(orig *otlpmetrics.ExponentialHistogram, state *inte
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExponentialHistogram() ExponentialHistogram {
-	return newExponentialHistogram(internal.NewOrigPtrExponentialHistogram(), internal.NewState())
+	return newExponentialHistogram(internal.NewOrigExponentialHistogram(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_exponentialhistogram_test.go
+++ b/pdata/pmetric/generated_exponentialhistogram_test.go
@@ -25,8 +25,8 @@ func TestExponentialHistogram_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExponentialHistogram(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newExponentialHistogram(internal.NewOrigPtrExponentialHistogram(), sharedState)) })
-	assert.Panics(t, func() { newExponentialHistogram(internal.NewOrigPtrExponentialHistogram(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newExponentialHistogram(internal.NewOrigExponentialHistogram(), sharedState)) })
+	assert.Panics(t, func() { newExponentialHistogram(internal.NewOrigExponentialHistogram(), sharedState).MoveTo(dest) })
 }
 
 func TestExponentialHistogram_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestExponentialHistogram_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newExponentialHistogram(internal.NewOrigPtrExponentialHistogram(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newExponentialHistogram(internal.NewOrigExponentialHistogram(), sharedState)) })
 }
 
 func TestExponentialHistogram_DataPoints(t *testing.T) {

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint.go
@@ -36,7 +36,7 @@ func newExponentialHistogramDataPoint(orig *otlpmetrics.ExponentialHistogramData
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExponentialHistogramDataPoint() ExponentialHistogramDataPoint {
-	return newExponentialHistogramDataPoint(internal.NewOrigPtrExponentialHistogramDataPoint(), internal.NewState())
+	return newExponentialHistogramDataPoint(internal.NewOrigExponentialHistogramDataPoint(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
@@ -27,10 +27,10 @@ func TestExponentialHistogramDataPoint_MoveTo(t *testing.T) {
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExponentialHistogramDataPoint(internal.NewOrigPtrExponentialHistogramDataPoint(), sharedState))
+		ms.MoveTo(newExponentialHistogramDataPoint(internal.NewOrigExponentialHistogramDataPoint(), sharedState))
 	})
 	assert.Panics(t, func() {
-		newExponentialHistogramDataPoint(internal.NewOrigPtrExponentialHistogramDataPoint(), sharedState).MoveTo(dest)
+		newExponentialHistogramDataPoint(internal.NewOrigExponentialHistogramDataPoint(), sharedState).MoveTo(dest)
 	})
 }
 
@@ -45,7 +45,7 @@ func TestExponentialHistogramDataPoint_CopyTo(t *testing.T) {
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExponentialHistogramDataPoint(internal.NewOrigPtrExponentialHistogramDataPoint(), sharedState))
+		ms.CopyTo(newExponentialHistogramDataPoint(internal.NewOrigExponentialHistogramDataPoint(), sharedState))
 	})
 }
 

--- a/pdata/pmetric/generated_exponentialhistogramdatapointbuckets.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointbuckets.go
@@ -33,7 +33,7 @@ func newExponentialHistogramDataPointBuckets(orig *otlpmetrics.ExponentialHistog
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExponentialHistogramDataPointBuckets() ExponentialHistogramDataPointBuckets {
-	return newExponentialHistogramDataPointBuckets(internal.NewOrigPtrExponentialHistogramDataPoint_Buckets(), internal.NewState())
+	return newExponentialHistogramDataPointBuckets(internal.NewOrigExponentialHistogramDataPoint_Buckets(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_exponentialhistogramdatapointbuckets_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointbuckets_test.go
@@ -27,10 +27,10 @@ func TestExponentialHistogramDataPointBuckets_MoveTo(t *testing.T) {
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExponentialHistogramDataPointBuckets(internal.NewOrigPtrExponentialHistogramDataPoint_Buckets(), sharedState))
+		ms.MoveTo(newExponentialHistogramDataPointBuckets(internal.NewOrigExponentialHistogramDataPoint_Buckets(), sharedState))
 	})
 	assert.Panics(t, func() {
-		newExponentialHistogramDataPointBuckets(internal.NewOrigPtrExponentialHistogramDataPoint_Buckets(), sharedState).MoveTo(dest)
+		newExponentialHistogramDataPointBuckets(internal.NewOrigExponentialHistogramDataPoint_Buckets(), sharedState).MoveTo(dest)
 	})
 }
 
@@ -45,7 +45,7 @@ func TestExponentialHistogramDataPointBuckets_CopyTo(t *testing.T) {
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExponentialHistogramDataPointBuckets(internal.NewOrigPtrExponentialHistogramDataPoint_Buckets(), sharedState))
+		ms.CopyTo(newExponentialHistogramDataPointBuckets(internal.NewOrigExponentialHistogramDataPoint_Buckets(), sharedState))
 	})
 }
 

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
@@ -99,7 +99,7 @@ func (es ExponentialHistogramDataPointSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ExponentialHistogramDataPoint.
 func (es ExponentialHistogramDataPointSlice) AppendEmpty() ExponentialHistogramDataPoint {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrExponentialHistogramDataPoint())
+	*es.orig = append(*es.orig, internal.NewOrigExponentialHistogramDataPoint())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pmetric/generated_gauge.go
+++ b/pdata/pmetric/generated_gauge.go
@@ -32,7 +32,7 @@ func newGauge(orig *otlpmetrics.Gauge, state *internal.State) Gauge {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewGauge() Gauge {
-	return newGauge(internal.NewOrigPtrGauge(), internal.NewState())
+	return newGauge(internal.NewOrigGauge(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_gauge_test.go
+++ b/pdata/pmetric/generated_gauge_test.go
@@ -24,8 +24,8 @@ func TestGauge_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestGauge(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newGauge(internal.NewOrigPtrGauge(), sharedState)) })
-	assert.Panics(t, func() { newGauge(internal.NewOrigPtrGauge(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newGauge(internal.NewOrigGauge(), sharedState)) })
+	assert.Panics(t, func() { newGauge(internal.NewOrigGauge(), sharedState).MoveTo(dest) })
 }
 
 func TestGauge_CopyTo(t *testing.T) {
@@ -38,7 +38,7 @@ func TestGauge_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newGauge(internal.NewOrigPtrGauge(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newGauge(internal.NewOrigGauge(), sharedState)) })
 }
 
 func TestGauge_DataPoints(t *testing.T) {

--- a/pdata/pmetric/generated_histogram.go
+++ b/pdata/pmetric/generated_histogram.go
@@ -32,7 +32,7 @@ func newHistogram(orig *otlpmetrics.Histogram, state *internal.State) Histogram 
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewHistogram() Histogram {
-	return newHistogram(internal.NewOrigPtrHistogram(), internal.NewState())
+	return newHistogram(internal.NewOrigHistogram(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_histogram_test.go
+++ b/pdata/pmetric/generated_histogram_test.go
@@ -25,8 +25,8 @@ func TestHistogram_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestHistogram(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newHistogram(internal.NewOrigPtrHistogram(), sharedState)) })
-	assert.Panics(t, func() { newHistogram(internal.NewOrigPtrHistogram(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newHistogram(internal.NewOrigHistogram(), sharedState)) })
+	assert.Panics(t, func() { newHistogram(internal.NewOrigHistogram(), sharedState).MoveTo(dest) })
 }
 
 func TestHistogram_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestHistogram_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newHistogram(internal.NewOrigPtrHistogram(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newHistogram(internal.NewOrigHistogram(), sharedState)) })
 }
 
 func TestHistogram_DataPoints(t *testing.T) {

--- a/pdata/pmetric/generated_histogramdatapoint.go
+++ b/pdata/pmetric/generated_histogramdatapoint.go
@@ -33,7 +33,7 @@ func newHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint, state *internal
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewHistogramDataPoint() HistogramDataPoint {
-	return newHistogramDataPoint(internal.NewOrigPtrHistogramDataPoint(), internal.NewState())
+	return newHistogramDataPoint(internal.NewOrigHistogramDataPoint(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_histogramdatapoint_test.go
+++ b/pdata/pmetric/generated_histogramdatapoint_test.go
@@ -26,8 +26,8 @@ func TestHistogramDataPoint_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestHistogramDataPoint(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newHistogramDataPoint(internal.NewOrigPtrHistogramDataPoint(), sharedState)) })
-	assert.Panics(t, func() { newHistogramDataPoint(internal.NewOrigPtrHistogramDataPoint(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newHistogramDataPoint(internal.NewOrigHistogramDataPoint(), sharedState)) })
+	assert.Panics(t, func() { newHistogramDataPoint(internal.NewOrigHistogramDataPoint(), sharedState).MoveTo(dest) })
 }
 
 func TestHistogramDataPoint_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestHistogramDataPoint_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newHistogramDataPoint(internal.NewOrigPtrHistogramDataPoint(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newHistogramDataPoint(internal.NewOrigHistogramDataPoint(), sharedState)) })
 }
 
 func TestHistogramDataPoint_Attributes(t *testing.T) {

--- a/pdata/pmetric/generated_histogramdatapointslice.go
+++ b/pdata/pmetric/generated_histogramdatapointslice.go
@@ -99,7 +99,7 @@ func (es HistogramDataPointSlice) EnsureCapacity(newCap int) {
 // It returns the newly added HistogramDataPoint.
 func (es HistogramDataPointSlice) AppendEmpty() HistogramDataPoint {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrHistogramDataPoint())
+	*es.orig = append(*es.orig, internal.NewOrigHistogramDataPoint())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pmetric/generated_metric.go
+++ b/pdata/pmetric/generated_metric.go
@@ -34,7 +34,7 @@ func newMetric(orig *otlpmetrics.Metric, state *internal.State) Metric {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewMetric() Metric {
-	return newMetric(internal.NewOrigPtrMetric(), internal.NewState())
+	return newMetric(internal.NewOrigMetric(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_metric_test.go
+++ b/pdata/pmetric/generated_metric_test.go
@@ -26,8 +26,8 @@ func TestMetric_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestMetric(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newMetric(internal.NewOrigPtrMetric(), sharedState)) })
-	assert.Panics(t, func() { newMetric(internal.NewOrigPtrMetric(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newMetric(internal.NewOrigMetric(), sharedState)) })
+	assert.Panics(t, func() { newMetric(internal.NewOrigMetric(), sharedState).MoveTo(dest) })
 }
 
 func TestMetric_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestMetric_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newMetric(internal.NewOrigPtrMetric(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newMetric(internal.NewOrigMetric(), sharedState)) })
 }
 
 func TestMetric_Name(t *testing.T) {

--- a/pdata/pmetric/generated_metrics.go
+++ b/pdata/pmetric/generated_metrics.go
@@ -30,7 +30,7 @@ func newMetrics(orig *otlpcollectormetrics.ExportMetricsServiceRequest, state *i
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewMetrics() Metrics {
-	return newMetrics(internal.NewOrigPtrExportMetricsServiceRequest(), internal.NewState())
+	return newMetrics(internal.NewOrigExportMetricsServiceRequest(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_metrics_test.go
+++ b/pdata/pmetric/generated_metrics_test.go
@@ -24,8 +24,8 @@ func TestMetrics_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestMetrics(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newMetrics(internal.NewOrigPtrExportMetricsServiceRequest(), sharedState)) })
-	assert.Panics(t, func() { newMetrics(internal.NewOrigPtrExportMetricsServiceRequest(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newMetrics(internal.NewOrigExportMetricsServiceRequest(), sharedState)) })
+	assert.Panics(t, func() { newMetrics(internal.NewOrigExportMetricsServiceRequest(), sharedState).MoveTo(dest) })
 }
 
 func TestMetrics_CopyTo(t *testing.T) {
@@ -38,7 +38,7 @@ func TestMetrics_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newMetrics(internal.NewOrigPtrExportMetricsServiceRequest(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newMetrics(internal.NewOrigExportMetricsServiceRequest(), sharedState)) })
 }
 
 func TestMetrics_ResourceMetrics(t *testing.T) {

--- a/pdata/pmetric/generated_metricslice.go
+++ b/pdata/pmetric/generated_metricslice.go
@@ -99,7 +99,7 @@ func (es MetricSlice) EnsureCapacity(newCap int) {
 // It returns the newly added Metric.
 func (es MetricSlice) AppendEmpty() Metric {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrMetric())
+	*es.orig = append(*es.orig, internal.NewOrigMetric())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pmetric/generated_numberdatapoint.go
+++ b/pdata/pmetric/generated_numberdatapoint.go
@@ -33,7 +33,7 @@ func newNumberDataPoint(orig *otlpmetrics.NumberDataPoint, state *internal.State
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewNumberDataPoint() NumberDataPoint {
-	return newNumberDataPoint(internal.NewOrigPtrNumberDataPoint(), internal.NewState())
+	return newNumberDataPoint(internal.NewOrigNumberDataPoint(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_numberdatapoint_test.go
+++ b/pdata/pmetric/generated_numberdatapoint_test.go
@@ -26,8 +26,8 @@ func TestNumberDataPoint_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestNumberDataPoint(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newNumberDataPoint(internal.NewOrigPtrNumberDataPoint(), sharedState)) })
-	assert.Panics(t, func() { newNumberDataPoint(internal.NewOrigPtrNumberDataPoint(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newNumberDataPoint(internal.NewOrigNumberDataPoint(), sharedState)) })
+	assert.Panics(t, func() { newNumberDataPoint(internal.NewOrigNumberDataPoint(), sharedState).MoveTo(dest) })
 }
 
 func TestNumberDataPoint_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestNumberDataPoint_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newNumberDataPoint(internal.NewOrigPtrNumberDataPoint(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newNumberDataPoint(internal.NewOrigNumberDataPoint(), sharedState)) })
 }
 
 func TestNumberDataPoint_Attributes(t *testing.T) {

--- a/pdata/pmetric/generated_numberdatapointslice.go
+++ b/pdata/pmetric/generated_numberdatapointslice.go
@@ -99,7 +99,7 @@ func (es NumberDataPointSlice) EnsureCapacity(newCap int) {
 // It returns the newly added NumberDataPoint.
 func (es NumberDataPointSlice) AppendEmpty() NumberDataPoint {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrNumberDataPoint())
+	*es.orig = append(*es.orig, internal.NewOrigNumberDataPoint())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pmetric/generated_resourcemetrics.go
+++ b/pdata/pmetric/generated_resourcemetrics.go
@@ -33,7 +33,7 @@ func newResourceMetrics(orig *otlpmetrics.ResourceMetrics, state *internal.State
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResourceMetrics() ResourceMetrics {
-	return newResourceMetrics(internal.NewOrigPtrResourceMetrics(), internal.NewState())
+	return newResourceMetrics(internal.NewOrigResourceMetrics(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_resourcemetrics_test.go
+++ b/pdata/pmetric/generated_resourcemetrics_test.go
@@ -26,8 +26,8 @@ func TestResourceMetrics_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResourceMetrics(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newResourceMetrics(internal.NewOrigPtrResourceMetrics(), sharedState)) })
-	assert.Panics(t, func() { newResourceMetrics(internal.NewOrigPtrResourceMetrics(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newResourceMetrics(internal.NewOrigResourceMetrics(), sharedState)) })
+	assert.Panics(t, func() { newResourceMetrics(internal.NewOrigResourceMetrics(), sharedState).MoveTo(dest) })
 }
 
 func TestResourceMetrics_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestResourceMetrics_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newResourceMetrics(internal.NewOrigPtrResourceMetrics(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newResourceMetrics(internal.NewOrigResourceMetrics(), sharedState)) })
 }
 
 func TestResourceMetrics_Resource(t *testing.T) {

--- a/pdata/pmetric/generated_resourcemetricsslice.go
+++ b/pdata/pmetric/generated_resourcemetricsslice.go
@@ -99,7 +99,7 @@ func (es ResourceMetricsSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ResourceMetrics.
 func (es ResourceMetricsSlice) AppendEmpty() ResourceMetrics {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrResourceMetrics())
+	*es.orig = append(*es.orig, internal.NewOrigResourceMetrics())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pmetric/generated_scopemetrics.go
+++ b/pdata/pmetric/generated_scopemetrics.go
@@ -33,7 +33,7 @@ func newScopeMetrics(orig *otlpmetrics.ScopeMetrics, state *internal.State) Scop
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewScopeMetrics() ScopeMetrics {
-	return newScopeMetrics(internal.NewOrigPtrScopeMetrics(), internal.NewState())
+	return newScopeMetrics(internal.NewOrigScopeMetrics(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_scopemetrics_test.go
+++ b/pdata/pmetric/generated_scopemetrics_test.go
@@ -26,8 +26,8 @@ func TestScopeMetrics_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestScopeMetrics(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newScopeMetrics(internal.NewOrigPtrScopeMetrics(), sharedState)) })
-	assert.Panics(t, func() { newScopeMetrics(internal.NewOrigPtrScopeMetrics(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newScopeMetrics(internal.NewOrigScopeMetrics(), sharedState)) })
+	assert.Panics(t, func() { newScopeMetrics(internal.NewOrigScopeMetrics(), sharedState).MoveTo(dest) })
 }
 
 func TestScopeMetrics_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestScopeMetrics_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newScopeMetrics(internal.NewOrigPtrScopeMetrics(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newScopeMetrics(internal.NewOrigScopeMetrics(), sharedState)) })
 }
 
 func TestScopeMetrics_Scope(t *testing.T) {

--- a/pdata/pmetric/generated_scopemetricsslice.go
+++ b/pdata/pmetric/generated_scopemetricsslice.go
@@ -99,7 +99,7 @@ func (es ScopeMetricsSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ScopeMetrics.
 func (es ScopeMetricsSlice) AppendEmpty() ScopeMetrics {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrScopeMetrics())
+	*es.orig = append(*es.orig, internal.NewOrigScopeMetrics())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pmetric/generated_sum.go
+++ b/pdata/pmetric/generated_sum.go
@@ -32,7 +32,7 @@ func newSum(orig *otlpmetrics.Sum, state *internal.State) Sum {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSum() Sum {
-	return newSum(internal.NewOrigPtrSum(), internal.NewState())
+	return newSum(internal.NewOrigSum(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_sum_test.go
+++ b/pdata/pmetric/generated_sum_test.go
@@ -25,8 +25,8 @@ func TestSum_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSum(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newSum(internal.NewOrigPtrSum(), sharedState)) })
-	assert.Panics(t, func() { newSum(internal.NewOrigPtrSum(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newSum(internal.NewOrigSum(), sharedState)) })
+	assert.Panics(t, func() { newSum(internal.NewOrigSum(), sharedState).MoveTo(dest) })
 }
 
 func TestSum_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestSum_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newSum(internal.NewOrigPtrSum(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newSum(internal.NewOrigSum(), sharedState)) })
 }
 
 func TestSum_DataPoints(t *testing.T) {

--- a/pdata/pmetric/generated_summary.go
+++ b/pdata/pmetric/generated_summary.go
@@ -32,7 +32,7 @@ func newSummary(orig *otlpmetrics.Summary, state *internal.State) Summary {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSummary() Summary {
-	return newSummary(internal.NewOrigPtrSummary(), internal.NewState())
+	return newSummary(internal.NewOrigSummary(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_summary_test.go
+++ b/pdata/pmetric/generated_summary_test.go
@@ -24,8 +24,8 @@ func TestSummary_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSummary(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newSummary(internal.NewOrigPtrSummary(), sharedState)) })
-	assert.Panics(t, func() { newSummary(internal.NewOrigPtrSummary(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newSummary(internal.NewOrigSummary(), sharedState)) })
+	assert.Panics(t, func() { newSummary(internal.NewOrigSummary(), sharedState).MoveTo(dest) })
 }
 
 func TestSummary_CopyTo(t *testing.T) {
@@ -38,7 +38,7 @@ func TestSummary_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newSummary(internal.NewOrigPtrSummary(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newSummary(internal.NewOrigSummary(), sharedState)) })
 }
 
 func TestSummary_DataPoints(t *testing.T) {

--- a/pdata/pmetric/generated_summarydatapoint.go
+++ b/pdata/pmetric/generated_summarydatapoint.go
@@ -33,7 +33,7 @@ func newSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint, state *internal.Sta
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSummaryDataPoint() SummaryDataPoint {
-	return newSummaryDataPoint(internal.NewOrigPtrSummaryDataPoint(), internal.NewState())
+	return newSummaryDataPoint(internal.NewOrigSummaryDataPoint(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_summarydatapoint_test.go
+++ b/pdata/pmetric/generated_summarydatapoint_test.go
@@ -26,8 +26,8 @@ func TestSummaryDataPoint_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSummaryDataPoint(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newSummaryDataPoint(internal.NewOrigPtrSummaryDataPoint(), sharedState)) })
-	assert.Panics(t, func() { newSummaryDataPoint(internal.NewOrigPtrSummaryDataPoint(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newSummaryDataPoint(internal.NewOrigSummaryDataPoint(), sharedState)) })
+	assert.Panics(t, func() { newSummaryDataPoint(internal.NewOrigSummaryDataPoint(), sharedState).MoveTo(dest) })
 }
 
 func TestSummaryDataPoint_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestSummaryDataPoint_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newSummaryDataPoint(internal.NewOrigPtrSummaryDataPoint(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newSummaryDataPoint(internal.NewOrigSummaryDataPoint(), sharedState)) })
 }
 
 func TestSummaryDataPoint_Attributes(t *testing.T) {

--- a/pdata/pmetric/generated_summarydatapointslice.go
+++ b/pdata/pmetric/generated_summarydatapointslice.go
@@ -99,7 +99,7 @@ func (es SummaryDataPointSlice) EnsureCapacity(newCap int) {
 // It returns the newly added SummaryDataPoint.
 func (es SummaryDataPointSlice) AppendEmpty() SummaryDataPoint {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrSummaryDataPoint())
+	*es.orig = append(*es.orig, internal.NewOrigSummaryDataPoint())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pmetric/generated_summarydatapointvalueatquantile.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantile.go
@@ -32,7 +32,7 @@ func newSummaryDataPointValueAtQuantile(orig *otlpmetrics.SummaryDataPoint_Value
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSummaryDataPointValueAtQuantile() SummaryDataPointValueAtQuantile {
-	return newSummaryDataPointValueAtQuantile(internal.NewOrigPtrSummaryDataPoint_ValueAtQuantile(), internal.NewState())
+	return newSummaryDataPointValueAtQuantile(internal.NewOrigSummaryDataPoint_ValueAtQuantile(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/generated_summarydatapointvalueatquantile_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantile_test.go
@@ -26,10 +26,10 @@ func TestSummaryDataPointValueAtQuantile_MoveTo(t *testing.T) {
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newSummaryDataPointValueAtQuantile(internal.NewOrigPtrSummaryDataPoint_ValueAtQuantile(), sharedState))
+		ms.MoveTo(newSummaryDataPointValueAtQuantile(internal.NewOrigSummaryDataPoint_ValueAtQuantile(), sharedState))
 	})
 	assert.Panics(t, func() {
-		newSummaryDataPointValueAtQuantile(internal.NewOrigPtrSummaryDataPoint_ValueAtQuantile(), sharedState).MoveTo(dest)
+		newSummaryDataPointValueAtQuantile(internal.NewOrigSummaryDataPoint_ValueAtQuantile(), sharedState).MoveTo(dest)
 	})
 }
 
@@ -44,7 +44,7 @@ func TestSummaryDataPointValueAtQuantile_CopyTo(t *testing.T) {
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newSummaryDataPointValueAtQuantile(internal.NewOrigPtrSummaryDataPoint_ValueAtQuantile(), sharedState))
+		ms.CopyTo(newSummaryDataPointValueAtQuantile(internal.NewOrigSummaryDataPoint_ValueAtQuantile(), sharedState))
 	})
 }
 

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
@@ -99,7 +99,7 @@ func (es SummaryDataPointValueAtQuantileSlice) EnsureCapacity(newCap int) {
 // It returns the newly added SummaryDataPointValueAtQuantile.
 func (es SummaryDataPointValueAtQuantileSlice) AppendEmpty() SummaryDataPointValueAtQuantile {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrSummaryDataPoint_ValueAtQuantile())
+	*es.orig = append(*es.orig, internal.NewOrigSummaryDataPoint_ValueAtQuantile())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess.go
@@ -32,7 +32,7 @@ func newExportPartialSuccess(orig *otlpcollectormetrics.ExportMetricsPartialSucc
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportPartialSuccess() ExportPartialSuccess {
-	return newExportPartialSuccess(internal.NewOrigPtrExportMetricsPartialSuccess(), internal.NewState())
+	return newExportPartialSuccess(internal.NewOrigExportMetricsPartialSuccess(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess_test.go
@@ -25,11 +25,9 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { ms.MoveTo(newExportPartialSuccess(internal.NewOrigExportMetricsPartialSuccess(), sharedState)) })
 	assert.Panics(t, func() {
-		ms.MoveTo(newExportPartialSuccess(internal.NewOrigPtrExportMetricsPartialSuccess(), sharedState))
-	})
-	assert.Panics(t, func() {
-		newExportPartialSuccess(internal.NewOrigPtrExportMetricsPartialSuccess(), sharedState).MoveTo(dest)
+		newExportPartialSuccess(internal.NewOrigExportMetricsPartialSuccess(), sharedState).MoveTo(dest)
 	})
 }
 
@@ -43,9 +41,7 @@ func TestExportPartialSuccess_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() {
-		ms.CopyTo(newExportPartialSuccess(internal.NewOrigPtrExportMetricsPartialSuccess(), sharedState))
-	})
+	assert.Panics(t, func() { ms.CopyTo(newExportPartialSuccess(internal.NewOrigExportMetricsPartialSuccess(), sharedState)) })
 }
 
 func TestExportPartialSuccess_RejectedDataPoints(t *testing.T) {

--- a/pdata/pmetric/pmetricotlp/generated_exportresponse.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportresponse.go
@@ -32,7 +32,7 @@ func newExportResponse(orig *otlpcollectormetrics.ExportMetricsServiceResponse, 
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportResponse() ExportResponse {
-	return newExportResponse(internal.NewOrigPtrExportMetricsServiceResponse(), internal.NewState())
+	return newExportResponse(internal.NewOrigExportMetricsServiceResponse(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pmetric/pmetricotlp/generated_exportresponse_test.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportresponse_test.go
@@ -24,8 +24,8 @@ func TestExportResponse_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportResponse(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newExportResponse(internal.NewOrigPtrExportMetricsServiceResponse(), sharedState)) })
-	assert.Panics(t, func() { newExportResponse(internal.NewOrigPtrExportMetricsServiceResponse(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newExportResponse(internal.NewOrigExportMetricsServiceResponse(), sharedState)) })
+	assert.Panics(t, func() { newExportResponse(internal.NewOrigExportMetricsServiceResponse(), sharedState).MoveTo(dest) })
 }
 
 func TestExportResponse_CopyTo(t *testing.T) {
@@ -38,7 +38,7 @@ func TestExportResponse_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newExportResponse(internal.NewOrigPtrExportMetricsServiceResponse(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newExportResponse(internal.NewOrigExportMetricsServiceResponse(), sharedState)) })
 }
 
 func TestExportResponse_PartialSuccess(t *testing.T) {

--- a/pdata/pprofile/generated_attribute.go
+++ b/pdata/pprofile/generated_attribute.go
@@ -33,7 +33,7 @@ func newAttribute(orig *otlpcommon.KeyValue, state *internal.State) Attribute {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewAttribute() Attribute {
-	return newAttribute(internal.NewOrigPtrKeyValue(), internal.NewState())
+	return newAttribute(internal.NewOrigKeyValue(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_attribute_test.go
+++ b/pdata/pprofile/generated_attribute_test.go
@@ -26,8 +26,8 @@ func TestAttribute_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestAttribute(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newAttribute(internal.NewOrigPtrKeyValue(), sharedState)) })
-	assert.Panics(t, func() { newAttribute(internal.NewOrigPtrKeyValue(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newAttribute(internal.NewOrigKeyValue(), sharedState)) })
+	assert.Panics(t, func() { newAttribute(internal.NewOrigKeyValue(), sharedState).MoveTo(dest) })
 }
 
 func TestAttribute_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestAttribute_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newAttribute(internal.NewOrigPtrKeyValue(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newAttribute(internal.NewOrigKeyValue(), sharedState)) })
 }
 
 func TestAttribute_Key(t *testing.T) {

--- a/pdata/pprofile/generated_attributeunit.go
+++ b/pdata/pprofile/generated_attributeunit.go
@@ -32,7 +32,7 @@ func newAttributeUnit(orig *otlpprofiles.AttributeUnit, state *internal.State) A
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewAttributeUnit() AttributeUnit {
-	return newAttributeUnit(internal.NewOrigPtrAttributeUnit(), internal.NewState())
+	return newAttributeUnit(internal.NewOrigAttributeUnit(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_attributeunit_test.go
+++ b/pdata/pprofile/generated_attributeunit_test.go
@@ -25,8 +25,8 @@ func TestAttributeUnit_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestAttributeUnit(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newAttributeUnit(internal.NewOrigPtrAttributeUnit(), sharedState)) })
-	assert.Panics(t, func() { newAttributeUnit(internal.NewOrigPtrAttributeUnit(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newAttributeUnit(internal.NewOrigAttributeUnit(), sharedState)) })
+	assert.Panics(t, func() { newAttributeUnit(internal.NewOrigAttributeUnit(), sharedState).MoveTo(dest) })
 }
 
 func TestAttributeUnit_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestAttributeUnit_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newAttributeUnit(internal.NewOrigPtrAttributeUnit(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newAttributeUnit(internal.NewOrigAttributeUnit(), sharedState)) })
 }
 
 func TestAttributeUnit_AttributeKeyStrindex(t *testing.T) {

--- a/pdata/pprofile/generated_attributeunitslice.go
+++ b/pdata/pprofile/generated_attributeunitslice.go
@@ -99,7 +99,7 @@ func (es AttributeUnitSlice) EnsureCapacity(newCap int) {
 // It returns the newly added AttributeUnit.
 func (es AttributeUnitSlice) AppendEmpty() AttributeUnit {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrAttributeUnit())
+	*es.orig = append(*es.orig, internal.NewOrigAttributeUnit())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_function.go
+++ b/pdata/pprofile/generated_function.go
@@ -32,7 +32,7 @@ func newFunction(orig *otlpprofiles.Function, state *internal.State) Function {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewFunction() Function {
-	return newFunction(internal.NewOrigPtrFunction(), internal.NewState())
+	return newFunction(internal.NewOrigFunction(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_function_test.go
+++ b/pdata/pprofile/generated_function_test.go
@@ -25,8 +25,8 @@ func TestFunction_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestFunction(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newFunction(internal.NewOrigPtrFunction(), sharedState)) })
-	assert.Panics(t, func() { newFunction(internal.NewOrigPtrFunction(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newFunction(internal.NewOrigFunction(), sharedState)) })
+	assert.Panics(t, func() { newFunction(internal.NewOrigFunction(), sharedState).MoveTo(dest) })
 }
 
 func TestFunction_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestFunction_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newFunction(internal.NewOrigPtrFunction(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newFunction(internal.NewOrigFunction(), sharedState)) })
 }
 
 func TestFunction_NameStrindex(t *testing.T) {

--- a/pdata/pprofile/generated_functionslice.go
+++ b/pdata/pprofile/generated_functionslice.go
@@ -99,7 +99,7 @@ func (es FunctionSlice) EnsureCapacity(newCap int) {
 // It returns the newly added Function.
 func (es FunctionSlice) AppendEmpty() Function {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrFunction())
+	*es.orig = append(*es.orig, internal.NewOrigFunction())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_line.go
+++ b/pdata/pprofile/generated_line.go
@@ -32,7 +32,7 @@ func newLine(orig *otlpprofiles.Line, state *internal.State) Line {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLine() Line {
-	return newLine(internal.NewOrigPtrLine(), internal.NewState())
+	return newLine(internal.NewOrigLine(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_line_test.go
+++ b/pdata/pprofile/generated_line_test.go
@@ -25,8 +25,8 @@ func TestLine_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLine(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newLine(internal.NewOrigPtrLine(), sharedState)) })
-	assert.Panics(t, func() { newLine(internal.NewOrigPtrLine(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newLine(internal.NewOrigLine(), sharedState)) })
+	assert.Panics(t, func() { newLine(internal.NewOrigLine(), sharedState).MoveTo(dest) })
 }
 
 func TestLine_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestLine_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newLine(internal.NewOrigPtrLine(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newLine(internal.NewOrigLine(), sharedState)) })
 }
 
 func TestLine_FunctionIndex(t *testing.T) {

--- a/pdata/pprofile/generated_lineslice.go
+++ b/pdata/pprofile/generated_lineslice.go
@@ -99,7 +99,7 @@ func (es LineSlice) EnsureCapacity(newCap int) {
 // It returns the newly added Line.
 func (es LineSlice) AppendEmpty() Line {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrLine())
+	*es.orig = append(*es.orig, internal.NewOrigLine())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_link.go
+++ b/pdata/pprofile/generated_link.go
@@ -34,7 +34,7 @@ func newLink(orig *otlpprofiles.Link, state *internal.State) Link {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLink() Link {
-	return newLink(internal.NewOrigPtrLink(), internal.NewState())
+	return newLink(internal.NewOrigLink(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_link_test.go
+++ b/pdata/pprofile/generated_link_test.go
@@ -26,8 +26,8 @@ func TestLink_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLink(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newLink(internal.NewOrigPtrLink(), sharedState)) })
-	assert.Panics(t, func() { newLink(internal.NewOrigPtrLink(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newLink(internal.NewOrigLink(), sharedState)) })
+	assert.Panics(t, func() { newLink(internal.NewOrigLink(), sharedState).MoveTo(dest) })
 }
 
 func TestLink_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestLink_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newLink(internal.NewOrigPtrLink(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newLink(internal.NewOrigLink(), sharedState)) })
 }
 
 func TestLink_TraceID(t *testing.T) {

--- a/pdata/pprofile/generated_linkslice.go
+++ b/pdata/pprofile/generated_linkslice.go
@@ -99,7 +99,7 @@ func (es LinkSlice) EnsureCapacity(newCap int) {
 // It returns the newly added Link.
 func (es LinkSlice) AppendEmpty() Link {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrLink())
+	*es.orig = append(*es.orig, internal.NewOrigLink())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_location.go
+++ b/pdata/pprofile/generated_location.go
@@ -33,7 +33,7 @@ func newLocation(orig *otlpprofiles.Location, state *internal.State) Location {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewLocation() Location {
-	return newLocation(internal.NewOrigPtrLocation(), internal.NewState())
+	return newLocation(internal.NewOrigLocation(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_location_test.go
+++ b/pdata/pprofile/generated_location_test.go
@@ -26,8 +26,8 @@ func TestLocation_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestLocation(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newLocation(internal.NewOrigPtrLocation(), sharedState)) })
-	assert.Panics(t, func() { newLocation(internal.NewOrigPtrLocation(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newLocation(internal.NewOrigLocation(), sharedState)) })
+	assert.Panics(t, func() { newLocation(internal.NewOrigLocation(), sharedState).MoveTo(dest) })
 }
 
 func TestLocation_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestLocation_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newLocation(internal.NewOrigPtrLocation(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newLocation(internal.NewOrigLocation(), sharedState)) })
 }
 
 func TestLocation_MappingIndex(t *testing.T) {

--- a/pdata/pprofile/generated_locationslice.go
+++ b/pdata/pprofile/generated_locationslice.go
@@ -99,7 +99,7 @@ func (es LocationSlice) EnsureCapacity(newCap int) {
 // It returns the newly added Location.
 func (es LocationSlice) AppendEmpty() Location {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrLocation())
+	*es.orig = append(*es.orig, internal.NewOrigLocation())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_mapping.go
+++ b/pdata/pprofile/generated_mapping.go
@@ -33,7 +33,7 @@ func newMapping(orig *otlpprofiles.Mapping, state *internal.State) Mapping {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewMapping() Mapping {
-	return newMapping(internal.NewOrigPtrMapping(), internal.NewState())
+	return newMapping(internal.NewOrigMapping(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_mapping_test.go
+++ b/pdata/pprofile/generated_mapping_test.go
@@ -26,8 +26,8 @@ func TestMapping_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestMapping(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newMapping(internal.NewOrigPtrMapping(), sharedState)) })
-	assert.Panics(t, func() { newMapping(internal.NewOrigPtrMapping(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newMapping(internal.NewOrigMapping(), sharedState)) })
+	assert.Panics(t, func() { newMapping(internal.NewOrigMapping(), sharedState).MoveTo(dest) })
 }
 
 func TestMapping_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestMapping_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newMapping(internal.NewOrigPtrMapping(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newMapping(internal.NewOrigMapping(), sharedState)) })
 }
 
 func TestMapping_MemoryStart(t *testing.T) {

--- a/pdata/pprofile/generated_mappingslice.go
+++ b/pdata/pprofile/generated_mappingslice.go
@@ -99,7 +99,7 @@ func (es MappingSlice) EnsureCapacity(newCap int) {
 // It returns the newly added Mapping.
 func (es MappingSlice) AppendEmpty() Mapping {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrMapping())
+	*es.orig = append(*es.orig, internal.NewOrigMapping())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_profile.go
+++ b/pdata/pprofile/generated_profile.go
@@ -34,7 +34,7 @@ func newProfile(orig *otlpprofiles.Profile, state *internal.State) Profile {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewProfile() Profile {
-	return newProfile(internal.NewOrigPtrProfile(), internal.NewState())
+	return newProfile(internal.NewOrigProfile(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_profile_test.go
+++ b/pdata/pprofile/generated_profile_test.go
@@ -27,8 +27,8 @@ func TestProfile_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestProfile(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newProfile(internal.NewOrigPtrProfile(), sharedState)) })
-	assert.Panics(t, func() { newProfile(internal.NewOrigPtrProfile(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newProfile(internal.NewOrigProfile(), sharedState)) })
+	assert.Panics(t, func() { newProfile(internal.NewOrigProfile(), sharedState).MoveTo(dest) })
 }
 
 func TestProfile_CopyTo(t *testing.T) {
@@ -41,7 +41,7 @@ func TestProfile_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newProfile(internal.NewOrigPtrProfile(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newProfile(internal.NewOrigProfile(), sharedState)) })
 }
 
 func TestProfile_SampleType(t *testing.T) {

--- a/pdata/pprofile/generated_profiles.go
+++ b/pdata/pprofile/generated_profiles.go
@@ -30,7 +30,7 @@ func newProfiles(orig *otlpcollectorprofiles.ExportProfilesServiceRequest, state
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewProfiles() Profiles {
-	return newProfiles(internal.NewOrigPtrExportProfilesServiceRequest(), internal.NewState())
+	return newProfiles(internal.NewOrigExportProfilesServiceRequest(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_profiles_test.go
+++ b/pdata/pprofile/generated_profiles_test.go
@@ -24,8 +24,8 @@ func TestProfiles_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestProfiles(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newProfiles(internal.NewOrigPtrExportProfilesServiceRequest(), sharedState)) })
-	assert.Panics(t, func() { newProfiles(internal.NewOrigPtrExportProfilesServiceRequest(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newProfiles(internal.NewOrigExportProfilesServiceRequest(), sharedState)) })
+	assert.Panics(t, func() { newProfiles(internal.NewOrigExportProfilesServiceRequest(), sharedState).MoveTo(dest) })
 }
 
 func TestProfiles_CopyTo(t *testing.T) {
@@ -38,7 +38,7 @@ func TestProfiles_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newProfiles(internal.NewOrigPtrExportProfilesServiceRequest(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newProfiles(internal.NewOrigExportProfilesServiceRequest(), sharedState)) })
 }
 
 func TestProfiles_ResourceProfiles(t *testing.T) {

--- a/pdata/pprofile/generated_profilesdictionary.go
+++ b/pdata/pprofile/generated_profilesdictionary.go
@@ -33,7 +33,7 @@ func newProfilesDictionary(orig *otlpprofiles.ProfilesDictionary, state *interna
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewProfilesDictionary() ProfilesDictionary {
-	return newProfilesDictionary(internal.NewOrigPtrProfilesDictionary(), internal.NewState())
+	return newProfilesDictionary(internal.NewOrigProfilesDictionary(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_profilesdictionary_test.go
+++ b/pdata/pprofile/generated_profilesdictionary_test.go
@@ -25,8 +25,8 @@ func TestProfilesDictionary_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestProfilesDictionary(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newProfilesDictionary(internal.NewOrigPtrProfilesDictionary(), sharedState)) })
-	assert.Panics(t, func() { newProfilesDictionary(internal.NewOrigPtrProfilesDictionary(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newProfilesDictionary(internal.NewOrigProfilesDictionary(), sharedState)) })
+	assert.Panics(t, func() { newProfilesDictionary(internal.NewOrigProfilesDictionary(), sharedState).MoveTo(dest) })
 }
 
 func TestProfilesDictionary_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestProfilesDictionary_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newProfilesDictionary(internal.NewOrigPtrProfilesDictionary(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newProfilesDictionary(internal.NewOrigProfilesDictionary(), sharedState)) })
 }
 
 func TestProfilesDictionary_MappingTable(t *testing.T) {

--- a/pdata/pprofile/generated_profilesslice.go
+++ b/pdata/pprofile/generated_profilesslice.go
@@ -99,7 +99,7 @@ func (es ProfilesSlice) EnsureCapacity(newCap int) {
 // It returns the newly added Profile.
 func (es ProfilesSlice) AppendEmpty() Profile {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrProfile())
+	*es.orig = append(*es.orig, internal.NewOrigProfile())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_resourceprofiles.go
+++ b/pdata/pprofile/generated_resourceprofiles.go
@@ -33,7 +33,7 @@ func newResourceProfiles(orig *otlpprofiles.ResourceProfiles, state *internal.St
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResourceProfiles() ResourceProfiles {
-	return newResourceProfiles(internal.NewOrigPtrResourceProfiles(), internal.NewState())
+	return newResourceProfiles(internal.NewOrigResourceProfiles(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_resourceprofiles_test.go
+++ b/pdata/pprofile/generated_resourceprofiles_test.go
@@ -26,8 +26,8 @@ func TestResourceProfiles_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResourceProfiles(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newResourceProfiles(internal.NewOrigPtrResourceProfiles(), sharedState)) })
-	assert.Panics(t, func() { newResourceProfiles(internal.NewOrigPtrResourceProfiles(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newResourceProfiles(internal.NewOrigResourceProfiles(), sharedState)) })
+	assert.Panics(t, func() { newResourceProfiles(internal.NewOrigResourceProfiles(), sharedState).MoveTo(dest) })
 }
 
 func TestResourceProfiles_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestResourceProfiles_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newResourceProfiles(internal.NewOrigPtrResourceProfiles(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newResourceProfiles(internal.NewOrigResourceProfiles(), sharedState)) })
 }
 
 func TestResourceProfiles_Resource(t *testing.T) {

--- a/pdata/pprofile/generated_resourceprofilesslice.go
+++ b/pdata/pprofile/generated_resourceprofilesslice.go
@@ -99,7 +99,7 @@ func (es ResourceProfilesSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ResourceProfiles.
 func (es ResourceProfilesSlice) AppendEmpty() ResourceProfiles {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrResourceProfiles())
+	*es.orig = append(*es.orig, internal.NewOrigResourceProfiles())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_sample.go
+++ b/pdata/pprofile/generated_sample.go
@@ -33,7 +33,7 @@ func newSample(orig *otlpprofiles.Sample, state *internal.State) Sample {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSample() Sample {
-	return newSample(internal.NewOrigPtrSample(), internal.NewState())
+	return newSample(internal.NewOrigSample(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_sample_test.go
+++ b/pdata/pprofile/generated_sample_test.go
@@ -26,8 +26,8 @@ func TestSample_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSample(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newSample(internal.NewOrigPtrSample(), sharedState)) })
-	assert.Panics(t, func() { newSample(internal.NewOrigPtrSample(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newSample(internal.NewOrigSample(), sharedState)) })
+	assert.Panics(t, func() { newSample(internal.NewOrigSample(), sharedState).MoveTo(dest) })
 }
 
 func TestSample_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestSample_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newSample(internal.NewOrigPtrSample(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newSample(internal.NewOrigSample(), sharedState)) })
 }
 
 func TestSample_LocationsStartIndex(t *testing.T) {

--- a/pdata/pprofile/generated_sampleslice.go
+++ b/pdata/pprofile/generated_sampleslice.go
@@ -99,7 +99,7 @@ func (es SampleSlice) EnsureCapacity(newCap int) {
 // It returns the newly added Sample.
 func (es SampleSlice) AppendEmpty() Sample {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrSample())
+	*es.orig = append(*es.orig, internal.NewOrigSample())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_scopeprofiles.go
+++ b/pdata/pprofile/generated_scopeprofiles.go
@@ -33,7 +33,7 @@ func newScopeProfiles(orig *otlpprofiles.ScopeProfiles, state *internal.State) S
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewScopeProfiles() ScopeProfiles {
-	return newScopeProfiles(internal.NewOrigPtrScopeProfiles(), internal.NewState())
+	return newScopeProfiles(internal.NewOrigScopeProfiles(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_scopeprofiles_test.go
+++ b/pdata/pprofile/generated_scopeprofiles_test.go
@@ -26,8 +26,8 @@ func TestScopeProfiles_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestScopeProfiles(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newScopeProfiles(internal.NewOrigPtrScopeProfiles(), sharedState)) })
-	assert.Panics(t, func() { newScopeProfiles(internal.NewOrigPtrScopeProfiles(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newScopeProfiles(internal.NewOrigScopeProfiles(), sharedState)) })
+	assert.Panics(t, func() { newScopeProfiles(internal.NewOrigScopeProfiles(), sharedState).MoveTo(dest) })
 }
 
 func TestScopeProfiles_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestScopeProfiles_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newScopeProfiles(internal.NewOrigPtrScopeProfiles(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newScopeProfiles(internal.NewOrigScopeProfiles(), sharedState)) })
 }
 
 func TestScopeProfiles_Scope(t *testing.T) {

--- a/pdata/pprofile/generated_scopeprofilesslice.go
+++ b/pdata/pprofile/generated_scopeprofilesslice.go
@@ -99,7 +99,7 @@ func (es ScopeProfilesSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ScopeProfiles.
 func (es ScopeProfilesSlice) AppendEmpty() ScopeProfiles {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrScopeProfiles())
+	*es.orig = append(*es.orig, internal.NewOrigScopeProfiles())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/generated_valuetype.go
+++ b/pdata/pprofile/generated_valuetype.go
@@ -32,7 +32,7 @@ func newValueType(orig *otlpprofiles.ValueType, state *internal.State) ValueType
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewValueType() ValueType {
-	return newValueType(internal.NewOrigPtrValueType(), internal.NewState())
+	return newValueType(internal.NewOrigValueType(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/generated_valuetype_test.go
+++ b/pdata/pprofile/generated_valuetype_test.go
@@ -25,8 +25,8 @@ func TestValueType_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestValueType(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newValueType(internal.NewOrigPtrValueType(), sharedState)) })
-	assert.Panics(t, func() { newValueType(internal.NewOrigPtrValueType(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newValueType(internal.NewOrigValueType(), sharedState)) })
+	assert.Panics(t, func() { newValueType(internal.NewOrigValueType(), sharedState).MoveTo(dest) })
 }
 
 func TestValueType_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestValueType_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newValueType(internal.NewOrigPtrValueType(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newValueType(internal.NewOrigValueType(), sharedState)) })
 }
 
 func TestValueType_TypeStrindex(t *testing.T) {

--- a/pdata/pprofile/generated_valuetypeslice.go
+++ b/pdata/pprofile/generated_valuetypeslice.go
@@ -99,7 +99,7 @@ func (es ValueTypeSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ValueType.
 func (es ValueTypeSlice) AppendEmpty() ValueType {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrValueType())
+	*es.orig = append(*es.orig, internal.NewOrigValueType())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess.go
@@ -32,7 +32,7 @@ func newExportPartialSuccess(orig *otlpcollectorprofiles.ExportProfilesPartialSu
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportPartialSuccess() ExportPartialSuccess {
-	return newExportPartialSuccess(internal.NewOrigPtrExportProfilesPartialSuccess(), internal.NewState())
+	return newExportPartialSuccess(internal.NewOrigExportProfilesPartialSuccess(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportpartialsuccess_test.go
@@ -26,10 +26,10 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.MoveTo(newExportPartialSuccess(internal.NewOrigPtrExportProfilesPartialSuccess(), sharedState))
+		ms.MoveTo(newExportPartialSuccess(internal.NewOrigExportProfilesPartialSuccess(), sharedState))
 	})
 	assert.Panics(t, func() {
-		newExportPartialSuccess(internal.NewOrigPtrExportProfilesPartialSuccess(), sharedState).MoveTo(dest)
+		newExportPartialSuccess(internal.NewOrigExportProfilesPartialSuccess(), sharedState).MoveTo(dest)
 	})
 }
 
@@ -44,7 +44,7 @@ func TestExportPartialSuccess_CopyTo(t *testing.T) {
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
 	assert.Panics(t, func() {
-		ms.CopyTo(newExportPartialSuccess(internal.NewOrigPtrExportProfilesPartialSuccess(), sharedState))
+		ms.CopyTo(newExportPartialSuccess(internal.NewOrigExportProfilesPartialSuccess(), sharedState))
 	})
 }
 

--- a/pdata/pprofile/pprofileotlp/generated_exportresponse.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportresponse.go
@@ -32,7 +32,7 @@ func newExportResponse(orig *otlpcollectorprofiles.ExportProfilesServiceResponse
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportResponse() ExportResponse {
-	return newExportResponse(internal.NewOrigPtrExportProfilesServiceResponse(), internal.NewState())
+	return newExportResponse(internal.NewOrigExportProfilesServiceResponse(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/pprofile/pprofileotlp/generated_exportresponse_test.go
+++ b/pdata/pprofile/pprofileotlp/generated_exportresponse_test.go
@@ -24,10 +24,8 @@ func TestExportResponse_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportResponse(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newExportResponse(internal.NewOrigPtrExportProfilesServiceResponse(), sharedState)) })
-	assert.Panics(t, func() {
-		newExportResponse(internal.NewOrigPtrExportProfilesServiceResponse(), sharedState).MoveTo(dest)
-	})
+	assert.Panics(t, func() { ms.MoveTo(newExportResponse(internal.NewOrigExportProfilesServiceResponse(), sharedState)) })
+	assert.Panics(t, func() { newExportResponse(internal.NewOrigExportProfilesServiceResponse(), sharedState).MoveTo(dest) })
 }
 
 func TestExportResponse_CopyTo(t *testing.T) {
@@ -40,7 +38,7 @@ func TestExportResponse_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newExportResponse(internal.NewOrigPtrExportProfilesServiceResponse(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newExportResponse(internal.NewOrigExportProfilesServiceResponse(), sharedState)) })
 }
 
 func TestExportResponse_PartialSuccess(t *testing.T) {

--- a/pdata/ptrace/generated_resourcespans.go
+++ b/pdata/ptrace/generated_resourcespans.go
@@ -33,7 +33,7 @@ func newResourceSpans(orig *otlptrace.ResourceSpans, state *internal.State) Reso
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewResourceSpans() ResourceSpans {
-	return newResourceSpans(internal.NewOrigPtrResourceSpans(), internal.NewState())
+	return newResourceSpans(internal.NewOrigResourceSpans(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_resourcespans_test.go
+++ b/pdata/ptrace/generated_resourcespans_test.go
@@ -26,8 +26,8 @@ func TestResourceSpans_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestResourceSpans(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newResourceSpans(internal.NewOrigPtrResourceSpans(), sharedState)) })
-	assert.Panics(t, func() { newResourceSpans(internal.NewOrigPtrResourceSpans(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newResourceSpans(internal.NewOrigResourceSpans(), sharedState)) })
+	assert.Panics(t, func() { newResourceSpans(internal.NewOrigResourceSpans(), sharedState).MoveTo(dest) })
 }
 
 func TestResourceSpans_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestResourceSpans_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newResourceSpans(internal.NewOrigPtrResourceSpans(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newResourceSpans(internal.NewOrigResourceSpans(), sharedState)) })
 }
 
 func TestResourceSpans_Resource(t *testing.T) {

--- a/pdata/ptrace/generated_resourcespansslice.go
+++ b/pdata/ptrace/generated_resourcespansslice.go
@@ -99,7 +99,7 @@ func (es ResourceSpansSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ResourceSpans.
 func (es ResourceSpansSlice) AppendEmpty() ResourceSpans {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrResourceSpans())
+	*es.orig = append(*es.orig, internal.NewOrigResourceSpans())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/ptrace/generated_scopespans.go
+++ b/pdata/ptrace/generated_scopespans.go
@@ -33,7 +33,7 @@ func newScopeSpans(orig *otlptrace.ScopeSpans, state *internal.State) ScopeSpans
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewScopeSpans() ScopeSpans {
-	return newScopeSpans(internal.NewOrigPtrScopeSpans(), internal.NewState())
+	return newScopeSpans(internal.NewOrigScopeSpans(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_scopespans_test.go
+++ b/pdata/ptrace/generated_scopespans_test.go
@@ -26,8 +26,8 @@ func TestScopeSpans_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestScopeSpans(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newScopeSpans(internal.NewOrigPtrScopeSpans(), sharedState)) })
-	assert.Panics(t, func() { newScopeSpans(internal.NewOrigPtrScopeSpans(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newScopeSpans(internal.NewOrigScopeSpans(), sharedState)) })
+	assert.Panics(t, func() { newScopeSpans(internal.NewOrigScopeSpans(), sharedState).MoveTo(dest) })
 }
 
 func TestScopeSpans_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestScopeSpans_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newScopeSpans(internal.NewOrigPtrScopeSpans(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newScopeSpans(internal.NewOrigScopeSpans(), sharedState)) })
 }
 
 func TestScopeSpans_Scope(t *testing.T) {

--- a/pdata/ptrace/generated_scopespansslice.go
+++ b/pdata/ptrace/generated_scopespansslice.go
@@ -99,7 +99,7 @@ func (es ScopeSpansSlice) EnsureCapacity(newCap int) {
 // It returns the newly added ScopeSpans.
 func (es ScopeSpansSlice) AppendEmpty() ScopeSpans {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrScopeSpans())
+	*es.orig = append(*es.orig, internal.NewOrigScopeSpans())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/ptrace/generated_span.go
+++ b/pdata/ptrace/generated_span.go
@@ -35,7 +35,7 @@ func newSpan(orig *otlptrace.Span, state *internal.State) Span {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSpan() Span {
-	return newSpan(internal.NewOrigPtrSpan(), internal.NewState())
+	return newSpan(internal.NewOrigSpan(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_span_test.go
+++ b/pdata/ptrace/generated_span_test.go
@@ -27,8 +27,8 @@ func TestSpan_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSpan(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newSpan(internal.NewOrigPtrSpan(), sharedState)) })
-	assert.Panics(t, func() { newSpan(internal.NewOrigPtrSpan(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newSpan(internal.NewOrigSpan(), sharedState)) })
+	assert.Panics(t, func() { newSpan(internal.NewOrigSpan(), sharedState).MoveTo(dest) })
 }
 
 func TestSpan_CopyTo(t *testing.T) {
@@ -41,7 +41,7 @@ func TestSpan_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newSpan(internal.NewOrigPtrSpan(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newSpan(internal.NewOrigSpan(), sharedState)) })
 }
 
 func TestSpan_TraceID(t *testing.T) {

--- a/pdata/ptrace/generated_spanevent.go
+++ b/pdata/ptrace/generated_spanevent.go
@@ -34,7 +34,7 @@ func newSpanEvent(orig *otlptrace.Span_Event, state *internal.State) SpanEvent {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSpanEvent() SpanEvent {
-	return newSpanEvent(internal.NewOrigPtrSpan_Event(), internal.NewState())
+	return newSpanEvent(internal.NewOrigSpan_Event(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_spanevent_test.go
+++ b/pdata/ptrace/generated_spanevent_test.go
@@ -26,8 +26,8 @@ func TestSpanEvent_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSpanEvent(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newSpanEvent(internal.NewOrigPtrSpan_Event(), sharedState)) })
-	assert.Panics(t, func() { newSpanEvent(internal.NewOrigPtrSpan_Event(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newSpanEvent(internal.NewOrigSpan_Event(), sharedState)) })
+	assert.Panics(t, func() { newSpanEvent(internal.NewOrigSpan_Event(), sharedState).MoveTo(dest) })
 }
 
 func TestSpanEvent_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestSpanEvent_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newSpanEvent(internal.NewOrigPtrSpan_Event(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newSpanEvent(internal.NewOrigSpan_Event(), sharedState)) })
 }
 
 func TestSpanEvent_Timestamp(t *testing.T) {

--- a/pdata/ptrace/generated_spaneventslice.go
+++ b/pdata/ptrace/generated_spaneventslice.go
@@ -99,7 +99,7 @@ func (es SpanEventSlice) EnsureCapacity(newCap int) {
 // It returns the newly added SpanEvent.
 func (es SpanEventSlice) AppendEmpty() SpanEvent {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrSpan_Event())
+	*es.orig = append(*es.orig, internal.NewOrigSpan_Event())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/ptrace/generated_spanlink.go
+++ b/pdata/ptrace/generated_spanlink.go
@@ -36,7 +36,7 @@ func newSpanLink(orig *otlptrace.Span_Link, state *internal.State) SpanLink {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewSpanLink() SpanLink {
-	return newSpanLink(internal.NewOrigPtrSpan_Link(), internal.NewState())
+	return newSpanLink(internal.NewOrigSpan_Link(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_spanlink_test.go
+++ b/pdata/ptrace/generated_spanlink_test.go
@@ -27,8 +27,8 @@ func TestSpanLink_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestSpanLink(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newSpanLink(internal.NewOrigPtrSpan_Link(), sharedState)) })
-	assert.Panics(t, func() { newSpanLink(internal.NewOrigPtrSpan_Link(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newSpanLink(internal.NewOrigSpan_Link(), sharedState)) })
+	assert.Panics(t, func() { newSpanLink(internal.NewOrigSpan_Link(), sharedState).MoveTo(dest) })
 }
 
 func TestSpanLink_CopyTo(t *testing.T) {
@@ -41,7 +41,7 @@ func TestSpanLink_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newSpanLink(internal.NewOrigPtrSpan_Link(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newSpanLink(internal.NewOrigSpan_Link(), sharedState)) })
 }
 
 func TestSpanLink_TraceID(t *testing.T) {

--- a/pdata/ptrace/generated_spanlinkslice.go
+++ b/pdata/ptrace/generated_spanlinkslice.go
@@ -99,7 +99,7 @@ func (es SpanLinkSlice) EnsureCapacity(newCap int) {
 // It returns the newly added SpanLink.
 func (es SpanLinkSlice) AppendEmpty() SpanLink {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrSpan_Link())
+	*es.orig = append(*es.orig, internal.NewOrigSpan_Link())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/ptrace/generated_spanslice.go
+++ b/pdata/ptrace/generated_spanslice.go
@@ -99,7 +99,7 @@ func (es SpanSlice) EnsureCapacity(newCap int) {
 // It returns the newly added Span.
 func (es SpanSlice) AppendEmpty() Span {
 	es.state.AssertMutable()
-	*es.orig = append(*es.orig, internal.NewOrigPtrSpan())
+	*es.orig = append(*es.orig, internal.NewOrigSpan())
 	return es.At(es.Len() - 1)
 }
 

--- a/pdata/ptrace/generated_status.go
+++ b/pdata/ptrace/generated_status.go
@@ -33,7 +33,7 @@ func newStatus(orig *otlptrace.Status, state *internal.State) Status {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewStatus() Status {
-	return newStatus(internal.NewOrigPtrStatus(), internal.NewState())
+	return newStatus(internal.NewOrigStatus(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_status_test.go
+++ b/pdata/ptrace/generated_status_test.go
@@ -25,8 +25,8 @@ func TestStatus_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestStatus(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newStatus(internal.NewOrigPtrStatus(), sharedState)) })
-	assert.Panics(t, func() { newStatus(internal.NewOrigPtrStatus(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newStatus(internal.NewOrigStatus(), sharedState)) })
+	assert.Panics(t, func() { newStatus(internal.NewOrigStatus(), sharedState).MoveTo(dest) })
 }
 
 func TestStatus_CopyTo(t *testing.T) {
@@ -39,7 +39,7 @@ func TestStatus_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newStatus(internal.NewOrigPtrStatus(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newStatus(internal.NewOrigStatus(), sharedState)) })
 }
 
 func TestStatus_Message(t *testing.T) {

--- a/pdata/ptrace/generated_traces.go
+++ b/pdata/ptrace/generated_traces.go
@@ -30,7 +30,7 @@ func newTraces(orig *otlpcollectortrace.ExportTraceServiceRequest, state *intern
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewTraces() Traces {
-	return newTraces(internal.NewOrigPtrExportTraceServiceRequest(), internal.NewState())
+	return newTraces(internal.NewOrigExportTraceServiceRequest(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/generated_traces_test.go
+++ b/pdata/ptrace/generated_traces_test.go
@@ -24,8 +24,8 @@ func TestTraces_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestTraces(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newTraces(internal.NewOrigPtrExportTraceServiceRequest(), sharedState)) })
-	assert.Panics(t, func() { newTraces(internal.NewOrigPtrExportTraceServiceRequest(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newTraces(internal.NewOrigExportTraceServiceRequest(), sharedState)) })
+	assert.Panics(t, func() { newTraces(internal.NewOrigExportTraceServiceRequest(), sharedState).MoveTo(dest) })
 }
 
 func TestTraces_CopyTo(t *testing.T) {
@@ -38,7 +38,7 @@ func TestTraces_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newTraces(internal.NewOrigPtrExportTraceServiceRequest(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newTraces(internal.NewOrigExportTraceServiceRequest(), sharedState)) })
 }
 
 func TestTraces_ResourceSpans(t *testing.T) {

--- a/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess.go
@@ -32,7 +32,7 @@ func newExportPartialSuccess(orig *otlpcollectortrace.ExportTracePartialSuccess,
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportPartialSuccess() ExportPartialSuccess {
-	return newExportPartialSuccess(internal.NewOrigPtrExportTracePartialSuccess(), internal.NewState())
+	return newExportPartialSuccess(internal.NewOrigExportTracePartialSuccess(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess_test.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess_test.go
@@ -25,12 +25,8 @@ func TestExportPartialSuccess_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportPartialSuccess(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() {
-		ms.MoveTo(newExportPartialSuccess(internal.NewOrigPtrExportTracePartialSuccess(), sharedState))
-	})
-	assert.Panics(t, func() {
-		newExportPartialSuccess(internal.NewOrigPtrExportTracePartialSuccess(), sharedState).MoveTo(dest)
-	})
+	assert.Panics(t, func() { ms.MoveTo(newExportPartialSuccess(internal.NewOrigExportTracePartialSuccess(), sharedState)) })
+	assert.Panics(t, func() { newExportPartialSuccess(internal.NewOrigExportTracePartialSuccess(), sharedState).MoveTo(dest) })
 }
 
 func TestExportPartialSuccess_CopyTo(t *testing.T) {
@@ -43,9 +39,7 @@ func TestExportPartialSuccess_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() {
-		ms.CopyTo(newExportPartialSuccess(internal.NewOrigPtrExportTracePartialSuccess(), sharedState))
-	})
+	assert.Panics(t, func() { ms.CopyTo(newExportPartialSuccess(internal.NewOrigExportTracePartialSuccess(), sharedState)) })
 }
 
 func TestExportPartialSuccess_RejectedSpans(t *testing.T) {

--- a/pdata/ptrace/ptraceotlp/generated_exportresponse.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportresponse.go
@@ -32,7 +32,7 @@ func newExportResponse(orig *otlpcollectortrace.ExportTraceServiceResponse, stat
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewExportResponse() ExportResponse {
-	return newExportResponse(internal.NewOrigPtrExportTraceServiceResponse(), internal.NewState())
+	return newExportResponse(internal.NewOrigExportTraceServiceResponse(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/ptrace/ptraceotlp/generated_exportresponse_test.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportresponse_test.go
@@ -24,8 +24,8 @@ func TestExportResponse_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestExportResponse(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newExportResponse(internal.NewOrigPtrExportTraceServiceResponse(), sharedState)) })
-	assert.Panics(t, func() { newExportResponse(internal.NewOrigPtrExportTraceServiceResponse(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newExportResponse(internal.NewOrigExportTraceServiceResponse(), sharedState)) })
+	assert.Panics(t, func() { newExportResponse(internal.NewOrigExportTraceServiceResponse(), sharedState).MoveTo(dest) })
 }
 
 func TestExportResponse_CopyTo(t *testing.T) {
@@ -38,7 +38,7 @@ func TestExportResponse_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newExportResponse(internal.NewOrigPtrExportTraceServiceResponse(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newExportResponse(internal.NewOrigExportTraceServiceResponse(), sharedState)) })
 }
 
 func TestExportResponse_PartialSuccess(t *testing.T) {

--- a/pdata/xpdata/entity/generated_entityref.go
+++ b/pdata/xpdata/entity/generated_entityref.go
@@ -28,7 +28,7 @@ func newEntityRef(orig *otlpcommon.EntityRef, state *internal.State) EntityRef {
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
 func NewEntityRef() EntityRef {
-	return newEntityRef(internal.NewOrigPtrEntityRef(), internal.NewState())
+	return newEntityRef(internal.NewOrigEntityRef(), internal.NewState())
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and

--- a/pdata/xpdata/entity/generated_entityref_test.go
+++ b/pdata/xpdata/entity/generated_entityref_test.go
@@ -26,8 +26,8 @@ func TestEntityRef_MoveTo(t *testing.T) {
 	assert.Equal(t, generateTestEntityRef(), dest)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.MoveTo(newEntityRef(internal.NewOrigPtrEntityRef(), sharedState)) })
-	assert.Panics(t, func() { newEntityRef(internal.NewOrigPtrEntityRef(), sharedState).MoveTo(dest) })
+	assert.Panics(t, func() { ms.MoveTo(newEntityRef(internal.NewOrigEntityRef(), sharedState)) })
+	assert.Panics(t, func() { newEntityRef(internal.NewOrigEntityRef(), sharedState).MoveTo(dest) })
 }
 
 func TestEntityRef_CopyTo(t *testing.T) {
@@ -40,7 +40,7 @@ func TestEntityRef_CopyTo(t *testing.T) {
 	assert.Equal(t, orig, ms)
 	sharedState := internal.NewState()
 	sharedState.MarkReadOnly()
-	assert.Panics(t, func() { ms.CopyTo(newEntityRef(internal.NewOrigPtrEntityRef(), sharedState)) })
+	assert.Panics(t, func() { ms.CopyTo(newEntityRef(internal.NewOrigEntityRef(), sharedState)) })
 }
 
 func TestEntityRef_SchemaUrl(t *testing.T) {

--- a/pdata/xpdata/entity/generated_entityrefslice.go
+++ b/pdata/xpdata/entity/generated_entityrefslice.go
@@ -96,7 +96,7 @@ func (es EntityRefSlice) EnsureCapacity(newCap int) {
 // It returns the newly added EntityRef.
 func (es EntityRefSlice) AppendEmpty() EntityRef {
 	es.getState().AssertMutable()
-	*es.getOrig() = append(*es.getOrig(), internal.NewOrigPtrEntityRef())
+	*es.getOrig() = append(*es.getOrig(), internal.NewOrigEntityRef())
 	return es.At(es.Len() - 1)
 }
 


### PR DESCRIPTION
The only non-test change is in the Unmarshal proto but that generates exactly the same code using the "defaultValue" for the message.