### PR TITLE
[exporterhelper][batcher] - Fix the bug related to worker pool

### DIFF
--- a/.chloggen/batcher-bug-workers.yaml
+++ b/.chloggen/batcher-bug-workers.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Prevent uncontrolled goroutines in batcher due to a incorrect worker pool behaviour.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/batcher-bug-workers.yaml
+++ b/.chloggen/batcher-bug-workers.yaml
@@ -10,7 +10,7 @@ component: exporterhelper
 note: Prevent uncontrolled goroutines in batcher due to a incorrect worker pool behaviour.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [13689]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
@@ -262,8 +262,8 @@ func newWorkerPool(maxWorkers int) *workerPool {
 func (wp *workerPool) execute(f func()) {
 	<-wp.workers
 	go func() {
+		defer wp.workers <- struct{}{}
 		f()
-		wp.workers <- struct{}{}
 	}()
 }
 

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
@@ -261,8 +261,10 @@ func newWorkerPool(maxWorkers int) *workerPool {
 
 func (wp *workerPool) execute(f func()) {
 	<-wp.workers
-	go f()
-	wp.workers <- struct{}{}
+	go func() {
+		f()
+		wp.workers <- struct{}{}
+	}()
 }
 
 type multiDone []queue.Done

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
@@ -262,7 +262,9 @@ func newWorkerPool(maxWorkers int) *workerPool {
 func (wp *workerPool) execute(f func()) {
 	<-wp.workers
 	go func() {
-		defer wp.workers <- struct{}{}
+		defer func() {
+			wp.workers <- struct{}{}
+		}()
 		f()
 	}()
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

While working on an unrelated tasks, I observed unrestricted number of `partitionBatcher.flush(..)` being spinned. This resulted in `ConsumeLogs` being called excessively.  
If I understand correctly, we're supposed to return the worker to `qb.workerPool` only when the `consumeFunc` has returned. Right now, we're calling the `consumeFunc` in a background goroutine and returning the worker immediately in the main goroutine. 

Here's the previous behaviour for comparision: https://github.com/open-telemetry/opentelemetry-collector/pull/13164/files#diff-e3328327e734297f98f035f3eb463dc25c06843b82e6d48053020a94df0b9e94L189-L198

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Did manual testing and verified the number of goroutines via profiling.
