### PR TITLE
[exporterhelper] Add exporter_dropped_* reporting capability and metrcs

### DIFF
--- a/.chloggen/exporter_dropped_metrics.yaml
+++ b/.chloggen/exporter_dropped_metrics.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add exporter_dropped_* metrics to track dropped items
+
+# One or more tracking issues or pull requests related to the change
+issues: [13643]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api, user]

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -118,3 +118,30 @@ service:
 ```
 
 [filestorage]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage
+
+### Handling Dropped Items
+
+When an exporter needs to drop items due to specification requirements or incompatibility (not due to actual errors), `DroppedItems` type can be used to properly track these dropped items in telemetry:
+
+```go
+import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+
+// When dropping all items due to specification requirements
+if !isCompatibleWithExporter(data) {
+    return internal.NewDroppedItems("non-monotonic delta sum metrics not supported", len(data))
+}
+
+// When dropping only some items (partial drop)
+compatible, incompatible := filterCompatibleItems(data)
+if len(incompatible) > 0 {
+    return internal.NewDroppedItems("incompatible data format", len(incompatible))
+}
+```
+
+This will:
+- Increment the `otelcol_exporter_dropped_*` metrics with the correct count
+- Provide clear telemetry about why items were dropped and how many
+- Allow operators to distinguish between actual failures and specification-compliant drops
+- Support partial drops where only some items are incompatible
+
+The `DroppedItems` is not treated as a failure by the pipeline, but it provides visibility into data that cannot be exported due to format or specification constraints.

--- a/exporter/exporterhelper/documentation.md
+++ b/exporter/exporterhelper/documentation.md
@@ -6,6 +6,30 @@
 
 The following telemetry is emitted by this component.
 
+### otelcol_exporter_dropped_log_records
+
+Number of log records dropped due to incompatibility or specification requirements. [alpha]
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| {records} | Sum | Int | true |
+
+### otelcol_exporter_dropped_metric_points
+
+Number of metric points dropped due to incompatibility or specification requirements. [alpha]
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| {datapoints} | Sum | Int | true |
+
+### otelcol_exporter_dropped_spans
+
+Number of spans dropped due to incompatibility or specification requirements. [alpha]
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| {spans} | Sum | Int | true |
+
 ### otelcol_exporter_enqueue_failed_log_records
 
 Number of log records failed to be added to the sending queue. [alpha]

--- a/exporter/exporterhelper/generated_package_test.go
+++ b/exporter/exporterhelper/generated_package_test.go
@@ -3,9 +3,8 @@
 package exporterhelper
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -28,6 +28,9 @@ type TelemetryBuilder struct {
 	meter                             metric.Meter
 	mu                                sync.Mutex
 	registrations                     []metric.Registration
+	ExporterDroppedLogRecords         metric.Int64Counter
+	ExporterDroppedMetricPoints       metric.Int64Counter
+	ExporterDroppedSpans              metric.Int64Counter
 	ExporterEnqueueFailedLogRecords   metric.Int64Counter
 	ExporterEnqueueFailedMetricPoints metric.Int64Counter
 	ExporterEnqueueFailedSpans        metric.Int64Counter
@@ -110,6 +113,24 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
+	builder.ExporterDroppedLogRecords, err = builder.meter.Int64Counter(
+		"otelcol_exporter_dropped_log_records",
+		metric.WithDescription("Number of log records dropped due to incompatibility or specification requirements. [alpha]"),
+		metric.WithUnit("{records}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ExporterDroppedMetricPoints, err = builder.meter.Int64Counter(
+		"otelcol_exporter_dropped_metric_points",
+		metric.WithDescription("Number of metric points dropped due to incompatibility or specification requirements. [alpha]"),
+		metric.WithUnit("{datapoints}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ExporterDroppedSpans, err = builder.meter.Int64Counter(
+		"otelcol_exporter_dropped_spans",
+		metric.WithDescription("Number of spans dropped due to incompatibility or specification requirements. [alpha]"),
+		metric.WithUnit("{spans}"),
+	)
+	errs = errors.Join(errs, err)
 	builder.ExporterEnqueueFailedLogRecords, err = builder.meter.Int64Counter(
 		"otelcol_exporter_enqueue_failed_log_records",
 		metric.WithDescription("Number of log records failed to be added to the sending queue. [alpha]"),

--- a/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest.go
@@ -6,11 +6,58 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
-
-	"go.opentelemetry.io/collector/component/componenttest"
 )
+
+func AssertEqualExporterDroppedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_exporter_dropped_log_records",
+		Description: "Number of log records dropped due to incompatibility or specification requirements. [alpha]",
+		Unit:        "{records}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_exporter_dropped_log_records")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualExporterDroppedMetricPoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_exporter_dropped_metric_points",
+		Description: "Number of metric points dropped due to incompatibility or specification requirements. [alpha]",
+		Unit:        "{datapoints}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_exporter_dropped_metric_points")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualExporterDroppedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_exporter_dropped_spans",
+		Description: "Number of spans dropped due to incompatibility or specification requirements. [alpha]",
+		Unit:        "{spans}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_exporter_dropped_spans")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
 
 func AssertEqualExporterEnqueueFailedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{

--- a/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest_test.go
@@ -28,6 +28,9 @@ func TestSetupTelemetry(t *testing.T) {
 		observer.Observe(1)
 		return nil
 	}))
+	tb.ExporterDroppedLogRecords.Add(context.Background(), 1)
+	tb.ExporterDroppedMetricPoints.Add(context.Background(), 1)
+	tb.ExporterDroppedSpans.Add(context.Background(), 1)
 	tb.ExporterEnqueueFailedLogRecords.Add(context.Background(), 1)
 	tb.ExporterEnqueueFailedMetricPoints.Add(context.Background(), 1)
 	tb.ExporterEnqueueFailedSpans.Add(context.Background(), 1)
@@ -37,6 +40,15 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ExporterSentLogRecords.Add(context.Background(), 1)
 	tb.ExporterSentMetricPoints.Add(context.Background(), 1)
 	tb.ExporterSentSpans.Add(context.Background(), 1)
+	AssertEqualExporterDroppedLogRecords(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualExporterDroppedMetricPoints(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualExporterDroppedSpans(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterEnqueueFailedLogRecords(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())

--- a/exporter/exporterhelper/internal/obs_report_sender.go
+++ b/exporter/exporterhelper/internal/obs_report_sender.go
@@ -5,6 +5,7 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 
 import (
 	"context"
+	"errors"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -20,6 +21,44 @@ import (
 	"go.opentelemetry.io/collector/pipeline"
 )
 
+type DroppedItems struct {
+	reason string
+	count  int
+}
+
+func NewDroppedItems(reason string, count int) error {
+	return &DroppedItems{reason: reason, count: count}
+}
+
+func (e *DroppedItems) Error() string {
+	return "items dropped: " + e.reason
+}
+
+func (e *DroppedItems) Count() int {
+	return e.count
+}
+
+func IsDroppedItems(err error) bool {
+	var droppedItems *DroppedItems
+	return errors.As(err, &droppedItems)
+}
+
+func GetDroppedReason(err error) string {
+	var droppedItems *DroppedItems
+	if errors.As(err, &droppedItems) {
+		return droppedItems.reason
+	}
+	return ""
+}
+
+func GetDroppedCount(err error) int {
+	var droppedItems *DroppedItems
+	if errors.As(err, &droppedItems) {
+		return droppedItems.count
+	}
+	return 0
+}
+
 const (
 	// spanNameSep is duplicate between receiver and exporter.
 	spanNameSep = "/"
@@ -34,19 +73,22 @@ const (
 	ItemsSent = "items.sent"
 	// ItemsFailed used to track number of items that failed to be sent by exporters.
 	ItemsFailed = "items.failed"
+	// ItemsDropped used to track number of items that were dropped by exporters.
+	ItemsDropped = "items.dropped"
 )
 
 type obsReportSender[K request.Request] struct {
 	component.StartFunc
 	component.ShutdownFunc
 
-	spanName        string
-	tracer          trace.Tracer
-	spanAttrs       trace.SpanStartEventOption
-	metricAttr      metric.MeasurementOption
-	itemsSentInst   metric.Int64Counter
-	itemsFailedInst metric.Int64Counter
-	next            sender.Sender[K]
+	spanName         string
+	tracer           trace.Tracer
+	spanAttrs        trace.SpanStartEventOption
+	metricAttr       metric.MeasurementOption
+	itemsSentInst    metric.Int64Counter
+	itemsFailedInst  metric.Int64Counter
+	itemsDroppedInst metric.Int64Counter
+	next             sender.Sender[K]
 }
 
 func newObsReportSender[K request.Request](set exporter.Settings, signal pipeline.Signal, next sender.Sender[K]) (sender.Sender[K], error) {
@@ -70,14 +112,17 @@ func newObsReportSender[K request.Request](set exporter.Settings, signal pipelin
 	case pipeline.SignalTraces:
 		or.itemsSentInst = telemetryBuilder.ExporterSentSpans
 		or.itemsFailedInst = telemetryBuilder.ExporterSendFailedSpans
+		or.itemsDroppedInst = telemetryBuilder.ExporterDroppedSpans
 
 	case pipeline.SignalMetrics:
 		or.itemsSentInst = telemetryBuilder.ExporterSentMetricPoints
 		or.itemsFailedInst = telemetryBuilder.ExporterSendFailedMetricPoints
+		or.itemsDroppedInst = telemetryBuilder.ExporterDroppedMetricPoints
 
 	case pipeline.SignalLogs:
 		or.itemsSentInst = telemetryBuilder.ExporterSentLogRecords
 		or.itemsFailedInst = telemetryBuilder.ExporterSendFailedLogRecords
+		or.itemsDroppedInst = telemetryBuilder.ExporterDroppedLogRecords
 	}
 
 	return or, nil
@@ -106,7 +151,7 @@ func (ors *obsReportSender[K]) startOp(ctx context.Context) context.Context {
 
 // EndOp completes the export operation that was started with StartOp.
 func (ors *obsReportSender[K]) endOp(ctx context.Context, numLogRecords int, err error) {
-	numSent, numFailedToSend := toNumItems(numLogRecords, err)
+	numSent, numFailedToSend, numDropped := toNumItems(numLogRecords, err)
 
 	// No metrics recorded for profiles.
 	if ors.itemsSentInst != nil {
@@ -116,6 +161,10 @@ func (ors *obsReportSender[K]) endOp(ctx context.Context, numLogRecords int, err
 	if ors.itemsFailedInst != nil {
 		ors.itemsFailedInst.Add(ctx, numFailedToSend, ors.metricAttr)
 	}
+	// No metrics recorded for profiles.
+	if ors.itemsDroppedInst != nil {
+		ors.itemsDroppedInst.Add(ctx, numDropped, ors.metricAttr)
+	}
 
 	span := trace.SpanFromContext(ctx)
 	defer span.End()
@@ -124,6 +173,7 @@ func (ors *obsReportSender[K]) endOp(ctx context.Context, numLogRecords int, err
 		span.SetAttributes(
 			attribute.Int64(ItemsSent, numSent),
 			attribute.Int64(ItemsFailed, numFailedToSend),
+			attribute.Int64(ItemsDropped, numDropped),
 		)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
@@ -131,9 +181,16 @@ func (ors *obsReportSender[K]) endOp(ctx context.Context, numLogRecords int, err
 	}
 }
 
-func toNumItems(numExportedItems int, err error) (int64, int64) {
+func toNumItems(numExportedItems int, err error) (int64, int64, int64) {
 	if err != nil {
-		return 0, int64(numExportedItems)
+		if IsDroppedItems(err) {
+			droppedCount := GetDroppedCount(err)
+			if droppedCount > 0 {
+				return int64(numExportedItems - droppedCount), 0, int64(droppedCount)
+			}
+			return 0, 0, int64(numExportedItems)
+		}
+		return 0, int64(numExportedItems), 0
 	}
-	return int64(numExportedItems), 0
+	return int64(numExportedItems), 0, 0
 }

--- a/exporter/exporterhelper/internal/queuebatch/generated_package_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/generated_package_test.go
@@ -3,9 +3,8 @@
 package queuebatch
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/exporter/exporterhelper/metadata.yaml
+++ b/exporter/exporterhelper/metadata.yaml
@@ -33,6 +33,16 @@ telemetry:
         value_type: int
         monotonic: true
 
+    exporter_dropped_spans:
+      enabled: true
+      stability:
+        level: alpha
+      description: Number of spans dropped due to incompatibility or specification requirements.
+      unit: "{spans}"
+      sum:
+        value_type: int
+        monotonic: true
+
     exporter_enqueue_failed_spans:
       enabled: true
       stability:
@@ -63,6 +73,16 @@ telemetry:
         value_type: int
         monotonic: true
 
+    exporter_dropped_metric_points:
+      enabled: true
+      stability:
+        level: alpha
+      description: Number of metric points dropped due to incompatibility or specification requirements.
+      unit: "{datapoints}"
+      sum:
+        value_type: int
+        monotonic: true
+
     exporter_enqueue_failed_metric_points:
       enabled: true
       stability:
@@ -88,6 +108,16 @@ telemetry:
       stability:
         level: alpha
       description: Number of log records in failed attempts to send to destination.
+      unit: "{records}"
+      sum:
+        value_type: int
+        monotonic: true
+
+    exporter_dropped_log_records:
+      enabled: true
+      stability:
+        level: alpha
+      description: Number of log records dropped due to incompatibility or specification requirements.
       unit: "{records}"
       sum:
         value_type: int


### PR DESCRIPTION
#### Description
Add exporter_dropped_* metrics to track dropped items, allowing exporter devs to report back the number of dropped items.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13643

<!--Describe the documentation added.-->
#### Documentation
Added instructions for exporter devs

