### PR TITLE
Revert configgrpc to grpc.NewClient

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -282,8 +282,7 @@ func (cc *ClientConfig) ToClientConn(
 	if err != nil {
 		return nil, err
 	}
-	//nolint:staticcheck // SA1019 see https://github.com/open-telemetry/opentelemetry-collector/pull/11575
-	return grpc.DialContext(ctx, cc.sanitizedEndpoint(), grpcOpts...)
+	return grpc.NewClient(cc.sanitizedEndpoint(), grpcOpts...)
 }
 
 func (cc *ClientConfig) addHeadersIfAbsent(ctx context.Context) context.Context {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Due to a bug in grpc-go that enforced use of a dns resolver in grpc.NewClient, host based proxy settings were not properly applied. Due to this we reverted back to using DialContext in Release 0.113.0 #11575. This has since been patched in grpc-go [here ](https://github.com/grpc/grpc-go/pull/7881). 

Due to this fix we can now again go back to using NewClient. 

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13632

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
