### PR TITLE
Fix TestLoadTLSServerConfigReload

### DIFF
--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -345,15 +345,11 @@ func TestLoadTLSServerConfigReload(t *testing.T) {
 
 	overwriteClientCA(t, tmpCaPath, "ca-2.crt")
 
-	assert.Eventually(t, func() bool {
-		_, loadError := tlsCfg.GetConfigForClient(nil)
-		return loadError == nil
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		secondClient, err := tlsCfg.GetConfigForClient(nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, firstClient.ClientCAs, secondClient.ClientCAs)
 	}, 5*time.Second, 10*time.Millisecond)
-
-	secondClient, err := tlsCfg.GetConfigForClient(nil)
-	require.NoError(t, err)
-
-	assert.NotEqual(t, firstClient.ClientCAs, secondClient.ClientCAs)
 }
 
 func TestLoadTLSServerConfigFailingReload(t *testing.T) {


### PR DESCRIPTION
#### Description

This fixes a test in configtls that started failing after upgrading testify.

The test checks that the automatic certificate reloading feature works. However, the logic was a bit broken, and the test will fail if `assert.Eventually` performs its first check before the reloader has had the chance to do its job.

I believe it started failing because of [this change](https://github.com/stretchr/testify/pull/1427) in testify, making it so that `assert.Eventually(condition, timeout, period)` immediately checks for `condition` instead of waiting `period` before performing the first check.
