### PR TITLE
Add custom grpc/encoding that replaces proto and calls into our formats first

### DIFF
--- a/.chloggen/add-custom-encoder.yaml
+++ b/.chloggen/add-custom-encoder.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add custom grpc/encoding that replaces proto and calls into the custom marshal/unmarshal logic in pdata.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13631]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This change should not affect other gRPC calls since it fallbacks to the default grpc/proto encoding if requests are not pdata/otlp requests.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pdata/internal/grpcencoding/encoding.go
+++ b/pdata/internal/grpcencoding/encoding.go
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package grpcencoding // import "go.opentelemetry.io/collector/pdata/internal/grpcencoding"
+
+import (
+	"google.golang.org/grpc/encoding"
+	"google.golang.org/grpc/mem"
+
+	"go.opentelemetry.io/collector/pdata/internal"
+	otlpcollectorlogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/logs/v1"
+	otlpcollectormetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/metrics/v1"
+	otlpcollectorprofile "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/profiles/v1development"
+	otlpcollectortraces "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/trace/v1"
+)
+
+var (
+	defaultBufferPoolSizes = []int{
+		256,
+		4 << 10,   // 4KB (go page size)
+		16 << 10,  // 16KB (max HTTP/2 frame size used by gRPC)
+		32 << 10,  // 32KB (default buffer size for io.Copy)
+		512 << 10, // 512KB
+		1 << 20,   // 1MB
+		4 << 20,   // 4MB
+		16 << 20,  // 16MB
+	}
+	otelBufferPool = mem.NewTieredBufferPool(defaultBufferPoolSizes...)
+)
+
+// DefaultBufferPool returns the current default buffer pool. It is a BufferPool
+// created with mem.NewTieredBufferPool that uses a set of default sizes optimized for
+// expected telemetry workflows.
+func DefaultBufferPool() mem.BufferPool {
+	return otelBufferPool
+}
+
+// Name is the name registered for the proto compressor.
+const Name = "proto"
+
+func init() {
+	encoding.RegisterCodecV2(&codecV2{delegate: encoding.GetCodecV2(Name)})
+}
+
+// codecV2 is a custom proto encoding that uses a different tier schema for the TieredBufferPool as well
+// as it call into the custom marshal/unmarshal logic that works with memory pooling.
+// If not an otlp payload fallback on the default grpc/proto encoding.
+type codecV2 struct {
+	delegate encoding.CodecV2
+}
+
+func (c *codecV2) Marshal(v any) (mem.BufferSlice, error) {
+	switch req := v.(type) {
+	case *otlpcollectorlogs.ExportLogsServiceRequest:
+		size := internal.SizeProtoOrigExportLogsServiceRequest(req)
+		buf := otelBufferPool.Get(size)
+		n := internal.MarshalProtoOrigExportLogsServiceRequest(req, (*buf)[:size])
+		*buf = (*buf)[:n]
+		return []mem.Buffer{mem.NewBuffer(buf, otelBufferPool)}, nil
+	case *otlpcollectormetrics.ExportMetricsServiceRequest:
+		size := internal.SizeProtoOrigExportMetricsServiceRequest(req)
+		buf := otelBufferPool.Get(size)
+		n := internal.MarshalProtoOrigExportMetricsServiceRequest(req, (*buf)[:size])
+		*buf = (*buf)[:n]
+		return []mem.Buffer{mem.NewBuffer(buf, otelBufferPool)}, nil
+	case *otlpcollectortraces.ExportTraceServiceRequest:
+		size := internal.SizeProtoOrigExportTraceServiceRequest(req)
+		buf := otelBufferPool.Get(size)
+		n := internal.MarshalProtoOrigExportTraceServiceRequest(req, (*buf)[:size])
+		*buf = (*buf)[:n]
+		return []mem.Buffer{mem.NewBuffer(buf, otelBufferPool)}, nil
+	case *otlpcollectorprofile.ExportProfilesServiceRequest:
+		size := internal.SizeProtoOrigExportProfilesServiceRequest(req)
+		buf := otelBufferPool.Get(size)
+		n := internal.MarshalProtoOrigExportProfilesServiceRequest(req, (*buf)[:size])
+		*buf = (*buf)[:n]
+		return []mem.Buffer{mem.NewBuffer(buf, otelBufferPool)}, nil
+	}
+
+	return c.delegate.Marshal(v)
+}
+
+func (c *codecV2) Unmarshal(data mem.BufferSlice, v any) (err error) {
+	switch req := v.(type) {
+	case *otlpcollectorlogs.ExportLogsServiceRequest:
+		// TODO: Upgrade custom Unmarshal logic to support reading from mem.BufferSlice.
+		buf := data.MaterializeToBuffer(otelBufferPool)
+		defer buf.Free()
+		return internal.UnmarshalProtoOrigExportLogsServiceRequest(req, buf.ReadOnlyData())
+	case *otlpcollectormetrics.ExportMetricsServiceRequest:
+		// TODO: Upgrade custom Unmarshal logic to support reading from mem.BufferSlice.
+		buf := data.MaterializeToBuffer(otelBufferPool)
+		defer buf.Free()
+		return internal.UnmarshalProtoOrigExportMetricsServiceRequest(req, buf.ReadOnlyData())
+	case *otlpcollectortraces.ExportTraceServiceRequest:
+		// TODO: Upgrade custom Unmarshal logic to support reading from mem.BufferSlice.
+		buf := data.MaterializeToBuffer(otelBufferPool)
+		defer buf.Free()
+		return internal.UnmarshalProtoOrigExportTraceServiceRequest(req, buf.ReadOnlyData())
+	case *otlpcollectorprofile.ExportProfilesServiceRequest:
+		// TODO: Upgrade custom Unmarshal logic to support reading from mem.BufferSlice.
+		buf := data.MaterializeToBuffer(otelBufferPool)
+		defer buf.Free()
+		return internal.UnmarshalProtoOrigExportProfilesServiceRequest(req, buf.ReadOnlyData())
+	}
+
+	return c.delegate.Unmarshal(data, v)
+}
+
+func (c *codecV2) Name() string {
+	return Name
+}

--- a/pdata/plog/plogotlp/grpc.go
+++ b/pdata/plog/plogotlp/grpc.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpcollectorlog "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/logs/v1"
+	_ "go.opentelemetry.io/collector/pdata/internal/grpcencoding" // enforces custom gRPC encoding to be loaded.
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
 )
 

--- a/pdata/pmetric/pmetricotlp/grpc.go
+++ b/pdata/pmetric/pmetricotlp/grpc.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpcollectormetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/metrics/v1"
+	_ "go.opentelemetry.io/collector/pdata/internal/grpcencoding" // enforces custom gRPC encoding to be loaded.
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
 )
 

--- a/pdata/pprofile/pprofileotlp/grpc.go
+++ b/pdata/pprofile/pprofileotlp/grpc.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpcollectorprofile "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/profiles/v1development"
+	_ "go.opentelemetry.io/collector/pdata/internal/grpcencoding" // enforces custom gRPC encoding to be loaded.
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
 )
 

--- a/pdata/ptrace/ptraceotlp/grpc.go
+++ b/pdata/ptrace/ptraceotlp/grpc.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpcollectortrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/trace/v1"
+	_ "go.opentelemetry.io/collector/pdata/internal/grpcencoding" // enforces custom gRPC encoding to be loaded.
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
 )
 


### PR DESCRIPTION
This change should not affect other gRPC calls since it fallbacks to the default grpc/proto encoding if requests are not pdata/otlp requests.