### PR TITLE
[chore] Small nits, consistent JSON and Proto logic to call into internal

### DIFF
--- a/pdata/ptrace/ptraceotlp/request.go
+++ b/pdata/ptrace/ptraceotlp/request.go
@@ -4,15 +4,13 @@
 package ptraceotlp // import "go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 
 import (
+	"slices"
+
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpcollectortrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/trace/v1"
+	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-)
-
-var (
-	jsonMarshaler   = &ptrace.JSONMarshaler{}
-	jsonUnmarshaler = &ptrace.JSONUnmarshaler{}
 )
 
 // ExportRequest represents the request for gRPC/HTTP client/server.
@@ -66,17 +64,21 @@ func (ms ExportRequest) UnmarshalProto(data []byte) error {
 
 // MarshalJSON marshals ExportRequest into JSON bytes.
 func (ms ExportRequest) MarshalJSON() ([]byte, error) {
-	return jsonMarshaler.MarshalTraces(ptrace.Traces(internal.NewTraces(ms.orig, nil)))
+	dest := json.BorrowStream(nil)
+	defer json.ReturnStream(dest)
+	internal.MarshalJSONOrigExportTraceServiceRequest(ms.orig, dest)
+	if dest.Error() != nil {
+		return nil, dest.Error()
+	}
+	return slices.Clone(dest.Buffer()), nil
 }
 
 // UnmarshalJSON unmarshalls ExportRequest from JSON bytes.
 func (ms ExportRequest) UnmarshalJSON(data []byte) error {
-	td, err := jsonUnmarshaler.UnmarshalTraces(data)
-	if err != nil {
-		return err
-	}
-	*ms.orig = *internal.GetOrigTraces(internal.Traces(td))
-	return nil
+	iter := json.BorrowIterator(data)
+	defer json.ReturnIterator(iter)
+	internal.UnmarshalJSONOrigExportTraceServiceRequest(ms.orig, iter)
+	return iter.Error()
 }
 
 func (ms ExportRequest) Traces() ptrace.Traces {


### PR DESCRIPTION
The main idea is that the [*]otlp/Request is for http/grpc OTLP communication, but the Marshaler is only marshaling non-protocol specific data.