### PR TITLE
[internal/cmd/pdatagen] Parsing of non-packed primitive arrays

### DIFF
--- a/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_buckets.go
+++ b/pdata/internal/generated_wrapper_exponentialhistogramdatapoint_buckets.go
@@ -165,25 +165,34 @@ func UnmarshalProtoOrigExponentialHistogramDataPoint_Buckets(orig *otlpmetrics.E
 
 			orig.Offset = int32(uint32(num>>1) ^ uint32(int32((num&1)<<31)>>31))
 		case 2:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field BucketCounts", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			var num uint64
-			for startPos < pos {
-				num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				var num uint64
+				for startPos < pos {
+					num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.BucketCounts = append(orig.BucketCounts, uint64(num))
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field BucketCounts", pos-startPos)
+				}
+			case proto.WireTypeVarint:
+				var num uint64
+				num, pos, err = proto.ConsumeVarint(buf, pos)
 				if err != nil {
 					return err
 				}
 				orig.BucketCounts = append(orig.BucketCounts, uint64(num))
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field BucketCounts", pos-startPos)
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field BucketCounts", wireType)
 			}
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_wrapper_histogramdatapoint.go
+++ b/pdata/internal/generated_wrapper_histogramdatapoint.go
@@ -524,50 +524,68 @@ func UnmarshalProtoOrigHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint, 
 			ov.Sum = math.Float64frombits(num)
 			orig.Sum_ = ov
 		case 6:
-			if wireType != proto.WireTypeLen {
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				size := length / 8
+				orig.BucketCounts = make([]uint64, size)
+				var num uint64
+				for i := 0; i < size; i++ {
+					num, startPos, err = proto.ConsumeI64(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.BucketCounts[i] = uint64(num)
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field BucketCounts", pos-startPos)
+				}
+			case proto.WireTypeI64:
+				var num uint64
+				num, pos, err = proto.ConsumeI64(buf, pos)
+				if err != nil {
+					return err
+				}
+				orig.BucketCounts = append(orig.BucketCounts, uint64(num))
+			default:
 				return fmt.Errorf("proto: wrong wireType = %d for field BucketCounts", wireType)
 			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			size := length / 8
-			orig.BucketCounts = make([]uint64, size)
-			var num uint64
-			for i := 0; i < size; i++ {
-				num, startPos, err = proto.ConsumeI64(buf[:pos], startPos)
-				if err != nil {
-					return err
-				}
-				orig.BucketCounts[i] = uint64(num)
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field BucketCounts", pos-startPos)
-			}
 		case 7:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field ExplicitBounds", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			size := length / 8
-			orig.ExplicitBounds = make([]float64, size)
-			var num uint64
-			for i := 0; i < size; i++ {
-				num, startPos, err = proto.ConsumeI64(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
 				if err != nil {
 					return err
 				}
-				orig.ExplicitBounds[i] = math.Float64frombits(num)
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field ExplicitBounds", pos-startPos)
+				startPos := pos - length
+				size := length / 8
+				orig.ExplicitBounds = make([]float64, size)
+				var num uint64
+				for i := 0; i < size; i++ {
+					num, startPos, err = proto.ConsumeI64(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.ExplicitBounds[i] = math.Float64frombits(num)
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field ExplicitBounds", pos-startPos)
+				}
+			case proto.WireTypeI64:
+				var num uint64
+				num, pos, err = proto.ConsumeI64(buf, pos)
+				if err != nil {
+					return err
+				}
+				orig.ExplicitBounds = append(orig.ExplicitBounds, math.Float64frombits(num))
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field ExplicitBounds", wireType)
 			}
 
 		case 8:

--- a/pdata/internal/generated_wrapper_location.go
+++ b/pdata/internal/generated_wrapper_location.go
@@ -314,25 +314,34 @@ func UnmarshalProtoOrigLocation(orig *otlpprofiles.Location, buf []byte) error {
 
 			orig.IsFolded = num != 0
 		case 5:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field AttributeIndices", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			var num uint64
-			for startPos < pos {
-				num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				var num uint64
+				for startPos < pos {
+					num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.AttributeIndices = append(orig.AttributeIndices, int32(num))
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field AttributeIndices", pos-startPos)
+				}
+			case proto.WireTypeVarint:
+				var num uint64
+				num, pos, err = proto.ConsumeVarint(buf, pos)
 				if err != nil {
 					return err
 				}
 				orig.AttributeIndices = append(orig.AttributeIndices, int32(num))
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field AttributeIndices", pos-startPos)
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field AttributeIndices", wireType)
 			}
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_wrapper_mapping.go
+++ b/pdata/internal/generated_wrapper_mapping.go
@@ -333,25 +333,34 @@ func UnmarshalProtoOrigMapping(orig *otlpprofiles.Mapping, buf []byte) error {
 
 			orig.FilenameStrindex = int32(num)
 		case 5:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field AttributeIndices", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			var num uint64
-			for startPos < pos {
-				num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				var num uint64
+				for startPos < pos {
+					num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.AttributeIndices = append(orig.AttributeIndices, int32(num))
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field AttributeIndices", pos-startPos)
+				}
+			case proto.WireTypeVarint:
+				var num uint64
+				num, pos, err = proto.ConsumeVarint(buf, pos)
 				if err != nil {
 					return err
 				}
 				orig.AttributeIndices = append(orig.AttributeIndices, int32(num))
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field AttributeIndices", pos-startPos)
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field AttributeIndices", wireType)
 			}
 
 		case 6:

--- a/pdata/internal/generated_wrapper_profile.go
+++ b/pdata/internal/generated_wrapper_profile.go
@@ -458,25 +458,34 @@ func UnmarshalProtoOrigProfile(orig *otlpprofiles.Profile, buf []byte) error {
 				return err
 			}
 		case 3:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field LocationIndices", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			var num uint64
-			for startPos < pos {
-				num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				var num uint64
+				for startPos < pos {
+					num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.LocationIndices = append(orig.LocationIndices, int32(num))
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field LocationIndices", pos-startPos)
+				}
+			case proto.WireTypeVarint:
+				var num uint64
+				num, pos, err = proto.ConsumeVarint(buf, pos)
 				if err != nil {
 					return err
 				}
 				orig.LocationIndices = append(orig.LocationIndices, int32(num))
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field LocationIndices", pos-startPos)
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field LocationIndices", wireType)
 			}
 
 		case 4:
@@ -531,25 +540,34 @@ func UnmarshalProtoOrigProfile(orig *otlpprofiles.Profile, buf []byte) error {
 
 			orig.Period = int64(num)
 		case 8:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field CommentStrindices", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			var num uint64
-			for startPos < pos {
-				num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				var num uint64
+				for startPos < pos {
+					num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.CommentStrindices = append(orig.CommentStrindices, int32(num))
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field CommentStrindices", pos-startPos)
+				}
+			case proto.WireTypeVarint:
+				var num uint64
+				num, pos, err = proto.ConsumeVarint(buf, pos)
 				if err != nil {
 					return err
 				}
 				orig.CommentStrindices = append(orig.CommentStrindices, int32(num))
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field CommentStrindices", pos-startPos)
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field CommentStrindices", wireType)
 			}
 
 		case 9:
@@ -619,25 +637,34 @@ func UnmarshalProtoOrigProfile(orig *otlpprofiles.Profile, buf []byte) error {
 				copy(orig.OriginalPayload, buf[startPos:pos])
 			}
 		case 14:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field AttributeIndices", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			var num uint64
-			for startPos < pos {
-				num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				var num uint64
+				for startPos < pos {
+					num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.AttributeIndices = append(orig.AttributeIndices, int32(num))
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field AttributeIndices", pos-startPos)
+				}
+			case proto.WireTypeVarint:
+				var num uint64
+				num, pos, err = proto.ConsumeVarint(buf, pos)
 				if err != nil {
 					return err
 				}
 				orig.AttributeIndices = append(orig.AttributeIndices, int32(num))
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field AttributeIndices", pos-startPos)
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field AttributeIndices", wireType)
 			}
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_wrapper_sample.go
+++ b/pdata/internal/generated_wrapper_sample.go
@@ -311,46 +311,64 @@ func UnmarshalProtoOrigSample(orig *otlpprofiles.Sample, buf []byte) error {
 
 			orig.LocationsLength = int32(num)
 		case 3:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			var num uint64
-			for startPos < pos {
-				num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				var num uint64
+				for startPos < pos {
+					num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.Value = append(orig.Value, int64(num))
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field Value", pos-startPos)
+				}
+			case proto.WireTypeVarint:
+				var num uint64
+				num, pos, err = proto.ConsumeVarint(buf, pos)
 				if err != nil {
 					return err
 				}
 				orig.Value = append(orig.Value, int64(num))
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field Value", pos-startPos)
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
 			}
 		case 4:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field AttributeIndices", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			var num uint64
-			for startPos < pos {
-				num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				var num uint64
+				for startPos < pos {
+					num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.AttributeIndices = append(orig.AttributeIndices, int32(num))
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field AttributeIndices", pos-startPos)
+				}
+			case proto.WireTypeVarint:
+				var num uint64
+				num, pos, err = proto.ConsumeVarint(buf, pos)
 				if err != nil {
 					return err
 				}
 				orig.AttributeIndices = append(orig.AttributeIndices, int32(num))
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field AttributeIndices", pos-startPos)
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field AttributeIndices", wireType)
 			}
 
 		case 5:
@@ -371,25 +389,34 @@ func UnmarshalProtoOrigSample(orig *otlpprofiles.Sample, buf []byte) error {
 			ov.LinkIndex = int32(num)
 			orig.LinkIndex_ = ov
 		case 6:
-			if wireType != proto.WireTypeLen {
-				return fmt.Errorf("proto: wrong wireType = %d for field TimestampsUnixNano", wireType)
-			}
-			var length int
-			length, pos, err = proto.ConsumeLen(buf, pos)
-			if err != nil {
-				return err
-			}
-			startPos := pos - length
-			var num uint64
-			for startPos < pos {
-				num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+			switch wireType {
+			case proto.WireTypeLen:
+				var length int
+				length, pos, err = proto.ConsumeLen(buf, pos)
+				if err != nil {
+					return err
+				}
+				startPos := pos - length
+				var num uint64
+				for startPos < pos {
+					num, startPos, err = proto.ConsumeVarint(buf[:pos], startPos)
+					if err != nil {
+						return err
+					}
+					orig.TimestampsUnixNano = append(orig.TimestampsUnixNano, uint64(num))
+				}
+				if startPos != pos {
+					return fmt.Errorf("proto: invalid field len = %d for field TimestampsUnixNano", pos-startPos)
+				}
+			case proto.WireTypeVarint:
+				var num uint64
+				num, pos, err = proto.ConsumeVarint(buf, pos)
 				if err != nil {
 					return err
 				}
 				orig.TimestampsUnixNano = append(orig.TimestampsUnixNano, uint64(num))
-			}
-			if startPos != pos {
-				return fmt.Errorf("proto: invalid field len = %d for field TimestampsUnixNano", pos-startPos)
+			default:
+				return fmt.Errorf("proto: wrong wireType = %d for field TimestampsUnixNano", wireType)
 			}
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)


### PR DESCRIPTION
#### Description

Protobuf has two possible encodings for a repeated field with wire type VARINT/I32/I64:
- repeat the field tag for each value (like for repeated fields with other wire types)
- use a "packed" representation: use a single field tag with wire type LEN containing all the values

The packed representation is the default, but [the Protobuf documentation](https://protobuf.dev/programming-guides/encoding/#repeated) notes that:

> Protocol buffer parsers must be able to parse repeated fields that were compiled as packed as if they were not packed, and vice versa. This permits adding [packed=true] to existing fields in a forward- and backward-compatible way.

The current Protobuf parser generated by pdatagen expects the packed representation and returns an error if the "unpacked" representation is provided instead, causing slightly off-spec clients to fail exporting telemetry to the Collector. This PR fixes that by implementing parsing of unpacked repeated fields.

#### Link to tracking issue
Fixes #13727

#### Testing
I tested this PR against the basic reproduction I provided in the tracking issue and confirmed that it should fix the issue.
