### PR TITLE
Avoid copying the pcommon.Map when same origin

### DIFF
--- a/.chloggen/fix-map-copy.yaml
+++ b/.chloggen/fix-map-copy.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid copying the pcommon.Map when same origin
+
+# One or more tracking issues or pull requests related to the change
+issues: [13731]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is a very large improvement if using OTTL with map functions since it will avoid a map copy.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pdata/pcommon/map.go
+++ b/pdata/pcommon/map.go
@@ -268,6 +268,9 @@ func (m Map) MoveTo(dest Map) {
 // CopyTo copies all elements from the current map overriding the destination.
 func (m Map) CopyTo(dest Map) {
 	dest.getState().AssertMutable()
+	if m.getOrig() == dest.getOrig() {
+		return
+	}
 	*dest.getOrig() = internal.CopyOrigKeyValueSlice(*dest.getOrig(), *m.getOrig())
 }
 

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -440,6 +440,10 @@ func TestMap_CopyTo(t *testing.T) {
 	(*dest.getOrig())[0].Value = otlpcommon.AnyValue{}
 	Map(internal.GenerateTestMap()).CopyTo(dest)
 	assert.Equal(t, Map(internal.GenerateTestMap()), dest)
+
+	// Test CopyTo same size slice
+	dest.CopyTo(dest)
+	assert.Equal(t, Map(internal.GenerateTestMap()), dest)
 }
 
 func TestMap_CopyToAndEnsureCapacity(t *testing.T) {


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42350