### PR TITLE
otelcol: use sync.Once in Shutdown

### DIFF
--- a/.chloggen/collector-shutdown.yaml
+++ b/.chloggen/collector-shutdown.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otelcol
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a potential deadlock during collector shutdown.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13740]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"sync/atomic"
 	"syscall"
 
@@ -105,6 +106,8 @@ type Collector struct {
 
 	// shutdownChan is used to terminate the collector.
 	shutdownChan chan struct{}
+	shutdownOnce sync.Once
+
 	// signalsChannel is used to receive termination signals from the OS.
 	signalsChannel chan os.Signal
 	// asyncErrorChannel is used to signal a fatal error from any component.
@@ -150,14 +153,9 @@ func (col *Collector) GetState() State {
 
 // Shutdown shuts down the collector server.
 func (col *Collector) Shutdown() {
-	// Only shutdown if we're in a Running or Starting State else noop
-	state := col.GetState()
-	if state == StateRunning || state == StateStarting {
-		defer func() {
-			_ = recover()
-		}()
+	col.shutdownOnce.Do(func() {
 		close(col.shutdownChan)
-	}
+	})
 }
 
 func buildModuleInfo(m map[component.Type]string) map[component.Type]service.ModuleInfo {


### PR DESCRIPTION
#### Description

Make sure that Shutdown closes the shutdown channel at most once, but don't use the collector state to determine this. That's because the state may be "closing" during a config reload.

#### Link to tracking issue

Fixes #13740

#### Testing

Applied diff in the linked issue, does not trigger the bug anymore.

#### Documentation

N/A