### PR TITLE
[chore] service: register process metrics unconditionally

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -193,10 +193,8 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		return nil, err
 	}
 
-	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && len(mpConfig.Readers) != 0 {
-		if err = proctelemetry.RegisterProcessMetrics(srv.telemetrySettings); err != nil {
-			return nil, fmt.Errorf("failed to register process metrics: %w", err)
-		}
+	if err := proctelemetry.RegisterProcessMetrics(srv.telemetrySettings); err != nil {
+		return nil, fmt.Errorf("failed to register process metrics: %w", err)
 	}
 	return srv, nil
 }


### PR DESCRIPTION
#### Description

Don't check the metrics level/readers before registering process metrics. The registrations will be no-ops if metrics level is "none" or there are no readers, in which case the overhead is negligible.

This is also necessary as part of https://github.com/open-telemetry/opentelemetry-collector/issues/4970, since the telemetry config will become opaque.

#### Link to tracking issue

Part of #4970

#### Testing

N/A

#### Documentation

N/A