### PR TITLE
[cmd/mdatagen] Add lint/ordering validation for metadata.yaml

### DIFF
--- a/.chloggen/feat_13781.yaml
+++ b/.chloggen/feat_13781.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: "cmd/mdatagen"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add lint/ordering validation for metadata.yaml"
+
+# One or more tracking issues or pull requests related to the change
+issues: [13781]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/mdatagen/internal/command.go
+++ b/cmd/mdatagen/internal/command.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -76,6 +77,15 @@ func run(ymlPath string) error {
 
 	ymlDir := filepath.Dir(ymlPath)
 	packageName := filepath.Base(ymlDir)
+
+	raw, readErr := os.ReadFile(ymlPath)
+	if readErr != nil {
+		return fmt.Errorf("failed reading %v: %w", ymlPath, readErr)
+	}
+
+	if err := validateYAMLKeyOrder(raw); err != nil {
+		return fmt.Errorf("metadata.yaml ordering check failed: %w", err)
+	}
 
 	md, err := LoadMetadata(ymlPath)
 	if err != nil {
@@ -403,4 +413,66 @@ func generateFile(tmplFile, outputFile string, md Metadata, goPackage string) er
 	}
 
 	return formatErr
+}
+
+func validateMappingKeysSorted(root *yaml.Node, path ...string) error {
+	// unwrap doc
+	n := root
+	if n.Kind == yaml.DocumentNode && len(n.Content) > 0 {
+		n = n.Content[0]
+	}
+	// follow path
+	for _, seg := range path {
+		if n.Kind != yaml.MappingNode {
+			return nil
+		}
+		var next *yaml.Node
+		for i := 0; i < len(n.Content); i += 2 {
+			if n.Content[i].Value == seg {
+				next = n.Content[i+1]
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		n = next
+	}
+	if n.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	// collect keys
+	keys := make([]string, 0, len(n.Content)/2)
+	for i := 0; i < len(n.Content); i += 2 {
+		keys = append(keys, n.Content[i].Value)
+	}
+	sorted := append([]string(nil), keys...)
+	slices.Sort(sorted)
+	for i := range keys {
+		if keys[i] != sorted[i] {
+			return fmt.Errorf("%v keys are not sorted: %v", path, keys)
+		}
+	}
+	return nil
+}
+
+// ValidateYAMLKeyOrder checks the sections we care about.
+func validateYAMLKeyOrder(raw []byte) error {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return err
+	}
+	for _, p := range [][]string{
+		{"resource_attributes"},
+		{"attributes"},
+		{"metrics"},
+		{"events"},
+		{"telemetry", "metrics"},
+	} {
+		if err := validateMappingKeysSorted(&doc, p...); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -156,10 +157,8 @@ func (md *Metadata) supportsSignal(signal string) bool {
 	}
 
 	for _, signals := range md.Status.Stability {
-		for _, s := range signals {
-			if s == signal {
-				return true
-			}
+		if slices.Contains(signals, signal) {
+			return true
 		}
 	}
 

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -6,6 +6,7 @@ package internal
 import (
 	"io/fs"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -172,12 +173,7 @@ func TestSupportsSignal(t *testing.T) {
 }
 
 func contains(r string, rs []string) bool {
-	for _, s := range rs {
-		if s == r {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(rs, r)
 }
 
 func TestCodeCovID(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Extend mdatagen to validate that keys in metadata.yaml files are alphabetically sorted (resource_attributes, attributes, metrics, events, and telemetry.metrics).

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13781 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

WIP adding tests for ordering

```sh
❯ mdatagen metadata.yaml
Error: metadata.yaml ordering check failed: [telemetry metrics] keys are not sorted: [metric1 metric0]
Error: metadata.yaml ordering check failed: [telemetry metrics] keys are not sorted: [metric1 metric0]
```

```sh
❯ mdatagen metadata.yaml
Error: metadata.yaml ordering check failed: [resource_attributes] keys are not sorted: [cloud.region cloud.availability_zone cloud.provider host.id host.name]
Error: metadata.yaml ordering check failed: [resource_attributes] keys are not sorted: [cloud.region cloud.availability_zone cloud.provider host.id host.name]
```
