### PR TITLE
[chore] update docs to include missing config

### DIFF
--- a/exporter/debugexporter/README.md
+++ b/exporter/debugexporter/README.md
@@ -38,6 +38,7 @@ The following settings are optional:
   Refer to [Zap docs](https://godoc.org/go.uber.org/zap/zapcore#NewSampler) for more details
   on how sampling parameters impact number of messages.
 - `use_internal_logger` (default = `true`): uses the collector's internal logger for output. See [below](#using-the-collectors-internal-logger) for description.
+- `sending_queue`: see [Sending Queue](../exporterhelper/README.md#sending-queue) for the full set of available options.
 
 Example configuration:
 

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -7,12 +7,17 @@ Currently, this includes queuing, batching, timeouts, and retries.
 
 The following configuration options can be modified:
 
+### Retry on Failure
+
 - `retry_on_failure`
   - `enabled` (default = true)
   - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`
   - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
   - `max_elapsed_time` (default = 300s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`. If set to 0, the retries are never stopped.
   - `multiplier` (default = 1.5): Factor by which the retry interval is multiplied on each attempt; ignored if `enabled` is `false`
+
+### Sending Queue
+
 - `sending_queue`
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`
@@ -30,6 +35,9 @@ The following configuration options can be modified:
     - `sizer`: Overrides the sizer set at the `sending_queue` level for batching. Available options:
       - `items`: number of the smallest parts of each signal (spans, metric data points, log records);
       - `bytes`: the size of serialized data in bytes (the least performant option).
+
+### Timeout
+
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend
 
 The `initial_interval`, `max_interval`, `max_elapsed_time`, and `timeout` options accept 

--- a/exporter/otlpexporter/README.md
+++ b/exporter/otlpexporter/README.md
@@ -29,6 +29,9 @@ using the gRPC protocol. The valid syntax is described
 [here](https://github.com/grpc/grpc/blob/master/doc/naming.md).
 If a scheme of `https` is used then client transport security is enabled and overrides the `insecure` setting.
 - `tls`: see [TLS Configuration Settings](../../config/configtls/README.md) for the full set of available options.
+- `retry_on_failure`:  see [Retry on Failure](../exporterhelper/README.md#retry-on-failure) for the full set of available options.
+- `sending_queue`: see [Sending Queue](../exporterhelper/README.md#sending-queue) for the full set of available options.
+- `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend.
 
 Example:
 

--- a/exporter/otlphttpexporter/README.md
+++ b/exporter/otlphttpexporter/README.md
@@ -41,6 +41,8 @@ The following settings can be optionally configured:
 - `read_buffer_size` (default = 0): ReadBufferSize for HTTP client.
 - `write_buffer_size` (default = 512 * 1024): WriteBufferSize for HTTP client.
 - `encoding` (default = proto): The encoding to use for the messages (valid options: `proto`, `json`)
+- `retry_on_failure`:  see [Retry on Failure](../exporterhelper/README.md#retry-on-failure) for the full set of available options.
+- `sending_queue`: see [Sending Queue](../exporterhelper/README.md#sending-queue) for the full set of available options.
 
 Example:
 


### PR DESCRIPTION
The retry on failure and sending queue configuration for a few exporters were missing. Adding that here.
