### PR TITLE
[PoC][pdata/pcommon] - Enhance FromRaw method

### DIFF
--- a/.chloggen/enhance-fromraw.yaml
+++ b/.chloggen/enhance-fromraw.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enhance FromRaw method to support slices of supported types and custom types that are maps 
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR enhances `FromRaw` method to support: 
1. slices of supported types
    - For eg. if we pass a slice of `[]string`, it will fail. But we support the `string` type
2.  custom types that are maps 
    - This is a special case when the user has defined a custom type, with `map[string]any` as the underlying type.
    - We use reflection to convert the type to `map[string]any`
3. We can optionally support `time.Time` by converting it to a ISO 8601 format string. 

I'm happy to hear @bogdandrutu and @dmitryax's thoughts on this enhancement. 

#### Testing

Will add testing if we decide to go forward with this change.
