### PR TITLE
[exporterhelper] Move experimental symbols to xexporterhelper

### DIFF
--- a/.chloggen/mx-psi_move-exporterhelper-experimental-stuff.yaml
+++ b/.chloggen/mx-psi_move-exporterhelper-experimental-stuff.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate all experimental symbols in exporterhelper and move them to xexporterhelper
+
+# One or more tracking issues or pull requests related to the change
+issues: [11143]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/internal/constants.go
+++ b/exporter/exporterhelper/internal/constants.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+
+import "errors"
+
+var (
+	// errNilConfig is returned when an empty name is given.
+	errNilConfig = errors.New("nil config")
+	// errNilLogger is returned when a logger is nil
+	errNilLogger = errors.New("nil logger")
+	// errNilConsumeRequest is returned when a nil PushTraces is given.
+	errNilConsumeRequest = errors.New("nil RequestConsumeFunc")
+	// errNilPushTraces is returned when a nil PushTraces is given.
+	errNilPushTraces = errors.New("nil PushTraces")
+	// errNilPushMetrics is returned when a nil PushMetrics is given.
+	errNilPushMetrics = errors.New("nil PushMetrics")
+	// errNilPushLogs is returned when a nil PushLogs is given.
+	errNilPushLogs = errors.New("nil PushLogs")
+	// errNilTracesConverter is returned when a nil RequestFromTracesFunc is given.
+	errNilTracesConverter = errors.New("nil RequestFromTracesFunc")
+	// errNilMetricsConverter is returned when a nil RequestFromMetricsFunc is given.
+	errNilMetricsConverter = errors.New("nil RequestFromMetricsFunc")
+	// errNilLogsConverter is returned when a nil RequestFromLogsFunc is given.
+	errNilLogsConverter = errors.New("nil RequestFromLogsFunc")
+)

--- a/exporter/exporterhelper/internal/new_request.go
+++ b/exporter/exporterhelper/internal/new_request.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.uber.org/zap"
 )
@@ -61,6 +62,59 @@ func newConsumeLogs(converter request.RequestConverterFunc[plog.Logs], be *BaseE
 		if err != nil {
 			logger.Error("Failed to convert logs. Dropping data.",
 				zap.Int("dropped_log_records", ld.LogRecordCount()),
+				zap.Error(err))
+			return consumererror.NewPermanent(err)
+		}
+		return be.Send(ctx, req)
+	}
+}
+
+type tracesExporter struct {
+	*BaseExporter
+	consumer.Traces
+}
+
+// NewTracesRequest creates a new traces exporter based on a custom TracesConverter and Sender.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewTracesRequest(
+	_ context.Context,
+	set exporter.Settings,
+	converter request.RequestConverterFunc[ptrace.Traces],
+	pusher request.RequestConsumeFunc,
+	options ...Option,
+) (exporter.Traces, error) {
+	if set.Logger == nil {
+		return nil, errNilLogger
+	}
+
+	if converter == nil {
+		return nil, errNilTracesConverter
+	}
+
+	if pusher == nil {
+		return nil, errNilConsumeRequest
+	}
+
+	be, err := NewBaseExporter(set, pipeline.SignalTraces, pusher, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	tc, err := consumer.NewTraces(newConsumeTraces(converter, be, set.Logger), be.ConsumerOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tracesExporter{BaseExporter: be, Traces: tc}, nil
+}
+
+func newConsumeTraces(converter request.RequestConverterFunc[ptrace.Traces], be *BaseExporter, logger *zap.Logger) consumer.ConsumeTracesFunc {
+	return func(ctx context.Context, td ptrace.Traces) error {
+		req, err := converter(ctx, td)
+		if err != nil {
+			logger.Error("Failed to convert traces. Dropping data.",
+				zap.Int("dropped_spans", td.SpanCount()),
 				zap.Error(err))
 			return consumererror.NewPermanent(err)
 		}

--- a/exporter/exporterhelper/internal/new_request.go
+++ b/exporter/exporterhelper/internal/new_request.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.uber.org/zap"
@@ -115,6 +116,59 @@ func newConsumeTraces(converter request.RequestConverterFunc[ptrace.Traces], be 
 		if err != nil {
 			logger.Error("Failed to convert traces. Dropping data.",
 				zap.Int("dropped_spans", td.SpanCount()),
+				zap.Error(err))
+			return consumererror.NewPermanent(err)
+		}
+		return be.Send(ctx, req)
+	}
+}
+
+type metricsExporter struct {
+	*BaseExporter
+	consumer.Metrics
+}
+
+// NewMetricsRequest creates a new metrics exporter based on a custom MetricsConverter and Sender.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewMetricsRequest(
+	_ context.Context,
+	set exporter.Settings,
+	converter request.RequestConverterFunc[pmetric.Metrics],
+	pusher request.RequestConsumeFunc,
+	options ...Option,
+) (exporter.Metrics, error) {
+	if set.Logger == nil {
+		return nil, errNilLogger
+	}
+
+	if converter == nil {
+		return nil, errNilMetricsConverter
+	}
+
+	if pusher == nil {
+		return nil, errNilConsumeRequest
+	}
+
+	be, err := NewBaseExporter(set, pipeline.SignalMetrics, pusher, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	mc, err := consumer.NewMetrics(newConsumeMetrics(converter, be, set.Logger), be.ConsumerOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &metricsExporter{BaseExporter: be, Metrics: mc}, nil
+}
+
+func newConsumeMetrics(converter request.RequestConverterFunc[pmetric.Metrics], be *BaseExporter, logger *zap.Logger) consumer.ConsumeMetricsFunc {
+	return func(ctx context.Context, md pmetric.Metrics) error {
+		req, err := converter(ctx, md)
+		if err != nil {
+			logger.Error("Failed to convert metrics. Dropping data.",
+				zap.Int("dropped_data_points", md.DataPointCount()),
 				zap.Error(err))
 			return consumererror.NewPermanent(err)
 		}

--- a/exporter/exporterhelper/internal/new_request_test.go
+++ b/exporter/exporterhelper/internal/new_request_test.go
@@ -1,0 +1,108 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/requesttest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sendertest"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestLogsRequest_NilLogger(t *testing.T) {
+	le, err := NewLogsRequest(context.Background(), exporter.Settings{}, requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[request.Request]())
+	require.Nil(t, le)
+	require.Equal(t, errNilLogger, err)
+}
+
+func TestLogsRequest_NilLogsConverter(t *testing.T) {
+	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, sendertest.NewNopSenderFunc[request.Request]())
+	require.Nil(t, le)
+	require.Equal(t, errNilLogsConverter, err)
+}
+
+func TestLogsRequest_NilPushLogsData(t *testing.T) {
+	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType), requesttest.RequestFromLogsFunc(nil), nil)
+	require.Nil(t, le)
+	require.Equal(t, errNilConsumeRequest, err)
+}
+
+func TestLogsRequest_Default(t *testing.T) {
+	ld := plog.NewLogs()
+	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
+		requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[request.Request]())
+	assert.NotNil(t, le)
+	require.NoError(t, err)
+
+	assert.Equal(t, consumer.Capabilities{MutatesData: false}, le.Capabilities())
+	assert.NoError(t, le.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, le.ConsumeLogs(context.Background(), ld))
+	assert.NoError(t, le.Shutdown(context.Background()))
+}
+
+func TestLogsRequest_WithCapabilities(t *testing.T) {
+	capabilities := consumer.Capabilities{MutatesData: true}
+	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
+		requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[request.Request](), WithCapabilities(capabilities))
+	require.NoError(t, err)
+	require.NotNil(t, le)
+
+	assert.Equal(t, capabilities, le.Capabilities())
+}
+
+func TestLogsRequest_WithShutdown(t *testing.T) {
+	shutdownCalled := false
+	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
+
+	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
+		requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[request.Request](), WithShutdown(shutdown))
+	assert.NotNil(t, le)
+	assert.NoError(t, err)
+
+	assert.NoError(t, le.Shutdown(context.Background()))
+	assert.True(t, shutdownCalled)
+}
+
+func TestLogsRequest_Default_ConvertError(t *testing.T) {
+	ld := plog.NewLogs()
+	want := errors.New("convert_error")
+	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
+		requesttest.RequestFromLogsFunc(want), sendertest.NewNopSenderFunc[request.Request]())
+	require.NoError(t, err)
+	require.NotNil(t, le)
+	require.Equal(t, consumererror.NewPermanent(want), le.ConsumeLogs(context.Background(), ld))
+}
+
+func TestLogsRequest_Default_ExportError(t *testing.T) {
+	ld := plog.NewLogs()
+	want := errors.New("export_error")
+	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
+		requesttest.RequestFromLogsFunc(nil), sendertest.NewErrSenderFunc[request.Request](want))
+	require.NoError(t, err)
+	require.NotNil(t, le)
+	require.Equal(t, want, le.ConsumeLogs(context.Background(), ld))
+}
+
+func TestLogsRequest_WithShutdown_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	shutdownErr := func(context.Context) error { return want }
+
+	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
+		requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[request.Request](), WithShutdown(shutdownErr))
+	assert.NotNil(t, le)
+	require.NoError(t, err)
+
+	assert.Equal(t, want, le.Shutdown(context.Background()))
+}

--- a/exporter/exporterhelper/internal/request/request.go
+++ b/exporter/exporterhelper/internal/request/request.go
@@ -5,6 +5,8 @@ package request // import "go.opentelemetry.io/collector/exporter/exporterhelper
 
 import (
 	"context"
+
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
 )
 
 // Request represents a single request that can be sent to an external endpoint.
@@ -41,3 +43,9 @@ type ErrorHandler interface {
 	// Otherwise, it should return the original Request.
 	OnError(error) Request
 }
+
+type RequestConverterFunc[T any] func(context.Context, T) (Request, error)
+
+// RequestConsumeFunc processes the request. After the function returns, the request is no longer accessible,
+// and accessing it is considered undefined behavior.
+type RequestConsumeFunc = sender.SendFunc[Request]

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -146,6 +146,18 @@ func NewLogs(
 		append([]Option{internal.WithQueueBatchSettings(NewLogsQueueBatchSettings())}, options...)...)
 }
 
+// Deprecated [v0.136.0]: Use xexporterhelper.NewLogsRequest instead.
+// NewLogsRequest creates new logs exporter based on custom LogsConverter and Sender.
+func NewLogsRequest(
+	ctx context.Context,
+	set exporter.Settings,
+	converter RequestConverterFunc[plog.Logs],
+	pusher RequestConsumeFunc,
+	options ...Option,
+) (exporter.Logs, error) {
+	return internal.NewLogsRequest(ctx, set, converter, pusher, options...)
+}
+
 // requestConsumeFromLogs returns a RequestConsumeFunc that consumes plog.Logs.
 func requestConsumeFromLogs(pusher consumer.ConsumeLogsFunc) RequestConsumeFunc {
 	return func(ctx context.Context, request Request) error {

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 
-	"go.uber.org/zap"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -20,7 +18,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/xpdata/pref"
 	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
-	"go.opentelemetry.io/collector/pipeline"
 )
 
 var (
@@ -131,11 +128,6 @@ func (req *logsRequest) BytesSize() int {
 	return logsMarshaler.LogsSize(req.ld)
 }
 
-type logsExporter struct {
-	*internal.BaseExporter
-	consumer.Logs
-}
-
 // NewLogs creates an exporter.Logs that records observability logs and wraps every request with a Span.
 func NewLogs(
 	ctx context.Context,
@@ -150,7 +142,7 @@ func NewLogs(
 	if pusher == nil {
 		return nil, errNilPushLogs
 	}
-	return NewLogsRequest(ctx, set, requestFromLogs(), requestConsumeFromLogs(pusher),
+	return internal.NewLogsRequest(ctx, set, requestFromLogs(), requestConsumeFromLogs(pusher),
 		append([]Option{internal.WithQueueBatchSettings(NewLogsQueueBatchSettings())}, options...)...)
 }
 
@@ -165,53 +157,5 @@ func requestConsumeFromLogs(pusher consumer.ConsumeLogsFunc) RequestConsumeFunc 
 func requestFromLogs() RequestConverterFunc[plog.Logs] {
 	return func(_ context.Context, ld plog.Logs) (Request, error) {
 		return newLogsRequest(ld), nil
-	}
-}
-
-// NewLogsRequest creates new logs exporter based on custom LogsConverter and Sender.
-// Experimental: This API is at the early stage of development and may change without backward compatibility
-// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
-func NewLogsRequest(
-	_ context.Context,
-	set exporter.Settings,
-	converter RequestConverterFunc[plog.Logs],
-	pusher RequestConsumeFunc,
-	options ...Option,
-) (exporter.Logs, error) {
-	if set.Logger == nil {
-		return nil, errNilLogger
-	}
-
-	if converter == nil {
-		return nil, errNilLogsConverter
-	}
-
-	if pusher == nil {
-		return nil, errNilConsumeRequest
-	}
-
-	be, err := internal.NewBaseExporter(set, pipeline.SignalLogs, pusher, options...)
-	if err != nil {
-		return nil, err
-	}
-
-	lc, err := consumer.NewLogs(newConsumeLogs(converter, be, set.Logger), be.ConsumerOptions...)
-	if err != nil {
-		return nil, err
-	}
-
-	return &logsExporter{BaseExporter: be, Logs: lc}, nil
-}
-
-func newConsumeLogs(converter RequestConverterFunc[plog.Logs], be *internal.BaseExporter, logger *zap.Logger) consumer.ConsumeLogsFunc {
-	return func(ctx context.Context, ld plog.Logs) error {
-		req, err := converter(ctx, ld)
-		if err != nil {
-			logger.Error("Failed to convert logs. Dropping data.",
-				zap.Int("dropped_log_records", ld.LogRecordCount()),
-				zap.Error(err))
-			return consumererror.NewPermanent(err)
-		}
-		return be.Send(ctx, req)
 	}
 }

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -71,46 +71,15 @@ func TestLogs_NilLogger(t *testing.T) {
 	require.Equal(t, errNilLogger, err)
 }
 
-func TestLogsRequest_NilLogger(t *testing.T) {
-	le, err := NewLogsRequest(context.Background(), exporter.Settings{}, requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[Request]())
-	require.Nil(t, le)
-	require.Equal(t, errNilLogger, err)
-}
-
 func TestLogs_NilPushLogsData(t *testing.T) {
 	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, nil)
 	require.Nil(t, le)
 	require.Equal(t, errNilPushLogs, err)
 }
 
-func TestLogsRequest_NilLogsConverter(t *testing.T) {
-	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, sendertest.NewNopSenderFunc[Request]())
-	require.Nil(t, le)
-	require.Equal(t, errNilLogsConverter, err)
-}
-
-func TestLogsRequest_NilPushLogsData(t *testing.T) {
-	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType), requesttest.RequestFromLogsFunc(nil), nil)
-	require.Nil(t, le)
-	require.Equal(t, errNilConsumeRequest, err)
-}
-
 func TestLogs_Default(t *testing.T) {
 	ld := plog.NewLogs()
 	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil))
-	assert.NotNil(t, le)
-	require.NoError(t, err)
-
-	assert.Equal(t, consumer.Capabilities{MutatesData: false}, le.Capabilities())
-	assert.NoError(t, le.Start(context.Background(), componenttest.NewNopHost()))
-	assert.NoError(t, le.ConsumeLogs(context.Background(), ld))
-	assert.NoError(t, le.Shutdown(context.Background()))
-}
-
-func TestLogsRequest_Default(t *testing.T) {
-	ld := plog.NewLogs()
-	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[Request]())
 	assert.NotNil(t, le)
 	require.NoError(t, err)
 
@@ -129,40 +98,10 @@ func TestLogs_WithCapabilities(t *testing.T) {
 	assert.Equal(t, capabilities, le.Capabilities())
 }
 
-func TestLogsRequest_WithCapabilities(t *testing.T) {
-	capabilities := consumer.Capabilities{MutatesData: true}
-	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[Request](), WithCapabilities(capabilities))
-	require.NoError(t, err)
-	require.NotNil(t, le)
-
-	assert.Equal(t, capabilities, le.Capabilities())
-}
-
 func TestLogs_Default_ReturnError(t *testing.T) {
 	ld := plog.NewLogs()
 	want := errors.New("my_error")
 	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(want))
-	require.NoError(t, err)
-	require.NotNil(t, le)
-	require.Equal(t, want, le.ConsumeLogs(context.Background(), ld))
-}
-
-func TestLogsRequest_Default_ConvertError(t *testing.T) {
-	ld := plog.NewLogs()
-	want := errors.New("convert_error")
-	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromLogsFunc(want), sendertest.NewNopSenderFunc[Request]())
-	require.NoError(t, err)
-	require.NotNil(t, le)
-	require.Equal(t, consumererror.NewPermanent(want), le.ConsumeLogs(context.Background(), ld))
-}
-
-func TestLogsRequest_Default_ExportError(t *testing.T) {
-	ld := plog.NewLogs()
-	want := errors.New("export_error")
-	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromLogsFunc(nil), sendertest.NewErrSenderFunc[Request](want))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 	require.Equal(t, want, le.ConsumeLogs(context.Background(), ld))
@@ -279,7 +218,7 @@ func TestLogsRequest_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	le, err := NewLogsRequest(context.Background(),
+	le, err := internal.NewLogsRequest(context.Background(),
 		exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 		requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[Request]())
 	require.NoError(t, err)
@@ -305,7 +244,7 @@ func TestLogsRequest_WithRecordMetrics_ExportError(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	le, err := NewLogsRequest(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+	le, err := internal.NewLogsRequest(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 		requesttest.RequestFromLogsFunc(nil), sendertest.NewErrSenderFunc[Request](want))
 	require.NoError(t, err)
 	require.NotNil(t, le)
@@ -333,7 +272,7 @@ func TestLogsRequest_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
-	le, err := NewLogsRequest(context.Background(), set, requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[Request]())
+	le, err := internal.NewLogsRequest(context.Background(), set, requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[Request]())
 	require.NoError(t, err)
 	require.NotNil(t, le)
 	checkWrapSpanForLogs(t, sr, set.TracerProvider.Tracer("test"), le, nil)
@@ -361,7 +300,7 @@ func TestLogsRequest_WithSpan_ReturnError(t *testing.T) {
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
 	want := errors.New("my_error")
-	le, err := NewLogsRequest(context.Background(), set, requesttest.RequestFromLogsFunc(nil), sendertest.NewErrSenderFunc[Request](want))
+	le, err := internal.NewLogsRequest(context.Background(), set, requesttest.RequestFromLogsFunc(nil), sendertest.NewErrSenderFunc[Request](want))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 	checkWrapSpanForLogs(t, sr, set.TracerProvider.Tracer("test"), le, want)
@@ -379,36 +318,11 @@ func TestLogs_WithShutdown(t *testing.T) {
 	assert.True(t, shutdownCalled)
 }
 
-func TestLogsRequest_WithShutdown(t *testing.T) {
-	shutdownCalled := false
-	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
-
-	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[Request](), WithShutdown(shutdown))
-	assert.NotNil(t, le)
-	assert.NoError(t, err)
-
-	assert.NoError(t, le.Shutdown(context.Background()))
-	assert.True(t, shutdownCalled)
-}
-
 func TestLogs_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
 	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithShutdown(shutdownErr))
-	assert.NotNil(t, le)
-	require.NoError(t, err)
-
-	assert.Equal(t, want, le.Shutdown(context.Background()))
-}
-
-func TestLogsRequest_WithShutdown_ReturnError(t *testing.T) {
-	want := errors.New("my_error")
-	shutdownErr := func(context.Context) error { return want }
-
-	le, err := NewLogsRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromLogsFunc(nil), sendertest.NewNopSenderFunc[Request](), WithShutdown(shutdownErr))
 	assert.NotNil(t, le)
 	require.NoError(t, err)
 

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -127,7 +127,6 @@ func (req *metricsRequest) BytesSize() int {
 	return metricsMarshaler.MetricsSize(req.md)
 }
 
-
 // NewMetrics creates an exporter.Metrics that records observability metrics and wraps every request with a Span.
 func NewMetrics(
 	ctx context.Context,
@@ -146,6 +145,18 @@ func NewMetrics(
 		append([]Option{internal.WithQueueBatchSettings(NewMetricsQueueBatchSettings())}, options...)...)
 }
 
+// Deprecated [v0.136.0]: Use xexporterhelper.NewMetricsRequest instead.
+// NewMetricsRequest creates a new metrics exporter based on a custom MetricsConverter and Sender.
+func NewMetricsRequest(
+	ctx context.Context,
+	set exporter.Settings,
+	converter RequestConverterFunc[pmetric.Metrics],
+	pusher RequestConsumeFunc,
+	options ...Option,
+) (exporter.Metrics, error) {
+	return internal.NewMetricsRequest(ctx, set, converter, pusher, options...)
+}
+
 // requestConsumeFromMetrics returns a RequestConsumeFunc that consumes pmetric.Metrics.
 func requestConsumeFromMetrics(pusher consumer.ConsumeMetricsFunc) RequestConsumeFunc {
 	return func(ctx context.Context, request Request) error {
@@ -159,4 +170,3 @@ func requestFromMetrics() RequestConverterFunc[pmetric.Metrics] {
 		return newMetricsRequest(md), nil
 	}
 }
-

--- a/exporter/exporterhelper/queue_batch.go
+++ b/exporter/exporterhelper/queue_batch.go
@@ -40,6 +40,7 @@ var ErrQueueIsFull = queue.ErrQueueIsFull
 // They include things line Encoding to be used with persistent queue, or the available Sizers, etc.
 type QueueBatchSettings = queuebatch.Settings[Request]
 
+// Deprecated: [v0.136.0] Use xexporterhelper.WithQueueBatch.
 // WithQueueBatch enables queueing and batching for an exporter.
 // This option should be used with the new exporter helpers New[Traces|Metrics|Logs]RequestExporter.
 // Experimental: This API is at the early stage of development and may change without backward compatibility

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -4,10 +4,7 @@
 package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporterhelper"
 
 import (
-	"context"
-
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
 )
 
 // Request represents a single request that can be sent to an external endpoint.
@@ -26,11 +23,11 @@ type RequestErrorHandler = request.ErrorHandler
 // RequestConverterFunc converts pdata telemetry into a user-defined Request.
 // Experimental: This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
-type RequestConverterFunc[T any] func(context.Context, T) (Request, error)
+type RequestConverterFunc[T any] = request.RequestConverterFunc[T]
 
 // RequestConsumeFunc processes the request. After the function returns, the request is no longer accessible,
 // and accessing it is considered undefined behavior.
-type RequestConsumeFunc = sender.SendFunc[Request]
+type RequestConsumeFunc = request.RequestConsumeFunc
 
 // RequestSizer is an interface that returns the size of the given request.
 type RequestSizer = request.Sizer[Request]

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -12,6 +12,7 @@ import (
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
 type Request = request.Request
 
+// Deprecated: [v0.136.0] Use xexporterhelper.RequestErroHandler
 // RequestErrorHandler is an optional interface that can be implemented by Request to provide a way handle partial
 // temporary failures. For example, if some items failed to process and can be retried, this interface allows to
 // return a new Request that contains the items left to be sent. Otherwise, the original Request should be returned.

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -127,7 +127,6 @@ func (req *tracesRequest) BytesSize() int {
 	return tracesMarshaler.TracesSize(req.td)
 }
 
-
 // NewTraces creates an exporter.Traces that records observability metrics and wraps every request with a Span.
 func NewTraces(
 	ctx context.Context,
@@ -146,6 +145,18 @@ func NewTraces(
 		append([]Option{internal.WithQueueBatchSettings(NewTracesQueueBatchSettings())}, options...)...)
 }
 
+// Deprecated [v0.136.0]: Use xexporterhelper.NewTracesRequest instead.\
+// NewTracesRequest creates a new traces exporter based on a custom TracesConverter and Sender.
+func NewTracesRequest(
+	ctx context.Context,
+	set exporter.Settings,
+	converter RequestConverterFunc[ptrace.Traces],
+	pusher RequestConsumeFunc,
+	options ...Option,
+) (exporter.Traces, error) {
+	return internal.NewTracesRequest(ctx, set, converter, pusher, options...)
+}
+
 // requestConsumeFromTraces returns a RequestConsumeFunc that consumes ptrace.Traces.
 func requestConsumeFromTraces(pusher consumer.ConsumeTracesFunc) RequestConsumeFunc {
 	return func(ctx context.Context, request Request) error {
@@ -159,4 +170,3 @@ func requestFromTraces() RequestConverterFunc[ptrace.Traces] {
 		return newTracesRequest(traces), nil
 	}
 }
-

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 
-	"go.uber.org/zap"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -20,7 +18,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/xpdata/pref"
 	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
-	"go.opentelemetry.io/collector/pipeline"
 )
 
 var (
@@ -130,10 +127,6 @@ func (req *tracesRequest) BytesSize() int {
 	return tracesMarshaler.TracesSize(req.td)
 }
 
-type tracesExporter struct {
-	*internal.BaseExporter
-	consumer.Traces
-}
 
 // NewTraces creates an exporter.Traces that records observability metrics and wraps every request with a Span.
 func NewTraces(
@@ -149,7 +142,7 @@ func NewTraces(
 	if pusher == nil {
 		return nil, errNilPushTraces
 	}
-	return NewTracesRequest(ctx, set, requestFromTraces(), requestConsumeFromTraces(pusher),
+	return internal.NewTracesRequest(ctx, set, requestFromTraces(), requestConsumeFromTraces(pusher),
 		append([]Option{internal.WithQueueBatchSettings(NewTracesQueueBatchSettings())}, options...)...)
 }
 
@@ -167,50 +160,3 @@ func requestFromTraces() RequestConverterFunc[ptrace.Traces] {
 	}
 }
 
-// NewTracesRequest creates a new traces exporter based on a custom TracesConverter and Sender.
-// Experimental: This API is at the early stage of development and may change without backward compatibility
-// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
-func NewTracesRequest(
-	_ context.Context,
-	set exporter.Settings,
-	converter RequestConverterFunc[ptrace.Traces],
-	pusher RequestConsumeFunc,
-	options ...Option,
-) (exporter.Traces, error) {
-	if set.Logger == nil {
-		return nil, errNilLogger
-	}
-
-	if converter == nil {
-		return nil, errNilTracesConverter
-	}
-
-	if pusher == nil {
-		return nil, errNilConsumeRequest
-	}
-
-	be, err := internal.NewBaseExporter(set, pipeline.SignalTraces, pusher, options...)
-	if err != nil {
-		return nil, err
-	}
-
-	tc, err := consumer.NewTraces(newConsumeTraces(converter, be, set.Logger), be.ConsumerOptions...)
-	if err != nil {
-		return nil, err
-	}
-
-	return &tracesExporter{BaseExporter: be, Traces: tc}, nil
-}
-
-func newConsumeTraces(converter RequestConverterFunc[ptrace.Traces], be *internal.BaseExporter, logger *zap.Logger) consumer.ConsumeTracesFunc {
-	return func(ctx context.Context, td ptrace.Traces) error {
-		req, err := converter(ctx, td)
-		if err != nil {
-			logger.Error("Failed to convert traces. Dropping data.",
-				zap.Int("dropped_spans", td.SpanCount()),
-				zap.Error(err))
-			return consumererror.NewPermanent(err)
-		}
-		return be.Send(ctx, req)
-	}
-}

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -67,46 +67,15 @@ func TestTraces_NilLogger(t *testing.T) {
 	require.Equal(t, errNilLogger, err)
 }
 
-func TestTracesRequest_NilLogger(t *testing.T) {
-	te, err := NewTracesRequest(context.Background(), exporter.Settings{}, requesttest.RequestFromTracesFunc(nil), sendertest.NewNopSenderFunc[Request]())
-	require.Nil(t, te)
-	require.Equal(t, errNilLogger, err)
-}
-
 func TestTraces_NilPushTraceData(t *testing.T) {
 	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, nil)
 	require.Nil(t, te)
 	require.Equal(t, errNilPushTraces, err)
 }
 
-func TestTracesRequest_NilTracesConverter(t *testing.T) {
-	te, err := NewTracesRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, sendertest.NewNopSenderFunc[Request]())
-	require.Nil(t, te)
-	require.Equal(t, errNilTracesConverter, err)
-}
-
-func TestTracesRequest_NilPushTraceData(t *testing.T) {
-	te, err := NewTracesRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType), requesttest.RequestFromTracesFunc(nil), nil)
-	require.Nil(t, te)
-	require.Equal(t, errNilConsumeRequest, err)
-}
-
 func TestTraces_Default(t *testing.T) {
 	td := ptrace.NewTraces()
 	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil))
-	assert.NotNil(t, te)
-	require.NoError(t, err)
-
-	assert.Equal(t, consumer.Capabilities{MutatesData: false}, te.Capabilities())
-	assert.NoError(t, te.Start(context.Background(), componenttest.NewNopHost()))
-	assert.NoError(t, te.ConsumeTraces(context.Background(), td))
-	assert.NoError(t, te.Shutdown(context.Background()))
-}
-
-func TestTracesRequest_Default(t *testing.T) {
-	td := ptrace.NewTraces()
-	te, err := NewTracesRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromTracesFunc(nil), sendertest.NewNopSenderFunc[Request]())
 	assert.NotNil(t, te)
 	require.NoError(t, err)
 
@@ -125,16 +94,6 @@ func TestTraces_WithCapabilities(t *testing.T) {
 	assert.Equal(t, capabilities, te.Capabilities())
 }
 
-func TestTracesRequest_WithCapabilities(t *testing.T) {
-	capabilities := consumer.Capabilities{MutatesData: true}
-	te, err := NewTracesRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromTracesFunc(nil), sendertest.NewNopSenderFunc[Request](), WithCapabilities(capabilities))
-	assert.NotNil(t, te)
-	require.NoError(t, err)
-
-	assert.Equal(t, capabilities, te.Capabilities())
-}
-
 func TestTraces_Default_ReturnError(t *testing.T) {
 	td := ptrace.NewTraces()
 	want := errors.New("my_error")
@@ -146,25 +105,6 @@ func TestTraces_Default_ReturnError(t *testing.T) {
 	require.Equal(t, want, err)
 }
 
-func TestTracesRequest_Default_ConvertError(t *testing.T) {
-	td := ptrace.NewTraces()
-	want := errors.New("convert_error")
-	te, err := NewTracesRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromTracesFunc(want), sendertest.NewNopSenderFunc[Request]())
-	require.NoError(t, err)
-	require.NotNil(t, te)
-	require.Equal(t, consumererror.NewPermanent(want), te.ConsumeTraces(context.Background(), td))
-}
-
-func TestTracesRequest_Default_ExportError(t *testing.T) {
-	td := ptrace.NewTraces()
-	want := errors.New("export_error")
-	te, err := NewTracesRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromTracesFunc(nil), sendertest.NewErrSenderFunc[Request](want))
-	require.NoError(t, err)
-	require.NotNil(t, te)
-	require.Equal(t, want, te.ConsumeTraces(context.Background(), td))
-}
 
 func TestTraces_WithPersistentQueue(t *testing.T) {
 	fgOrigReadState := queue.PersistRequestContextOnRead
@@ -277,7 +217,7 @@ func TestTracesRequest_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTracesRequest(context.Background(),
+	te, err := internal.NewTracesRequest(context.Background(),
 		exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 		requesttest.RequestFromTracesFunc(nil), sendertest.NewNopSenderFunc[Request]())
 	require.NoError(t, err)
@@ -303,7 +243,7 @@ func TestTracesRequest_WithRecordMetrics_RequestSenderError(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTracesRequest(context.Background(),
+	te, err := internal.NewTracesRequest(context.Background(),
 		exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
 		requesttest.RequestFromTracesFunc(nil), sendertest.NewErrSenderFunc[Request](want))
 	require.NoError(t, err)
@@ -333,7 +273,7 @@ func TestTracesRequest_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
-	te, err := NewTracesRequest(context.Background(), set, requesttest.RequestFromTracesFunc(nil), sendertest.NewNopSenderFunc[Request]())
+	te, err := internal.NewTracesRequest(context.Background(), set, requesttest.RequestFromTracesFunc(nil), sendertest.NewNopSenderFunc[Request]())
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -363,7 +303,7 @@ func TestTracesRequest_WithSpan_ExportError(t *testing.T) {
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
 	want := errors.New("export_error")
-	te, err := NewTracesRequest(context.Background(), set, requesttest.RequestFromTracesFunc(nil), sendertest.NewErrSenderFunc[Request](want))
+	te, err := internal.NewTracesRequest(context.Background(), set, requesttest.RequestFromTracesFunc(nil), sendertest.NewErrSenderFunc[Request](want))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -383,38 +323,11 @@ func TestTraces_WithShutdown(t *testing.T) {
 	assert.True(t, shutdownCalled)
 }
 
-func TestTracesRequest_WithShutdown(t *testing.T) {
-	shutdownCalled := false
-	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
-
-	te, err := NewTracesRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromTracesFunc(nil), sendertest.NewNopSenderFunc[Request](), WithShutdown(shutdown))
-	assert.NotNil(t, te)
-	assert.NoError(t, err)
-
-	assert.NoError(t, te.Start(context.Background(), componenttest.NewNopHost()))
-	assert.NoError(t, te.Shutdown(context.Background()))
-	assert.True(t, shutdownCalled)
-}
-
 func TestTraces_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
 	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithShutdown(shutdownErr))
-	assert.NotNil(t, te)
-	assert.NoError(t, err)
-
-	assert.NoError(t, te.Start(context.Background(), componenttest.NewNopHost()))
-	assert.Equal(t, want, te.Shutdown(context.Background()))
-}
-
-func TestTracesRequest_WithShutdown_ReturnError(t *testing.T) {
-	want := errors.New("my_error")
-	shutdownErr := func(context.Context) error { return want }
-
-	te, err := NewTracesRequest(context.Background(), exportertest.NewNopSettings(exportertest.NopType),
-		requesttest.RequestFromTracesFunc(nil), sendertest.NewNopSenderFunc[Request](), WithShutdown(shutdownErr))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 

--- a/exporter/exporterhelper/xexporterhelper/new_request.go
+++ b/exporter/exporterhelper/xexporterhelper/new_request.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package xexporterhelper // import "go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// NewLogsRequest creates new logs exporter based on custom LogsConverter and Sender.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewLogsRequest(
+	ctx context.Context,
+	set exporter.Settings,
+	converter RequestConverterFunc[plog.Logs],
+	pusher RequestConsumeFunc,
+	options ...exporterhelper.Option,
+) (exporter.Logs, error) {
+	return internal.NewLogsRequest(ctx, set, converter, pusher, options...)
+}
+
+// NewMetricsRequest creates new metrics exporter based on custom MetricsConverter and Sender.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewMetricsRequest(
+	ctx context.Context,
+	set exporter.Settings,
+	converter RequestConverterFunc[pmetric.Metrics],
+	pusher RequestConsumeFunc,
+	options ...exporterhelper.Option,
+) (exporter.Metrics, error) {
+	return internal.NewMetricsRequest(ctx, set, converter, pusher, options...)
+}
+
+// NewTracesRequest creates new traces exporter based on custom TracesConverter and Sender.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewTracesRequest(
+	ctx context.Context,
+	set exporter.Settings,
+	converter RequestConverterFunc[ptrace.Traces],
+	pusher RequestConsumeFunc,
+	options ...exporterhelper.Option,
+) (exporter.Traces, error) {
+	return internal.NewTracesRequest(ctx, set, converter, pusher, options...)
+}

--- a/exporter/exporterhelper/xexporterhelper/new_request.go
+++ b/exporter/exporterhelper/xexporterhelper/new_request.go
@@ -52,3 +52,11 @@ func NewTracesRequest(
 ) (exporter.Traces, error) {
 	return internal.NewTracesRequest(ctx, set, converter, pusher, options...)
 }
+
+// WithQueueBatch enables queueing and batching for an exporter.
+// This option should be used with the new exporter helpers New[Traces|Metrics|Logs]RequestExporter.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func WithQueueBatch(cfg exporterhelper.QueueBatchConfig, set exporterhelper.QueueBatchSettings) exporterhelper.Option {
+	return internal.WithQueueBatch(cfg, set)
+}

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -176,8 +176,8 @@ func requestFromProfiles() exporterhelper.RequestConverterFunc[pprofile.Profiles
 func NewProfilesRequest(
 	_ context.Context,
 	set exporter.Settings,
-	converter exporterhelper.RequestConverterFunc[pprofile.Profiles],
-	pusher exporterhelper.RequestConsumeFunc,
+	converter RequestConverterFunc[pprofile.Profiles],
+	pusher RequestConsumeFunc,
 	options ...exporterhelper.Option,
 ) (xexporter.Profiles, error) {
 	if set.Logger == nil {

--- a/exporter/exporterhelper/xexporterhelper/request.go
+++ b/exporter/exporterhelper/xexporterhelper/request.go
@@ -1,16 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporterhelper"
+package xexporterhelper // import "go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper"
 
-import (
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
-)
-
-// Request represents a single request that can be sent to an external endpoint.
-// Experimental: This API is at the early stage of development and may change without backward compatibility
-// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
-type Request = request.Request
+import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/request" // Request represents a single request that can be sent to an external endpoint.
 
 // RequestErrorHandler is an optional interface that can be implemented by Request to provide a way handle partial
 // temporary failures. For example, if some items failed to process and can be retried, this interface allows to
@@ -20,29 +13,11 @@ type Request = request.Request
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
 type RequestErrorHandler = request.ErrorHandler
 
-// Deprecated: [v0.136.0] Use xexporterhelper.RequestConsumeFunc.
 // RequestConverterFunc converts pdata telemetry into a user-defined Request.
 // Experimental: This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
 type RequestConverterFunc[T any] = request.RequestConverterFunc[T]
 
-// Deprecated: [v0.136.0] Use xexporterhelper.RequestConsumeFunc.
 // RequestConsumeFunc processes the request. After the function returns, the request is no longer accessible,
 // and accessing it is considered undefined behavior.
 type RequestConsumeFunc = request.RequestConsumeFunc
-
-// RequestSizer is an interface that returns the size of the given request.
-type RequestSizer = request.Sizer[Request]
-
-// Deprecated: [v0.129.0] no need, always supported.
-func NewRequestsSizer() RequestSizer {
-	return request.RequestsSizer[Request]{}
-}
-
-type RequestSizerType = request.SizerType
-
-var (
-	RequestSizerTypeBytes    = request.SizerTypeBytes
-	RequestSizerTypeItems    = request.SizerTypeItems
-	RequestSizerTypeRequests = request.SizerTypeRequests
-)


### PR DESCRIPTION
#### Description

<!-- Issue number if applicable -->

Moves all symbols marked as 'Experimental' to xexporterhelper.

#### Link to tracking issue
Updates #11143