### PR TITLE
Fix pprofile timestamp unix nano to be a fixed64

### DIFF
--- a/.chloggen/profiles-otlp-1-8-0.yaml
+++ b/.chloggen/profiles-otlp-1-8-0.yaml
@@ -10,7 +10,7 @@ component: pdata/pprofile
 note: Upgrade the OTLP protobuf definitions to version 1.8.0
 
 # One or more tracking issues or pull requests related to the change
-issues: [13758]
+issues: [13758, 13825]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/internal/cmd/pdatagen/internal/pdata/pprofile_package.go
+++ b/internal/cmd/pdatagen/internal/pdata/pprofile_package.go
@@ -232,13 +232,7 @@ var profile = &messageStruct{
 			fieldName:       "Time",
 			originFieldName: "TimeUnixNano",
 			protoID:         3,
-			returnType: &TypedType{
-				structName:  "Timestamp",
-				packageName: "pcommon",
-				protoType:   proto.TypeFixed64,
-				defaultVal:  "0",
-				testVal:     "1234567890",
-			},
+			returnType:      timestampType,
 		},
 		&TypedField{
 			fieldName:       "Duration",

--- a/internal/cmd/pdatagen/internal/pdata/pprofile_package.go
+++ b/internal/cmd/pdatagen/internal/pdata/pprofile_package.go
@@ -235,7 +235,7 @@ var profile = &messageStruct{
 			returnType: &TypedType{
 				structName:  "Timestamp",
 				packageName: "pcommon",
-				protoType:   proto.TypeUint64,
+				protoType:   proto.TypeFixed64,
 				defaultVal:  "0",
 				testVal:     "1234567890",
 			},

--- a/pdata/internal/generated_wrapper_profile_test.go
+++ b/pdata/internal/generated_wrapper_profile_test.go
@@ -145,7 +145,7 @@ func genTestFailingUnmarshalProtoValuesProfile() map[string][]byte {
 		"Sample/wrong_wire_type":                 {0x14},
 		"Sample/missing_value":                   {0x12},
 		"TimeUnixNano/wrong_wire_type":           {0x1c},
-		"TimeUnixNano/missing_value":             {0x18},
+		"TimeUnixNano/missing_value":             {0x19},
 		"DurationNano/wrong_wire_type":           {0x24},
 		"DurationNano/missing_value":             {0x20},
 		"PeriodType/wrong_wire_type":             {0x2c},

--- a/service/internal/graph/obs_test.go
+++ b/service/internal/graph/obs_test.go
@@ -548,7 +548,7 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.receiver.produced.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 1271,
+				): 1254,
 			},
 		},
 		attribute.NewSet(
@@ -570,12 +570,12 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.processor.consumed.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 1271,
+				): 1254,
 			},
 			"otelcol.processor.produced.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 1271,
+				): 1254,
 			},
 		},
 		attribute.NewSet(
@@ -602,17 +602,17 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.connector.consumed.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 1271,
+				): 1254,
 			},
 			"otelcol.connector.produced.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 					attribute.String("otelcol.pipeline.id", "profiles/right"),
-				): 668,
+				): 659,
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 					attribute.String("otelcol.pipeline.id", "profiles/left"),
-				): 603,
+				): 595,
 			},
 		},
 		attribute.NewSet(
@@ -628,7 +628,7 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.exporter.consumed.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 668,
+				): 659,
 			},
 		},
 		attribute.NewSet(
@@ -644,7 +644,7 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.exporter.consumed.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 603,
+				): 595,
 			},
 		},
 	}


### PR DESCRIPTION
This was missed in my previous PR. The `timestamp_unix_nano` field has changed to be a fixed rather than uint.
See https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/profiles/v1development/profiles.proto#L257