### PR TITLE
Remove built pdatagen before regenerating pdata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,9 +246,12 @@ genproto_sub:
 	@rm -rf $(OPENTELEMETRY_PROTO_SRC_DIR)/*
 	@rm -rf $(OPENTELEMETRY_PROTO_SRC_DIR)/.* > /dev/null 2>&1 || true
 
+remove-pdatagen:
+	rm -f .tools/pdatagen
+
 # Generate structs, functions and tests for pdata package. Must be used after any changes
 # to proto and after running `make genproto`
-genpdata: $(PDATAGEN)
+genpdata: remove-pdatagen $(PDATAGEN)
 	$(PDATAGEN)
 	$(MAKE) -C pdata fmt
 


### PR DESCRIPTION
The pdata definitions are now stored directly within pdatagen. So if we rely on the cached pdatagen binary, updates in the files will never be rebuilt.

This wasn't an issue before https://github.com/open-telemetry/opentelemetry-collector/pull/13398, as we used `go run` rather than a tool.