### PR TITLE
Use email to exclude otelbot from merge freeze

### DIFF
--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -24,7 +24,7 @@ jobs:
     # This condition is to avoid blocking the PR causing the freeze in the first place.
     if: |
       (!startsWith(github.event.pull_request.title || github.event.merge_group.head_commit.message, '[chore] Prepare release')) ||
-      (!(github.event.pull_request.user.login == 'otelbot[bot]' || github.event.merge_group.head_commit.author.name == 'otelbot'))
+      ((github.event.pull_request.user.email || github.event.merge_group.head_commit.author.email) != '197425009+otelbot@users.noreply.github.com')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
#### Description
This PR changes the criterion which excludes otelbot's "Prepare release" PRs from the merge freeze they cause, so that we check the email address instead of the name of the committer. The address was taken from [otelbot's last commit on its latest PR](https://github.com/open-telemetry/opentelemetry-collector/commit/8e24523e66c3acfeb18dd3086f7f198f3953bae5.patch).

#### Link to tracking issue
Updates #13789
 
Hopefully fixes it, but let's wait until next release to see if it worked.
