### PR TITLE
[exporterhelper] Enable block_on_overflow by default

### DIFF
--- a/exporter/exporterhelper/internal/queue_sender.go
+++ b/exporter/exporterhelper/internal/queue_sender.go
@@ -14,7 +14,7 @@ import (
 )
 
 // NewDefaultQueueConfig returns the default config for queuebatch.Config.
-// By default, the queue stores 1000 requests of telemetry and is non-blocking when full.
+// By default, the queue stores 1000 requests of telemetry and is blocking when full.
 func NewDefaultQueueConfig() queuebatch.Config {
 	return queuebatch.Config{
 		Enabled:      true,
@@ -24,7 +24,7 @@ func NewDefaultQueueConfig() queuebatch.Config {
 		// This can be estimated at 1-4 GB worth of maximum memory usage
 		// This default is probably still too high, and may be adjusted further down in a future release
 		QueueSize:       1_000,
-		BlockOnOverflow: false,
+		BlockOnOverflow: true,
 	}
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is a test to see how our test suite behaves with `block_on_overflow` set to `true`
