### PR TITLE
[chore][exporterhelper] Give more verbose errors

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -5,6 +5,7 @@ package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhel
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -112,23 +113,23 @@ func (cfg *BatchConfig) Validate() error {
 
 	// Only support items or bytes sizer for batch at this moment.
 	if cfg.Sizer != request.SizerTypeItems && cfg.Sizer != request.SizerTypeBytes {
-		return errors.New("`batch` supports only `items` or `bytes` sizer")
+		return fmt.Errorf("`batch` supports only `items` or `bytes` sizer, found %q", cfg.Sizer.String())
 	}
 
 	if cfg.FlushTimeout <= 0 {
-		return errors.New("`flush_timeout` must be positive")
+		return fmt.Errorf("`flush_timeout` must be positive, found %d", cfg.FlushTimeout)
 	}
 
 	if cfg.MinSize < 0 {
-		return errors.New("`min_size` must be non-negative")
+		return fmt.Errorf("`min_size` must be non-negative, found %d", cfg.MinSize)
 	}
 
 	if cfg.MaxSize < 0 {
-		return errors.New("`max_size` must be non-negative")
+		return fmt.Errorf("`max_size` must be non-negative, found %d", cfg.MaxSize)
 	}
 
 	if cfg.MaxSize > 0 && cfg.MaxSize < cfg.MinSize {
-		return errors.New("`max_size` must be greater or equal to `min_size`")
+		return fmt.Errorf("`max_size` (%d) must be greater or equal to `min_size` (%d)", cfg.MaxSize, cfg.MinSize)
 	}
 
 	return nil

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -42,7 +42,7 @@ func TestConfig_Validate(t *testing.T) {
 
 	cfg = newTestConfig()
 	cfg.Batch.Get().Sizer = request.SizerType{}
-	require.EqualError(t, xconfmap.Validate(cfg), "batch: `batch` supports only `items` or `bytes` sizer")
+	require.EqualError(t, xconfmap.Validate(cfg), "batch: `batch` supports only `items` or `bytes` sizer, found \"\"")
 
 	cfg = newTestConfig()
 	cfg.Sizer = request.SizerTypeBytes
@@ -59,28 +59,28 @@ func TestBatchConfig_Validate(t *testing.T) {
 
 	cfg = newTestBatchConfig()
 	cfg.FlushTimeout = 0
-	require.EqualError(t, xconfmap.Validate(cfg), "`flush_timeout` must be positive")
+	require.EqualError(t, xconfmap.Validate(cfg), "`flush_timeout` must be positive, found 0")
 
 	cfg = newTestBatchConfig()
 	cfg.MinSize = -1
-	require.EqualError(t, xconfmap.Validate(cfg), "`min_size` must be non-negative")
+	require.EqualError(t, xconfmap.Validate(cfg), "`min_size` must be non-negative, found -1")
 
 	cfg = newTestBatchConfig()
 	cfg.MaxSize = -1
-	require.EqualError(t, xconfmap.Validate(cfg), "`max_size` must be non-negative")
+	require.EqualError(t, xconfmap.Validate(cfg), "`max_size` must be non-negative, found -1")
 
 	cfg = newTestBatchConfig()
 	cfg.Sizer = request.SizerTypeRequests
-	require.EqualError(t, xconfmap.Validate(cfg), "`batch` supports only `items` or `bytes` sizer")
+	require.EqualError(t, xconfmap.Validate(cfg), "`batch` supports only `items` or `bytes` sizer, found \"requests\"")
 
 	cfg = newTestBatchConfig()
 	cfg.Sizer = request.SizerType{}
-	require.EqualError(t, xconfmap.Validate(cfg), "`batch` supports only `items` or `bytes` sizer")
+	require.EqualError(t, xconfmap.Validate(cfg), "`batch` supports only `items` or `bytes` sizer, found \"\"")
 
 	cfg = newTestBatchConfig()
 	cfg.MinSize = 2048
 	cfg.MaxSize = 1024
-	require.EqualError(t, xconfmap.Validate(cfg), "`max_size` must be greater or equal to `min_size`")
+	require.EqualError(t, xconfmap.Validate(cfg), "`max_size` (1024) must be greater or equal to `min_size` (2048)")
 }
 
 func newTestBatchConfig() BatchConfig {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Make it so that `exporterhelper` gives more verbose errors when you get something wrong on the `QueueBatchConfig` section.
