### PR TITLE
[chore][exporterhelper] Clarify that you need to set at least one of the fields

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -28,7 +28,7 @@ The following configuration options can be modified:
     - `items`: number of the smallest parts of each signal (spans, metric data points, log records);
     - `bytes`: the size of serialized data in bytes (the least performant option).
   - `queue_size` (default = 1000): Maximum size the queue can accept. Measured in units defined by `sizer`
-  - `batch` disabled by default if not defined
+  - `batch` disabled by default if not defined. You must set at least one of the fields below to enable batching.
     - `flush_timeout`: time after which a batch will be sent regardless of its size. Must be a non-zero value
     - `min_size`: the minimum size of a batch.
     - `max_size`: the maximum size of a batch, enables batch splitting. The maximum size of a batch should be greater than or equal to the minimum size of a batch.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

When I first read this I mistakenly assumed that `sending_queue::batch` had a default configuration with `configoptional.Default` and thus that `sending_queue::batch` would work, but this is not the case: it is set to `configoptional.None`.

This means that

```
sending_queue:
  enabled: true
  batch:
```

is equivalent to doing

```
sending_queue:
  enabled: true
```

to enable it one must at least do something like:

```
sending_queue:
  batch:
    sizer: items
```
