### PR TITLE
[exporterhelper] Add default value for sending_queue::batch section

### DIFF
--- a/.chloggen/mx-psi_configoptional-default-for-batch-config.yaml
+++ b/.chloggen/mx-psi_configoptional-default-for-batch-config.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add default values for `sending_queue::batch` configuration.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13766]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Setting `sending_queue::batch` to an empty value now results in the same setup as the default batch processor configuration.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -29,10 +29,10 @@ The following configuration options can be modified:
     - `bytes`: the size of serialized data in bytes (the least performant option).
   - `queue_size` (default = 1000): Maximum size the queue can accept. Measured in units defined by `sizer`
   - `batch` disabled by default if not defined
-    - `flush_timeout`: time after which a batch will be sent regardless of its size. Must be a non-zero value
-    - `min_size`: the minimum size of a batch.
-    - `max_size`: the maximum size of a batch, enables batch splitting. The maximum size of a batch should be greater than or equal to the minimum size of a batch.
-    - `sizer`: Overrides the sizer set at the `sending_queue` level for batching. Available options:
+    - `flush_timeout` (default (if section is defined) = 200 ms): time after which a batch will be sent regardless of its size. Must be a non-zero value
+    - `min_size` (default (if section is defined) = 8192): the minimum size of a batch.
+    - `max_size` (default (if section is defined) = 0): the maximum size of a batch, enables batch splitting. The maximum size of a batch should be greater than or equal to the minimum size of a batch. If set to zero, there is no maximum size.
+    - `sizer` (default (if section is defined) = items): Overrides the sizer set at the `sending_queue` level for batching. Available options:
       - `items`: number of the smallest parts of each signal (spans, metric data points, log records);
       - `bytes`: the size of serialized data in bytes (the least performant option).
 

--- a/exporter/exporterhelper/internal/queue_sender.go
+++ b/exporter/exporterhelper/internal/queue_sender.go
@@ -5,9 +5,11 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
@@ -25,6 +27,11 @@ func NewDefaultQueueConfig() queuebatch.Config {
 		// This default is probably still too high, and may be adjusted further down in a future release
 		QueueSize:       1_000,
 		BlockOnOverflow: false,
+		Batch: configoptional.Default(queuebatch.BatchConfig{
+			FlushTimeout: 200 * time.Millisecond,
+			Sizer:        request.SizerTypeItems,
+			MinSize:      8192,
+		}),
 	}
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds default value for `sending_queue::batch` section. This means that setting

```yaml
sending_queue:
  batch:
```

will now result in 

```yaml
sending_queue:
  batch:
   sizer: items
   flush_timeout: 200ms
   min_size: 8192
```

#### Testing

<!--Describe the documentation added.-->

#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->

Updates documentation from exporter/exporterhelper
