### PR TITLE
[chore] Move missing experimental symbols to xexporterhelper

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/encoding.go
+++ b/exporter/exporterhelper/internal/queuebatch/encoding.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+
+import "context"
+
+// encoding defines the encoding to be used if persistent queue is configured.
+// Duplicate definition with exporterhelper.QueueBatchEncoding since aliasing generics is not supported by default.
+type encoding[T any] interface {
+	// Marshal is a function that can marshal a request and its context into bytes.
+	Marshal(context.Context, T) ([]byte, error)
+
+	// Unmarshal is a function that can unmarshal bytes into a request and its context.
+	Unmarshal([]byte) (context.Context, T, error)
+}

--- a/exporter/exporterhelper/internal/queuebatch/logs.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs.go
@@ -125,14 +125,14 @@ func (req *logsRequest) BytesSize() int {
 	return logsMarshaler.LogsSize(req.ld)
 }
 
-// requestConsumeFromLogs returns a RequestConsumeFunc that consumes plog.Logs.
+// RequestConsumeFromLogs returns a RequestConsumeFunc that consumes plog.Logs.
 func RequestConsumeFromLogs(pusher consumer.ConsumeLogsFunc) request.RequestConsumeFunc {
 	return func(ctx context.Context, request request.Request) error {
 		return pusher.ConsumeLogs(ctx, request.(*logsRequest).ld)
 	}
 }
 
-// requestFromLogs returns a RequestFromLogsFunc that converts plog.Logs into a Request.
+// RequestFromLogs returns a RequestFromLogsFunc that converts plog.Logs into a Request.
 func RequestFromLogs() request.RequestConverterFunc[plog.Logs] {
 	return func(_ context.Context, ld plog.Logs) (request.Request, error) {
 		return newLogsRequest(ld), nil

--- a/exporter/exporterhelper/internal/queuebatch/logs.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs.go
@@ -1,0 +1,140 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
+)
+
+var (
+	logsMarshaler   = &plog.ProtoMarshaler{}
+	logsUnmarshaler = &plog.ProtoUnmarshaler{}
+)
+
+// NewLogsQueueBatchSettings returns a new QueueBatchSettings to configure to WithQueueBatch when using plog.Logs.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewLogsQueueBatchSettings() Settings[request.Request] {
+	return Settings[request.Request]{
+		ReferenceCounter: logsReferenceCounter{},
+		Encoding:         logsEncoding{},
+		ItemsSizer:       request.NewItemsSizer(),
+		BytesSizer: request.BaseSizer{
+			SizeofFunc: func(req request.Request) int64 {
+				return int64(logsMarshaler.LogsSize(req.(*logsRequest).ld))
+			},
+		},
+	}
+}
+
+var (
+	_ request.Request      = (*logsRequest)(nil)
+	_ request.ErrorHandler = (*logsRequest)(nil)
+)
+
+type logsRequest struct {
+	ld         plog.Logs
+	cachedSize int
+}
+
+func newLogsRequest(ld plog.Logs) request.Request {
+	return &logsRequest{
+		ld:         ld,
+		cachedSize: -1,
+	}
+}
+
+type logsEncoding struct{}
+
+var _ encoding[request.Request] = logsEncoding{}
+
+func (logsEncoding) Unmarshal(bytes []byte) (context.Context, request.Request, error) {
+	if queue.PersistRequestContextOnRead() {
+		ctx, logs, err := pdatareq.UnmarshalLogs(bytes)
+		if errors.Is(err, pdatareq.ErrInvalidFormat) {
+			// fall back to unmarshaling without context
+			logs, err = logsUnmarshaler.UnmarshalLogs(bytes)
+		}
+		return ctx, newLogsRequest(logs), err
+	}
+
+	logs, err := logsUnmarshaler.UnmarshalLogs(bytes)
+	if err != nil {
+		var req request.Request
+		return context.Background(), req, err
+	}
+	return context.Background(), newLogsRequest(logs), nil
+}
+
+func (logsEncoding) Marshal(ctx context.Context, req request.Request) ([]byte, error) {
+	logs := req.(*logsRequest).ld
+	if queue.PersistRequestContextOnWrite() {
+		return pdatareq.MarshalLogs(ctx, logs)
+	}
+	return logsMarshaler.MarshalLogs(logs)
+}
+
+var _ queue.ReferenceCounter[request.Request] = logsReferenceCounter{}
+
+type logsReferenceCounter struct{}
+
+func (logsReferenceCounter) Ref(req request.Request) {
+	pref.RefLogs(req.(*logsRequest).ld)
+}
+
+func (logsReferenceCounter) Unref(req request.Request) {
+	pref.UnrefLogs(req.(*logsRequest).ld)
+}
+
+func (req *logsRequest) OnError(err error) request.Request {
+	var logError consumererror.Logs
+	if errors.As(err, &logError) {
+		// TODO: Add logic to unref the new request created here.
+		return newLogsRequest(logError.Data())
+	}
+	return req
+}
+
+func (req *logsRequest) ItemsCount() int {
+	return req.ld.LogRecordCount()
+}
+
+func (req *logsRequest) size(sizer sizer.LogsSizer) int {
+	if req.cachedSize == -1 {
+		req.cachedSize = sizer.LogsSize(req.ld)
+	}
+	return req.cachedSize
+}
+
+func (req *logsRequest) setCachedSize(size int) {
+	req.cachedSize = size
+}
+
+func (req *logsRequest) BytesSize() int {
+	return logsMarshaler.LogsSize(req.ld)
+}
+
+// requestConsumeFromLogs returns a RequestConsumeFunc that consumes plog.Logs.
+func RequestConsumeFromLogs(pusher consumer.ConsumeLogsFunc) request.RequestConsumeFunc {
+	return func(ctx context.Context, request request.Request) error {
+		return pusher.ConsumeLogs(ctx, request.(*logsRequest).ld)
+	}
+}
+
+// requestFromLogs returns a RequestFromLogsFunc that converts plog.Logs into a Request.
+func RequestFromLogs() request.RequestConverterFunc[plog.Logs] {
+	return func(_ context.Context, ld plog.Logs) (request.Request, error) {
+		return newLogsRequest(ld), nil
+	}
+}

--- a/exporter/exporterhelper/internal/queuebatch/logs_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/pdata/plog"

--- a/exporter/exporterhelper/internal/queuebatch/logs_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/testdata"
+)
+
+func TestLogsRequest(t *testing.T) {
+	lr := newLogsRequest(testdata.GenerateLogs(1))
+
+	logErr := consumererror.NewLogs(errors.New("some error"), plog.NewLogs())
+	assert.Equal(
+		t,
+		newLogsRequest(plog.NewLogs()),
+		lr.(request.ErrorHandler).OnError(logErr),
+	)
+}

--- a/exporter/exporterhelper/internal/queuebatch/metrics.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics.go
@@ -1,0 +1,136 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
+)
+
+var (
+	metricsMarshaler   = &pmetric.ProtoMarshaler{}
+	metricsUnmarshaler = &pmetric.ProtoUnmarshaler{}
+)
+
+func NewMetricsQueueBatchSettings() Settings[request.Request] {
+	return Settings[request.Request]{
+		ReferenceCounter: metricsReferenceCounter{},
+		Encoding:         metricsEncoding{},
+		ItemsSizer:       request.NewItemsSizer(),
+		BytesSizer: request.BaseSizer{
+			SizeofFunc: func(req request.Request) int64 {
+				return int64(metricsMarshaler.MetricsSize(req.(*metricsRequest).md))
+			},
+		},
+	}
+}
+
+var (
+	_ request.Request      = (*metricsRequest)(nil)
+	_ request.ErrorHandler = (*metricsRequest)(nil)
+)
+
+type metricsRequest struct {
+	md         pmetric.Metrics
+	cachedSize int
+}
+
+func newMetricsRequest(md pmetric.Metrics) request.Request {
+	return &metricsRequest{
+		md:         md,
+		cachedSize: -1,
+	}
+}
+
+type metricsEncoding struct{}
+
+var _ encoding[request.Request] = metricsEncoding{}
+
+func (metricsEncoding) Unmarshal(bytes []byte) (context.Context, request.Request, error) {
+	if queue.PersistRequestContextOnRead() {
+		ctx, metrics, err := pdatareq.UnmarshalMetrics(bytes)
+		if errors.Is(err, pdatareq.ErrInvalidFormat) {
+			// fall back to unmarshaling without context
+			metrics, err = metricsUnmarshaler.UnmarshalMetrics(bytes)
+		}
+		return ctx, newMetricsRequest(metrics), err
+	}
+	metrics, err := metricsUnmarshaler.UnmarshalMetrics(bytes)
+	if err != nil {
+		var req request.Request
+		return context.Background(), req, err
+	}
+	return context.Background(), newMetricsRequest(metrics), nil
+}
+
+func (metricsEncoding) Marshal(ctx context.Context, req request.Request) ([]byte, error) {
+	metrics := req.(*metricsRequest).md
+	if queue.PersistRequestContextOnWrite() {
+		return pdatareq.MarshalMetrics(ctx, metrics)
+	}
+	return metricsMarshaler.MarshalMetrics(metrics)
+}
+
+var _ queue.ReferenceCounter[request.Request] = metricsReferenceCounter{}
+
+type metricsReferenceCounter struct{}
+
+func (metricsReferenceCounter) Ref(req request.Request) {
+	pref.RefMetrics(req.(*metricsRequest).md)
+}
+
+func (metricsReferenceCounter) Unref(req request.Request) {
+	pref.UnrefMetrics(req.(*metricsRequest).md)
+}
+
+func (req *metricsRequest) OnError(err error) request.Request {
+	var metricsError consumererror.Metrics
+	if errors.As(err, &metricsError) {
+		// TODO: Add logic to unref the new request created here.
+		return newMetricsRequest(metricsError.Data())
+	}
+	return req
+}
+
+func (req *metricsRequest) ItemsCount() int {
+	return req.md.DataPointCount()
+}
+
+func (req *metricsRequest) size(sizer sizer.MetricsSizer) int {
+	if req.cachedSize == -1 {
+		req.cachedSize = sizer.MetricsSize(req.md)
+	}
+	return req.cachedSize
+}
+
+func (req *metricsRequest) setCachedSize(count int) {
+	req.cachedSize = count
+}
+
+func (req *metricsRequest) BytesSize() int {
+	return metricsMarshaler.MetricsSize(req.md)
+}
+
+// RequestFromMetrics returns a RequestFromMetricsFunc that converts pdata.Metrics into a Request.
+func RequestFromMetrics() request.RequestConverterFunc[pmetric.Metrics] {
+	return func(_ context.Context, md pmetric.Metrics) (request.Request, error) {
+		return newMetricsRequest(md), nil
+	}
+}
+
+// RequestConsumeFromMetrics returns a RequestConsumeFunc that consumes pmetric.Metrics.
+func RequestConsumeFromMetrics(pusher consumer.ConsumeMetricsFunc) request.RequestConsumeFunc {
+	return func(ctx context.Context, request request.Request) error {
+		return pusher.ConsumeMetrics(ctx, request.(*metricsRequest).md)
+	}
+}

--- a/exporter/exporterhelper/internal/queuebatch/metrics_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/testdata"
+)
+
+func TestMetricsRequest(t *testing.T) {
+	mr := newMetricsRequest(testdata.GenerateMetrics(1))
+
+	metricsErr := consumererror.NewMetrics(errors.New("some error"), pmetric.NewMetrics())
+	assert.Equal(
+		t,
+		newMetricsRequest(pmetric.NewMetrics()),
+		mr.(request.ErrorHandler).OnError(metricsErr),
+	)
+}

--- a/exporter/exporterhelper/internal/queuebatch/metrics_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/pdata/pmetric"

--- a/exporter/exporterhelper/internal/queuebatch/traces.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces.go
@@ -1,0 +1,139 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/xpdata/pref"
+	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
+)
+
+var (
+	tracesMarshaler   = &ptrace.ProtoMarshaler{}
+	tracesUnmarshaler = &ptrace.ProtoUnmarshaler{}
+)
+
+// NewTracesQueueBatchSettings returns a new QueueBatchSettings to configure to WithQueueBatch when using ptrace.Traces.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewTracesQueueBatchSettings() Settings[request.Request] {
+	return Settings[request.Request]{
+		ReferenceCounter: tracesReferenceCounter{},
+		Encoding:         tracesEncoding{},
+		ItemsSizer:       request.NewItemsSizer(),
+		BytesSizer: request.BaseSizer{
+			SizeofFunc: func(req request.Request) int64 {
+				return int64(tracesMarshaler.TracesSize(req.(*tracesRequest).td))
+			},
+		},
+	}
+}
+
+var (
+	_ request.Request      = (*tracesRequest)(nil)
+	_ request.ErrorHandler = (*tracesRequest)(nil)
+)
+
+type tracesRequest struct {
+	td         ptrace.Traces
+	cachedSize int
+}
+
+func newTracesRequest(td ptrace.Traces) request.Request {
+	return &tracesRequest{
+		td:         td,
+		cachedSize: -1,
+	}
+}
+
+type tracesEncoding struct{}
+
+var _ encoding[request.Request] = tracesEncoding{}
+
+func (tracesEncoding) Unmarshal(bytes []byte) (context.Context, request.Request, error) {
+	if queue.PersistRequestContextOnRead() {
+		ctx, traces, err := pdatareq.UnmarshalTraces(bytes)
+		if errors.Is(err, pdatareq.ErrInvalidFormat) {
+			// fall back to unmarshaling without context
+			traces, err = tracesUnmarshaler.UnmarshalTraces(bytes)
+		}
+		return ctx, newTracesRequest(traces), err
+	}
+	traces, err := tracesUnmarshaler.UnmarshalTraces(bytes)
+	if err != nil {
+		var req request.Request
+		return context.Background(), req, err
+	}
+	return context.Background(), newTracesRequest(traces), nil
+}
+
+func (tracesEncoding) Marshal(ctx context.Context, req request.Request) ([]byte, error) {
+	traces := req.(*tracesRequest).td
+	if queue.PersistRequestContextOnWrite() {
+		return pdatareq.MarshalTraces(ctx, traces)
+	}
+	return tracesMarshaler.MarshalTraces(traces)
+}
+
+var _ queue.ReferenceCounter[request.Request] = tracesReferenceCounter{}
+
+type tracesReferenceCounter struct{}
+
+func (tracesReferenceCounter) Ref(req request.Request) {
+	pref.RefTraces(req.(*tracesRequest).td)
+}
+
+func (tracesReferenceCounter) Unref(req request.Request) {
+	pref.UnrefTraces(req.(*tracesRequest).td)
+}
+
+func (req *tracesRequest) OnError(err error) request.Request {
+	var traceError consumererror.Traces
+	if errors.As(err, &traceError) {
+		// TODO: Add logic to unref the new request created here.
+		return newTracesRequest(traceError.Data())
+	}
+	return req
+}
+
+func (req *tracesRequest) ItemsCount() int {
+	return req.td.SpanCount()
+}
+
+func (req *tracesRequest) size(sizer sizer.TracesSizer) int {
+	if req.cachedSize == -1 {
+		req.cachedSize = sizer.TracesSize(req.td)
+	}
+	return req.cachedSize
+}
+
+func (req *tracesRequest) setCachedSize(size int) {
+	req.cachedSize = size
+}
+
+func (req *tracesRequest) BytesSize() int {
+	return tracesMarshaler.TracesSize(req.td)
+}
+
+// requestConsumeFromTraces returns a RequestConsumeFunc that consumes ptrace.Traces.
+func RequestConsumeFromTraces(pusher consumer.ConsumeTracesFunc) request.RequestConsumeFunc {
+	return func(ctx context.Context, request request.Request) error {
+		return pusher.ConsumeTraces(ctx, request.(*tracesRequest).td)
+	}
+}
+
+// requestFromTraces returns a RequestConverterFunc that converts ptrace.Traces into a Request.
+func RequestFromTraces() request.RequestConverterFunc[ptrace.Traces] {
+	return func(_ context.Context, traces ptrace.Traces) (request.Request, error) {
+		return newTracesRequest(traces), nil
+	}
+}

--- a/exporter/exporterhelper/internal/queuebatch/traces.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces.go
@@ -124,14 +124,14 @@ func (req *tracesRequest) BytesSize() int {
 	return tracesMarshaler.TracesSize(req.td)
 }
 
-// requestConsumeFromTraces returns a RequestConsumeFunc that consumes ptrace.Traces.
+// RequestConsumeFromTraces returns a RequestConsumeFunc that consumes ptrace.Traces.
 func RequestConsumeFromTraces(pusher consumer.ConsumeTracesFunc) request.RequestConsumeFunc {
 	return func(ctx context.Context, request request.Request) error {
 		return pusher.ConsumeTraces(ctx, request.(*tracesRequest).td)
 	}
 }
 
-// requestFromTraces returns a RequestConverterFunc that converts ptrace.Traces into a Request.
+// RequestFromTraces returns a RequestConverterFunc that converts ptrace.Traces into a Request.
 func RequestFromTraces() request.RequestConverterFunc[ptrace.Traces] {
 	return func(_ context.Context, traces ptrace.Traces) (request.Request, error) {
 		return newTracesRequest(traces), nil

--- a/exporter/exporterhelper/internal/queuebatch/traces_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/pdata/ptrace"

--- a/exporter/exporterhelper/internal/queuebatch/traces_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_test.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/testdata"
+)
+
+func TestTracesRequest(t *testing.T) {
+	mr := newTracesRequest(testdata.GenerateTraces(1))
+
+	traceErr := consumererror.NewTraces(errors.New("some error"), ptrace.NewTraces())
+	assert.Equal(t, newTracesRequest(ptrace.NewTraces()), mr.(request.ErrorHandler).OnError(traceErr))
+}

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -5,127 +5,21 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 
 import (
 	"context"
-	"errors"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"go.opentelemetry.io/collector/pdata/xpdata/pref"
-	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
-)
-
-var (
-	logsMarshaler   = &plog.ProtoMarshaler{}
-	logsUnmarshaler = &plog.ProtoUnmarshaler{}
 )
 
 // NewLogsQueueBatchSettings returns a new QueueBatchSettings to configure to WithQueueBatch when using plog.Logs.
 // Experimental: This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+// Deprecated: [v0.136.0] Use xexporterhelper.NewLogsQueueBatchSettings instead.
 func NewLogsQueueBatchSettings() QueueBatchSettings {
-	return QueueBatchSettings{
-		ReferenceCounter: logsReferenceCounter{},
-		Encoding:         logsEncoding{},
-		ItemsSizer:       request.NewItemsSizer(),
-		BytesSizer: request.BaseSizer{
-			SizeofFunc: func(req request.Request) int64 {
-				return int64(logsMarshaler.LogsSize(req.(*logsRequest).ld))
-			},
-		},
-	}
-}
-
-var (
-	_ request.Request      = (*logsRequest)(nil)
-	_ request.ErrorHandler = (*logsRequest)(nil)
-)
-
-type logsRequest struct {
-	ld         plog.Logs
-	cachedSize int
-}
-
-func newLogsRequest(ld plog.Logs) Request {
-	return &logsRequest{
-		ld:         ld,
-		cachedSize: -1,
-	}
-}
-
-type logsEncoding struct{}
-
-var _ QueueBatchEncoding[Request] = logsEncoding{}
-
-func (logsEncoding) Unmarshal(bytes []byte) (context.Context, Request, error) {
-	if queue.PersistRequestContextOnRead() {
-		ctx, logs, err := pdatareq.UnmarshalLogs(bytes)
-		if errors.Is(err, pdatareq.ErrInvalidFormat) {
-			// fall back to unmarshaling without context
-			logs, err = logsUnmarshaler.UnmarshalLogs(bytes)
-		}
-		return ctx, newLogsRequest(logs), err
-	}
-
-	logs, err := logsUnmarshaler.UnmarshalLogs(bytes)
-	if err != nil {
-		var req Request
-		return context.Background(), req, err
-	}
-	return context.Background(), newLogsRequest(logs), nil
-}
-
-func (logsEncoding) Marshal(ctx context.Context, req Request) ([]byte, error) {
-	logs := req.(*logsRequest).ld
-	if queue.PersistRequestContextOnWrite() {
-		return pdatareq.MarshalLogs(ctx, logs)
-	}
-	return logsMarshaler.MarshalLogs(logs)
-}
-
-var _ queue.ReferenceCounter[Request] = logsReferenceCounter{}
-
-type logsReferenceCounter struct{}
-
-func (logsReferenceCounter) Ref(req Request) {
-	pref.RefLogs(req.(*logsRequest).ld)
-}
-
-func (logsReferenceCounter) Unref(req Request) {
-	pref.UnrefLogs(req.(*logsRequest).ld)
-}
-
-func (req *logsRequest) OnError(err error) Request {
-	var logError consumererror.Logs
-	if errors.As(err, &logError) {
-		// TODO: Add logic to unref the new request created here.
-		return newLogsRequest(logError.Data())
-	}
-	return req
-}
-
-func (req *logsRequest) ItemsCount() int {
-	return req.ld.LogRecordCount()
-}
-
-func (req *logsRequest) size(sizer sizer.LogsSizer) int {
-	if req.cachedSize == -1 {
-		req.cachedSize = sizer.LogsSize(req.ld)
-	}
-	return req.cachedSize
-}
-
-func (req *logsRequest) setCachedSize(size int) {
-	req.cachedSize = size
-}
-
-func (req *logsRequest) BytesSize() int {
-	return logsMarshaler.LogsSize(req.ld)
+	return queuebatch.NewLogsQueueBatchSettings()
 }
 
 // NewLogs creates an exporter.Logs that records observability logs and wraps every request with a Span.
@@ -142,7 +36,7 @@ func NewLogs(
 	if pusher == nil {
 		return nil, errNilPushLogs
 	}
-	return internal.NewLogsRequest(ctx, set, requestFromLogs(), requestConsumeFromLogs(pusher),
+	return internal.NewLogsRequest(ctx, set, queuebatch.RequestFromLogs(), queuebatch.RequestConsumeFromLogs(pusher),
 		append([]Option{internal.WithQueueBatchSettings(NewLogsQueueBatchSettings())}, options...)...)
 }
 
@@ -156,18 +50,4 @@ func NewLogsRequest(
 	options ...Option,
 ) (exporter.Logs, error) {
 	return internal.NewLogsRequest(ctx, set, converter, pusher, options...)
-}
-
-// requestConsumeFromLogs returns a RequestConsumeFunc that consumes plog.Logs.
-func requestConsumeFromLogs(pusher consumer.ConsumeLogsFunc) RequestConsumeFunc {
-	return func(ctx context.Context, request Request) error {
-		return pusher.ConsumeLogs(ctx, request.(*logsRequest).ld)
-	}
-}
-
-// requestFromLogs returns a RequestFromLogsFunc that converts plog.Logs into a Request.
-func requestFromLogs() RequestConverterFunc[plog.Logs] {
-	return func(_ context.Context, ld plog.Logs) (Request, error) {
-		return newLogsRequest(ld), nil
-	}
 }

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
@@ -47,17 +46,6 @@ var (
 	fakeLogsName   = component.MustNewIDWithName("fake_logs_exporter", "with_name")
 	fakeLogsConfig = struct{}{}
 )
-
-func TestLogsRequest(t *testing.T) {
-	lr := newLogsRequest(testdata.GenerateLogs(1))
-
-	logErr := consumererror.NewLogs(errors.New("some error"), plog.NewLogs())
-	assert.Equal(
-		t,
-		newLogsRequest(plog.NewLogs()),
-		lr.(RequestErrorHandler).OnError(logErr),
-	)
-}
 
 func TestLogs_InvalidName(t *testing.T) {
 	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newPushLogsData(nil))

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -5,126 +5,21 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 
 import (
 	"context"
-	"errors"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/pdata/xpdata/pref"
-	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
-)
-
-var (
-	metricsMarshaler   = &pmetric.ProtoMarshaler{}
-	metricsUnmarshaler = &pmetric.ProtoUnmarshaler{}
 )
 
 // NewMetricsQueueBatchSettings returns a new QueueBatchSettings to configure to WithQueueBatch when using pmetric.Metrics.
 // Experimental: This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+// Deprecated [v0.136.0]: Use xexporterhelper.NewMetricsQueueBatchSettings instead.
 func NewMetricsQueueBatchSettings() QueueBatchSettings {
-	return QueueBatchSettings{
-		ReferenceCounter: metricsReferenceCounter{},
-		Encoding:         metricsEncoding{},
-		ItemsSizer:       request.NewItemsSizer(),
-		BytesSizer: request.BaseSizer{
-			SizeofFunc: func(req request.Request) int64 {
-				return int64(metricsMarshaler.MetricsSize(req.(*metricsRequest).md))
-			},
-		},
-	}
-}
-
-var (
-	_ request.Request      = (*metricsRequest)(nil)
-	_ request.ErrorHandler = (*metricsRequest)(nil)
-)
-
-type metricsRequest struct {
-	md         pmetric.Metrics
-	cachedSize int
-}
-
-func newMetricsRequest(md pmetric.Metrics) Request {
-	return &metricsRequest{
-		md:         md,
-		cachedSize: -1,
-	}
-}
-
-type metricsEncoding struct{}
-
-var _ QueueBatchEncoding[Request] = metricsEncoding{}
-
-func (metricsEncoding) Unmarshal(bytes []byte) (context.Context, Request, error) {
-	if queue.PersistRequestContextOnRead() {
-		ctx, metrics, err := pdatareq.UnmarshalMetrics(bytes)
-		if errors.Is(err, pdatareq.ErrInvalidFormat) {
-			// fall back to unmarshaling without context
-			metrics, err = metricsUnmarshaler.UnmarshalMetrics(bytes)
-		}
-		return ctx, newMetricsRequest(metrics), err
-	}
-	metrics, err := metricsUnmarshaler.UnmarshalMetrics(bytes)
-	if err != nil {
-		var req Request
-		return context.Background(), req, err
-	}
-	return context.Background(), newMetricsRequest(metrics), nil
-}
-
-func (metricsEncoding) Marshal(ctx context.Context, req Request) ([]byte, error) {
-	metrics := req.(*metricsRequest).md
-	if queue.PersistRequestContextOnWrite() {
-		return pdatareq.MarshalMetrics(ctx, metrics)
-	}
-	return metricsMarshaler.MarshalMetrics(metrics)
-}
-
-var _ queue.ReferenceCounter[Request] = metricsReferenceCounter{}
-
-type metricsReferenceCounter struct{}
-
-func (metricsReferenceCounter) Ref(req Request) {
-	pref.RefMetrics(req.(*metricsRequest).md)
-}
-
-func (metricsReferenceCounter) Unref(req Request) {
-	pref.UnrefMetrics(req.(*metricsRequest).md)
-}
-
-func (req *metricsRequest) OnError(err error) Request {
-	var metricsError consumererror.Metrics
-	if errors.As(err, &metricsError) {
-		// TODO: Add logic to unref the new request created here.
-		return newMetricsRequest(metricsError.Data())
-	}
-	return req
-}
-
-func (req *metricsRequest) ItemsCount() int {
-	return req.md.DataPointCount()
-}
-
-func (req *metricsRequest) size(sizer sizer.MetricsSizer) int {
-	if req.cachedSize == -1 {
-		req.cachedSize = sizer.MetricsSize(req.md)
-	}
-	return req.cachedSize
-}
-
-func (req *metricsRequest) setCachedSize(count int) {
-	req.cachedSize = count
-}
-
-func (req *metricsRequest) BytesSize() int {
-	return metricsMarshaler.MetricsSize(req.md)
+	return queuebatch.NewMetricsQueueBatchSettings()
 }
 
 // NewMetrics creates an exporter.Metrics that records observability metrics and wraps every request with a Span.
@@ -141,7 +36,7 @@ func NewMetrics(
 	if pusher == nil {
 		return nil, errNilPushMetrics
 	}
-	return internal.NewMetricsRequest(ctx, set, requestFromMetrics(), requestConsumeFromMetrics(pusher),
+	return internal.NewMetricsRequest(ctx, set, queuebatch.RequestFromMetrics(), queuebatch.RequestConsumeFromMetrics(pusher),
 		append([]Option{internal.WithQueueBatchSettings(NewMetricsQueueBatchSettings())}, options...)...)
 }
 
@@ -155,18 +50,4 @@ func NewMetricsRequest(
 	options ...Option,
 ) (exporter.Metrics, error) {
 	return internal.NewMetricsRequest(ctx, set, converter, pusher, options...)
-}
-
-// requestConsumeFromMetrics returns a RequestConsumeFunc that consumes pmetric.Metrics.
-func requestConsumeFromMetrics(pusher consumer.ConsumeMetricsFunc) RequestConsumeFunc {
-	return func(ctx context.Context, request Request) error {
-		return pusher.ConsumeMetrics(ctx, request.(*metricsRequest).md)
-	}
-}
-
-// requestFromMetrics returns a RequestFromMetricsFunc that converts pdata.Metrics into a Request.
-func requestFromMetrics() RequestConverterFunc[pmetric.Metrics] {
-	return func(_ context.Context, md pmetric.Metrics) (Request, error) {
-		return newMetricsRequest(md), nil
-	}
 }

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
@@ -47,17 +46,6 @@ var (
 	fakeMetricsName   = component.MustNewIDWithName("fake_metrics_exporter", "with_name")
 	fakeMetricsConfig = struct{}{}
 )
-
-func TestMetricsRequest(t *testing.T) {
-	mr := newMetricsRequest(testdata.GenerateMetrics(1))
-
-	metricsErr := consumererror.NewMetrics(errors.New("some error"), pmetric.NewMetrics())
-	assert.Equal(
-		t,
-		newMetricsRequest(pmetric.NewMetrics()),
-		mr.(RequestErrorHandler).OnError(metricsErr),
-	)
-}
 
 func TestMetrics_NilConfig(t *testing.T) {
 	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newPushMetricsData(nil))

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -5,126 +5,21 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 
 import (
 	"context"
-	"errors"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.opentelemetry.io/collector/pdata/xpdata/pref"
-	pdatareq "go.opentelemetry.io/collector/pdata/xpdata/request"
-)
-
-var (
-	tracesMarshaler   = &ptrace.ProtoMarshaler{}
-	tracesUnmarshaler = &ptrace.ProtoUnmarshaler{}
 )
 
 // NewTracesQueueBatchSettings returns a new QueueBatchSettings to configure to WithQueueBatch when using ptrace.Traces.
 // Experimental: This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+// Deprecated: [v0.136.0] Use xexporterhelper.NewTracesQueueBatchSettings instead.
 func NewTracesQueueBatchSettings() QueueBatchSettings {
-	return QueueBatchSettings{
-		ReferenceCounter: tracesReferenceCounter{},
-		Encoding:         tracesEncoding{},
-		ItemsSizer:       request.NewItemsSizer(),
-		BytesSizer: request.BaseSizer{
-			SizeofFunc: func(req request.Request) int64 {
-				return int64(tracesMarshaler.TracesSize(req.(*tracesRequest).td))
-			},
-		},
-	}
-}
-
-var (
-	_ request.Request      = (*tracesRequest)(nil)
-	_ request.ErrorHandler = (*tracesRequest)(nil)
-)
-
-type tracesRequest struct {
-	td         ptrace.Traces
-	cachedSize int
-}
-
-func newTracesRequest(td ptrace.Traces) Request {
-	return &tracesRequest{
-		td:         td,
-		cachedSize: -1,
-	}
-}
-
-type tracesEncoding struct{}
-
-var _ QueueBatchEncoding[Request] = tracesEncoding{}
-
-func (tracesEncoding) Unmarshal(bytes []byte) (context.Context, Request, error) {
-	if queue.PersistRequestContextOnRead() {
-		ctx, traces, err := pdatareq.UnmarshalTraces(bytes)
-		if errors.Is(err, pdatareq.ErrInvalidFormat) {
-			// fall back to unmarshaling without context
-			traces, err = tracesUnmarshaler.UnmarshalTraces(bytes)
-		}
-		return ctx, newTracesRequest(traces), err
-	}
-	traces, err := tracesUnmarshaler.UnmarshalTraces(bytes)
-	if err != nil {
-		var req Request
-		return context.Background(), req, err
-	}
-	return context.Background(), newTracesRequest(traces), nil
-}
-
-func (tracesEncoding) Marshal(ctx context.Context, req Request) ([]byte, error) {
-	traces := req.(*tracesRequest).td
-	if queue.PersistRequestContextOnWrite() {
-		return pdatareq.MarshalTraces(ctx, traces)
-	}
-	return tracesMarshaler.MarshalTraces(traces)
-}
-
-var _ queue.ReferenceCounter[Request] = tracesReferenceCounter{}
-
-type tracesReferenceCounter struct{}
-
-func (tracesReferenceCounter) Ref(req Request) {
-	pref.RefTraces(req.(*tracesRequest).td)
-}
-
-func (tracesReferenceCounter) Unref(req Request) {
-	pref.UnrefTraces(req.(*tracesRequest).td)
-}
-
-func (req *tracesRequest) OnError(err error) Request {
-	var traceError consumererror.Traces
-	if errors.As(err, &traceError) {
-		// TODO: Add logic to unref the new request created here.
-		return newTracesRequest(traceError.Data())
-	}
-	return req
-}
-
-func (req *tracesRequest) ItemsCount() int {
-	return req.td.SpanCount()
-}
-
-func (req *tracesRequest) size(sizer sizer.TracesSizer) int {
-	if req.cachedSize == -1 {
-		req.cachedSize = sizer.TracesSize(req.td)
-	}
-	return req.cachedSize
-}
-
-func (req *tracesRequest) setCachedSize(size int) {
-	req.cachedSize = size
-}
-
-func (req *tracesRequest) BytesSize() int {
-	return tracesMarshaler.TracesSize(req.td)
+	return queuebatch.NewTracesQueueBatchSettings()
 }
 
 // NewTraces creates an exporter.Traces that records observability metrics and wraps every request with a Span.
@@ -141,7 +36,7 @@ func NewTraces(
 	if pusher == nil {
 		return nil, errNilPushTraces
 	}
-	return internal.NewTracesRequest(ctx, set, requestFromTraces(), requestConsumeFromTraces(pusher),
+	return internal.NewTracesRequest(ctx, set, queuebatch.RequestFromTraces(), queuebatch.RequestConsumeFromTraces(pusher),
 		append([]Option{internal.WithQueueBatchSettings(NewTracesQueueBatchSettings())}, options...)...)
 }
 
@@ -155,18 +50,4 @@ func NewTracesRequest(
 	options ...Option,
 ) (exporter.Traces, error) {
 	return internal.NewTracesRequest(ctx, set, converter, pusher, options...)
-}
-
-// requestConsumeFromTraces returns a RequestConsumeFunc that consumes ptrace.Traces.
-func requestConsumeFromTraces(pusher consumer.ConsumeTracesFunc) RequestConsumeFunc {
-	return func(ctx context.Context, request Request) error {
-		return pusher.ConsumeTraces(ctx, request.(*tracesRequest).td)
-	}
-}
-
-// requestFromTraces returns a RequestConverterFunc that converts ptrace.Traces into a Request.
-func requestFromTraces() RequestConverterFunc[ptrace.Traces] {
-	return func(_ context.Context, traces ptrace.Traces) (Request, error) {
-		return newTracesRequest(traces), nil
-	}
 }

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
@@ -47,13 +46,6 @@ var (
 	fakeTracesName   = component.MustNewIDWithName("fake_traces_exporter", "with_name")
 	fakeTracesConfig = struct{}{}
 )
-
-func TestTracesRequest(t *testing.T) {
-	mr := newTracesRequest(testdata.GenerateTraces(1))
-
-	traceErr := consumererror.NewTraces(errors.New("some error"), ptrace.NewTraces())
-	assert.Equal(t, newTracesRequest(ptrace.NewTraces()), mr.(RequestErrorHandler).OnError(traceErr))
-}
 
 func TestTraces_InvalidName(t *testing.T) {
 	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newTraceDataPusher(nil))

--- a/exporter/exporterhelper/xexporterhelper/new_request.go
+++ b/exporter/exporterhelper/xexporterhelper/new_request.go
@@ -58,6 +58,27 @@ func NewTracesRequest(
 // They include things line Encoding to be used with persistent queue, or the available Sizers, etc.
 type QueueBatchSettings = queuebatch.Settings[Request]
 
+// NewMetricsQueueBatchSettings returns a new QueueBatchSettings to configure to WithQueueBatch when using pmetric.Metrics.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewMetricsQueueBatchSettings() QueueBatchSettings {
+	return queuebatch.NewMetricsQueueBatchSettings()
+}
+
+// NewLogsQueueBatchSettings returns a new QueueBatchSettings to configure to WithQueueBatch when using plog.Logs.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewLogsQueueBatchSettings() QueueBatchSettings {
+	return queuebatch.NewLogsQueueBatchSettings()
+}
+
+// NewTracesQueueBatchSettings returns a new QueueBatchSettings to configure to WithQueueBatch when using ptrace.Traces.
+// Experimental: This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewTracesQueueBatchSettings() QueueBatchSettings {
+	return queuebatch.NewTracesQueueBatchSettings()
+}
+
 // WithQueueBatch enables queueing and batching for an exporter.
 // This option should be used with the new exporter helpers New[Traces|Metrics|Logs]RequestExporter.
 // Experimental: This API is at the early stage of development and may change without backward compatibility


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

I forgot to move these symbols in #13821.

#### Link to tracking issue

Relates to open-telemetry/opentelemetry-collector-contrib/pull/42782, which is how I noticed.

Follows #13821

Updates #11143
