### PR TITLE
[mdatagen] Set metrics' default stability to development

### DIFF
--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"go.opentelemetry.io/collector/component"
+
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 )
@@ -63,8 +65,22 @@ func LoadMetadata(filePath string) (Metadata, error) {
 
 	setAttributesFullName(md.Attributes)
 	setAttributesFullName(md.ResourceAttributes)
+	setDefaultMetricStabilityLevel(md.Metrics)
+
+	//for _, metric := range md.Metrics {
+	//	panic(metric.Stability.Level.String())
+	//}
 
 	return md, nil
+}
+
+func setDefaultMetricStabilityLevel(metrics map[MetricName]Metric) {
+	for mName, metric := range metrics {
+		if metric.Stability.Level == component.StabilityLevelUndefined {
+			metric.Stability.Level = component.StabilityLevelDevelopment
+			metrics[mName] = metric
+		}
+	}
 }
 
 var componentTypes = []string{

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -221,6 +221,9 @@ func TestLoadMetadata(t *testing.T) {
 							Enabled:               true,
 							Description:           "Monotonic cumulative sum int metric enabled by default.",
 							ExtendedDocumentation: "The metric will be become optional soon.",
+							Stability: Stability{
+								Level: component.StabilityLevelDevelopment,
+							},
 							Warnings: Warnings{
 								IfEnabledNotSet: "This metric will be disabled by default soon.",
 							},
@@ -237,6 +240,7 @@ func TestLoadMetadata(t *testing.T) {
 						Signal: Signal{
 							Enabled:     false,
 							Description: "[DEPRECATED] Gauge double metric disabled by default.",
+							Stability:   Stability{Level: component.StabilityLevelDeprecated},
 							Warnings: Warnings{
 								IfConfigured: "This metric is deprecated and will be removed soon.",
 							},
@@ -251,6 +255,7 @@ func TestLoadMetadata(t *testing.T) {
 						Signal: Signal{
 							Enabled:     false,
 							Description: "[DEPRECATED] Gauge double metric disabled by default.",
+							Stability:   Stability{Level: component.StabilityLevelDeprecated},
 							Warnings: Warnings{
 								IfConfigured: "This metric is deprecated and will be removed soon.",
 							},
@@ -265,6 +270,7 @@ func TestLoadMetadata(t *testing.T) {
 					"default.metric.to_be_removed": {
 						Signal: Signal{
 							Enabled:               true,
+							Stability:             Stability{Level: component.StabilityLevelDeprecated},
 							Description:           "[DEPRECATED] Non-monotonic delta sum double metric enabled by default.",
 							ExtendedDocumentation: "The metric will be removed soon.",
 							Warnings: Warnings{
@@ -280,7 +286,10 @@ func TestLoadMetadata(t *testing.T) {
 					},
 					"metric.input_type": {
 						Signal: Signal{
-							Enabled:     true,
+							Enabled: true,
+							Stability: Stability{
+								Level: component.StabilityLevelBeta,
+							},
 							Description: "Monotonic cumulative sum int metric with string input_type enabled by default.",
 							Attributes:  []AttributeName{"string_attr", "overridden_int_attr", "enum_attr", "slice_attr", "map_attr"},
 						},
@@ -332,7 +341,7 @@ func TestLoadMetadata(t *testing.T) {
 						"batch_size_trigger_send": {
 							Signal: Signal{
 								Enabled:     true,
-								Stability:   Stability{Level: "deprecated", From: "v0.110.0"},
+								Stability:   Stability{Level: component.StabilityLevelDeprecated, From: "v0.110.0"},
 								Description: "Number of times the batch was sent due to a size trigger",
 							},
 							Unit: strPtr("{times}"),
@@ -344,7 +353,7 @@ func TestLoadMetadata(t *testing.T) {
 						"request_duration": {
 							Signal: Signal{
 								Enabled:     true,
-								Stability:   Stability{Level: "alpha"},
+								Stability:   Stability{Level: component.StabilityLevelAlpha},
 								Description: "Duration of request",
 							},
 							Unit: strPtr("s"),
@@ -356,7 +365,7 @@ func TestLoadMetadata(t *testing.T) {
 						"process_runtime_total_alloc_bytes": {
 							Signal: Signal{
 								Enabled:     true,
-								Stability:   Stability{Level: "stable"},
+								Stability:   Stability{Level: component.StabilityLevelStable},
 								Description: "Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')",
 							},
 							Unit: strPtr("By"),
@@ -371,7 +380,7 @@ func TestLoadMetadata(t *testing.T) {
 						"queue_length": {
 							Signal: Signal{
 								Enabled:               true,
-								Stability:             Stability{Level: "alpha"},
+								Stability:             Stability{Level: component.StabilityLevelAlpha},
 								Description:           "This metric is optional and therefore not initialized in NewTelemetryBuilder.",
 								ExtendedDocumentation: "For example this metric only exists if feature A is enabled.",
 							},

--- a/cmd/mdatagen/internal/metric.go
+++ b/cmd/mdatagen/internal/metric.go
@@ -6,7 +6,6 @@ package internal // import "go.opentelemetry.io/collector/cmd/mdatagen/internal"
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -48,18 +47,19 @@ type Metric struct {
 }
 
 type Stability struct {
-	Level string `mapstructure:"level"`
-	From  string `mapstructure:"from"`
+	Level component.StabilityLevel `mapstructure:"level"`
+	From  string                   `mapstructure:"from"`
 }
 
 func (s Stability) String() string {
-	if s.Level == "" || strings.EqualFold(s.Level, component.StabilityLevelStable.String()) {
+	if s.Level == component.StabilityLevelUndefined ||
+		s.Level == component.StabilityLevelStable {
 		return ""
 	}
 	if s.From != "" {
-		return fmt.Sprintf(" [%s since %s]", s.Level, s.From)
+		return fmt.Sprintf(" [%s since %s]", s.Level.String(), s.From)
 	}
-	return fmt.Sprintf(" [%s]", s.Level)
+	return fmt.Sprintf(" [%s]", s.Level.String())
 }
 
 func (m *Metric) validate() error {

--- a/cmd/mdatagen/internal/sampleconnector/documentation.md
+++ b/cmd/mdatagen/internal/sampleconnector/documentation.md
@@ -18,9 +18,9 @@ Monotonic cumulative sum int metric enabled by default.
 
 The metric will be become optional soon.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | Development |
 
 #### Attributes
 
@@ -38,17 +38,17 @@ The metric will be become optional soon.
 
 The metric will be removed soon.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Double | Delta | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Delta | false | Deprecated |
 
 ### metric.input_type
 
 Monotonic cumulative sum int metric with string input_type enabled by default.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | Beta |
 
 #### Attributes
 
@@ -74,9 +74,9 @@ metrics:
 
 [DEPRECATED] Gauge double metric disabled by default.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Deprecated |
 
 #### Attributes
 
@@ -90,9 +90,9 @@ metrics:
 
 [DEPRECATED] Gauge double metric disabled by default.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-|  | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+|  | Gauge | Double | Deprecated |
 
 #### Attributes
 

--- a/cmd/mdatagen/internal/sampleconnector/metadata.yaml
+++ b/cmd/mdatagen/internal/sampleconnector/metadata.yaml
@@ -116,6 +116,8 @@ metrics:
     enabled: false
     description: "[DEPRECATED] Gauge double metric disabled by default."
     unit: "1"
+    stability:
+      level: deprecated
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr, boolean_attr2]
@@ -126,6 +128,8 @@ metrics:
     enabled: false
     description: "[DEPRECATED] Gauge double metric disabled by default."
     unit: ""
+    stability:
+      level: deprecated
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr]
@@ -136,6 +140,8 @@ metrics:
     enabled: true
     description: "[DEPRECATED] Non-monotonic delta sum double metric enabled by default."
     extended_documentation: The metric will be removed soon.
+    stability:
+      level: deprecated
     unit: s
     sum:
       value_type: double
@@ -146,6 +152,8 @@ metrics:
 
   metric.input_type:
     enabled: true
+    stability:
+      level: beta
     description: Monotonic cumulative sum int metric with string input_type enabled by default.
     unit: s
     sum:

--- a/cmd/mdatagen/internal/samplereceiver/documentation.md
+++ b/cmd/mdatagen/internal/samplereceiver/documentation.md
@@ -18,9 +18,9 @@ Monotonic cumulative sum int metric enabled by default.
 
 The metric will be become optional soon.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | Development |
 
 #### Attributes
 
@@ -40,17 +40,17 @@ The metric will be become optional soon.
 
 The metric will be removed soon.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Double | Delta | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Delta | false | Deprecated |
 
 ### metric.input_type
 
 Monotonic cumulative sum int metric with string input_type enabled by default.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | Beta |
 
 #### Attributes
 
@@ -76,9 +76,9 @@ metrics:
 
 [DEPRECATED] Gauge double metric disabled by default.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Deprecated |
 
 #### Attributes
 
@@ -93,9 +93,9 @@ metrics:
 
 [DEPRECATED] Gauge double metric disabled by default.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-|  | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+|  | Gauge | Double | Deprecated |
 
 #### Attributes
 
@@ -190,11 +190,11 @@ The following telemetry is emitted by this component.
 
 ### otelcol_batch_size_trigger_send
 
-Number of times the batch was sent due to a size trigger [deprecated since v0.110.0]
+Number of times the batch was sent due to a size trigger [Deprecated since v0.110.0]
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
-| {times} | Sum | Int | true | deprecated |
+| {times} | Sum | Int | true | Deprecated |
 
 ### otelcol_process_runtime_total_alloc_bytes
 
@@ -202,7 +202,7 @@ Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalA
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
-| By | Sum | Int | true | stable |
+| By | Sum | Int | true | Stable |
 
 ### otelcol_queue_capacity
 
@@ -214,18 +214,18 @@ Queue capacity - sync gauge example.
 
 ### otelcol_queue_length
 
-This metric is optional and therefore not initialized in NewTelemetryBuilder. [alpha]
+This metric is optional and therefore not initialized in NewTelemetryBuilder. [Alpha]
 
 For example this metric only exists if feature A is enabled.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
-| {items} | Gauge | Int | alpha |
+| {items} | Gauge | Int | Alpha |
 
 ### otelcol_request_duration
 
-Duration of request [alpha]
+Duration of request [Alpha]
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
-| s | Histogram | Double | alpha |
+| s | Histogram | Double | Alpha |

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_telemetry.go
@@ -106,7 +106,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.BatchSizeTriggerSend, err = builder.meter.Int64Counter(
 		"otelcol_batch_size_trigger_send",
-		metric.WithDescription("Number of times the batch was sent due to a size trigger [deprecated since v0.110.0]"),
+		metric.WithDescription("Number of times the batch was sent due to a size trigger [Deprecated since v0.110.0]"),
 		metric.WithUnit("{times}"),
 	)
 	errs = errors.Join(errs, err)
@@ -124,13 +124,13 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.QueueLength, err = builder.meter.Int64ObservableGauge(
 		"otelcol_queue_length",
-		metric.WithDescription("This metric is optional and therefore not initialized in NewTelemetryBuilder. [alpha]"),
+		metric.WithDescription("This metric is optional and therefore not initialized in NewTelemetryBuilder. [Alpha]"),
 		metric.WithUnit("{items}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.RequestDuration, err = builder.meter.Float64Histogram(
 		"otelcol_request_duration",
-		metric.WithDescription("Duration of request [alpha]"),
+		metric.WithDescription("Duration of request [Alpha]"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries([]float64{1, 10, 100}...),
 	)

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadatatest/generated_telemetrytest.go
@@ -25,7 +25,7 @@ func NewSettings(tt *componenttest.Telemetry) receiver.Settings {
 func AssertEqualBatchSizeTriggerSend(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_batch_size_trigger_send",
-		Description: "Number of times the batch was sent due to a size trigger [deprecated since v0.110.0]",
+		Description: "Number of times the batch was sent due to a size trigger [Deprecated since v0.110.0]",
 		Unit:        "{times}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -71,7 +71,7 @@ func AssertEqualQueueCapacity(t *testing.T, tt *componenttest.Telemetry, dps []m
 func AssertEqualQueueLength(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_queue_length",
-		Description: "This metric is optional and therefore not initialized in NewTelemetryBuilder. [alpha]",
+		Description: "This metric is optional and therefore not initialized in NewTelemetryBuilder. [Alpha]",
 		Unit:        "{items}",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,
@@ -85,7 +85,7 @@ func AssertEqualQueueLength(t *testing.T, tt *componenttest.Telemetry, dps []met
 func AssertEqualRequestDuration(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_request_duration",
-		Description: "Duration of request [alpha]",
+		Description: "Duration of request [Alpha]",
 		Unit:        "s",
 		Data: metricdata.Histogram[float64]{
 			Temporality: metricdata.CumulativeTemporality,

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -158,6 +158,8 @@ metrics:
     enabled: false
     description: "[DEPRECATED] Gauge double metric disabled by default."
     unit: "1"
+    stability:
+      level: deprecated
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr, boolean_attr2, optional_string_attr]
@@ -168,6 +170,8 @@ metrics:
     enabled: false
     description: "[DEPRECATED] Gauge double metric disabled by default."
     unit: ""
+    stability:
+      level: deprecated
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr]
@@ -179,6 +183,8 @@ metrics:
     description: "[DEPRECATED] Non-monotonic delta sum double metric enabled by default."
     extended_documentation: The metric will be removed soon.
     unit: s
+    stability:
+      level: deprecated
     sum:
       value_type: double
       monotonic: false
@@ -188,6 +194,8 @@ metrics:
 
   metric.input_type:
     enabled: true
+    stability:
+      level: beta
     description: Monotonic cumulative sum int metric with string input_type enabled by default.
     unit: s
     sum:

--- a/cmd/mdatagen/internal/samplescraper/documentation.md
+++ b/cmd/mdatagen/internal/samplescraper/documentation.md
@@ -18,9 +18,9 @@ Monotonic cumulative sum int metric enabled by default.
 
 The metric will be become optional soon.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | Development |
 
 #### Attributes
 
@@ -38,9 +38,9 @@ The metric will be become optional soon.
 
 The metric will be removed soon.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Double | Delta | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Delta | false | Deprecated |
 
 ### metric.input_type
 
@@ -48,7 +48,7 @@ Monotonic cumulative sum int metric with string input_type enabled by default.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| s | Sum | Int | Cumulative | true | beta |
+| s | Sum | Int | Cumulative | true | Beta |
 
 #### Attributes
 
@@ -74,9 +74,9 @@ metrics:
 
 [DEPRECATED] Gauge double metric disabled by default.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Deprecated |
 
 #### Attributes
 
@@ -92,7 +92,7 @@ metrics:
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
-|  | Gauge | Double | deprecated |
+|  | Gauge | Double | Deprecated |
 
 #### Attributes
 

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -117,6 +117,8 @@ metrics:
     enabled: false
     description: "[DEPRECATED] Gauge double metric disabled by default."
     unit: "1"
+    stability:
+      level: deprecated
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr, boolean_attr2]
@@ -138,6 +140,8 @@ metrics:
   default.metric.to_be_removed:
     enabled: true
     description: "[DEPRECATED] Non-monotonic delta sum double metric enabled by default."
+    stability:
+      level: deprecated
     extended_documentation: The metric will be removed soon.
     unit: s
     sum:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Follow-up of https://github.com/open-telemetry/opentelemetry-collector/pull/13756. Sets default metric's stability to `development`.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tuned

<!--Describe the documentation added.-->
#### Documentation
~

<!--Please delete paragraphs that you did not use before submitting.-->
