### PR TITLE
Revert "Use email to exclude otelbot from merge freeze"

### DIFF
--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -24,7 +24,7 @@ jobs:
     # This condition is to avoid blocking the PR causing the freeze in the first place.
     if: |
       (!startsWith(github.event.pull_request.title || github.event.merge_group.head_commit.message, '[chore] Prepare release')) ||
-      ((github.event.pull_request.user.email || github.event.merge_group.head_commit.author.email) != '197425009+otelbot@users.noreply.github.com')
+      (!(github.event.pull_request.user.login == 'otelbot[bot]' || github.event.merge_group.head_commit.author.name == 'otelbot'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector#13841

doesn't work out: http://github.com/open-telemetry/opentelemetry-collector/actions/runs/17916357387/job/50939517357?pr=13874