### PR TITLE
[chore] Try fixing merge freeze CI again

### DIFF
--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -24,7 +24,7 @@ jobs:
     # This condition is to avoid blocking the PR causing the freeze in the first place.
     if: |
       (!startsWith(github.event.pull_request.title || github.event.merge_group.head_commit.message, '[chore] Prepare release')) ||
-      ((github.event.pull_request.user.email || github.event.merge_group.head_commit.author.email) != '197425009+otelbot@users.noreply.github.com')
+      (!(github.event.pull_request.user.login == 'otelbot[bot]' || github.event.merge_group.head_commit.author.email == '197425009+otelbot@users.noreply.github.com'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
#### Description

Half-revert of #13841: use author login to find the otelbot in PR CI (which historically seems to work), and use author email to find it in merge queue CI (as of yet untested).
