### PR TITLE
internal/cmd/pdatagen: add support for specifying a work dir

### DIFF
--- a/internal/cmd/pdatagen/main.go
+++ b/internal/cmd/pdatagen/main.go
@@ -4,20 +4,31 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"os"
+
 	"go.opentelemetry.io/collector/internal/cmd/pdatagen/internal/pdata"
 )
 
-func check(e error) {
+// checkErr prints the given error and exits when e is non-nil.
+func checkErr(e error) {
 	if e != nil {
-		panic(e)
+		fmt.Println(e)
+		os.Exit(1)
 	}
 }
 
 func main() {
+	var workdir string
+	flag.StringVar(&workdir, "C", ".", "set work directory")
+	flag.Parse()
+
+	checkErr(os.Chdir(workdir))
 	for _, fp := range pdata.AllPackages {
-		check(fp.GenerateFiles())
-		check(fp.GenerateTestFiles())
-		check(fp.GenerateInternalFiles())
-		check(fp.GenerateInternalTestsFiles())
+		checkErr(fp.GenerateFiles())
+		checkErr(fp.GenerateTestFiles())
+		checkErr(fp.GenerateInternalFiles())
+		checkErr(fp.GenerateInternalTestsFiles())
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds a new flag (`-C path`) to the `pdatagen` utility, which allows specifying the workdir for the tool.

Currently `pdatagen` expects to find the respective files in`pdata` directory of the `$cwd`. When `pdatagen` is called outside of the `$repo_root` the tool fails, because it cannot find `pdata` and panics.

This PR adds an optional `-C path` flag, which would allow `pdatagen` to use an alternative workdir, and also be able to be called outside of the `$repo_root` directory.

See  #13844 for more details about this PR and the proposed changes. The commit from this PR have been extracted from #13844 .

<!-- Issue number if applicable -->
#### Link to tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
