### PR TITLE
[chore] service/telemetry: remove unused type alias

### DIFF
--- a/.chloggen/service-telemetry-rm-tracesconfig.yaml
+++ b/.chloggen/service-telemetry-rm-tracesconfig.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removed unused TracesConfig type alias from package service/telemetry
+
+# One or more tracking issues or pull requests related to the change
+issues: [13891]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This type now exists in service/telemetry/otelconftelemetry
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/service/telemetry/telemetry.go
+++ b/service/telemetry/telemetry.go
@@ -16,13 +16,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/service/telemetry/internal/migration"
 )
-
-// NOTE TracesConfig will be removed once opentelemetry-collector-contrib
-// has been updated to use otelconftelemetry instead; use at your own risk.
-// See https://github.com/open-telemetry/opentelemetry-collector/issues/4970
-type TracesConfig = migration.TracesConfigV030
 
 // LoggerSettings holds settings for building logger providers.
 type LoggerSettings struct {


### PR DESCRIPTION
#### Description

Since https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41963 was merged, there are no more references to this type alias.

#### Link to tracking issue

Related to #4970

#### Testing

N/A

#### Documentation

N/A