### PR TITLE
service/telemetry: deprecate TracesConfig

### DIFF
--- a/.chloggen/telemetry-tracesconfig-deprecated.yaml
+++ b/.chloggen/telemetry-tracesconfig-deprecated.yaml
@@ -10,7 +10,7 @@ component: service
 note: service/telemetry.TracesConfig is deprecated
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [13904]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/telemetry-tracesconfig-deprecated.yaml
+++ b/.chloggen/telemetry-tracesconfig-deprecated.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: service/telemetry.TracesConfig is deprecated
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+ This type alias has been added to otelconftelemetry.TracesConfig,
+ where the otelconf-based telemetry implementation now lives.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.github/workflows/utils/cspell.json
+++ b/.github/workflows/utils/cspell.json
@@ -336,6 +336,8 @@
       "otelbot",
       "otelcol",
       "otelcoltest",
+      "otelconf",
+      "otelconftelemetry",
       "otelcorecol",
       "otelgrpc",
       "otelhttp",

--- a/service/telemetry/telemetry.go
+++ b/service/telemetry/telemetry.go
@@ -19,9 +19,7 @@ import (
 	"go.opentelemetry.io/collector/service/telemetry/internal/migration"
 )
 
-// NOTE TracesConfig will be removed once opentelemetry-collector-contrib
-// has been updated to use otelconftelemetry instead; use at your own risk.
-// See https://github.com/open-telemetry/opentelemetry-collector/issues/4970
+// Deprecated: [v0.137.0] Use otelconftelemetry.TracesConfig instead.
 type TracesConfig = migration.TracesConfigV030
 
 // LoggerSettings holds settings for building logger providers.


### PR DESCRIPTION
#### Description

service/telemetry.TracesConfig is deprecated. This type alias has been added to otelconftelemetry.TracesConfig as part of #4970, which is where the otelconf-based telemetry implementation now lives.

#### Link to tracking issue

Relates to #4970

#### Testing

N/A

#### Documentation

N/A