### PR TITLE
[chore][ci] port check-codeowners workflow from contrib

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@
 cmd/builder/                                 @open-telemetry/collector-approvers
 cmd/mdatagen/                                @open-telemetry/collector-approvers @dmitryax
 cmd/mdatagen/internal/sampleconnector/       @open-telemetry/collector-approvers
+cmd/mdatagen/internal/samplefactoryreceiver/ @open-telemetry/collector-approvers @dmitryax
 cmd/mdatagen/internal/sampleprocessor/       @open-telemetry/collector-approvers
 cmd/mdatagen/internal/samplereceiver/        @open-telemetry/collector-approvers @dmitryax
 cmd/mdatagen/internal/samplescraper/         @open-telemetry/collector-approvers @dmitryax

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -20,6 +20,8 @@ body:
       # Start components list
       - cmd/builder
       - cmd/mdatagen
+      - cmd/mdatagen/internal/sampleconnector
+      - cmd/mdatagen/internal/samplefactoryreceiver
       - cmd/mdatagen/internal/sampleprocessor
       - cmd/mdatagen/internal/samplereceiver
       - cmd/mdatagen/internal/samplescraper
@@ -35,8 +37,8 @@ body:
       - docs/rfcs
       - exporter/debug
       - exporter/exporterhelper
+      - exporter/exporterhelper/internal/queuebatch
       - exporter/exporterhelper/xexporterhelper
-      - exporter/exporterqueue
       - exporter/nop
       - exporter/otlp
       - exporter/otlphttp

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -14,6 +14,8 @@ body:
       # Start components list
       - cmd/builder
       - cmd/mdatagen
+      - cmd/mdatagen/internal/sampleconnector
+      - cmd/mdatagen/internal/samplefactoryreceiver
       - cmd/mdatagen/internal/sampleprocessor
       - cmd/mdatagen/internal/samplereceiver
       - cmd/mdatagen/internal/samplescraper
@@ -29,8 +31,8 @@ body:
       - docs/rfcs
       - exporter/debug
       - exporter/exporterhelper
+      - exporter/exporterhelper/internal/queuebatch
       - exporter/exporterhelper/xexporterhelper
-      - exporter/exporterqueue
       - exporter/nop
       - exporter/otlp
       - exporter/otlphttp

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -13,6 +13,8 @@ body:
       # Start components list
       - cmd/builder
       - cmd/mdatagen
+      - cmd/mdatagen/internal/sampleconnector
+      - cmd/mdatagen/internal/samplefactoryreceiver
       - cmd/mdatagen/internal/sampleprocessor
       - cmd/mdatagen/internal/samplereceiver
       - cmd/mdatagen/internal/samplescraper
@@ -28,8 +30,8 @@ body:
       - docs/rfcs
       - exporter/debug
       - exporter/exporterhelper
+      - exporter/exporterhelper/internal/queuebatch
       - exporter/exporterhelper/xexporterhelper
-      - exporter/exporterqueue
       - exporter/nop
       - exporter/otlp
       - exporter/otlphttp

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -1,0 +1,65 @@
+name: codeowners
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/CODEOWNERS"
+      - "**/metadata.yaml"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+  pull_request_target:
+    paths:
+      - ".github/CODEOWNERS"
+      - "**/metadata.yaml"
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
+env:
+  # Make sure to exit early if cache segment download times out after 2 minutes.
+  # We limit cache download as a whole to 5 minutes.
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+
+# Do not cancel this workflow on main. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  check-codeowners:
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    if: ${{ github.actor != 'dependabot[bot]' && github.repository == 'open-telemetry/opentelemetry-collector' }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+        id: go-setup
+        with:
+          go-version: oldstable
+          cache-dependency-path: "**/*.sum"
+
+      - name: Install tools
+        run: |
+          make install-tools
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          path: pr
+
+      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: otelbot-token
+        with:
+          app-id: ${{ vars.OTELBOT_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+
+      - name: Gen CODEOWNERS
+        run: |
+          cd pr
+          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} ../.tools/githubgen --default-codeowner "open-telemetry/collector-approvers" codeowners
+          git diff -s --exit-code || (echo 'Generated code is out of date, please run "make generate-codeowners" or apply this diff and commit the changes in this PR.' && git diff && exit 1)

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -42,10 +42,6 @@ jobs:
           go-version: oldstable
           cache-dependency-path: "**/*.sum"
 
-      - name: Install tools
-        run: |
-          make install-tools
-
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           ref: ${{github.event.pull_request.head.ref}}

--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ generate-gh-issue-templates: $(GITHUBGEN)
 
 .PHONY: generate-codeowners
 generate-codeowners: $(GITHUBGEN)
-	$(GITHUBGEN) --default-codeowner "open-telemetry/collector-approvers" codeowners
+	$(GITHUBGEN) --default-codeowner "open-telemetry/collector-approvers" -skipgithub codeowners
 
 .PHONY: gengithub
 gengithub: $(GITHUBGEN) generate-codeowners generate-gh-issue-templates


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR ports the `check-codeowners` workflow from the `opentelemetry-collector-contrib` repository.

On this side, the command referenced in the workflow is `make generate-codeowners` instead of `make gencodeowners` as is in the contrib version. In the `Makefile`, I added the `-skipgithub` to avoid giving an error like below when the members run it.

```sh
2025/09/25 22:52:36 set the environment variable `GITHUB_TOKEN` to a PAT token to authenticate
```

I ran `gengithub`, which also produced some changes in issue templates.

Like the PR https://github.com/open-telemetry/opentelemetry-collector/pull/13898, I also removed the `make install-tools` from this workflow.