### PR TITLE
[mdatagen] Add semconv reference for signals in metadata schema

### DIFF
--- a/.chloggen/mdatagen_add_semconv_ref.yaml
+++ b/.chloggen/mdatagen_add_semconv_ref.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Introduce semantic convention reference for signal in metadata schema
+
+# One or more tracking issues or pull requests related to the change
+issues: [13297]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -122,8 +122,8 @@ func (md *Metadata) validateMetricsAndEvents() error {
 	var errs error
 	usedAttrs := map[AttributeName]bool{}
 	errs = errors.Join(errs,
-		validateMetrics(md.Metrics, md.Attributes, usedAttrs),
-		validateMetrics(md.Telemetry.Metrics, md.Attributes, usedAttrs),
+		validateMetrics(md.Metrics, md.Attributes, usedAttrs, md.SemConvVersion),
+		validateMetrics(md.Telemetry.Metrics, md.Attributes, usedAttrs, md.SemConvVersion),
 		validateEvents(md.Events, md.Attributes, usedAttrs),
 		md.validateAttributes(usedAttrs))
 	return errs
@@ -166,10 +166,10 @@ func (md *Metadata) supportsSignal(signal string) bool {
 	return false
 }
 
-func validateMetrics(metrics map[MetricName]Metric, attributes map[AttributeName]Attribute, usedAttrs map[AttributeName]bool) error {
+func validateMetrics(metrics map[MetricName]Metric, attributes map[AttributeName]Attribute, usedAttrs map[AttributeName]bool, semConvVersion string) error {
 	var errs error
 	for mn, m := range metrics {
-		if err := m.validate(); err != nil {
+		if err := m.validate(mn, semConvVersion); err != nil {
 			errs = errors.Join(errs, fmt.Errorf(`metric "%v": %w`, mn, err))
 			continue
 		}

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -278,6 +278,10 @@ func (mvt ValueType) Primitive() string {
 	}
 }
 
+type SemanticConvention struct {
+	SemanticConventionRef string `mapstructure:"semconv_ref"`
+}
+
 type Warnings struct {
 	// A warning that will be displayed if the field is enabled in user config.
 	IfEnabled string `mapstructure:"if_enabled"`
@@ -352,6 +356,9 @@ type Signal struct {
 
 	// Description of the signal.
 	Description string `mapstructure:"description"`
+
+	// The semantic convention reference of the signal.
+	SemanticConvention *SemanticConvention `mapstructure:"semantic_convention"`
 
 	// The stability level of the signal.
 	Stability Stability `mapstructure:"stability"`

--- a/cmd/mdatagen/internal/metric.go
+++ b/cmd/mdatagen/internal/metric.go
@@ -6,6 +6,7 @@ package internal // import "go.opentelemetry.io/collector/cmd/mdatagen/internal"
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -15,6 +16,8 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
+
+var reNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
 
 type MetricName string
 
@@ -62,7 +65,7 @@ func (s Stability) String() string {
 	return fmt.Sprintf(" [%s]", s.Level)
 }
 
-func (m *Metric) validate() error {
+func (m *Metric) validate(metricName MetricName, semConvVersion string) error {
 	var errs error
 	if m.Sum == nil && m.Gauge == nil && m.Histogram == nil {
 		errs = errors.Join(errs, errors.New("missing metric type key, "+
@@ -84,7 +87,46 @@ func (m *Metric) validate() error {
 	if m.Gauge != nil {
 		errs = errors.Join(errs, m.Gauge.Validate())
 	}
+	if m.SemanticConvention != nil {
+		if err := validateSemConvMetricURL(m.SemanticConvention.SemanticConventionRef, semConvVersion, string(metricName)); err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
 	return errs
+}
+
+func metricAnchor(metricName string) string {
+	m := strings.ToLower(strings.TrimSpace(metricName))
+	m = reNonAlnum.ReplaceAllString(m, "")
+	return "metric-" + m
+}
+
+// validateSemConvMetricURL verifies the URL matches exactly:
+// https://github.com/open-telemetry/semantic-conventions/blob/<semConvVersion>/*#metric-<metricName>
+func validateSemConvMetricURL(rawURL, semConvVersion, metricName string) error {
+	if strings.TrimSpace(rawURL) == "" {
+		return fmt.Errorf("url is empty")
+	}
+	if strings.TrimSpace(semConvVersion) == "" {
+		return fmt.Errorf("semConvVersion is empty")
+	}
+	if strings.TrimSpace(metricName) == "" {
+		return fmt.Errorf("metricName is empty")
+	}
+	semConvVersion = "v" + semConvVersion
+
+	anchor := metricAnchor(metricName)
+	// Build a strict regex that enforces https, repo, blob, given version, any doc path, and exact anchor.
+	pattern := fmt.Sprintf(`^https://github\.com/open-telemetry/semantic-conventions/blob/%s/[^#\s]+#%s$`,
+		regexp.QuoteMeta(semConvVersion),
+		regexp.QuoteMeta(anchor),
+	)
+	re := regexp.MustCompile(pattern)
+	if !re.MatchString(rawURL) {
+		return fmt.Errorf("invalid semantic-conventions URL: want https://github.com/open-telemetry/semantic-conventions/blob/%s/*#%s, got %q",
+			semConvVersion, anchor, rawURL)
+	}
+	return nil
 }
 
 func (m *Metric) Unmarshal(parser *confmap.Conf) error {

--- a/cmd/mdatagen/internal/samplescraper/documentation.md
+++ b/cmd/mdatagen/internal/samplescraper/documentation.md
@@ -60,6 +60,16 @@ Monotonic cumulative sum int metric with string input_type enabled by default.
 | slice_attr | Attribute with a slice value. | Any Slice | false |
 | map_attr | Attribute with a map value. | Any Map | false |
 
+### system.cpu.time
+
+Monotonic cumulative sum int metric enabled by default.
+
+The metric will be become optional soon.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability | Semantic Convention |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- | ------------------- |
+| s | Sum | Int | Cumulative | true | beta | [system.cpu.time](https://github.com/open-telemetry/semantic-conventions/blob/v1.35.0/docs/system/system-metrics.md#metric-systemcputime) |
+
 ## Optional Metrics
 
 The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:

--- a/cmd/mdatagen/internal/samplescraper/documentation.md
+++ b/cmd/mdatagen/internal/samplescraper/documentation.md
@@ -68,7 +68,7 @@ The metric will be become optional soon.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability | Semantic Convention |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- | ------------------- |
-| s | Sum | Int | Cumulative | true | beta | [system.cpu.time](https://github.com/open-telemetry/semantic-conventions/blob/v1.35.0/docs/system/system-metrics.md#metric-systemcputime) |
+| s | Sum | Int | Cumulative | true | beta | [system.cpu.time](https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/system/system-metrics.md#metric-systemcputime) |
 
 ## Optional Metrics
 

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
@@ -33,6 +33,7 @@ type MetricsConfig struct {
 	MetricInputType          MetricConfig `mapstructure:"metric.input_type"`
 	OptionalMetric           MetricConfig `mapstructure:"optional.metric"`
 	OptionalMetricEmptyUnit  MetricConfig `mapstructure:"optional.metric.empty_unit"`
+	SystemCPUTime            MetricConfig `mapstructure:"system.cpu.time"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -51,6 +52,9 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		OptionalMetricEmptyUnit: MetricConfig{
 			Enabled: false,
+		},
+		SystemCPUTime: MetricConfig{
+			Enabled: true,
 		},
 	}
 }

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config_test.go
@@ -32,6 +32,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MetricInputType:          MetricConfig{Enabled: true},
 					OptionalMetric:           MetricConfig{Enabled: true},
 					OptionalMetricEmptyUnit:  MetricConfig{Enabled: true},
+					SystemCPUTime:            MetricConfig{Enabled: true},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					MapResourceAttr:                  ResourceAttributeConfig{Enabled: true},
@@ -54,6 +55,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MetricInputType:          MetricConfig{Enabled: false},
 					OptionalMetric:           MetricConfig{Enabled: false},
 					OptionalMetricEmptyUnit:  MetricConfig{Enabled: false},
+					SystemCPUTime:            MetricConfig{Enabled: false},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					MapResourceAttr:                  ResourceAttributeConfig{Enabled: false},

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_logs.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_logs.go
@@ -3,7 +3,7 @@
 package metadata
 
 import (
-	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.37.0"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.37.0"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics.go
@@ -62,6 +62,9 @@ var MetricsInfo = metricsInfo{
 	OptionalMetricEmptyUnit: metricInfo{
 		Name: "optional.metric.empty_unit",
 	},
+	SystemCPUTime: metricInfo{
+		Name: "system.cpu.time",
+	},
 }
 
 type metricsInfo struct {
@@ -70,6 +73,7 @@ type metricsInfo struct {
 	MetricInputType          metricInfo
 	OptionalMetric           metricInfo
 	OptionalMetricEmptyUnit  metricInfo
+	SystemCPUTime            metricInfo
 }
 
 type metricInfo struct {
@@ -346,6 +350,57 @@ func newMetricOptionalMetricEmptyUnit(cfg MetricConfig) metricOptionalMetricEmpt
 	return m
 }
 
+type metricSystemCPUTime struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	config   MetricConfig   // metric config provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills system.cpu.time metric with initial data.
+func (m *metricSystemCPUTime) init() {
+	m.data.SetName("system.cpu.time")
+	m.data.SetDescription("Monotonic cumulative sum int metric enabled by default.")
+	m.data.SetUnit("s")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSystemCPUTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSystemCPUTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSystemCPUTime(cfg MetricConfig) metricSystemCPUTime {
+	m := metricSystemCPUTime{config: cfg}
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
@@ -361,6 +416,7 @@ type MetricsBuilder struct {
 	metricMetricInputType          metricMetricInputType
 	metricOptionalMetric           metricOptionalMetric
 	metricOptionalMetricEmptyUnit  metricOptionalMetricEmptyUnit
+	metricSystemCPUTime            metricSystemCPUTime
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -412,6 +468,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings scraper.Settings, opti
 		metricMetricInputType:          newMetricMetricInputType(mbc.Metrics.MetricInputType),
 		metricOptionalMetric:           newMetricOptionalMetric(mbc.Metrics.OptionalMetric),
 		metricOptionalMetricEmptyUnit:  newMetricOptionalMetricEmptyUnit(mbc.Metrics.OptionalMetricEmptyUnit),
+		metricSystemCPUTime:            newMetricSystemCPUTime(mbc.Metrics.SystemCPUTime),
 		resourceAttributeIncludeFilter: make(map[string]filter.Filter),
 		resourceAttributeExcludeFilter: make(map[string]filter.Filter),
 	}
@@ -538,6 +595,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMetricInputType.emit(ils.Metrics())
 	mb.metricOptionalMetric.emit(ils.Metrics())
 	mb.metricOptionalMetricEmptyUnit.emit(ils.Metrics())
+	mb.metricSystemCPUTime.emit(ils.Metrics())
 
 	for _, op := range options {
 		op.apply(rm)
@@ -597,6 +655,11 @@ func (mb *MetricsBuilder) RecordOptionalMetricDataPoint(ts pcommon.Timestamp, va
 // RecordOptionalMetricEmptyUnitDataPoint adds a data point to optional.metric.empty_unit metric.
 func (mb *MetricsBuilder) RecordOptionalMetricEmptyUnitDataPoint(ts pcommon.Timestamp, val float64, stringAttrAttributeValue string, booleanAttrAttributeValue bool) {
 	mb.metricOptionalMetricEmptyUnit.recordDataPoint(mb.startTime, ts, val, stringAttrAttributeValue, booleanAttrAttributeValue)
+}
+
+// RecordSystemCPUTimeDataPoint adds a data point to system.cpu.time metric.
+func (mb *MetricsBuilder) RecordSystemCPUTimeDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricSystemCPUTime.recordDataPoint(mb.startTime, ts, val)
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics_test.go
@@ -115,6 +115,10 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordOptionalMetricEmptyUnitDataPoint(ts, 1, "string_attr-val", true)
 
+			defaultMetricsCount++
+			allMetricsCount++
+			mb.RecordSystemCPUTimeDataPoint(ts, 1)
+
 			rb := mb.NewResourceBuilder()
 			rb.SetMapResourceAttr(map[string]any{"key1": "map.resource.attr-val1", "key2": "map.resource.attr-val2"})
 			rb.SetOptionalResourceAttr("optional.resource.attr-val")
@@ -257,6 +261,20 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("boolean_attr")
 					assert.True(t, ok)
 					assert.True(t, attrVal.Bool())
+				case "system.cpu.time":
+					assert.False(t, validatedMetrics["system.cpu.time"], "Found a duplicate in the metrics slice: system.cpu.time")
+					validatedMetrics["system.cpu.time"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+					assert.Equal(t, "Monotonic cumulative sum int metric enabled by default.", ms.At(i).Description())
+					assert.Equal(t, "s", ms.At(i).Unit())
+					assert.True(t, ms.At(i).Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+					dp := ms.At(i).Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				}
 			}
 		})

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/testdata/config.yaml
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/testdata/config.yaml
@@ -11,6 +11,8 @@ all_set:
       enabled: true
     optional.metric.empty_unit:
       enabled: true
+    system.cpu.time:
+      enabled: true
   resource_attributes:
     map.resource.attr:
       enabled: true
@@ -39,6 +41,8 @@ none_set:
     optional.metric:
       enabled: false
     optional.metric.empty_unit:
+      enabled: false
+    system.cpu.time:
       enabled: false
   resource_attributes:
     map.resource.attr:

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -100,6 +100,19 @@ attributes:
     type: map
 
 metrics:
+  system.cpu.time:
+    enabled: true
+    stability:
+      level: beta
+    description: Monotonic cumulative sum int metric enabled by default.
+    extended_documentation: The metric will be become optional soon.
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    semantic_convention:
+      semconv_ref: https://github.com/open-telemetry/semantic-conventions/blob/v1.35.0/docs/system/system-metrics.md#metric-systemcputime
   default.metric:
     enabled: true
     description: Monotonic cumulative sum int metric enabled by default.

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -3,7 +3,7 @@
 type: sample
 github_project: open-telemetry/opentelemetry-collector
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.37.0
 
 status:
   disable_codecov_badge: true
@@ -112,7 +112,7 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     semantic_convention:
-      semconv_ref: https://github.com/open-telemetry/semantic-conventions/blob/v1.35.0/docs/system/system-metrics.md#metric-systemcputime
+      semconv_ref: https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/system/system-metrics.md#metric-systemcputime
   default.metric:
     enabled: true
     description: Monotonic cumulative sum int metric enabled by default.

--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -12,12 +12,13 @@
 
 {{- end }}
 
-| Unit | Metric Type | Value Type |{{ if $metric.Data.HasAggregated }} Aggregation Temporality |{{ end }}{{ if $metric.Data.HasMonotonic }} Monotonic |{{ end }}{{ if $metric.Stability.Level }} Stability |{{ end }}
-| ---- | ----------- | ---------- |{{ if $metric.Data.HasAggregated }} ----------------------- |{{ end }}{{ if $metric.Data.HasMonotonic }} --------- |{{ end }}{{ if $metric.Stability.Level }} --------- |{{ end }}
+| Unit | Metric Type | Value Type |{{ if $metric.Data.HasAggregated }} Aggregation Temporality |{{ end }}{{ if $metric.Data.HasMonotonic }} Monotonic |{{ end }}{{ if $metric.Stability.Level }} Stability |{{ end }}{{ if $metric.SemanticConvention }} Semantic Convention |{{ end }}
+| ---- | ----------- | ---------- |{{ if $metric.Data.HasAggregated }} ----------------------- |{{ end }}{{ if $metric.Data.HasMonotonic }} --------- |{{ end }}{{ if $metric.Stability.Level }} --------- |{{ end }}{{ if $metric.SemanticConvention }} ------------------- |{{ end }}
 | {{ $metric.Unit }} | {{ $metric.Data.Type }} | {{ $metric.Data.MetricValueType }} |
 {{- if $metric.Data.HasAggregated }} {{ $metric.Data.AggregationTemporality }} |{{ end }}
 {{- if $metric.Data.HasMonotonic }} {{ $metric.Data.Monotonic }} |{{ end }}
 {{- if $metric.Stability.Level }} {{ $metric.Stability.Level }} |{{ end }}
+{{- if $metric.SemanticConvention }} [{{ $metricName }}]({{ $metric.SemanticConvention.SemanticConventionRef }}) |{{ end }}
 
 {{- if $metric.Attributes }}
 
@@ -79,11 +80,12 @@
 
 {{- end }}
 
-| Unit | Metric Type | Value Type |{{ if $metric.Data.HasMonotonic }} Monotonic |{{ end }}{{ if $metric.Stability.Level }} Stability |{{ end }}
-| ---- | ----------- | ---------- |{{ if $metric.Data.HasMonotonic }} --------- |{{ end }}{{ if $metric.Stability.Level }} --------- |{{ end }}
+| Unit | Metric Type | Value Type |{{ if $metric.Data.HasMonotonic }} Monotonic |{{ end }}{{ if $metric.Stability.Level }} Stability |{{ end }}{{ if $metric.SemanticConvention }} Semantic Convention |{{ end }}
+| ---- | ----------- | ---------- |{{ if $metric.Data.HasMonotonic }} --------- |{{ end }}{{ if $metric.Stability.Level }} --------- |{{ end }}{{ if $metric.SemanticConvention }} ------------------- |{{ end }}
 | {{ $metric.Unit }} | {{ $metric.Data.Type }} | {{ $metric.Data.MetricValueType }} |
 {{- if $metric.Data.HasMonotonic }} {{ $metric.Data.Monotonic }} |{{ end }}
 {{- if $metric.Stability.Level }} {{ $metric.Stability.Level }} |{{ end }}
+{{- if $metric.SemanticConvention }} [{{ $metricName }}]({{ $metric.SemanticConvention.SemanticConventionRef }}) |{{ end }}
 
 {{- if $metric.Attributes }}
 

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -124,6 +124,9 @@ metrics:
       level: <development|alpha|beta|stable|deprecated>
       # Optional: the version current stability was introduced
       from:
+    # Optional: the reference to a semantic convention. Required when stability_level equals stable
+    semantic_convention:
+      semconv_ref:
 
 # Optional: map of event names with the key being the event name and value
 # being described below.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds support in mdatagen for defining SemConv reference for signals.

Enhancing your metrics/signals in `metadata.yaml` like bellow:

```yaml
metrics:
  system.cpu.time:
    enabled: true
    stability:
      level: beta
    description: Monotonic cumulative sum int metric enabled by default.
    unit: s
    sum:
      value_type: int
      monotonic: true
      aggregation_temporality: cumulative
    semantic_convention:
      semconv_ref: https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/system/system-metrics.md#metric-systemcputime
```

Will provide the following generated docs:

### system.cpu.time

Monotonic cumulative sum int metric enabled by default.

| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability | Semantic Convention |
| ---- | ----------- | ---------- | ----------------------- | --------- | --------- | ------------------- |
| s | Sum | Int | Cumulative | true | beta | [system.cpu.time](https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/system/system-metrics.md#metric-systemcputime) |

Validation is added so as to ensure that provided SemConv urls match the top_level semconv version as well as the metric's name.

<!-- Issue number if applicable -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/13297

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation

Tuned

<!--Please delete paragraphs that you did not use before submitting.-->
