### PR TITLE
Standardize changelog component list

### DIFF
--- a/.chloggen/README.md
+++ b/.chloggen/README.md
@@ -1,0 +1,34 @@
+### Changelog folder
+
+This repo uses `chloggen` to manage its changelog files. You can find the source code for the tool [here](https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/chloggen).
+
+Here is a quick explanation of the `config.yaml` file for chloggen:
+
+```yaml
+# The directory that stores individual changelog entries.
+# Each entry is stored in a dedicated yaml file.
+# - 'chloggen new' will copy the 'template_yaml' to this directory as a new entry file.
+# - 'chloggen validate' will validate that all entry files are valid.
+# - 'chloggen update' will read and delete all entry files in this directory, and update 'changelog_md'.
+# Specify as relative path from root of repo.
+# (Optional) Default: .chloggen
+entries_dir: .chloggen
+
+# This file is used as the input for individual changelog entries.
+# Specify as relative path from root of repo.
+# (Optional) Default: .chloggen/TEMPLATE.yaml
+template_yaml: .chloggen/TEMPLATE.yaml
+
+summary_template: .chloggen/summary.tmpl
+
+# The CHANGELOG file or files to which 'chloggen update' will write new entries
+# (Optional) Default filename: CHANGELOG.md
+change_logs:
+  user: CHANGELOG.md
+  api: CHANGELOG-API.md
+
+# The default change_log or change_logs to which an entry should be added.
+# If 'change_logs' is specified in this file, and no value is specified for 'default_change_logs',
+# then 'change_logs' MUST be specified in every entry file.
+default_change_logs: [user]
+```

--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -1,26 +1,53 @@
-# The directory that stores individual changelog entries.
-# Each entry is stored in a dedicated yaml file.
-# - 'chloggen new' will copy the 'template_yaml' to this directory as a new entry file.
-# - 'chloggen validate' will validate that all entry files are valid.
-# - 'chloggen update' will read and delete all entry files in this directory, and update 'changelog_md'.
-# Specify as relative path from root of repo.
-# (Optional) Default: .chloggen
-entries_dir: .chloggen
-
-# This file is used as the input for individual changelog entries.
-# Specify as relative path from root of repo.
-# (Optional) Default: .chloggen/TEMPLATE.yaml
-template_yaml: .chloggen/TEMPLATE.yaml
-
-summary_template: .chloggen/summary.tmpl
-
-# The CHANGELOG file or files to which 'chloggen update' will write new entries
-# (Optional) Default filename: CHANGELOG.md
 change_logs:
-  user: CHANGELOG.md
-  api: CHANGELOG-API.md
-
-# The default change_log or change_logs to which an entry should be added.
-# If 'change_logs' is specified in this file, and no value is specified for 'default_change_logs',
-# then 'change_logs' MUST be specified in every entry file.
-default_change_logs: [user]
+    api: CHANGELOG-API.md
+    user: CHANGELOG.md
+default_change_logs:
+    - user
+entries_dir: .chloggen
+template_yaml: .chloggen/TEMPLATE.yaml
+summary_template: .chloggen/summary.tmpl
+components:
+    - all
+    - cmd/builder
+    - cmd/mdatagen
+    - connector/forward
+    - connector/sample
+    - consumer/xconsumer
+    - docs/rfcs
+    - exporter/debug
+    - exporter/nop
+    - exporter/otlp
+    - exporter/otlphttp
+    - extension/memory_limiter
+    - extension/xextension
+    - extension/xextension
+    - extension/zpages
+    - pdata/pprofile
+    - pkg/confmap
+    - pkg/exporterhelper
+    - pkg/pdata
+    - pkg/processorhelper
+    - pkg/queuebatch
+    - pkg/receiverhelper
+    - pkg/scraper
+    - pkg/scraperhelper
+    - pkg/service
+    - pkg/xconnector
+    - pkg/xexporter
+    - pkg/xexporterhelper
+    - pkg/xprocessor
+    - pkg/xreceiver
+    - processor/batch
+    - processor/memory_limiter
+    - processor/sample
+    - provider/env
+    - provider/file
+    - provider/http
+    - provider/https
+    - provider/yaml
+    - receiver/nop
+    - receiver/otlp
+    - receiver/sample
+    - receiver/sample
+    - scraper/sample
+    - service/graph

--- a/.chloggen/control-attribute-enabled.yaml
+++ b/.chloggen/control-attribute-enabled.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: mdatagen
+component: cmd/mdatagen
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Improve validation for resource attribute `enabled` field in metadata files

--- a/.chloggen/fix_cmd_mdata-gen-metrics.yml
+++ b/.chloggen/fix_cmd_mdata-gen-metrics.yml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: mdatagen
+component: cmd/mdatagen
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix mdatagen generated_metrics for connectors

--- a/.chloggen/mowies-standardize-chloggen-components.yaml
+++ b/.chloggen/mowies-standardize-chloggen-components.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changelog entries will now have their component field checked against a list of valid components.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13924]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This will ensure a more standardized changelog format which makes it easier to parse.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/mx-psi_configoptional-1.0.yaml
+++ b/.chloggen/mx-psi_configoptional-1.0.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: configoptional
+component: all
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Mark configoptional as stable

--- a/.chloggen/mx-psi_mark-configauth-as-1.0.yaml
+++ b/.chloggen/mx-psi_mark-configauth-as-1.0.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: configauth
+component: all
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Mark configauth module as 1.0

--- a/.chloggen/mx-psi_remove-deprecated-symbols-exporterhelper.yaml
+++ b/.chloggen/mx-psi_remove-deprecated-symbols-exporterhelper.yaml
@@ -4,7 +4,7 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: exporterhelper
+component: pkg/exporterhelper
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Remove all experimental symbols in exporterhelper 

--- a/.chloggen/stable-use-custom-proto.yaml
+++ b/.chloggen/stable-use-custom-proto.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: pdata
+component: pkg/pdata
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Mark featuregate pdata.useCustomProtoEncoding as stable

--- a/.chloggen/telemetry-tracesconfig-deprecated.yaml
+++ b/.chloggen/telemetry-tracesconfig-deprecated.yaml
@@ -4,7 +4,7 @@
 change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
-component: service
+component: all
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: service/telemetry.TracesConfig is deprecated

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Ensure changelog config.yaml is up to date
         run: |
           make generate-chloggen-components
-          if [[ $(git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./.chloggen/config.yaml) ]]; then
+          if [[ $(git diff --name-only) ]]; then
             echo ".chloggen/config.yaml is out of date. Please run 'make generate-chloggen-components' and commit the changes."
             false
           else

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -58,6 +58,16 @@ jobs:
           echo "CHANGELOG.md and CHANGELOG-API.md were not modified."
           fi
 
+      - name: Ensure changelog config.yaml is up to date
+        run: |
+          make generate-chloggen-components
+          if [[ $(git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./.chloggen/config.yaml)]]; then
+            echo "chloggen config.yaml (.chloggen/config.yaml) is not up to date. Please update it using 'make generate-chloggen-components'"
+          else
+            echo "chloggen config.yaml is up to date"
+          fi
+          git checkout $PR_HEAD ./.chloggen/config.yaml
+
       - name: Ensure ./.chloggen/*.yaml addition(s)
         run: |
           if [[ 1 -gt $(git diff --diff-filter=A --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./.chloggen | grep -c \\.yaml) ]]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -62,11 +62,12 @@ jobs:
         run: |
           make generate-chloggen-components
           if [[ $(git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./.chloggen/config.yaml) ]]; then
-            echo "chloggen config.yaml (.chloggen/config.yaml) is not up to date. Please update it using 'make generate-chloggen-components'"
+            echo ".chloggen/config.yaml is out of date. Please run 'make generate-chloggen-components' and commit the changes."
+            false
           else
-            echo "chloggen config.yaml is up to date"
+            echo ".chloggen/config.yaml is up to date."
           fi
-          git checkout $PR_HEAD ./.chloggen/config.yaml
+          git checkout $PR_HEAD -- ./.chloggen/config.yaml
 
       - name: Ensure ./.chloggen/*.yaml addition(s)
         run: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Ensure changelog config.yaml is up to date
         run: |
           make generate-chloggen-components
-          if [[ $(git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./.chloggen/config.yaml)]]; then
+          if [[ $(git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./.chloggen/config.yaml) ]]; then
             echo "chloggen config.yaml (.chloggen/config.yaml) is not up to date. Please update it using 'make generate-chloggen-components'"
           else
             echo "chloggen config.yaml is up to date"

--- a/Makefile
+++ b/Makefile
@@ -475,3 +475,7 @@ gengithub: $(GITHUBGEN) generate-codeowners generate-gh-issue-templates
 .PHONY: gendistributions
 gendistributions: $(GITHUBGEN)
 	$(GITHUBGEN) distributions
+
+.PHONY: generate-chloggen-components
+generate-chloggen-components: $(GITHUBGEN)
+	$(GITHUBGEN) chloggen-components


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds some code to generate the list of allowed components for `chloggen`.
All tooling was already prepared previously so we just need to make use of the features.
The PR also adds a CI check to validate the component label in all changelog entries.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13923

<!--Describe the documentation added.-->
#### Documentation

I added a readme file as a replacement for the code comments in `.chloggen/config.yaml` since those are removed during auto generation of the file.

<!--Please delete paragraphs that you did not use before submitting.-->
