### PR TITLE
[chore] Fix check-merge-freeze check

### DIFF
--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -24,7 +24,7 @@ jobs:
     # This condition is to avoid blocking the PR causing the freeze in the first place.
     if: |
       (!startsWith(github.event.pull_request.title || github.event.merge_group.head_commit.message, '[chore] Prepare release')) ||
-      ((github.event.pull_request.user.login || github.event.merge_group.head_commit.author.name) == 'otelbot[bot]')
+      ((github.event.pull_request.user.login || github.event.merge_group.head_commit.author.name) != 'otelbot[bot]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
To unblock https://github.com/open-telemetry/opentelemetry-collector/pull/13933

To logic seems incorrect. The check should run when 
```
(!startsWith(title, '[chore] Prepare release')) || (user != 'otelbot[bot]')

or 

!(startsWith(title, '[chore] Prepare release')) && (user == 'otelbot[bot]'))
```

instead of
```
(!startsWith(title, '[chore] Prepare release')) || (user == 'otelbot[bot]')
```