### PR TITLE
[chore] Fix check-codeowners workflow

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -54,8 +54,10 @@ jobs:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
+      # NOTE: the make command below intentionally uses the Makefile from the
+      # target branch, and not the PR checkout, since it runs with the
+      # pull_request_target event and has elevated permissions.
       - name: Gen CODEOWNERS
         run: |
-          cd pr
-          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} ../.tools/githubgen --default-codeowner "open-telemetry/collector-approvers" codeowners
+          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=./pr" make generate-codeowners
           git diff -s --exit-code || (echo 'Generated code is out of date, please run "make generate-codeowners" or apply this diff and commit the changes in this PR.' && git diff && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -462,21 +462,24 @@ mdatagen-test:
 	cd cmd/mdatagen && $(MAKE) fmt
 	cd cmd/mdatagen && $(GOCMD) test ./...
 
+GITHUBGEN_ARGS ?= -skipgithub
+GITHUBGEN := $(GO_TOOL) githubgen $(GITHUBGEN_ARGS)
+
 .PHONY: generate-gh-issue-templates
 generate-gh-issue-templates:
-	$(GO_TOOL) githubgen issue-templates
+	$(GITHUBGEN) issue-templates
 
 .PHONY: generate-codeowners
 generate-codeowners:
-	$(GO_TOOL) githubgen --default-codeowner "open-telemetry/collector-approvers" -skipgithub codeowners
+	$(GITHUBGEN) --default-codeowner "open-telemetry/collector-approvers" codeowners
 
 .PHONY: gengithub
 gengithub: generate-codeowners generate-gh-issue-templates
 
 .PHONY: gendistributions
 gendistributions:
-	$(GO_TOOL) githubgen distributions
+	$(GITHUBGEN) distributions
 
 .PHONY: generate-chloggen-components
-generate-chloggen-components: $(GITHUBGEN)
-	$(GO_TOOL) githubgen chloggen-components
+generate-chloggen-components:
+	$(GITHUBGEN) chloggen-components


### PR DESCRIPTION
#### Description

Update the check-codeowners workflow to use the `make generate-codeowners` target rather than invoking the githubgen tool directly.

#### Link to tracking issue

Fixes the check-codeowners workflow to align with https://github.com/open-telemetry/opentelemetry-collector/pull/13906

#### Testing

N/A

#### Documentation

N/A