### PR TITLE
[chore] Use pseudoversion for telemetrytest

### DIFF
--- a/service/go.mod
+++ b/service/go.mod
@@ -47,7 +47,7 @@ require (
 	go.opentelemetry.io/collector/receiver/receivertest v0.137.0
 	go.opentelemetry.io/collector/receiver/xreceiver v0.137.0
 	go.opentelemetry.io/collector/service/hostcapabilities v0.137.0
-	go.opentelemetry.io/collector/service/telemetry/telemetrytest v0.137.0
+	go.opentelemetry.io/collector/service/telemetry/telemetrytest v0.0.0-20251010094443-567586048b9f
 	go.opentelemetry.io/contrib/otelconf v0.18.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.38.0
 	go.opentelemetry.io/otel v1.38.0


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Unblocks update-otel job, which failed because of this:

```
 go: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal tested by
  	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal.test imports
  	go.opentelemetry.io/collector/otelcol imports
  	go.opentelemetry.io/collector/service tested by
  	go.opentelemetry.io/collector/service.test imports
  	go.opentelemetry.io/collector/service/telemetry/telemetrytest: reading go.opentelemetry.io/collector/service/telemetry/telemetrytest/go.mod at revision service/telemetry/telemetrytest/v0.137.0: unknown revision service/telemetry/telemetrytest/v0.137.0
```

<!-- Issue number if applicable -->

#### Link to tracking issue

Fixes open-telemetry/opentelemetry-collector-contrib/issues/43412
