### PR TITLE
Fix genotelcorecol in CI

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -4,7 +4,7 @@ module go.opentelemetry.io/collector/cmd/otelcorecol
 
 go 1.24.0
 
-toolchain go1.24.8
+toolchain go1.24.9
 
 require (
 	go.opentelemetry.io/collector/component v1.43.0


### PR DESCRIPTION
CI is using the latest minor version, so when running `make genotelcorecol`, it upgrades from 1.24.8 to 1.24.9, which fails CI.

See https://github.com/open-telemetry/opentelemetry-collector/actions/runs/18489269457/job/52678913721?pr=14007