### PR TITLE
[tiny][chore] Remove `actionlint` label for `windows-11-arm`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,8 +1,5 @@
 self-hosted-runner:
-  labels:
-    # Actionlint doesn't include yet windows-11-arm as a known runner, adding it
-    # manually, see https://github.com/rhysd/actionlint/issues/533.
-    - windows-11-arm
+  labels: []
 
 config-variables: null
 


### PR DESCRIPTION
Latest version of `actionlint`, see [release notes](https://github.com/rhysd/actionlint/releases/tag/v1.7.8), natively recognizes `windows-11-arm` runners.

Follow-up to https://github.com/open-telemetry/opentelemetry-collector/pull/13772#discussion_r2341652920
