### PR TITLE
[chore] update ping-codeowners-issue to match the valid label

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-issues.sh
+++ b/.github/workflows/scripts/ping-codeowners-issues.sh
@@ -20,4 +20,4 @@ if [[ -z "${OWNERS}" ]]; then
     exit 0
 fi
 
-gh issue comment "${ISSUE}" --body "Pinging code owners for ${COMPONENT}: ${OWNERS}. See [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself. For example, comment '/label priority:p2 -needs-triaged' to set the priority and remove the needs-triaged label."
+gh issue comment "${ISSUE}" --body "Pinging code owners for ${COMPONENT}: ${OWNERS}. See [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself. For example, comment '/label priority:p2 -needs-triage' to set the priority and remove the needs-triage label."


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Update the `ping-codeowners-issue.sh` script to match the valid label of `needs-triage`.