### PR TITLE
Remove usage of generics for request.Sizer, no need to have it

### DIFF
--- a/exporter/exporterhelper/internal/queue/memory_queue.go
+++ b/exporter/exporterhelper/internal/queue/memory_queue.go
@@ -26,10 +26,10 @@ var (
 )
 
 // memoryQueue is an in-memory implementation of a Queue.
-type memoryQueue[T any] struct {
+type memoryQueue[T request.Request] struct {
 	component.StartFunc
 	refCounter ReferenceCounter[T]
-	sizer      request.Sizer[T]
+	sizer      request.Sizer
 	cap        int64
 
 	mu              sync.Mutex
@@ -47,7 +47,7 @@ type memoryQueue[T any] struct {
 func newMemoryQueue[T request.Request](set Settings[T]) readableQueue[T] {
 	sq := &memoryQueue[T]{
 		refCounter:      set.ReferenceCounter,
-		sizer:           set.activeSizer(),
+		sizer:           request.NewSizer(set.SizerType),
 		cap:             set.Capacity,
 		items:           &linkedQueue[T]{},
 		waitForResult:   set.WaitForResult,

--- a/exporter/exporterhelper/internal/queue/persistent_queue.go
+++ b/exporter/exporterhelper/internal/queue/persistent_queue.go
@@ -68,15 +68,15 @@ var indexDonePool = sync.Pool{
 //	 write          read    x     └── currently dispatched item
 //	 index          index   x
 //	                        xxxx deleted
-type persistentQueue[T any] struct {
+type persistentQueue[T request.Request] struct {
 	logger      *zap.Logger
 	client      storage.Client
 	encoding    Encoding[T]
 	capacity    int64
 	sizerType   request.SizerType
-	activeSizer request.Sizer[T]
-	itemsSizer  request.Sizer[T]
-	bytesSizer  request.Sizer[T]
+	activeSizer request.Sizer
+	itemsSizer  request.Sizer
+	bytesSizer  request.Sizer
 	storageID   component.ID
 	id          component.ID
 	signal      pipeline.Signal
@@ -99,9 +99,9 @@ func newPersistentQueue[T request.Request](set Settings[T]) readableQueue[T] {
 		encoding:        set.Encoding,
 		capacity:        set.Capacity,
 		sizerType:       set.SizerType,
-		activeSizer:     set.activeSizer(),
-		itemsSizer:      request.NewItemsSizer[T](),
-		bytesSizer:      request.NewBytesSizer[T](),
+		activeSizer:     request.NewSizer(set.SizerType),
+		itemsSizer:      request.NewItemsSizer(),
+		bytesSizer:      request.NewBytesSizer(),
 		storageID:       *set.StorageID,
 		id:              set.ID,
 		signal:          set.Signal,

--- a/exporter/exporterhelper/internal/queue/queue.go
+++ b/exporter/exporterhelper/internal/queue/queue.go
@@ -78,17 +78,6 @@ type Settings[T request.Request] struct {
 	Telemetry        component.TelemetrySettings
 }
 
-func (set *Settings[T]) activeSizer() request.Sizer[T] {
-	switch set.SizerType {
-	case request.SizerTypeBytes:
-		return request.NewBytesSizer[T]()
-	case request.SizerTypeItems:
-		return request.NewItemsSizer[T]()
-	default:
-		return request.RequestsSizer[T]{}
-	}
-}
-
 func NewQueue[T request.Request](set Settings[T], next ConsumeFunc[T]) (Queue[T], error) {
 	q := newBaseQueue(set)
 	oq, err := newObsQueue(set, newAsyncQueue(q, set.NumConsumers, next, set.ReferenceCounter))

--- a/exporter/exporterhelper/internal/queuebatch/batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/batcher.go
@@ -35,7 +35,7 @@ func NewBatcher(cfg configoptional.Optional[BatchConfig], set batcherSettings[re
 		return newDisabledBatcher(set.next), nil
 	}
 
-	sizer := activeSizer[request.Request](cfg.Get().Sizer)
+	sizer := request.NewSizer(cfg.Get().Sizer)
 	if sizer == nil {
 		return nil, fmt.Errorf("queue_batch: unsupported sizer %q", cfg.Get().Sizer)
 	}
@@ -45,15 +45,4 @@ func NewBatcher(cfg configoptional.Optional[BatchConfig], set batcherSettings[re
 	}
 
 	return newMultiBatcher(*cfg.Get(), sizer, newWorkerPool(set.maxWorkers), set.partitioner, set.mergeCtx, set.next, set.logger), nil
-}
-
-func activeSizer[T request.Request](sizerType request.SizerType) request.Sizer[T] {
-	switch sizerType {
-	case request.SizerTypeBytes:
-		return request.NewBytesSizer[T]()
-	case request.SizerTypeItems:
-		return request.NewItemsSizer[T]()
-	default:
-		return request.RequestsSizer[T]{}
-	}
 }

--- a/exporter/exporterhelper/internal/queuebatch/multi_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/multi_batcher.go
@@ -14,12 +14,10 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
 )
 
-var _ Batcher[request.Request] = (*multiBatcher)(nil)
-
 type multiBatcher struct {
 	cfg         BatchConfig
 	wp          *workerPool
-	sizer       request.Sizer[request.Request]
+	sizer       request.Sizer
 	partitioner Partitioner[request.Request]
 	mergeCtx    func(context.Context, context.Context) context.Context
 	consumeFunc sender.SendFunc[request.Request]
@@ -29,7 +27,7 @@ type multiBatcher struct {
 
 func newMultiBatcher(
 	bCfg BatchConfig,
-	sizer request.Sizer[request.Request],
+	sizer request.Sizer,
 	wp *workerPool,
 	partitioner Partitioner[request.Request],
 	mergeCtx func(context.Context, context.Context) context.Context,

--- a/exporter/exporterhelper/internal/queuebatch/multi_batcher_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/multi_batcher_test.go
@@ -28,7 +28,7 @@ func TestMultiBatcher_NoTimeout(t *testing.T) {
 	type partitionKey struct{}
 
 	ba := newMultiBatcher(cfg,
-		request.NewItemsSizer[request.Request](),
+		request.NewItemsSizer(),
 		newWorkerPool(1),
 		NewPartitioner(func(ctx context.Context, _ request.Request) string {
 			return ctx.Value(partitionKey{}).(string)
@@ -81,7 +81,7 @@ func TestMultiBatcher_Timeout(t *testing.T) {
 	type partitionKey struct{}
 
 	ba := newMultiBatcher(cfg,
-		request.NewItemsSizer[request.Request](),
+		request.NewItemsSizer(),
 		newWorkerPool(1),
 		NewPartitioner(func(ctx context.Context, _ request.Request) string {
 			return ctx.Value(partitionKey{}).(string)

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
@@ -29,7 +29,7 @@ type batch struct {
 type partitionBatcher struct {
 	cfg            BatchConfig
 	wp             *workerPool
-	sizer          request.Sizer[request.Request]
+	sizer          request.Sizer
 	mergeCtx       func(context.Context, context.Context) context.Context
 	consumeFunc    sender.SendFunc[request.Request]
 	stopWG         sync.WaitGroup
@@ -42,7 +42,7 @@ type partitionBatcher struct {
 
 func newPartitionBatcher(
 	cfg BatchConfig,
-	sizer request.Sizer[request.Request],
+	sizer request.Sizer,
 	mergeCtx func(context.Context, context.Context) context.Context,
 	wp *workerPool,
 	next sender.SendFunc[request.Request],

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
@@ -29,31 +29,31 @@ func TestPartitionBatcher_NoSplit_MinThresholdZero_TimeoutDisabled(t *testing.T)
 	tests := []struct {
 		name       string
 		sizerType  request.SizerType
-		sizer      request.Sizer[request.Request]
+		sizer      request.Sizer
 		maxWorkers int
 	}{
 		{
 			name:       "items/one_worker",
 			sizerType:  request.SizerTypeItems,
-			sizer:      request.NewItemsSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 1,
 		},
 		{
 			name:       "items/three_workers",
 			sizerType:  request.SizerTypeItems,
-			sizer:      request.NewItemsSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 3,
 		},
 		{
 			name:       "bytes/one_worker",
 			sizerType:  request.SizerTypeBytes,
-			sizer:      request.NewBytesSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 1,
 		},
 		{
 			name:       "bytes/three_workers",
 			sizerType:  request.SizerTypeBytes,
-			sizer:      request.NewBytesSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 3,
 		},
 	}
@@ -95,31 +95,31 @@ func TestPartitionBatcher_NoSplit_TimeoutDisabled(t *testing.T) {
 	tests := []struct {
 		name       string
 		sizerType  request.SizerType
-		sizer      request.Sizer[request.Request]
+		sizer      request.Sizer
 		maxWorkers int
 	}{
 		{
 			name:       "items/one_worker",
 			sizerType:  request.SizerTypeItems,
-			sizer:      request.NewItemsSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 1,
 		},
 		{
 			name:       "items/three_workers",
 			sizerType:  request.SizerTypeItems,
-			sizer:      request.NewItemsSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 3,
 		},
 		{
 			name:       "bytes/one_worker",
 			sizerType:  request.SizerTypeBytes,
-			sizer:      request.NewBytesSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 1,
 		},
 		{
 			name:       "bytes/three_workers",
 			sizerType:  request.SizerTypeBytes,
-			sizer:      request.NewBytesSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 3,
 		},
 	}
@@ -176,31 +176,31 @@ func TestPartitionBatcher_NoSplit_WithTimeout(t *testing.T) {
 	tests := []struct {
 		name       string
 		sizerType  request.SizerType
-		sizer      request.Sizer[request.Request]
+		sizer      request.Sizer
 		maxWorkers int
 	}{
 		{
 			name:       "items/one_worker",
 			sizerType:  request.SizerTypeItems,
-			sizer:      request.NewItemsSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 1,
 		},
 		{
 			name:       "items/three_workers",
 			sizerType:  request.SizerTypeItems,
-			sizer:      request.NewItemsSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 3,
 		},
 		{
 			name:       "bytes/one_worker",
 			sizerType:  request.SizerTypeBytes,
-			sizer:      request.NewBytesSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 1,
 		},
 		{
 			name:       "bytes/three_workers",
 			sizerType:  request.SizerTypeBytes,
-			sizer:      request.NewBytesSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 3,
 		},
 	}
@@ -247,31 +247,31 @@ func TestPartitionBatcher_Split_TimeoutDisabled(t *testing.T) {
 	tests := []struct {
 		name       string
 		sizerType  request.SizerType
-		sizer      request.Sizer[request.Request]
+		sizer      request.Sizer
 		maxWorkers int
 	}{
 		{
 			name:       "items/one_worker",
 			sizerType:  request.SizerTypeItems,
-			sizer:      request.NewItemsSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 1,
 		},
 		{
 			name:       "items/three_workers",
 			sizerType:  request.SizerTypeItems,
-			sizer:      request.NewItemsSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 3,
 		},
 		{
 			name:       "bytes/one_worker",
 			sizerType:  request.SizerTypeBytes,
-			sizer:      request.NewBytesSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 1,
 		},
 		{
 			name:       "bytes/three_workers",
 			sizerType:  request.SizerTypeBytes,
-			sizer:      request.NewBytesSizer[request.Request](),
+			sizer:      request.NewItemsSizer(),
 			maxWorkers: 3,
 		},
 	}
@@ -333,7 +333,7 @@ func TestPartitionBatcher_Shutdown(t *testing.T) {
 	}
 
 	sink := requesttest.NewSink()
-	ba := newPartitionBatcher(cfg, request.NewItemsSizer[request.Request](), nil, newWorkerPool(2), sink.Export, zap.NewNop())
+	ba := newPartitionBatcher(cfg, request.NewItemsSizer(), nil, newWorkerPool(2), sink.Export, zap.NewNop())
 	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
 
 	done := newFakeDone()
@@ -362,7 +362,7 @@ func TestPartitionBatcher_MergeError(t *testing.T) {
 	}
 
 	sink := requesttest.NewSink()
-	ba := newPartitionBatcher(cfg, request.NewItemsSizer[request.Request](), nil, newWorkerPool(2), sink.Export, zap.NewNop())
+	ba := newPartitionBatcher(cfg, request.NewItemsSizer(), nil, newWorkerPool(2), sink.Export, zap.NewNop())
 	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
 		require.NoError(t, ba.Shutdown(context.Background()))
@@ -396,7 +396,7 @@ func TestPartitionBatcher_PartialSuccessError(t *testing.T) {
 	core, observed := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
 	sink := requesttest.NewSink()
-	ba := newPartitionBatcher(cfg, request.NewItemsSizer[request.Request](), nil, newWorkerPool(1), sink.Export, logger)
+	ba := newPartitionBatcher(cfg, request.NewItemsSizer(), nil, newWorkerPool(1), sink.Export, logger)
 	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
 
 	done := newFakeDone()
@@ -438,7 +438,7 @@ func TestSPartitionBatcher_PartialSuccessError_AfterOkRequest(t *testing.T) {
 	core, observed := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
 	sink := requesttest.NewSink()
-	ba := newPartitionBatcher(cfg, request.NewItemsSizer[request.Request](), nil, newWorkerPool(1), sink.Export, logger)
+	ba := newPartitionBatcher(cfg, request.NewItemsSizer(), nil, newWorkerPool(1), sink.Export, logger)
 	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
 
 	done := newFakeDone()
@@ -498,7 +498,7 @@ func TestShardBatcher_EmptyRequestList(t *testing.T) {
 	}
 
 	sink := requesttest.NewSink()
-	ba := newPartitionBatcher(cfg, request.NewItemsSizer[request.Request](), nil, newWorkerPool(1), sink.Export, zap.NewNop())
+	ba := newPartitionBatcher(cfg, request.NewItemsSizer(), nil, newWorkerPool(1), sink.Export, zap.NewNop())
 	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
 		require.NoError(t, ba.Shutdown(context.Background()))
@@ -548,7 +548,7 @@ func TestPartitionBatcher_ContextMerging(t *testing.T) {
 				MinSize:      10,
 			}
 			sink := requesttest.NewSink()
-			ba := newPartitionBatcher(cfg, request.NewItemsSizer[request.Request](), tt.mergeCtxFunc, newWorkerPool(1), sink.Export, zap.NewNop())
+			ba := newPartitionBatcher(cfg, request.NewItemsSizer(), tt.mergeCtxFunc, newWorkerPool(1), sink.Export, zap.NewNop())
 			require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
 
 			done := newFakeDone()

--- a/exporter/exporterhelper/internal/request/sizer.go
+++ b/exporter/exporterhelper/internal/request/sizer.go
@@ -55,33 +55,44 @@ func (s *SizerType) String() string {
 }
 
 // Sizer is an interface that returns the size of the given element.
-type Sizer[T any] interface {
-	Sizeof(T) int64
+type Sizer interface {
+	Sizeof(Request) int64
+}
+
+func NewSizer(sizerType SizerType) Sizer {
+	switch sizerType {
+	case SizerTypeBytes:
+		return NewBytesSizer()
+	case SizerTypeItems:
+		return NewItemsSizer()
+	default:
+		return RequestsSizer{}
+	}
 }
 
 // RequestsSizer is a Sizer implementation that returns the size of a queue element as one request.
-type RequestsSizer[T any] struct{}
+type RequestsSizer struct{}
 
-func (rs RequestsSizer[T]) Sizeof(T) int64 {
+func (rs RequestsSizer) Sizeof(Request) int64 {
 	return 1
 }
 
-type itemsSizer[T Request] struct{}
+type itemsSizer struct{}
 
-func (itemsSizer[T]) Sizeof(t T) int64 {
-	return int64(t.ItemsCount())
+func (itemsSizer) Sizeof(req Request) int64 {
+	return int64(req.ItemsCount())
 }
 
-type bytesSizer[T Request] struct{}
+type bytesSizer struct{}
 
-func (bytesSizer[T]) Sizeof(t T) int64 {
-	return int64(t.BytesSize())
+func (bytesSizer) Sizeof(req Request) int64 {
+	return int64(req.BytesSize())
 }
 
-func NewItemsSizer[T Request]() Sizer[T] {
-	return itemsSizer[T]{}
+func NewItemsSizer() Sizer {
+	return itemsSizer{}
 }
 
-func NewBytesSizer[T Request]() Sizer[T] {
-	return bytesSizer[T]{}
+func NewBytesSizer() Sizer {
+	return bytesSizer{}
 }

--- a/exporter/exporterhelper/internal/request/sizer_test.go
+++ b/exporter/exporterhelper/internal/request/sizer_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestItemsSizer(t *testing.T) {
-	sz := request.NewItemsSizer[request.Request]()
+	sz := request.NewItemsSizer()
 	assert.EqualValues(t, 3, sz.Sizeof(&requesttest.FakeRequest{Items: 3}))
 }
 


### PR DESCRIPTION
Internal cleanup, no need for changelog.