### PR TITLE
[pdata/pcommon] Add `RemoveIf` method to primitive slice types

### DIFF
--- a/.chloggen/pdata-primitive-slice-removeif.yaml
+++ b/.chloggen/pdata-primitive-slice-removeif.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata/pcommon
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `RemoveIf` method to primitive slice types (StringSlice, Int64Slice, UInt64Slice, Float64Slice, Int32Slice, ByteSlice)"
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice.go.tmpl
@@ -126,6 +126,28 @@ func (ms {{ .structName }}) MoveAndAppendTo(dest {{ .structName }}) {
   *ms.getOrig() = nil
 }
 
+// RemoveIf calls f sequentially for each element present in the slice.
+// If f returns true, the element is removed from the slice.
+func (ms {{ .structName }}) RemoveIf(f func({{ .itemType }}) bool) {
+	ms.getState().AssertMutable()
+	newLen := 0
+	for i := 0; i < len(*ms.getOrig()); i++ {
+		if f((*ms.getOrig())[i]) {
+			continue
+		}
+		if newLen == i {
+			// Nothing to move, element is at the right place.
+			newLen++
+			continue
+		}
+		(*ms.getOrig())[newLen] = (*ms.getOrig())[i]
+		var zero {{ .itemType }}
+		(*ms.getOrig())[i] = zero
+		newLen++
+	}
+	*ms.getOrig() = (*ms.getOrig())[:newLen]
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms {{ .structName }}) CopyTo(dest {{ .structName }}) {
 	dest.getState().AssertMutable()

--- a/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice_test.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice_test.go.tmpl
@@ -153,6 +153,32 @@ func Test{{ .structName }}MoveAndAppendTo(t *testing.T) {
   assert.Equal(t, ms2.Len(), 6)
 }
 
+func Test{{ .structName }}RemoveIf(t *testing.T) {
+	emptySlice := New{{ .structName }}()
+	emptySlice.RemoveIf(func(el {{ .itemType }}) bool {
+		t.Fail()
+		return false
+	})
+
+	ms := New{{ .structName }}()
+	ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
+	pos := 0
+	ms.RemoveIf(func(el {{ .itemType }}) bool {
+		pos++
+		return pos%2 == 1
+	})
+	assert.Equal(t, pos/2, ms.Len())
+}
+
+func Test{{ .structName }}RemoveIfAll(t *testing.T) {
+	ms := New{{ .structName }}()
+	ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
+	ms.RemoveIf(func(el {{ .itemType }}) bool {
+		return true
+	})
+	assert.Equal(t, 0, ms.Len())
+}
+
 func Test{{ .structName }}Equal(t *testing.T) {
 	ms := New{{ .structName }}()
 	ms2 := New{{ .structName }}()

--- a/pdata/pcommon/generated_byteslice.go
+++ b/pdata/pcommon/generated_byteslice.go
@@ -127,6 +127,28 @@ func (ms ByteSlice) MoveAndAppendTo(dest ByteSlice) {
 	*ms.getOrig() = nil
 }
 
+// RemoveIf calls f sequentially for each element present in the slice.
+// If f returns true, the element is removed from the slice.
+func (ms ByteSlice) RemoveIf(f func(byte) bool) {
+	ms.getState().AssertMutable()
+	newLen := 0
+	for i := 0; i < len(*ms.getOrig()); i++ {
+		if f((*ms.getOrig())[i]) {
+			continue
+		}
+		if newLen == i {
+			// Nothing to move, element is at the right place.
+			newLen++
+			continue
+		}
+		(*ms.getOrig())[newLen] = (*ms.getOrig())[i]
+		var zero byte
+		(*ms.getOrig())[i] = zero
+		newLen++
+	}
+	*ms.getOrig() = (*ms.getOrig())[:newLen]
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms ByteSlice) CopyTo(dest ByteSlice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_byteslice_test.go
+++ b/pdata/pcommon/generated_byteslice_test.go
@@ -118,6 +118,32 @@ func TestByteSliceMoveAndAppendTo(t *testing.T) {
 	assert.Equal(t, ms2.Len(), 6)
 }
 
+func TestByteSliceRemoveIf(t *testing.T) {
+	emptySlice := NewByteSlice()
+	emptySlice.RemoveIf(func(el byte) bool {
+		t.Fail()
+		return false
+	})
+
+	ms := NewByteSlice()
+	ms.FromRaw([]byte{1, 2, 3})
+	pos := 0
+	ms.RemoveIf(func(el byte) bool {
+		pos++
+		return pos%2 == 1
+	})
+	assert.Equal(t, pos/2, ms.Len())
+}
+
+func TestByteSliceRemoveIfAll(t *testing.T) {
+	ms := NewByteSlice()
+	ms.FromRaw([]byte{1, 2, 3})
+	ms.RemoveIf(func(el byte) bool {
+		return true
+	})
+	assert.Equal(t, 0, ms.Len())
+}
+
 func TestByteSliceEqual(t *testing.T) {
 	ms := NewByteSlice()
 	ms2 := NewByteSlice()

--- a/pdata/pcommon/generated_float64slice.go
+++ b/pdata/pcommon/generated_float64slice.go
@@ -127,6 +127,28 @@ func (ms Float64Slice) MoveAndAppendTo(dest Float64Slice) {
 	*ms.getOrig() = nil
 }
 
+// RemoveIf calls f sequentially for each element present in the slice.
+// If f returns true, the element is removed from the slice.
+func (ms Float64Slice) RemoveIf(f func(float64) bool) {
+	ms.getState().AssertMutable()
+	newLen := 0
+	for i := 0; i < len(*ms.getOrig()); i++ {
+		if f((*ms.getOrig())[i]) {
+			continue
+		}
+		if newLen == i {
+			// Nothing to move, element is at the right place.
+			newLen++
+			continue
+		}
+		(*ms.getOrig())[newLen] = (*ms.getOrig())[i]
+		var zero float64
+		(*ms.getOrig())[i] = zero
+		newLen++
+	}
+	*ms.getOrig() = (*ms.getOrig())[:newLen]
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms Float64Slice) CopyTo(dest Float64Slice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_float64slice_test.go
+++ b/pdata/pcommon/generated_float64slice_test.go
@@ -118,6 +118,32 @@ func TestFloat64SliceMoveAndAppendTo(t *testing.T) {
 	assert.Equal(t, ms2.Len(), 6)
 }
 
+func TestFloat64SliceRemoveIf(t *testing.T) {
+	emptySlice := NewFloat64Slice()
+	emptySlice.RemoveIf(func(el float64) bool {
+		t.Fail()
+		return false
+	})
+
+	ms := NewFloat64Slice()
+	ms.FromRaw([]float64{1.1, 2.2, 3.3})
+	pos := 0
+	ms.RemoveIf(func(el float64) bool {
+		pos++
+		return pos%2 == 1
+	})
+	assert.Equal(t, pos/2, ms.Len())
+}
+
+func TestFloat64SliceRemoveIfAll(t *testing.T) {
+	ms := NewFloat64Slice()
+	ms.FromRaw([]float64{1.1, 2.2, 3.3})
+	ms.RemoveIf(func(el float64) bool {
+		return true
+	})
+	assert.Equal(t, 0, ms.Len())
+}
+
 func TestFloat64SliceEqual(t *testing.T) {
 	ms := NewFloat64Slice()
 	ms2 := NewFloat64Slice()

--- a/pdata/pcommon/generated_int32slice.go
+++ b/pdata/pcommon/generated_int32slice.go
@@ -127,6 +127,28 @@ func (ms Int32Slice) MoveAndAppendTo(dest Int32Slice) {
 	*ms.getOrig() = nil
 }
 
+// RemoveIf calls f sequentially for each element present in the slice.
+// If f returns true, the element is removed from the slice.
+func (ms Int32Slice) RemoveIf(f func(int32) bool) {
+	ms.getState().AssertMutable()
+	newLen := 0
+	for i := 0; i < len(*ms.getOrig()); i++ {
+		if f((*ms.getOrig())[i]) {
+			continue
+		}
+		if newLen == i {
+			// Nothing to move, element is at the right place.
+			newLen++
+			continue
+		}
+		(*ms.getOrig())[newLen] = (*ms.getOrig())[i]
+		var zero int32
+		(*ms.getOrig())[i] = zero
+		newLen++
+	}
+	*ms.getOrig() = (*ms.getOrig())[:newLen]
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms Int32Slice) CopyTo(dest Int32Slice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_int32slice_test.go
+++ b/pdata/pcommon/generated_int32slice_test.go
@@ -118,6 +118,32 @@ func TestInt32SliceMoveAndAppendTo(t *testing.T) {
 	assert.Equal(t, ms2.Len(), 6)
 }
 
+func TestInt32SliceRemoveIf(t *testing.T) {
+	emptySlice := NewInt32Slice()
+	emptySlice.RemoveIf(func(el int32) bool {
+		t.Fail()
+		return false
+	})
+
+	ms := NewInt32Slice()
+	ms.FromRaw([]int32{1, 2, 3})
+	pos := 0
+	ms.RemoveIf(func(el int32) bool {
+		pos++
+		return pos%2 == 1
+	})
+	assert.Equal(t, pos/2, ms.Len())
+}
+
+func TestInt32SliceRemoveIfAll(t *testing.T) {
+	ms := NewInt32Slice()
+	ms.FromRaw([]int32{1, 2, 3})
+	ms.RemoveIf(func(el int32) bool {
+		return true
+	})
+	assert.Equal(t, 0, ms.Len())
+}
+
 func TestInt32SliceEqual(t *testing.T) {
 	ms := NewInt32Slice()
 	ms2 := NewInt32Slice()

--- a/pdata/pcommon/generated_int64slice.go
+++ b/pdata/pcommon/generated_int64slice.go
@@ -127,6 +127,28 @@ func (ms Int64Slice) MoveAndAppendTo(dest Int64Slice) {
 	*ms.getOrig() = nil
 }
 
+// RemoveIf calls f sequentially for each element present in the slice.
+// If f returns true, the element is removed from the slice.
+func (ms Int64Slice) RemoveIf(f func(int64) bool) {
+	ms.getState().AssertMutable()
+	newLen := 0
+	for i := 0; i < len(*ms.getOrig()); i++ {
+		if f((*ms.getOrig())[i]) {
+			continue
+		}
+		if newLen == i {
+			// Nothing to move, element is at the right place.
+			newLen++
+			continue
+		}
+		(*ms.getOrig())[newLen] = (*ms.getOrig())[i]
+		var zero int64
+		(*ms.getOrig())[i] = zero
+		newLen++
+	}
+	*ms.getOrig() = (*ms.getOrig())[:newLen]
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms Int64Slice) CopyTo(dest Int64Slice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_int64slice_test.go
+++ b/pdata/pcommon/generated_int64slice_test.go
@@ -118,6 +118,32 @@ func TestInt64SliceMoveAndAppendTo(t *testing.T) {
 	assert.Equal(t, ms2.Len(), 6)
 }
 
+func TestInt64SliceRemoveIf(t *testing.T) {
+	emptySlice := NewInt64Slice()
+	emptySlice.RemoveIf(func(el int64) bool {
+		t.Fail()
+		return false
+	})
+
+	ms := NewInt64Slice()
+	ms.FromRaw([]int64{1, 2, 3})
+	pos := 0
+	ms.RemoveIf(func(el int64) bool {
+		pos++
+		return pos%2 == 1
+	})
+	assert.Equal(t, pos/2, ms.Len())
+}
+
+func TestInt64SliceRemoveIfAll(t *testing.T) {
+	ms := NewInt64Slice()
+	ms.FromRaw([]int64{1, 2, 3})
+	ms.RemoveIf(func(el int64) bool {
+		return true
+	})
+	assert.Equal(t, 0, ms.Len())
+}
+
 func TestInt64SliceEqual(t *testing.T) {
 	ms := NewInt64Slice()
 	ms2 := NewInt64Slice()

--- a/pdata/pcommon/generated_stringslice.go
+++ b/pdata/pcommon/generated_stringslice.go
@@ -127,6 +127,28 @@ func (ms StringSlice) MoveAndAppendTo(dest StringSlice) {
 	*ms.getOrig() = nil
 }
 
+// RemoveIf calls f sequentially for each element present in the slice.
+// If f returns true, the element is removed from the slice.
+func (ms StringSlice) RemoveIf(f func(string) bool) {
+	ms.getState().AssertMutable()
+	newLen := 0
+	for i := 0; i < len(*ms.getOrig()); i++ {
+		if f((*ms.getOrig())[i]) {
+			continue
+		}
+		if newLen == i {
+			// Nothing to move, element is at the right place.
+			newLen++
+			continue
+		}
+		(*ms.getOrig())[newLen] = (*ms.getOrig())[i]
+		var zero string
+		(*ms.getOrig())[i] = zero
+		newLen++
+	}
+	*ms.getOrig() = (*ms.getOrig())[:newLen]
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms StringSlice) CopyTo(dest StringSlice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_stringslice_test.go
+++ b/pdata/pcommon/generated_stringslice_test.go
@@ -118,6 +118,32 @@ func TestStringSliceMoveAndAppendTo(t *testing.T) {
 	assert.Equal(t, ms2.Len(), 6)
 }
 
+func TestStringSliceRemoveIf(t *testing.T) {
+	emptySlice := NewStringSlice()
+	emptySlice.RemoveIf(func(el string) bool {
+		t.Fail()
+		return false
+	})
+
+	ms := NewStringSlice()
+	ms.FromRaw([]string{"a", "b", "c"})
+	pos := 0
+	ms.RemoveIf(func(el string) bool {
+		pos++
+		return pos%2 == 1
+	})
+	assert.Equal(t, pos/2, ms.Len())
+}
+
+func TestStringSliceRemoveIfAll(t *testing.T) {
+	ms := NewStringSlice()
+	ms.FromRaw([]string{"a", "b", "c"})
+	ms.RemoveIf(func(el string) bool {
+		return true
+	})
+	assert.Equal(t, 0, ms.Len())
+}
+
 func TestStringSliceEqual(t *testing.T) {
 	ms := NewStringSlice()
 	ms2 := NewStringSlice()

--- a/pdata/pcommon/generated_uint64slice.go
+++ b/pdata/pcommon/generated_uint64slice.go
@@ -127,6 +127,28 @@ func (ms UInt64Slice) MoveAndAppendTo(dest UInt64Slice) {
 	*ms.getOrig() = nil
 }
 
+// RemoveIf calls f sequentially for each element present in the slice.
+// If f returns true, the element is removed from the slice.
+func (ms UInt64Slice) RemoveIf(f func(uint64) bool) {
+	ms.getState().AssertMutable()
+	newLen := 0
+	for i := 0; i < len(*ms.getOrig()); i++ {
+		if f((*ms.getOrig())[i]) {
+			continue
+		}
+		if newLen == i {
+			// Nothing to move, element is at the right place.
+			newLen++
+			continue
+		}
+		(*ms.getOrig())[newLen] = (*ms.getOrig())[i]
+		var zero uint64
+		(*ms.getOrig())[i] = zero
+		newLen++
+	}
+	*ms.getOrig() = (*ms.getOrig())[:newLen]
+}
+
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms UInt64Slice) CopyTo(dest UInt64Slice) {
 	dest.getState().AssertMutable()

--- a/pdata/pcommon/generated_uint64slice_test.go
+++ b/pdata/pcommon/generated_uint64slice_test.go
@@ -118,6 +118,32 @@ func TestUInt64SliceMoveAndAppendTo(t *testing.T) {
 	assert.Equal(t, ms2.Len(), 6)
 }
 
+func TestUInt64SliceRemoveIf(t *testing.T) {
+	emptySlice := NewUInt64Slice()
+	emptySlice.RemoveIf(func(el uint64) bool {
+		t.Fail()
+		return false
+	})
+
+	ms := NewUInt64Slice()
+	ms.FromRaw([]uint64{1, 2, 3})
+	pos := 0
+	ms.RemoveIf(func(el uint64) bool {
+		pos++
+		return pos%2 == 1
+	})
+	assert.Equal(t, pos/2, ms.Len())
+}
+
+func TestUInt64SliceRemoveIfAll(t *testing.T) {
+	ms := NewUInt64Slice()
+	ms.FromRaw([]uint64{1, 2, 3})
+	ms.RemoveIf(func(el uint64) bool {
+		return true
+	})
+	assert.Equal(t, 0, ms.Len())
+}
+
 func TestUInt64SliceEqual(t *testing.T) {
 	ms := NewUInt64Slice()
 	ms2 := NewUInt64Slice()


### PR DESCRIPTION
Add `RemoveIf` method to primitive slice types (StringSlice, Int64Slice, UInt64Slice, Float64Slice, Int32Slice, ByteSlice) implemented consistently with other slices
