### PR TITLE
Add axw as a triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ the role of the [release manager](./docs/release.md#release-manager).
 
 ### Triagers
 
+- [Andrew Wilkins](https://github.com/axw), Elastic
 - [Andrzej Stencel](https://github.com/andrzej-stencel), Elastic
 - [Chao Weng](https://github.com/sincejune), AppDynamics
 - [Vihas Makwana](https://github.com/VihasMakwana), Elastic


### PR DESCRIPTION
Andrew has a consistent number of good PRs (https://github.com/open-telemetry/opentelemetry-collector/commits?author=axw), as well as plenty of contributions on various initiatives within the collector.

This is to add him as a triager.