### PR TITLE
[exporter/debug]: disable sending queue by default

### DIFF
--- a/.chloggen/debug-exporter-disable-queue.yaml
+++ b/.chloggen/debug-exporter-disable-queue.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporter/debug
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable sending queue by default
+
+# One or more tracking issues or pull requests related to the change
+issues: [14138]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The recently added sending queue configuration in Debug exporter was enabled by default and had a problematic default size of 1.
+  This change disables the sending queue by default.
+  Users can enable and configure the sending queue if needed.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/debugexporter/README.md
+++ b/exporter/debugexporter/README.md
@@ -38,7 +38,7 @@ The following settings are optional:
   Refer to [Zap docs](https://godoc.org/go.uber.org/zap/zapcore#NewSampler) for more details
   on how sampling parameters impact number of messages.
 - `use_internal_logger` (default = `true`): uses the collector's internal logger for output. See [below](#using-the-collectors-internal-logger) for description.
-- `sending_queue`: see [Sending Queue](../exporterhelper/README.md#sending-queue) for the full set of available options.
+- `sending_queue` (disabled by default): see [Sending Queue](../exporterhelper/README.md#sending-queue) for the full set of available options.
 
 Example configuration:
 

--- a/exporter/debugexporter/config_test.go
+++ b/exporter/debugexporter/config_test.go
@@ -25,7 +25,7 @@ func TestUnmarshalDefaultConfig(t *testing.T) {
 
 func TestUnmarshalConfig(t *testing.T) {
 	queueCfg := exporterhelper.NewDefaultQueueConfig()
-	queueCfg.QueueSize = 1
+	queueCfg.Enabled = false
 	tests := []struct {
 		filename    string
 		cfg         *Config

--- a/exporter/debugexporter/factory.go
+++ b/exporter/debugexporter/factory.go
@@ -43,7 +43,7 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	queueCfg := exporterhelper.NewDefaultQueueConfig()
-	queueCfg.QueueSize = 1
+	queueCfg.Enabled = false
 
 	return &Config{
 		Verbosity:          configtelemetry.LevelBasic,


### PR DESCRIPTION
#### Description

The recently added (https://github.com/open-telemetry/opentelemetry-collector/pull/13791, https://github.com/open-telemetry/opentelemetry-collector/pull/14101) sending queue functionality in the Debug exporter had a default size of 1, causing issue described in https://github.com/open-telemetry/opentelemetry-collector/issues/14138.

I propose to disable the queue by default in the Debug exporter.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/14138

#### Testing

Updated unit tests.

I would feel better if the queue scenarios where better covered by tests. On the other hand, I don't want to have similar queue/batching tests duplicated in all exporters.

#### Documentation

Updated documentation to say the sending queue is disabled by default.