### PR TITLE
Clarify expected behavior on component shutdown

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -46,7 +46,7 @@ type Component interface {
 	// If there are any background operations running by the component they must be aborted before
 	// this function returns. Remember that if you started any long-running background operations from
 	// the Start() method, those operations must be also cancelled. If there are any buffers in the
-	// component, they should be cleared and the data sent immediately to the next component.
+	// component, they should be flushed with the data being sent immediately to the next component.
 	//
 	// The component's lifecycle is completed once the Shutdown() method returns. No other
 	// methods of the component are called after that. If necessary a new component with


### PR DESCRIPTION

<!--Describe the documentation added.-->
#### Documentation

The old text to me was ambiguous as "cleared" typically means "emptied with the contents destroyed" (i.e., like the `clear` built-in function), but the API semantics actually expect the buffer to be _flushed_. This came up [on Slack][slack_thread] and it was suggested I open a PR.

[slack_thread]: https://cloud-native.slack.com/archives/C01N6P7KR6W/p1763268895514129?thread_ts=1763186839.475819&cid=C01N6P7KR6W
<!--Please delete paragraphs that you did not use before submitting.-->
