### PR TITLE
[chore] Use pseudo-versions for internal/testutil

### DIFF
--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/knadh/koanf/v2 v2.3.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/featuregate v1.45.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -23,7 +23,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.139.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.139.0
 	go.opentelemetry.io/collector/exporter/xexporter v0.139.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
 	go.opentelemetry.io/collector/pdata v1.45.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.139.0
 	go.opentelemetry.io/collector/pdata/testdata v0.139.0

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -22,7 +22,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.139.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.139.0
 	go.opentelemetry.io/collector/exporter/xexporter v0.139.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
 	go.opentelemetry.io/collector/pdata v1.45.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.139.0
 	go.uber.org/goleak v1.3.0

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/confmap v1.45.0
 	go.opentelemetry.io/collector/extension v1.45.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.139.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
 	go.opentelemetry.io/contrib/zpages v0.63.0
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -34,7 +34,7 @@ require (
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.139.0
 	go.opentelemetry.io/collector/extension v1.45.0
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.139.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
 	go.opentelemetry.io/collector/otelcol v0.139.0
 	go.opentelemetry.io/collector/pdata v1.45.0
 	go.opentelemetry.io/collector/pdata/testdata v0.139.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -23,7 +23,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.139.0
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.139.0
 	go.opentelemetry.io/collector/internal/telemetry v0.139.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
 	go.opentelemetry.io/collector/pdata v1.45.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.139.0
 	go.opentelemetry.io/collector/pdata/testdata v0.139.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -32,7 +32,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.45.0
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.139.0
 	go.opentelemetry.io/collector/internal/telemetry v0.139.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
 	go.opentelemetry.io/collector/otelcol v0.139.0
 	go.opentelemetry.io/collector/pdata v1.45.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.139.0


### PR DESCRIPTION
#### Description
New module `internal/testutil` (introduced in #14076) is currently imported with version `v0.0.0-00010101000000-000000000000`. This PR replaces those imports by a real pseudo-version to unblock update-otel.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44276
