### PR TITLE
Fix prepare release 0.140.0 again

### DIFF
--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/knadh/koanf/v2 v2.3.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/featuregate v1.46.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
+	go.opentelemetry.io/collector/internal/testutil v0.140.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -23,7 +23,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.140.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.140.0
 	go.opentelemetry.io/collector/exporter/xexporter v0.140.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
+	go.opentelemetry.io/collector/internal/testutil v0.140.0
 	go.opentelemetry.io/collector/pdata v1.46.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.140.0
 	go.opentelemetry.io/collector/pdata/testdata v0.140.0

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -22,7 +22,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.140.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.140.0
 	go.opentelemetry.io/collector/exporter/xexporter v0.140.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
+	go.opentelemetry.io/collector/internal/testutil v0.140.0
 	go.opentelemetry.io/collector/pdata v1.46.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.140.0
 	go.uber.org/goleak v1.3.0

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/confmap v1.46.0
 	go.opentelemetry.io/collector/extension v1.46.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.140.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
+	go.opentelemetry.io/collector/internal/testutil v0.140.0
 	go.opentelemetry.io/contrib/zpages v0.63.0
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -34,7 +34,7 @@ require (
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.140.0
 	go.opentelemetry.io/collector/extension v1.46.0
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.140.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
+	go.opentelemetry.io/collector/internal/testutil v0.140.0
 	go.opentelemetry.io/collector/otelcol v0.140.0
 	go.opentelemetry.io/collector/pdata v1.46.0
 	go.opentelemetry.io/collector/pdata/testdata v0.140.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -23,7 +23,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.140.0
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.140.0
 	go.opentelemetry.io/collector/internal/telemetry v0.140.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
+	go.opentelemetry.io/collector/internal/testutil v0.140.0
 	go.opentelemetry.io/collector/pdata v1.46.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.140.0
 	go.opentelemetry.io/collector/pdata/testdata v0.140.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -32,7 +32,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.46.0
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.140.0
 	go.opentelemetry.io/collector/internal/telemetry v0.140.0
-	go.opentelemetry.io/collector/internal/testutil v0.0.0-20251114225300-6341969f2e6a
+	go.opentelemetry.io/collector/internal/testutil v0.140.0
 	go.opentelemetry.io/collector/otelcol v0.140.0
 	go.opentelemetry.io/collector/pdata v1.46.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.140.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -38,6 +38,7 @@ module-sets:
       - go.opentelemetry.io/collector/internal/fanoutconsumer
       - go.opentelemetry.io/collector/internal/sharedcomponent
       - go.opentelemetry.io/collector/internal/telemetry
+      - go.opentelemetry.io/collector/internal/testutil
       - go.opentelemetry.io/collector/cmd/builder
       - go.opentelemetry.io/collector/cmd/mdatagen
       - go.opentelemetry.io/collector/component/componentstatus
@@ -100,6 +101,5 @@ excluded-modules:
   - go.opentelemetry.io/collector/cmd/otelcorecol
   - go.opentelemetry.io/collector/internal/cmd/pdatagen
   - go.opentelemetry.io/collector/internal/e2e
-  - go.opentelemetry.io/collector/internal/testutil
   - go.opentelemetry.io/collector/internal/tools
   - go.opentelemetry.io/collector/confmap/internal/e2e


### PR DESCRIPTION
#### Description

It seems `internal/testutil` was added under `excluded-modules:` in `versions.yaml`, which prevents it from being versioned. This is probably a mistake, since the module is imported by tests in various other modules.

This PR makes `internal/testutil` a regular beta module, and updates imports to it to 0.140.0 since multimod did not do it the first time around.
