### PR TITLE
[chore] Fix benchmark

### DIFF
--- a/exporter/exporterhelper/internal/queue/persistent_queue_test.go
+++ b/exporter/exporterhelper/internal/queue/persistent_queue_test.go
@@ -806,11 +806,12 @@ func BenchmarkPersistentQueue(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		require.NoError(b, ps.Offer(context.Background(), req))
-	}
-
-	for b.Loop() {
-		require.True(b, consume(ps, func(context.Context, intRequest) error { return nil }))
+		for range 100 {
+			require.NoError(b, ps.Offer(context.Background(), req))
+		}
+		for range 100 {
+			require.True(b, consume(ps, func(context.Context, intRequest) error { return nil }))
+		}
 	}
 	require.NoError(b, ext.Shutdown(context.Background()))
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`b.Loop()` should not be used after it has returned false.

This changes the code to run offer a bunch of times and then consume a bunch of times

I believe this is what is making codspeed fail.
