### PR TITLE
[chore] Update internal dependencies in xscraper

### DIFF
--- a/scraper/xscraper/go.mod
+++ b/scraper/xscraper/go.mod
@@ -7,9 +7,9 @@ require (
 	go.opentelemetry.io/collector/component v1.46.0
 	go.opentelemetry.io/collector/component/componenttest v0.140.0
 	go.opentelemetry.io/collector/pdata v1.46.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.136.0
+	go.opentelemetry.io/collector/pdata/pprofile v0.140.0
 	go.opentelemetry.io/collector/pipeline v1.46.0
-	go.opentelemetry.io/collector/scraper v0.136.0
+	go.opentelemetry.io/collector/scraper v0.140.0
 	go.uber.org/goleak v1.3.0
 )
 


### PR DESCRIPTION
#### Description
Dependencies on other core modules were out-of-date when the PR was merged. Replacement of #14210 because it didn't run contrib tests for some reason.
