### PR TITLE
[chore] Fix BenchmarkProfilesUsage

### DIFF
--- a/pdata/pprofile/profiles_test.go
+++ b/pdata/pprofile/profiles_test.go
@@ -171,7 +171,7 @@ func TestProfilesSwitchDictionary(t *testing.T) {
 func BenchmarkProfilesUsage(b *testing.B) {
 	pd := generateTestProfiles()
 	ts := pcommon.NewTimestampFromTime(time.Now())
-	dur := uint64(time.Second.Nanoseconds())
+	dur := uint64(1_000_000_000)
 	testValProfileID := ProfileID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
 	testSecondValProfileID := ProfileID([16]byte{2, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
 


### PR DESCRIPTION
#### Description

The `Duration` and `SetDuration` methods were deprecated in #14188, and their implementations are now no-ops, causing [a benchmark to fail](https://github.com/open-telemetry/opentelemetry-collector/actions/runs/19668308741/job/56330560134). I updated the benchmark to use `DurationNano` and `SetDurationNano` instead.
