### PR TITLE
[configoptional] Fix behavior when unmarshaling with 'enabled: false'

### DIFF
--- a/.chloggen/mx-psi_scrub-zero-value-contents.yaml
+++ b/.chloggen/mx-psi_scrub-zero-value-contents.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/config/configoptional
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure that configoptional.None values resulting from unmarshaling are equivalent to configoptional.Optional zero value.
+
+# One or more tracking issues or pull requests related to the change
+issues: [14218]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configoptional/optional.go
+++ b/config/configoptional/optional.go
@@ -222,6 +222,9 @@ func (o *Optional[T]) Unmarshal(conf *confmap.Conf) error {
 		o.flavor = someFlavor
 	} else {
 		o.flavor = noneFlavor
+		// override o.value with zero value.
+		var zero T
+		o.value = zero
 	}
 
 	return nil

--- a/config/configoptional/optional_test.go
+++ b/config/configoptional/optional_test.go
@@ -528,6 +528,21 @@ func TestAddFieldEnabledFeatureGate(t *testing.T) {
 	}
 }
 
+func TestEnabledFalseResetsValue(t *testing.T) {
+	oldVal := addEnabledFieldFeatureGate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(addEnabledFieldFeatureGateID, true))
+	defer func() { require.NoError(t, featuregate.GlobalRegistry().Set(addEnabledFieldFeatureGateID, oldVal)) }()
+
+	cfg := Config[Sub]{Sub1: Some(Sub{Foo: "initial"})}
+	require.True(t, cfg.Sub1.HasValue())
+
+	cm := confmap.NewFromStringMap(map[string]any{
+		"sub": map[string]any{"enabled": false, "foo": "ignored"},
+	})
+	require.NoError(t, cm.Unmarshal(&cfg))
+	require.Equal(t, None[Sub](), cfg.Sub1)
+}
+
 func TestUnmarshalErrorEnabledInvalidType(t *testing.T) {
 	oldVal := addEnabledFieldFeatureGate.IsEnabled()
 	require.NoError(t, featuregate.GlobalRegistry().Set(addEnabledFieldFeatureGateID, true))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Updates `configoptional.Optional.Unmarshal` to set the inner value to the zero value when the resulting value is a `configoptional.None`.
