### PR TITLE
fix: tests for conditionally_required enum attribute

### DIFF
--- a/cmd/mdatagen/internal/sampleconnector/documentation.md
+++ b/cmd/mdatagen/internal/sampleconnector/documentation.md
@@ -28,7 +28,7 @@ The metric will be become optional soon.
 | ---- | ----------- | ------ | -------- |
 | string_attr | Attribute with any string value. | Any Str | Recommended |
 | state | Integer attribute with overridden name. | Any Int | Recommended |
-| enum_attr | Attribute with a known set of string values. | Str: ``red``, ``green``, ``blue`` | Recommended |
+| enum_attr | Attribute with a known set of string values. | Str: ``red``, ``green``, ``blue`` | Conditionally Required |
 | slice_attr | Attribute with a slice value. | Any Slice | Recommended |
 | map_attr | Attribute with a map value. | Any Map | Recommended |
 
@@ -56,7 +56,7 @@ Monotonic cumulative sum int metric with string input_type enabled by default.
 | ---- | ----------- | ------ | -------- |
 | string_attr | Attribute with any string value. | Any Str | Recommended |
 | state | Integer attribute with overridden name. | Any Int | Recommended |
-| enum_attr | Attribute with a known set of string values. | Str: ``red``, ``green``, ``blue`` | Recommended |
+| enum_attr | Attribute with a known set of string values. | Str: ``red``, ``green``, ``blue`` | Conditionally Required |
 | slice_attr | Attribute with a slice value. | Any Slice | Recommended |
 | map_attr | Attribute with a map value. | Any Map | Recommended |
 

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics.go
@@ -88,6 +88,22 @@ type metricInfo struct {
 	Name string
 }
 
+type MetricAttributeOption interface {
+	apply(pmetric.NumberDataPoint)
+}
+
+type metricAttributeOptionFunc func(pmetric.NumberDataPoint)
+
+func (maof metricAttributeOptionFunc) apply(dp pmetric.NumberDataPoint) {
+	maof(dp)
+}
+
+func WithEnumAttrMetricAttribute(enumAttrAttributeValue AttributeEnumAttr) MetricAttributeOption {
+	return metricAttributeOptionFunc(func(dp pmetric.NumberDataPoint) {
+		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue.String())
+	})
+}
+
 type metricDefaultMetric struct {
 	data          pmetric.Metric // data buffer for generated metric.
 	config        MetricConfig   // metric config provided by user.
@@ -106,7 +122,7 @@ func (m *metricDefaultMetric) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue string, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any) {
+func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any, options ...MetricAttributeOption) {
 	if !m.config.Enabled {
 		return
 	}
@@ -120,14 +136,14 @@ func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	if slices.Contains(m.config.EnabledAttributes, "state") {
 		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, "enum_attr") {
-		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
-	}
 	if slices.Contains(m.config.EnabledAttributes, "slice_attr") {
 		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
 	}
 	if slices.Contains(m.config.EnabledAttributes, "map_attr") {
 		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
+	}
+	for _, op := range options {
+		op.apply(dp)
 	}
 
 	var s string
@@ -294,7 +310,7 @@ func (m *metricMetricInputType) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricMetricInputType) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue string, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any) {
+func (m *metricMetricInputType) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any, options ...MetricAttributeOption) {
 	if !m.config.Enabled {
 		return
 	}
@@ -308,14 +324,14 @@ func (m *metricMetricInputType) recordDataPoint(start pcommon.Timestamp, ts pcom
 	if slices.Contains(m.config.EnabledAttributes, "state") {
 		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, "enum_attr") {
-		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
-	}
 	if slices.Contains(m.config.EnabledAttributes, "slice_attr") {
 		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
 	}
 	if slices.Contains(m.config.EnabledAttributes, "map_attr") {
 		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
+	}
+	for _, op := range options {
+		op.apply(dp)
 	}
 
 	var s string
@@ -881,8 +897,8 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 }
 
 // RecordDefaultMetricDataPoint adds a data point to default.metric metric.
-func (mb *MetricsBuilder) RecordDefaultMetricDataPoint(ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue AttributeEnumAttr, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any) {
-	mb.metricDefaultMetric.recordDataPoint(mb.startTime, ts, val, stringAttrAttributeValue, overriddenIntAttrAttributeValue, enumAttrAttributeValue.String(), sliceAttrAttributeValue, mapAttrAttributeValue)
+func (mb *MetricsBuilder) RecordDefaultMetricDataPoint(ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any, options ...MetricAttributeOption) {
+	mb.metricDefaultMetric.recordDataPoint(mb.startTime, ts, val, stringAttrAttributeValue, overriddenIntAttrAttributeValue, sliceAttrAttributeValue, mapAttrAttributeValue, options...)
 }
 
 // RecordDefaultMetricToBeRemovedDataPoint adds a data point to default.metric.to_be_removed metric.
@@ -891,12 +907,12 @@ func (mb *MetricsBuilder) RecordDefaultMetricToBeRemovedDataPoint(ts pcommon.Tim
 }
 
 // RecordMetricInputTypeDataPoint adds a data point to metric.input_type metric.
-func (mb *MetricsBuilder) RecordMetricInputTypeDataPoint(ts pcommon.Timestamp, inputVal string, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue AttributeEnumAttr, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any) error {
+func (mb *MetricsBuilder) RecordMetricInputTypeDataPoint(ts pcommon.Timestamp, inputVal string, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any, options ...MetricAttributeOption) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
 	if err != nil {
 		return fmt.Errorf("failed to parse int64 for MetricInputType, value was %s: %w", inputVal, err)
 	}
-	mb.metricMetricInputType.recordDataPoint(mb.startTime, ts, val, stringAttrAttributeValue, overriddenIntAttrAttributeValue, enumAttrAttributeValue.String(), sliceAttrAttributeValue, mapAttrAttributeValue)
+	mb.metricMetricInputType.recordDataPoint(mb.startTime, ts, val, stringAttrAttributeValue, overriddenIntAttrAttributeValue, sliceAttrAttributeValue, mapAttrAttributeValue, options...)
 	return nil
 }
 

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics_test.go
@@ -113,9 +113,9 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordDefaultMetricDataPoint(ts, 1, "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"})
+			mb.RecordDefaultMetricDataPoint(ts, 1, "string_attr-val", 19, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"}, WithEnumAttrMetricAttribute(AttributeEnumAttrRed))
 			if tt.name == "reaggregate_set" {
-				mb.RecordDefaultMetricDataPoint(ts, 3, "string_attr-val-2", 20, AttributeEnumAttrGreen, []any{"slice_attr-item3", "slice_attr-item4"}, map[string]any{"key3": "map_attr-val3", "key4": "map_attr-val4"})
+				mb.RecordDefaultMetricDataPoint(ts, 3, "string_attr-val-2", 20, []any{"slice_attr-item3", "slice_attr-item4"}, map[string]any{"key3": "map_attr-val3", "key4": "map_attr-val4"}, WithEnumAttrMetricAttribute(AttributeEnumAttrRed))
 			}
 
 			defaultMetricsCount++
@@ -127,9 +127,9 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordMetricInputTypeDataPoint(ts, "1", "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"})
+			mb.RecordMetricInputTypeDataPoint(ts, "1", "string_attr-val", 19, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"}, WithEnumAttrMetricAttribute(AttributeEnumAttrRed))
 			if tt.name == "reaggregate_set" {
-				mb.RecordMetricInputTypeDataPoint(ts, "3", "string_attr-val-2", 20, AttributeEnumAttrGreen, []any{"slice_attr-item3", "slice_attr-item4"}, map[string]any{"key3": "map_attr-val3", "key4": "map_attr-val4"})
+				mb.RecordMetricInputTypeDataPoint(ts, "3", "string_attr-val-2", 20, []any{"slice_attr-item3", "slice_attr-item4"}, map[string]any{"key3": "map_attr-val3", "key4": "map_attr-val4"}, WithEnumAttrMetricAttribute(AttributeEnumAttrRed))
 			}
 
 			allMetricsCount++
@@ -239,8 +239,6 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.False(t, ok)
 						_, ok = dp.Attributes().Get("state")
 						assert.False(t, ok)
-						_, ok = dp.Attributes().Get("enum_attr")
-						assert.False(t, ok)
 						_, ok = dp.Attributes().Get("slice_attr")
 						assert.False(t, ok)
 						_, ok = dp.Attributes().Get("map_attr")
@@ -341,8 +339,6 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("string_attr")
 						assert.False(t, ok)
 						_, ok = dp.Attributes().Get("state")
-						assert.False(t, ok)
-						_, ok = dp.Attributes().Get("enum_attr")
 						assert.False(t, ok)
 						_, ok = dp.Attributes().Get("slice_attr")
 						assert.False(t, ok)

--- a/cmd/mdatagen/internal/sampleconnector/metadata.yaml
+++ b/cmd/mdatagen/internal/sampleconnector/metadata.yaml
@@ -92,6 +92,7 @@ attributes:
     description: Attribute with a known set of string values.
     type: string
     enum: [red, green, blue]
+    requirement_level: conditionally_required
 
   map_attr:
     description: Attribute with a map value.

--- a/cmd/mdatagen/internal/templates/helper.tmpl
+++ b/cmd/mdatagen/internal/templates/helper.tmpl
@@ -24,6 +24,10 @@
   }
 {{- end -}}
 
+{{- define "putAttributeEnum" -}}
+	dp.Attributes().PutStr("{{ (attributeInfo .).Name }}", {{ .RenderUnexported }}AttributeValue.String())
+{{- end -}}
+
 {{- define "getAttributeValue" -}}
 {{ if (attributeInfo .).Enum }}Attribute{{ .Render }}{{ (index (attributeInfo .).Enum 0) | publicVar }}{{ else }}{{ (attributeInfo .).TestValue }}{{ end }}
 {{- end -}}

--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -100,11 +100,19 @@ func (maof metricAttributeOptionFunc) apply(dp pmetric.NumberDataPoint) {
 }
 
 {{ range getMetricConditionalAttributes .Attributes }}
+{{- if (attributeInfo .).Enum }}
+func With{{ .Render }}MetricAttribute({{ .RenderUnexported }}AttributeValue Attribute{{ .Render }}) MetricAttributeOption {
+	return metricAttributeOptionFunc(func(dp pmetric.NumberDataPoint) {
+		{{- template "putAttributeEnum" . }}
+	})
+}
+{{- else }}
 func With{{ .Render }}MetricAttribute({{ .RenderUnexported }}AttributeValue {{ (attributeInfo .).Type.Primitive }}) MetricAttributeOption {
 	return metricAttributeOptionFunc(func(dp pmetric.NumberDataPoint) {
 		{{- template "putAttribute" . }}
 	})
 }
+{{- end }}
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In order to fix invalid generated tests signature of `With<attribute-name>MetricAttribute` was changed to receive corresponding enum type in case of enum attribute.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #14196

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tested locally using `make mdatagen-test`

