### PR TITLE
[fips140][`configtls.TestTPM_tpmCertificate_errors`] Skip test if `GODEBUG=fips140=only` is set

### DIFF
--- a/config/configtls/tpm_test.go
+++ b/config/configtls/tpm_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestTPM_loadCertificate(t *testing.T) {
+	testutil.SkipIfFIPSOnly(t, "use of CFB is not allowed in FIPS 140-only mode")
 	tpm, err := simulator.OpenSimulator()
 	require.NoError(t, err)
 	defer tpm.Close()
@@ -100,6 +101,7 @@ func TestTPM_loadCertificate_error(t *testing.T) {
 }
 
 func TestTPM_tpmCertificate_errors(t *testing.T) {
+	testutil.SkipIfFIPSOnly(t, "use of CFB is not allowed in FIPS 140-only mode")
 	tpm, err := simulator.OpenSimulator()
 	require.NoError(t, err)
 	defer tpm.Close()
@@ -190,7 +192,6 @@ func TestTPM_open(t *testing.T) {
 }
 
 func createTPMKeyCert(t *testing.T, tpm transport.TPMCloser) ([]byte, []byte) {
-	testutil.SkipIfFIPSOnly(t, "use of CFB is not allowed in FIPS 140-only mode")
 	tpmKey, err := keyfile.NewLoadableKey(tpm, tpm2.TPMAlgECC, 256, []byte(""))
 	require.NoError(t, err)
 	tpmKeySigner, err := tpmKey.Signer(tpm, []byte(""), []byte(""))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In #14225, we skipped the `configtls.TestTPM_loadCertificate` unit test if the tests were run with `GODEBUG=fips140=only`.  Otherwise, the unit test failed with a `panic: crypto/cipher: use of CFB is not allowed in FIPS 140-only mode` error.  

Turns out there was a second unit test in the same package that needed skipping for the same reason: `configtls.TestTPM_tpmCertificate_errors`.  This PR skips it too.

<!-- Issue number if applicable -->
#### Link to tracking issue
Follow up to #14225
