### PR TITLE
[chore] Skip or bump some benchmarks to reduce noise

### DIFF
--- a/config/confighttp/compressor_test.go
+++ b/config/confighttp/compressor_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/config/configcompression"
+	"go.opentelemetry.io/collector/internal/testutil"
 )
 
 func BenchmarkCompression(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	benchmarks := []struct {
 		codec    configcompression.Type
 		name     string

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -23,6 +23,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.141.0
 	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.141.0
 	go.opentelemetry.io/collector/featuregate v1.47.0
+	go.opentelemetry.io/collector/internal/testutil v0.141.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
 	go.uber.org/goleak v1.3.0

--- a/exporter/exporterhelper/go.mod
+++ b/exporter/exporterhelper/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensiontest v0.141.0
 	go.opentelemetry.io/collector/extension/xextension v0.141.0
 	go.opentelemetry.io/collector/featuregate v1.47.0
+	go.opentelemetry.io/collector/internal/testutil v0.141.0
 	go.opentelemetry.io/collector/pdata v1.47.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.141.0
 	go.opentelemetry.io/collector/pdata/testdata v0.141.0

--- a/exporter/exporterhelper/internal/queuebatch/logs_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_batch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
+	"go.opentelemetry.io/collector/internal/testutil"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/testdata"
 )
@@ -325,6 +326,7 @@ func TestLogsMergeSplitUnknownSizerType(t *testing.T) {
 }
 
 func BenchmarkSplittingBasedOnItemCountManySmallLogs(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// All requests merge into a single batch.
 	b.ReportAllocs()
 	for b.Loop() {
@@ -339,6 +341,7 @@ func BenchmarkSplittingBasedOnItemCountManySmallLogs(b *testing.B) {
 }
 
 func BenchmarkSplittingBasedOnByteSizeManySmallLogs(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// All requests merge into a single batch.
 	b.ReportAllocs()
 	for b.Loop() {
@@ -353,6 +356,7 @@ func BenchmarkSplittingBasedOnByteSizeManySmallLogs(b *testing.B) {
 }
 
 func BenchmarkSplittingBasedOnItemCountManyLogsSlightlyAboveLimit(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// Every incoming request results in a split.
 	b.ReportAllocs()
 	for b.Loop() {
@@ -367,6 +371,7 @@ func BenchmarkSplittingBasedOnItemCountManyLogsSlightlyAboveLimit(b *testing.B) 
 }
 
 func BenchmarkSplittingBasedOnByteSizeManyLogsSlightlyAboveLimit(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// Every incoming request results in a split.
 	b.ReportAllocs()
 	for b.Loop() {
@@ -382,6 +387,7 @@ func BenchmarkSplittingBasedOnByteSizeManyLogsSlightlyAboveLimit(b *testing.B) {
 }
 
 func BenchmarkSplittingBasedOnItemCountHugeLogs(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// One request splits into many batches.
 	b.ReportAllocs()
 	for b.Loop() {
@@ -394,6 +400,7 @@ func BenchmarkSplittingBasedOnItemCountHugeLogs(b *testing.B) {
 }
 
 func BenchmarkSplittingBasedOnByteSizeHugeLogs(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// One request splits into many batches.
 	b.ReportAllocs()
 	for b.Loop() {

--- a/exporter/exporterhelper/internal/queuebatch/metrics_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_batch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
+	"go.opentelemetry.io/collector/internal/testutil"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/testdata"
 )
@@ -264,6 +265,7 @@ func TestMergeSplitManySmallMetrics(t *testing.T) {
 }
 
 func BenchmarkSplittingBasedOnItemCountManySmallMetrics(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// All requests merge into a single batch.
 	b.ReportAllocs()
 	for b.Loop() {
@@ -278,6 +280,7 @@ func BenchmarkSplittingBasedOnItemCountManySmallMetrics(b *testing.B) {
 }
 
 func BenchmarkSplittingBasedOnItemCountManyMetricsSlightlyAboveLimit(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// Every incoming request results in a split.
 	b.ReportAllocs()
 	for b.Loop() {
@@ -292,6 +295,7 @@ func BenchmarkSplittingBasedOnItemCountManyMetricsSlightlyAboveLimit(b *testing.
 }
 
 func BenchmarkSplittingBasedOnItemCountHugeMetrics(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// One request splits into many batches.
 	b.ReportAllocs()
 	for b.Loop() {

--- a/exporter/exporterhelper/internal/queuebatch/traces_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_batch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
+	"go.opentelemetry.io/collector/internal/testutil"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/testdata"
 )
@@ -338,6 +339,7 @@ func TestTracesMergeSplitUnknownSizerType(t *testing.T) {
 }
 
 func BenchmarkSplittingBasedOnItemCountManySmallTraces(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// All requests merge into a single batch.
 	b.ReportAllocs()
 	for b.Loop() {
@@ -352,6 +354,7 @@ func BenchmarkSplittingBasedOnItemCountManySmallTraces(b *testing.B) {
 }
 
 func BenchmarkSplittingBasedOnItemCountManyTracesSlightlyAboveLimit(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// Every incoming request results in a split.
 	b.ReportAllocs()
 	for b.Loop() {
@@ -366,6 +369,7 @@ func BenchmarkSplittingBasedOnItemCountManyTracesSlightlyAboveLimit(b *testing.B
 }
 
 func BenchmarkSplittingBasedOnItemCountHugeTraces(b *testing.B) {
+	testutil.SkipGCHeavyBench(b)
 	// One request splits into many batches.
 	b.ReportAllocs()
 	for b.Loop() {

--- a/internal/testutil/benchmarks.go
+++ b/internal/testutil/benchmarks.go
@@ -15,3 +15,12 @@ func SkipMemoryBench(b *testing.B) {
 		b.Skip("Skipping since the 'MEMBENCH' environment variable was not set")
 	}
 }
+
+// SkipGCHeavyBench will skip GC-heavy benchmarks on CI.
+// These benchmarks tend to be flaky with the current settings since garbage
+// collection pauses can take ~50ms which is significant with the current benchmark times.
+func SkipGCHeavyBench(b *testing.B) {
+	if os.Getenv("GCHEAVYBENCH") == "" {
+		b.Skip("Skipping since the 'GCHEAVYBENCH' environment variable was not set. See https://github.com/open-telemetry/opentelemetry-collector/issues/14257.")
+	}
+}

--- a/pdata/plog/pb_test.go
+++ b/pdata/plog/pb_test.go
@@ -73,9 +73,9 @@ func TestProtoSizerEmptyLogs(t *testing.T) {
 	assert.Equal(t, 0, sizer.LogsSize(NewLogs()))
 }
 
-func BenchmarkLogsToProto(b *testing.B) {
+func BenchmarkLogsToProto2k(b *testing.B) {
 	marshaler := &ProtoMarshaler{}
-	logs := generateBenchmarkLogs(128)
+	logs := generateBenchmarkLogs(2_000)
 
 	for b.Loop() {
 		buf, err := marshaler.MarshalLogs(logs)
@@ -84,10 +84,10 @@ func BenchmarkLogsToProto(b *testing.B) {
 	}
 }
 
-func BenchmarkLogsFromProto(b *testing.B) {
+func BenchmarkLogsFromProto2k(b *testing.B) {
 	marshaler := &ProtoMarshaler{}
 	unmarshaler := &ProtoUnmarshaler{}
-	baseLogs := generateBenchmarkLogs(128)
+	baseLogs := generateBenchmarkLogs(2_000)
 	buf, err := marshaler.MarshalLogs(baseLogs)
 	require.NoError(b, err)
 	assert.NotEmpty(b, buf)

--- a/pdata/pmetric/pb_test.go
+++ b/pdata/pmetric/pb_test.go
@@ -73,9 +73,9 @@ func TestProtoSizerEmptyMetrics(t *testing.T) {
 	assert.Equal(t, 0, sizer.MetricsSize(NewMetrics()))
 }
 
-func BenchmarkMetricsToProto(b *testing.B) {
+func BenchmarkMetricsToProto2k(b *testing.B) {
 	marshaler := &ProtoMarshaler{}
-	metrics := generateBenchmarkMetrics(128)
+	metrics := generateBenchmarkMetrics(2_000)
 
 	for b.Loop() {
 		buf, err := marshaler.MarshalMetrics(metrics)
@@ -84,10 +84,10 @@ func BenchmarkMetricsToProto(b *testing.B) {
 	}
 }
 
-func BenchmarkMetricsFromProto(b *testing.B) {
+func BenchmarkMetricsFromProto10k(b *testing.B) {
 	marshaler := &ProtoMarshaler{}
 	unmarshaler := &ProtoUnmarshaler{}
-	baseMetrics := generateBenchmarkMetrics(128)
+	baseMetrics := generateBenchmarkMetrics(2_000)
 	buf, err := marshaler.MarshalMetrics(baseMetrics)
 	require.NoError(b, err)
 	assert.NotEmpty(b, buf)

--- a/pdata/ptrace/pb_test.go
+++ b/pdata/ptrace/pb_test.go
@@ -74,9 +74,9 @@ func TestProtoSizerEmptyTraces(t *testing.T) {
 	assert.Equal(t, 0, sizer.TracesSize(NewTraces()))
 }
 
-func BenchmarkTracesToProto(b *testing.B) {
+func BenchmarkTracesToProto2k(b *testing.B) {
 	marshaler := &ProtoMarshaler{}
-	traces := generateBenchmarkTraces(128)
+	traces := generateBenchmarkTraces(2_000)
 
 	for b.Loop() {
 		buf, err := marshaler.MarshalTraces(traces)
@@ -85,10 +85,10 @@ func BenchmarkTracesToProto(b *testing.B) {
 	}
 }
 
-func BenchmarkTracesFromProto(b *testing.B) {
+func BenchmarkTracesFromProto2k(b *testing.B) {
 	marshaler := &ProtoMarshaler{}
 	unmarshaler := &ProtoUnmarshaler{}
-	baseTraces := generateBenchmarkTraces(128)
+	baseTraces := generateBenchmarkTraces(2_000)
 	buf, err := marshaler.MarshalTraces(baseTraces)
 	require.NoError(b, err)
 	assert.NotEmpty(b, buf)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Bumps size to 2k on some benchmarks to hopefully make those benchmarks more reliable.

Skips a bunch of other benchmarks that are allocation-heavy and currently are more noise than signal.

#### Link to tracking issue
Relates to #14257
