### PR TITLE
[exporter/otlphttp] Add retryable_statuses to control which HTTP codes trigger retries

### DIFF
--- a/.chloggen/otlphttp-non-retryable-status.yaml
+++ b/.chloggen/otlphttp-non-retryable-status.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporter/otlp_http
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `retryable_statuses` configuration option to control which HTTP status codes trigger retries.
+
+# One or more tracking issues or pull requests related to the change
+issues: [14228]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The new `retry_on_failure.retryable_statuses` field (default: [429, 502, 503, 504]) allows
+  configuring which HTTP status codes should trigger retries. Codes not in this list are treated
+  as permanent errors. This is useful in gateway mode to prevent retrying rate limit errors (429)
+  while still retrying server errors.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/otlphttpexporter/README.md
+++ b/exporter/otlphttpexporter/README.md
@@ -44,6 +44,7 @@ The following settings can be optionally configured:
 - `write_buffer_size` (default = 512 * 1024): WriteBufferSize for HTTP client.
 - `encoding` (default = proto): The encoding to use for the messages (valid options: `proto`, `json`)
 - `retry_on_failure`:  see [Retry on Failure](../exporterhelper/README.md#retry-on-failure) for the full set of available options.
+  - `retryable_statuses` (default = [429, 502, 503, 504]): List of HTTP status codes that should trigger retries. This option allows limiting which codes will be retried in case a backend is known to return codes that are not actually retryable.
 - `sending_queue`: see [Sending Queue](../exporterhelper/README.md#sending-queue) for the full set of available options.
 
 Example:
@@ -70,6 +71,17 @@ exporters:
   otlp_http:
     ...
     encoding: json
+```
+
+To customize which HTTP status codes should trigger retries (should only be done for certain backends):
+
+```yaml
+exporters:
+  otlp_http:
+    endpoint: https://backend:4318
+    retry_on_failure:
+      enabled: true
+      retryable_statuses: [502, 503, 504]  # Don't retry 429 rate limits
 ```
 
 The full list of settings exposed for this exporter are documented [here](./config.go)

--- a/exporter/otlphttpexporter/testdata/config.yaml
+++ b/exporter/otlphttpexporter/testdata/config.yaml
@@ -18,6 +18,7 @@ retry_on_failure:
   multiplier: 1.3
   max_interval: 60s
   max_elapsed_time: 10m
+  # retryable_statuses: [429, 502, 503, 504]  # Optional: list of HTTP codes that should trigger retries
 headers:
   "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
   header1: "234"


### PR DESCRIPTION
#### Description

Adds a new `non_retryable_status` configuration field to the OTLP HTTP exporter's `retry_on_failure` section, allowing users to specify HTTP status codes that should NOT trigger internal retries.

- **Problem:** By default, the OTLP HTTP exporter retries on 429, 502, 503, and 504 per the OTLP specification. In gateway deployments, continuing to retry when backends return rate limits or temporary failures causes queue buildup and potential data loss.

- **Solution:** This change allows treating normally-retryable codes as permanent errors, preventing internal retry loops.

Fixes #14228

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Unit tests: Added test cases covering default behavior and custom non-retryable codes.
- Config validation: Added TestConfigValidate with test cases for valid codes, empty list, and invalid codes (too low/high)
- All existing tests passes

#### Documentation

- README.md: Added configuration option description and example usage in gateway mode
- testdata/config.yaml: Updated sample configuration with commented example