### PR TITLE
[xpdata/entity] Rename methods to use updated entity terminology

### DIFF
--- a/.chloggen/entity-identifying-descriptive-attributes.yaml
+++ b/.chloggen/entity-identifying-descriptive-attributes.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pdata/xpdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Rename `Entity.IDAttributes()` to `Entity.IdentifyingAttributes()` and `Entity.DescriptionAttributes()` to `Entity.DescriptiveAttributes()` to align with OpenTelemetry specification terminology for attributes."
+
+# One or more tracking issues or pull requests related to the change
+issues: [14275]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pdata/xpdata/entity/entity.go
+++ b/pdata/xpdata/entity/entity.go
@@ -28,16 +28,16 @@ func (e Entity) SetSchemaURL(schemaURL string) {
 	e.ref.SetSchemaUrl(schemaURL)
 }
 
-// IDAttributes returns an EntityAttributeMap for managing the entity's id attributes.
-func (e Entity) IDAttributes() EntityAttributeMap {
+// IdentifyingAttributes returns an EntityAttributeMap for managing the entity's identifying attributes.
+func (e Entity) IdentifyingAttributes() EntityAttributeMap {
 	return EntityAttributeMap{
 		keys:       e.ref.IdKeys(),
 		attributes: e.attributes,
 	}
 }
 
-// DescriptionAttributes returns an EntityAttributeMap for managing the entity's description attributes.
-func (e Entity) DescriptionAttributes() EntityAttributeMap {
+// DescriptiveAttributes returns an EntityAttributeMap for managing the entity's descriptive attributes.
+func (e Entity) DescriptiveAttributes() EntityAttributeMap {
 	return EntityAttributeMap{
 		keys:       e.ref.DescriptionKeys(),
 		attributes: e.attributes,

--- a/pdata/xpdata/entity/entity_attribute_map.go
+++ b/pdata/xpdata/entity/entity_attribute_map.go
@@ -35,8 +35,8 @@ func (m EntityAttributeMap) Get(key string) (pcommon.Value, bool) {
 //
 // Use this method before calling Put* methods to avoid conflicts:
 //
-//	if entity.IDAttributes().CanPut("service.name") {
-//	    entity.IDAttributes().PutStr("service.name", "my-service")
+//	if entity.IdentifyingAttributes().CanPut("service.name") {
+//	    entity.IdentifyingAttributes().PutStr("service.name", "my-service")
 //	}
 func (m EntityAttributeMap) CanPut(key string) bool {
 	if m.containsKey(key) {

--- a/pdata/xpdata/entity/entity_map_test.go
+++ b/pdata/xpdata/entity/entity_map_test.go
@@ -35,13 +35,13 @@ func TestEntityMap_PutEmpty(t *testing.T) {
 func TestEntityMap_PutEmpty_Override(t *testing.T) {
 	em := NewEntityMap()
 	e1 := em.PutEmpty("service")
-	e1.IDAttributes().PutStr("service.name", "my-service")
+	e1.IdentifyingAttributes().PutStr("service.name", "my-service")
 	assert.Equal(t, 1, em.Len())
 
 	e2 := em.PutEmpty("service")
 	assert.Equal(t, 1, em.Len())
 
-	_, ok := e2.IDAttributes().Get("service.name")
+	_, ok := e2.IdentifyingAttributes().Get("service.name")
 	assert.False(t, ok)
 }
 
@@ -61,39 +61,39 @@ func TestEntityMap_AttributesIsolation(t *testing.T) {
 	em := NewEntityMap()
 
 	e1 := em.PutEmpty("service")
-	e1.IDAttributes().PutStr("service.name", "my-service")
+	e1.IdentifyingAttributes().PutStr("service.name", "my-service")
 
 	e2 := em.PutEmpty("host")
-	e2.IDAttributes().PutStr("host.name", "my-host")
+	e2.IdentifyingAttributes().PutStr("host.name", "my-host")
 
 	service, ok := em.Get("service")
 	assert.True(t, ok)
-	val, ok := service.IDAttributes().Get("service.name")
+	val, ok := service.IdentifyingAttributes().Get("service.name")
 	assert.True(t, ok)
 	assert.Equal(t, "my-service", val.Str())
 
 	host, ok := em.Get("host")
 	assert.True(t, ok)
-	val, ok = host.IDAttributes().Get("host.name")
+	val, ok = host.IdentifyingAttributes().Get("host.name")
 	assert.True(t, ok)
 	assert.Equal(t, "my-host", val.Str())
 
-	_, ok = service.IDAttributes().Get("host.name")
+	_, ok = service.IdentifyingAttributes().Get("host.name")
 	assert.False(t, ok)
 
-	_, ok = host.IDAttributes().Get("service.name")
+	_, ok = host.IdentifyingAttributes().Get("service.name")
 	assert.False(t, ok)
 }
 
 func TestEntityMap_Get(t *testing.T) {
 	em := NewEntityMap()
 	e1 := em.PutEmpty("service")
-	e1.IDAttributes().PutStr("service.name", "my-service")
+	e1.IdentifyingAttributes().PutStr("service.name", "my-service")
 
 	e2, ok := em.Get("service")
 	assert.True(t, ok)
 	assert.Equal(t, "service", e2.Type())
-	val, ok := e2.IDAttributes().Get("service.name")
+	val, ok := e2.IdentifyingAttributes().Get("service.name")
 	assert.True(t, ok)
 	assert.Equal(t, "my-service", val.Str())
 
@@ -104,8 +104,8 @@ func TestEntityMap_Get(t *testing.T) {
 func TestEntityMap_Remove(t *testing.T) {
 	em := NewEntityMap()
 	e1 := em.PutEmpty("service")
-	e1.IDAttributes().PutStr("service.name", "my-service")
-	e1.DescriptionAttributes().PutStr("service.version", "1.0.0")
+	e1.IdentifyingAttributes().PutStr("service.name", "my-service")
+	e1.DescriptiveAttributes().PutStr("service.version", "1.0.0")
 
 	assert.Equal(t, 1, em.Len())
 	assert.Equal(t, 2, em.attributes.Len())
@@ -121,13 +121,13 @@ func TestEntityMap_Remove(t *testing.T) {
 func TestEntityMap_All(t *testing.T) {
 	em := NewEntityMap()
 	e1 := em.PutEmpty("service")
-	e1.IDAttributes().PutStr("service.name", "my-service")
+	e1.IdentifyingAttributes().PutStr("service.name", "my-service")
 
 	e2 := em.PutEmpty("host")
-	e2.IDAttributes().PutStr("host.name", "my-host")
+	e2.IdentifyingAttributes().PutStr("host.name", "my-host")
 
 	e3 := em.PutEmpty("process")
-	e3.IDAttributes().PutStr("process.pid", "1234")
+	e3.IdentifyingAttributes().PutStr("process.pid", "1234")
 
 	types := make(map[string]bool)
 	attributes := make(map[string]string)
@@ -136,15 +136,15 @@ func TestEntityMap_All(t *testing.T) {
 		types[entityType] = true
 		switch entityType {
 		case "service":
-			val, ok := entity.IDAttributes().Get("service.name")
+			val, ok := entity.IdentifyingAttributes().Get("service.name")
 			assert.True(t, ok)
 			attributes[entityType] = val.Str()
 		case "host":
-			val, ok := entity.IDAttributes().Get("host.name")
+			val, ok := entity.IdentifyingAttributes().Get("host.name")
 			assert.True(t, ok)
 			attributes[entityType] = val.Str()
 		case "process":
-			val, ok := entity.IDAttributes().Get("process.pid")
+			val, ok := entity.IdentifyingAttributes().Get("process.pid")
 			assert.True(t, ok)
 			attributes[entityType] = val.Str()
 		}

--- a/pdata/xpdata/entity/entity_test.go
+++ b/pdata/xpdata/entity/entity_test.go
@@ -29,26 +29,26 @@ func TestEntity_SchemaURL(t *testing.T) {
 	assert.Equal(t, "https://opentelemetry.io/schemas/1.1.0", e.SchemaURL())
 }
 
-func TestEntity_IDAttributes(t *testing.T) {
+func TestEntity_IdentifyingAttributes(t *testing.T) {
 	em := NewEntityMap()
 	e := em.PutEmpty("service")
 
-	idAttrs := e.IDAttributes()
+	idAttrs := e.IdentifyingAttributes()
 	idAttrs.PutStr("key1", "value1")
 
-	val, ok := e.IDAttributes().Get("key1")
+	val, ok := e.IdentifyingAttributes().Get("key1")
 	assert.True(t, ok)
 	assert.Equal(t, "value1", val.Str())
 }
 
-func TestEntity_DescriptionAttributes(t *testing.T) {
+func TestEntity_DescriptiveAttributes(t *testing.T) {
 	em := NewEntityMap()
 	e := em.PutEmpty("service")
 
-	descAttrs := e.DescriptionAttributes()
+	descAttrs := e.DescriptiveAttributes()
 	descAttrs.PutStr("key1", "value1")
 
-	val, ok := e.DescriptionAttributes().Get("key1")
+	val, ok := e.DescriptiveAttributes().Get("key1")
 	assert.True(t, ok)
 	assert.Equal(t, "value1", val.Str())
 }
@@ -57,21 +57,21 @@ func TestEntity_IdAndDescriptionAttributes_Isolated(t *testing.T) {
 	em := NewEntityMap()
 	e := em.PutEmpty("service")
 
-	e.IDAttributes().PutStr("id.key", "id-value")
-	e.DescriptionAttributes().PutStr("desc.key", "desc-value")
+	e.IdentifyingAttributes().PutStr("id.key", "id-value")
+	e.DescriptiveAttributes().PutStr("desc.key", "desc-value")
 
-	val, ok := e.IDAttributes().Get("id.key")
+	val, ok := e.IdentifyingAttributes().Get("id.key")
 	assert.True(t, ok)
 	assert.Equal(t, "id-value", val.Str())
 
-	_, ok = e.IDAttributes().Get("desc.key")
+	_, ok = e.IdentifyingAttributes().Get("desc.key")
 	assert.False(t, ok)
 
-	val, ok = e.DescriptionAttributes().Get("desc.key")
+	val, ok = e.DescriptiveAttributes().Get("desc.key")
 	assert.True(t, ok)
 	assert.Equal(t, "desc-value", val.Str())
 
-	_, ok = e.DescriptionAttributes().Get("id.key")
+	_, ok = e.DescriptiveAttributes().Get("id.key")
 	assert.False(t, ok)
 }
 
@@ -79,18 +79,18 @@ func TestEntity_IdAndDescriptionAttributes_CanPut(t *testing.T) {
 	em := NewEntityMap()
 	e := em.PutEmpty("service")
 
-	e.IDAttributes().PutStr("shared.key", "id-value")
+	e.IdentifyingAttributes().PutStr("shared.key", "id-value")
 
-	assert.True(t, e.IDAttributes().CanPut("shared.key"))
-	assert.False(t, e.DescriptionAttributes().CanPut("shared.key"))
+	assert.True(t, e.IdentifyingAttributes().CanPut("shared.key"))
+	assert.False(t, e.DescriptiveAttributes().CanPut("shared.key"))
 
-	e.DescriptionAttributes().PutStr("shared.key", "desc-value")
+	e.DescriptiveAttributes().PutStr("shared.key", "desc-value")
 
-	val, ok := e.IDAttributes().Get("shared.key")
+	val, ok := e.IdentifyingAttributes().Get("shared.key")
 	assert.True(t, ok)
 	assert.Equal(t, "desc-value", val.Str())
 
-	val, ok = e.DescriptionAttributes().Get("shared.key")
+	val, ok = e.DescriptiveAttributes().Get("shared.key")
 	assert.True(t, ok)
 	assert.Equal(t, "desc-value", val.Str())
 }


### PR DESCRIPTION
Rename Entity API methods to align with OpenTelemetry specification terminology for attributes in entity context:
  - IDAttributes() → IdentifyingAttributes()
  - DescriptionAttributes() → DescriptiveAttributes()

This change applies the "Identifying" and "Descriptive" terms specifically to Attributes (not Entity or Entity Keys), as clarified in https://github.com/open-telemetry/opentelemetry-specification/issues/4700
