### PR TITLE
[chore] [mdatagen] Update entities terminology in generated docs

### DIFF
--- a/cmd/mdatagen/internal/sampleconnector/documentation.md
+++ b/cmd/mdatagen/internal/sampleconnector/documentation.md
@@ -124,8 +124,8 @@ A test entity.
 
 **Stability:** stable
 
-**Identity Attributes:**
+**Identifying Attributes:**
 - `string.resource.attr`
 
-**Description Attributes:**
+**Descriptive Attributes:**
 - `map.resource.attr`

--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -233,7 +233,7 @@ The following entities are defined for this component:
 
 {{- if $entity.Identity }}
 
-**Identity Attributes:**
+**Identifying Attributes:**
 {{- range $entity.Identity }}
 - `{{ .Ref }}`
 {{- end }}
@@ -241,7 +241,7 @@ The following entities are defined for this component:
 
 {{- if $entity.Description }}
 
-**Description Attributes:**
+**Descriptive Attributes:**
 {{- range $entity.Description }}
 - `{{ .Ref }}`
 {{- end }}


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-collector/pull/14275. Updates mdatagen documentation template to use "Identifying Attributes" and "Descriptive Attributes" terminology (instead of "Identity Attributes" and "Description Attributes") when documenting entities.

This aligns the generated documentation with OpenTelemetry specification terminology for attributes in entity context, as clarified in open-telemetry/opentelemetry-specification#4700
