### PR TITLE
Don't duplicate stack in profiles testdata

### DIFF
--- a/pdata/testdata/profile.go
+++ b/pdata/testdata/profile.go
@@ -50,12 +50,13 @@ func fillProfileOne(dic pprofile.ProfilesDictionary, profile pprofile.Profile) {
 
 	loc := pprofile.NewLocation()
 	loc.SetAddress(1)
-	id, _ := pprofile.SetLocation(dic.LocationTable(), loc)
-	stack := dic.StackTable().AppendEmpty()
-	stack.LocationIndices().Append(id)
+	locID, _ := pprofile.SetLocation(dic.LocationTable(), loc)
+	stack := pprofile.NewStack()
+	stack.LocationIndices().Append(locID)
+	stackID, _ := pprofile.SetStack(dic.StackTable(), stack)
 
 	sample := profile.Samples().AppendEmpty()
-	sample.SetStackIndex(1)
+	sample.SetStackIndex(stackID)
 	sample.Values().Append(4)
 	sample.AttributeIndices().Append(0)
 }
@@ -67,12 +68,13 @@ func fillProfileTwo(dic pprofile.ProfilesDictionary, profile pprofile.Profile) {
 
 	loc := pprofile.NewLocation()
 	loc.SetAddress(2)
-	id, _ := pprofile.SetLocation(dic.LocationTable(), loc)
-	stack := dic.StackTable().AppendEmpty()
-	stack.LocationIndices().Append(id)
+	locID, _ := pprofile.SetLocation(dic.LocationTable(), loc)
+	stack := pprofile.NewStack()
+	stack.LocationIndices().Append(locID)
+	stackID, _ := pprofile.SetStack(dic.StackTable(), stack)
 
 	sample := profile.Samples().AppendEmpty()
-	sample.SetStackIndex(1)
+	sample.SetStackIndex(stackID)
 	sample.Values().Append(9)
 	sample.AttributeIndices().Append(0)
 }

--- a/service/internal/graph/obs_test.go
+++ b/service/internal/graph/obs_test.go
@@ -548,7 +548,7 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.receiver.produced.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 1118,
+				): 1035,
 			},
 		},
 		attribute.NewSet(
@@ -570,12 +570,12 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.processor.consumed.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 1118,
+				): 1035,
 			},
 			"otelcol.processor.produced.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 1118,
+				): 1035,
 			},
 		},
 		attribute.NewSet(
@@ -602,17 +602,17 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.connector.consumed.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 1118,
+				): 1035,
 			},
 			"otelcol.connector.produced.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 					attribute.String("otelcol.pipeline.id", "profiles/right"),
-				): 587,
+				): 542,
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 					attribute.String("otelcol.pipeline.id", "profiles/left"),
-				): 531,
+				): 493,
 			},
 		},
 		attribute.NewSet(
@@ -628,7 +628,7 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.exporter.consumed.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 587,
+				): 542,
 			},
 		},
 		attribute.NewSet(
@@ -644,7 +644,7 @@ func TestComponentInstrumentation(t *testing.T) {
 			"otelcol.exporter.consumed.size": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
-				): 531,
+				): 493,
 			},
 		},
 	}


### PR DESCRIPTION
When generating profiles testdata, we currently create a new stack for each profile.
For each profile type, all stacks are the same though.

The dictionary expects unique entries though. And having duplicates causes issues when manipulating data (such as when we want to merge).