### PR TITLE
Pause the stale PR action for the holidays

### DIFF
--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -7,6 +7,7 @@ permissions: read-all
 
 jobs:
   stale:
+    if: ${{ false }} # Stale action paused for the holidays
     permissions:
       issues: write # for actions/stale to close stale issues
       pull-requests: write # for actions/stale to close stale PRs


### PR DESCRIPTION
As OpenTelemetry is globally going on a break over the holidays, this pauses the stale PR action, so we don't come back with lots of PRs to reopen.