### PR TITLE
Avoid using interfaces/oneof like style for optional fields

### DIFF
--- a/.chloggen/avoid-pointers-optional.yaml
+++ b/.chloggen/avoid-pointers-optional.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid using interfaces/oneof like style for optional fields
+
+# One or more tracking issues or pull requests related to the change
+issues: [14333]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/cmd/pdatagen/internal/pdata/one_of_field.go
+++ b/internal/cmd/pdatagen/internal/pdata/one_of_field.go
@@ -178,6 +178,10 @@ func (of *oneOfProtoField) DefaultValue() string {
 	panic("implement me")
 }
 
+func (of *oneOfProtoField) GenTest() string {
+	return "orig." + of.GetName() + " = " + of.TestValue()
+}
+
 func (of *oneOfProtoField) TestValue() string {
 	return "&" + of.protoName + "_" + of.fields[0].GetName() + "{" + of.fields[0].GetName() + ": " + of.fields[0].TestValue() + "}"
 }

--- a/internal/cmd/pdatagen/internal/pdata/optional_primitive_field.go
+++ b/internal/cmd/pdatagen/internal/pdata/optional_primitive_field.go
@@ -11,25 +11,25 @@ import (
 
 const optionalPrimitiveAccessorsTemplate = `// {{ .fieldName }} returns the {{ .lowerFieldName }} associated with this {{ .structName }}.
 func (ms {{ .structName }}) {{ .fieldName }}() {{ .returnType }} {
-	return ms.orig.Get{{ .fieldName }}()
+	return ms.orig.{{ .fieldName }}
 }
 
 // Has{{ .fieldName }} returns true if the {{ .structName }} contains a
 // {{ .fieldName }} value otherwise.
 func (ms {{ .structName }}) Has{{ .fieldName }}() bool {
-	return ms.orig.{{ .fieldName }}_ != nil
+	return ms.orig.Has{{ .fieldName }}()
 }
 
 // Set{{ .fieldName }} replaces the {{ .lowerFieldName }} associated with this {{ .structName }}.
 func (ms {{ .structName }}) Set{{ .fieldName }}(v {{ .returnType }}) {
 	ms.state.AssertMutable()
-	ms.orig.{{ .fieldName }}_ = &internal.{{ .originStructType }}{{ "{" }}{{ .fieldName }}: v}
+	ms.orig.Set{{ .fieldName }}(v)
 }
 
 // Remove{{ .fieldName }} removes the {{ .lowerFieldName }} associated with this {{ .structName }}.
 func (ms {{ .structName }}) Remove{{ .fieldName }}() {
 	ms.state.AssertMutable()
-	ms.orig.{{ .fieldName }}_ = nil
+	ms.orig.Remove{{ .fieldName }}()
 }`
 
 const optionalPrimitiveAccessorsTestTemplate = `func Test{{ .structName }}_{{ .fieldName }}(t *testing.T) {
@@ -57,16 +57,6 @@ const optionalPrimitiveAccessorsTestTemplate = `func Test{{ .structName }}_{{ .f
 const optionalPrimitiveSetTestTemplate = `orig.{{ .fieldName }}_ = &internal.{{ .originStructType }}{
 {{- .fieldName }}: {{ .testValue }}}`
 
-const optionalOneOfMessageOrigTemplate = `
-func (m *{{ .ParentMessageName }}) Get{{ .OneOfGroup }}() any {
-	if m != nil {
-		return m.{{ .Name }}_
-	}
-	return nil
-}
-
-`
-
 type OptionalPrimitiveField struct {
 	fieldName string
 	protoID   uint32
@@ -85,66 +75,24 @@ func (opv *OptionalPrimitiveField) GenerateTestValue(ms *messageStruct) string {
 	return template.Execute(template.Parse("optionalPrimitiveSetTestTemplate", []byte(optionalPrimitiveSetTestTemplate)), opv.templateFields(ms))
 }
 
-type optionalPrimitiveProtoField struct {
-	*proto.Field
-}
-
-func (opv optionalPrimitiveProtoField) GetName() string {
-	return opv.Name + "_"
-}
-
-func (opv optionalPrimitiveProtoField) TestValue() string {
-	return "&" + opv.OneOfMessageName + "{" + opv.Name + ": " + opv.Field.TestValue() + "}"
-}
-
-func (opv optionalPrimitiveProtoField) GenMessageField() string {
-	return opv.Name + "_ any"
-}
-
-func (opv optionalPrimitiveProtoField) GenOneOfMessages() string {
-	return template.Execute(template.Parse("optionalOneOfMessageOrigTemplate", []byte(optionalOneOfMessageOrigTemplate)), opv.Field) + opv.Field.GenOneOfMessages()
-}
-
-func (opv optionalPrimitiveProtoField) GenCopy() string {
-	return "switch t := src." + opv.Name + "_.(type) {\n\tcase *" + opv.OneOfMessageName + ":\n\t" + opv.Field.GenCopy() + "\ndefault: dest." + opv.Name + "_ = nil\n}\n"
-}
-
-func (opv optionalPrimitiveProtoField) GenDelete() string {
-	return "switch ov := orig." + opv.Name + "_.(type) {\n\tcase *" + opv.OneOfMessageName + ":\n\t" + opv.Field.GenDelete() + "\n}\n"
-}
-
-func (opv optionalPrimitiveProtoField) GenMarshalJSON() string {
-	return "if orig, ok := orig." + opv.Name + "_.(*" + opv.OneOfMessageName + "); ok {\n\t" + opv.Field.GenMarshalJSON() + "}"
-}
-
-func (opv optionalPrimitiveProtoField) GenSizeProto() string {
-	return "if orig, ok := orig." + opv.Name + "_.(*" + opv.OneOfMessageName + "); ok {\n\t_ = orig\n\t" + opv.Field.GenSizeProto() + "}"
-}
-
-func (opv optionalPrimitiveProtoField) GenMarshalProto() string {
-	return "if orig, ok := orig." + opv.Name + "_.(*" + opv.OneOfMessageName + "); ok {\n\t" + opv.Field.GenMarshalProto() + "}"
-}
-
 func (opv *OptionalPrimitiveField) toProtoField(ms *messageStruct) proto.FieldInterface {
-	return optionalPrimitiveProtoField{&proto.Field{
+	return &proto.Field{
 		Type:              opv.protoType,
 		ID:                opv.protoID,
-		OneOfGroup:        opv.fieldName + "_",
 		Name:              opv.fieldName,
-		OneOfMessageName:  ms.protoName + "_" + opv.fieldName,
 		ParentMessageName: ms.protoName,
 		Nullable:          true,
-	}}
+	}
 }
 
 func (opv *OptionalPrimitiveField) templateFields(ms *messageStruct) map[string]any {
-	pf := opv.toProtoField(ms).(optionalPrimitiveProtoField)
+	pf := opv.toProtoField(ms).(*proto.Field)
 	return map[string]any{
 		"structName":       ms.getName(),
 		"defaultVal":       pf.DefaultValue(),
 		"fieldName":        opv.fieldName,
 		"lowerFieldName":   strings.ToLower(opv.fieldName),
-		"testValue":        pf.Field.TestValue(),
+		"testValue":        pf.TestValue(),
 		"returnType":       pf.GoType(),
 		"originName":       ms.getOriginName(),
 		"originStructName": ms.getOriginFullName(),

--- a/internal/cmd/pdatagen/internal/proto/copy.go
+++ b/internal/cmd/pdatagen/internal/proto/copy.go
@@ -9,9 +9,7 @@ import (
 
 const copyOther = `{{ if .repeated -}}
 	dest.{{ .fieldName }} = append(dest.{{ .fieldName }}[:0], src.{{ .fieldName }}...)
-{{- else if not .nullable -}}
-	dest.{{ .fieldName }} = src.{{ .fieldName }}
-{{ else -}}
+{{ else if ne .oneOfGroup "" -}}
 	var ov *{{ .oneOfMessageName }}
 	if !UseProtoPooling.IsEnabled() {
 		ov = &{{ .oneOfMessageName }}{}
@@ -20,6 +18,14 @@ const copyOther = `{{ if .repeated -}}
 	}
 	ov.{{ .fieldName }} = t.{{ .fieldName }}
 	dest.{{ .oneOfGroup }} = ov
+{{ else if .nullable -}}
+	if src.Has{{ .fieldName }}() {
+		dest.Set{{ .fieldName }}(src.{{ .fieldName }})
+	} else {
+		dest.Remove{{ .fieldName }}()
+	}
+{{ else -}}
+	dest.{{ .fieldName }} = src.{{ .fieldName }}
 {{- end }}`
 
 const copyMessage = `{{ if .repeated -}}

--- a/internal/cmd/pdatagen/internal/proto/enum.go
+++ b/internal/cmd/pdatagen/internal/proto/enum.go
@@ -53,13 +53,3 @@ type EnumField struct {
 func (ms *Enum) GenerateEnum() []byte {
 	return []byte(template.Execute(template.Parse("enumMessageTemplate", []byte(enumMessageTemplate)), ms))
 }
-
-func (ms *Enum) templateFields(imports, testImports []string) map[string]any {
-	return map[string]any{
-		"fields":      ms.Fields,
-		"messageName": ms.Name,
-		"description": ms.Description,
-		"imports":     imports,
-		"testImports": testImports,
-	}
-}

--- a/internal/cmd/pdatagen/internal/proto/field.go
+++ b/internal/cmd/pdatagen/internal/proto/field.go
@@ -35,6 +35,8 @@ type FieldInterface interface {
 
 	GenOneOfMessages() string
 
+	GenTest() string
+
 	GoType() string
 
 	DefaultValue() string
@@ -105,6 +107,17 @@ func (pf *Field) DefaultValue() string {
 	}
 }
 
+func (pf *Field) GenTest() string {
+	if pf.Repeated {
+		return "orig." + pf.GetName() + " = " + pf.TestValue()
+	}
+
+	if pf.Type != TypeMessage && pf.Nullable {
+		return "orig.Set" + pf.GetName() + "(" + pf.TestValue() + ")"
+	}
+	return "orig." + pf.GetName() + " = " + pf.TestValue()
+}
+
 func (pf *Field) TestValue() string {
 	if pf.Repeated {
 		return pf.MemberGoType() + "{" + pf.DefaultValue() + ", " + pf.rawTestValue() + "}"
@@ -171,7 +184,10 @@ func (pf *Field) MemberGoType() string {
 	if pf.Repeated {
 		return "[]" + ptrGoType()
 	}
-	return ptrGoType()
+	if pf.Type == TypeMessage {
+		return ptrGoType()
+	}
+	return pf.GoType()
 }
 
 func (pf *Field) GenMessageField() string {

--- a/internal/cmd/pdatagen/internal/proto/json_marshal.go
+++ b/internal/cmd/pdatagen/internal/proto/json_marshal.go
@@ -20,15 +20,19 @@ const marshalJSONPrimitive = `{{ if .repeated -}}
 		}
 		dest.WriteArrayEnd()
 	}
+{{ else if ne .oneOfGroup "" -}}
+		dest.WriteObjectField("{{ .jsonTag }}")
+		dest.Write{{ upperFirst .goType }}(orig.{{ .fieldName }})
 {{- else }}
 {{- if not .nullable -}}
 	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+{{- else -}}
+	if orig.Has{{ .fieldName }} () {
 {{ end -}}
 		dest.WriteObjectField("{{ .jsonTag }}")
 		dest.Write{{ upperFirst .goType }}(orig.{{ .fieldName }})
-{{- if not .nullable -}}
 	}
-{{- end }}{{- end }}`
+{{- end }}`
 
 const marshalJSONEnum = `{{ if .repeated -}}
 	if len(orig.{{ .fieldName }}) > 0 {

--- a/internal/cmd/pdatagen/internal/proto/json_unmarshal.go
+++ b/internal/cmd/pdatagen/internal/proto/json_unmarshal.go
@@ -17,7 +17,7 @@ const unmarshalJSONPrimitive = `	case {{ .allJSONTags }}:
 	for iter.ReadArray() {
 		orig.{{ .fieldName }} = append(orig.{{ .fieldName }}, iter.Read{{ upperFirst .goType }}())
 	}
-{{ else if .nullable -}}
+{{ else if ne .oneOfGroup "" -}}
 	{
 		var ov *{{ .oneOfMessageName }}
 		if !UseProtoPooling.IsEnabled() {
@@ -28,6 +28,8 @@ const unmarshalJSONPrimitive = `	case {{ .allJSONTags }}:
 		ov.{{ .fieldName }} = iter.Read{{ upperFirst .goType }}()
 		orig.{{ .oneOfGroup }} = ov
 	}
+{{ else if .nullable -}}
+	orig.Set{{ .fieldName }}(iter.Read{{ upperFirst .goType }}())
 {{ else -}}
 	orig.{{ .fieldName }} = iter.Read{{ upperFirst .goType }}()
 {{- end }}`

--- a/internal/cmd/pdatagen/internal/proto/metadata.go
+++ b/internal/cmd/pdatagen/internal/proto/metadata.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package proto // import "go.opentelemetry.io/collector/internal/cmd/pdatagen/internal/proto"
+
+import (
+	"go.opentelemetry.io/collector/internal/cmd/pdatagen/internal/template"
+)
+
+const metadataMessageTemplate = `
+{{- range .OptionalFields }}
+const fieldBlock{{ $.Name }}{{ .Name }} = uint64({{ .Value }} >> 6)
+const fieldBit{{ $.Name }}{{ .Name }} = uint64(1 << {{ .Value }} & 0x3F)
+
+func (m *{{ $.Name }}) Set{{ .Name }}(value {{ .GoType }}) {
+	m.{{ .Name }} = value
+	m.metadata[fieldBlock{{ $.Name }}{{ .Name }}] |= fieldBit{{ $.Name }}{{ .Name }}
+}
+
+func (m *{{ $.Name }}) Remove{{ .Name }}() {
+	m.{{ .Name }} = {{ .DefaultValue }}
+	m.metadata[fieldBlock{{ $.Name }}{{ .Name }}] &^= fieldBit{{ $.Name }}{{ .Name }}
+}
+
+func (m *{{ $.Name }}) Has{{ .Name }}() bool {
+	return m.metadata[fieldBlock{{ $.Name }}{{ .Name }}] & fieldBit{{ $.Name }}{{ .Name }} != 0
+}
+{{- end }}
+
+`
+
+type Metadata struct {
+	Name           string
+	OptionalFields []*MetadataOptionalField
+}
+
+type MetadataOptionalField struct {
+	*Field
+	Value int
+}
+
+func newMetadata(ms *Message) *Metadata {
+	meta := &Metadata{
+		Name: ms.Name,
+	}
+	value := 0
+	for _, fieldI := range ms.Fields {
+		field, ok := fieldI.(*Field)
+		if !ok {
+			continue
+		}
+		if field.Repeated {
+			continue
+		}
+		switch field.Type {
+		case TypeDouble, TypeFloat, TypeInt32, TypeInt64, TypeUint32, TypeUint64, TypeSInt32, TypeSInt64, TypeFixed32, TypeFixed64, TypeSFixed32, TypeSFixed64, TypeBool:
+			if !field.Nullable {
+				continue
+			}
+		default:
+			continue
+		}
+		meta.OptionalFields = append(meta.OptionalFields, &MetadataOptionalField{
+			Field: field,
+			Value: value,
+		})
+		value++
+	}
+	if len(meta.OptionalFields) == 0 {
+		return nil
+	}
+	return meta
+}
+
+func (meta *Metadata) Generate() []byte {
+	return []byte(template.Execute(template.Parse("metadataMessageTemplate", []byte(metadataMessageTemplate)), meta))
+}

--- a/internal/cmd/pdatagen/internal/proto/proto_marshal.go
+++ b/internal/cmd/pdatagen/internal/proto/proto_marshal.go
@@ -22,19 +22,27 @@ const marshalProtoFloat = `{{ if .repeated -}}
 		buf[pos] = {{ . }}
 		{{ end -}}
 	}
-{{- else }}
-{{- if not .nullable -}}
-	if orig.{{ .fieldName }} != 0 {
-{{ end -}}
+{{- else if ne .oneOfGroup "" -}}
 		pos -= {{ div .bitSize 8 }}
 		binary.LittleEndian.PutUint{{ .bitSize }}(buf[pos:], math.Float{{ .bitSize }}bits(orig.{{ .fieldName }}))
 		{{ range .protoTag -}}
 		pos--
 		buf[pos] = {{ . }}
 		{{ end -}}
-{{- if not .nullable -}}
+{{- else }}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
+		pos -= {{ div .bitSize 8 }}
+		binary.LittleEndian.PutUint{{ .bitSize }}(buf[pos:], math.Float{{ .bitSize }}bits(orig.{{ .fieldName }}))
+		{{ range .protoTag -}}
+		pos--
+		buf[pos] = {{ . }}
+		{{ end -}}
 	}
-{{- end }}{{- end }}`
+{{- end }}`
 
 const marshalProtoFixed = `{{ if .repeated -}}
 	l = len(orig.{{ .fieldName }})
@@ -49,19 +57,27 @@ const marshalProtoFixed = `{{ if .repeated -}}
 		buf[pos] = {{ . }}
 		{{ end -}}
 	}
-{{- else }}
-{{- if not .nullable -}}
-	if orig.{{ .fieldName }} != 0 {
-{{ end -}}
+{{- else if ne .oneOfGroup "" -}}
 		pos -= {{ div .bitSize 8 }}
 		binary.LittleEndian.PutUint{{ .bitSize }}(buf[pos:], uint{{ .bitSize }}(orig.{{ .fieldName }}))
 		{{ range .protoTag -}}
 		pos--
 		buf[pos] = {{ . }}
 		{{ end -}}
-{{- if not .nullable -}}
+{{- else }}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
+		pos -= {{ div .bitSize 8 }}
+		binary.LittleEndian.PutUint{{ .bitSize }}(buf[pos:], uint{{ .bitSize }}(orig.{{ .fieldName }}))
+		{{ range .protoTag -}}
+		pos--
+		buf[pos] = {{ . }}
+		{{ end -}}
 	}
-{{- end }}{{- end }}`
+{{- end }}`
 
 const marshalProtoBool = `{{ if .repeated -}}
 	l = len(orig.{{ .fieldName }})
@@ -80,10 +96,7 @@ const marshalProtoBool = `{{ if .repeated -}}
 		buf[pos] = {{ . }}
 		{{ end -}}
 	}
-{{- else }}
-{{- if not .nullable -}}
-	if orig.{{ .fieldName }} {
-{{ end -}}
+{{- else if ne .oneOfGroup "" -}}
 		pos--
 		if orig.{{ .fieldName }} {
 			buf[pos] = 1
@@ -94,9 +107,24 @@ const marshalProtoBool = `{{ if .repeated -}}
 		pos--
 		buf[pos] = {{ . }}
 		{{ end -}}
-{{- if not .nullable -}}
+{{- else }}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
+		pos--
+		if orig.{{ .fieldName }} {
+			buf[pos] = 1
+		} else {
+			buf[pos] = 0
+		}
+		{{ range .protoTag -}}
+		pos--
+		buf[pos] = {{ . }}
+		{{ end -}}
 	}
-{{- end }}{{- end }}`
+{{- end }}`
 
 const marshalProtoVarint = `{{ if .repeated -}}
 	l = len(orig.{{ .fieldName }})
@@ -111,18 +139,25 @@ const marshalProtoVarint = `{{ if .repeated -}}
 		buf[pos] = {{ . }}
 		{{ end -}}
 	}
-{{- else }}
-{{- if not .nullable -}}
-	if orig.{{ .fieldName }} != 0 {
-{{ end -}}
+{{- else if ne .oneOfGroup "" -}}
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.{{ .fieldName }}))
 		{{ range .protoTag -}}
 		pos--
 		buf[pos] = {{ . }}
 		{{ end -}}
-{{- if not .nullable -}}
+{{- else }}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
+		pos = proto.EncodeVarint(buf, pos, uint64(orig.{{ .fieldName }}))
+		{{ range .protoTag -}}
+		pos--
+		buf[pos] = {{ . }}
+		{{ end -}}
 	}
-{{- end }}{{- end }}`
+{{- end }}`
 
 const marshalProtoBytesString = `{{ if .repeated -}}
 	for i := len(orig.{{ .fieldName }}) - 1; i >= 0; i-- {
@@ -194,18 +229,25 @@ const marshalProtoSignedVarint = `{{ if .repeated -}}
 		buf[pos] = {{ . }}
 		{{ end -}}
 	}
-{{- else }}
-{{- if not .nullable -}}
-	if orig.{{ .fieldName }} != 0 {
-{{ end -}}
+{{- else if ne .oneOfGroup "" -}}
 		pos = proto.EncodeVarint(buf, pos, uint64((uint{{ .bitSize }}(orig.{{ .fieldName }})<<1)^uint{{ .bitSize }}(orig.{{ .fieldName }}>>{{ sub .bitSize 1}})))
 		{{ range .protoTag -}}
 		pos--
 		buf[pos] = {{ . }}
 		{{ end -}}
-{{- if not .nullable -}}
+{{- else }}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
+		pos = proto.EncodeVarint(buf, pos, uint64((uint{{ .bitSize }}(orig.{{ .fieldName }})<<1)^uint{{ .bitSize }}(orig.{{ .fieldName }}>>{{ sub .bitSize 1}})))
+		{{ range .protoTag -}}
+		pos--
+		buf[pos] = {{ . }}
+		{{ end -}}
 	}
-{{- end }}{{- end }}`
+{{- end }}`
 
 func (pf *Field) GenMarshalProto() string {
 	tf := pf.getTemplateFields()

--- a/internal/cmd/pdatagen/internal/proto/proto_size.go
+++ b/internal/cmd/pdatagen/internal/proto/proto_size.go
@@ -15,12 +15,16 @@ const sizeProtoI8 = `{{ if .repeated -}}
 		l *= 8
 		n+= {{ .protoTagSize }} + proto.Sov(uint64(l)) + l
 	}
-{{- else if not .nullable -}}
-	if orig.{{ .fieldName }} != 0 {
+{{- else if ne .oneOfGroup "" -}}
+		n+= {{ add .protoTagSize 8 }}
+{{- else -}}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
 		n+= {{ add .protoTagSize 8 }}
 	}
-{{- else -}}
-	n+= {{ add .protoTagSize 8 }}
 {{- end }}`
 
 const sizeProtoI4 = `{{ if .repeated -}}
@@ -29,12 +33,16 @@ const sizeProtoI4 = `{{ if .repeated -}}
 		l *= 4
 		n+= + {{ .protoTagSize }} + proto.Sov(uint64(l)) + l
 	}
-{{- else if not .nullable -}}
-	if orig.{{ .fieldName }} != 0 {
+{{- else if ne .oneOfGroup "" -}}
+		n+= {{ add .protoTagSize 4 }}
+{{- else -}}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
 		n+= {{ add .protoTagSize 4 }}
 	}
-{{- else -}}
-	n+= {{ add .protoTagSize 4 }}
 {{- end }}`
 
 const sizeProtoBool = `{{ if .repeated -}}
@@ -42,12 +50,16 @@ const sizeProtoBool = `{{ if .repeated -}}
 	if l > 0 {
 		n+= + {{ .protoTagSize }} + proto.Sov(uint64(l)) + l
 	}
-{{- else if not .nullable -}}
-	if orig.{{ .fieldName }} {
+{{- else if ne .oneOfGroup "" -}}
+		n+= {{ add .protoTagSize 1 }}
+{{- else -}}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
 		n+= {{ add .protoTagSize 1 }}
 	}
-{{- else -}}
-	n+= {{ add .protoTagSize 1 }}
 {{- end }}`
 
 const sizeProtoVarint = `{{ if .repeated -}}
@@ -58,12 +70,16 @@ const sizeProtoVarint = `{{ if .repeated -}}
 		}
 		n+= {{ .protoTagSize }} + proto.Sov(uint64(l)) + l
 	}
-{{- else if not .nullable -}}
-	if orig.{{ .fieldName }} != 0 {
+{{- else if ne .oneOfGroup "" -}}
+		n+= {{ .protoTagSize }} + proto.Sov(uint64(orig.{{ .fieldName }}))
+{{- else -}}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
 		n+= {{ .protoTagSize }} + proto.Sov(uint64(orig.{{ .fieldName }}))
 	}
-{{- else -}}
-	n+= {{ .protoTagSize }} + proto.Sov(uint64(orig.{{ .fieldName }}))
 {{- end }}`
 
 const sizeProtoBytesString = `{{ if .repeated -}}
@@ -71,14 +87,14 @@ const sizeProtoBytesString = `{{ if .repeated -}}
 		l = len(s)
 		n+= {{ .protoTagSize }} + proto.Sov(uint64(l)) + l
 	}
-{{- else if not .nullable -}}
+{{- else if ne .oneOfGroup "" -}}
+		l = len(orig.{{ .fieldName }})
+		n+= {{ .protoTagSize }} + proto.Sov(uint64(l)) + l
+{{- else }}
 	l = len(orig.{{ .fieldName }})
 	if l > 0 {
 		n+= {{ .protoTagSize }} + proto.Sov(uint64(l)) + l
 	}
-{{- else -}}
-	l = len(orig.{{ .fieldName }})
-	n+= {{ .protoTagSize }} + proto.Sov(uint64(l)) + l
 {{- end }}`
 
 const sizeProtoMessage = `{{ if .repeated -}}
@@ -104,12 +120,16 @@ const sizeProtoSignedVarint = `{{ if .repeated -}}
 		}
 		n+= {{ .protoTagSize }} + proto.Sov(uint64(l)) + l
 	}
-{{- else if not .nullable -}}
-	if orig.{{ .fieldName }} != 0 {
+{{- else if ne .oneOfGroup "" -}}
+	n+= {{ .protoTagSize }} + proto.Soz(uint64(orig.{{ .fieldName }}))
+{{- else -}}
+	{{- if not .nullable -}}
+	if orig.{{ .fieldName }} != {{ .defaultValue }} {
+	{{- else -}}
+	if orig.Has{{ .fieldName }}() {
+	{{- end }}
 		n+= {{ .protoTagSize }} + proto.Soz(uint64(orig.{{ .fieldName }}))
 	}
-{{- else -}}
-	n+= {{ .protoTagSize }} + proto.Soz(uint64(orig.{{ .fieldName }}))
 {{- end }}`
 
 func (pf *Field) GenSizeProto() string {

--- a/internal/cmd/pdatagen/internal/proto/proto_unmarshal.go
+++ b/internal/cmd/pdatagen/internal/proto/proto_unmarshal.go
@@ -61,7 +61,9 @@ const unmarshalProtoFloat = `{{ if .repeated -}}
 		}
 		ov.{{ .fieldName }} = math.Float{{ .bitSize }}frombits(num)
 		orig.{{ .oneOfGroup }} = ov
-{{- else }}
+{{- else if .nullable -}}
+		orig.Set{{ .fieldName }}(math.Float{{ .bitSize }}frombits(num))
+{{- else -}}
 		orig.{{ .fieldName }} = math.Float{{ .bitSize }}frombits(num)
 {{- end }}{{- end }}`
 
@@ -173,7 +175,9 @@ const unmarshalProtoBool = `{{ if .repeated -}}
 		}
 		ov.{{ .fieldName }} = num != 0
 		orig.{{ .oneOfGroup }} = ov
-{{- else }}
+{{- else if .nullable -}}
+		orig.Set{{ .fieldName }}(num != 0)
+{{- else -}}
 		orig.{{ .fieldName }} = num != 0
 {{- end }}{{- end }}`
 
@@ -227,7 +231,9 @@ const unmarshalProtoVarint = `{{ if .repeated -}}
 		}
 		ov.{{ .fieldName }} = {{ .goType }}(num)
 		orig.{{ .oneOfGroup }} = ov
-{{- else }}
+{{- else if .nullable -}}
+		orig.Set{{ .fieldName }}({{ .goType }}(num))
+{{- else -}}
 		orig.{{ .fieldName }} = {{ .goType }}(num)
 {{- end }}{{- end }}`
 
@@ -385,7 +391,9 @@ const unmarshalProtoSignedVarint = `{{ if .repeated -}}
 		}
 		ov.{{ .fieldName }} = int{{ .bitSize }}(uint{{ .bitSize }}(num >> 1) ^ uint{{ .bitSize }}(int{{ .bitSize }}((num&1)<<{{ sub .bitSize 1 }})>>{{ sub .bitSize 1 }}))
 		orig.{{ .oneOfGroup }} = ov
-{{- else }}
+{{- else if .nullable -}}
+		orig.Set{{ .fieldName }}(int{{ .bitSize }}(uint{{ .bitSize }}(num >> 1) ^ uint{{ .bitSize }}(int{{ .bitSize }}((num&1)<<{{ sub .bitSize 1 }})>>{{ sub .bitSize 1 }})))
+{{- else -}}
 		orig.{{ .fieldName }} = int{{ .bitSize }}(uint{{ .bitSize }}(num >> 1) ^ uint{{ .bitSize }}(int{{ .bitSize }}((num&1)<<{{ sub .bitSize 1 }})>>{{ sub .bitSize 1 }}))
 {{- end }}{{- end }}`
 

--- a/internal/cmd/pdatagen/internal/proto/templates/message.go.tmpl
+++ b/internal/cmd/pdatagen/internal/proto/templates/message.go.tmpl
@@ -20,7 +20,11 @@ import (
 type {{ .messageName }} struct {
 {{- range .fields }}
     {{ .GenMessageField }}
-{{- end }}}
+{{- end }}
+{{ if gt .metadataSize 0 -}}
+    metadata [{{ .metadataSize }}]uint64
+{{ end -}}
+}
 
 var (
 	protoPool{{ .messageName }} = sync.Pool{
@@ -199,10 +203,14 @@ func (orig *{{ .messageName }}) UnmarshalProto(buf []byte) error {
 	return nil
 }
 
+{{ if gt .metadataSize 0 -}}
+{{ call .GenerateMetadata }}
+{{ end -}}
+
 func GenTest{{ .messageName }}() *{{ .messageName }} {
     orig := New{{ .messageName }}()
     {{- range .fields }}
-    orig.{{ .GetName }} = {{ .TestValue }}
+    {{ .GenTest }}
     {{- end }}
     return orig
 }

--- a/internal/cmd/pdatagen/internal/proto/test_encoding_values.go
+++ b/internal/cmd/pdatagen/internal/proto/test_encoding_values.go
@@ -13,6 +13,12 @@ import (
 const encodingTestValuesScalar = `{{ if ne .oneOfGroup "" -}}
 "{{ .fieldName }}/default": { {{ .oneOfGroup }}: &{{ .oneOfMessageName }}{{ "{" }}{{ .fieldName }}: {{ .defaultValue }}} },
 "{{ .fieldName }}/test": { {{ .oneOfGroup }}: &{{ .oneOfMessageName }}{{ "{" }}{{ .fieldName }}: {{ .testValue }}} },
+{{- else if .nullable }}
+"{{ .fieldName }}/test": func () *{{ .parentMessageName }} { 
+	ms := New{{ .parentMessageName }}() 
+	ms.Set{{ .fieldName }}({{ .testValue }})
+	return ms
+}(),
 {{- else }}
 "{{ .fieldName }}/test": { {{ .fieldName }}: {{ .testValue }} },
 {{- end }}`

--- a/pdata/internal/generated_proto_anyvalue.go
+++ b/pdata/internal/generated_proto_anyvalue.go
@@ -237,6 +237,7 @@ func CopyAnyValue(dest, src *AnyValue) *AnyValue {
 		}
 		ov.StringValue = t.StringValue
 		dest.Value = ov
+
 	case *AnyValue_BoolValue:
 		var ov *AnyValue_BoolValue
 		if !UseProtoPooling.IsEnabled() {
@@ -246,6 +247,7 @@ func CopyAnyValue(dest, src *AnyValue) *AnyValue {
 		}
 		ov.BoolValue = t.BoolValue
 		dest.Value = ov
+
 	case *AnyValue_IntValue:
 		var ov *AnyValue_IntValue
 		if !UseProtoPooling.IsEnabled() {
@@ -255,6 +257,7 @@ func CopyAnyValue(dest, src *AnyValue) *AnyValue {
 		}
 		ov.IntValue = t.IntValue
 		dest.Value = ov
+
 	case *AnyValue_DoubleValue:
 		var ov *AnyValue_DoubleValue
 		if !UseProtoPooling.IsEnabled() {
@@ -264,6 +267,7 @@ func CopyAnyValue(dest, src *AnyValue) *AnyValue {
 		}
 		ov.DoubleValue = t.DoubleValue
 		dest.Value = ov
+
 	case *AnyValue_ArrayValue:
 		var ov *AnyValue_ArrayValue
 		if !UseProtoPooling.IsEnabled() {
@@ -295,6 +299,7 @@ func CopyAnyValue(dest, src *AnyValue) *AnyValue {
 		}
 		ov.BytesValue = t.BytesValue
 		dest.Value = ov
+
 	default:
 		dest.Value = nil
 	}

--- a/pdata/internal/generated_proto_entityref.go
+++ b/pdata/internal/generated_proto_entityref.go
@@ -66,10 +66,9 @@ func CopyEntityRef(dest, src *EntityRef) *EntityRef {
 		dest = NewEntityRef()
 	}
 	dest.SchemaUrl = src.SchemaUrl
-
 	dest.Type = src.Type
-
 	dest.IdKeys = append(dest.IdKeys[:0], src.IdKeys...)
+
 	dest.DescriptionKeys = append(dest.DescriptionKeys[:0], src.DescriptionKeys...)
 
 	return dest
@@ -148,6 +147,7 @@ func (orig *EntityRef) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	if len(orig.DescriptionKeys) > 0 {
 		dest.WriteObjectField("descriptionKeys")
 		dest.WriteArrayStart()
@@ -158,6 +158,7 @@ func (orig *EntityRef) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	dest.WriteObjectEnd()
 }
 
@@ -189,10 +190,12 @@ func (orig *EntityRef) SizeProto() int {
 	var n int
 	var l int
 	_ = l
+
 	l = len(orig.SchemaUrl)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.Type)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_exemplar.go
+++ b/pdata/internal/generated_proto_exemplar.go
@@ -135,7 +135,6 @@ func CopyExemplar(dest, src *Exemplar) *Exemplar {
 	dest.FilteredAttributes = CopyKeyValueSlice(dest.FilteredAttributes, src.FilteredAttributes)
 
 	dest.TimeUnixNano = src.TimeUnixNano
-
 	switch t := src.Value.(type) {
 	case *Exemplar_AsDouble:
 		var ov *Exemplar_AsDouble
@@ -146,6 +145,7 @@ func CopyExemplar(dest, src *Exemplar) *Exemplar {
 		}
 		ov.AsDouble = t.AsDouble
 		dest.Value = ov
+
 	case *Exemplar_AsInt:
 		var ov *Exemplar_AsInt
 		if !UseProtoPooling.IsEnabled() {
@@ -155,6 +155,7 @@ func CopyExemplar(dest, src *Exemplar) *Exemplar {
 		}
 		ov.AsInt = t.AsInt
 		dest.Value = ov
+
 	default:
 		dest.Value = nil
 	}
@@ -310,7 +311,7 @@ func (orig *Exemplar) SizeProto() int {
 		l = orig.FilteredAttributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		n += 9
 	}
 	switch orig := orig.Value.(type) {
@@ -340,7 +341,7 @@ func (orig *Exemplar) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x3a
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.TimeUnixNano))
 		pos--

--- a/pdata/internal/generated_proto_exponentialhistogram.go
+++ b/pdata/internal/generated_proto_exponentialhistogram.go
@@ -175,7 +175,7 @@ func (orig *ExponentialHistogram) SizeProto() int {
 		l = orig.DataPoints[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.AggregationTemporality != 0 {
+	if orig.AggregationTemporality != AggregationTemporality(0) {
 		n += 1 + proto.Sov(uint64(orig.AggregationTemporality))
 	}
 	return n
@@ -192,7 +192,7 @@ func (orig *ExponentialHistogram) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0xa
 	}
-	if orig.AggregationTemporality != 0 {
+	if orig.AggregationTemporality != AggregationTemporality(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.AggregationTemporality))
 		pos--
 		buf[pos] = 0x10
@@ -240,7 +240,6 @@ func (orig *ExponentialHistogram) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.AggregationTemporality = AggregationTemporality(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_exponentialhistogramdatapoint.go
+++ b/pdata/internal/generated_proto_exponentialhistogramdatapoint.go
@@ -16,60 +16,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func (m *ExponentialHistogramDataPoint) GetSum_() any {
-	if m != nil {
-		return m.Sum_
-	}
-	return nil
-}
-
-type ExponentialHistogramDataPoint_Sum struct {
-	Sum float64
-}
-
-func (m *ExponentialHistogramDataPoint) GetSum() float64 {
-	if v, ok := m.GetSum_().(*ExponentialHistogramDataPoint_Sum); ok {
-		return v.Sum
-	}
-	return float64(0)
-}
-
-func (m *ExponentialHistogramDataPoint) GetMin_() any {
-	if m != nil {
-		return m.Min_
-	}
-	return nil
-}
-
-type ExponentialHistogramDataPoint_Min struct {
-	Min float64
-}
-
-func (m *ExponentialHistogramDataPoint) GetMin() float64 {
-	if v, ok := m.GetMin_().(*ExponentialHistogramDataPoint_Min); ok {
-		return v.Min
-	}
-	return float64(0)
-}
-
-func (m *ExponentialHistogramDataPoint) GetMax_() any {
-	if m != nil {
-		return m.Max_
-	}
-	return nil
-}
-
-type ExponentialHistogramDataPoint_Max struct {
-	Max float64
-}
-
-func (m *ExponentialHistogramDataPoint) GetMax() float64 {
-	if v, ok := m.GetMax_().(*ExponentialHistogramDataPoint_Max); ok {
-		return v.Max
-	}
-	return float64(0)
-}
-
 // ExponentialHistogramDataPoint is a single data point in a timeseries that describes the
 // time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
 // summary statistics for a population of values, it may optionally contain the
@@ -79,39 +25,23 @@ type ExponentialHistogramDataPoint struct {
 	StartTimeUnixNano uint64
 	TimeUnixNano      uint64
 	Count             uint64
-	Sum_              any
+	Sum               float64
 	Scale             int32
 	ZeroCount         uint64
 	Positive          ExponentialHistogramDataPointBuckets
 	Negative          ExponentialHistogramDataPointBuckets
 	Flags             uint32
 	Exemplars         []Exemplar
-	Min_              any
-	Max_              any
+	Min               float64
+	Max               float64
 	ZeroThreshold     float64
+	metadata          [1]uint64
 }
 
 var (
 	protoPoolExponentialHistogramDataPoint = sync.Pool{
 		New: func() any {
 			return &ExponentialHistogramDataPoint{}
-		},
-	}
-	ProtoPoolExponentialHistogramDataPoint_Sum = sync.Pool{
-		New: func() any {
-			return &ExponentialHistogramDataPoint_Sum{}
-		},
-	}
-
-	ProtoPoolExponentialHistogramDataPoint_Min = sync.Pool{
-		New: func() any {
-			return &ExponentialHistogramDataPoint_Min{}
-		},
-	}
-
-	ProtoPoolExponentialHistogramDataPoint_Max = sync.Pool{
-		New: func() any {
-			return &ExponentialHistogramDataPoint_Max{}
 		},
 	}
 )
@@ -136,34 +66,10 @@ func DeleteExponentialHistogramDataPoint(orig *ExponentialHistogramDataPoint, nu
 	for i := range orig.Attributes {
 		DeleteKeyValue(&orig.Attributes[i], false)
 	}
-	switch ov := orig.Sum_.(type) {
-	case *ExponentialHistogramDataPoint_Sum:
-		if UseProtoPooling.IsEnabled() {
-			ov.Sum = float64(0)
-			ProtoPoolExponentialHistogramDataPoint_Sum.Put(ov)
-		}
-
-	}
 	DeleteExponentialHistogramDataPointBuckets(&orig.Positive, false)
 	DeleteExponentialHistogramDataPointBuckets(&orig.Negative, false)
 	for i := range orig.Exemplars {
 		DeleteExemplar(&orig.Exemplars[i], false)
-	}
-	switch ov := orig.Min_.(type) {
-	case *ExponentialHistogramDataPoint_Min:
-		if UseProtoPooling.IsEnabled() {
-			ov.Min = float64(0)
-			ProtoPoolExponentialHistogramDataPoint_Min.Put(ov)
-		}
-
-	}
-	switch ov := orig.Max_.(type) {
-	case *ExponentialHistogramDataPoint_Max:
-		if UseProtoPooling.IsEnabled() {
-			ov.Max = float64(0)
-			ProtoPoolExponentialHistogramDataPoint_Max.Put(ov)
-		}
-
 	}
 
 	orig.Reset()
@@ -188,63 +94,33 @@ func CopyExponentialHistogramDataPoint(dest, src *ExponentialHistogramDataPoint)
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.StartTimeUnixNano = src.StartTimeUnixNano
-
 	dest.TimeUnixNano = src.TimeUnixNano
-
 	dest.Count = src.Count
-
-	switch t := src.Sum_.(type) {
-	case *ExponentialHistogramDataPoint_Sum:
-		var ov *ExponentialHistogramDataPoint_Sum
-		if !UseProtoPooling.IsEnabled() {
-			ov = &ExponentialHistogramDataPoint_Sum{}
-		} else {
-			ov = ProtoPoolExponentialHistogramDataPoint_Sum.Get().(*ExponentialHistogramDataPoint_Sum)
-		}
-		ov.Sum = t.Sum
-		dest.Sum_ = ov
-	default:
-		dest.Sum_ = nil
+	if src.HasSum() {
+		dest.SetSum(src.Sum)
+	} else {
+		dest.RemoveSum()
 	}
 
 	dest.Scale = src.Scale
-
 	dest.ZeroCount = src.ZeroCount
-
 	CopyExponentialHistogramDataPointBuckets(&dest.Positive, &src.Positive)
 
 	CopyExponentialHistogramDataPointBuckets(&dest.Negative, &src.Negative)
 
 	dest.Flags = src.Flags
-
 	dest.Exemplars = CopyExemplarSlice(dest.Exemplars, src.Exemplars)
 
-	switch t := src.Min_.(type) {
-	case *ExponentialHistogramDataPoint_Min:
-		var ov *ExponentialHistogramDataPoint_Min
-		if !UseProtoPooling.IsEnabled() {
-			ov = &ExponentialHistogramDataPoint_Min{}
-		} else {
-			ov = ProtoPoolExponentialHistogramDataPoint_Min.Get().(*ExponentialHistogramDataPoint_Min)
-		}
-		ov.Min = t.Min
-		dest.Min_ = ov
-	default:
-		dest.Min_ = nil
+	if src.HasMin() {
+		dest.SetMin(src.Min)
+	} else {
+		dest.RemoveMin()
 	}
 
-	switch t := src.Max_.(type) {
-	case *ExponentialHistogramDataPoint_Max:
-		var ov *ExponentialHistogramDataPoint_Max
-		if !UseProtoPooling.IsEnabled() {
-			ov = &ExponentialHistogramDataPoint_Max{}
-		} else {
-			ov = ProtoPoolExponentialHistogramDataPoint_Max.Get().(*ExponentialHistogramDataPoint_Max)
-		}
-		ov.Max = t.Max
-		dest.Max_ = ov
-	default:
-		dest.Max_ = nil
+	if src.HasMax() {
+		dest.SetMax(src.Max)
+	} else {
+		dest.RemoveMax()
 	}
 
 	dest.ZeroThreshold = src.ZeroThreshold
@@ -329,7 +205,7 @@ func (orig *ExponentialHistogramDataPoint) MarshalJSON(dest *json.Stream) {
 		dest.WriteObjectField("count")
 		dest.WriteUint64(orig.Count)
 	}
-	if orig, ok := orig.Sum_.(*ExponentialHistogramDataPoint_Sum); ok {
+	if orig.HasSum() {
 		dest.WriteObjectField("sum")
 		dest.WriteFloat64(orig.Sum)
 	}
@@ -359,11 +235,11 @@ func (orig *ExponentialHistogramDataPoint) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
-	if orig, ok := orig.Min_.(*ExponentialHistogramDataPoint_Min); ok {
+	if orig.HasMin() {
 		dest.WriteObjectField("min")
 		dest.WriteFloat64(orig.Min)
 	}
-	if orig, ok := orig.Max_.(*ExponentialHistogramDataPoint_Max); ok {
+	if orig.HasMax() {
 		dest.WriteObjectField("max")
 		dest.WriteFloat64(orig.Max)
 	}
@@ -391,16 +267,7 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalJSON(iter *json.Iterator) {
 		case "count":
 			orig.Count = iter.ReadUint64()
 		case "sum":
-			{
-				var ov *ExponentialHistogramDataPoint_Sum
-				if !UseProtoPooling.IsEnabled() {
-					ov = &ExponentialHistogramDataPoint_Sum{}
-				} else {
-					ov = ProtoPoolExponentialHistogramDataPoint_Sum.Get().(*ExponentialHistogramDataPoint_Sum)
-				}
-				ov.Sum = iter.ReadFloat64()
-				orig.Sum_ = ov
-			}
+			orig.SetSum(iter.ReadFloat64())
 
 		case "scale":
 			orig.Scale = iter.ReadInt32()
@@ -421,28 +288,10 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		case "min":
-			{
-				var ov *ExponentialHistogramDataPoint_Min
-				if !UseProtoPooling.IsEnabled() {
-					ov = &ExponentialHistogramDataPoint_Min{}
-				} else {
-					ov = ProtoPoolExponentialHistogramDataPoint_Min.Get().(*ExponentialHistogramDataPoint_Min)
-				}
-				ov.Min = iter.ReadFloat64()
-				orig.Min_ = ov
-			}
+			orig.SetMin(iter.ReadFloat64())
 
 		case "max":
-			{
-				var ov *ExponentialHistogramDataPoint_Max
-				if !UseProtoPooling.IsEnabled() {
-					ov = &ExponentialHistogramDataPoint_Max{}
-				} else {
-					ov = ProtoPoolExponentialHistogramDataPoint_Max.Get().(*ExponentialHistogramDataPoint_Max)
-				}
-				ov.Max = iter.ReadFloat64()
-				orig.Max_ = ov
-			}
+			orig.SetMax(iter.ReadFloat64())
 
 		case "zeroThreshold", "zero_threshold":
 			orig.ZeroThreshold = iter.ReadFloat64()
@@ -460,45 +309,42 @@ func (orig *ExponentialHistogramDataPoint) SizeProto() int {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.Count != 0 {
+	if orig.Count != uint64(0) {
 		n += 9
 	}
-	if orig, ok := orig.Sum_.(*ExponentialHistogramDataPoint_Sum); ok {
-		_ = orig
+	if orig.HasSum() {
 		n += 9
 	}
-	if orig.Scale != 0 {
+	if orig.Scale != int32(0) {
 		n += 1 + proto.Soz(uint64(orig.Scale))
 	}
-	if orig.ZeroCount != 0 {
+	if orig.ZeroCount != uint64(0) {
 		n += 9
 	}
 	l = orig.Positive.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
 	l = orig.Negative.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.Flags))
 	}
 	for i := range orig.Exemplars {
 		l = orig.Exemplars[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig, ok := orig.Min_.(*ExponentialHistogramDataPoint_Min); ok {
-		_ = orig
+	if orig.HasMin() {
 		n += 9
 	}
-	if orig, ok := orig.Max_.(*ExponentialHistogramDataPoint_Max); ok {
-		_ = orig
+	if orig.HasMax() {
 		n += 9
 	}
-	if orig.ZeroThreshold != 0 {
+	if orig.ZeroThreshold != float64(0) {
 		n += 9
 	}
 	return n
@@ -515,36 +361,36 @@ func (orig *ExponentialHistogramDataPoint) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0xa
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.StartTimeUnixNano))
 		pos--
 		buf[pos] = 0x11
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.TimeUnixNano))
 		pos--
 		buf[pos] = 0x19
 	}
-	if orig.Count != 0 {
+	if orig.Count != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.Count))
 		pos--
 		buf[pos] = 0x21
 	}
-	if orig, ok := orig.Sum_.(*ExponentialHistogramDataPoint_Sum); ok {
+	if orig.HasSum() {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.Sum))
 		pos--
 		buf[pos] = 0x29
 	}
-	if orig.Scale != 0 {
+	if orig.Scale != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64((uint32(orig.Scale)<<1)^uint32(orig.Scale>>31)))
 		pos--
 		buf[pos] = 0x30
 	}
-	if orig.ZeroCount != 0 {
+	if orig.ZeroCount != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.ZeroCount))
 		pos--
@@ -562,7 +408,7 @@ func (orig *ExponentialHistogramDataPoint) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x4a
 
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Flags))
 		pos--
 		buf[pos] = 0x50
@@ -574,19 +420,19 @@ func (orig *ExponentialHistogramDataPoint) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x5a
 	}
-	if orig, ok := orig.Min_.(*ExponentialHistogramDataPoint_Min); ok {
+	if orig.HasMin() {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.Min))
 		pos--
 		buf[pos] = 0x61
 	}
-	if orig, ok := orig.Max_.(*ExponentialHistogramDataPoint_Max); ok {
+	if orig.HasMax() {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.Max))
 		pos--
 		buf[pos] = 0x69
 	}
-	if orig.ZeroThreshold != 0 {
+	if orig.ZeroThreshold != float64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.ZeroThreshold))
 		pos--
@@ -671,14 +517,7 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-			var ov *ExponentialHistogramDataPoint_Sum
-			if !UseProtoPooling.IsEnabled() {
-				ov = &ExponentialHistogramDataPoint_Sum{}
-			} else {
-				ov = ProtoPoolExponentialHistogramDataPoint_Sum.Get().(*ExponentialHistogramDataPoint_Sum)
-			}
-			ov.Sum = math.Float64frombits(num)
-			orig.Sum_ = ov
+			orig.SetSum(math.Float64frombits(num))
 
 		case 6:
 			if wireType != proto.WireTypeVarint {
@@ -689,7 +528,6 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Scale = int32(uint32(num>>1) ^ uint32(int32((num&1)<<31)>>31))
 
 		case 7:
@@ -745,7 +583,6 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Flags = uint32(num)
 
 		case 11:
@@ -773,14 +610,7 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-			var ov *ExponentialHistogramDataPoint_Min
-			if !UseProtoPooling.IsEnabled() {
-				ov = &ExponentialHistogramDataPoint_Min{}
-			} else {
-				ov = ProtoPoolExponentialHistogramDataPoint_Min.Get().(*ExponentialHistogramDataPoint_Min)
-			}
-			ov.Min = math.Float64frombits(num)
-			orig.Min_ = ov
+			orig.SetMin(math.Float64frombits(num))
 
 		case 13:
 			if wireType != proto.WireTypeI64 {
@@ -791,14 +621,7 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-			var ov *ExponentialHistogramDataPoint_Max
-			if !UseProtoPooling.IsEnabled() {
-				ov = &ExponentialHistogramDataPoint_Max{}
-			} else {
-				ov = ProtoPoolExponentialHistogramDataPoint_Max.Get().(*ExponentialHistogramDataPoint_Max)
-			}
-			ov.Max = math.Float64frombits(num)
-			orig.Max_ = ov
+			orig.SetMax(math.Float64frombits(num))
 
 		case 14:
 			if wireType != proto.WireTypeI64 {
@@ -809,7 +632,6 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.ZeroThreshold = math.Float64frombits(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)
@@ -821,21 +643,72 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalProto(buf []byte) error {
 	return nil
 }
 
+const fieldBlockExponentialHistogramDataPointSum = uint64(0 >> 6)
+const fieldBitExponentialHistogramDataPointSum = uint64(1 << 0 & 0x3F)
+
+func (m *ExponentialHistogramDataPoint) SetSum(value float64) {
+	m.Sum = value
+	m.metadata[fieldBlockExponentialHistogramDataPointSum] |= fieldBitExponentialHistogramDataPointSum
+}
+
+func (m *ExponentialHistogramDataPoint) RemoveSum() {
+	m.Sum = float64(0)
+	m.metadata[fieldBlockExponentialHistogramDataPointSum] &^= fieldBitExponentialHistogramDataPointSum
+}
+
+func (m *ExponentialHistogramDataPoint) HasSum() bool {
+	return m.metadata[fieldBlockExponentialHistogramDataPointSum]&fieldBitExponentialHistogramDataPointSum != 0
+}
+
+const fieldBlockExponentialHistogramDataPointMin = uint64(1 >> 6)
+const fieldBitExponentialHistogramDataPointMin = uint64(1 << 1 & 0x3F)
+
+func (m *ExponentialHistogramDataPoint) SetMin(value float64) {
+	m.Min = value
+	m.metadata[fieldBlockExponentialHistogramDataPointMin] |= fieldBitExponentialHistogramDataPointMin
+}
+
+func (m *ExponentialHistogramDataPoint) RemoveMin() {
+	m.Min = float64(0)
+	m.metadata[fieldBlockExponentialHistogramDataPointMin] &^= fieldBitExponentialHistogramDataPointMin
+}
+
+func (m *ExponentialHistogramDataPoint) HasMin() bool {
+	return m.metadata[fieldBlockExponentialHistogramDataPointMin]&fieldBitExponentialHistogramDataPointMin != 0
+}
+
+const fieldBlockExponentialHistogramDataPointMax = uint64(2 >> 6)
+const fieldBitExponentialHistogramDataPointMax = uint64(1 << 2 & 0x3F)
+
+func (m *ExponentialHistogramDataPoint) SetMax(value float64) {
+	m.Max = value
+	m.metadata[fieldBlockExponentialHistogramDataPointMax] |= fieldBitExponentialHistogramDataPointMax
+}
+
+func (m *ExponentialHistogramDataPoint) RemoveMax() {
+	m.Max = float64(0)
+	m.metadata[fieldBlockExponentialHistogramDataPointMax] &^= fieldBitExponentialHistogramDataPointMax
+}
+
+func (m *ExponentialHistogramDataPoint) HasMax() bool {
+	return m.metadata[fieldBlockExponentialHistogramDataPointMax]&fieldBitExponentialHistogramDataPointMax != 0
+}
+
 func GenTestExponentialHistogramDataPoint() *ExponentialHistogramDataPoint {
 	orig := NewExponentialHistogramDataPoint()
 	orig.Attributes = []KeyValue{{}, *GenTestKeyValue()}
 	orig.StartTimeUnixNano = uint64(13)
 	orig.TimeUnixNano = uint64(13)
 	orig.Count = uint64(13)
-	orig.Sum_ = &ExponentialHistogramDataPoint_Sum{Sum: float64(3.1415926)}
+	orig.SetSum(float64(3.1415926))
 	orig.Scale = int32(13)
 	orig.ZeroCount = uint64(13)
 	orig.Positive = *GenTestExponentialHistogramDataPointBuckets()
 	orig.Negative = *GenTestExponentialHistogramDataPointBuckets()
 	orig.Flags = uint32(13)
 	orig.Exemplars = []Exemplar{{}, *GenTestExemplar()}
-	orig.Min_ = &ExponentialHistogramDataPoint_Min{Min: float64(3.1415926)}
-	orig.Max_ = &ExponentialHistogramDataPoint_Max{Max: float64(3.1415926)}
+	orig.SetMin(float64(3.1415926))
+	orig.SetMax(float64(3.1415926))
 	orig.ZeroThreshold = float64(3.1415926)
 	return orig
 }

--- a/pdata/internal/generated_proto_exponentialhistogramdatapoint_test.go
+++ b/pdata/internal/generated_proto_exponentialhistogramdatapoint_test.go
@@ -226,16 +226,28 @@ func genTestEncodingValuesExponentialHistogramDataPoint() map[string]*Exponentia
 		"Attributes/test":        {Attributes: []KeyValue{{}, *GenTestKeyValue()}},
 		"StartTimeUnixNano/test": {StartTimeUnixNano: uint64(13)},
 		"TimeUnixNano/test":      {TimeUnixNano: uint64(13)},
-		"Count/test":             {Count: uint64(13)}, "Sum/default": {Sum_: &ExponentialHistogramDataPoint_Sum{Sum: float64(0)}},
-		"Sum/test":       {Sum_: &ExponentialHistogramDataPoint_Sum{Sum: float64(3.1415926)}},
+		"Count/test":             {Count: uint64(13)},
+		"Sum/test": func() *ExponentialHistogramDataPoint {
+			ms := NewExponentialHistogramDataPoint()
+			ms.SetSum(float64(3.1415926))
+			return ms
+		}(),
 		"Scale/test":     {Scale: int32(13)},
 		"ZeroCount/test": {ZeroCount: uint64(13)},
 		"Positive/test":  {Positive: *GenTestExponentialHistogramDataPointBuckets()},
 		"Negative/test":  {Negative: *GenTestExponentialHistogramDataPointBuckets()},
 		"Flags/test":     {Flags: uint32(13)},
-		"Exemplars/test": {Exemplars: []Exemplar{{}, *GenTestExemplar()}}, "Min/default": {Min_: &ExponentialHistogramDataPoint_Min{Min: float64(0)}},
-		"Min/test": {Min_: &ExponentialHistogramDataPoint_Min{Min: float64(3.1415926)}}, "Max/default": {Max_: &ExponentialHistogramDataPoint_Max{Max: float64(0)}},
-		"Max/test":           {Max_: &ExponentialHistogramDataPoint_Max{Max: float64(3.1415926)}},
+		"Exemplars/test": {Exemplars: []Exemplar{{}, *GenTestExemplar()}},
+		"Min/test": func() *ExponentialHistogramDataPoint {
+			ms := NewExponentialHistogramDataPoint()
+			ms.SetMin(float64(3.1415926))
+			return ms
+		}(),
+		"Max/test": func() *ExponentialHistogramDataPoint {
+			ms := NewExponentialHistogramDataPoint()
+			ms.SetMax(float64(3.1415926))
+			return ms
+		}(),
 		"ZeroThreshold/test": {ZeroThreshold: float64(3.1415926)},
 	}
 }

--- a/pdata/internal/generated_proto_exponentialhistogramdatapointbuckets.go
+++ b/pdata/internal/generated_proto_exponentialhistogramdatapointbuckets.go
@@ -65,7 +65,6 @@ func CopyExponentialHistogramDataPointBuckets(dest, src *ExponentialHistogramDat
 		dest = NewExponentialHistogramDataPointBuckets()
 	}
 	dest.Offset = src.Offset
-
 	dest.BucketCounts = append(dest.BucketCounts[:0], src.BucketCounts...)
 
 	return dest
@@ -140,6 +139,7 @@ func (orig *ExponentialHistogramDataPointBuckets) MarshalJSON(dest *json.Stream)
 		}
 		dest.WriteArrayEnd()
 	}
+
 	dest.WriteObjectEnd()
 }
 
@@ -164,7 +164,7 @@ func (orig *ExponentialHistogramDataPointBuckets) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.Offset != 0 {
+	if orig.Offset != int32(0) {
 		n += 1 + proto.Soz(uint64(orig.Offset))
 	}
 	if len(orig.BucketCounts) > 0 {
@@ -181,7 +181,7 @@ func (orig *ExponentialHistogramDataPointBuckets) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.Offset != 0 {
+	if orig.Offset != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64((uint32(orig.Offset)<<1)^uint32(orig.Offset>>31)))
 		pos--
 		buf[pos] = 0x8
@@ -223,7 +223,6 @@ func (orig *ExponentialHistogramDataPointBuckets) UnmarshalProto(buf []byte) err
 			if err != nil {
 				return err
 			}
-
 			orig.Offset = int32(uint32(num>>1) ^ uint32(int32((num&1)<<31)>>31))
 		case 2:
 			switch wireType {

--- a/pdata/internal/generated_proto_exportlogspartialsuccess.go
+++ b/pdata/internal/generated_proto_exportlogspartialsuccess.go
@@ -65,7 +65,6 @@ func CopyExportLogsPartialSuccess(dest, src *ExportLogsPartialSuccess) *ExportLo
 		dest = NewExportLogsPartialSuccess()
 	}
 	dest.RejectedLogRecords = src.RejectedLogRecords
-
 	dest.ErrorMessage = src.ErrorMessage
 
 	return dest
@@ -155,9 +154,10 @@ func (orig *ExportLogsPartialSuccess) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.RejectedLogRecords != 0 {
+	if orig.RejectedLogRecords != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.RejectedLogRecords))
 	}
+
 	l = len(orig.ErrorMessage)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -169,7 +169,7 @@ func (orig *ExportLogsPartialSuccess) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.RejectedLogRecords != 0 {
+	if orig.RejectedLogRecords != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.RejectedLogRecords))
 		pos--
 		buf[pos] = 0x8
@@ -209,7 +209,6 @@ func (orig *ExportLogsPartialSuccess) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.RejectedLogRecords = int64(num)
 
 		case 2:

--- a/pdata/internal/generated_proto_exportmetricspartialsuccess.go
+++ b/pdata/internal/generated_proto_exportmetricspartialsuccess.go
@@ -65,7 +65,6 @@ func CopyExportMetricsPartialSuccess(dest, src *ExportMetricsPartialSuccess) *Ex
 		dest = NewExportMetricsPartialSuccess()
 	}
 	dest.RejectedDataPoints = src.RejectedDataPoints
-
 	dest.ErrorMessage = src.ErrorMessage
 
 	return dest
@@ -155,9 +154,10 @@ func (orig *ExportMetricsPartialSuccess) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.RejectedDataPoints != 0 {
+	if orig.RejectedDataPoints != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.RejectedDataPoints))
 	}
+
 	l = len(orig.ErrorMessage)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -169,7 +169,7 @@ func (orig *ExportMetricsPartialSuccess) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.RejectedDataPoints != 0 {
+	if orig.RejectedDataPoints != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.RejectedDataPoints))
 		pos--
 		buf[pos] = 0x8
@@ -209,7 +209,6 @@ func (orig *ExportMetricsPartialSuccess) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.RejectedDataPoints = int64(num)
 
 		case 2:

--- a/pdata/internal/generated_proto_exportprofilespartialsuccess.go
+++ b/pdata/internal/generated_proto_exportprofilespartialsuccess.go
@@ -65,7 +65,6 @@ func CopyExportProfilesPartialSuccess(dest, src *ExportProfilesPartialSuccess) *
 		dest = NewExportProfilesPartialSuccess()
 	}
 	dest.RejectedProfiles = src.RejectedProfiles
-
 	dest.ErrorMessage = src.ErrorMessage
 
 	return dest
@@ -155,9 +154,10 @@ func (orig *ExportProfilesPartialSuccess) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.RejectedProfiles != 0 {
+	if orig.RejectedProfiles != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.RejectedProfiles))
 	}
+
 	l = len(orig.ErrorMessage)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -169,7 +169,7 @@ func (orig *ExportProfilesPartialSuccess) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.RejectedProfiles != 0 {
+	if orig.RejectedProfiles != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.RejectedProfiles))
 		pos--
 		buf[pos] = 0x8
@@ -209,7 +209,6 @@ func (orig *ExportProfilesPartialSuccess) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.RejectedProfiles = int64(num)
 
 		case 2:

--- a/pdata/internal/generated_proto_exporttracepartialsuccess.go
+++ b/pdata/internal/generated_proto_exporttracepartialsuccess.go
@@ -65,7 +65,6 @@ func CopyExportTracePartialSuccess(dest, src *ExportTracePartialSuccess) *Export
 		dest = NewExportTracePartialSuccess()
 	}
 	dest.RejectedSpans = src.RejectedSpans
-
 	dest.ErrorMessage = src.ErrorMessage
 
 	return dest
@@ -155,9 +154,10 @@ func (orig *ExportTracePartialSuccess) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.RejectedSpans != 0 {
+	if orig.RejectedSpans != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.RejectedSpans))
 	}
+
 	l = len(orig.ErrorMessage)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -169,7 +169,7 @@ func (orig *ExportTracePartialSuccess) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.RejectedSpans != 0 {
+	if orig.RejectedSpans != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.RejectedSpans))
 		pos--
 		buf[pos] = 0x8
@@ -209,7 +209,6 @@ func (orig *ExportTracePartialSuccess) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.RejectedSpans = int64(num)
 
 		case 2:

--- a/pdata/internal/generated_proto_function.go
+++ b/pdata/internal/generated_proto_function.go
@@ -67,11 +67,8 @@ func CopyFunction(dest, src *Function) *Function {
 		dest = NewFunction()
 	}
 	dest.NameStrindex = src.NameStrindex
-
 	dest.SystemNameStrindex = src.SystemNameStrindex
-
 	dest.FilenameStrindex = src.FilenameStrindex
-
 	dest.StartLine = src.StartLine
 
 	return dest
@@ -173,16 +170,16 @@ func (orig *Function) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.NameStrindex != 0 {
+	if orig.NameStrindex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.NameStrindex))
 	}
-	if orig.SystemNameStrindex != 0 {
+	if orig.SystemNameStrindex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.SystemNameStrindex))
 	}
-	if orig.FilenameStrindex != 0 {
+	if orig.FilenameStrindex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.FilenameStrindex))
 	}
-	if orig.StartLine != 0 {
+	if orig.StartLine != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.StartLine))
 	}
 	return n
@@ -192,22 +189,22 @@ func (orig *Function) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.NameStrindex != 0 {
+	if orig.NameStrindex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.NameStrindex))
 		pos--
 		buf[pos] = 0x8
 	}
-	if orig.SystemNameStrindex != 0 {
+	if orig.SystemNameStrindex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.SystemNameStrindex))
 		pos--
 		buf[pos] = 0x10
 	}
-	if orig.FilenameStrindex != 0 {
+	if orig.FilenameStrindex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.FilenameStrindex))
 		pos--
 		buf[pos] = 0x18
 	}
-	if orig.StartLine != 0 {
+	if orig.StartLine != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.StartLine))
 		pos--
 		buf[pos] = 0x20
@@ -239,7 +236,6 @@ func (orig *Function) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.NameStrindex = int32(num)
 
 		case 2:
@@ -251,7 +247,6 @@ func (orig *Function) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.SystemNameStrindex = int32(num)
 
 		case 3:
@@ -263,7 +258,6 @@ func (orig *Function) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.FilenameStrindex = int32(num)
 
 		case 4:
@@ -275,7 +269,6 @@ func (orig *Function) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.StartLine = int64(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_histogram.go
+++ b/pdata/internal/generated_proto_histogram.go
@@ -174,7 +174,7 @@ func (orig *Histogram) SizeProto() int {
 		l = orig.DataPoints[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.AggregationTemporality != 0 {
+	if orig.AggregationTemporality != AggregationTemporality(0) {
 		n += 1 + proto.Sov(uint64(orig.AggregationTemporality))
 	}
 	return n
@@ -191,7 +191,7 @@ func (orig *Histogram) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0xa
 	}
-	if orig.AggregationTemporality != 0 {
+	if orig.AggregationTemporality != AggregationTemporality(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.AggregationTemporality))
 		pos--
 		buf[pos] = 0x10
@@ -239,7 +239,6 @@ func (orig *Histogram) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.AggregationTemporality = AggregationTemporality(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_histogramdatapoint.go
+++ b/pdata/internal/generated_proto_histogramdatapoint.go
@@ -16,96 +16,26 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/proto"
 )
 
-func (m *HistogramDataPoint) GetSum_() any {
-	if m != nil {
-		return m.Sum_
-	}
-	return nil
-}
-
-type HistogramDataPoint_Sum struct {
-	Sum float64
-}
-
-func (m *HistogramDataPoint) GetSum() float64 {
-	if v, ok := m.GetSum_().(*HistogramDataPoint_Sum); ok {
-		return v.Sum
-	}
-	return float64(0)
-}
-
-func (m *HistogramDataPoint) GetMin_() any {
-	if m != nil {
-		return m.Min_
-	}
-	return nil
-}
-
-type HistogramDataPoint_Min struct {
-	Min float64
-}
-
-func (m *HistogramDataPoint) GetMin() float64 {
-	if v, ok := m.GetMin_().(*HistogramDataPoint_Min); ok {
-		return v.Min
-	}
-	return float64(0)
-}
-
-func (m *HistogramDataPoint) GetMax_() any {
-	if m != nil {
-		return m.Max_
-	}
-	return nil
-}
-
-type HistogramDataPoint_Max struct {
-	Max float64
-}
-
-func (m *HistogramDataPoint) GetMax() float64 {
-	if v, ok := m.GetMax_().(*HistogramDataPoint_Max); ok {
-		return v.Max
-	}
-	return float64(0)
-}
-
 // HistogramDataPoint is a single data point in a timeseries that describes the time-varying values of a Histogram of values.
 type HistogramDataPoint struct {
 	Attributes        []KeyValue
 	StartTimeUnixNano uint64
 	TimeUnixNano      uint64
 	Count             uint64
-	Sum_              any
+	Sum               float64
 	BucketCounts      []uint64
 	ExplicitBounds    []float64
 	Exemplars         []Exemplar
 	Flags             uint32
-	Min_              any
-	Max_              any
+	Min               float64
+	Max               float64
+	metadata          [1]uint64
 }
 
 var (
 	protoPoolHistogramDataPoint = sync.Pool{
 		New: func() any {
 			return &HistogramDataPoint{}
-		},
-	}
-	ProtoPoolHistogramDataPoint_Sum = sync.Pool{
-		New: func() any {
-			return &HistogramDataPoint_Sum{}
-		},
-	}
-
-	ProtoPoolHistogramDataPoint_Min = sync.Pool{
-		New: func() any {
-			return &HistogramDataPoint_Min{}
-		},
-	}
-
-	ProtoPoolHistogramDataPoint_Max = sync.Pool{
-		New: func() any {
-			return &HistogramDataPoint_Max{}
 		},
 	}
 )
@@ -130,32 +60,8 @@ func DeleteHistogramDataPoint(orig *HistogramDataPoint, nullable bool) {
 	for i := range orig.Attributes {
 		DeleteKeyValue(&orig.Attributes[i], false)
 	}
-	switch ov := orig.Sum_.(type) {
-	case *HistogramDataPoint_Sum:
-		if UseProtoPooling.IsEnabled() {
-			ov.Sum = float64(0)
-			ProtoPoolHistogramDataPoint_Sum.Put(ov)
-		}
-
-	}
 	for i := range orig.Exemplars {
 		DeleteExemplar(&orig.Exemplars[i], false)
-	}
-	switch ov := orig.Min_.(type) {
-	case *HistogramDataPoint_Min:
-		if UseProtoPooling.IsEnabled() {
-			ov.Min = float64(0)
-			ProtoPoolHistogramDataPoint_Min.Put(ov)
-		}
-
-	}
-	switch ov := orig.Max_.(type) {
-	case *HistogramDataPoint_Max:
-		if UseProtoPooling.IsEnabled() {
-			ov.Max = float64(0)
-			ProtoPoolHistogramDataPoint_Max.Put(ov)
-		}
-
 	}
 
 	orig.Reset()
@@ -180,57 +86,31 @@ func CopyHistogramDataPoint(dest, src *HistogramDataPoint) *HistogramDataPoint {
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.StartTimeUnixNano = src.StartTimeUnixNano
-
 	dest.TimeUnixNano = src.TimeUnixNano
-
 	dest.Count = src.Count
-
-	switch t := src.Sum_.(type) {
-	case *HistogramDataPoint_Sum:
-		var ov *HistogramDataPoint_Sum
-		if !UseProtoPooling.IsEnabled() {
-			ov = &HistogramDataPoint_Sum{}
-		} else {
-			ov = ProtoPoolHistogramDataPoint_Sum.Get().(*HistogramDataPoint_Sum)
-		}
-		ov.Sum = t.Sum
-		dest.Sum_ = ov
-	default:
-		dest.Sum_ = nil
+	if src.HasSum() {
+		dest.SetSum(src.Sum)
+	} else {
+		dest.RemoveSum()
 	}
 
 	dest.BucketCounts = append(dest.BucketCounts[:0], src.BucketCounts...)
+
 	dest.ExplicitBounds = append(dest.ExplicitBounds[:0], src.ExplicitBounds...)
+
 	dest.Exemplars = CopyExemplarSlice(dest.Exemplars, src.Exemplars)
 
 	dest.Flags = src.Flags
-
-	switch t := src.Min_.(type) {
-	case *HistogramDataPoint_Min:
-		var ov *HistogramDataPoint_Min
-		if !UseProtoPooling.IsEnabled() {
-			ov = &HistogramDataPoint_Min{}
-		} else {
-			ov = ProtoPoolHistogramDataPoint_Min.Get().(*HistogramDataPoint_Min)
-		}
-		ov.Min = t.Min
-		dest.Min_ = ov
-	default:
-		dest.Min_ = nil
+	if src.HasMin() {
+		dest.SetMin(src.Min)
+	} else {
+		dest.RemoveMin()
 	}
 
-	switch t := src.Max_.(type) {
-	case *HistogramDataPoint_Max:
-		var ov *HistogramDataPoint_Max
-		if !UseProtoPooling.IsEnabled() {
-			ov = &HistogramDataPoint_Max{}
-		} else {
-			ov = ProtoPoolHistogramDataPoint_Max.Get().(*HistogramDataPoint_Max)
-		}
-		ov.Max = t.Max
-		dest.Max_ = ov
-	default:
-		dest.Max_ = nil
+	if src.HasMax() {
+		dest.SetMax(src.Max)
+	} else {
+		dest.RemoveMax()
 	}
 
 	return dest
@@ -313,7 +193,7 @@ func (orig *HistogramDataPoint) MarshalJSON(dest *json.Stream) {
 		dest.WriteObjectField("count")
 		dest.WriteUint64(orig.Count)
 	}
-	if orig, ok := orig.Sum_.(*HistogramDataPoint_Sum); ok {
+	if orig.HasSum() {
 		dest.WriteObjectField("sum")
 		dest.WriteFloat64(orig.Sum)
 	}
@@ -327,6 +207,7 @@ func (orig *HistogramDataPoint) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	if len(orig.ExplicitBounds) > 0 {
 		dest.WriteObjectField("explicitBounds")
 		dest.WriteArrayStart()
@@ -337,6 +218,7 @@ func (orig *HistogramDataPoint) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	if len(orig.Exemplars) > 0 {
 		dest.WriteObjectField("exemplars")
 		dest.WriteArrayStart()
@@ -351,11 +233,11 @@ func (orig *HistogramDataPoint) MarshalJSON(dest *json.Stream) {
 		dest.WriteObjectField("flags")
 		dest.WriteUint32(orig.Flags)
 	}
-	if orig, ok := orig.Min_.(*HistogramDataPoint_Min); ok {
+	if orig.HasMin() {
 		dest.WriteObjectField("min")
 		dest.WriteFloat64(orig.Min)
 	}
-	if orig, ok := orig.Max_.(*HistogramDataPoint_Max); ok {
+	if orig.HasMax() {
 		dest.WriteObjectField("max")
 		dest.WriteFloat64(orig.Max)
 	}
@@ -379,16 +261,7 @@ func (orig *HistogramDataPoint) UnmarshalJSON(iter *json.Iterator) {
 		case "count":
 			orig.Count = iter.ReadUint64()
 		case "sum":
-			{
-				var ov *HistogramDataPoint_Sum
-				if !UseProtoPooling.IsEnabled() {
-					ov = &HistogramDataPoint_Sum{}
-				} else {
-					ov = ProtoPoolHistogramDataPoint_Sum.Get().(*HistogramDataPoint_Sum)
-				}
-				ov.Sum = iter.ReadFloat64()
-				orig.Sum_ = ov
-			}
+			orig.SetSum(iter.ReadFloat64())
 
 		case "bucketCounts", "bucket_counts":
 			for iter.ReadArray() {
@@ -409,28 +282,10 @@ func (orig *HistogramDataPoint) UnmarshalJSON(iter *json.Iterator) {
 		case "flags":
 			orig.Flags = iter.ReadUint32()
 		case "min":
-			{
-				var ov *HistogramDataPoint_Min
-				if !UseProtoPooling.IsEnabled() {
-					ov = &HistogramDataPoint_Min{}
-				} else {
-					ov = ProtoPoolHistogramDataPoint_Min.Get().(*HistogramDataPoint_Min)
-				}
-				ov.Min = iter.ReadFloat64()
-				orig.Min_ = ov
-			}
+			orig.SetMin(iter.ReadFloat64())
 
 		case "max":
-			{
-				var ov *HistogramDataPoint_Max
-				if !UseProtoPooling.IsEnabled() {
-					ov = &HistogramDataPoint_Max{}
-				} else {
-					ov = ProtoPoolHistogramDataPoint_Max.Get().(*HistogramDataPoint_Max)
-				}
-				ov.Max = iter.ReadFloat64()
-				orig.Max_ = ov
-			}
+			orig.SetMax(iter.ReadFloat64())
 
 		default:
 			iter.Skip()
@@ -446,17 +301,16 @@ func (orig *HistogramDataPoint) SizeProto() int {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.Count != 0 {
+	if orig.Count != uint64(0) {
 		n += 9
 	}
-	if orig, ok := orig.Sum_.(*HistogramDataPoint_Sum); ok {
-		_ = orig
+	if orig.HasSum() {
 		n += 9
 	}
 	l = len(orig.BucketCounts)
@@ -473,15 +327,13 @@ func (orig *HistogramDataPoint) SizeProto() int {
 		l = orig.Exemplars[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.Flags))
 	}
-	if orig, ok := orig.Min_.(*HistogramDataPoint_Min); ok {
-		_ = orig
+	if orig.HasMin() {
 		n += 9
 	}
-	if orig, ok := orig.Max_.(*HistogramDataPoint_Max); ok {
-		_ = orig
+	if orig.HasMax() {
 		n += 9
 	}
 	return n
@@ -498,25 +350,25 @@ func (orig *HistogramDataPoint) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x4a
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.StartTimeUnixNano))
 		pos--
 		buf[pos] = 0x11
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.TimeUnixNano))
 		pos--
 		buf[pos] = 0x19
 	}
-	if orig.Count != 0 {
+	if orig.Count != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.Count))
 		pos--
 		buf[pos] = 0x21
 	}
-	if orig, ok := orig.Sum_.(*HistogramDataPoint_Sum); ok {
+	if orig.HasSum() {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.Sum))
 		pos--
@@ -549,18 +401,18 @@ func (orig *HistogramDataPoint) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x42
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Flags))
 		pos--
 		buf[pos] = 0x50
 	}
-	if orig, ok := orig.Min_.(*HistogramDataPoint_Min); ok {
+	if orig.HasMin() {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.Min))
 		pos--
 		buf[pos] = 0x59
 	}
-	if orig, ok := orig.Max_.(*HistogramDataPoint_Max); ok {
+	if orig.HasMax() {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.Max))
 		pos--
@@ -645,14 +497,7 @@ func (orig *HistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-			var ov *HistogramDataPoint_Sum
-			if !UseProtoPooling.IsEnabled() {
-				ov = &HistogramDataPoint_Sum{}
-			} else {
-				ov = ProtoPoolHistogramDataPoint_Sum.Get().(*HistogramDataPoint_Sum)
-			}
-			ov.Sum = math.Float64frombits(num)
-			orig.Sum_ = ov
+			orig.SetSum(math.Float64frombits(num))
 		case 6:
 			switch wireType {
 			case proto.WireTypeLen:
@@ -743,7 +588,6 @@ func (orig *HistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Flags = uint32(num)
 
 		case 11:
@@ -755,14 +599,7 @@ func (orig *HistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-			var ov *HistogramDataPoint_Min
-			if !UseProtoPooling.IsEnabled() {
-				ov = &HistogramDataPoint_Min{}
-			} else {
-				ov = ProtoPoolHistogramDataPoint_Min.Get().(*HistogramDataPoint_Min)
-			}
-			ov.Min = math.Float64frombits(num)
-			orig.Min_ = ov
+			orig.SetMin(math.Float64frombits(num))
 
 		case 12:
 			if wireType != proto.WireTypeI64 {
@@ -773,14 +610,7 @@ func (orig *HistogramDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-			var ov *HistogramDataPoint_Max
-			if !UseProtoPooling.IsEnabled() {
-				ov = &HistogramDataPoint_Max{}
-			} else {
-				ov = ProtoPoolHistogramDataPoint_Max.Get().(*HistogramDataPoint_Max)
-			}
-			ov.Max = math.Float64frombits(num)
-			orig.Max_ = ov
+			orig.SetMax(math.Float64frombits(num))
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)
 			if err != nil {
@@ -791,19 +621,70 @@ func (orig *HistogramDataPoint) UnmarshalProto(buf []byte) error {
 	return nil
 }
 
+const fieldBlockHistogramDataPointSum = uint64(0 >> 6)
+const fieldBitHistogramDataPointSum = uint64(1 << 0 & 0x3F)
+
+func (m *HistogramDataPoint) SetSum(value float64) {
+	m.Sum = value
+	m.metadata[fieldBlockHistogramDataPointSum] |= fieldBitHistogramDataPointSum
+}
+
+func (m *HistogramDataPoint) RemoveSum() {
+	m.Sum = float64(0)
+	m.metadata[fieldBlockHistogramDataPointSum] &^= fieldBitHistogramDataPointSum
+}
+
+func (m *HistogramDataPoint) HasSum() bool {
+	return m.metadata[fieldBlockHistogramDataPointSum]&fieldBitHistogramDataPointSum != 0
+}
+
+const fieldBlockHistogramDataPointMin = uint64(1 >> 6)
+const fieldBitHistogramDataPointMin = uint64(1 << 1 & 0x3F)
+
+func (m *HistogramDataPoint) SetMin(value float64) {
+	m.Min = value
+	m.metadata[fieldBlockHistogramDataPointMin] |= fieldBitHistogramDataPointMin
+}
+
+func (m *HistogramDataPoint) RemoveMin() {
+	m.Min = float64(0)
+	m.metadata[fieldBlockHistogramDataPointMin] &^= fieldBitHistogramDataPointMin
+}
+
+func (m *HistogramDataPoint) HasMin() bool {
+	return m.metadata[fieldBlockHistogramDataPointMin]&fieldBitHistogramDataPointMin != 0
+}
+
+const fieldBlockHistogramDataPointMax = uint64(2 >> 6)
+const fieldBitHistogramDataPointMax = uint64(1 << 2 & 0x3F)
+
+func (m *HistogramDataPoint) SetMax(value float64) {
+	m.Max = value
+	m.metadata[fieldBlockHistogramDataPointMax] |= fieldBitHistogramDataPointMax
+}
+
+func (m *HistogramDataPoint) RemoveMax() {
+	m.Max = float64(0)
+	m.metadata[fieldBlockHistogramDataPointMax] &^= fieldBitHistogramDataPointMax
+}
+
+func (m *HistogramDataPoint) HasMax() bool {
+	return m.metadata[fieldBlockHistogramDataPointMax]&fieldBitHistogramDataPointMax != 0
+}
+
 func GenTestHistogramDataPoint() *HistogramDataPoint {
 	orig := NewHistogramDataPoint()
 	orig.Attributes = []KeyValue{{}, *GenTestKeyValue()}
 	orig.StartTimeUnixNano = uint64(13)
 	orig.TimeUnixNano = uint64(13)
 	orig.Count = uint64(13)
-	orig.Sum_ = &HistogramDataPoint_Sum{Sum: float64(3.1415926)}
+	orig.SetSum(float64(3.1415926))
 	orig.BucketCounts = []uint64{uint64(0), uint64(13)}
 	orig.ExplicitBounds = []float64{float64(0), float64(3.1415926)}
 	orig.Exemplars = []Exemplar{{}, *GenTestExemplar()}
 	orig.Flags = uint32(13)
-	orig.Min_ = &HistogramDataPoint_Min{Min: float64(3.1415926)}
-	orig.Max_ = &HistogramDataPoint_Max{Max: float64(3.1415926)}
+	orig.SetMin(float64(3.1415926))
+	orig.SetMax(float64(3.1415926))
 	return orig
 }
 

--- a/pdata/internal/generated_proto_histogramdatapoint_test.go
+++ b/pdata/internal/generated_proto_histogramdatapoint_test.go
@@ -220,13 +220,25 @@ func genTestEncodingValuesHistogramDataPoint() map[string]*HistogramDataPoint {
 		"Attributes/test":        {Attributes: []KeyValue{{}, *GenTestKeyValue()}},
 		"StartTimeUnixNano/test": {StartTimeUnixNano: uint64(13)},
 		"TimeUnixNano/test":      {TimeUnixNano: uint64(13)},
-		"Count/test":             {Count: uint64(13)}, "Sum/default": {Sum_: &HistogramDataPoint_Sum{Sum: float64(0)}},
-		"Sum/test":            {Sum_: &HistogramDataPoint_Sum{Sum: float64(3.1415926)}},
+		"Count/test":             {Count: uint64(13)},
+		"Sum/test": func() *HistogramDataPoint {
+			ms := NewHistogramDataPoint()
+			ms.SetSum(float64(3.1415926))
+			return ms
+		}(),
 		"BucketCounts/test":   {BucketCounts: []uint64{uint64(0), uint64(13)}},
 		"ExplicitBounds/test": {ExplicitBounds: []float64{float64(0), float64(3.1415926)}},
 		"Exemplars/test":      {Exemplars: []Exemplar{{}, *GenTestExemplar()}},
-		"Flags/test":          {Flags: uint32(13)}, "Min/default": {Min_: &HistogramDataPoint_Min{Min: float64(0)}},
-		"Min/test": {Min_: &HistogramDataPoint_Min{Min: float64(3.1415926)}}, "Max/default": {Max_: &HistogramDataPoint_Max{Max: float64(0)}},
-		"Max/test": {Max_: &HistogramDataPoint_Max{Max: float64(3.1415926)}},
+		"Flags/test":          {Flags: uint32(13)},
+		"Min/test": func() *HistogramDataPoint {
+			ms := NewHistogramDataPoint()
+			ms.SetMin(float64(3.1415926))
+			return ms
+		}(),
+		"Max/test": func() *HistogramDataPoint {
+			ms := NewHistogramDataPoint()
+			ms.SetMax(float64(3.1415926))
+			return ms
+		}(),
 	}
 }

--- a/pdata/internal/generated_proto_instrumentationscope.go
+++ b/pdata/internal/generated_proto_instrumentationscope.go
@@ -71,9 +71,7 @@ func CopyInstrumentationScope(dest, src *InstrumentationScope) *InstrumentationS
 		dest = NewInstrumentationScope()
 	}
 	dest.Name = src.Name
-
 	dest.Version = src.Version
-
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.DroppedAttributesCount = src.DroppedAttributesCount
@@ -187,10 +185,12 @@ func (orig *InstrumentationScope) SizeProto() int {
 	var n int
 	var l int
 	_ = l
+
 	l = len(orig.Name)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.Version)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -199,7 +199,7 @@ func (orig *InstrumentationScope) SizeProto() int {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.DroppedAttributesCount))
 	}
 	return n
@@ -232,7 +232,7 @@ func (orig *InstrumentationScope) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x1a
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DroppedAttributesCount))
 		pos--
 		buf[pos] = 0x20
@@ -304,7 +304,6 @@ func (orig *InstrumentationScope) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DroppedAttributesCount = uint32(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_ipaddr.go
+++ b/pdata/internal/generated_proto_ipaddr.go
@@ -64,7 +64,6 @@ func CopyIPAddr(dest, src *IPAddr) *IPAddr {
 		dest = NewIPAddr()
 	}
 	dest.IP = src.IP
-
 	dest.Zone = src.Zone
 
 	return dest
@@ -155,10 +154,12 @@ func (orig *IPAddr) SizeProto() int {
 	var n int
 	var l int
 	_ = l
+
 	l = len(orig.IP)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.Zone)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_keyvalue.go
+++ b/pdata/internal/generated_proto_keyvalue.go
@@ -66,7 +66,6 @@ func CopyKeyValue(dest, src *KeyValue) *KeyValue {
 		dest = NewKeyValue()
 	}
 	dest.Key = src.Key
-
 	CopyAnyValue(&dest.Value, &src.Value)
 
 	return dest
@@ -155,6 +154,7 @@ func (orig *KeyValue) SizeProto() int {
 	var n int
 	var l int
 	_ = l
+
 	l = len(orig.Key)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_keyvalueandunit.go
+++ b/pdata/internal/generated_proto_keyvalueandunit.go
@@ -70,7 +70,6 @@ func CopyKeyValueAndUnit(dest, src *KeyValueAndUnit) *KeyValueAndUnit {
 		dest = NewKeyValueAndUnit()
 	}
 	dest.KeyStrindex = src.KeyStrindex
-
 	CopyAnyValue(&dest.Value, &src.Value)
 
 	dest.UnitStrindex = src.UnitStrindex
@@ -167,12 +166,12 @@ func (orig *KeyValueAndUnit) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.KeyStrindex != 0 {
+	if orig.KeyStrindex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.KeyStrindex))
 	}
 	l = orig.Value.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.UnitStrindex != 0 {
+	if orig.UnitStrindex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.UnitStrindex))
 	}
 	return n
@@ -182,7 +181,7 @@ func (orig *KeyValueAndUnit) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.KeyStrindex != 0 {
+	if orig.KeyStrindex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.KeyStrindex))
 		pos--
 		buf[pos] = 0x8
@@ -193,7 +192,7 @@ func (orig *KeyValueAndUnit) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x12
 
-	if orig.UnitStrindex != 0 {
+	if orig.UnitStrindex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.UnitStrindex))
 		pos--
 		buf[pos] = 0x18
@@ -225,7 +224,6 @@ func (orig *KeyValueAndUnit) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.KeyStrindex = int32(num)
 
 		case 2:
@@ -253,7 +251,6 @@ func (orig *KeyValueAndUnit) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.UnitStrindex = int32(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_line.go
+++ b/pdata/internal/generated_proto_line.go
@@ -66,9 +66,7 @@ func CopyLine(dest, src *Line) *Line {
 		dest = NewLine()
 	}
 	dest.FunctionIndex = src.FunctionIndex
-
 	dest.Line = src.Line
-
 	dest.Column = src.Column
 
 	return dest
@@ -164,13 +162,13 @@ func (orig *Line) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.FunctionIndex != 0 {
+	if orig.FunctionIndex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.FunctionIndex))
 	}
-	if orig.Line != 0 {
+	if orig.Line != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.Line))
 	}
-	if orig.Column != 0 {
+	if orig.Column != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.Column))
 	}
 	return n
@@ -180,17 +178,17 @@ func (orig *Line) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.FunctionIndex != 0 {
+	if orig.FunctionIndex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.FunctionIndex))
 		pos--
 		buf[pos] = 0x8
 	}
-	if orig.Line != 0 {
+	if orig.Line != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Line))
 		pos--
 		buf[pos] = 0x10
 	}
-	if orig.Column != 0 {
+	if orig.Column != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Column))
 		pos--
 		buf[pos] = 0x18
@@ -222,7 +220,6 @@ func (orig *Line) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.FunctionIndex = int32(num)
 
 		case 2:
@@ -234,7 +231,6 @@ func (orig *Line) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Line = int64(num)
 
 		case 3:
@@ -246,7 +242,6 @@ func (orig *Line) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Column = int64(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_location.go
+++ b/pdata/internal/generated_proto_location.go
@@ -71,9 +71,7 @@ func CopyLocation(dest, src *Location) *Location {
 		dest = NewLocation()
 	}
 	dest.MappingIndex = src.MappingIndex
-
 	dest.Address = src.Address
-
 	dest.Lines = CopyLinePtrSlice(dest.Lines, src.Lines)
 
 	dest.AttributeIndices = append(dest.AttributeIndices[:0], src.AttributeIndices...)
@@ -164,6 +162,7 @@ func (orig *Location) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	dest.WriteObjectEnd()
 }
 
@@ -196,10 +195,10 @@ func (orig *Location) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.MappingIndex != 0 {
+	if orig.MappingIndex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.MappingIndex))
 	}
-	if orig.Address != 0 {
+	if orig.Address != uint64(0) {
 		n += 1 + proto.Sov(uint64(orig.Address))
 	}
 	for i := range orig.Lines {
@@ -220,12 +219,12 @@ func (orig *Location) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.MappingIndex != 0 {
+	if orig.MappingIndex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.MappingIndex))
 		pos--
 		buf[pos] = 0x8
 	}
-	if orig.Address != 0 {
+	if orig.Address != uint64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Address))
 		pos--
 		buf[pos] = 0x10
@@ -274,7 +273,6 @@ func (orig *Location) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.MappingIndex = int32(num)
 
 		case 2:
@@ -286,7 +284,6 @@ func (orig *Location) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Address = uint64(num)
 
 		case 3:

--- a/pdata/internal/generated_proto_logrecord.go
+++ b/pdata/internal/generated_proto_logrecord.go
@@ -83,21 +83,15 @@ func CopyLogRecord(dest, src *LogRecord) *LogRecord {
 		dest = NewLogRecord()
 	}
 	dest.TimeUnixNano = src.TimeUnixNano
-
 	dest.ObservedTimeUnixNano = src.ObservedTimeUnixNano
-
 	dest.SeverityNumber = src.SeverityNumber
-
 	dest.SeverityText = src.SeverityText
-
 	CopyAnyValue(&dest.Body, &src.Body)
 
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.DroppedAttributesCount = src.DroppedAttributesCount
-
 	dest.Flags = src.Flags
-
 	CopyTraceID(&dest.TraceId, &src.TraceId)
 
 	CopySpanID(&dest.SpanId, &src.SpanId)
@@ -257,15 +251,16 @@ func (orig *LogRecord) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.ObservedTimeUnixNano != 0 {
+	if orig.ObservedTimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.SeverityNumber != 0 {
+	if orig.SeverityNumber != SeverityNumber(0) {
 		n += 1 + proto.Sov(uint64(orig.SeverityNumber))
 	}
+
 	l = len(orig.SeverityText)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -276,16 +271,17 @@ func (orig *LogRecord) SizeProto() int {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.DroppedAttributesCount))
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		n += 5
 	}
 	l = orig.TraceId.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
 	l = orig.SpanId.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
+
 	l = len(orig.EventName)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -297,19 +293,19 @@ func (orig *LogRecord) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.TimeUnixNano))
 		pos--
 		buf[pos] = 0x9
 	}
-	if orig.ObservedTimeUnixNano != 0 {
+	if orig.ObservedTimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.ObservedTimeUnixNano))
 		pos--
 		buf[pos] = 0x59
 	}
-	if orig.SeverityNumber != 0 {
+	if orig.SeverityNumber != SeverityNumber(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.SeverityNumber))
 		pos--
 		buf[pos] = 0x10
@@ -335,12 +331,12 @@ func (orig *LogRecord) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x32
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DroppedAttributesCount))
 		pos--
 		buf[pos] = 0x38
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		pos -= 4
 		binary.LittleEndian.PutUint32(buf[pos:], uint32(orig.Flags))
 		pos--
@@ -417,7 +413,6 @@ func (orig *LogRecord) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.SeverityNumber = SeverityNumber(num)
 
 		case 3:
@@ -473,7 +468,6 @@ func (orig *LogRecord) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DroppedAttributesCount = uint32(num)
 
 		case 8:

--- a/pdata/internal/generated_proto_logsrequest.go
+++ b/pdata/internal/generated_proto_logsrequest.go
@@ -173,7 +173,7 @@ func (orig *LogsRequest) SizeProto() int {
 	}
 	l = orig.LogsData.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.FormatVersion != 0 {
+	if orig.FormatVersion != uint32(0) {
 		n += 5
 	}
 	return n
@@ -196,7 +196,7 @@ func (orig *LogsRequest) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x1a
 
-	if orig.FormatVersion != 0 {
+	if orig.FormatVersion != uint32(0) {
 		pos -= 4
 		binary.LittleEndian.PutUint32(buf[pos:], uint32(orig.FormatVersion))
 		pos--

--- a/pdata/internal/generated_proto_mapping.go
+++ b/pdata/internal/generated_proto_mapping.go
@@ -68,13 +68,9 @@ func CopyMapping(dest, src *Mapping) *Mapping {
 		dest = NewMapping()
 	}
 	dest.MemoryStart = src.MemoryStart
-
 	dest.MemoryLimit = src.MemoryLimit
-
 	dest.FileOffset = src.FileOffset
-
 	dest.FilenameStrindex = src.FilenameStrindex
-
 	dest.AttributeIndices = append(dest.AttributeIndices[:0], src.AttributeIndices...)
 
 	return dest
@@ -161,6 +157,7 @@ func (orig *Mapping) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	dest.WriteObjectEnd()
 }
 
@@ -191,16 +188,16 @@ func (orig *Mapping) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.MemoryStart != 0 {
+	if orig.MemoryStart != uint64(0) {
 		n += 1 + proto.Sov(uint64(orig.MemoryStart))
 	}
-	if orig.MemoryLimit != 0 {
+	if orig.MemoryLimit != uint64(0) {
 		n += 1 + proto.Sov(uint64(orig.MemoryLimit))
 	}
-	if orig.FileOffset != 0 {
+	if orig.FileOffset != uint64(0) {
 		n += 1 + proto.Sov(uint64(orig.FileOffset))
 	}
-	if orig.FilenameStrindex != 0 {
+	if orig.FilenameStrindex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.FilenameStrindex))
 	}
 	if len(orig.AttributeIndices) > 0 {
@@ -217,22 +214,22 @@ func (orig *Mapping) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.MemoryStart != 0 {
+	if orig.MemoryStart != uint64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.MemoryStart))
 		pos--
 		buf[pos] = 0x8
 	}
-	if orig.MemoryLimit != 0 {
+	if orig.MemoryLimit != uint64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.MemoryLimit))
 		pos--
 		buf[pos] = 0x10
 	}
-	if orig.FileOffset != 0 {
+	if orig.FileOffset != uint64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.FileOffset))
 		pos--
 		buf[pos] = 0x18
 	}
-	if orig.FilenameStrindex != 0 {
+	if orig.FilenameStrindex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.FilenameStrindex))
 		pos--
 		buf[pos] = 0x20
@@ -274,7 +271,6 @@ func (orig *Mapping) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.MemoryStart = uint64(num)
 
 		case 2:
@@ -286,7 +282,6 @@ func (orig *Mapping) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.MemoryLimit = uint64(num)
 
 		case 3:
@@ -298,7 +293,6 @@ func (orig *Mapping) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.FileOffset = uint64(num)
 
 		case 4:
@@ -310,7 +304,6 @@ func (orig *Mapping) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.FilenameStrindex = int32(num)
 		case 5:
 			switch wireType {

--- a/pdata/internal/generated_proto_metric.go
+++ b/pdata/internal/generated_proto_metric.go
@@ -188,11 +188,8 @@ func CopyMetric(dest, src *Metric) *Metric {
 		dest = NewMetric()
 	}
 	dest.Name = src.Name
-
 	dest.Description = src.Description
-
 	dest.Unit = src.Unit
-
 	switch t := src.Data.(type) {
 	case *Metric_Gauge:
 		var ov *Metric_Gauge
@@ -456,14 +453,17 @@ func (orig *Metric) SizeProto() int {
 	var n int
 	var l int
 	_ = l
+
 	l = len(orig.Name)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.Description)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.Unit)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_metricsrequest.go
+++ b/pdata/internal/generated_proto_metricsrequest.go
@@ -173,7 +173,7 @@ func (orig *MetricsRequest) SizeProto() int {
 	}
 	l = orig.MetricsData.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.FormatVersion != 0 {
+	if orig.FormatVersion != uint32(0) {
 		n += 5
 	}
 	return n
@@ -196,7 +196,7 @@ func (orig *MetricsRequest) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x1a
 
-	if orig.FormatVersion != 0 {
+	if orig.FormatVersion != uint32(0) {
 		pos -= 4
 		binary.LittleEndian.PutUint32(buf[pos:], uint32(orig.FormatVersion))
 		pos--

--- a/pdata/internal/generated_proto_numberdatapoint.go
+++ b/pdata/internal/generated_proto_numberdatapoint.go
@@ -134,9 +134,7 @@ func CopyNumberDataPoint(dest, src *NumberDataPoint) *NumberDataPoint {
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.StartTimeUnixNano = src.StartTimeUnixNano
-
 	dest.TimeUnixNano = src.TimeUnixNano
-
 	switch t := src.Value.(type) {
 	case *NumberDataPoint_AsDouble:
 		var ov *NumberDataPoint_AsDouble
@@ -147,6 +145,7 @@ func CopyNumberDataPoint(dest, src *NumberDataPoint) *NumberDataPoint {
 		}
 		ov.AsDouble = t.AsDouble
 		dest.Value = ov
+
 	case *NumberDataPoint_AsInt:
 		var ov *NumberDataPoint_AsInt
 		if !UseProtoPooling.IsEnabled() {
@@ -156,6 +155,7 @@ func CopyNumberDataPoint(dest, src *NumberDataPoint) *NumberDataPoint {
 		}
 		ov.AsInt = t.AsInt
 		dest.Value = ov
+
 	default:
 		dest.Value = nil
 	}
@@ -325,10 +325,10 @@ func (orig *NumberDataPoint) SizeProto() int {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		n += 9
 	}
 	switch orig := orig.Value.(type) {
@@ -344,7 +344,7 @@ func (orig *NumberDataPoint) SizeProto() int {
 		l = orig.Exemplars[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.Flags))
 	}
 	return n
@@ -361,13 +361,13 @@ func (orig *NumberDataPoint) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x3a
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.StartTimeUnixNano))
 		pos--
 		buf[pos] = 0x11
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.TimeUnixNano))
 		pos--
@@ -394,7 +394,7 @@ func (orig *NumberDataPoint) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x2a
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Flags))
 		pos--
 		buf[pos] = 0x40
@@ -518,7 +518,6 @@ func (orig *NumberDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Flags = uint32(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_profile.go
+++ b/pdata/internal/generated_proto_profile.go
@@ -87,21 +87,15 @@ func CopyProfile(dest, src *Profile) *Profile {
 	dest.Samples = CopySamplePtrSlice(dest.Samples, src.Samples)
 
 	dest.TimeUnixNano = src.TimeUnixNano
-
 	dest.DurationNano = src.DurationNano
-
 	CopyValueType(&dest.PeriodType, &src.PeriodType)
 
 	dest.Period = src.Period
-
 	CopyProfileID(&dest.ProfileId, &src.ProfileId)
 
 	dest.DroppedAttributesCount = src.DroppedAttributesCount
-
 	dest.OriginalPayloadFormat = src.OriginalPayloadFormat
-
 	dest.OriginalPayload = src.OriginalPayload
-
 	dest.AttributeIndices = append(dest.AttributeIndices[:0], src.AttributeIndices...)
 
 	return dest
@@ -215,6 +209,7 @@ func (orig *Profile) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	dest.WriteObjectEnd()
 }
 
@@ -270,26 +265,28 @@ func (orig *Profile) SizeProto() int {
 		l = orig.Samples[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.DurationNano != 0 {
+	if orig.DurationNano != uint64(0) {
 		n += 1 + proto.Sov(uint64(orig.DurationNano))
 	}
 	l = orig.PeriodType.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.Period != 0 {
+	if orig.Period != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.Period))
 	}
 	l = orig.ProfileId.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.DroppedAttributesCount))
 	}
+
 	l = len(orig.OriginalPayloadFormat)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.OriginalPayload)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -321,13 +318,13 @@ func (orig *Profile) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x12
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.TimeUnixNano))
 		pos--
 		buf[pos] = 0x19
 	}
-	if orig.DurationNano != 0 {
+	if orig.DurationNano != uint64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DurationNano))
 		pos--
 		buf[pos] = 0x20
@@ -338,7 +335,7 @@ func (orig *Profile) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x2a
 
-	if orig.Period != 0 {
+	if orig.Period != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Period))
 		pos--
 		buf[pos] = 0x30
@@ -349,7 +346,7 @@ func (orig *Profile) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x3a
 
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DroppedAttributesCount))
 		pos--
 		buf[pos] = 0x40
@@ -451,7 +448,6 @@ func (orig *Profile) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DurationNano = uint64(num)
 
 		case 5:
@@ -479,7 +475,6 @@ func (orig *Profile) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Period = int64(num)
 
 		case 7:
@@ -507,7 +502,6 @@ func (orig *Profile) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DroppedAttributesCount = uint32(num)
 
 		case 9:

--- a/pdata/internal/generated_proto_profilesdictionary.go
+++ b/pdata/internal/generated_proto_profilesdictionary.go
@@ -97,6 +97,7 @@ func CopyProfilesDictionary(dest, src *ProfilesDictionary) *ProfilesDictionary {
 	dest.LinkTable = CopyLinkPtrSlice(dest.LinkTable, src.LinkTable)
 
 	dest.StringTable = append(dest.StringTable[:0], src.StringTable...)
+
 	dest.AttributeTable = CopyKeyValueAndUnitPtrSlice(dest.AttributeTable, src.AttributeTable)
 
 	dest.StackTable = CopyStackPtrSlice(dest.StackTable, src.StackTable)
@@ -209,6 +210,7 @@ func (orig *ProfilesDictionary) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	if len(orig.AttributeTable) > 0 {
 		dest.WriteObjectField("attributeTable")
 		dest.WriteArrayStart()

--- a/pdata/internal/generated_proto_profilesrequest.go
+++ b/pdata/internal/generated_proto_profilesrequest.go
@@ -173,7 +173,7 @@ func (orig *ProfilesRequest) SizeProto() int {
 	}
 	l = orig.ProfilesData.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.FormatVersion != 0 {
+	if orig.FormatVersion != uint32(0) {
 		n += 5
 	}
 	return n
@@ -196,7 +196,7 @@ func (orig *ProfilesRequest) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x1a
 
-	if orig.FormatVersion != 0 {
+	if orig.FormatVersion != uint32(0) {
 		pos -= 4
 		binary.LittleEndian.PutUint32(buf[pos:], uint32(orig.FormatVersion))
 		pos--

--- a/pdata/internal/generated_proto_resource.go
+++ b/pdata/internal/generated_proto_resource.go
@@ -75,7 +75,6 @@ func CopyResource(dest, src *Resource) *Resource {
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.DroppedAttributesCount = src.DroppedAttributesCount
-
 	dest.EntityRefs = CopyEntityRefPtrSlice(dest.EntityRefs, src.EntityRefs)
 
 	return dest
@@ -195,7 +194,7 @@ func (orig *Resource) SizeProto() int {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.DroppedAttributesCount))
 	}
 	for i := range orig.EntityRefs {
@@ -216,7 +215,7 @@ func (orig *Resource) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0xa
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DroppedAttributesCount))
 		pos--
 		buf[pos] = 0x10
@@ -271,7 +270,6 @@ func (orig *Resource) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DroppedAttributesCount = uint32(num)
 
 		case 3:

--- a/pdata/internal/generated_proto_resourcelogs.go
+++ b/pdata/internal/generated_proto_resourcelogs.go
@@ -79,7 +79,6 @@ func CopyResourceLogs(dest, src *ResourceLogs) *ResourceLogs {
 	dest.ScopeLogs = CopyScopeLogsPtrSlice(dest.ScopeLogs, src.ScopeLogs)
 
 	dest.SchemaUrl = src.SchemaUrl
-
 	dest.DeprecatedScopeLogs = CopyScopeLogsPtrSlice(dest.DeprecatedScopeLogs, src.DeprecatedScopeLogs)
 
 	return dest
@@ -206,6 +205,7 @@ func (orig *ResourceLogs) SizeProto() int {
 		l = orig.ScopeLogs[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.SchemaUrl)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_resourcemetrics.go
+++ b/pdata/internal/generated_proto_resourcemetrics.go
@@ -79,7 +79,6 @@ func CopyResourceMetrics(dest, src *ResourceMetrics) *ResourceMetrics {
 	dest.ScopeMetrics = CopyScopeMetricsPtrSlice(dest.ScopeMetrics, src.ScopeMetrics)
 
 	dest.SchemaUrl = src.SchemaUrl
-
 	dest.DeprecatedScopeMetrics = CopyScopeMetricsPtrSlice(dest.DeprecatedScopeMetrics, src.DeprecatedScopeMetrics)
 
 	return dest
@@ -206,6 +205,7 @@ func (orig *ResourceMetrics) SizeProto() int {
 		l = orig.ScopeMetrics[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.SchemaUrl)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_resourceprofiles.go
+++ b/pdata/internal/generated_proto_resourceprofiles.go
@@ -184,6 +184,7 @@ func (orig *ResourceProfiles) SizeProto() int {
 		l = orig.ScopeProfiles[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.SchemaUrl)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_resourcespans.go
+++ b/pdata/internal/generated_proto_resourcespans.go
@@ -79,7 +79,6 @@ func CopyResourceSpans(dest, src *ResourceSpans) *ResourceSpans {
 	dest.ScopeSpans = CopyScopeSpansPtrSlice(dest.ScopeSpans, src.ScopeSpans)
 
 	dest.SchemaUrl = src.SchemaUrl
-
 	dest.DeprecatedScopeSpans = CopyScopeSpansPtrSlice(dest.DeprecatedScopeSpans, src.DeprecatedScopeSpans)
 
 	return dest
@@ -206,6 +205,7 @@ func (orig *ResourceSpans) SizeProto() int {
 		l = orig.ScopeSpans[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.SchemaUrl)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_sample.go
+++ b/pdata/internal/generated_proto_sample.go
@@ -69,11 +69,11 @@ func CopySample(dest, src *Sample) *Sample {
 		dest = NewSample()
 	}
 	dest.StackIndex = src.StackIndex
-
 	dest.Values = append(dest.Values[:0], src.Values...)
-	dest.AttributeIndices = append(dest.AttributeIndices[:0], src.AttributeIndices...)
-	dest.LinkIndex = src.LinkIndex
 
+	dest.AttributeIndices = append(dest.AttributeIndices[:0], src.AttributeIndices...)
+
+	dest.LinkIndex = src.LinkIndex
 	dest.TimestampsUnixNano = append(dest.TimestampsUnixNano[:0], src.TimestampsUnixNano...)
 
 	return dest
@@ -148,6 +148,7 @@ func (orig *Sample) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	if len(orig.AttributeIndices) > 0 {
 		dest.WriteObjectField("attributeIndices")
 		dest.WriteArrayStart()
@@ -158,6 +159,7 @@ func (orig *Sample) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	if orig.LinkIndex != int32(0) {
 		dest.WriteObjectField("linkIndex")
 		dest.WriteInt32(orig.LinkIndex)
@@ -172,6 +174,7 @@ func (orig *Sample) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	dest.WriteObjectEnd()
 }
 
@@ -208,7 +211,7 @@ func (orig *Sample) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.StackIndex != 0 {
+	if orig.StackIndex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.StackIndex))
 	}
 	if len(orig.Values) > 0 {
@@ -225,7 +228,7 @@ func (orig *Sample) SizeProto() int {
 		}
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.LinkIndex != 0 {
+	if orig.LinkIndex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.LinkIndex))
 	}
 	l = len(orig.TimestampsUnixNano)
@@ -240,7 +243,7 @@ func (orig *Sample) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.StackIndex != 0 {
+	if orig.StackIndex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.StackIndex))
 		pos--
 		buf[pos] = 0x8
@@ -265,7 +268,7 @@ func (orig *Sample) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x1a
 	}
-	if orig.LinkIndex != 0 {
+	if orig.LinkIndex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.LinkIndex))
 		pos--
 		buf[pos] = 0x20
@@ -307,7 +310,6 @@ func (orig *Sample) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.StackIndex = int32(num)
 		case 2:
 			switch wireType {
@@ -379,7 +381,6 @@ func (orig *Sample) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.LinkIndex = int32(num)
 		case 5:
 			switch wireType {

--- a/pdata/internal/generated_proto_scopelogs.go
+++ b/pdata/internal/generated_proto_scopelogs.go
@@ -184,6 +184,7 @@ func (orig *ScopeLogs) SizeProto() int {
 		l = orig.LogRecords[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.SchemaUrl)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_scopemetrics.go
+++ b/pdata/internal/generated_proto_scopemetrics.go
@@ -184,6 +184,7 @@ func (orig *ScopeMetrics) SizeProto() int {
 		l = orig.Metrics[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.SchemaUrl)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_scopeprofiles.go
+++ b/pdata/internal/generated_proto_scopeprofiles.go
@@ -184,6 +184,7 @@ func (orig *ScopeProfiles) SizeProto() int {
 		l = orig.Profiles[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.SchemaUrl)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_scopespans.go
+++ b/pdata/internal/generated_proto_scopespans.go
@@ -184,6 +184,7 @@ func (orig *ScopeSpans) SizeProto() int {
 		l = orig.Spans[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.SchemaUrl)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_span.go
+++ b/pdata/internal/generated_proto_span.go
@@ -99,31 +99,22 @@ func CopySpan(dest, src *Span) *Span {
 	CopySpanID(&dest.SpanId, &src.SpanId)
 
 	dest.TraceState = src.TraceState
-
 	CopySpanID(&dest.ParentSpanId, &src.ParentSpanId)
 
 	dest.Flags = src.Flags
-
 	dest.Name = src.Name
-
 	dest.Kind = src.Kind
-
 	dest.StartTimeUnixNano = src.StartTimeUnixNano
-
 	dest.EndTimeUnixNano = src.EndTimeUnixNano
-
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.DroppedAttributesCount = src.DroppedAttributesCount
-
 	dest.Events = CopySpanEventPtrSlice(dest.Events, src.Events)
 
 	dest.DroppedEventsCount = src.DroppedEventsCount
-
 	dest.Links = CopySpanLinkPtrSlice(dest.Links, src.Links)
 
 	dest.DroppedLinksCount = src.DroppedLinksCount
-
 	CopyStatus(&dest.Status, &src.Status)
 
 	return dest
@@ -334,47 +325,49 @@ func (orig *Span) SizeProto() int {
 	n += 1 + proto.Sov(uint64(l)) + l
 	l = orig.SpanId.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
+
 	l = len(orig.TraceState)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
 	l = orig.ParentSpanId.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		n += 6
 	}
+
 	l = len(orig.Name)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.Kind != 0 {
+	if orig.Kind != SpanKind(0) {
 		n += 1 + proto.Sov(uint64(orig.Kind))
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.EndTimeUnixNano != 0 {
+	if orig.EndTimeUnixNano != uint64(0) {
 		n += 9
 	}
 	for i := range orig.Attributes {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.DroppedAttributesCount))
 	}
 	for i := range orig.Events {
 		l = orig.Events[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.DroppedEventsCount != 0 {
+	if orig.DroppedEventsCount != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.DroppedEventsCount))
 	}
 	for i := range orig.Links {
 		l = orig.Links[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.DroppedLinksCount != 0 {
+	if orig.DroppedLinksCount != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.DroppedLinksCount))
 	}
 	l = orig.Status.SizeProto()
@@ -412,7 +405,7 @@ func (orig *Span) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x22
 
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		pos -= 4
 		binary.LittleEndian.PutUint32(buf[pos:], uint32(orig.Flags))
 		pos--
@@ -428,18 +421,18 @@ func (orig *Span) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x2a
 	}
-	if orig.Kind != 0 {
+	if orig.Kind != SpanKind(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Kind))
 		pos--
 		buf[pos] = 0x30
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.StartTimeUnixNano))
 		pos--
 		buf[pos] = 0x39
 	}
-	if orig.EndTimeUnixNano != 0 {
+	if orig.EndTimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.EndTimeUnixNano))
 		pos--
@@ -452,7 +445,7 @@ func (orig *Span) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x4a
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DroppedAttributesCount))
 		pos--
 		buf[pos] = 0x50
@@ -464,7 +457,7 @@ func (orig *Span) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x5a
 	}
-	if orig.DroppedEventsCount != 0 {
+	if orig.DroppedEventsCount != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DroppedEventsCount))
 		pos--
 		buf[pos] = 0x60
@@ -476,7 +469,7 @@ func (orig *Span) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x6a
 	}
-	if orig.DroppedLinksCount != 0 {
+	if orig.DroppedLinksCount != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DroppedLinksCount))
 		pos--
 		buf[pos] = 0x70
@@ -598,7 +591,6 @@ func (orig *Span) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Kind = SpanKind(num)
 
 		case 7:
@@ -650,7 +642,6 @@ func (orig *Span) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DroppedAttributesCount = uint32(num)
 
 		case 11:
@@ -678,7 +669,6 @@ func (orig *Span) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DroppedEventsCount = uint32(num)
 
 		case 13:
@@ -706,7 +696,6 @@ func (orig *Span) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DroppedLinksCount = uint32(num)
 
 		case 15:

--- a/pdata/internal/generated_proto_spancontext.go
+++ b/pdata/internal/generated_proto_spancontext.go
@@ -75,9 +75,7 @@ func CopySpanContext(dest, src *SpanContext) *SpanContext {
 	CopySpanID(&dest.SpanID, &src.SpanID)
 
 	dest.TraceFlags = src.TraceFlags
-
 	dest.TraceState = src.TraceState
-
 	dest.Remote = src.Remote
 
 	return dest
@@ -191,14 +189,15 @@ func (orig *SpanContext) SizeProto() int {
 	n += 1 + proto.Sov(uint64(l)) + l
 	l = orig.SpanID.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.TraceFlags != 0 {
+	if orig.TraceFlags != uint32(0) {
 		n += 5
 	}
+
 	l = len(orig.TraceState)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.Remote {
+	if orig.Remote != false {
 		n += 2
 	}
 	return n
@@ -220,7 +219,7 @@ func (orig *SpanContext) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x12
 
-	if orig.TraceFlags != 0 {
+	if orig.TraceFlags != uint32(0) {
 		pos -= 4
 		binary.LittleEndian.PutUint32(buf[pos:], uint32(orig.TraceFlags))
 		pos--
@@ -234,7 +233,7 @@ func (orig *SpanContext) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x22
 	}
-	if orig.Remote {
+	if orig.Remote != false {
 		pos--
 		if orig.Remote {
 			buf[pos] = 1
@@ -327,7 +326,6 @@ func (orig *SpanContext) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Remote = num != 0
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_spanevent.go
+++ b/pdata/internal/generated_proto_spanevent.go
@@ -73,9 +73,7 @@ func CopySpanEvent(dest, src *SpanEvent) *SpanEvent {
 		dest = NewSpanEvent()
 	}
 	dest.TimeUnixNano = src.TimeUnixNano
-
 	dest.Name = src.Name
-
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.DroppedAttributesCount = src.DroppedAttributesCount
@@ -189,9 +187,10 @@ func (orig *SpanEvent) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		n += 9
 	}
+
 	l = len(orig.Name)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -200,7 +199,7 @@ func (orig *SpanEvent) SizeProto() int {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.DroppedAttributesCount))
 	}
 	return n
@@ -210,7 +209,7 @@ func (orig *SpanEvent) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.TimeUnixNano))
 		pos--
@@ -231,7 +230,7 @@ func (orig *SpanEvent) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x1a
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DroppedAttributesCount))
 		pos--
 		buf[pos] = 0x20
@@ -303,7 +302,6 @@ func (orig *SpanEvent) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DroppedAttributesCount = uint32(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_spanlink.go
+++ b/pdata/internal/generated_proto_spanlink.go
@@ -82,11 +82,9 @@ func CopySpanLink(dest, src *SpanLink) *SpanLink {
 	CopySpanID(&dest.SpanId, &src.SpanId)
 
 	dest.TraceState = src.TraceState
-
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.DroppedAttributesCount = src.DroppedAttributesCount
-
 	dest.Flags = src.Flags
 
 	return dest
@@ -216,6 +214,7 @@ func (orig *SpanLink) SizeProto() int {
 	n += 1 + proto.Sov(uint64(l)) + l
 	l = orig.SpanId.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
+
 	l = len(orig.TraceState)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -224,10 +223,10 @@ func (orig *SpanLink) SizeProto() int {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.DroppedAttributesCount))
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		n += 5
 	}
 	return n
@@ -264,12 +263,12 @@ func (orig *SpanLink) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x22
 	}
-	if orig.DroppedAttributesCount != 0 {
+	if orig.DroppedAttributesCount != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.DroppedAttributesCount))
 		pos--
 		buf[pos] = 0x28
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		pos -= 4
 		binary.LittleEndian.PutUint32(buf[pos:], uint32(orig.Flags))
 		pos--
@@ -362,7 +361,6 @@ func (orig *SpanLink) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.DroppedAttributesCount = uint32(num)
 
 		case 6:

--- a/pdata/internal/generated_proto_stack.go
+++ b/pdata/internal/generated_proto_stack.go
@@ -134,6 +134,7 @@ func (orig *Stack) MarshalJSON(dest *json.Stream) {
 		}
 		dest.WriteArrayEnd()
 	}
+
 	dest.WriteObjectEnd()
 }
 

--- a/pdata/internal/generated_proto_status.go
+++ b/pdata/internal/generated_proto_status.go
@@ -66,7 +66,6 @@ func CopyStatus(dest, src *Status) *Status {
 		dest = NewStatus()
 	}
 	dest.Message = src.Message
-
 	dest.Code = src.Code
 
 	return dest
@@ -157,11 +156,12 @@ func (orig *Status) SizeProto() int {
 	var n int
 	var l int
 	_ = l
+
 	l = len(orig.Message)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.Code != 0 {
+	if orig.Code != StatusCode(0) {
 		n += 1 + proto.Sov(uint64(orig.Code))
 	}
 	return n
@@ -179,7 +179,7 @@ func (orig *Status) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x12
 	}
-	if orig.Code != 0 {
+	if orig.Code != StatusCode(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Code))
 		pos--
 		buf[pos] = 0x18
@@ -223,7 +223,6 @@ func (orig *Status) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Code = StatusCode(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_sum.go
+++ b/pdata/internal/generated_proto_sum.go
@@ -72,7 +72,6 @@ func CopySum(dest, src *Sum) *Sum {
 	dest.DataPoints = CopyNumberDataPointPtrSlice(dest.DataPoints, src.DataPoints)
 
 	dest.AggregationTemporality = src.AggregationTemporality
-
 	dest.IsMonotonic = src.IsMonotonic
 
 	return dest
@@ -183,10 +182,10 @@ func (orig *Sum) SizeProto() int {
 		l = orig.DataPoints[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.AggregationTemporality != 0 {
+	if orig.AggregationTemporality != AggregationTemporality(0) {
 		n += 1 + proto.Sov(uint64(orig.AggregationTemporality))
 	}
-	if orig.IsMonotonic {
+	if orig.IsMonotonic != false {
 		n += 2
 	}
 	return n
@@ -203,12 +202,12 @@ func (orig *Sum) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0xa
 	}
-	if orig.AggregationTemporality != 0 {
+	if orig.AggregationTemporality != AggregationTemporality(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.AggregationTemporality))
 		pos--
 		buf[pos] = 0x10
 	}
-	if orig.IsMonotonic {
+	if orig.IsMonotonic != false {
 		pos--
 		if orig.IsMonotonic {
 			buf[pos] = 1
@@ -261,7 +260,6 @@ func (orig *Sum) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.AggregationTemporality = AggregationTemporality(num)
 
 		case 3:
@@ -273,7 +271,6 @@ func (orig *Sum) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.IsMonotonic = num != 0
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_summarydatapoint.go
+++ b/pdata/internal/generated_proto_summarydatapoint.go
@@ -81,13 +81,9 @@ func CopySummaryDataPoint(dest, src *SummaryDataPoint) *SummaryDataPoint {
 	dest.Attributes = CopyKeyValueSlice(dest.Attributes, src.Attributes)
 
 	dest.StartTimeUnixNano = src.StartTimeUnixNano
-
 	dest.TimeUnixNano = src.TimeUnixNano
-
 	dest.Count = src.Count
-
 	dest.Sum = src.Sum
-
 	dest.QuantileValues = CopySummaryDataPointValueAtQuantilePtrSlice(dest.QuantileValues, src.QuantileValues)
 
 	dest.Flags = src.Flags
@@ -233,23 +229,23 @@ func (orig *SummaryDataPoint) SizeProto() int {
 		l = orig.Attributes[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		n += 9
 	}
-	if orig.Count != 0 {
+	if orig.Count != uint64(0) {
 		n += 9
 	}
-	if orig.Sum != 0 {
+	if orig.Sum != float64(0) {
 		n += 9
 	}
 	for i := range orig.QuantileValues {
 		l = orig.QuantileValues[i].SizeProto()
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		n += 1 + proto.Sov(uint64(orig.Flags))
 	}
 	return n
@@ -266,25 +262,25 @@ func (orig *SummaryDataPoint) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x3a
 	}
-	if orig.StartTimeUnixNano != 0 {
+	if orig.StartTimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.StartTimeUnixNano))
 		pos--
 		buf[pos] = 0x11
 	}
-	if orig.TimeUnixNano != 0 {
+	if orig.TimeUnixNano != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.TimeUnixNano))
 		pos--
 		buf[pos] = 0x19
 	}
-	if orig.Count != 0 {
+	if orig.Count != uint64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], uint64(orig.Count))
 		pos--
 		buf[pos] = 0x21
 	}
-	if orig.Sum != 0 {
+	if orig.Sum != float64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.Sum))
 		pos--
@@ -297,7 +293,7 @@ func (orig *SummaryDataPoint) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0x32
 	}
-	if orig.Flags != 0 {
+	if orig.Flags != uint32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Flags))
 		pos--
 		buf[pos] = 0x40
@@ -381,7 +377,6 @@ func (orig *SummaryDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Sum = math.Float64frombits(num)
 
 		case 6:
@@ -409,7 +404,6 @@ func (orig *SummaryDataPoint) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Flags = uint32(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_summarydatapointvalueatquantile.go
+++ b/pdata/internal/generated_proto_summarydatapointvalueatquantile.go
@@ -67,7 +67,6 @@ func CopySummaryDataPointValueAtQuantile(dest, src *SummaryDataPointValueAtQuant
 		dest = NewSummaryDataPointValueAtQuantile()
 	}
 	dest.Quantile = src.Quantile
-
 	dest.Value = src.Value
 
 	return dest
@@ -157,10 +156,10 @@ func (orig *SummaryDataPointValueAtQuantile) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.Quantile != 0 {
+	if orig.Quantile != float64(0) {
 		n += 9
 	}
-	if orig.Value != 0 {
+	if orig.Value != float64(0) {
 		n += 9
 	}
 	return n
@@ -170,13 +169,13 @@ func (orig *SummaryDataPointValueAtQuantile) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.Quantile != 0 {
+	if orig.Quantile != float64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.Quantile))
 		pos--
 		buf[pos] = 0x9
 	}
-	if orig.Value != 0 {
+	if orig.Value != float64(0) {
 		pos -= 8
 		binary.LittleEndian.PutUint64(buf[pos:], math.Float64bits(orig.Value))
 		pos--
@@ -209,7 +208,6 @@ func (orig *SummaryDataPointValueAtQuantile) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Quantile = math.Float64frombits(num)
 
 		case 2:
@@ -221,7 +219,6 @@ func (orig *SummaryDataPointValueAtQuantile) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Value = math.Float64frombits(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/internal/generated_proto_tcpaddr.go
+++ b/pdata/internal/generated_proto_tcpaddr.go
@@ -65,9 +65,7 @@ func CopyTCPAddr(dest, src *TCPAddr) *TCPAddr {
 		dest = NewTCPAddr()
 	}
 	dest.IP = src.IP
-
 	dest.Port = src.Port
-
 	dest.Zone = src.Zone
 
 	return dest
@@ -164,13 +162,15 @@ func (orig *TCPAddr) SizeProto() int {
 	var n int
 	var l int
 	_ = l
+
 	l = len(orig.IP)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.Port != 0 {
+	if orig.Port != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.Port))
 	}
+
 	l = len(orig.Zone)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -190,7 +190,7 @@ func (orig *TCPAddr) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0xa
 	}
-	if orig.Port != 0 {
+	if orig.Port != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Port))
 		pos--
 		buf[pos] = 0x10
@@ -245,7 +245,6 @@ func (orig *TCPAddr) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Port = int64(num)
 
 		case 3:

--- a/pdata/internal/generated_proto_tracesrequest.go
+++ b/pdata/internal/generated_proto_tracesrequest.go
@@ -173,7 +173,7 @@ func (orig *TracesRequest) SizeProto() int {
 	}
 	l = orig.TracesData.SizeProto()
 	n += 1 + proto.Sov(uint64(l)) + l
-	if orig.FormatVersion != 0 {
+	if orig.FormatVersion != uint32(0) {
 		n += 5
 	}
 	return n
@@ -196,7 +196,7 @@ func (orig *TracesRequest) MarshalProto(buf []byte) int {
 	pos--
 	buf[pos] = 0x1a
 
-	if orig.FormatVersion != 0 {
+	if orig.FormatVersion != uint32(0) {
 		pos -= 4
 		binary.LittleEndian.PutUint32(buf[pos:], uint32(orig.FormatVersion))
 		pos--

--- a/pdata/internal/generated_proto_udpaddr.go
+++ b/pdata/internal/generated_proto_udpaddr.go
@@ -65,9 +65,7 @@ func CopyUDPAddr(dest, src *UDPAddr) *UDPAddr {
 		dest = NewUDPAddr()
 	}
 	dest.IP = src.IP
-
 	dest.Port = src.Port
-
 	dest.Zone = src.Zone
 
 	return dest
@@ -164,13 +162,15 @@ func (orig *UDPAddr) SizeProto() int {
 	var n int
 	var l int
 	_ = l
+
 	l = len(orig.IP)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
-	if orig.Port != 0 {
+	if orig.Port != int64(0) {
 		n += 1 + proto.Sov(uint64(orig.Port))
 	}
+
 	l = len(orig.Zone)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
@@ -190,7 +190,7 @@ func (orig *UDPAddr) MarshalProto(buf []byte) int {
 		pos--
 		buf[pos] = 0xa
 	}
-	if orig.Port != 0 {
+	if orig.Port != int64(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.Port))
 		pos--
 		buf[pos] = 0x10
@@ -245,7 +245,6 @@ func (orig *UDPAddr) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.Port = int64(num)
 
 		case 3:

--- a/pdata/internal/generated_proto_unixaddr.go
+++ b/pdata/internal/generated_proto_unixaddr.go
@@ -64,7 +64,6 @@ func CopyUnixAddr(dest, src *UnixAddr) *UnixAddr {
 		dest = NewUnixAddr()
 	}
 	dest.Name = src.Name
-
 	dest.Net = src.Net
 
 	return dest
@@ -154,10 +153,12 @@ func (orig *UnixAddr) SizeProto() int {
 	var n int
 	var l int
 	_ = l
+
 	l = len(orig.Name)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
+
 	l = len(orig.Net)
 	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l

--- a/pdata/internal/generated_proto_valuetype.go
+++ b/pdata/internal/generated_proto_valuetype.go
@@ -65,7 +65,6 @@ func CopyValueType(dest, src *ValueType) *ValueType {
 		dest = NewValueType()
 	}
 	dest.TypeStrindex = src.TypeStrindex
-
 	dest.UnitStrindex = src.UnitStrindex
 
 	return dest
@@ -155,10 +154,10 @@ func (orig *ValueType) SizeProto() int {
 	var n int
 	var l int
 	_ = l
-	if orig.TypeStrindex != 0 {
+	if orig.TypeStrindex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.TypeStrindex))
 	}
-	if orig.UnitStrindex != 0 {
+	if orig.UnitStrindex != int32(0) {
 		n += 1 + proto.Sov(uint64(orig.UnitStrindex))
 	}
 	return n
@@ -168,12 +167,12 @@ func (orig *ValueType) MarshalProto(buf []byte) int {
 	pos := len(buf)
 	var l int
 	_ = l
-	if orig.TypeStrindex != 0 {
+	if orig.TypeStrindex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.TypeStrindex))
 		pos--
 		buf[pos] = 0x8
 	}
-	if orig.UnitStrindex != 0 {
+	if orig.UnitStrindex != int32(0) {
 		pos = proto.EncodeVarint(buf, pos, uint64(orig.UnitStrindex))
 		pos--
 		buf[pos] = 0x10
@@ -205,7 +204,6 @@ func (orig *ValueType) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.TypeStrindex = int32(num)
 
 		case 2:
@@ -217,7 +215,6 @@ func (orig *ValueType) UnmarshalProto(buf []byte) error {
 			if err != nil {
 				return err
 			}
-
 			orig.UnitStrindex = int32(num)
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint.go
@@ -91,25 +91,25 @@ func (ms ExponentialHistogramDataPoint) SetCount(v uint64) {
 
 // Sum returns the sum associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) Sum() float64 {
-	return ms.orig.GetSum()
+	return ms.orig.Sum
 }
 
 // HasSum returns true if the ExponentialHistogramDataPoint contains a
 // Sum value otherwise.
 func (ms ExponentialHistogramDataPoint) HasSum() bool {
-	return ms.orig.Sum_ != nil
+	return ms.orig.HasSum()
 }
 
 // SetSum replaces the sum associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) SetSum(v float64) {
 	ms.state.AssertMutable()
-	ms.orig.Sum_ = &internal.ExponentialHistogramDataPoint_Sum{Sum: v}
+	ms.orig.SetSum(v)
 }
 
 // RemoveSum removes the sum associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) RemoveSum() {
 	ms.state.AssertMutable()
-	ms.orig.Sum_ = nil
+	ms.orig.RemoveSum()
 }
 
 // Scale returns the scale associated with this ExponentialHistogramDataPoint.
@@ -162,48 +162,48 @@ func (ms ExponentialHistogramDataPoint) Exemplars() ExemplarSlice {
 
 // Min returns the min associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) Min() float64 {
-	return ms.orig.GetMin()
+	return ms.orig.Min
 }
 
 // HasMin returns true if the ExponentialHistogramDataPoint contains a
 // Min value otherwise.
 func (ms ExponentialHistogramDataPoint) HasMin() bool {
-	return ms.orig.Min_ != nil
+	return ms.orig.HasMin()
 }
 
 // SetMin replaces the min associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) SetMin(v float64) {
 	ms.state.AssertMutable()
-	ms.orig.Min_ = &internal.ExponentialHistogramDataPoint_Min{Min: v}
+	ms.orig.SetMin(v)
 }
 
 // RemoveMin removes the min associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) RemoveMin() {
 	ms.state.AssertMutable()
-	ms.orig.Min_ = nil
+	ms.orig.RemoveMin()
 }
 
 // Max returns the max associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) Max() float64 {
-	return ms.orig.GetMax()
+	return ms.orig.Max
 }
 
 // HasMax returns true if the ExponentialHistogramDataPoint contains a
 // Max value otherwise.
 func (ms ExponentialHistogramDataPoint) HasMax() bool {
-	return ms.orig.Max_ != nil
+	return ms.orig.HasMax()
 }
 
 // SetMax replaces the max associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) SetMax(v float64) {
 	ms.state.AssertMutable()
-	ms.orig.Max_ = &internal.ExponentialHistogramDataPoint_Max{Max: v}
+	ms.orig.SetMax(v)
 }
 
 // RemoveMax removes the max associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) RemoveMax() {
 	ms.state.AssertMutable()
-	ms.orig.Max_ = nil
+	ms.orig.RemoveMax()
 }
 
 // ZeroThreshold returns the zerothreshold associated with this ExponentialHistogramDataPoint.

--- a/pdata/pmetric/generated_histogramdatapoint.go
+++ b/pdata/pmetric/generated_histogramdatapoint.go
@@ -88,25 +88,25 @@ func (ms HistogramDataPoint) SetCount(v uint64) {
 
 // Sum returns the sum associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) Sum() float64 {
-	return ms.orig.GetSum()
+	return ms.orig.Sum
 }
 
 // HasSum returns true if the HistogramDataPoint contains a
 // Sum value otherwise.
 func (ms HistogramDataPoint) HasSum() bool {
-	return ms.orig.Sum_ != nil
+	return ms.orig.HasSum()
 }
 
 // SetSum replaces the sum associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) SetSum(v float64) {
 	ms.state.AssertMutable()
-	ms.orig.Sum_ = &internal.HistogramDataPoint_Sum{Sum: v}
+	ms.orig.SetSum(v)
 }
 
 // RemoveSum removes the sum associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) RemoveSum() {
 	ms.state.AssertMutable()
-	ms.orig.Sum_ = nil
+	ms.orig.RemoveSum()
 }
 
 // BucketCounts returns the BucketCounts associated with this HistogramDataPoint.
@@ -137,48 +137,48 @@ func (ms HistogramDataPoint) SetFlags(v DataPointFlags) {
 
 // Min returns the min associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) Min() float64 {
-	return ms.orig.GetMin()
+	return ms.orig.Min
 }
 
 // HasMin returns true if the HistogramDataPoint contains a
 // Min value otherwise.
 func (ms HistogramDataPoint) HasMin() bool {
-	return ms.orig.Min_ != nil
+	return ms.orig.HasMin()
 }
 
 // SetMin replaces the min associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) SetMin(v float64) {
 	ms.state.AssertMutable()
-	ms.orig.Min_ = &internal.HistogramDataPoint_Min{Min: v}
+	ms.orig.SetMin(v)
 }
 
 // RemoveMin removes the min associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) RemoveMin() {
 	ms.state.AssertMutable()
-	ms.orig.Min_ = nil
+	ms.orig.RemoveMin()
 }
 
 // Max returns the max associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) Max() float64 {
-	return ms.orig.GetMax()
+	return ms.orig.Max
 }
 
 // HasMax returns true if the HistogramDataPoint contains a
 // Max value otherwise.
 func (ms HistogramDataPoint) HasMax() bool {
-	return ms.orig.Max_ != nil
+	return ms.orig.HasMax()
 }
 
 // SetMax replaces the max associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) SetMax(v float64) {
 	ms.state.AssertMutable()
-	ms.orig.Max_ = &internal.HistogramDataPoint_Max{Max: v}
+	ms.orig.SetMax(v)
 }
 
 // RemoveMax removes the max associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) RemoveMax() {
 	ms.state.AssertMutable()
-	ms.orig.Max_ = nil
+	ms.orig.RemoveMax()
 }
 
 // CopyTo copies all properties from the current struct overriding the destination.


### PR DESCRIPTION
This changes how to handle optional primitive fields, instead of using a "oneof" like style, define a metadata for each message that for the moment only contains information if the optional fields are present of not.

Alternative considered to use a pointer to the value instead of "any" that would reduce the size of the field from 16B to 8B but would keep an extra allocation.

**Before:**
```
BenchmarkMarshalAndUnmarshal/empty
BenchmarkMarshalAndUnmarshal/empty-12         	16115462	        73.64 ns/op	     224 B/op	       1 allocs/op
BenchmarkMarshalAndUnmarshal/all
BenchmarkMarshalAndUnmarshal/all-12           	 1844172	       641.0 ns/op	     800 B/op	      21 allocs/op
```

**After:**
```
BenchmarkMarshalAndUnmarshal/empty
BenchmarkMarshalAndUnmarshal/empty-12         	18948967	        62.91 ns/op	     208 B/op	       1 allocs/op
BenchmarkMarshalAndUnmarshal/all
BenchmarkMarshalAndUnmarshal/all-12           	 1914825	       624.3 ns/op	     760 B/op	      18 allocs/op
```

**Bechmark code:**
```golang
func BenchmarkMarshalAndUnmarshal(b *testing.B) {
	tests := map[string]*ExponentialHistogramDataPoint{
		"empty": NewExponentialHistogramDataPoint(),
		"all": GenTestExponentialHistogramDataPoint(),
	}
	for name, src := range tests {
		b.Run(name, func(b *testing.B) {
			buf := make([]byte, src.SizeProto())
			b.ReportAllocs()
			b.ResetTimer()
			for b.Loop() {
				gotSize := src.MarshalProto(buf)
				if len(buf) != gotSize {
					b.Fatalf("size mismatch: %d vs %d", len(buf), gotSize)
				}

				dest := NewExponentialHistogramDataPoint()
				if err := dest.UnmarshalProto(buf); err != nil {
					b.Fatal(err)
				}
			}
		})
	}
}
```
