### PR TITLE
[chore] Enable Renovate updates for indirect Go dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -134,6 +134,15 @@
         "toolchain"
       ],
       "enabled": false
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "enabled": true
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
The `tidy-dependencies.yml` workflow currently runs `go mod tidy` after Renovate PRs to update indirect dependencies that Renovate doesn't handle. This change tests if Renovate can manage indirect dependencies, potentially eliminating the need for the workflow.

###  Next Steps
  - Monitor Renovate PRs over the next few weeks
  - If the tidy-dependencies workflow stops making commits, we'll disable it
