### PR TITLE
[xprocessor] Use receiver pointer in xprocessor factory methods

### DIFF
--- a/.chloggen/use-pointer-in-xprocessor-factory-methods.yaml
+++ b/.chloggen/use-pointer-in-xprocessor-factory-methods.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/xprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use pointer receivers in xprocessor factory methods for consistency with other factories.
+
+# One or more tracking issues or pull requests related to the change
+issues: [14348]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/processor/xprocessor/processor.go
+++ b/processor/xprocessor/processor.go
@@ -58,11 +58,11 @@ type factory struct {
 	profilesStabilityLevel component.StabilityLevel
 }
 
-func (f factory) ProfilesStability() component.StabilityLevel {
+func (f *factory) ProfilesStability() component.StabilityLevel {
 	return f.profilesStabilityLevel
 }
 
-func (f factory) CreateProfiles(ctx context.Context, set processor.Settings, cfg component.Config, next xconsumer.Profiles) (Profiles, error) {
+func (f *factory) CreateProfiles(ctx context.Context, set processor.Settings, cfg component.Config, next xconsumer.Profiles) (Profiles, error) {
 	if f.createProfilesFunc == nil {
 		return nil, pipeline.ErrSignalNotSupported
 	}


### PR DESCRIPTION
This change brings this factory into consistency with other factories that define methods using pointer receivers. While this is technically a breaking change, the likelihood of it causing any issues on the user side is extremely low.