### PR TITLE
[xconnector] Add component ID type validation to factory methods

### DIFF
--- a/.chloggen/xconnector-id-validation.yaml
+++ b/.chloggen/xconnector-id-validation.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/xconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add component ID type validation to all xconnector Create methods
+
+# One or more tracking issues or pull requests related to the change
+issues: [14357]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/connector/xconnector/connector.go
+++ b/connector/xconnector/connector.go
@@ -268,12 +268,18 @@ func (f *factory) CreateTracesToProfiles(ctx context.Context, set connector.Sett
 	if f.createTracesToProfilesFunc == nil {
 		return nil, internal.ErrDataTypes(set.ID, pipeline.SignalTraces, xpipeline.SignalProfiles)
 	}
+	if set.ID.Type() != f.Type() {
+		return nil, internal.ErrIDMismatch(set.ID, f.Type())
+	}
 	return f.createTracesToProfilesFunc(ctx, set, cfg, next)
 }
 
 func (f *factory) CreateMetricsToProfiles(ctx context.Context, set connector.Settings, cfg component.Config, next xconsumer.Profiles) (connector.Metrics, error) {
 	if f.createMetricsToProfilesFunc == nil {
 		return nil, internal.ErrDataTypes(set.ID, pipeline.SignalMetrics, xpipeline.SignalProfiles)
+	}
+	if set.ID.Type() != f.Type() {
+		return nil, internal.ErrIDMismatch(set.ID, f.Type())
 	}
 	return f.createMetricsToProfilesFunc(ctx, set, cfg, next)
 }
@@ -282,12 +288,18 @@ func (f *factory) CreateLogsToProfiles(ctx context.Context, set connector.Settin
 	if f.createLogsToProfilesFunc == nil {
 		return nil, internal.ErrDataTypes(set.ID, pipeline.SignalLogs, xpipeline.SignalProfiles)
 	}
+	if set.ID.Type() != f.Type() {
+		return nil, internal.ErrIDMismatch(set.ID, f.Type())
+	}
 	return f.createLogsToProfilesFunc(ctx, set, cfg, next)
 }
 
 func (f *factory) CreateProfilesToProfiles(ctx context.Context, set connector.Settings, cfg component.Config, next xconsumer.Profiles) (Profiles, error) {
 	if f.createProfilesToProfilesFunc == nil {
 		return nil, internal.ErrDataTypes(set.ID, xpipeline.SignalProfiles, xpipeline.SignalProfiles)
+	}
+	if set.ID.Type() != f.Type() {
+		return nil, internal.ErrIDMismatch(set.ID, f.Type())
 	}
 	return f.createProfilesToProfilesFunc(ctx, set, cfg, next)
 }
@@ -296,6 +308,9 @@ func (f *factory) CreateProfilesToTraces(ctx context.Context, set connector.Sett
 	if f.createProfilesToTracesFunc == nil {
 		return nil, internal.ErrDataTypes(set.ID, xpipeline.SignalProfiles, pipeline.SignalTraces)
 	}
+	if set.ID.Type() != f.Type() {
+		return nil, internal.ErrIDMismatch(set.ID, f.Type())
+	}
 	return f.createProfilesToTracesFunc(ctx, set, cfg, next)
 }
 
@@ -303,12 +318,18 @@ func (f *factory) CreateProfilesToMetrics(ctx context.Context, set connector.Set
 	if f.createProfilesToMetricsFunc == nil {
 		return nil, internal.ErrDataTypes(set.ID, xpipeline.SignalProfiles, pipeline.SignalMetrics)
 	}
+	if set.ID.Type() != f.Type() {
+		return nil, internal.ErrIDMismatch(set.ID, f.Type())
+	}
 	return f.createProfilesToMetricsFunc(ctx, set, cfg, next)
 }
 
 func (f *factory) CreateProfilesToLogs(ctx context.Context, set connector.Settings, cfg component.Config, next consumer.Logs) (Profiles, error) {
 	if f.createProfilesToLogsFunc == nil {
 		return nil, internal.ErrDataTypes(set.ID, xpipeline.SignalProfiles, pipeline.SignalLogs)
+	}
+	if set.ID.Type() != f.Type() {
+		return nil, internal.ErrIDMismatch(set.ID, f.Type())
 	}
 	return f.createProfilesToLogsFunc(ctx, set, cfg, next)
 }

--- a/connector/xconnector/connector_test.go
+++ b/connector/xconnector/connector_test.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	testType = component.MustNewType("test")
-	testID   = component.MustNewIDWithName("type", "name")
+	testID   = component.MustNewIDWithName(testType.String(), "name")
 )
 
 func TestNewFactoryNoOptions(t *testing.T) {
@@ -53,10 +53,14 @@ func TestNewFactoryWithSameTypes(t *testing.T) {
 	)
 	assert.Equal(t, testType, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
+	wrongID := component.MustNewID("wrong")
+	wrongIDErrStr := internal.ErrIDMismatch(wrongID, testType).Error()
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.ProfilesToProfilesStability())
 	_, err := factory.CreateProfilesToProfiles(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	require.NoError(t, err)
+	_, err = factory.CreateProfilesToProfiles(context.Background(), connector.Settings{ID: wrongID}, &defaultCfg, consumertest.NewNop())
+	require.ErrorContains(t, err, wrongIDErrStr)
 
 	_, err = factory.CreateProfilesToTraces(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	assert.Equal(t, err, internal.ErrDataTypes(testID, xpipeline.SignalProfiles, pipeline.SignalTraces))
@@ -79,6 +83,8 @@ func TestNewFactoryWithTranslateTypes(t *testing.T) {
 	)
 	assert.Equal(t, testType, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
+	wrongID := component.MustNewID("wrong")
+	wrongIDErrStr := internal.ErrIDMismatch(wrongID, testType).Error()
 
 	_, err := factory.CreateProfilesToProfiles(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	assert.Equal(t, err, internal.ErrDataTypes(testID, xpipeline.SignalProfiles, xpipeline.SignalProfiles))
@@ -86,26 +92,38 @@ func TestNewFactoryWithTranslateTypes(t *testing.T) {
 	assert.Equal(t, component.StabilityLevelBeta, factory.TracesToProfilesStability())
 	_, err = factory.CreateTracesToProfiles(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	require.NoError(t, err)
+	_, err = factory.CreateTracesToProfiles(context.Background(), connector.Settings{ID: wrongID}, &defaultCfg, consumertest.NewNop())
+	require.ErrorContains(t, err, wrongIDErrStr)
 
 	assert.Equal(t, component.StabilityLevelDevelopment, factory.MetricsToProfilesStability())
 	_, err = factory.CreateMetricsToProfiles(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	require.NoError(t, err)
+	_, err = factory.CreateMetricsToProfiles(context.Background(), connector.Settings{ID: wrongID}, &defaultCfg, consumertest.NewNop())
+	require.ErrorContains(t, err, wrongIDErrStr)
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.LogsToProfilesStability())
 	_, err = factory.CreateLogsToProfiles(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	require.NoError(t, err)
+	_, err = factory.CreateLogsToProfiles(context.Background(), connector.Settings{ID: wrongID}, &defaultCfg, consumertest.NewNop())
+	require.ErrorContains(t, err, wrongIDErrStr)
 
 	assert.Equal(t, component.StabilityLevelBeta, factory.ProfilesToTracesStability())
 	_, err = factory.CreateProfilesToTraces(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	require.NoError(t, err)
+	_, err = factory.CreateProfilesToTraces(context.Background(), connector.Settings{ID: wrongID}, &defaultCfg, consumertest.NewNop())
+	require.ErrorContains(t, err, wrongIDErrStr)
 
 	assert.Equal(t, component.StabilityLevelDevelopment, factory.ProfilesToMetricsStability())
 	_, err = factory.CreateProfilesToMetrics(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
 	require.NoError(t, err)
+	_, err = factory.CreateProfilesToMetrics(context.Background(), connector.Settings{ID: wrongID}, &defaultCfg, consumertest.NewNop())
+	require.ErrorContains(t, err, wrongIDErrStr)
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.ProfilesToLogsStability())
 	_, err = factory.CreateProfilesToLogs(context.Background(), connector.Settings{ID: testID}, &defaultCfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	_, err = factory.CreateProfilesToLogs(context.Background(), connector.Settings{ID: wrongID}, &defaultCfg, consumertest.NewNop())
+	require.ErrorContains(t, err, wrongIDErrStr)
 }
 
 var nopInstance = &nopConnector{


### PR DESCRIPTION
Adds component ID type validation to all xconnector Create methods to match the pattern used in the all other factories. The checks were missed in https://github.com/open-telemetry/opentelemetry-collector/pull/12381
