### PR TITLE
[chore] Fix small issues in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,8 +86,8 @@
         "gomod"
       ],
       "groupName": "All google.golang.org packages",
-      "matchSourceUrls": [
-        "https://google.golang.org{/,}**"
+      "matchPackageNames": [
+        "google.golang.org{/,}**"
       ]
     },
     {
@@ -153,6 +153,6 @@
     "prEditedNotification"
   ],
   "postUpdateOptions": [
-    "gomodTidy",
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
- Fix google.golang.org grouping. The url is wrong, it's hosted on github, use package names instead
- Remove trailing comma to have valid json
