### PR TITLE
[chore] Disable noisy indirect dependency updates with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -134,15 +134,6 @@
         "toolchain"
       ],
       "enabled": false
-    },
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepTypes": [
-        "indirect"
-      ],
-      "enabled": true
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
Rolling back https://github.com/open-telemetry/opentelemetry-collector/pull/14345

Enabling indirect updates does not fully eliminate the need for the tidy-dependencies job, but it generates a large number of noisy PRs for every indirect dependency.

We can wait for the resolution of https://github.com/renovatebot/renovate/issues/12999 and see whether it helps instead.
