### PR TITLE
[chore][receiver/otlp] Add sequential logs benchmark

### DIFF
--- a/receiver/otlpreceiver/otlp_benchmark_test.go
+++ b/receiver/otlpreceiver/otlp_benchmark_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	itemsPerRequest     = 5_000
+	itemsPerRequest     = 10_000
 	protobufContentType = "application/x-protobuf"
 )
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds two benchmarks for receiving OTLP logs over HTTP (proto) and gRPC.

The goal is to have reliable but not necessarily realistic benchmarks. As such this benchmark does not test concurrent requests (which is important and we should do on a different PR).

If these look okay and prove to be non-flaky enough on main, I will add benchmarks for the other stable signals as well.

<!-- Issue number if applicable -->
#### Link to tracking issue

Updates #14111
Updates #12979