### PR TITLE
receiver: add PartialReceiveError for partial success metrics

### DIFF
--- a/receiver/receivererror/doc.go
+++ b/receiver/receivererror/doc.go
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package receivererror provides error types for receivers.
+//
+// The PartialReceiveError type allows receivers to report partial success
+// when processing data. This enables accurate observability metrics that
+// distinguish between:
+//   - Full success (no error)
+//   - Partial success (error with specific failure count)
+//   - Full failure (regular error, all items failed)
+package receivererror // import "go.opentelemetry.io/collector/receiver/receivererror"

--- a/receiver/receivererror/partialreceiveerror.go
+++ b/receiver/receivererror/partialreceiveerror.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receivererror // import "go.opentelemetry.io/collector/receiver/receivererror"
+
+import "errors"
+
+// PartialReceiveError is an error to represent that a subset of received data
+// failed to be processed by the receiver (e.g., due to translation errors,
+// validation failures, or other internal receiver issues).
+//
+// When returned from a receiver's data processing, the observability helper
+// uses the Failed count to correctly report partial success metrics:
+// - accepted items = total items - Failed
+// - failed items = Failed
+type PartialReceiveError struct {
+	error
+	// Failed is the number of items that failed to be processed.
+	// This count should not exceed the total number of items received.
+	Failed int
+}
+
+// NewPartialReceiveError creates a PartialReceiveError for failed data.
+// Use this error type only when a subset of data failed to be processed
+// by the receiver. The failed parameter indicates the number of items
+// that could not be processed.
+func NewPartialReceiveError(err error, failed int) error {
+	return PartialReceiveError{
+		error:  err,
+		Failed: failed,
+	}
+}
+
+// Unwrap returns the wrapped error for use by errors.Is and errors.As.
+func (e PartialReceiveError) Unwrap() error {
+	return e.error
+}
+
+// IsPartialReceiveError checks if an error was created with NewPartialReceiveError
+// or contains one such error in its Unwrap() tree.
+func IsPartialReceiveError(err error) bool {
+	var partialErr PartialReceiveError
+	return errors.As(err, &partialErr)
+}
+
+// FailedItemsFromError extracts the failed item count from an error.
+// If the error is not a PartialReceiveError, returns 0 and false.
+func FailedItemsFromError(err error) (int, bool) {
+	var partialErr PartialReceiveError
+	if errors.As(err, &partialErr) {
+		return partialErr.Failed, true
+	}
+	return 0, false
+}

--- a/receiver/receivererror/partialreceiveerror_test.go
+++ b/receiver/receivererror/partialreceiveerror_test.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receivererror
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartialReceiveError(t *testing.T) {
+	innerErr := errors.New("translation failed for 3 metrics")
+	partialErr := NewPartialReceiveError(innerErr, 3)
+
+	assert.Equal(t, "translation failed for 3 metrics", partialErr.Error())
+	assert.Equal(t, innerErr, errors.Unwrap(partialErr))
+}
+
+func TestIsPartialReceiveError(t *testing.T) {
+	innerErr := errors.New("validation error")
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "regular error",
+			err:      errors.New("regular error"),
+			expected: false,
+		},
+		{
+			name:     "partial receive error",
+			err:      NewPartialReceiveError(innerErr, 5),
+			expected: true,
+		},
+		{
+			name:     "wrapped partial receive error",
+			err:      fmt.Errorf("wrapped: %w", NewPartialReceiveError(innerErr, 5)),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsPartialReceiveError(tt.err))
+		})
+	}
+}
+
+func TestFailedItemsFromError(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		expectedCount int
+		expectedOk    bool
+	}{
+		{
+			name:          "nil error",
+			err:           nil,
+			expectedCount: 0,
+			expectedOk:    false,
+		},
+		{
+			name:          "regular error",
+			err:           errors.New("regular error"),
+			expectedCount: 0,
+			expectedOk:    false,
+		},
+		{
+			name:          "partial receive error with 5 failed",
+			err:           NewPartialReceiveError(errors.New("test"), 5),
+			expectedCount: 5,
+			expectedOk:    true,
+		},
+		{
+			name:          "wrapped partial receive error",
+			err:           fmt.Errorf("wrapped: %w", NewPartialReceiveError(errors.New("test"), 10)),
+			expectedCount: 10,
+			expectedOk:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, ok := FailedItemsFromError(tt.err)
+			assert.Equal(t, tt.expectedCount, count)
+			assert.Equal(t, tt.expectedOk, ok)
+		})
+	}
+}
+
+func TestPartialReceiveErrorUnwrap(t *testing.T) {
+	innerErr := errors.New("inner error")
+	partialErr := NewPartialReceiveError(innerErr, 7)
+
+	// Test errors.Is
+	require.True(t, errors.Is(partialErr, innerErr))
+
+	// Test errors.As
+	var target PartialReceiveError
+	require.True(t, errors.As(partialErr, &target))
+	assert.Equal(t, 7, target.Failed)
+}


### PR DESCRIPTION
Fixes #14440

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Receiver observability metrics currently follow an all-or-nothing error model: when a receiver returns any error, all received items are marked as failed or refused. This behavior is inaccurate for receivers that can partially process data (for example, when only some metrics fail translation or validation).

This change introduces a new receiver-specific error type, receivererror.PartialReceiveError, which allows receivers to report the exact number of items that failed during processing. The observability helper detects this error and:

- Records accepted items as total − failed
- Records failed items accurately 
- Preserves existing behavior for full failures and downstream errors
- Treats partial success as a successful request for otelcol_receiver_requests

This enables accurate self-observability metrics without breaking existing receivers or dashboards.
<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #14440

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit tests for receivererror.PartialReceiveError, including:
> Error detection
> Failed item extraction
> Wrapped error handling

Added tests in receiverhelper/obsreport_test.go to validate:
> Correct accepted / failed counts for partial errors
> Behavior across all signal types (traces, metrics, logs, profiles)
> Correct interaction with the receiver metrics feature gate
> Correct outcome attribute for partial success

All existing tests continue to pass.
<!--Describe the documentation added.-->
#### Documentation
Added package-level documentation for receivererror describing partial success semantics and intended usage.
<!--Please delete paragraphs that you did not use before submitting.-->
