### PR TITLE
confighttp: don't run unix-specific test on macos

### DIFF
--- a/config/confighttp/server_test.go
+++ b/config/confighttp/server_test.go
@@ -280,7 +280,7 @@ func TestHttpServerTLS(t *testing.T) {
 }
 
 func TestHttpServerTransport(t *testing.T) {
-	if runtime.GOOS == "unix" {
+	if runtime.GOOS == "linux" {
 		t.Run("unix", func(t *testing.T) {
 			addr := "@" + t.Name() // abstract unix socket
 			sc := &ServerConfig{


### PR DESCRIPTION
This test can't run on macOS, where abstract unix sockets aren't supported.
This is already kind of hinted with the subtest name.