### PR TITLE
 Fix race condition and goroutine leak in multiBatcher during shutdown

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/multi_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/multi_batcher.go
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
+
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"go.uber.org/zap"
@@ -14,6 +16,9 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
 )
 
+// errBatcherStopped is returned when Consume is called after the batcher has been stopped.
+var errBatcherStopped = errors.New("batcher is stopped")
+
 type multiBatcher struct {
 	cfg         BatchConfig
 	wp          *workerPool
@@ -23,6 +28,10 @@ type multiBatcher struct {
 	consumeFunc sender.SendFunc[request.Request]
 	shards      sync.Map
 	logger      *zap.Logger
+
+	// mu protects stopped flag and synchronizes shard creation with shutdown.
+	mu      sync.Mutex
+	stopped bool
 }
 
 func newMultiBatcher(
@@ -45,22 +54,35 @@ func newMultiBatcher(
 	}
 }
 
-func (mb *multiBatcher) getPartition(ctx context.Context, req request.Request) *partitionBatcher {
+func (mb *multiBatcher) getPartition(ctx context.Context, req request.Request) (*partitionBatcher, bool) {
 	key := mb.partitioner.GetKey(ctx, req)
 	s, found := mb.shards.Load(key)
 	// Fast path, shard already created.
 	if found {
-		return s.(*partitionBatcher)
+		return s.(*partitionBatcher), true
+	}
+
+	// Slow path: need to create a new shard. Synchronize with Shutdown to prevent
+	// goroutine leaks from shards created after Shutdown has started iterating.
+	mb.mu.Lock()
+	if mb.stopped {
+		mb.mu.Unlock()
+		return nil, false
+	}
+
+	// Double-check after acquiring lock in case another goroutine added the shard.
+	s, found = mb.shards.Load(key)
+	if found {
+		mb.mu.Unlock()
+		return s.(*partitionBatcher), true
 	}
 
 	newS := newPartitionBatcher(mb.cfg, mb.sizer, mb.mergeCtx, mb.wp, mb.consumeFunc, mb.logger)
 	_ = newS.Start(ctx, nil)
-	s, loaded := mb.shards.LoadOrStore(key, newS)
-	// If not loaded, there was a race condition in adding the new shard. Shutdown the newly created shard.
-	if loaded {
-		_ = newS.Shutdown(ctx)
-	}
-	return s.(*partitionBatcher)
+	mb.shards.Store(key, newS)
+	mb.mu.Unlock()
+
+	return newS, true
 }
 
 func (mb *multiBatcher) Start(context.Context, component.Host) error {
@@ -68,11 +90,22 @@ func (mb *multiBatcher) Start(context.Context, component.Host) error {
 }
 
 func (mb *multiBatcher) Consume(ctx context.Context, req request.Request, done queue.Done) {
-	shard := mb.getPartition(ctx, req)
+	shard, ok := mb.getPartition(ctx, req)
+	if !ok {
+		// Batcher is stopped, signal done with shutdown error.
+		done.OnDone(errBatcherStopped)
+		return
+	}
 	shard.Consume(ctx, req, done)
 }
 
 func (mb *multiBatcher) Shutdown(ctx context.Context) error {
+	// Set stopped flag while holding the lock to prevent new shards from being
+	// created after we start iterating. This ensures all shards are properly shutdown.
+	mb.mu.Lock()
+	mb.stopped = true
+	mb.mu.Unlock()
+
 	var wg sync.WaitGroup
 	mb.shards.Range(func(_, shard any) bool {
 		wg.Add(1)


### PR DESCRIPTION
### Summary

This PR fixes a race condition in the multiBatcher where new partition batchers can be created while shutdown is already in progress. Because shard creation and shutdown were not synchronized, shards created during this window were not tracked by Shutdown(), leaving their internal goroutines running and allowing telemetry to be sent into already-closed exporter pipelines, resulting in silent data loss and goroutine leaks.

The fix prevents new shard creation once shutdown begins and ensures all existing shards are properly shut down.

---

### Affected Area

File: exporter/exporterhelper/internal/queuebatch/multi_batcher.go
Functions: getPartition(), Shutdown(), and Consume()

---

### Problem Description

multiBatcher dynamically creates partition shards in getPartition() and immediately starts their internal timer goroutines. Simultaneously, Shutdown() iterates over the current shards using sync.Map.Range() and shuts them down.

Since Range() does not provide a consistent snapshot and shard creation was not synchronized with shutdown, it was possible for a shard to be started after Shutdown() had already finished iterating. That shard would never be stopped, its goroutines would continue running, and any telemetry routed to it would be sent into a pipeline that has already been stopped.

---

### Why This Is Critical

Goroutine Leaks: Causes leaks on every shutdown or hot reload under load.
Silent Telemetry Loss: Data is routed to late-created "zombie" shards that attempt to export to a closed pipeline.
Production Stability: Can prevent clean process shutdown and impacts high-cardinality/multi-tenant deployments most severely.

---

### Fix Approach

I implemented a Double-Checked Locking pattern to ensure safety without regressing performance on the hot path.
Lifecycle Synchronization: Introduced a stopped flag and sync.Mutex to synchronize getPartition() and Shutdown().
Performance Neutrality: Preserves the lock-free "fast path" using sync.Map.Load for existing shards. The mutex is only acquired during new shard creation or the shutdown sequence.
Shutdown Sealing: Shutdown() now sets the stopped flag under lock before iterating over shards. This ensures no new shards can be spawned once the closing process begins.
Graceful Rejection: Updated Consume() to detect the stopped state and signal OnDone with an error, providing feedback to the caller rather than failing silently.

---

### Testing Verified

Unit Test: Added TestMultiBatcher_ConsumeAfterShutdown to verify that consuming after shutdown returns an error and does not spawn new shards.
Race Detector: Verified the fix using go test -race to ensure the new synchronization logic is correct.

---

### Impact After Fix

No goroutine leaks during shutdown or reload.
No silent data loss from late-created shards.
Clean and predictable collector shutdown under high-cardinality partitioning.