### PR TITLE
Display trace and span IDs for logs in debug exporter

### DIFF
--- a/exporter/debugexporter/internal/otlptext/logs.go
+++ b/exporter/debugexporter/internal/otlptext/logs.go
@@ -44,8 +44,8 @@ func (textLogsMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 				}
 				buf.logEntry("Body: %s", valueToString(lr.Body()))
 				buf.logAttributes("Attributes", lr.Attributes())
-				buf.logEntry("Trace ID: %s", lr.TraceID())
-				buf.logEntry("Span ID: %s", lr.SpanID())
+				buf.logAttr("Trace ID", lr.TraceID())
+				buf.logAttr("Span ID", lr.SpanID())
 				buf.logEntry("Flags: %d", lr.Flags())
 			}
 		}

--- a/exporter/debugexporter/internal/otlptext/testdata/logs/embedded_maps.out
+++ b/exporter/debugexporter/internal/otlptext/testdata/logs/embedded_maps.out
@@ -12,6 +12,6 @@ Body: Map({"key1":"val1","key2":{"key21":"val21","key22":"val22"}})
 Attributes:
      -> key1: Map({"key11":"val11","key12":"val12","key13":{"key131":"val131"}})
      -> key2: Str(val2)
-Trace ID: 
-Span ID: 
+    Trace ID       : 
+    Span ID        : 
 Flags: 0

--- a/exporter/debugexporter/internal/otlptext/testdata/logs/log_with_event_name.out
+++ b/exporter/debugexporter/internal/otlptext/testdata/logs/log_with_event_name.out
@@ -13,6 +13,6 @@ Body: Str(This is a log message)
 Attributes:
      -> app: Str(server)
      -> instance_num: Int(1)
-Trace ID: 08040201000000000000000000000000
-Span ID: 0102040800000000
+    Trace ID       : 08040201000000000000000000000000
+    Span ID        : 0102040800000000
 Flags: 0

--- a/exporter/debugexporter/internal/otlptext/testdata/logs/logs_with_entity_refs.out
+++ b/exporter/debugexporter/internal/otlptext/testdata/logs/logs_with_entity_refs.out
@@ -27,6 +27,6 @@ SeverityNumber: Info(9)
 Body: Str(This is a test log message)
 Attributes:
      -> test.attribute: Str(test-value)
-Trace ID: 
-Span ID: 
+    Trace ID       : 
+    Span ID        : 
 Flags: 0

--- a/exporter/debugexporter/internal/otlptext/testdata/logs/one_record.out
+++ b/exporter/debugexporter/internal/otlptext/testdata/logs/one_record.out
@@ -14,6 +14,6 @@ Body: Str(This is a log message)
 Attributes:
      -> app: Str(server)
      -> instance_num: Int(1)
-Trace ID: 08040201000000000000000000000000
-Span ID: 0102040800000000
+    Trace ID       : 08040201000000000000000000000000
+    Span ID        : 0102040800000000
 Flags: 0

--- a/exporter/debugexporter/internal/otlptext/testdata/logs/two_records.out
+++ b/exporter/debugexporter/internal/otlptext/testdata/logs/two_records.out
@@ -14,8 +14,8 @@ Body: Str(This is a log message)
 Attributes:
      -> app: Str(server)
      -> instance_num: Int(1)
-Trace ID: 08040201000000000000000000000000
-Span ID: 0102040800000000
+    Trace ID       : 08040201000000000000000000000000
+    Span ID        : 0102040800000000
 Flags: 0
 LogRecord #1
 ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
@@ -26,6 +26,6 @@ Body: Str(something happened)
 Attributes:
      -> customer: Str(acme)
      -> env: Str(dev)
-Trace ID: 
-Span ID: 
+    Trace ID       : 
+    Span ID        : 
 Flags: 0


### PR DESCRIPTION
The debug exporter currently does not display the top-level TraceID and SpanID for log records, even when these fields are present and correctly populated in incoming OTLP LogRecord data.

This PR updates the debug exporter to render the log record’s top-level trace and span IDs when available, making the debug output accurately reflect the data received by the Collector.

Problem:
OTLP log records may contain valid top-level TraceID and SpanID fields
These fields are preserved through the logs pipeline
The debug exporter always renders Trace ID: and Span ID: as empty for logs
This makes it difficult to verify log–trace correlation during debugging, even though the data is present
Attributes containing trace_id and span_id are shown correctly, which further contributes to the confusion.

Solution:
The debug exporter’s log rendering logic is updated to:
Read the top-level TraceID and SpanID directly from log records
Format and display them in the existing debug output fields
The change is limited to the debug exporter and does not affect log ingestion, processing, or exporting behavior.
Backward Compatibility
No breaking changes
Logs without trace/span context continue to render as before
No impact on non-debug exporters
Tests
Added unit test coverage to ensure trace and span IDs are rendered in debug output when present on log records
Related Issue

Closes #13207
