### PR TITLE
confmap: AllKeys should return empty keys for nil config

### DIFF
--- a/.chloggen/confmap-allkeys-nil-config.yaml
+++ b/.chloggen/confmap-allkeys-nil-config.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: pkg/confmap
+note: Fix AllKeys to return empty keys for nil config
+issues: [14483]

--- a/confmap/internal/conf.go
+++ b/confmap/internal/conf.go
@@ -82,6 +82,9 @@ func (l *Conf) Marshal(rawVal any, opts ...MarshalOption) error {
 // AllKeys returns all keys holding a value, regardless of where they are set.
 // Nested keys are returned with a KeyDelimiter separator.
 func (l *Conf) AllKeys() []string {
+	if l.isNil {
+		return nil
+	}
 	return l.k.Keys()
 }
 

--- a/confmap/internal/confmap_test.go
+++ b/confmap/internal/confmap_test.go
@@ -1292,6 +1292,14 @@ func TestConfIsNil(t *testing.T) {
 	}
 }
 
+func TestConfAllKeysNil(t *testing.T) {
+	conf := NewFromStringMap(nil)
+	require.True(t, conf.isNil)
+
+	require.NoError(t, conf.k.Set("a.b", 1))
+	require.Empty(t, conf.AllKeys())
+}
+
 func TestConfmapNilMerge(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Conf.isNil represents a configuration created from nil (no user config).

The contract and existing tests expect AllKeys() to return an empty slice when isNil is true, but the implementation always returned keys from the internal koanf state.

This change makes AllKeys() respect nil-config semantics by returning empty keys when isNil is true.
