### PR TITLE
Allow adding additional gRPC option to existing components

### DIFF
--- a/.chloggen/bdrutu-14497.yaml
+++ b/.chloggen/bdrutu-14497.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/config/configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow adding additional gRPC option to existing components.
+
+# One or more tracking issues or pull requests related to the change
+issues: [14497]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api, user]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The intent is to be able to add custom grpc.DialOption and grpc.ServerOptions to the connection used by the OTLP exporter/receiver.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #14497

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit testes added.

<!--Describe the documentation added.-->
#### Documentation
Documented the new API.
<!--Please delete paragraphs that you did not use before submitting.-->
