### PR TITLE
[config/confighttp] Fix high cardinality span name from request method from confighttp server internal telemetry

### DIFF
--- a/.chloggen/confighttp_high-cardinality-span-name.yaml
+++ b/.chloggen/confighttp_high-cardinality-span-name.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: config/confighttp
+component: pkg/config/confighttp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix high cardinality span name from request method from confighttp server internal telemetry

--- a/.chloggen/confighttp_high-cardinality-span-name.yaml
+++ b/.chloggen/confighttp_high-cardinality-span-name.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: config/confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix high cardinality span name from request method from confighttp server internal telemetry
+
+# One or more tracking issues or pull requests related to the change
+issues: [14516]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Follow spec to bound request method cardinality.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/config/confighttp/server.go
+++ b/config/confighttp/server.go
@@ -391,8 +391,7 @@ func standardizeHTTPMethod(method string, unknown string) string {
 	method = strings.ToUpper(method)
 	switch method {
 	case http.MethodConnect, http.MethodDelete, http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodPatch, http.MethodPost, http.MethodPut, http.MethodTrace:
-	default:
-		return unknown
+		return method
 	}
-	return method
+	return unknown
 }

--- a/config/confighttp/server.go
+++ b/config/confighttp/server.go
@@ -387,7 +387,7 @@ func maxRequestBodySizeInterceptor(next http.Handler, maxRecvSize int64) http.Ha
 
 // standardizeHTTPMethod returns an upper case HTTP method if well-known, otherwise unknown.
 // Based on https://github.com/open-telemetry/opentelemetry-go-contrib/blob/1530d71edc6d40d0659187d069081b639ef1b394/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/util.go#L119
-func standardizeHTTPMethod(method string, unknown string) string {
+func standardizeHTTPMethod(method, unknown string) string {
 	method = strings.ToUpper(method)
 	switch method {
 	case http.MethodConnect, http.MethodDelete, http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodPatch, http.MethodPost, http.MethodPut, http.MethodTrace:

--- a/config/confighttp/server.go
+++ b/config/confighttp/server.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/rs/cors"
@@ -266,13 +267,18 @@ func (sc *ServerConfig) ToServer(ctx context.Context, extensions map[component.I
 				//
 				//   "HTTP span names SHOULD be {method} {target} if there is a (low-cardinality) target available.
 				//   If there is no (low-cardinality) {target} available, HTTP span names SHOULD be {method}.
-				//   ...
+				//
+				//   The {method} MUST be {http.request.method} if the method represents the original method known
+				//   to the instrumentation. In other cases (when {http.request.method} is set to _OTHER),
+				//   {method} MUST be HTTP.
+				//
 				//   Instrumentation MUST NOT default to using URI path as a {target}."
 				//
+				method := standardizeHTTPMethod(r.Method, "HTTP")
 				if r.Pattern != "" {
-					return r.Method + " " + r.Pattern
+					return method + " " + r.Pattern
 				}
-				return r.Method
+				return method
 			}),
 			otelhttp.WithMeterProvider(settings.MeterProvider),
 		},
@@ -377,4 +383,16 @@ func maxRequestBodySizeInterceptor(next http.Handler, maxRecvSize int64) http.Ha
 		r.Body = http.MaxBytesReader(w, r.Body, maxRecvSize)
 		next.ServeHTTP(w, r)
 	})
+}
+
+// standardizeHTTPMethod returns an upper case HTTP method if well-known, otherwise unknown.
+// Based on https://github.com/open-telemetry/opentelemetry-go-contrib/blob/1530d71edc6d40d0659187d069081b639ef1b394/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/util.go#L119
+func standardizeHTTPMethod(method string, unknown string) string {
+	method = strings.ToUpper(method)
+	switch method {
+	case http.MethodConnect, http.MethodDelete, http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodPatch, http.MethodPost, http.MethodPut, http.MethodTrace:
+	default:
+		return unknown
+	}
+	return method
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Bound cardinality from request method in span name by passing thorugh upper case request method only if well known, otherwise set `{method}` to `HTTP`.

Implemented according to https://opentelemetry.io/docs/specs/semconv/http/http-spans/

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #14516

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit test for unknown method and lowercase method.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
