### PR TITLE
Add gRPC middleware Context-aware interfaces

### DIFF
--- a/config/configmiddleware/configmiddleware.go
+++ b/config/configmiddleware/configmiddleware.go
@@ -68,8 +68,15 @@ func (m Config) GetHTTPServerHandler(_ context.Context, extensions map[component
 // extensionmiddleware.GRPCClient from the map of extensions, and
 // returns the gRPC dial options. If a middleware is not found, an
 // error is returned.  This should only be used by gRPC clients.
-func (m Config) GetGRPCClientOptions(_ context.Context, extensions map[component.ID]component.Component) ([]grpc.DialOption, error) {
+//
+// This function first checks if the extension implements
+// GRPCClientContext (which accepts a context), falling back to
+// GRPCClient for backwards compatibility.
+func (m Config) GetGRPCClientOptions(ctx context.Context, extensions map[component.ID]component.Component) ([]grpc.DialOption, error) {
 	if ext, found := extensions[m.ID]; found {
+		if client, ok := ext.(extensionmiddleware.GRPCClientContext); ok {
+			return client.GetGRPCClientOptionsContext(ctx)
+		}
 		if client, ok := ext.(extensionmiddleware.GRPCClient); ok {
 			return client.GetGRPCClientOptions()
 		}
@@ -82,8 +89,15 @@ func (m Config) GetGRPCClientOptions(_ context.Context, extensions map[component
 // extensionmiddleware.GRPCServer from the map of extensions, and
 // returns the gRPC server options. If a middleware is not found, an
 // error is returned.  This should only be used by gRPC servers.
-func (m Config) GetGRPCServerOptions(_ context.Context, extensions map[component.ID]component.Component) ([]grpc.ServerOption, error) {
+//
+// This function first checks if the extension implements
+// GRPCServerContext (which accepts a context), falling back to
+// GRPCServer for backwards compatibility.
+func (m Config) GetGRPCServerOptions(ctx context.Context, extensions map[component.ID]component.Component) ([]grpc.ServerOption, error) {
 	if ext, found := extensions[m.ID]; found {
+		if server, ok := ext.(extensionmiddleware.GRPCServerContext); ok {
+			return server.GetGRPCServerOptionsContext(ctx)
+		}
 		if server, ok := ext.(extensionmiddleware.GRPCServer); ok {
 			return server.GetGRPCServerOptions()
 		}

--- a/extension/extensionmiddleware/README.md
+++ b/extension/extensionmiddleware/README.md
@@ -54,3 +54,5 @@ server-side middleware object.
 
 - **GRPCClient**: The extension returns `[]grpc.DialOption`.
 - **GRPCServer**: The extension returns `[]grpc.ServerOption`.
+- **GRPCClientContext**: Like `GRPCClient`, but accepts a `context.Context` for operations requiring it (e.g., fetching TLS credentials from a remote source).
+- **GRPCServerContext**: Like `GRPCServer`, but accepts a `context.Context`.

--- a/extension/extensionmiddleware/client.go
+++ b/extension/extensionmiddleware/client.go
@@ -4,28 +4,46 @@
 package extensionmiddleware // import "go.opentelemetry.io/collector/extension/extensionmiddleware"
 
 import (
+	"context"
 	"net/http"
 
 	"google.golang.org/grpc"
 )
 
 // HTTPClient is an interface for HTTP client middleware extensions.
+// This is an open interface for capability detection - extensions
+// implement this interface to provide HTTP client middleware.
 type HTTPClient interface {
 	// GetHTTPRoundTripper wraps the provided client RoundTripper.
 	GetHTTPRoundTripper(http.RoundTripper) (http.RoundTripper, error)
 }
 
 // GRPCClient is an interface for gRPC client middleware extensions.
+// This is an open interface for capability detection - extensions
+// implement this interface to provide gRPC client middleware.
 type GRPCClient interface {
 	// GetGRPCClientOptions returns the gRPC dial options to use for client connections.
 	GetGRPCClientOptions() ([]grpc.DialOption, error)
 }
 
+// GRPCClientContext is an extended interface for gRPC client middleware
+// that accepts a context parameter. Extensions should implement this interface
+// when they need context for operations like fetching TLS credentials from
+// a remote source.
+//
+// This interface is consumed by configgrpc via configmiddleware.
+type GRPCClientContext interface {
+	// GetGRPCClientOptionsContext returns the gRPC dial options with context support.
+	GetGRPCClientOptionsContext(context.Context) ([]grpc.DialOption, error)
+}
+
 var _ HTTPClient = (*GetHTTPRoundTripperFunc)(nil)
 
 // GetHTTPRoundTripperFunc is a function that implements HTTPClient.
+// The nil value is a valid no-op implementation that returns the base unchanged.
 type GetHTTPRoundTripperFunc func(base http.RoundTripper) (http.RoundTripper, error)
 
+// GetHTTPRoundTripper implements HTTPClient. A nil function returns base unchanged.
 func (f GetHTTPRoundTripperFunc) GetHTTPRoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
 	if f == nil {
 		return base, nil
@@ -36,11 +54,27 @@ func (f GetHTTPRoundTripperFunc) GetHTTPRoundTripper(base http.RoundTripper) (ht
 var _ GRPCClient = (*GetGRPCClientOptionsFunc)(nil)
 
 // GetGRPCClientOptionsFunc is a function that implements GRPCClient.
+// The nil value is a valid no-op implementation that returns no options.
 type GetGRPCClientOptionsFunc func() ([]grpc.DialOption, error)
 
+// GetGRPCClientOptions implements GRPCClient. A nil function returns nil options.
 func (f GetGRPCClientOptionsFunc) GetGRPCClientOptions() ([]grpc.DialOption, error) {
 	if f == nil {
 		return nil, nil
 	}
 	return f()
+}
+
+var _ GRPCClientContext = (*GetGRPCClientOptionsContextFunc)(nil)
+
+// GetGRPCClientOptionsContextFunc is a function that implements GRPCClientContext.
+// The nil value is a valid no-op implementation that returns no options.
+type GetGRPCClientOptionsContextFunc func(context.Context) ([]grpc.DialOption, error)
+
+// GetGRPCClientOptionsContext implements GRPCClientContext. A nil function returns nil options.
+func (f GetGRPCClientOptionsContextFunc) GetGRPCClientOptionsContext(ctx context.Context) ([]grpc.DialOption, error) {
+	if f == nil {
+		return nil, nil
+	}
+	return f(ctx)
 }

--- a/extension/extensionmiddleware/extensionmiddlewaretest/err.go
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/err.go
@@ -4,6 +4,7 @@
 package extensionmiddlewaretest // import "go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest"
 
 import (
+	"context"
 	"net/http"
 
 	"google.golang.org/grpc"
@@ -14,11 +15,13 @@ import (
 )
 
 var (
-	_ extension.Extension            = (*baseExtension)(nil)
-	_ extensionmiddleware.HTTPClient = (*baseExtension)(nil)
-	_ extensionmiddleware.GRPCClient = (*baseExtension)(nil)
-	_ extensionmiddleware.HTTPServer = (*baseExtension)(nil)
-	_ extensionmiddleware.GRPCServer = (*baseExtension)(nil)
+	_ extension.Extension                   = (*baseExtension)(nil)
+	_ extensionmiddleware.HTTPClient        = (*baseExtension)(nil)
+	_ extensionmiddleware.GRPCClient        = (*baseExtension)(nil)
+	_ extensionmiddleware.GRPCClientContext = (*baseExtension)(nil)
+	_ extensionmiddleware.HTTPServer        = (*baseExtension)(nil)
+	_ extensionmiddleware.GRPCServer        = (*baseExtension)(nil)
+	_ extensionmiddleware.GRPCServerContext = (*baseExtension)(nil)
 )
 
 type baseExtension struct {
@@ -26,8 +29,10 @@ type baseExtension struct {
 	component.ShutdownFunc
 	extensionmiddleware.GetHTTPHandlerFunc
 	extensionmiddleware.GetGRPCServerOptionsFunc
+	extensionmiddleware.GetGRPCServerOptionsContextFunc
 	extensionmiddleware.GetHTTPRoundTripperFunc
 	extensionmiddleware.GetGRPCClientOptionsFunc
+	extensionmiddleware.GetGRPCClientOptionsContextFunc
 }
 
 // NewErr returns a new [extension.Extension] that implements all
@@ -40,10 +45,16 @@ func NewErr(err error) extension.Extension {
 		GetGRPCClientOptionsFunc: func() ([]grpc.DialOption, error) {
 			return nil, err
 		},
+		GetGRPCClientOptionsContextFunc: func(context.Context) ([]grpc.DialOption, error) {
+			return nil, err
+		},
 		GetHTTPHandlerFunc: func(http.Handler) (http.Handler, error) {
 			return nil, err
 		},
 		GetGRPCServerOptionsFunc: func() ([]grpc.ServerOption, error) {
+			return nil, err
+		},
+		GetGRPCServerOptionsContextFunc: func(context.Context) ([]grpc.ServerOption, error) {
 			return nil, err
 		},
 	}

--- a/extension/extensionmiddleware/extensionmiddlewaretest/err_test.go
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/err_test.go
@@ -4,6 +4,7 @@
 package extensionmiddlewaretest
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -24,6 +25,11 @@ func TestErrClient(t *testing.T) {
 	require.True(t, ok)
 	_, err = grpcClient.GetGRPCClientOptions()
 	require.Error(t, err)
+
+	grpcClientContext, ok := client.(extensionmiddleware.GRPCClientContext)
+	require.True(t, ok)
+	_, err = grpcClientContext.GetGRPCClientOptionsContext(context.Background())
+	require.Error(t, err)
 }
 
 func TestErrServer(t *testing.T) {
@@ -37,5 +43,10 @@ func TestErrServer(t *testing.T) {
 	grpcServer, ok := server.(extensionmiddleware.GRPCServer)
 	require.True(t, ok)
 	_, err = grpcServer.GetGRPCServerOptions()
+	require.Error(t, err)
+
+	grpcServerContext, ok := server.(extensionmiddleware.GRPCServerContext)
+	require.True(t, ok)
+	_, err = grpcServerContext.GetGRPCServerOptionsContext(context.Background())
 	require.Error(t, err)
 }

--- a/extension/extensionmiddleware/extensionmiddlewaretest/nop_test.go
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/nop_test.go
@@ -4,6 +4,7 @@
 package extensionmiddlewaretest
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -26,6 +27,12 @@ func TestNopClient(t *testing.T) {
 	grpcOpts, err := grpcClient.GetGRPCClientOptions()
 	require.NoError(t, err)
 	require.Nil(t, grpcOpts)
+
+	grpcClientContext, ok := client.(extensionmiddleware.GRPCClientContext)
+	require.True(t, ok)
+	grpcOptsContext, err := grpcClientContext.GetGRPCClientOptionsContext(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, grpcOptsContext)
 }
 
 func TestNopServer(t *testing.T) {
@@ -42,6 +49,12 @@ func TestNopServer(t *testing.T) {
 	grpcOpts, err := grpcServer.GetGRPCServerOptions()
 	require.NoError(t, err)
 	require.Nil(t, grpcOpts)
+
+	grpcServerContext, ok := client.(extensionmiddleware.GRPCServerContext)
+	require.True(t, ok)
+	grpcOptsContext, err := grpcServerContext.GetGRPCServerOptionsContext(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, grpcOptsContext)
 }
 
 func TestRoundTripperFunc(t *testing.T) {

--- a/extension/extensionmiddleware/server.go
+++ b/extension/extensionmiddleware/server.go
@@ -4,28 +4,46 @@
 package extensionmiddleware // import "go.opentelemetry.io/collector/extension/extensionmiddleware"
 
 import (
+	"context"
 	"net/http"
 
 	"google.golang.org/grpc"
 )
 
 // HTTPServer defines the interface for HTTP server middleware extensions.
+// This is an open interface for capability detection - extensions
+// implement this interface to provide HTTP server middleware.
 type HTTPServer interface {
 	// GetHTTPHandler wraps the provided base http.Handler.
 	GetHTTPHandler(base http.Handler) (http.Handler, error)
 }
 
 // GRPCServer defines the interface for gRPC server middleware extensions.
+// This is an open interface for capability detection - extensions
+// implement this interface to provide gRPC server middleware.
 type GRPCServer interface {
 	// GetGRPCServerOptions returns options for a gRPC server.
 	GetGRPCServerOptions() ([]grpc.ServerOption, error)
 }
 
+// GRPCServerContext is an extended interface for gRPC server middleware
+// that accepts a context parameter. Extensions should implement this interface
+// when they need context for operations like fetching TLS credentials from
+// a remote source.
+//
+// This interface is consumed by configgrpc via configmiddleware.
+type GRPCServerContext interface {
+	// GetGRPCServerOptionsContext returns the gRPC server options with context support.
+	GetGRPCServerOptionsContext(context.Context) ([]grpc.ServerOption, error)
+}
+
 var _ HTTPServer = (*GetHTTPHandlerFunc)(nil)
 
 // GetHTTPHandlerFunc is a function that implements HTTPServer.
+// The nil value is a valid no-op implementation that returns base unchanged.
 type GetHTTPHandlerFunc func(base http.Handler) (http.Handler, error)
 
+// GetHTTPHandler implements HTTPServer. A nil function returns base unchanged.
 func (f GetHTTPHandlerFunc) GetHTTPHandler(base http.Handler) (http.Handler, error) {
 	if f == nil {
 		return base, nil
@@ -36,11 +54,27 @@ func (f GetHTTPHandlerFunc) GetHTTPHandler(base http.Handler) (http.Handler, err
 var _ GRPCServer = (*GetGRPCServerOptionsFunc)(nil)
 
 // GetGRPCServerOptionsFunc is a function that implements GRPCServer.
+// The nil value is a valid no-op implementation that returns no options.
 type GetGRPCServerOptionsFunc func() ([]grpc.ServerOption, error)
 
+// GetGRPCServerOptions implements GRPCServer. A nil function returns nil options.
 func (f GetGRPCServerOptionsFunc) GetGRPCServerOptions() ([]grpc.ServerOption, error) {
 	if f == nil {
 		return nil, nil
 	}
 	return f()
+}
+
+var _ GRPCServerContext = (*GetGRPCServerOptionsContextFunc)(nil)
+
+// GetGRPCServerOptionsContextFunc is a function that implements GRPCServerContext.
+// The nil value is a valid no-op implementation that returns no options.
+type GetGRPCServerOptionsContextFunc func(context.Context) ([]grpc.ServerOption, error)
+
+// GetGRPCServerOptionsContext implements GRPCServerContext. A nil function returns nil options.
+func (f GetGRPCServerOptionsContextFunc) GetGRPCServerOptionsContext(ctx context.Context) ([]grpc.ServerOption, error) {
+	if f == nil {
+		return nil, nil
+	}
+	return f(ctx)
 }


### PR DESCRIPTION
#### Description

The gRPC middleware interface does not support initializing context-aware middleware. This requires a new method for both client and server. 

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/14523

#### Testing

✅ 

#### Documentation

✅ 
