### PR TITLE
fix(logging): avoid logging sensitive data at info/error levels (fixe…

### DIFF
--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -91,7 +91,7 @@ func (zpe *zpagesExtension) Start(ctx context.Context, host component.Host) erro
 		return err
 	}
 
-	zpe.telemetry.Logger.Info("Starting zPages extension", zap.Any("config", zpe.config))
+	zpe.telemetry.Logger.Info("Starting zPages extension", zap.String("endpoint", zpe.config.NetAddr.Endpoint))
 	zpe.server, err = zpe.config.ToServer(ctx, host.GetExtensions(), zpe.telemetry, zPagesMux)
 	if err != nil {
 		return err


### PR DESCRIPTION


#### Description

Prevents sensitive or potentially sensitive information from being logged at
Info or Error levels. Updates logging to avoid exposing sensitive data while
preserving useful debugging signals and maintaining existing logging behavior.

#### Link to tracking issue

Fixes #14431

#### Testing

- Ran `go test ./...`
- Verified sensitive fields are not logged at Info or Error levels.
- Confirmed no regressions in existing logging-related tests.

#### Documentation

No documentation changes were required.