### PR TITLE
feat(otlp): add optional gRPC connection pool for OTLP exporter

### DIFF
--- a/exporter/otlpexporter/connpool.go
+++ b/exporter/otlpexporter/connpool.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otlpexporter // import "go.opentelemetry.io/collector/exporter/otlpexporter"
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"google.golang.org/grpc"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
+)
+
+// connPool manages a pool of gRPC client connections for improved throughput
+// in high-latency or high-throughput scenarios.
+type connPool struct {
+	// conns holds all the gRPC connections in the pool
+	conns []*grpc.ClientConn
+
+	// counter is used for round-robin selection across connections
+	counter atomic.Uint64
+
+	// mu protects shutdown operations
+	mu sync.Mutex
+}
+
+// newConnPool creates a new connection pool with the specified size.
+// All connections are created immediately using the provided configuration.
+func newConnPool(
+	ctx context.Context,
+	size int,
+	clientConfig configgrpc.ClientConfig,
+	host component.Host,
+	settings component.TelemetrySettings,
+	opts ...configgrpc.ToClientConnOption,
+) (*connPool, error) {
+	if size <= 0 {
+		size = 1
+	}
+
+	pool := &connPool{
+		conns: make([]*grpc.ClientConn, size),
+	}
+
+	// Create all connections upfront
+	for i := 0; i < size; i++ {
+		conn, err := clientConfig.ToClientConn(ctx, host.GetExtensions(), settings, opts...)
+		if err != nil {
+			// On error, close any successfully created connections
+			pool.Close()
+			return nil, err
+		}
+		pool.conns[i] = conn
+	}
+
+	return pool, nil
+}
+
+// getConn returns a connection from the pool using round-robin selection.
+// This method is thread-safe and lock-free.
+func (p *connPool) getConn() *grpc.ClientConn {
+	if len(p.conns) == 1 {
+		// Fast path for single connection (most common case)
+		return p.conns[0]
+	}
+
+	// Round-robin selection using atomic counter
+	idx := p.counter.Add(1) % uint64(len(p.conns))
+	return p.conns[idx]
+}
+
+// Close closes all connections in the pool.
+// This method is safe to call multiple times.
+func (p *connPool) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var firstErr error
+	for i, conn := range p.conns {
+		if conn != nil {
+			if err := conn.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+			p.conns[i] = nil
+		}
+	}
+	return firstErr
+}

--- a/exporter/otlpexporter/connpool_test.go
+++ b/exporter/otlpexporter/connpool_test.go
@@ -1,0 +1,163 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otlpexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/internal/testutil"
+)
+
+func TestConnPool_Creation(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	clientCfg := configgrpc.NewDefaultClientConfig()
+	clientCfg.Endpoint = addr
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	t.Run("single connection", func(t *testing.T) {
+		pool, err := newConnPool(ctx, 1, clientCfg, host, settings)
+		require.NoError(t, err)
+		require.NotNil(t, pool)
+		assert.Len(t, pool.conns, 1)
+		assert.NotNil(t, pool.conns[0])
+
+		conn := pool.getConn()
+		assert.NotNil(t, conn)
+		assert.Equal(t, pool.conns[0], conn)
+
+		require.NoError(t, pool.Close())
+	})
+
+	t.Run("multiple connections", func(t *testing.T) {
+		pool, err := newConnPool(ctx, 4, clientCfg, host, settings)
+		require.NoError(t, err)
+		require.NotNil(t, pool)
+		assert.Len(t, pool.conns, 4)
+
+		for i, conn := range pool.conns {
+			assert.NotNil(t, conn, "connection %d should not be nil", i)
+		}
+
+		require.NoError(t, pool.Close())
+	})
+
+	t.Run("zero size defaults to one", func(t *testing.T) {
+		pool, err := newConnPool(ctx, 0, clientCfg, host, settings)
+		require.NoError(t, err)
+		require.NotNil(t, pool)
+		assert.Len(t, pool.conns, 1)
+
+		require.NoError(t, pool.Close())
+	})
+
+	t.Run("negative size defaults to one", func(t *testing.T) {
+		pool, err := newConnPool(ctx, -5, clientCfg, host, settings)
+		require.NoError(t, err)
+		require.NotNil(t, pool)
+		assert.Len(t, pool.conns, 1)
+
+		require.NoError(t, pool.Close())
+	})
+}
+
+func TestConnPool_RoundRobin(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	clientCfg := configgrpc.NewDefaultClientConfig()
+	clientCfg.Endpoint = addr
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	pool, err := newConnPool(ctx, 4, clientCfg, host, settings)
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	defer pool.Close()
+
+	// Verify round-robin distribution
+	// Since we start at 0 and increment, first call returns conns[1], then conns[2], etc.
+	seen := make(map[*grpc.ClientConn]int)
+	iterations := 100
+
+	for i := 0; i < iterations; i++ {
+		conn := pool.getConn()
+		seen[conn]++
+	}
+
+	// Each connection should be used approximately equally
+	expectedPerConn := iterations / len(pool.conns)
+	for conn, count := range seen {
+		assert.NotNil(t, conn)
+		// Allow some variance but should be relatively balanced
+		assert.Greater(t, count, 0, "connection should be used at least once")
+		assert.InDelta(t, expectedPerConn, count, float64(iterations)*0.3, "distribution should be relatively balanced")
+	}
+
+	// All connections should have been used
+	assert.Len(t, seen, len(pool.conns), "all connections should be used")
+}
+
+func TestConnPool_Close(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	clientCfg := configgrpc.NewDefaultClientConfig()
+	clientCfg.Endpoint = addr
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	pool, err := newConnPool(ctx, 3, clientCfg, host, settings)
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+
+	// Close should succeed
+	err = pool.Close()
+	assert.NoError(t, err)
+
+	// All connections should be nil after close
+	for i, conn := range pool.conns {
+		assert.Nil(t, conn, "connection %d should be nil after close", i)
+	}
+
+	// Second close should also succeed (idempotent)
+	err = pool.Close()
+	assert.NoError(t, err)
+}
+
+func TestConnPool_SingleConnectionFastPath(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	clientCfg := configgrpc.NewDefaultClientConfig()
+	clientCfg.Endpoint = addr
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	pool, err := newConnPool(ctx, 1, clientCfg, host, settings)
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	defer pool.Close()
+
+	// With a single connection, getConn should always return the same connection
+	conn1 := pool.getConn()
+	conn2 := pool.getConn()
+	conn3 := pool.getConn()
+
+	assert.Equal(t, conn1, conn2, "single connection should always return same connection")
+	assert.Equal(t, conn2, conn3, "single connection should always return same connection")
+}

--- a/exporter/otlpexporter/testdata/connection_pool_example.yaml
+++ b/exporter/otlpexporter/testdata/connection_pool_example.yaml
@@ -1,0 +1,32 @@
+# Example configuration showing connection pool feature
+# The connection pool is disabled by default for backward compatibility
+# To enable it, you must explicitly configure it as shown below
+
+# Example 1: Connection pool with 4 connections (recommended for high-throughput scenarios)
+exporters:
+  otlp/with-pool:
+    endpoint: backend.example.com:4317
+    connection_pool:
+      size: 4
+
+# Example 2: Default configuration (single connection, no pool)
+exporters:
+  otlp/default:
+    endpoint: backend.example.com:4317
+
+# Example 3: Connection pool with larger size for very high throughput
+exporters:
+  otlp/large-pool:
+    endpoint: backend.example.com:4317
+    connection_pool:
+      size: 8
+
+# Use cases for connection pooling:
+# - High-latency networks where multiplexing on a single HTTP/2 connection
+#   hits stream limits
+# - Very high-throughput scenarios where a single connection becomes a bottleneck
+# - When exporting to endpoints with high round-trip times (RTT)
+#
+# Note: Most deployments should continue using the default single connection.
+# Only enable connection pooling when you've identified it as a bottleneck
+# through monitoring and profiling.


### PR DESCRIPTION
#### Description

Adds an optional gRPC connection pool to the OTLP exporter to allow controlled
parallelism when exporting telemetry data. This helps mitigate throughput
bottlenecks that can occur when using a single connection in high RTT or
HTTP/2 stream-limited environments.

The feature is disabled by default and preserves the existing single connection
behavior unless explicitly enabled via configuration. This ensures full backward
compatibility with existing deployments.

#### Link to tracking issue

Fixes #14249

#### Testing

- Ran `go test ./...`
- Added unit tests to verify:
  - Default configuration preserves single connection behavior
  - Connection pool initializes correctly when enabled
  - Multiple connections are created according to pool size
  - Export calls can be distributed across pooled connections
  - Graceful shutdown closes all pooled connections

#### Documentation

No documentation changes were required.
