### PR TITLE
otelcol: reject extra positional args for featuregate

### DIFF
--- a/.chloggen/otelcol-featuregate-max-args.yaml
+++ b/.chloggen/otelcol-featuregate-max-args.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: pkg/otelcol
+note: The featuregate subcommand now rejects extra positional arguments instead of silently ignoring them.
+issues: [14554]

--- a/otelcol/command.go
+++ b/otelcol/command.go
@@ -75,6 +75,7 @@ func newFeatureGateCommand() *cobra.Command {
 		Use:   "featuregate [feature-id]",
 		Short: "Display feature gates information",
 		Long:  "Display information about available feature gates and their status",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				found := false

--- a/otelcol/command_test.go
+++ b/otelcol/command_test.go
@@ -216,4 +216,11 @@ func TestNewFeatureGateCommand(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "feature \"non.existent.feature\" not found")
 	})
+
+	t.Run("rejects multiple arguments", func(t *testing.T) {
+		cmd := newFeatureGateCommand()
+		cmd.SetArgs([]string{"gate1", "gate2"})
+		err := cmd.Execute()
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
Passing multiple positional arguments to the featuregate command is silently accepted and extra arguments are ignored.

**Actual behavior**
Command succeeds and ignores additional positional arguments.

**Expected behavior**
Error: accepts at most 1 arg(s), received 2

**Steps to reproduce (from repo root, using the otelcorecol binary as an example):**
 - cd cmd/otelcorecol
 - go build -o otelcorecol .
 - ./otelcorecol featuregate gate1 gate2  

This change enforces the documented featuregate [feature-id] contract by rejecting extra positional arguments at the Cobra validation layer, consistent with other otelcol subcommands.