### PR TITLE
Add support for insecure TLS ciphers

### DIFF
--- a/.chloggen/tls-insecure-suites.yaml
+++ b/.chloggen/tls-insecure-suites.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: configtls
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for TLS insecure suites.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/tls-insecure-suites.yaml
+++ b/.chloggen/tls-insecure-suites.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: configtls
+component: pkg/config/configtls
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add support for TLS insecure cipher suites.

--- a/.chloggen/tls-insecure-suites.yaml
+++ b/.chloggen/tls-insecure-suites.yaml
@@ -7,10 +7,10 @@ change_type: enhancement
 component: configtls
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add support for TLS insecure suites.
+note: Add support for TLS insecure cipher suites.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [14557]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -288,13 +288,15 @@ func (c Config) loadTLSConfig() (*tls.Config, error) {
 		curvePreferences = allowedCurves
 	}
 
+	// Intentionally allowing insecure cipher suites for legacy system compatibility.
+	// Users explicitly configure cipher_suites in their configuration when needed.
 	return &tls.Config{
 		RootCAs:              certPool,
 		GetCertificate:       getCertificate,
 		GetClientCertificate: getClientCertificate,
 		MinVersion:           minTLS,
 		MaxVersion:           maxTLS,
-		CipherSuites:         cipherSuites,
+		CipherSuites:         cipherSuites, // lgtm[go/insecure-tls]
 		CurvePreferences:     curvePreferences,
 	}, nil
 }

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -304,7 +304,8 @@ func convertCipherSuites(cipherSuites []string) ([]uint16, error) {
 	var errs []error
 	for _, suite := range cipherSuites {
 		found := false
-		for _, supported := range tls.CipherSuites() {
+		allSuites := append(tls.CipherSuites(), tls.InsecureCipherSuites()...)
+		for _, supported := range allSuites {
 			if suite == supported.Name {
 				result = append(result, supported.ID)
 				found = true

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -711,6 +711,13 @@ func TestCipherSuites(t *testing.T) {
 			result: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
 		},
 		{
+			name: "insecure cipher suite set",
+			tlsSetting: Config{
+				CipherSuites: []string{"TLS_RSA_WITH_RC4_128_SHA"},
+			},
+			result: []uint16{tls.TLS_RSA_WITH_RC4_128_SHA},
+		},
+		{
 			name: "invalid cipher suite set",
 			tlsSetting: Config{
 				CipherSuites: []string{"FOO"},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds support for using insecure TLS ciphers.
The insecure ciphers are for instance used by the "Old"  TLS profile https://wiki.mozilla.org/Security/Server_Side_TLS. 


<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
