### PR TITLE
[chore] disable fips140 only for now

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -27,7 +27,9 @@ JUNIT_OUT_DIR ?= $(TOOLS_MOD_DIR)/testresults
 test:
     # GODEBUG=fips140=only is used to surface any FIPS-140-3 non-compliant cryptographic
     # calls into the Go standard library. See: https://go.dev/doc/security/fips140#fips-140-3-mode
-	GODEBUG=fips140=only $(GO_TOOL) gotestsum --packages="./..." -- $(GOTEST_OPT)
+	# disabling fips only to unblock CI. See https://github.com/open-telemetry/opentelemetry-collector/issues/13925
+	# GODEBUG=fips140=only $(GO_TOOL) gotestsum --packages="./..." -- $(GOTEST_OPT)
+	$(GO_TOOL) gotestsum --packages="./..." -- $(GOTEST_OPT)
 
 .PHONY: test-with-cover
 test-with-cover:


### PR DESCRIPTION
This is blocking the go upgrade, see https://github.com/open-telemetry/opentelemetry-collector/pull/14567 for more details.

Part of #13925
