### PR TITLE
[chore] Add js/wasm as a tier-3 platform

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -244,6 +244,8 @@ jobs:
             goarch: amd64
           - goos: darwin
             goarch: arm64
+          - goos: js
+            goarch: wasm
           - goos: linux
             goarch: 386
           - goos: linux

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -61,6 +61,7 @@ Tier 3 platforms are currently:
 | Platform      | Owner(s)                                                                                                                                                       |
 |---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | darwin/amd64  | [@h0cheung](https://github.com/h0cheung)                                                                                                                       |
+| js/wasm       | [@evan-bradley](https://github.com/evan-bradley), [@mx-psi](https://github.com/mx-psi)                                                                         |
 | linux/386     | [@andrzej-stencel](https://github.com/andrzej-stencel)                                                                                                         |
 | linux/arm     | [@Wal8800](https://github.com/Wal8800), [@atoulme](https://github.com/atoulme)                                                                                 |
 | linux/ppc64le | [@IBM-Currency-Helper](https://github.com/IBM-Currency-Helper), [@adilhusain-s](https://github.com/adilhusain-s), [@seth-priya](https://github.com/seth-priya) |


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds js/wasm as a build target. I will add workflow steps to produce a core/otlp distro binary in a follow-up.

I can also do the changes in -releases in a prerequisite PR, if there's a strong preference for doing it in that direction.

<!-- Issue number if applicable -->
#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/14542
