### PR TITLE
[mdatagen] Add optional relationships field to entity schema

### DIFF
--- a/.chloggen/telemetry-relationships.yaml
+++ b/.chloggen/telemetry-relationships.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add optional `relationships` field to entity schema in metadata.yaml
+
+# One or more tracking issues or pull requests related to the change
+issues: [14284]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -144,6 +144,22 @@ func TestValidate(t *testing.T) {
 			name:    "testdata/invalid_entity_stability.yaml",
 			wantErr: `unsupported stability level: "stable42"`,
 		},
+		{
+			name:    "testdata/entity_relationships_bidirectional.yaml",
+			wantErr: `duplicate relationship to target "k8s.replicaset" (only one relationship allowed between two entities)`,
+		},
+		{
+			name:    "testdata/entity_relationships_empty_type.yaml",
+			wantErr: `entity "k8s.pod": relationship type cannot be empty`,
+		},
+		{
+			name:    "testdata/entity_relationships_empty_target.yaml",
+			wantErr: `entity "k8s.pod": relationship target cannot be empty`,
+		},
+		{
+			name:    "testdata/entity_relationships_undefined_target.yaml",
+			wantErr: `entity "k8s.pod": relationship target "k8s.replicaset" does not exist`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/mdatagen/internal/testdata/entity_relationships_bidirectional.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_bidirectional.yaml
@@ -1,0 +1,33 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  k8s.replicaset.uid:
+    description: The unique identifier of the Kubernetes ReplicaSet
+    type: string
+    enabled: true
+  k8s.pod.uid:
+    description: The unique identifier of the Kubernetes pod
+    type: string
+    enabled: true
+
+entities:
+  - type: k8s.replicaset
+    brief: A Kubernetes ReplicaSet
+    stability: stable
+    identity:
+      - ref: k8s.replicaset.uid
+    relationships:
+      - type: controls
+        target: k8s.pod
+  - type: k8s.pod
+    brief: A Kubernetes pod
+    stability: stable
+    identity:
+      - ref: k8s.pod.uid
+    relationships:
+      - type: controlled_by
+        target: k8s.replicaset

--- a/cmd/mdatagen/internal/testdata/entity_relationships_empty_target.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_empty_target.yaml
@@ -1,0 +1,29 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  k8s.replicaset.uid:
+    description: The unique identifier of the Kubernetes ReplicaSet
+    type: string
+    enabled: true
+  k8s.pod.uid:
+    description: The unique identifier of the Kubernetes pod
+    type: string
+    enabled: true
+
+entities:
+  - type: k8s.replicaset
+    brief: A Kubernetes ReplicaSet
+    stability: stable
+    identity:
+      - ref: k8s.replicaset.uid
+  - type: k8s.pod
+    brief: A Kubernetes pod
+    stability: stable
+    identity:
+      - ref: k8s.pod.uid
+    relationships:
+      - type: controlled_by

--- a/cmd/mdatagen/internal/testdata/entity_relationships_empty_type.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_empty_type.yaml
@@ -1,0 +1,29 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  k8s.replicaset.uid:
+    description: The unique identifier of the Kubernetes ReplicaSet
+    type: string
+    enabled: true
+  k8s.pod.uid:
+    description: The unique identifier of the Kubernetes pod
+    type: string
+    enabled: true
+
+entities:
+  - type: k8s.replicaset
+    brief: A Kubernetes ReplicaSet
+    stability: stable
+    identity:
+      - ref: k8s.replicaset.uid
+  - type: k8s.pod
+    brief: A Kubernetes pod
+    stability: stable
+    identity:
+      - ref: k8s.pod.uid
+    relationships:
+      - target: k8s.replicaset

--- a/cmd/mdatagen/internal/testdata/entity_relationships_undefined_target.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_undefined_target.yaml
@@ -1,0 +1,21 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  k8s.pod.uid:
+    description: The unique identifier of the Kubernetes pod
+    type: string
+    enabled: true
+
+entities:
+  - type: k8s.pod
+    brief: A Kubernetes pod
+    stability: stable
+    identity:
+      - ref: k8s.pod.uid
+    relationships:
+      - type: controlled_by
+        target: k8s.replicaset

--- a/cmd/mdatagen/internal/testdata/entity_relationships_valid.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_valid.yaml
@@ -1,0 +1,42 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  k8s.replicaset.uid:
+    description: The unique identifier of the Kubernetes ReplicaSet
+    type: string
+    enabled: true
+  k8s.replicaset.name:
+    description: The name of the Kubernetes ReplicaSet
+    type: string
+    enabled: true
+  k8s.pod.uid:
+    description: The unique identifier of the Kubernetes pod
+    type: string
+    enabled: true
+  k8s.pod.name:
+    description: The name of the Kubernetes pod
+    type: string
+    enabled: true
+
+entities:
+  - type: k8s.replicaset
+    brief: A Kubernetes ReplicaSet
+    stability: stable
+    identity:
+      - ref: k8s.replicaset.uid
+    description:
+      - ref: k8s.replicaset.name
+  - type: k8s.pod
+    brief: A Kubernetes pod
+    stability: stable
+    identity:
+      - ref: k8s.pod.uid
+    description:
+      - ref: k8s.pod.name
+    relationships:
+      - type: controlled_by
+        target: k8s.replicaset

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -87,6 +87,16 @@ entities:
     # All referenced attributes must be defined in the resource_attributes section.
     description:
       - ref: string
+    # Optional: array of relationships to other entities. Relationships should be defined on only
+    # one end to avoid bidirectional definitions. It is recommended to define relationships on
+    # entities with lower lifespan (higher churn). For example, a pod should define its relationship
+    # to a replicaset, rather than the replicaset defining its relationship to pods.
+    relationships:
+      - # Required: the type of the relationship (e.g., "controlled_by", "parent", "peer").
+        type: string
+        # Required: the target entity type this entity relates to. Must reference an entity
+        # defined in the same metadata.yaml file.
+        target: string
 
 # Optional: map of attribute definitions with the key being the attribute name and value
 # being described below.


### PR DESCRIPTION
Work towards https://github.com/open-telemetry/opentelemetry-collector/issues/14284

This PR introduces an optional `relationships` field to define relationships between entities in metadata.yaml. No code or documentation is generated from relationships at this time.

The relationships will be used in the future for:
1. Immediate need: Determining what entities need to be associated with resources when only one "owning" entity is directly associated with the produced telemetry.
2. Long term: Sending the relationships along with entity events