### PR TITLE
[mdatagen] Require entity association for metrics and events when entities are defined

### DIFF
--- a/.chloggen/mdatagen-entity-association.yaml
+++ b/.chloggen/mdatagen-entity-association.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add entity association requirement for metrics and events when entities are defined
+
+# One or more tracking issues or pull requests related to the change
+issues: [14284]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -241,7 +241,8 @@ func (md *Metadata) validateMetricsAndEvents() error {
 		validateMetrics(md.Metrics, md.Attributes, usedAttrs, md.SemConvVersion),
 		validateMetrics(md.Telemetry.Metrics, md.Attributes, usedAttrs, md.SemConvVersion),
 		validateEvents(md.Events, md.Attributes, usedAttrs),
-		md.validateAttributes(usedAttrs))
+		md.validateAttributes(usedAttrs),
+		md.validateEntityAssociations())
 	return errs
 }
 
@@ -266,6 +267,36 @@ func (md *Metadata) validateAttributes(usedAttrs map[AttributeName]bool) error {
 	if len(unusedAttrs) > 0 {
 		errs = errors.Join(errs, fmt.Errorf("unused attributes: %v", unusedAttrs))
 	}
+	return errs
+}
+
+// validateEntityAssociations checks that if entities are defined, then each metric and event must be associated with an entity.
+func (md *Metadata) validateEntityAssociations() error {
+	var errs error
+	requireEntityAssociation := len(md.Entities) > 0
+	entityTypes := make(map[string]bool)
+	for _, entity := range md.Entities {
+		entityTypes[entity.Type] = true
+	}
+
+	for metricName, metric := range md.Metrics {
+		if requireEntityAssociation && metric.Entity == "" {
+			errs = errors.Join(errs, fmt.Errorf(`metric "%v": entity is required when entities are defined`, metricName))
+		}
+		if metric.Entity != "" && !entityTypes[metric.Entity] {
+			errs = errors.Join(errs, fmt.Errorf(`metric "%v": entity refers to undefined entity type: %v`, metricName, metric.Entity))
+		}
+	}
+
+	for eventName, event := range md.Events {
+		if requireEntityAssociation && event.Entity == "" {
+			errs = errors.Join(errs, fmt.Errorf(`event "%v": entity is required when entities are defined`, eventName))
+		}
+		if event.Entity != "" && !entityTypes[event.Entity] {
+			errs = errors.Join(errs, fmt.Errorf(`event "%v": entity refers to undefined entity type: %v`, eventName, event.Entity))
+		}
+	}
+
 	return errs
 }
 
@@ -656,6 +687,10 @@ type Signal struct {
 
 	// Attributes is the list of attributes that the signal emits.
 	Attributes []AttributeName `mapstructure:"attributes"`
+
+	// Entity is the type of entity this signal is associated with.
+	// Required when entities are defined.
+	Entity string `mapstructure:"entity"`
 }
 
 func (s Signal) HasConditionalAttributes(attrs map[AttributeName]Attribute) bool {

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -160,12 +160,36 @@ func TestValidate(t *testing.T) {
 			name:    "testdata/entity_relationships_undefined_target.yaml",
 			wantErr: `entity "k8s.pod": relationship target "k8s.replicaset" does not exist`,
 		},
+		{
+			name:    "testdata/entity_metric_missing_association.yaml",
+			wantErr: `metric "host.cpu.time": entity is required when entities are defined`,
+		},
+		{
+			name:    "testdata/entity_event_missing_association.yaml",
+			wantErr: `event "host.restart": entity is required when entities are defined`,
+		},
+		{
+			name:    "testdata/entity_undefined_reference.yaml",
+			wantErr: `metric "host.cpu.time": entity refers to undefined entity type: undefined_entity`,
+		},
+		{
+			name:    "testdata/entity_single_metric_missing_association.yaml",
+			wantErr: `metric "host.cpu.time": entity is required when entities are defined`,
+		},
+		{
+			name:    "testdata/entity_metrics_events_valid.yaml",
+			wantErr: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := LoadMetadata(tt.name)
-			require.Error(t, err)
-			require.ErrorContains(t, err, tt.wantErr)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/cmd/mdatagen/internal/sampleconnector/metadata.yaml
+++ b/cmd/mdatagen/internal/sampleconnector/metadata.yaml
@@ -123,6 +123,7 @@ metrics:
       aggregation_temporality: cumulative
     attributes:
       [string_attr, overridden_int_attr, enum_attr, slice_attr, map_attr]
+    entity: test.entity
     warnings:
       if_enabled_not_set: This metric will be disabled by default soon.
 
@@ -139,6 +140,7 @@ metrics:
       value_type: double
       monotonic: false
       aggregation_temporality: delta
+    entity: test.entity
     warnings:
       if_enabled: This metric is deprecated and will be removed soon.
 
@@ -154,6 +156,7 @@ metrics:
       aggregation_temporality: cumulative
     attributes:
       [string_attr, overridden_int_attr, enum_attr, slice_attr, map_attr]
+    entity: test.entity
 
   optional.metric:
     enabled: false
@@ -166,6 +169,7 @@ metrics:
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr, boolean_attr2]
+    entity: test.entity
     warnings:
       if_configured: This metric is deprecated and will be removed soon.
 
@@ -180,6 +184,7 @@ metrics:
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr]
+    entity: test.entity
     warnings:
       if_configured: This metric is deprecated and will be removed soon.
 
@@ -191,3 +196,4 @@ metrics:
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr]
+    entity: test.entity

--- a/cmd/mdatagen/internal/testdata/entity_event_missing_association.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_event_missing_association.yaml
@@ -1,0 +1,38 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  host.id:
+    description: The unique host identifier
+    type: string
+    enabled: true
+  process.pid:
+    description: The process identifier
+    type: int
+    enabled: true
+
+entities:
+  - type: host
+    brief: A host instance.
+    stability: stable
+    identity:
+      - ref: host.id
+  - type: process
+    brief: A process instance.
+    stability: stable
+    identity:
+      - ref: process.pid
+
+attributes:
+  test.attr:
+    description: Test attribute
+    type: string
+
+events:
+  host.restart:
+    enabled: true
+    description: Host restart event
+    attributes: [test.attr]

--- a/cmd/mdatagen/internal/testdata/entity_metric_missing_association.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_metric_missing_association.yaml
@@ -1,0 +1,44 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  host.id:
+    description: The unique host identifier
+    type: string
+    enabled: true
+  process.pid:
+    description: The process identifier
+    type: int
+    enabled: true
+
+entities:
+  - type: host
+    brief: A host instance.
+    stability: stable
+    identity:
+      - ref: host.id
+  - type: process
+    brief: A process instance.
+    stability: stable
+    identity:
+      - ref: process.pid
+
+attributes:
+  test.attr:
+    description: Test attribute
+    type: string
+
+metrics:
+  host.cpu.time:
+    enabled: true
+    description: Host CPU time
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    stability: stable
+    attributes: [test.attr]

--- a/cmd/mdatagen/internal/testdata/entity_metrics_events_valid.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_metrics_events_valid.yaml
@@ -1,0 +1,76 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  host.id:
+    description: The unique host identifier
+    type: string
+    enabled: true
+  host.name:
+    description: The hostname
+    type: string
+    enabled: true
+  process.pid:
+    description: The process identifier
+    type: int
+    enabled: true
+
+entities:
+  - type: host
+    brief: A host instance.
+    stability: stable
+    identity:
+      - ref: host.id
+    description:
+      - ref: host.name
+  - type: process
+    brief: A process instance.
+    stability: stable
+    identity:
+      - ref: process.pid
+
+attributes:
+  test.attr:
+    description: Test attribute
+    type: string
+
+metrics:
+  host.cpu.time:
+    enabled: true
+    description: Host CPU time
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    stability: stable
+    entity: host
+    attributes: [test.attr]
+
+  process.cpu.time:
+    enabled: true
+    description: Process CPU time
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    stability: stable
+    entity: process
+    attributes: [test.attr]
+
+events:
+  host.restart:
+    enabled: true
+    description: Host restart event
+    entity: host
+    attributes: [test.attr]
+
+  process.start:
+    enabled: true
+    description: Process start event
+    entity: process
+    attributes: [test.attr]

--- a/cmd/mdatagen/internal/testdata/entity_single_metric_missing_association.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_single_metric_missing_association.yaml
@@ -1,0 +1,35 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  host.id:
+    description: The unique host identifier
+    type: string
+    enabled: true
+
+entities:
+  - type: host
+    brief: A host instance.
+    stability: stable
+    identity:
+      - ref: host.id
+
+attributes:
+  test.attr:
+    description: Test attribute
+    type: string
+
+metrics:
+  host.cpu.time:
+    enabled: true
+    description: Host CPU time
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    stability: stable
+    attributes: [test.attr]

--- a/cmd/mdatagen/internal/testdata/entity_undefined_reference.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_undefined_reference.yaml
@@ -1,0 +1,36 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  host.id:
+    description: The unique host identifier
+    type: string
+    enabled: true
+
+entities:
+  - type: host
+    brief: A host instance.
+    stability: stable
+    identity:
+      - ref: host.id
+
+attributes:
+  test.attr:
+    description: Test attribute
+    type: string
+
+metrics:
+  host.cpu.time:
+    enabled: true
+    description: Host CPU time
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    stability: stable
+    entity: undefined_entity
+    attributes: [test.attr]

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -155,6 +155,10 @@ metrics:
       input_type: string
     # Optional: array of attributes that were defined in the attributes section that are emitted by this metric.
     attributes: [string]
+    # Optional: the entity type this metric is associated with.
+    # Required when entities are defined in the entities section.
+    # Must reference an entity type defined in the entities section.
+    entity: string
     # Required: the metric stability
     stability: <development|alpha|beta|stable|deprecated>
     # Deprecation information for the metric. Required when stability is `deprecated`.
@@ -188,6 +192,10 @@ events:
       if_configured:
     # Optional: array of attributes that were defined in the attributes section that are emitted by this event.
     attributes: [string]
+    # Optional: the entity type this event is associated with.
+    # Required when entities are defined in the entities section.
+    # Must reference an entity type defined in the entities section.
+    entity: string
 
 # Lifecycle tests generated for this component.
 tests:


### PR DESCRIPTION
Work towards https://github.com/open-telemetry/opentelemetry-collector/issues/14284

This PR enhances metadata.yaml validation to require that every metric (in the metrics section, not telemetry) and event (in the events section) must be associated with an entity when entities are defined.

This ensures proper entity relationships in components that produce entity-associated telemetry. The entity field references an entity type defined in the entities section.

For now, no code or documentation is generated, just validation rules:
- When entities are defined, all metrics and events must have an `entity` field
- The `entity` value must reference a valid entity type from the entities section
- Telemetry metrics are not subject to this requirement