### PR TITLE
fix: upgrade Go to 1.26.0 to resolve CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module go.opentelemetry.io/collector
 // For the OpenTelemetry Collector Core distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Summary
Upgrades Go version to 1.26.0 to fix a CRITICAL vulnerability in the Go standard library.

## CVE Fixed
CVE-2025-68121 (CRITICAL): crypto/tls session resumption vulnerability

This is a minimal version bump fix.