### PR TITLE
[chore] Temporarily disable CodSpeed

### DIFF
--- a/.github/workflows/go-benchmarks.yml
+++ b/.github/workflows/go-benchmarks.yml
@@ -1,10 +1,6 @@
 name: CodSpeed Benchmarks
 
 on:
-  push:
-    branches:
-      - "main"
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Temporarily disables automatically running CodSpeed on main and PRs while we determine how to make the workflow reliably run under the workflow time limit. This still retains the ability to manually trigger runs.

<!-- Issue number if applicable -->
#### Link to tracking issue

Related to https://github.com/open-telemetry/opentelemetry-collector/issues/14636