### PR TITLE
[chore] Add workflow to update all intra-core dependencies to pseudo-versions

### DIFF
--- a/.github/workflows/scripts/update-core-pseudo-versions.sh
+++ b/.github/workflows/scripts/update-core-pseudo-versions.sh
@@ -1,0 +1,212 @@
+#!/bin/bash -e
+#
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script updates all go.opentelemetry.io/collector dependencies in go.mod
+# files to use pseudo-versions derived from a specific commit on the main branch.
+#
+# This is useful for ensuring that all intra-core dependencies are consistent
+# when downstream repos (like collector-contrib) update to the latest main.
+#
+# Usage:
+#   ./update-core-pseudo-versions.sh [--commit <sha>] [--target-dir <dir>]
+#
+# Options:
+#   --commit <sha>       The commit SHA to use for pseudo-versions.
+#                        Defaults to HEAD of the main branch.
+#   --target-dir <dir>   The directory containing go.mod files to update.
+#                        Defaults to the current directory. When used from
+#                        collector-contrib, set this to the contrib repo root.
+#
+# Environment variables:
+#   CORE_REPO_DIR        Path to a local checkout of opentelemetry-collector.
+#                        If not set, the script expects to be run from inside
+#                        the core repo (or uses the repo where this script lives).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${CORE_REPO_DIR:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}"
+
+COMMIT=""
+TARGET_DIR="."
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --commit)
+            COMMIT="$2"
+            shift 2
+            ;;
+        --target-dir)
+            TARGET_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Resolve target directory to absolute path
+TARGET_DIR="$(cd "${TARGET_DIR}" && pwd)"
+
+# If no commit specified, use HEAD of main
+if [[ -z "${COMMIT}" ]]; then
+    pushd "${REPO_ROOT}" > /dev/null
+    COMMIT="$(git rev-parse HEAD)"
+    popd > /dev/null
+    echo "Using HEAD commit: ${COMMIT}"
+fi
+
+# Get the short commit hash (first 12 characters)
+SHORT_COMMIT="${COMMIT:0:12}"
+
+# Get the commit timestamp in the format Go uses for pseudo-versions (YYYYMMDDHHmmss)
+pushd "${REPO_ROOT}" > /dev/null
+COMMIT_TIMESTAMP="$(git log -1 --format='%cd' --date=format:'%Y%m%d%H%M%S' "${COMMIT}")"
+popd > /dev/null
+
+echo "Commit: ${COMMIT}"
+echo "Timestamp: ${COMMIT_TIMESTAMP}"
+echo ""
+
+# Parse versions.yaml to extract module sets and their versions
+# We need to compute pseudo-versions for both "stable" and "beta" module sets.
+VERSIONS_YAML="${REPO_ROOT}/versions.yaml"
+if [[ ! -f "${VERSIONS_YAML}" ]]; then
+    echo "Error: versions.yaml not found at ${VERSIONS_YAML}"
+    exit 1
+fi
+
+# Extract version for a given module set from versions.yaml
+get_version_for_set() {
+    local set_name="$1"
+    # Parse the version field under the given module-set
+    awk -v set="${set_name}" '
+        /^  [a-z]+:/ { current_set = $1; gsub(/:/, "", current_set) }
+        current_set == set && /version:/ { print $2; exit }
+    ' "${VERSIONS_YAML}"
+}
+
+# Extract modules for a given module set from versions.yaml
+get_modules_for_set() {
+    local set_name="$1"
+    awk -v set="${set_name}" '
+        /^  [a-z]+:/ { current_set = $1; gsub(/:/, "", current_set) }
+        current_set == set && /^      - / { gsub(/^      - /, ""); print }
+    ' "${VERSIONS_YAML}"
+}
+
+STABLE_VERSION="$(get_version_for_set "stable")"
+BETA_VERSION="$(get_version_for_set "beta")"
+
+if [[ -z "${STABLE_VERSION}" ]] || [[ -z "${BETA_VERSION}" ]]; then
+    echo "Error: Could not extract versions from versions.yaml"
+    echo "  stable: ${STABLE_VERSION}"
+    echo "  beta: ${BETA_VERSION}"
+    exit 1
+fi
+
+echo "Current stable version: ${STABLE_VERSION}"
+echo "Current beta version: ${BETA_VERSION}"
+
+# Compute pseudo-versions
+# Go pseudo-version format: vX.Y.(Z+1)-0.YYYYMMDDHHmmss-abcdefabcdef
+# For pre-release versions (v0.x.y), the format is the same.
+compute_pseudo_version() {
+    local version="$1"
+    # Strip leading 'v'
+    local ver="${version#v}"
+    # Split into major.minor.patch
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "${ver}"
+    # Increment patch
+    patch=$((patch + 1))
+    echo "v${major}.${minor}.${patch}-0.${COMMIT_TIMESTAMP}-${SHORT_COMMIT}"
+}
+
+STABLE_PSEUDO="$(compute_pseudo_version "${STABLE_VERSION}")"
+BETA_PSEUDO="$(compute_pseudo_version "${BETA_VERSION}")"
+
+echo "Stable pseudo-version: ${STABLE_PSEUDO}"
+echo "Beta pseudo-version: ${BETA_PSEUDO}"
+echo ""
+
+# Build a mapping of module -> pseudo-version
+declare -A MODULE_VERSIONS
+
+while IFS= read -r module; do
+    MODULE_VERSIONS["${module}"]="${STABLE_PSEUDO}"
+done <<< "$(get_modules_for_set "stable")"
+
+while IFS= read -r module; do
+    MODULE_VERSIONS["${module}"]="${BETA_PSEUDO}"
+done <<< "$(get_modules_for_set "beta")"
+
+echo "Found ${#MODULE_VERSIONS[@]} core modules to update"
+echo ""
+
+# Find all go.mod files in the target directory
+GO_MOD_FILES="$(find "${TARGET_DIR}" -name "go.mod" -not -path "*/vendor/*" | sort)"
+
+UPDATED_COUNT=0
+
+for go_mod in ${GO_MOD_FILES}; do
+    # Get the module name of this go.mod
+    MOD_NAME="$(head -1 "${go_mod}" | awk '{print $2}')"
+
+    EDITS=""
+    for module in "${!MODULE_VERSIONS[@]}"; do
+        pseudo="${MODULE_VERSIONS[${module}]}"
+
+        # Skip self-references
+        if [[ "${MOD_NAME}" == "${module}" ]]; then
+            continue
+        fi
+
+        # Check if this go.mod has a replace directive for this module pointing to a local path.
+        # If so, skip it — local replaces take precedence and the version doesn't matter.
+        if grep -qE "^replace\s+${module//./\\.}\s+=>" "${go_mod}" 2>/dev/null; then
+            continue
+        fi
+
+        # Check if this module is referenced in require blocks (direct or indirect)
+        if grep -qE "^\s+${module//./\\.}\s+v" "${go_mod}" 2>/dev/null; then
+            EDITS+=" -require=${module}@${pseudo}"
+        fi
+    done
+
+    if [[ -n "${EDITS}" ]]; then
+        echo "Updating: ${go_mod}"
+        # shellcheck disable=SC2086
+        go mod edit ${EDITS} "${go_mod}"
+        UPDATED_COUNT=$((UPDATED_COUNT + 1))
+    fi
+done
+
+echo ""
+echo "Updated ${UPDATED_COUNT} go.mod files"
+
+# Run go mod tidy on all updated modules if requested
+if [[ "${UPDATED_COUNT}" -gt 0 ]]; then
+    echo ""
+    echo "Running 'go mod tidy' across all modules..."
+    pushd "${TARGET_DIR}" > /dev/null
+    # If a Makefile with gotidy target exists, use it
+    if [[ -f "Makefile" ]] && grep -q "^gotidy:" "Makefile"; then
+        make gotidy
+    else
+        # Otherwise, tidy each go.mod individually
+        for go_mod in ${GO_MOD_FILES}; do
+            mod_dir="$(dirname "${go_mod}")"
+            echo "  Tidying ${mod_dir}"
+            (cd "${mod_dir}" && go mod tidy -compat=1.25.0 2>/dev/null || true)
+        done
+    fi
+    popd > /dev/null
+fi
+
+echo ""
+echo "Done! All intra-core dependencies updated to pseudo-versions."
+echo "  Stable modules: ${STABLE_PSEUDO}"
+echo "  Beta modules:   ${BETA_PSEUDO}"

--- a/.github/workflows/update-core-pseudo-versions.yml
+++ b/.github/workflows/update-core-pseudo-versions.yml
@@ -1,0 +1,279 @@
+name: "Update intra-core pseudo-versions"
+
+# This workflow updates all go.opentelemetry.io/collector dependencies across
+# the repository to use pseudo-versions derived from a specific commit on main.
+#
+# This is useful when collector-contrib's update workflow fails because some
+# indirect intra-core dependencies weren't updated. Rather than manually editing
+# each problematic go.mod, this workflow updates ALL intra-core references to a
+# consistent pseudo-version at once.
+#
+# See: https://github.com/open-telemetry/opentelemetry-collector/issues/XXXXX
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: >
+          The full commit SHA on main to derive pseudo-versions from.
+          Leave empty to use the current HEAD of main.
+        required: false
+        default: ""
+      target-repo:
+        description: >
+          The repository to update (in owner/repo format).
+          Leave empty to update this repository's own go.mod files.
+        required: false
+        default: ""
+      target-branch:
+        description: >
+          The branch name to create for the update PR.
+        required: false
+        default: "update-core-pseudo-versions"
+      dry-run:
+        description: >
+          If true, only print what would be updated without making changes.
+        type: boolean
+        required: false
+        default: false
+
+permissions: read-all
+
+jobs:
+  compute-pseudo-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      stable-pseudo: ${{ steps.compute.outputs.stable-pseudo }}
+      beta-pseudo: ${{ steps.compute.outputs.beta-pseudo }}
+      commit: ${{ steps.compute.outputs.commit }}
+    steps:
+      - name: Checkout core repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Compute pseudo-versions
+        id: compute
+        shell: bash
+        run: |
+          COMMIT="${{ inputs.commit }}"
+          if [[ -z "${COMMIT}" ]]; then
+            COMMIT="$(git rev-parse HEAD)"
+          fi
+
+          SHORT_COMMIT="${COMMIT:0:12}"
+          COMMIT_TIMESTAMP="$(git log -1 --format='%cd' --date=format:'%Y%m%d%H%M%S' "${COMMIT}")"
+
+          # Extract versions from versions.yaml
+          STABLE_VERSION="$(awk '/^  stable:/{found=1} found && /version:/{print $2; exit}' versions.yaml)"
+          BETA_VERSION="$(awk '/^  beta:/{found=1} found && /version:/{print $2; exit}' versions.yaml)"
+
+          # Compute pseudo-versions (increment patch, add pre-release suffix)
+          compute_pseudo() {
+            local ver="${1#v}"
+            IFS='.' read -r major minor patch <<< "${ver}"
+            patch=$((patch + 1))
+            echo "v${major}.${minor}.${patch}-0.${COMMIT_TIMESTAMP}-${SHORT_COMMIT}"
+          }
+
+          STABLE_PSEUDO="$(compute_pseudo "${STABLE_VERSION}")"
+          BETA_PSEUDO="$(compute_pseudo "${BETA_VERSION}")"
+
+          echo "commit=${COMMIT}" >> "${GITHUB_OUTPUT}"
+          echo "stable-pseudo=${STABLE_PSEUDO}" >> "${GITHUB_OUTPUT}"
+          echo "beta-pseudo=${BETA_PSEUDO}" >> "${GITHUB_OUTPUT}"
+
+          echo "## Computed Pseudo-Versions" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Module Set | Current Version | Pseudo-Version |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "|------------|----------------|----------------|" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Stable | ${STABLE_VERSION} | ${STABLE_PSEUDO} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Beta | ${BETA_VERSION} | ${BETA_PSEUDO} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Based on commit: [\`${SHORT_COMMIT}\`](https://github.com/${{ github.repository }}/commit/${COMMIT})" >> "${GITHUB_STEP_SUMMARY}"
+
+  update-dependencies:
+    needs: compute-pseudo-versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout core repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          path: core
+
+      - name: Checkout target repo
+        if: ${{ inputs.target-repo != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.target-repo }}
+          fetch-depth: 1
+          path: target
+
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: stable
+          cache: false
+
+      - name: Cache Go
+        id: go-cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/go/bin
+            ~/go/pkg/mod
+          key: go-cache-${{ runner.os }}-${{ runner.arch }}-pseudo-versions
+
+      - name: Update dependencies
+        id: update
+        shell: bash
+        env:
+          STABLE_PSEUDO: ${{ needs.compute-pseudo-versions.outputs.stable-pseudo }}
+          BETA_PSEUDO: ${{ needs.compute-pseudo-versions.outputs.beta-pseudo }}
+          COMMIT: ${{ needs.compute-pseudo-versions.outputs.commit }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          # Determine target directory
+          if [[ -n "${{ inputs.target-repo }}" ]]; then
+            TARGET_DIR="$(pwd)/target"
+          else
+            TARGET_DIR="$(pwd)/core"
+          fi
+
+          echo "Target directory: ${TARGET_DIR}"
+          echo "Stable pseudo-version: ${STABLE_PSEUDO}"
+          echo "Beta pseudo-version: ${BETA_PSEUDO}"
+          echo ""
+
+          CORE_DIR="$(pwd)/core"
+
+          # Build module-to-pseudo-version mapping from versions.yaml
+          VERSIONS_YAML="${CORE_DIR}/versions.yaml"
+
+          # Parse stable modules
+          declare -A MODULE_VERSIONS
+          current_set=""
+          while IFS= read -r line; do
+            if [[ "${line}" =~ ^[[:space:]]{2}([a-z]+): ]]; then
+              current_set="${BASH_REMATCH[1]}"
+            fi
+            if [[ "${current_set}" == "stable" && "${line}" =~ ^[[:space:]]*-[[:space:]](go\.opentelemetry\.io/collector.*) ]]; then
+              MODULE_VERSIONS["${BASH_REMATCH[1]}"]="${STABLE_PSEUDO}"
+            fi
+            if [[ "${current_set}" == "beta" && "${line}" =~ ^[[:space:]]*-[[:space:]](go\.opentelemetry\.io/collector.*) ]]; then
+              MODULE_VERSIONS["${BASH_REMATCH[1]}"]="${BETA_PSEUDO}"
+            fi
+          done < "${VERSIONS_YAML}"
+
+          echo "Found ${#MODULE_VERSIONS[@]} core modules"
+
+          # Find all go.mod files in target
+          GO_MOD_FILES="$(find "${TARGET_DIR}" -name "go.mod" -not -path "*/vendor/*" | sort)"
+
+          UPDATED_COUNT=0
+          UPDATED_LIST=""
+
+          for go_mod in ${GO_MOD_FILES}; do
+            MOD_NAME="$(head -1 "${go_mod}" | awk '{print $2}')"
+            EDITS=""
+
+            for module in "${!MODULE_VERSIONS[@]}"; do
+              pseudo="${MODULE_VERSIONS[${module}]}"
+
+              # Skip self-references
+              if [[ "${MOD_NAME}" == "${module}" ]]; then
+                continue
+              fi
+
+              # Skip if there's a local replace directive
+              if grep -qP "^replace\s+\Q${module}\E\s+=>\s+\.\./" "${go_mod}" 2>/dev/null; then
+                continue
+              fi
+
+              # Check if this module is referenced in go.mod
+              if grep -qP "^\s+\Q${module}\E\s+v" "${go_mod}" 2>/dev/null; then
+                EDITS+=" -require=${module}@${pseudo}"
+              fi
+            done
+
+            if [[ -n "${EDITS}" ]]; then
+              REL_PATH="${go_mod#"${TARGET_DIR}/"}"
+              if [[ "${DRY_RUN}" == "true" ]]; then
+                echo "[DRY RUN] Would update: ${REL_PATH}"
+                echo "  Edits: ${EDITS}"
+              else
+                echo "Updating: ${REL_PATH}"
+                # shellcheck disable=SC2086
+                go mod edit ${EDITS} "${go_mod}"
+              fi
+              UPDATED_COUNT=$((UPDATED_COUNT + 1))
+              UPDATED_LIST+="- \`${REL_PATH}\`\n"
+            fi
+          done
+
+          echo ""
+          echo "Updated ${UPDATED_COUNT} go.mod files"
+
+          # Run go mod tidy if not dry run
+          if [[ "${DRY_RUN}" != "true" && "${UPDATED_COUNT}" -gt 0 ]]; then
+            echo ""
+            echo "Running 'go mod tidy' across updated modules..."
+            for go_mod in ${GO_MOD_FILES}; do
+              mod_dir="$(dirname "${go_mod}")"
+              echo "  Tidying ${mod_dir#"${TARGET_DIR}/"}"
+              (cd "${mod_dir}" && go mod tidy -compat=1.25.0 2>&1) || true
+            done
+          fi
+
+          echo "updated-count=${UPDATED_COUNT}" >> "${GITHUB_OUTPUT}"
+
+          # Write summary
+          echo "## Update Results" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Updated **${UPDATED_COUNT}** go.mod files." >> "${GITHUB_STEP_SUMMARY}"
+          if [[ -n "${UPDATED_LIST}" ]]; then
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo "### Updated files:" >> "${GITHUB_STEP_SUMMARY}"
+            echo -e "${UPDATED_LIST}" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Create Pull Request
+        if: ${{ inputs.dry-run != true && steps.update.outputs.updated-count != '0' }}
+        working-directory: ${{ inputs.target-repo != '' && 'target' || 'core' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE_PSEUDO: ${{ needs.compute-pseudo-versions.outputs.stable-pseudo }}
+          BETA_PSEUDO: ${{ needs.compute-pseudo-versions.outputs.beta-pseudo }}
+          COMMIT: ${{ needs.compute-pseudo-versions.outputs.commit }}
+          BRANCH: ${{ inputs.target-branch }}
+        run: |
+          git config user.name otelbot
+          git config user.email 197425009+otelbot@users.noreply.github.com
+          git checkout -b "${BRANCH}"
+          git add --all
+          git diff --cached --exit-code && { echo "No changes to commit"; exit 0; }
+          git commit -m "Update intra-core dependencies to pseudo-versions
+
+          Stable modules: ${STABLE_PSEUDO}
+          Beta modules: ${BETA_PSEUDO}
+          Based on commit: ${COMMIT}"
+
+          git push --set-upstream origin "${BRANCH}" --force
+
+          gh pr create \
+            --head "${BRANCH}" \
+            --title "[chore] Update intra-core dependencies to pseudo-versions" \
+            --body "This PR updates all \`go.opentelemetry.io/collector\` dependencies to consistent pseudo-versions based on commit [\`${COMMIT:0:12}\`](https://github.com/${{ github.repository }}/commit/${COMMIT}).
+
+          **Pseudo-versions:**
+          - Stable modules: \`${STABLE_PSEUDO}\`
+          - Beta modules: \`${BETA_PSEUDO}\`
+
+          This ensures all intra-core dependencies use the same version, preventing issues where missing indirect dependencies cause compilation failures.
+
+          ---
+          *Generated by the [update-core-pseudo-versions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow.*"


### PR DESCRIPTION
Add a manually-triggered CI workflow and helper script to update all
`go.opentelemetry.io/collector/*` dependencies across go.mod files to
consistent pseudo-versions derived from a specific commit on main.

#### Description

Due to Go module graph pruning, [go.mod](cci:7://file:///Users/pratikmahalle/code/opentelemetry-collector/go.mod:0:0-0:0) files in collector-contrib
sometimes omit indirect intra-core dependencies. This means the existing
`update-otel` workflow in contrib cannot always update every core
dependency — it only sees what is explicitly listed. This leads to a
situation where module A is pinned to a pseudo-version of latest main
while module B (an indirect dep of A) is still at the last release,
causing errors like:

- `module A@latest found (vX.Y.Z), but does not contain package P`
- `package P provided by A at latest but not at required version`
- Compilation failures due to call-site/API mismatches between mixed versions

This PR adds two files:

- **[.github/workflows/update-core-pseudo-versions.yml](cci:7://file:///Users/pratikmahalle/code/opentelemetry-collector/.github/workflows/update-core-pseudo-versions.yml:0:0-0:0)** — A
  `workflow_dispatch` workflow with a `dry-run` option. It reads
  [versions.yaml](cci:7://file:///Users/pratikmahalle/code/opentelemetry-collector/versions.yaml:0:0-0:0) to discover all modules in the `stable` and `beta`
  module sets, computes a proper Go pseudo-version
  (`vX.Y.(Z+1)-0.TIMESTAMP-SHORTHASH`) for each set from the given
  commit, then updates every [go.mod](cci:7://file:///Users/pratikmahalle/code/opentelemetry-collector/go.mod:0:0-0:0) that references a core module
  (skipping self-references and local `replace` directives), runs
  `go mod tidy`, and opens a PR.

- **[.github/workflows/scripts/update-core-pseudo-versions.sh](cci:7://file:///Users/pratikmahalle/code/opentelemetry-collector/.github/workflows/scripts/update-core-pseudo-versions.sh:0:0-0:0)** — A
  standalone version of the same logic, runnable locally for quick
  manual fixes.

<!-- Issue number if applicable -->
#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/12409

#### Testing

- YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- Shell script syntax validated (`bash -n`)
- Workflow supports a `dry-run: true` input to preview affected files
  before making any changes
- Local script tested by parsing [versions.yaml](cci:7://file:///Users/pratikmahalle/code/opentelemetry-collector/versions.yaml:0:0-0:0) and computing
  pseudo-versions against the current HEAD commit

#### Documentation

The workflow file includes an in-file comment block explaining the
problem it solves and how to use it. The shell script includes a usage
block at the top with all available options and environment variables.
