### PR TITLE
[pdata/pprofile] Fix dictionary corruption during profile merging

### DIFF
--- a/.chloggen/pprofile-switchDictionary.yaml
+++ b/.chloggen/pprofile-switchDictionary.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pdata/pprofile
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix dictionary corruption during profile merging
+
+# One or more tracking issues or pull requests related to the change
+issues: [14647]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Reference types were being modified in place, causing source dictionaries to be corrupted with invalid indices. 
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pdata/pprofile/line.go
+++ b/pdata/pprofile/line.go
@@ -36,12 +36,15 @@ func (l Line) switchDictionary(src, dst ProfilesDictionary) error {
 		}
 
 		fn := src.FunctionTable().At(int(l.FunctionIndex()))
-		err := fn.switchDictionary(src, dst)
+		// Create a copy to avoid modifying the source FunctionTable in-place
+		fnCopy := NewFunction()
+		fn.CopyTo(fnCopy)
+		err := fnCopy.switchDictionary(src, dst)
 		if err != nil {
 			return fmt.Errorf("couldn't switch function dictionary: %w", err)
 		}
 
-		idx, err := SetFunction(dst.FunctionTable(), fn)
+		idx, err := SetFunction(dst.FunctionTable(), fnCopy)
 		if err != nil {
 			return fmt.Errorf("couldn't set function: %w", err)
 		}

--- a/pdata/pprofile/location.go
+++ b/pdata/pprofile/location.go
@@ -22,11 +22,14 @@ func (ms Location) switchDictionary(src, dst ProfilesDictionary) error {
 		}
 
 		mapping := src.MappingTable().At(int(ms.MappingIndex()))
-		err := mapping.switchDictionary(src, dst)
+		// Create a copy to avoid modifying the source MappingTable in-place
+		mappingCopy := NewMapping()
+		mapping.CopyTo(mappingCopy)
+		err := mappingCopy.switchDictionary(src, dst)
 		if err != nil {
 			return fmt.Errorf("couldn't switch dictionary for mapping: %w", err)
 		}
-		idx, err := SetMapping(dst.MappingTable(), mapping)
+		idx, err := SetMapping(dst.MappingTable(), mappingCopy)
 		if err != nil {
 			return fmt.Errorf("couldn't set mapping: %w", err)
 		}
@@ -39,11 +42,14 @@ func (ms Location) switchDictionary(src, dst ProfilesDictionary) error {
 		}
 
 		attr := src.AttributeTable().At(int(v))
-		err := attr.switchDictionary(src, dst)
+		// Create a copy to avoid modifying the source AttributeTable in-place
+		attrCopy := NewKeyValueAndUnit()
+		attr.CopyTo(attrCopy)
+		err := attrCopy.switchDictionary(src, dst)
 		if err != nil {
 			return fmt.Errorf("couldn't switch dictionary for attribute %d: %w", i, err)
 		}
-		idx, err := SetAttribute(dst.AttributeTable(), attr)
+		idx, err := SetAttribute(dst.AttributeTable(), attrCopy)
 		if err != nil {
 			return fmt.Errorf("couldn't set attribute %d: %w", i, err)
 		}

--- a/pdata/pprofile/mapping.go
+++ b/pdata/pprofile/mapping.go
@@ -35,11 +35,14 @@ func (ms Mapping) switchDictionary(src, dst ProfilesDictionary) error {
 		}
 
 		attr := src.AttributeTable().At(int(v))
-		err := attr.switchDictionary(src, dst)
+		// Create a copy to avoid modifying the source AttributeTable in-place
+		attrCopy := NewKeyValueAndUnit()
+		attr.CopyTo(attrCopy)
+		err := attrCopy.switchDictionary(src, dst)
 		if err != nil {
 			return fmt.Errorf("couldn't switch dictionary for attribute %d: %w", i, err)
 		}
-		idx, err := SetAttribute(dst.AttributeTable(), attr)
+		idx, err := SetAttribute(dst.AttributeTable(), attrCopy)
 		if err != nil {
 			return fmt.Errorf("couldn't set attribute %d: %w", i, err)
 		}

--- a/pdata/pprofile/profile.go
+++ b/pdata/pprofile/profile.go
@@ -18,11 +18,14 @@ func (ms Profile) switchDictionary(src, dst ProfilesDictionary) error {
 		}
 
 		attr := src.AttributeTable().At(int(v))
-		err := attr.switchDictionary(src, dst)
+		// Create a copy to avoid modifying the source AttributeTable in-place
+		attrCopy := NewKeyValueAndUnit()
+		attr.CopyTo(attrCopy)
+		err := attrCopy.switchDictionary(src, dst)
 		if err != nil {
 			return fmt.Errorf("couldn't switch dictionary for attribute %d: %w", i, err)
 		}
-		idx, err := SetAttribute(dst.AttributeTable(), attr)
+		idx, err := SetAttribute(dst.AttributeTable(), attrCopy)
 		if err != nil {
 			return fmt.Errorf("couldn't set attribute %d: %w", i, err)
 		}

--- a/pdata/pprofile/profiles_merge_test.go
+++ b/pdata/pprofile/profiles_merge_test.go
@@ -60,3 +60,95 @@ func TestProfilesMergeToError(t *testing.T) {
 
 	assert.Equal(t, 0, dest.ResourceProfiles().Len())
 }
+
+func TestProfilesMergeToCanReuseSource(t *testing.T) {
+	// This test verifies that switchDictionary does not mutate the source dictionary tables.
+	// Without proper copying, dictionary table entries are modified in-place, corrupting the source.
+	src := NewProfiles()
+
+	// Set up string table
+	src.Dictionary().StringTable().Append("", "attrKey", "attrValue", "funcName", "fileName")
+
+	// Set up function table - index 0 is reserved, so add a dummy first
+	src.Dictionary().FunctionTable().AppendEmpty()       // Index 0 (reserved as "not set")
+	fn := src.Dictionary().FunctionTable().AppendEmpty() // Index 1
+	fn.SetNameStrindex(3)                                // "funcName" (index 3 in string table)
+	fn.SetFilenameStrindex(4)                            // "fileName" (index 4 in string table)
+
+	// Set up location table - index 0 is reserved, so add a dummy first
+	src.Dictionary().LocationTable().AppendEmpty()        // Index 0 (reserved as "not set")
+	loc := src.Dictionary().LocationTable().AppendEmpty() // Index 1
+	line := loc.Lines().AppendEmpty()
+	line.SetFunctionIndex(1) // Index 1 in function table
+
+	// Set up stack table - index 0 is reserved, so add a dummy first
+	src.Dictionary().StackTable().AppendEmpty()          // Index 0 (reserved as "not set")
+	stack := src.Dictionary().StackTable().AppendEmpty() // Index 1
+	stack.LocationIndices().Append(1)                    // Index 1 in location table
+
+	// Set up attribute table - index 0 is reserved, so add a dummy first
+	src.Dictionary().AttributeTable().AppendEmpty()         // Index 0 (reserved as "not set")
+	attr := src.Dictionary().AttributeTable().AppendEmpty() // Index 1
+	attr.SetKeyStrindex(1)                                  // "attrKey" (index 1 in string table)
+
+	// Create a profile with a sample that uses all the dictionary entries
+	profile := src.ResourceProfiles().AppendEmpty().
+		ScopeProfiles().AppendEmpty().
+		Profiles().AppendEmpty()
+	profile.AttributeIndices().Append(1) // Index 1 in attribute table
+
+	sample := profile.Samples().AppendEmpty()
+	sample.AttributeIndices().Append(1) // Index 1 in attribute table
+	sample.SetStackIndex(1)             // Index 1 in stack table
+
+	// Save the original dictionary state before merge
+	// These should NOT change after switchDictionary is called
+	origAttrKeyIndex := src.Dictionary().AttributeTable().At(1).KeyStrindex()
+	origFuncNameIndex := src.Dictionary().FunctionTable().At(1).NameStrindex()
+	origFuncFileIndex := src.Dictionary().FunctionTable().At(1).FilenameStrindex()
+	origLineFuncIndex := src.Dictionary().LocationTable().At(1).Lines().At(0).FunctionIndex()
+
+	dest := NewProfiles()
+	dest.Dictionary().StringTable().Append("", "different", "strings", "here")
+
+	require.NoError(t, src.MergeTo(dest))
+
+	afterAttrKeyIndex := src.Dictionary().AttributeTable().At(1).KeyStrindex()
+
+	// Verify the source dictionary tables were NOT mutated
+	// (they should still reference the source's StringTable/FunctionTable indices)
+	assert.Equal(t, origAttrKeyIndex, afterAttrKeyIndex,
+		"AttributeTable entry was mutated - KeyStrindex changed")
+	assert.Equal(t, origFuncNameIndex, src.Dictionary().FunctionTable().At(1).NameStrindex(),
+		"FunctionTable entry was mutated - NameStrindex changed")
+	assert.Equal(t, origFuncFileIndex, src.Dictionary().FunctionTable().At(1).FilenameStrindex(),
+		"FunctionTable entry was mutated - FilenameStrindex changed")
+	assert.Equal(t, origLineFuncIndex, src.Dictionary().LocationTable().At(1).Lines().At(0).FunctionIndex(),
+		"LocationTable Line entry was mutated - FunctionIndex changed")
+
+	// Verify destination received the data with properly remapped indices
+	assert.Equal(t, 1, dest.ResourceProfiles().Len())
+	assert.Greater(t, dest.Dictionary().StringTable().Len(), 3)
+	assert.Positive(t, dest.Dictionary().AttributeTable().Len())
+
+	// Verify the function table entries in destination correctly resolve to the expected strings
+	// The function table should have been populated during switchDictionary when processing locations/lines
+	require.Positive(t, dest.Dictionary().FunctionTable().Len(),
+		"Destination FunctionTable should have entries after merge")
+	// Function might be at index 0 or 1 depending on whether dest includes dummy entries
+	// Find the function with our expected values
+	found := false
+	for i := 0; i < dest.Dictionary().FunctionTable().Len(); i++ {
+		destFn := dest.Dictionary().FunctionTable().At(i)
+		if destFn.NameStrindex() > 0 && destFn.FilenameStrindex() > 0 {
+			destFuncNameIdx := destFn.NameStrindex()
+			destFuncFileIdx := destFn.FilenameStrindex()
+			if dest.Dictionary().StringTable().At(int(destFuncNameIdx)) == "funcName" &&
+				dest.Dictionary().StringTable().At(int(destFuncFileIdx)) == "fileName" {
+				found = true
+				break
+			}
+		}
+	}
+	assert.True(t, found, "Destination FunctionTable should contain function with 'funcName' and 'fileName'")
+}

--- a/pdata/pprofile/sample.go
+++ b/pdata/pprofile/sample.go
@@ -14,11 +14,14 @@ func (ms Sample) switchDictionary(src, dst ProfilesDictionary) error {
 		}
 
 		attr := src.AttributeTable().At(int(v))
-		err := attr.switchDictionary(src, dst)
+		// Create a copy to avoid modifying the source AttributeTable in-place
+		attrCopy := NewKeyValueAndUnit()
+		attr.CopyTo(attrCopy)
+		err := attrCopy.switchDictionary(src, dst)
 		if err != nil {
 			return fmt.Errorf("couldn't switch dictionary for attribute %d: %w", i, err)
 		}
-		idx, err := SetAttribute(dst.AttributeTable(), attr)
+		idx, err := SetAttribute(dst.AttributeTable(), attrCopy)
 		if err != nil {
 			return fmt.Errorf("couldn't set attribute %d: %w", i, err)
 		}
@@ -43,12 +46,15 @@ func (ms Sample) switchDictionary(src, dst ProfilesDictionary) error {
 		}
 
 		stack := src.StackTable().At(int(ms.StackIndex()))
-		err := stack.switchDictionary(src, dst)
+		// Create a copy to avoid modifying the source StackTable in-place
+		stackCopy := NewStack()
+		stack.CopyTo(stackCopy)
+		err := stackCopy.switchDictionary(src, dst)
 		if err != nil {
 			return fmt.Errorf("couldn't switch stack dictionary: %w", err)
 		}
 
-		idx, err := SetStack(dst.StackTable(), stack)
+		idx, err := SetStack(dst.StackTable(), stackCopy)
 		if err != nil {
 			return fmt.Errorf("couldn't set stack: %w", err)
 		}

--- a/pdata/pprofile/stack.go
+++ b/pdata/pprofile/stack.go
@@ -31,11 +31,14 @@ func (ms Stack) switchDictionary(src, dst ProfilesDictionary) error {
 		}
 
 		loc := src.LocationTable().At(int(v))
-		err := loc.switchDictionary(src, dst)
+		// Create a copy to avoid modifying the source LocationTable in-place
+		locCopy := NewLocation()
+		loc.CopyTo(locCopy)
+		err := locCopy.switchDictionary(src, dst)
 		if err != nil {
 			return fmt.Errorf("couldn't switch dictionary for location: %w", err)
 		}
-		idx, err := SetLocation(dst.LocationTable(), loc)
+		idx, err := SetLocation(dst.LocationTable(), locCopy)
 		if err != nil {
 			return fmt.Errorf("couldn't set location %d: %w", i, err)
 		}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

pprofile types are reference types containing pointers to shared internal data. When src.SomeTable().At(i) is called, it returns a wrapper around a pointer to the underlying entry in the source dictionary, not a copy.

Calling switchDictionary() on these objects modifies their internal indices to reference the destination dictionary. Since these are reference types, this modification affects the source dictionary's tables, corrupting them by making their indices point to the wrong lookup table.

The fixed issue was discovered by error logs like the following:
```
failed merging profiles; error switching dictionary for resource profile 0: error switching dictionary for scope profile 0: error switching dictionary for profile 0: error switching dictionary for sample 0: couldn't switch stack dictionary: couldn't switch dictionary for location: couldn't switch dictionary for mapping: invalid attribute index 97
```



<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
