### PR TITLE
[chore] Doc for exporter metadata keys

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -57,7 +57,7 @@ Available `batch::sizer` options:
 - `items`: number of the smallest parts of each signal (spans, metric data points, log records);
 - `bytes`: the size of serialized data in bytes (the least performant option).
 
-- `parttion`: see below.
+- `partition`: see below.
 
 The `batch::partition` configuration defines the partitioning of the batches.
 


### PR DESCRIPTION
#### Documentation

Additional documentation PR for the [Enable metadata population in exporterhelper when sending_queue is enabled](https://github.com/open-telemetry/opentelemetry-collector/pull/14139#top)#14139

