### PR TITLE
Add concurrency control to prevent duplicate ping runs per issue

### DIFF
--- a/.github/workflows/ping-codeowners-issues.yml
+++ b/.github/workflows/ping-codeowners-issues.yml
@@ -10,6 +10,9 @@ jobs:
     permissions:
       issues: write
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ping-codeowners-${{ github.event.issue.number }}
+      cancel-in-progress: true
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
#### Description

This PR adds concurrency control to the `ping-codeowners-issues` workflow.

When multiple labels are added to the same issue in quick succession, the workflow may trigger multiple parallel runs, potentially resulting in duplicate pings to code owners.
By introducing a concurrency group scoped to the issue number, this change ensures that only one workflow execution per issue runs at a time. If a new run is triggered for the same issue, any in-progress run is cancelled.
This improves workflow reliability and prevents unnecessary duplicate executions.

#### Link to tracking issue
N/A

#### Testing

No functional behavior changes were introduced beyond preventing concurrent runs for the same issue. The workflow configuration was validated for syntax and minimal scope change.

#### Documentation

No documentation changes required.