### PR TITLE
[pdata/xpdata] Add new functions for entity API

### DIFF
--- a/.chloggen/xpdata-entity-helpers.yaml
+++ b/.chloggen/xpdata-entity-helpers.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pkg/xpdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `NewEntity` constructor, `Entity.CopyToResource`, and `EntityAttributeMap.All` to `pdata/xpdata/entity`"
+
+# One or more tracking issues or pull requests related to the change
+issues: [14659]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pdata/xpdata/entity/entity.go
+++ b/pdata/xpdata/entity/entity.go
@@ -16,6 +16,15 @@ type Entity struct {
 	attributes pcommon.Map
 }
 
+func NewEntity(t string) Entity {
+	ref := NewEntityRef()
+	ref.SetType(t)
+	return Entity{
+		ref:        ref,
+		attributes: pcommon.NewMap(),
+	}
+}
+
 func (e Entity) Type() string {
 	return e.ref.Type()
 }
@@ -41,5 +50,16 @@ func (e Entity) DescriptiveAttributes() EntityAttributeMap {
 	return EntityAttributeMap{
 		keys:       e.ref.DescriptionKeys(),
 		attributes: e.attributes,
+	}
+}
+
+// CopyToResource moves the entity to the provided resource by overriding existing entities and attributes.
+func (e Entity) CopyToResource(res pcommon.Resource) {
+	ent := ResourceEntities(res).PutEmpty(e.Type())
+	for k, v := range e.IdentifyingAttributes().All() {
+		v.CopyTo(ent.IdentifyingAttributes().PutEmpty(k))
+	}
+	for k, v := range e.DescriptiveAttributes().All() {
+		v.CopyTo(ent.DescriptiveAttributes().PutEmpty(k))
 	}
 }

--- a/pdata/xpdata/entity/entity_attribute_map.go
+++ b/pdata/xpdata/entity/entity_attribute_map.go
@@ -3,7 +3,11 @@
 
 package entity // import "go.opentelemetry.io/collector/pdata/xpdata/entity"
 
-import "go.opentelemetry.io/collector/pdata/pcommon"
+import (
+	"iter"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
 
 // EntityAttributeMap is a wrapper around pcommon.Map that restricts operations to only the keys
 // that belong to a specific set of entity attributes (either ID or Description attributes).
@@ -100,4 +104,16 @@ func (m EntityAttributeMap) containsKey(key string) bool {
 		}
 	}
 	return false
+}
+
+// All returns an iterator over the key-value pairs of the attributes belonging to this map's key set.
+func (m EntityAttributeMap) All() iter.Seq2[string, pcommon.Value] {
+	return func(yield func(string, pcommon.Value) bool) {
+		for _, k := range m.keys.All() {
+			v, ok := m.attributes.Get(k)
+			if ok && !yield(k, v) {
+				return
+			}
+		}
+	}
 }

--- a/pdata/xpdata/entity/entity_attribute_map_test.go
+++ b/pdata/xpdata/entity/entity_attribute_map_test.go
@@ -150,6 +150,30 @@ func TestEntityAttributeMap_CanPut(t *testing.T) {
 	assert.True(t, m.CanPut("new-key"))
 }
 
+func TestEntityAttributeMap_All(t *testing.T) {
+	m := newTestEntityAttributeMap()
+	m.PutStr("k1", "v1")
+	m.PutStr("k2", "v2")
+
+	// Add an attribute not owned by this map — it should not appear in All().
+	m.attributes.PutStr("not-owned", "v3")
+
+	got := make(map[string]string)
+	for k, v := range m.All() {
+		got[k] = v.Str()
+	}
+
+	assert.Equal(t, map[string]string{"k1": "v1", "k2": "v2"}, got)
+
+	// Verify early termination: breaking out of the loop stops iteration.
+	var count int
+	for range m.All() {
+		count++
+		break
+	}
+	assert.Equal(t, 1, count)
+}
+
 func newTestEntityAttributeMap() EntityAttributeMap {
 	return EntityAttributeMap{
 		keys:       pcommon.NewStringSlice(),

--- a/pdata/xpdata/entity/entity_test.go
+++ b/pdata/xpdata/entity/entity_test.go
@@ -7,7 +7,36 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
+
+func TestNewEntity(t *testing.T) {
+	e := NewEntity("service")
+	assert.Equal(t, "service", e.Type())
+	assert.Empty(t, e.SchemaURL())
+}
+
+func TestEntity_CopyToResource(t *testing.T) {
+	e := NewEntity("service")
+	e.IdentifyingAttributes().PutStr("service.name", "my-service")
+	e.DescriptiveAttributes().PutStr("service.version", "1.0.0")
+
+	res := pcommon.NewResource()
+	e.CopyToResource(res)
+
+	entities := ResourceEntities(res)
+	copied, ok := entities.Get("service")
+	assert.True(t, ok)
+
+	idVal, ok := copied.IdentifyingAttributes().Get("service.name")
+	assert.True(t, ok)
+	assert.Equal(t, "my-service", idVal.Str())
+
+	descVal, ok := copied.DescriptiveAttributes().Get("service.version")
+	assert.True(t, ok)
+	assert.Equal(t, "1.0.0", descVal.Str())
+}
 
 func TestEntity_Type(t *testing.T) {
 	em := NewEntityMap()


### PR DESCRIPTION
- `NewEntity(t string) Entity`: creates a standalone Entity with the given type
- `Entity.CopyToResource(res pcommon.Resource)`: copies the entity's identity and descriptive attributes into a resource's entity refs
- `EntityAttributeMap.All() iter.Seq2[string, pcommon.Value]`: iterates over the attribute key-value pairs belonging to this map's key set

These are needed for the new mdatagen entity-scoped MetricsBuilder API in https://github.com/open-telemetry/opentelemetry-collector/pull/14660
