### PR TITLE
fix(exporter/otlphttpexporter): include actual request URL in HTTP error messages

### DIFF
--- a/.chloggen/fix-otlphttpexporter-error-url.yaml
+++ b/.chloggen/fix-otlphttpexporter-error-url.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporter/otlphttpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Include actual request URL in HTTP error messages to improve debugging when middleware modifies request URLs
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -193,7 +193,7 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 
 	resp, err := e.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to make an HTTP request: %w", err)
+		return fmt.Errorf("failed to make an HTTP request to %s: %w", req.URL, err)
 	}
 
 	defer func() {


### PR DESCRIPTION
## Problem

When using extensions that modify the request URL (e.g., for dynamic routing), the error message from `otlphttpexporter` shows the original placeholder URL instead of the actual destination URL.

For example, with extension that routes requests from `http://localhost:4318/v1/logs` to `https://beta.example.com`, the error message shows:

`no more retries left: failed to make an HTTP request: Post "http://localhost:4318/v1/logs": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
`
## Root Cause

In `exporter/otlphttpexporter/otlp.go`, the `export` function wraps errors without including the actual request URL:

```go
resp, err := e.client.Do(req)
if err != nil {
    return fmt.Errorf("failed to make an HTTP request: %w", err)
}
```

The underlying `*url.Error` from `net/http` captures the URL before extension modifications, leading to misleading error messages.

## Solution

Include `req.URL` in the error message so it reflects any modifications made by extension:

```go
resp, err := e.client.Do(req)
if err != nil {
    return fmt.Errorf("failed to make an HTTP request to %s: %w", req.URL, err)
}
```

This ensures the error message shows the actual destination URL that the request was sent to, making debugging much easier.

## Testing

- Tested with a custom routing extension that modifies request URLs
- Error messages now correctly show the destination URL
- No breaking changes to error handling (error is still wrapped with `%w`)
- All existing tests pass

## Checklist

- [x] Tests pass
- [x] Changelog entry added

Made with [Cursor](https://cursor.com)