### PR TITLE
fix: update sortFactoriesByType to remove alias

### DIFF
--- a/.chloggen/fix-alias-printing.yaml
+++ b/.chloggen/fix-alias-printing.yaml
@@ -15,7 +15,7 @@ issues: [14682]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: This resolves an issue where aliased components were skipped.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/.chloggen/fix-alias-printing.yaml
+++ b/.chloggen/fix-alias-printing.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/otelcol
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Print components exactly once in the `otelcol components` command
+
+# One or more tracking issues or pull requests related to the change
+issues: [14682]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -136,24 +136,28 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 	}
 }
 
-func sortFactoriesByType[T component.Factory](factories map[component.Type]T) []T {
+func canonicalFactoryKeys[T component.Factory](factories map[component.Type]T) []component.Type {
 	keys := make([]component.Type, 0, len(factories))
 	for ct, f := range factories {
 		if ct == f.Type() { // keep canonical keys only
 			keys = append(keys, ct)
 		}
 	}
+	return keys
+}
+
+func sortFactoriesByType[T component.Factory](factories map[component.Type]T) []T {
+	keys := canonicalFactoryKeys(factories)
 
 	sort.Slice(keys, func(i, j int) bool {
 		return keys[i].String() < keys[j].String()
 	})
 
-	sorted := make([]T, 0, len(keys))
+	out := make([]T, 0, len(keys))
 	for _, ct := range keys {
-		sorted = append(sorted, factories[ct])
+		out = append(out, factories[ct])
 	}
-
-	return sorted
+	return out
 }
 
 func sortProvidersByScheme(providerModules map[string]string, provFactories []confmap.ProviderFactory, set confmap.ProviderSettings) []componentWithoutStability {

--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -137,26 +137,23 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 }
 
 func sortFactoriesByType[T component.Factory](factories map[component.Type]T) []T {
-	// Gather component types (factories map keys)
-	componentTypes := make([]component.Type, 0, len(factories))
-	for componentType := range factories {
-		componentTypes = append(componentTypes, componentType)
-	}
-
-	// Sort component types as strings
-	sort.Slice(componentTypes, func(i, j int) bool {
-		return componentTypes[i].String() < componentTypes[j].String()
-	})
-
-	// Build and return list of factories, sorted by component types
-	sortedFactories := make([]T, 0, len(factories))
-	for _, componentType := range componentTypes {
-		if !isComponentAlias(factories[componentType]) {
-			sortedFactories = append(sortedFactories, factories[componentType])
+	keys := make([]component.Type, 0, len(factories))
+	for ct, f := range factories {
+		if ct == f.Type() { // keep canonical keys only
+			keys = append(keys, ct)
 		}
 	}
 
-	return sortedFactories
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].String() < keys[j].String()
+	})
+
+	sorted := make([]T, 0, len(keys))
+	for _, ct := range keys {
+		sorted = append(sorted, factories[ct])
+	}
+
+	return sorted
 }
 
 func sortProvidersByScheme(providerModules map[string]string, provFactories []confmap.ProviderFactory, set confmap.ProviderSettings) []componentWithoutStability {

--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/extension"
-	"go.opentelemetry.io/collector/internal/componentalias"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
 )
@@ -165,9 +164,7 @@ func sortProvidersByScheme(providerModules map[string]string, provFactories []co
 	for _, f := range provFactories {
 		provF := f.Create(set)
 		scheme := provF.Scheme()
-		if !isComponentAlias(f) {
-			schemes = append(schemes, scheme)
-		}
+		schemes = append(schemes, scheme)
 	}
 
 	sort.Strings(schemes)
@@ -194,11 +191,4 @@ func sortConverterModules(modules []string) []componentWithoutStability {
 		})
 	}
 	return sortedModules
-}
-
-func isComponentAlias(component any) bool {
-	if al, ok := component.(componentalias.TypeAliasHolder); ok {
-		return al.DeprecatedAlias().String() != ""
-	}
-	return false
 }

--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -137,27 +137,27 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 }
 
 func canonicalFactoryKeys[T component.Factory](factories map[component.Type]T) []component.Type {
-	keys := make([]component.Type, 0, len(factories))
-	for ct, f := range factories {
-		if ct == f.Type() { // keep canonical keys only
-			keys = append(keys, ct)
+	// Gather component types (factories map keys)
+	componentTypes := make([]component.Type, 0, len(factories))
+	for componentType, f := range factories {
+		if componentType == f.Type() { // keep canonical keys only
+			componentTypes = append(componentTypes, componentType)
 		}
 	}
-	return keys
+	return componentTypes
 }
 
 func sortFactoriesByType[T component.Factory](factories map[component.Type]T) []T {
-	keys := canonicalFactoryKeys(factories)
-
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i].String() < keys[j].String()
+	componentTypes := canonicalFactoryKeys(factories)
+	sort.Slice(componentTypes, func(i, j int) bool {
+		return componentTypes[i].String() < componentTypes[j].String()
 	})
 
-	out := make([]T, 0, len(keys))
-	for _, ct := range keys {
-		out = append(out, factories[ct])
+	sortedFactories := make([]T, 0, len(componentTypes))
+	for _, componentType := range componentTypes {
+		sortedFactories = append(sortedFactories, factories[componentType])
 	}
-	return out
+	return sortedFactories
 }
 
 func sortProvidersByScheme(providerModules map[string]string, provFactories []confmap.ProviderFactory, set confmap.ProviderSettings) []componentWithoutStability {

--- a/otelcol/command_components_test.go
+++ b/otelcol/command_components_test.go
@@ -268,6 +268,13 @@ func TestSortFactoriesByType(t *testing.T) {
 			wantTypes: []string{},
 		},
 		{
+			name: "with a single factory",
+			factories: map[component.Type]mockFactory{
+				component.MustNewType("processor"): newMockFactory("processor"),
+			},
+			wantTypes: []string{"processor"},
+		},
+		{
 			name: "with canonical factories only (sorted by type)",
 			factories: map[component.Type]mockFactory{
 				// IMPORTANT: keys must match factory.Type() (this mirrors MakeFactoryMap output).

--- a/otelcol/command_components_test.go
+++ b/otelcol/command_components_test.go
@@ -260,68 +260,74 @@ func TestSortFactoriesByType(t *testing.T) {
 	for _, tt := range []struct {
 		name      string
 		factories map[component.Type]mockFactory
-		want      []mockFactory
+		wantTypes []string
 	}{
 		{
 			name:      "with an empty map",
 			factories: map[component.Type]mockFactory{},
-			want:      []mockFactory{},
+			wantTypes: []string{},
 		},
 		{
-			name: "with a single factory",
+			name: "with canonical factories only (sorted by type)",
 			factories: map[component.Type]mockFactory{
-				component.MustNewType("receiver"): newMockFactory("receiver_factory"),
+				// IMPORTANT: keys must match factory.Type() (this mirrors MakeFactoryMap output).
+				component.MustNewType("processor"): newMockFactory("processor"),
+				component.MustNewType("exporter"):  newMockFactory("exporter"),
+				component.MustNewType("receiver"):  newMockFactory("receiver"),
 			},
-			want: []mockFactory{
-				newMockFactory("receiver_factory"),
-			},
+			wantTypes: []string{"exporter", "processor", "receiver"},
 		},
 		{
-			name: "with multiple factories",
-			factories: map[component.Type]mockFactory{
-				component.MustNewType("processor"): newMockFactory("processor_factory"),
-				component.MustNewType("exporter"):  newMockFactory("exporter_factory"),
-				component.MustNewType("receiver"):  newMockFactory("receiver_factory"),
-			},
-			want: []mockFactory{
-				newMockFactory("exporter_factory"),
-				newMockFactory("processor_factory"),
-				newMockFactory("receiver_factory"),
-			},
-		}, {
-			name: "canonical factory with deprecated alias is incorrectly dropped (current bug)",
+			name: "exactly one canonical factory with deprecated alias (k8s_attributes -> k8sattributes)",
 			factories: func() map[component.Type]mockFactory {
-				canonicalType := component.MustNewType("k8s_attributes")
-				f := newMockFactory(canonicalType.String())
+				f := newMockFactory("k8s_attributes")
 				f.SetDeprecatedAlias(component.MustNewType("k8sattributes"))
 
+				// Model MakeFactoryMap behavior: alias key points to SAME factory value.
 				return map[component.Type]mockFactory{
-					canonicalType: f,
+					component.MustNewType("k8s_attributes"): f, // canonical key
+					component.MustNewType("k8sattributes"):  f, // alias key
 				}
 			}(),
-			want: []mockFactory{
-				newMockFactory("k8s_attributes"),
-			},
+			wantTypes: []string{"k8s_attributes"},
 		},
 		{
-			name: "with aliases factories",
+			name: "sort and ignore alias keys",
 			factories: func() map[component.Type]mockFactory {
-				alias := newMockFactory("alias_processor_factory")
-				alias.SetDeprecatedAlias(alias.Type())
+				// canonical: k8s_attributes, alias: k8sattributes
+				fK8s := newMockFactory("k8s_attributes")
+				fK8s.SetDeprecatedAlias(component.MustNewType("k8sattributes"))
 
+				// canonical: otlp_http, alias: otlphttp
+				fOtlpHTTP := newMockFactory("otlp_http")
+				fOtlpHTTP.SetDeprecatedAlias(component.MustNewType("otlphttp"))
+
+				// another canonical-only entry to verify ordering
+				fBatch := newMockFactory("batch")
+
+				// Model MakeFactoryMap behavior: alias keys point to SAME factory value.
 				return map[component.Type]mockFactory{
-					component.MustNewType("processor"):       newMockFactory("processor_factory"),
-					component.MustNewType("alias_processor"): alias,
+					component.MustNewType("k8s_attributes"): fK8s,
+					component.MustNewType("k8sattributes"):  fK8s,
+
+					component.MustNewType("otlp_http"): fOtlpHTTP,
+					component.MustNewType("otlphttp"):  fOtlpHTTP,
+
+					component.MustNewType("batch"): fBatch,
 				}
 			}(),
-			want: []mockFactory{
-				newMockFactory("processor_factory"),
-			},
+			wantTypes: []string{"batch", "k8s_attributes", "otlp_http"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sortFactoriesByType(tt.factories)
-			assert.Equal(t, tt.want, got)
+
+			gotTypes := make([]string, 0, len(got))
+			for _, f := range got {
+				gotTypes = append(gotTypes, f.Type().String())
+			}
+
+			assert.Equal(t, tt.wantTypes, gotTypes)
 		})
 	}
 }

--- a/otelcol/command_components_test.go
+++ b/otelcol/command_components_test.go
@@ -288,6 +288,20 @@ func TestSortFactoriesByType(t *testing.T) {
 				newMockFactory("processor_factory"),
 				newMockFactory("receiver_factory"),
 			},
+		}, {
+			name: "canonical factory with deprecated alias is incorrectly dropped (current bug)",
+			factories: func() map[component.Type]mockFactory {
+				canonicalType := component.MustNewType("k8s_attributes")
+				f := newMockFactory(canonicalType.String())
+				f.SetDeprecatedAlias(component.MustNewType("k8sattributes"))
+
+				return map[component.Type]mockFactory{
+					canonicalType: f,
+				}
+			}(),
+			want: []mockFactory{
+				newMockFactory("k8s_attributes"),
+			},
 		},
 		{
 			name: "with aliases factories",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
My understanding of MakeFactoryMap behavior is that alias entries are not separate alias factories. Instead, the alias key points to the same canonical factory so fixing the sorting to reflect that.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #14682

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unittest 

To manual test 

1. Add k8sattributesprocessor to otelcorecol
    `- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.147.0`

2. regenerate it  `make genotelcorecol `
3.  create binary  `make otelcorecol`
4. verify output  `./bin/otelcorecol components | grep -nE 'k8s_attributes|k8sattributes|otlp_http|otlphttp' `
```
25:    - name: k8s_attributes
26:      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.147.0
56:    - name: otlp_http
57:      module: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.147.0
```