### PR TITLE
Introduce UserAgent field to allow overriding the default gRPC user-agent string.

### DIFF
--- a/.chloggen/fix-otlp-grpc-user-agent.yaml
+++ b/.chloggen/fix-otlp-grpc-user-agent.yaml
@@ -1,0 +1,10 @@
+change_type: enhancement
+component: pkg/config/configgrpc
+note: Add `UserAgent` field to `ClientConfig` to allow overriding the default gRPC user-agent string.
+issues: [14686]
+subtext: |
+  The otlp gRPC exporter was unconditionally setting the User-Agent via
+  grpc.WithUserAgent() at dial time, which takes precedence over per-call
+  metadata, causing any user-configured User-Agent to be silently discarded.
+  A dedicated `UserAgent` field has been added to `ClientConfig` which, when
+  set, is used in the dial option directly instead of the default BuildInfo-derived string.

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -100,6 +100,11 @@ type ClientConfig struct {
 	// The headers associated with gRPC requests.
 	Headers configopaque.MapList `mapstructure:"headers,omitempty"`
 
+	// UserAgent overrides the default user-agent header sent on gRPC requests.
+	// The default is derived from the build info. When empty, the caller controls
+	// the user-agent via grpc.WithUserAgent or similar options.
+	UserAgent string `mapstructure:"user_agent,omitempty"`
+
 	// Sets the balancer in grpclb_policy to discover the servers. Default is pick_first.
 	// https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md
 	BalancerName string `mapstructure:"balancer_name"`
@@ -439,6 +444,10 @@ func (cc *ClientConfig) getGrpcDialOptions(
 		if wrapper, ok := opt.(grpcDialOptionWrapper); ok {
 			opts = append(opts, wrapper.opt)
 		}
+	}
+
+	if cc.UserAgent != "" {
+		opts = append(opts, grpc.WithUserAgent(cc.UserAgent))
 	}
 
 	return opts, nil

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -1319,3 +1319,25 @@ func tempSocketName(t *testing.T) string {
 	require.NoError(t, os.Remove(socket))
 	return socket
 }
+
+func TestGrpcClientUserAgent(t *testing.T) {
+	cc := &ClientConfig{
+		TLS: configtls.ClientConfig{
+			Insecure: true,
+		},
+		UserAgent: "my-distribution/1.0",
+	}
+	opts, err := cc.getGrpcDialOptions(
+		context.Background(),
+		nil,
+		componenttest.NewNopTelemetrySettings(),
+		[]ToClientConnOption{},
+	)
+	require.NoError(t, err)
+	/* Expecting 3 DialOptions:
+	 * - WithTransportCredentials (TLS)
+	 * - WithStatsHandler (always, for self-telemetry)
+	 * - WithUserAgent (from UserAgent field)
+	 */
+	assert.Len(t, opts, 3)
+}

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1041,4 +1042,49 @@ func TestSendProfilesWhenEndpointHasHttpScheme(t *testing.T) {
 			assert.EqualValues(t, 0, rcv.totalItems.Load())
 		})
 	}
+}
+
+func TestUserAgentHeader_OverriddenByConfig(t *testing.T) {
+	// Start an OTLP-compatible receiver.
+	ln, err := net.Listen("tcp", "localhost:")
+	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
+	rcv := otlpMetricsReceiverOnGRPCServer(ln)
+	defer rcv.srv.GracefulStop()
+
+	// Start an OTLP exporter with a custom User-Agent header.
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+	cfg.ClientConfig = configgrpc.ClientConfig{
+		Endpoint: ln.Addr().String(),
+		TLS: configtls.ClientConfig{
+			Insecure: true,
+		},
+		UserAgent: "My Distribution For The Collector",
+	}
+	set := exportertest.NewNopSettings(factory.Type())
+	set.BuildInfo.Description = "Collector"
+	set.BuildInfo.Version = "1.2.3test"
+
+	exp, err := factory.CreateMetrics(context.Background(), set, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+	defer func() {
+		assert.NoError(t, exp.Shutdown(context.Background()))
+	}()
+
+	require.NoError(t, exp.Start(context.Background(), componenttest.NewNopHost()))
+
+	// Send a metric to trigger an RPC.
+	require.NoError(t, exp.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
+
+	assert.Eventually(t, func() bool {
+		return rcv.requestCount.Load() > 0
+	}, 10*time.Second, 5*time.Millisecond)
+
+	md := rcv.getMetadata()
+	require.Len(t, md.Get("User-Agent"), 1)
+	// User-configured value must win over the builtin BuildInfo agent.
+	require.True(t, strings.HasPrefix(md.Get("User-Agent")[0], "My Distribution For The Collector"))
+	require.NotContains(t, md.Get("User-Agent")[0], "Collector/1.2.3test")
 }


### PR DESCRIPTION
fixes #14686
 
## Problem
 
When a user wants to override the `User-Agent` sent by the `otlp` (gRPC) exporter,
there is no way to do so. The downstream server always receives the builtin
`BuildInfo`-derived agent string (e.g. `opentelemetry-collector/0.145.0 (linux/amd64)`).
 
This is because `exporter/otlpexporter/otlp.go` unconditionally passes the builtin
agent to `grpc.WithUserAgent()` as a **dial option**:
 
```go
agentOpt := configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))
```
 
`grpc.WithUserAgent()` sets the `User-Agent` at the HTTP/2 transport level, which
takes precedence over any per-call metadata headers — so even if a user sets
`User-Agent` via `headers:`, the transport-level value wins and the user's value
is silently discarded.
 
## Fix
 
Following [review feedback](https://github.com/open-telemetry/opentelemetry-collector/pull/14699#discussion_r2073958620) from @bogdandrutu and @dmathieu, instead of
fixing this only inside `otlpexporter`, the fix is applied universally in
`configgrpc.ClientConfig` so that **all** gRPC components benefit:
 
1. **New `UserAgent` field on `ClientConfig`** (`mapstructure:"user_agent,omitempty"`)
   — a dedicated, first-class config knob for overriding the default gRPC user-agent.
 
2. **Wiring in `getGrpcDialOptions`** — when `cc.UserAgent` is set, a
   `grpc.WithUserAgent(cc.UserAgent)` dial option is appended **after** `extraOpts`.
   This ensures it takes precedence over the default `BuildInfo`-derived string that
   `otlpexporter` passes via `extraOpts`, since gRPC-Go applies dial options
   sequentially (last `WithUserAgent` wins).
 
3. **No changes to `otlp.go`** — the exporter continues passing the `BuildInfo`
   string as the default via `extraOpts`. When a user sets `user_agent:` in their
   config, `configgrpc` appends it last and it naturally overrides the default.
 
### Usage
 
```yaml
exporters:
  otlp:
    endpoint: "0.0.0.0:4444"
    user_agent: "My Distribution For The Collector"
    tls:
      insecure: true
```
 
## Testing
 
- **`TestGrpcClientUserAgent`** in `configgrpc_test.go` — verifies that setting
  `UserAgent` on `ClientConfig` produces the expected dial option in
  `getGrpcDialOptions`.
 
- **`TestUserAgentHeader_OverriddenByConfig`** in `otlp_test.go` — end-to-end test
  that starts a real gRPC server, configures the exporter with a custom `UserAgent`,
  sends metrics, and asserts the custom value reaches the server while the builtin
  `BuildInfo` agent string does not.