### PR TITLE
[chore] Fix lychee config keys

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,11 +1,6 @@
-include-fragments = true
-
 accept = ["200..=299", "429"]
 
 exclude  = [
     "^http(s)?://localhost",
     "^http(s)?://example.com"
 ]
-
-# better to be safe and avoid failures
-max-retries = 6


### PR DESCRIPTION
Fixes the CI job https://github.com/open-telemetry/opentelemetry-collector/actions/runs/22696233513/job/65804104304

The changelog link checker CI started failing after #14676 bumped `lycheeverse/lychee-action` from v2.7.0 to v2.8.0, which bundles lychee v0.23.0.

lycheeverse/lychee#1906 made unknown TOML keys a hard error instead of silently ignoring them. The two keys in `.github/lychee.toml` used hyphens (`include-fragments`, `max-retries`), but the actual struct field names use underscores (`include_fragments`, `max_retries`).

I'm disabling the options for now to keep the behavior as is. Will try to actually introduce the fragments check after that. I assume they might fail