### PR TITLE
[chore] [cmd/mdatagen] Remove redundant generated struct AttributeConfig

### DIFF
--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
@@ -54,11 +54,6 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// AttributeConfig holds configuration information for a particular metric.
-type AttributeConfig struct {
-	Enabled bool `mapstructure:"enabled"`
-}
-
 // MetricsConfig provides config for sample metrics.
 type MetricsConfig struct {
 	DefaultMetric            MetricConfig `mapstructure:"default.metric"`

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
@@ -54,11 +54,6 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// AttributeConfig holds configuration information for a particular metric.
-type AttributeConfig struct {
-	Enabled bool `mapstructure:"enabled"`
-}
-
 // MetricsConfig provides config for sample metrics.
 type MetricsConfig struct {
 	DefaultMetric                 MetricConfig `mapstructure:"default.metric"`

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
@@ -54,11 +54,6 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// AttributeConfig holds configuration information for a particular metric.
-type AttributeConfig struct {
-	Enabled bool `mapstructure:"enabled"`
-}
-
 // MetricsConfig provides config for sample metrics.
 type MetricsConfig struct {
 	DefaultMetric            MetricConfig `mapstructure:"default.metric"`

--- a/cmd/mdatagen/internal/templates/config.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config.go.tmpl
@@ -67,13 +67,6 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-{{- if $reag }}
-// AttributeConfig holds configuration information for a particular metric.
-type AttributeConfig struct {
-	Enabled bool `mapstructure:"enabled"`
-}
-{{- end }}
-
 // MetricsConfig provides config for {{ .Type }} metrics.
 type MetricsConfig struct {
 	{{- range $name, $metric := .Metrics }}


### PR DESCRIPTION
Remove redundant `AttributeConfig` struct that is generated if re-aggregation is enabled but was never needed. I don't think it needs a changelog item given that it's not even generated by default
