### PR TITLE
[chore] Fix changelog CI job

### DIFF
--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -29,15 +29,15 @@ components:
     - pkg/config/configauth
     - pkg/config/configcompression
     - pkg/config/configgrpc
-    - pkg/config/confighttp
     - pkg/config/confighttp/xconfighttp
     - pkg/config/configmiddleware
     - pkg/config/confignet
     - pkg/config/configopaque
-    - pkg/config/configoptional
     - pkg/config/configretry
     - pkg/config/configtelemetry
     - pkg/config/configtls
+    - pkg/confighttp
+    - pkg/configoptional
     - pkg/confmap
     - pkg/connector
     - pkg/connector/connectortest


### PR DESCRIPTION
By running `make generate-chloggen-components`

To avoid this issue in future: https://github.com/open-telemetry/opentelemetry-collector/pull/14726