### PR TITLE
[service/telemetry] Add telemetry.noDefaultMetricsReader feature gate to stop binding port 8888 by default

### DIFF
--- a/.chloggen/14727_telemetry_no_default_metrics_reader.yaml
+++ b/.chloggen/14727_telemetry_no_default_metrics_reader.yaml
@@ -1,0 +1,10 @@
+change_type: "breaking"
+component: "pkg/service"
+note: "Add feature gate `telemetry.noDefaultMetricsReader` to stop binding port 8888 by default for internal metrics."
+issues: [14727]
+subtext: |
+  When the `telemetry.noDefaultMetricsReader` feature gate is enabled, the collector will not
+  start a Prometheus metrics server on port 8888 by default. Users must explicitly configure
+  `service::telemetry::metrics::readers` to expose internal metrics. This gate is currently
+  Alpha (disabled by default) and will graduate to Beta in a future release.
+change_logs: ["user"]

--- a/service/documentation.md
+++ b/service/documentation.md
@@ -112,5 +112,6 @@ This component has the following feature gates:
 | `service.profilesSupport` | alpha | Controls whether profiles support can be enabled | v0.112.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector/pull/11477) |
 | `telemetry.UseLocalHostAsDefaultMetricsAddress` | beta | Controls whether default Prometheus metrics server use localhost as the default host for their endpoints | v0.111.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector/pull/11251) |
 | `telemetry.newPipelineTelemetry` | alpha | Injects component-identifying scope attributes in internal Collector metrics | v0.123.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md) |
+| `telemetry.noDefaultMetricsReader` | alpha | When enabled, the collector will not bind any default Prometheus metrics endpoint on port 8888. Users must explicitly configure service::telemetry::metrics::readers. | v0.148.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector/issues/14727) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/service/internal/metadata/generated_feature_gates.go
+++ b/service/internal/metadata/generated_feature_gates.go
@@ -37,3 +37,11 @@ var TelemetryNewPipelineTelemetryFeatureGate = featuregate.GlobalRegistry().Must
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md"),
 	featuregate.WithRegisterFromVersion("v0.123.0"),
 )
+
+var TelemetryNoDefaultMetricsReaderFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"telemetry.noDefaultMetricsReader",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, the collector will not bind any default Prometheus metrics endpoint on port 8888. Users must explicitly configure service::telemetry::metrics::readers."),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/14727"),
+	featuregate.WithRegisterFromVersion("v0.148.0"),
+)

--- a/service/metadata.yaml
+++ b/service/metadata.yaml
@@ -209,3 +209,8 @@ feature_gates:
     stage: alpha
     from_version: 'v0.123.0'
     reference_url: 'https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md'
+  - id: telemetry.noDefaultMetricsReader
+    description: 'When enabled, the collector will not bind any default Prometheus metrics endpoint on port 8888. Users must explicitly configure service::telemetry::metrics::readers.'
+    stage: alpha
+    from_version: 'v0.148.0'
+    reference_url: 'https://github.com/open-telemetry/opentelemetry-collector/issues/14727'

--- a/service/telemetry/otelconftelemetry/factory.go
+++ b/service/telemetry/otelconftelemetry/factory.go
@@ -28,12 +28,7 @@ func NewFactory() telemetry.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	metricsHost := "localhost"
-	if !metadata.TelemetryUseLocalHostAsDefaultMetricsAddressFeatureGate.IsEnabled() {
-		metricsHost = ""
-	}
-
-	return &Config{
+	cfg := &Config{
 		Logs: LogsConfig{
 			Level:       zapcore.InfoLevel,
 			Development: false,
@@ -52,6 +47,16 @@ func createDefaultConfig() component.Config {
 			DisableZapResource: false,
 		},
 		Metrics: MetricsConfig{
+			Level: configtelemetry.LevelNone,
+		},
+	}
+
+	if !metadata.TelemetryNoDefaultMetricsReaderFeatureGate.IsEnabled() {
+		metricsHost := "localhost"
+		if !metadata.TelemetryUseLocalHostAsDefaultMetricsAddressFeatureGate.IsEnabled() {
+			metricsHost = ""
+		}
+		cfg.Metrics = MetricsConfig{
 			Level: configtelemetry.LevelNormal,
 			MeterProvider: config.MeterProvider{
 				Readers: []config.MetricReader{
@@ -69,8 +74,10 @@ func createDefaultConfig() component.Config {
 					},
 				},
 			},
-		},
+		}
 	}
+
+	return cfg
 }
 
 func ptr[T any](v T) *T {

--- a/service/telemetry/otelconftelemetry/factory_test.go
+++ b/service/telemetry/otelconftelemetry/factory_test.go
@@ -1,6 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-
 package otelconftelemetry
 
 import (
@@ -10,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/service/internal/metadata"
 )
@@ -31,16 +31,34 @@ func TestDefaultConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("UseLocalHostAsDefaultMetricsAddress/"+strconv.FormatBool(tt.gate), func(t *testing.T) {
+			prevNoReader := metadata.TelemetryNoDefaultMetricsReaderFeatureGate.IsEnabled()
+			require.NoError(t, featuregate.GlobalRegistry().Set(metadata.TelemetryNoDefaultMetricsReaderFeatureGate.ID(), false))
+			defer func() {
+				require.NoError(t, featuregate.GlobalRegistry().Set(metadata.TelemetryNoDefaultMetricsReaderFeatureGate.ID(), prevNoReader))
+			}()
+
 			prev := metadata.TelemetryUseLocalHostAsDefaultMetricsAddressFeatureGate.IsEnabled()
 			require.NoError(t, featuregate.GlobalRegistry().Set(metadata.TelemetryUseLocalHostAsDefaultMetricsAddressFeatureGate.ID(), tt.gate))
 			defer func() {
-				// Restore previous value.
 				require.NoError(t, featuregate.GlobalRegistry().Set(metadata.TelemetryUseLocalHostAsDefaultMetricsAddressFeatureGate.ID(), prev))
 			}()
+
 			cfg := NewFactory().CreateDefaultConfig()
 			require.Len(t, cfg.(*Config).Metrics.Readers, 1)
 			assert.Equal(t, tt.expected, *cfg.(*Config).Metrics.Readers[0].Pull.Exporter.Prometheus.Host)
 			assert.Equal(t, 8888, *cfg.(*Config).Metrics.Readers[0].Pull.Exporter.Prometheus.Port)
 		})
 	}
+}
+
+func TestDefaultConfigNoDefaultMetricsReader(t *testing.T) {
+	prev := metadata.TelemetryNoDefaultMetricsReaderFeatureGate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(metadata.TelemetryNoDefaultMetricsReaderFeatureGate.ID(), true))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(metadata.TelemetryNoDefaultMetricsReaderFeatureGate.ID(), prev))
+	}()
+
+	cfg := NewFactory().CreateDefaultConfig()
+	assert.Empty(t, cfg.(*Config).Metrics.Readers)
+	assert.Equal(t, configtelemetry.LevelNone, cfg.(*Config).Metrics.Level)
 }


### PR DESCRIPTION
Fixes #14727

The collector currently binds port 8888 silently on every startup to
expose internal Prometheus metrics, even when the user has not explicitly
configured any metrics reader. This conflicts with other applications that
use the same port and violates the principle of least surprise.

This PR introduces the `telemetry.noDefaultMetricsReader` Alpha feature
gate. When enabled, the collector defaults to `level: none` with no
readers — meaning no port is bound unless the user explicitly configures
`service::telemetry::metrics::readers`.

## Why a feature gate?

This is a breaking change. The gate allows distributions to explicitly
configure their readers (see collector-releases#1405) before the default
flips, following the same pattern as `telemetry.UseLocalHostAsDefaultMetricsAddress`.

## Behaviour

| Gate state | Default metrics behaviour |
|---|---|
| disabled (default) | Prometheus server on `localhost:8888` (unchanged) |
| enabled | No port bound; user must configure `service::telemetry::metrics::readers` explicitly |

## Breaking change rollout

This follows the established feature gate graduation pattern used in this
repo (see `telemetry.UseLocalHostAsDefaultMetricsAddress` as precedent):

1. **This PR** — Alpha gate (off by default). Zero behaviour change for existing users. Distributions can opt in immediately.
2. **Future PR** — Graduate to Beta (on by default) once distributions have made the Prometheus reader explicit via [collector-releases#1405](https://github.com/open-telemetry/opentelemetry-collector-releases/pull/1405).
3. **Future PR** — Graduate to Stable and remove the fallback code entirely.

## Testing

- Existing `TestDefaultConfig` tests updated to explicitly disable the new gate, ensuring the legacy Prometheus reader behaviour is preserved when the gate is off.
- New `TestDefaultConfigNoDefaultMetricsReader` test verifies that when the gate is enabled, `Metrics.Readers` is empty and `Metrics.Level` is `LevelNone`.
- Full test suite and lint passed