### PR TITLE
otelcol: keep canonical component types in components output

### DIFF
--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -195,9 +195,21 @@ func sortConverterModules(modules []string) []componentWithoutStability {
 	return sortedModules
 }
 
-func isComponentAlias(component any) bool {
-	if al, ok := component.(componentalias.TypeAliasHolder); ok {
-		return al.DeprecatedAlias().String() != ""
+func isComponentAlias(comp any) bool {
+	al, ok := comp.(componentalias.TypeAliasHolder)
+	if !ok {
+		return false
 	}
-	return false
+
+	alias := al.DeprecatedAlias()
+	if alias.String() == "" {
+		return false
+	}
+
+	typed, ok := comp.(interface{ Type() component.Type })
+	if !ok {
+		return false
+	}
+
+	return typed.Type() == alias
 }

--- a/otelcol/command_components_test.go
+++ b/otelcol/command_components_test.go
@@ -304,6 +304,24 @@ func TestSortFactoriesByType(t *testing.T) {
 				newMockFactory("processor_factory"),
 			},
 		},
+		{
+			name: "with canonical factory that exposes deprecated alias",
+			factories: func() map[component.Type]mockFactory {
+				canonical := newMockFactory("k8s_attributes")
+				canonical.SetDeprecatedAlias(component.MustNewType("k8sattributes"))
+
+				return map[component.Type]mockFactory{
+					component.MustNewType("k8s_attributes"): canonical,
+				}
+			}(),
+			want: []mockFactory{
+				func() mockFactory {
+					canonical := newMockFactory("k8s_attributes")
+					canonical.SetDeprecatedAlias(component.MustNewType("k8sattributes"))
+					return canonical
+				}(),
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sortFactoriesByType(tt.factories)


### PR DESCRIPTION
#### Description
- Keep canonical component factories in `otelcol components` output even when they expose a deprecated alias.
- Update alias filtering to hide only true alias entries (where `factory.Type()` matches the deprecated alias), instead of hiding every factory that has `DeprecatedAlias()` set.
- Add a regression test for canonical factories with deprecated aliases (e.g. `k8s_attributes` with `k8sattributes` alias).

#### Link to tracking issue
Fixes #14682

#### Testing
- `cd otelcol && go test . -run 'TestSortFactoriesByType|TestComponentsStableOutput|TestNewBuildSubCommand'`

#### Documentation
- Not needed (behavior fix for CLI output).
