### PR TITLE
[chore] fix mdatagen codecov id generation

### DIFF
--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -88,7 +88,7 @@ func (md Metadata) GetCodeCovComponentID() string {
 		return md.Status.CodeCovComponentID
 	}
 
-	return strings.ReplaceAll(md.Status.Class+"_"+md.Type, "/", "_")
+	return strings.ReplaceAll(md.Status.Class+"_"+strings.ReplaceAll(md.Type, "_", ""), "/", "_")
 }
 
 func (md Metadata) HasEntities() bool {

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -231,6 +231,15 @@ func TestCodeCovID(t *testing.T) {
 			},
 			want: "exporter_file",
 		},
+		{
+			md: Metadata{
+				Type: "file_log_thing",
+				Status: &Status{
+					Class: "exporter",
+				},
+			},
+			want: "exporter_filelogthing",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The id generated included underscores in the type, this causes go packages to not match the types defined (which contain underscores)