### PR TITLE
otelcol: fix components command dropping canonical factories with deprecated aliases

### DIFF
--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -148,11 +148,14 @@ func sortFactoriesByType[T component.Factory](factories map[component.Type]T) []
 		return componentTypes[i].String() < componentTypes[j].String()
 	})
 
-	// Build and return list of factories, sorted by component types
+	// Build and return list of factories, sorted by component types.
+	// MakeFactoryMap registers each factory under both its canonical type and its deprecated alias
+	// type (if any). We only want to include the canonical entry here.
 	sortedFactories := make([]T, 0, len(factories))
 	for _, componentType := range componentTypes {
-		if !isComponentAlias(factories[componentType]) {
-			sortedFactories = append(sortedFactories, factories[componentType])
+		factory := factories[componentType]
+		if !isDeprecatedAliasEntry(componentType, factory) {
+			sortedFactories = append(sortedFactories, factory)
 		}
 	}
 
@@ -193,6 +196,18 @@ func sortConverterModules(modules []string) []componentWithoutStability {
 		})
 	}
 	return sortedModules
+}
+
+// isDeprecatedAliasEntry returns true when the factory is being accessed via its deprecated
+// alias type rather than its canonical type. MakeFactoryMap inserts the same factory under
+// two keys when a deprecated alias exists: the canonical key (factory.Type()) and the alias
+// key (factory.DeprecatedAlias()). An entry is the deprecated alias entry when the lookup
+// key differs from the factory's own type AND the factory advertises a deprecated alias.
+func isDeprecatedAliasEntry[T component.Factory](componentType component.Type, factory T) bool {
+	if al, ok := any(factory).(componentalias.TypeAliasHolder); ok {
+		return al.DeprecatedAlias().String() != "" && factory.Type() != componentType
+	}
+	return false
 }
 
 func isComponentAlias(component any) bool {

--- a/otelcol/command_components_test.go
+++ b/otelcol/command_components_test.go
@@ -304,6 +304,42 @@ func TestSortFactoriesByType(t *testing.T) {
 				newMockFactory("processor_factory"),
 			},
 		},
+		{
+			// Regression test for https://github.com/open-telemetry/opentelemetry-collector/issues/14682:
+			// a canonical factory that exposes a deprecated alias must not be dropped from the output.
+			name: "canonical factory with deprecated alias is not dropped",
+			factories: func() map[component.Type]mockFactory {
+				f := newMockFactory("k8s_attributes")
+				f.SetDeprecatedAlias(component.MustNewType("k8sattributes"))
+				return map[component.Type]mockFactory{
+					component.MustNewType("k8s_attributes"): f,
+				}
+			}(),
+			want: func() []mockFactory {
+				f := newMockFactory("k8s_attributes")
+				f.SetDeprecatedAlias(component.MustNewType("k8sattributes"))
+				return []mockFactory{f}
+			}(),
+		},
+		{
+			// Regression test for https://github.com/open-telemetry/opentelemetry-collector/issues/14682:
+			// when MakeFactoryMap registers the same factory under both the canonical key and the
+			// deprecated alias key, only the canonical entry must appear in the components output.
+			name: "deprecated alias entry excluded when both canonical and alias keys are present",
+			factories: func() map[component.Type]mockFactory {
+				f := newMockFactory("k8s_attributes")
+				f.SetDeprecatedAlias(component.MustNewType("k8sattributes"))
+				return map[component.Type]mockFactory{
+					component.MustNewType("k8s_attributes"): f,
+					component.MustNewType("k8sattributes"):  f,
+				}
+			}(),
+			want: func() []mockFactory {
+				f := newMockFactory("k8s_attributes")
+				f.SetDeprecatedAlias(component.MustNewType("k8sattributes"))
+				return []mockFactory{f}
+			}(),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sortFactoriesByType(tt.factories)


### PR DESCRIPTION
Fixes open-telemetry/opentelemetry-collector#14682

## Summary

When a component factory exposes a deprecated type alias, `MakeFactoryMap` registers the same factory under two keys: the canonical type (e.g. `k8s_attributes`) and the deprecated alias type (e.g. `k8sattributes`). The `sortFactoriesByType` function was filtering entries using `isComponentAlias`, which returns `true` whenever `DeprecatedAlias() != ""`. This caused **both** the canonical and the alias map entries to be skipped, so the component never appeared in the `otelcol components` output.

## Root cause

`isComponentAlias` only checked whether a deprecated alias was set, without considering which map key was being used to look up the factory. Since `MakeFactoryMap` stores the same factory object under both keys, the canonical entry was incorrectly treated as an alias.

## Fix

Added `isDeprecatedAliasEntry(componentType, factory)` which compares the map lookup key against the factory's own `Type()`:

- If `key == factory.Type()` → this is the canonical entry; include it even if a deprecated alias is set.
- If `key != factory.Type()` AND `DeprecatedAlias() != ""` → this is the deprecated alias entry; skip it.

The existing `isComponentAlias` helper is preserved unchanged and continues to be used in `sortProvidersByScheme` where the different semantics are appropriate.

## Tests

Two regression tests are added to `TestSortFactoriesByType`:
1. A canonical factory with a deprecated alias registered under only its canonical key must appear in the output.
2. When both the canonical and alias keys are present (as `MakeFactoryMap` produces), only the canonical entry must appear in the output.

All existing tests continue to pass.