### PR TITLE
cmd/mdatagen: fix reaggregation key mismatch in metrics tests

### DIFF
--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -471,6 +471,21 @@ foo
 	}
 }
 
+func TestGenerateMetricsTestUsesRawMetricNameForReaggregation(t *testing.T) {
+	md, err := LoadMetadata(filepath.Join("testdata", "reaggregation_dotted_metric.yaml"))
+	require.NoError(t, err)
+
+	outputFile := filepath.Join(t.TempDir(), "generated_metrics_test.go")
+	require.NoError(t, generateFile("templates/metrics_test.go.tmpl", outputFile, md, "metadata"))
+
+	contents, err := os.ReadFile(filepath.Clean(outputFile))
+	require.NoError(t, err)
+
+	require.Contains(t, string(contents), `aggMap["system.cpu.time"] = mb.metricSystemCPUTime.config.AggregationStrategy`)
+	require.Contains(t, string(contents), `switch aggMap["system.cpu.time"] {`)
+	require.NotContains(t, string(contents), `aggMap["SystemCPUTime"] =`)
+}
+
 func TestGenerateConfigFiles(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics_test.go
@@ -68,11 +68,11 @@ func TestMetricsBuilder(t *testing.T) {
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
-			aggMap["DefaultMetric"] = mb.metricDefaultMetric.config.AggregationStrategy
-			aggMap["MetricInputType"] = mb.metricMetricInputType.config.AggregationStrategy
-			aggMap["OptionalMetric"] = mb.metricOptionalMetric.config.AggregationStrategy
-			aggMap["OptionalMetricEmptyUnit"] = mb.metricOptionalMetricEmptyUnit.config.AggregationStrategy
-			aggMap["ReaggregateMetric"] = mb.metricReaggregateMetric.config.AggregationStrategy
+			aggMap["default.metric"] = mb.metricDefaultMetric.config.AggregationStrategy
+			aggMap["metric.input_type"] = mb.metricMetricInputType.config.AggregationStrategy
+			aggMap["optional.metric"] = mb.metricOptionalMetric.config.AggregationStrategy
+			aggMap["optional.metric.empty_unit"] = mb.metricOptionalMetricEmptyUnit.config.AggregationStrategy
+			aggMap["reaggregate.metric"] = mb.metricReaggregateMetric.config.AggregationStrategy
 
 			expectedWarnings := 0
 			if tt.metricsSet == testDataSetDefault {

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics_test.go
@@ -68,12 +68,12 @@ func TestMetricsBuilder(t *testing.T) {
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
-			aggMap["DefaultMetric"] = mb.metricDefaultMetric.config.AggregationStrategy
-			aggMap["MetricInputType"] = mb.metricMetricInputType.config.AggregationStrategy
-			aggMap["OptionalMetric"] = mb.metricOptionalMetric.config.AggregationStrategy
-			aggMap["OptionalMetricEmptyUnit"] = mb.metricOptionalMetricEmptyUnit.config.AggregationStrategy
-			aggMap["ReaggregateMetric"] = mb.metricReaggregateMetric.config.AggregationStrategy
-			aggMap["ReaggregateMetricWithRequired"] = mb.metricReaggregateMetricWithRequired.config.AggregationStrategy
+			aggMap["default.metric"] = mb.metricDefaultMetric.config.AggregationStrategy
+			aggMap["metric.input_type"] = mb.metricMetricInputType.config.AggregationStrategy
+			aggMap["optional.metric"] = mb.metricOptionalMetric.config.AggregationStrategy
+			aggMap["optional.metric.empty_unit"] = mb.metricOptionalMetricEmptyUnit.config.AggregationStrategy
+			aggMap["reaggregate.metric"] = mb.metricReaggregateMetric.config.AggregationStrategy
+			aggMap["reaggregate.metric.with_required"] = mb.metricReaggregateMetricWithRequired.config.AggregationStrategy
 
 			expectedWarnings := 0
 			if tt.metricsSet == testDataSetDefault {

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics_test.go
@@ -68,11 +68,11 @@ func TestMetricsBuilder(t *testing.T) {
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
-			aggMap["DefaultMetric"] = mb.metricDefaultMetric.config.AggregationStrategy
-			aggMap["MetricInputType"] = mb.metricMetricInputType.config.AggregationStrategy
-			aggMap["OptionalMetric"] = mb.metricOptionalMetric.config.AggregationStrategy
-			aggMap["OptionalMetricEmptyUnit"] = mb.metricOptionalMetricEmptyUnit.config.AggregationStrategy
-			aggMap["ReaggregateMetric"] = mb.metricReaggregateMetric.config.AggregationStrategy
+			aggMap["default.metric"] = mb.metricDefaultMetric.config.AggregationStrategy
+			aggMap["metric.input_type"] = mb.metricMetricInputType.config.AggregationStrategy
+			aggMap["optional.metric"] = mb.metricOptionalMetric.config.AggregationStrategy
+			aggMap["optional.metric.empty_unit"] = mb.metricOptionalMetricEmptyUnit.config.AggregationStrategy
+			aggMap["reaggregate.metric"] = mb.metricReaggregateMetric.config.AggregationStrategy
 
 			expectedWarnings := 0
 			if tt.metricsSet == testDataSetDefault {

--- a/cmd/mdatagen/internal/templates/config.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config.go.tmpl
@@ -5,11 +5,15 @@ package {{ .Package }}
 {{ $reag := .ReaggregationEnabled }}
 {{- $hasReagMetrics := false }}
 {{- range $name, $metric := .Metrics }}{{- if and $reag (hasAggregatableAttributes $metric.Attributes) }}{{- $hasReagMetrics = true }}{{- end }}{{- end }}
+{{- $needsSlicesImport := false }}
+{{- range $name, $metric := .Metrics }}{{- if and $reag (hasAggregatableAttributes $metric.Attributes) }}{{- range $metric.Attributes }}{{- if (attributeInfo .).IsRequired }}{{- $needsSlicesImport = true }}{{- end }}{{- end }}{{- end }}{{- end }}
 
 import (
 	{{- if $hasReagMetrics }}
 	"fmt"
+	{{- if $needsSlicesImport }}
 	"slices"
+	{{- end }}
 	{{- end }}
 
 	"go.opentelemetry.io/collector/confmap"

--- a/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
@@ -85,7 +85,7 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
 			{{- range $name, $metric := .Metrics }}
 			{{- if hasAggregatableAttributes $metric.Attributes }}
-			aggMap["{{ $name.Render }}"] = mb.metric{{ $name.Render }}.config.AggregationStrategy
+			aggMap["{{ $name }}"] = mb.metric{{ $name.Render }}.config.AggregationStrategy
 			{{- end }}
 			{{- end }}
 			{{- end }}

--- a/cmd/mdatagen/internal/testdata/reaggregation_dotted_metric.yaml
+++ b/cmd/mdatagen/internal/testdata/reaggregation_dotted_metric.yaml
@@ -1,0 +1,25 @@
+type: receiver
+reaggregation_enabled: true
+
+status:
+  class: receiver
+  stability:
+    development: [metrics]
+
+attributes:
+  opt_in_string_attr:
+    description: Opt-in string attr.
+    type: string
+    requirement_level: opt_in
+
+metrics:
+  system.cpu.time:
+    enabled: true
+    description: Metric used to verify reaggregation test generation for dotted names.
+    stability: development
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [opt_in_string_attr]


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix a reaggregation test-generation bug in `cmd/mdatagen`.

The generated metrics tests were storing aggregation strategies in `aggMap` using rendered Go identifier names, while the reaggregation checks read them back using the raw metric names. That mismatch breaks generated tests for metrics with dotted names such as `system.cpu.time`.

This change updates the metrics test template to use the raw metric name consistently for both storing and reading aggregation strategies. It also adds a regression test and dedicated testdata covering a reaggregation-enabled dotted metric, and regenerates the affected sample `generated_metrics_test.go` files.

A follow-up change also updates the generated config template to import `slices` only when it is needed. This avoids generating an unused `slices` import in config code.

<!-- Issue number if applicable -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46410#issuecomment-4044113951

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a regression test in `cmd/mdatagen/internal/command_test.go` that verifies generated metrics tests use the raw dotted metric name consistently when reaggregation is enabled.


<!--Please delete paragraphs that you did not use before submitting.-->
