### PR TITLE
[pdata] Use pool-aware constructors in gRPC service handlers

### DIFF
--- a/.chloggen/pdata-grpc-pool-aware-constructors.yaml
+++ b/.chloggen/pdata-grpc-pool-aware-constructors.yaml
@@ -1,0 +1,16 @@
+change_type: bug_fix
+
+component: pdata
+
+note: Use pool-aware constructors in gRPC service handlers so top-level request structs participate in the sync.Pool lifecycle.
+
+issues: []
+
+subtext: |
+  The gRPC service handlers for all signal types allocated the top-level
+  ExportXxxServiceRequest with bare new(), bypassing the sync.Pool when
+  pdata.useProtoPooling is enabled. This caused objects returned to the pool
+  via Delete to never be retrieved. The handlers now use the pool-aware
+  New*() constructors.
+
+change_logs: [api]

--- a/.chloggen/pdata-grpc-pool-aware-constructors.yaml
+++ b/.chloggen/pdata-grpc-pool-aware-constructors.yaml
@@ -4,7 +4,7 @@ component: pkg/pdata
 
 note: Use pool-aware constructors in gRPC service handlers so top-level request structs participate in the sync.Pool lifecycle.
 
-issues: []
+issues: [14763]
 
 subtext: |
   The gRPC service handlers for all signal types allocated the top-level

--- a/.chloggen/pdata-grpc-pool-aware-constructors.yaml
+++ b/.chloggen/pdata-grpc-pool-aware-constructors.yaml
@@ -1,6 +1,6 @@
 change_type: bug_fix
 
-component: pdata
+component: pkg/pdata
 
 note: Use pool-aware constructors in gRPC service handlers so top-level request structs participate in the sync.Pool lifecycle.
 

--- a/pdata/internal/otelgrpc/logs_service.go
+++ b/pdata/internal/otelgrpc/logs_service.go
@@ -57,7 +57,7 @@ func RegisterLogsServiceServer(s *grpc.Server, srv LogsServiceServer) {
 //
 //nolint:revive
 func logsServiceExportHandler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
-	in := new(internal.ExportLogsServiceRequest)
+	in := internal.NewExportLogsServiceRequest()
 	if err := dec(in); err != nil {
 		return nil, err
 	}

--- a/pdata/internal/otelgrpc/metrics_service.go
+++ b/pdata/internal/otelgrpc/metrics_service.go
@@ -57,7 +57,7 @@ func RegisterMetricsServiceServer(s *grpc.Server, srv MetricsServiceServer) {
 //
 //nolint:revive
 func metricsServiceExportHandler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
-	in := new(internal.ExportMetricsServiceRequest)
+	in := internal.NewExportMetricsServiceRequest()
 	if err := dec(in); err != nil {
 		return nil, err
 	}

--- a/pdata/internal/otelgrpc/profiles_service.go
+++ b/pdata/internal/otelgrpc/profiles_service.go
@@ -57,7 +57,7 @@ func RegisterProfilesServiceServer(s *grpc.Server, srv ProfilesServiceServer) {
 //
 //nolint:revive
 func profilesServiceExportHandler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
-	in := new(internal.ExportProfilesServiceRequest)
+	in := internal.NewExportProfilesServiceRequest()
 	if err := dec(in); err != nil {
 		return nil, err
 	}

--- a/pdata/internal/otelgrpc/trace_service.go
+++ b/pdata/internal/otelgrpc/trace_service.go
@@ -57,7 +57,7 @@ func RegisterTraceServiceServer(s *grpc.Server, srv TraceServiceServer) {
 //
 //nolint:revive
 func traceServiceExportHandler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
-	in := new(internal.ExportTraceServiceRequest)
+	in := internal.NewExportTraceServiceRequest()
 	if err := dec(in); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The gRPC service handlers for all four signal types allocate the top-level ExportXxxServiceRequest with bare new(), bypassing the sync.Pool when pdata.useProtoPooling is enabled. This means objects returned to the pool via Delete are never retrieved, so the pool accumulates unreused objects.

Replace new() with the pool-aware New*() constructors so the top-level request struct participates in the pool lifecycle.

benchstat (20 runs, pdata.useProtoPooling=true, 10k logs/request):

```
                             │   old (new())   │  new (New*())    │
                             │     sec/op      │  sec/op  vs base │
GRPCLogsSequentialPooling-12     3.858m ± 2%   3.811m ± 1%  ~ (p=0.165 n=20)
                             │      B/op       │   B/op   vs base │
GRPCLogsSequentialPooling-12    3.551Mi ± 2%  3.523Mi ± 1%  ~ (p=0.445 n=20)
                             │   allocs/op     │ allocs/op vs base│
GRPCLogsSequentialPooling-12     75.46k ± 0%   75.46k ± 0%  ~ (p=0.867 n=20)
```

No measurable perf difference (1 alloc out of 75k), but this is a correctness fix for the pool lifecycle.

Assisted-by: Claude Opus 4.6

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
