### PR TITLE
[cmd/mdatagen] [chore] Rename per-metric config types to include Metric infix

### DIFF
--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/config.schema.yaml
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/config.schema.yaml
@@ -5,7 +5,7 @@ $defs:
     type: object
     properties:
       default.metric:
-        description: "DefaultMetricConfig provides config for the default.metric metric."
+        description: "DefaultMetricMetricConfig provides config for the default.metric metric."
         type: object
         properties:
           enabled:
@@ -36,14 +36,14 @@ $defs:
               - "slice_attr"
               - "map_attr"
       default.metric.to_be_removed:
-        description: "DefaultMetricToBeRemovedConfig provides config for the default.metric.to_be_removed metric."
+        description: "DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric."
         type: object
         properties:
           enabled:
             type: boolean
             default: true
       metric.input_type:
-        description: "MetricInputTypeConfig provides config for the metric.input_type metric."
+        description: "MetricInputTypeMetricConfig provides config for the metric.input_type metric."
         type: object
         properties:
           enabled:
@@ -74,7 +74,7 @@ $defs:
               - "slice_attr"
               - "map_attr"
       optional.metric:
-        description: "OptionalMetricConfig provides config for the optional.metric metric."
+        description: "OptionalMetricMetricConfig provides config for the optional.metric metric."
         type: object
         properties:
           enabled:
@@ -101,7 +101,7 @@ $defs:
               - "boolean_attr"
               - "boolean_attr2"
       optional.metric.empty_unit:
-        description: "OptionalMetricEmptyUnitConfig provides config for the optional.metric.empty_unit metric."
+        description: "OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric."
         type: object
         properties:
           enabled:
@@ -126,7 +126,7 @@ $defs:
               - "string_attr"
               - "boolean_attr"
       reaggregate.metric:
-        description: "ReaggregateMetricConfig provides config for the reaggregate.metric metric."
+        description: "ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric."
         type: object
         properties:
           enabled:

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
@@ -9,27 +9,27 @@ import (
 	"go.opentelemetry.io/collector/filter"
 )
 
-// DefaultMetricAttributeKey specifies the key of an attribute for the default.metric metric.
-type DefaultMetricAttributeKey string
+// DefaultMetricMetricAttributeKey specifies the key of an attribute for the default.metric metric.
+type DefaultMetricMetricAttributeKey string
 
 const (
-	DefaultMetricAttributeKeyStringAttr        DefaultMetricAttributeKey = "string_attr"
-	DefaultMetricAttributeKeyOverriddenIntAttr DefaultMetricAttributeKey = "state"
-	DefaultMetricAttributeKeyEnumAttr          DefaultMetricAttributeKey = "enum_attr"
-	DefaultMetricAttributeKeySliceAttr         DefaultMetricAttributeKey = "slice_attr"
-	DefaultMetricAttributeKeyMapAttr           DefaultMetricAttributeKey = "map_attr"
+	DefaultMetricMetricAttributeKeyStringAttr        DefaultMetricMetricAttributeKey = "string_attr"
+	DefaultMetricMetricAttributeKeyOverriddenIntAttr DefaultMetricMetricAttributeKey = "state"
+	DefaultMetricMetricAttributeKeyEnumAttr          DefaultMetricMetricAttributeKey = "enum_attr"
+	DefaultMetricMetricAttributeKeySliceAttr         DefaultMetricMetricAttributeKey = "slice_attr"
+	DefaultMetricMetricAttributeKeyMapAttr           DefaultMetricMetricAttributeKey = "map_attr"
 )
 
-// DefaultMetricConfig provides config for the default.metric metric.
-type DefaultMetricConfig struct {
+// DefaultMetricMetricConfig provides config for the default.metric metric.
+type DefaultMetricMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                      `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []DefaultMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []DefaultMetricMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *DefaultMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *DefaultMetricMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -43,10 +43,10 @@ func (ms *DefaultMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *DefaultMetricConfig) Validate() error {
+func (ms *DefaultMetricMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr:
+		case DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr:
 		default:
 			return fmt.Errorf("metric default.metric doesn't have an attribute %v, valid attributes: [string_attr, state, enum_attr, slice_attr, map_attr]", val)
 		}
@@ -61,13 +61,13 @@ func (ms *DefaultMetricConfig) Validate() error {
 	return nil
 }
 
-// DefaultMetricToBeRemovedConfig provides config for the default.metric.to_be_removed metric.
-type DefaultMetricToBeRemovedConfig struct {
+// DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric.
+type DefaultMetricToBeRemovedMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *DefaultMetricToBeRemovedConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *DefaultMetricToBeRemovedMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -81,27 +81,27 @@ func (ms *DefaultMetricToBeRemovedConfig) Unmarshal(parser *confmap.Conf) error 
 	return nil
 }
 
-// MetricInputTypeAttributeKey specifies the key of an attribute for the metric.input_type metric.
-type MetricInputTypeAttributeKey string
+// MetricInputTypeMetricAttributeKey specifies the key of an attribute for the metric.input_type metric.
+type MetricInputTypeMetricAttributeKey string
 
 const (
-	MetricInputTypeAttributeKeyStringAttr        MetricInputTypeAttributeKey = "string_attr"
-	MetricInputTypeAttributeKeyOverriddenIntAttr MetricInputTypeAttributeKey = "state"
-	MetricInputTypeAttributeKeyEnumAttr          MetricInputTypeAttributeKey = "enum_attr"
-	MetricInputTypeAttributeKeySliceAttr         MetricInputTypeAttributeKey = "slice_attr"
-	MetricInputTypeAttributeKeyMapAttr           MetricInputTypeAttributeKey = "map_attr"
+	MetricInputTypeMetricAttributeKeyStringAttr        MetricInputTypeMetricAttributeKey = "string_attr"
+	MetricInputTypeMetricAttributeKeyOverriddenIntAttr MetricInputTypeMetricAttributeKey = "state"
+	MetricInputTypeMetricAttributeKeyEnumAttr          MetricInputTypeMetricAttributeKey = "enum_attr"
+	MetricInputTypeMetricAttributeKeySliceAttr         MetricInputTypeMetricAttributeKey = "slice_attr"
+	MetricInputTypeMetricAttributeKeyMapAttr           MetricInputTypeMetricAttributeKey = "map_attr"
 )
 
-// MetricInputTypeConfig provides config for the metric.input_type metric.
-type MetricInputTypeConfig struct {
+// MetricInputTypeMetricConfig provides config for the metric.input_type metric.
+type MetricInputTypeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                        `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []MetricInputTypeAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MetricInputTypeMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *MetricInputTypeConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricInputTypeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -115,10 +115,10 @@ func (ms *MetricInputTypeConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *MetricInputTypeConfig) Validate() error {
+func (ms *MetricInputTypeMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr:
+		case MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr:
 		default:
 			return fmt.Errorf("metric metric.input_type doesn't have an attribute %v, valid attributes: [string_attr, state, enum_attr, slice_attr, map_attr]", val)
 		}
@@ -133,25 +133,25 @@ func (ms *MetricInputTypeConfig) Validate() error {
 	return nil
 }
 
-// OptionalMetricAttributeKey specifies the key of an attribute for the optional.metric metric.
-type OptionalMetricAttributeKey string
+// OptionalMetricMetricAttributeKey specifies the key of an attribute for the optional.metric metric.
+type OptionalMetricMetricAttributeKey string
 
 const (
-	OptionalMetricAttributeKeyStringAttr   OptionalMetricAttributeKey = "string_attr"
-	OptionalMetricAttributeKeyBooleanAttr  OptionalMetricAttributeKey = "boolean_attr"
-	OptionalMetricAttributeKeyBooleanAttr2 OptionalMetricAttributeKey = "boolean_attr2"
+	OptionalMetricMetricAttributeKeyStringAttr   OptionalMetricMetricAttributeKey = "string_attr"
+	OptionalMetricMetricAttributeKeyBooleanAttr  OptionalMetricMetricAttributeKey = "boolean_attr"
+	OptionalMetricMetricAttributeKeyBooleanAttr2 OptionalMetricMetricAttributeKey = "boolean_attr2"
 )
 
-// OptionalMetricConfig provides config for the optional.metric metric.
-type OptionalMetricConfig struct {
+// OptionalMetricMetricConfig provides config for the optional.metric metric.
+type OptionalMetricMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                       `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OptionalMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OptionalMetricMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OptionalMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OptionalMetricMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -165,10 +165,10 @@ func (ms *OptionalMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *OptionalMetricConfig) Validate() error {
+func (ms *OptionalMetricMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2:
+		case OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2:
 		default:
 			return fmt.Errorf("metric optional.metric doesn't have an attribute %v, valid attributes: [string_attr, boolean_attr, boolean_attr2]", val)
 		}
@@ -183,24 +183,24 @@ func (ms *OptionalMetricConfig) Validate() error {
 	return nil
 }
 
-// OptionalMetricEmptyUnitAttributeKey specifies the key of an attribute for the optional.metric.empty_unit metric.
-type OptionalMetricEmptyUnitAttributeKey string
+// OptionalMetricEmptyUnitMetricAttributeKey specifies the key of an attribute for the optional.metric.empty_unit metric.
+type OptionalMetricEmptyUnitMetricAttributeKey string
 
 const (
-	OptionalMetricEmptyUnitAttributeKeyStringAttr  OptionalMetricEmptyUnitAttributeKey = "string_attr"
-	OptionalMetricEmptyUnitAttributeKeyBooleanAttr OptionalMetricEmptyUnitAttributeKey = "boolean_attr"
+	OptionalMetricEmptyUnitMetricAttributeKeyStringAttr  OptionalMetricEmptyUnitMetricAttributeKey = "string_attr"
+	OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr OptionalMetricEmptyUnitMetricAttributeKey = "boolean_attr"
 )
 
-// OptionalMetricEmptyUnitConfig provides config for the optional.metric.empty_unit metric.
-type OptionalMetricEmptyUnitConfig struct {
+// OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric.
+type OptionalMetricEmptyUnitMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OptionalMetricEmptyUnitAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OptionalMetricEmptyUnitMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OptionalMetricEmptyUnitConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OptionalMetricEmptyUnitMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -214,10 +214,10 @@ func (ms *OptionalMetricEmptyUnitConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *OptionalMetricEmptyUnitConfig) Validate() error {
+func (ms *OptionalMetricEmptyUnitMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr:
+		case OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr:
 		default:
 			return fmt.Errorf("metric optional.metric.empty_unit doesn't have an attribute %v, valid attributes: [string_attr, boolean_attr]", val)
 		}
@@ -232,24 +232,24 @@ func (ms *OptionalMetricEmptyUnitConfig) Validate() error {
 	return nil
 }
 
-// ReaggregateMetricAttributeKey specifies the key of an attribute for the reaggregate.metric metric.
-type ReaggregateMetricAttributeKey string
+// ReaggregateMetricMetricAttributeKey specifies the key of an attribute for the reaggregate.metric metric.
+type ReaggregateMetricMetricAttributeKey string
 
 const (
-	ReaggregateMetricAttributeKeyStringAttr  ReaggregateMetricAttributeKey = "string_attr"
-	ReaggregateMetricAttributeKeyBooleanAttr ReaggregateMetricAttributeKey = "boolean_attr"
+	ReaggregateMetricMetricAttributeKeyStringAttr  ReaggregateMetricMetricAttributeKey = "string_attr"
+	ReaggregateMetricMetricAttributeKeyBooleanAttr ReaggregateMetricMetricAttributeKey = "boolean_attr"
 )
 
-// ReaggregateMetricConfig provides config for the reaggregate.metric metric.
-type ReaggregateMetricConfig struct {
+// ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric.
+type ReaggregateMetricMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                          `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []ReaggregateMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ReaggregateMetricMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *ReaggregateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *ReaggregateMetricMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -263,10 +263,10 @@ func (ms *ReaggregateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *ReaggregateMetricConfig) Validate() error {
+func (ms *ReaggregateMetricMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr:
+		case ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr:
 		default:
 			return fmt.Errorf("metric reaggregate.metric doesn't have an attribute %v, valid attributes: [string_attr, boolean_attr]", val)
 		}
@@ -283,43 +283,43 @@ func (ms *ReaggregateMetricConfig) Validate() error {
 
 // MetricsConfig provides config for sample metrics.
 type MetricsConfig struct {
-	DefaultMetric            DefaultMetricConfig            `mapstructure:"default.metric"`
-	DefaultMetricToBeRemoved DefaultMetricToBeRemovedConfig `mapstructure:"default.metric.to_be_removed"`
-	MetricInputType          MetricInputTypeConfig          `mapstructure:"metric.input_type"`
-	OptionalMetric           OptionalMetricConfig           `mapstructure:"optional.metric"`
-	OptionalMetricEmptyUnit  OptionalMetricEmptyUnitConfig  `mapstructure:"optional.metric.empty_unit"`
-	ReaggregateMetric        ReaggregateMetricConfig        `mapstructure:"reaggregate.metric"`
+	DefaultMetric            DefaultMetricMetricConfig            `mapstructure:"default.metric"`
+	DefaultMetricToBeRemoved DefaultMetricToBeRemovedMetricConfig `mapstructure:"default.metric.to_be_removed"`
+	MetricInputType          MetricInputTypeMetricConfig          `mapstructure:"metric.input_type"`
+	OptionalMetric           OptionalMetricMetricConfig           `mapstructure:"optional.metric"`
+	OptionalMetricEmptyUnit  OptionalMetricEmptyUnitMetricConfig  `mapstructure:"optional.metric.empty_unit"`
+	ReaggregateMetric        ReaggregateMetricMetricConfig        `mapstructure:"reaggregate.metric"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		DefaultMetric: DefaultMetricConfig{
+		DefaultMetric: DefaultMetricMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []DefaultMetricAttributeKey{DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr},
+			EnabledAttributes:   []DefaultMetricMetricAttributeKey{DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr},
 		},
-		DefaultMetricToBeRemoved: DefaultMetricToBeRemovedConfig{
+		DefaultMetricToBeRemoved: DefaultMetricToBeRemovedMetricConfig{
 			Enabled: true,
 		},
-		MetricInputType: MetricInputTypeConfig{
+		MetricInputType: MetricInputTypeMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []MetricInputTypeAttributeKey{MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr},
+			EnabledAttributes:   []MetricInputTypeMetricAttributeKey{MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr},
 		},
-		OptionalMetric: OptionalMetricConfig{
+		OptionalMetric: OptionalMetricMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OptionalMetricAttributeKey{OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2},
+			EnabledAttributes:   []OptionalMetricMetricAttributeKey{OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2},
 		},
-		OptionalMetricEmptyUnit: OptionalMetricEmptyUnitConfig{
+		OptionalMetricEmptyUnit: OptionalMetricEmptyUnitMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OptionalMetricEmptyUnitAttributeKey{OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr},
+			EnabledAttributes:   []OptionalMetricEmptyUnitMetricAttributeKey{OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr},
 		},
-		ReaggregateMetric: ReaggregateMetricConfig{
+		ReaggregateMetric: ReaggregateMetricMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []ReaggregateMetricAttributeKey{ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr},
+			EnabledAttributes:   []ReaggregateMetricMetricAttributeKey{ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr},
 		},
 	}
 }

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config_test.go
@@ -27,33 +27,33 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					DefaultMetric: DefaultMetricConfig{
+					DefaultMetric: DefaultMetricMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []DefaultMetricAttributeKey{DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr},
+						EnabledAttributes:   []DefaultMetricMetricAttributeKey{DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr},
 					},
-					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedConfig{
+					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedMetricConfig{
 						Enabled: true,
 					},
-					MetricInputType: MetricInputTypeConfig{
+					MetricInputType: MetricInputTypeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MetricInputTypeAttributeKey{MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr},
+						EnabledAttributes:   []MetricInputTypeMetricAttributeKey{MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr},
 					},
-					OptionalMetric: OptionalMetricConfig{
+					OptionalMetric: OptionalMetricMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricAttributeKey{OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2},
+						EnabledAttributes:   []OptionalMetricMetricAttributeKey{OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2},
 					},
-					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitConfig{
+					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricEmptyUnitAttributeKey{OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr},
+						EnabledAttributes:   []OptionalMetricEmptyUnitMetricAttributeKey{OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr},
 					},
-					ReaggregateMetric: ReaggregateMetricConfig{
+					ReaggregateMetric: ReaggregateMetricMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []ReaggregateMetricAttributeKey{ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr},
+						EnabledAttributes:   []ReaggregateMetricMetricAttributeKey{ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -72,33 +72,33 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					DefaultMetric: DefaultMetricConfig{
+					DefaultMetric: DefaultMetricMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []DefaultMetricAttributeKey{DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr},
+						EnabledAttributes:   []DefaultMetricMetricAttributeKey{DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr},
 					},
-					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedConfig{
+					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedMetricConfig{
 						Enabled: false,
 					},
-					MetricInputType: MetricInputTypeConfig{
+					MetricInputType: MetricInputTypeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MetricInputTypeAttributeKey{MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr},
+						EnabledAttributes:   []MetricInputTypeMetricAttributeKey{MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr},
 					},
-					OptionalMetric: OptionalMetricConfig{
+					OptionalMetric: OptionalMetricMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricAttributeKey{OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2},
+						EnabledAttributes:   []OptionalMetricMetricAttributeKey{OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2},
 					},
-					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitConfig{
+					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricEmptyUnitAttributeKey{OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr},
+						EnabledAttributes:   []OptionalMetricEmptyUnitMetricAttributeKey{OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr},
 					},
-					ReaggregateMetric: ReaggregateMetricConfig{
+					ReaggregateMetric: ReaggregateMetricMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []ReaggregateMetricAttributeKey{ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr},
+						EnabledAttributes:   []ReaggregateMetricMetricAttributeKey{ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -117,7 +117,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(DefaultMetricConfig{}, DefaultMetricToBeRemovedConfig{}, MetricInputTypeConfig{}, OptionalMetricConfig{}, OptionalMetricEmptyUnitConfig{}, ReaggregateMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(DefaultMetricMetricConfig{}, DefaultMetricToBeRemovedMetricConfig{}, MetricInputTypeMetricConfig{}, OptionalMetricMetricConfig{}, OptionalMetricEmptyUnitMetricConfig{}, ReaggregateMetricMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics.go
@@ -89,10 +89,10 @@ type metricInfo struct {
 }
 
 type metricDefaultMetric struct {
-	data          pmetric.Metric      // data buffer for generated metric.
-	config        DefaultMetricConfig // metric config provided by user.
-	capacity      int                 // max observed number of data points added to the metric.
-	aggDataPoints []int64             // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric            // data buffer for generated metric.
+	config        DefaultMetricMetricConfig // metric config provided by user.
+	capacity      int                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                   // slice containing number of aggregated datapoints at each index
 }
 
 // init fills default.metric metric with initial data.
@@ -115,19 +115,19 @@ func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyOverriddenIntAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyOverriddenIntAttr) {
 		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyEnumAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyEnumAttr) {
 		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeySliceAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeySliceAttr) {
 		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyMapAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyMapAttr) {
 		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
 	}
 
@@ -181,7 +181,7 @@ func (m *metricDefaultMetric) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricDefaultMetric(cfg DefaultMetricConfig) metricDefaultMetric {
+func newMetricDefaultMetric(cfg DefaultMetricMetricConfig) metricDefaultMetric {
 	m := metricDefaultMetric{config: cfg}
 
 	if cfg.Enabled {
@@ -192,9 +192,9 @@ func newMetricDefaultMetric(cfg DefaultMetricConfig) metricDefaultMetric {
 }
 
 type metricDefaultMetricToBeRemoved struct {
-	data     pmetric.Metric                 // data buffer for generated metric.
-	config   DefaultMetricToBeRemovedConfig // metric config provided by user.
-	capacity int                            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   DefaultMetricToBeRemovedMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills default.metric.to_be_removed metric with initial data.
@@ -233,7 +233,7 @@ func (m *metricDefaultMetricToBeRemoved) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricDefaultMetricToBeRemoved(cfg DefaultMetricToBeRemovedConfig) metricDefaultMetricToBeRemoved {
+func newMetricDefaultMetricToBeRemoved(cfg DefaultMetricToBeRemovedMetricConfig) metricDefaultMetricToBeRemoved {
 	m := metricDefaultMetricToBeRemoved{config: cfg}
 
 	if cfg.Enabled {
@@ -244,10 +244,10 @@ func newMetricDefaultMetricToBeRemoved(cfg DefaultMetricToBeRemovedConfig) metri
 }
 
 type metricMetricInputType struct {
-	data          pmetric.Metric        // data buffer for generated metric.
-	config        MetricInputTypeConfig // metric config provided by user.
-	capacity      int                   // max observed number of data points added to the metric.
-	aggDataPoints []int64               // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric              // data buffer for generated metric.
+	config        MetricInputTypeMetricConfig // metric config provided by user.
+	capacity      int                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills metric.input_type metric with initial data.
@@ -270,19 +270,19 @@ func (m *metricMetricInputType) recordDataPoint(start pcommon.Timestamp, ts pcom
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyOverriddenIntAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyOverriddenIntAttr) {
 		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyEnumAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyEnumAttr) {
 		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeySliceAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeySliceAttr) {
 		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyMapAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyMapAttr) {
 		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
 	}
 
@@ -336,7 +336,7 @@ func (m *metricMetricInputType) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMetricInputType(cfg MetricInputTypeConfig) metricMetricInputType {
+func newMetricMetricInputType(cfg MetricInputTypeMetricConfig) metricMetricInputType {
 	m := metricMetricInputType{config: cfg}
 
 	if cfg.Enabled {
@@ -347,10 +347,10 @@ func newMetricMetricInputType(cfg MetricInputTypeConfig) metricMetricInputType {
 }
 
 type metricOptionalMetric struct {
-	data          pmetric.Metric       // data buffer for generated metric.
-	config        OptionalMetricConfig // metric config provided by user.
-	capacity      int                  // max observed number of data points added to the metric.
-	aggDataPoints []float64            // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric             // data buffer for generated metric.
+	config        OptionalMetricMetricConfig // metric config provided by user.
+	capacity      int                        // max observed number of data points added to the metric.
+	aggDataPoints []float64                  // slice containing number of aggregated datapoints at each index
 }
 
 // init fills optional.metric metric with initial data.
@@ -371,13 +371,13 @@ func (m *metricOptionalMetric) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricAttributeKeyBooleanAttr2) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricMetricAttributeKeyBooleanAttr2) {
 		dp.Attributes().PutBool("boolean_attr2", booleanAttr2AttributeValue)
 	}
 
@@ -431,7 +431,7 @@ func (m *metricOptionalMetric) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOptionalMetric(cfg OptionalMetricConfig) metricOptionalMetric {
+func newMetricOptionalMetric(cfg OptionalMetricMetricConfig) metricOptionalMetric {
 	m := metricOptionalMetric{config: cfg}
 
 	if cfg.Enabled {
@@ -442,10 +442,10 @@ func newMetricOptionalMetric(cfg OptionalMetricConfig) metricOptionalMetric {
 }
 
 type metricOptionalMetricEmptyUnit struct {
-	data          pmetric.Metric                // data buffer for generated metric.
-	config        OptionalMetricEmptyUnitConfig // metric config provided by user.
-	capacity      int                           // max observed number of data points added to the metric.
-	aggDataPoints []float64                     // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        OptionalMetricEmptyUnitMetricConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []float64                           // slice containing number of aggregated datapoints at each index
 }
 
 // init fills optional.metric.empty_unit metric with initial data.
@@ -466,10 +466,10 @@ func (m *metricOptionalMetricEmptyUnit) recordDataPoint(start pcommon.Timestamp,
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
 
@@ -523,7 +523,7 @@ func (m *metricOptionalMetricEmptyUnit) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOptionalMetricEmptyUnit(cfg OptionalMetricEmptyUnitConfig) metricOptionalMetricEmptyUnit {
+func newMetricOptionalMetricEmptyUnit(cfg OptionalMetricEmptyUnitMetricConfig) metricOptionalMetricEmptyUnit {
 	m := metricOptionalMetricEmptyUnit{config: cfg}
 
 	if cfg.Enabled {
@@ -534,10 +534,10 @@ func newMetricOptionalMetricEmptyUnit(cfg OptionalMetricEmptyUnitConfig) metricO
 }
 
 type metricReaggregateMetric struct {
-	data          pmetric.Metric          // data buffer for generated metric.
-	config        ReaggregateMetricConfig // metric config provided by user.
-	capacity      int                     // max observed number of data points added to the metric.
-	aggDataPoints []float64               // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        ReaggregateMetricMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []float64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills reaggregate.metric metric with initial data.
@@ -558,10 +558,10 @@ func (m *metricReaggregateMetric) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
 
@@ -615,7 +615,7 @@ func (m *metricReaggregateMetric) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricReaggregateMetric(cfg ReaggregateMetricConfig) metricReaggregateMetric {
+func newMetricReaggregateMetric(cfg ReaggregateMetricMetricConfig) metricReaggregateMetric {
 	m := metricReaggregateMetric{config: cfg}
 
 	if cfg.Enabled {

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/config.schema.yaml
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/config.schema.yaml
@@ -5,21 +5,21 @@ $defs:
     type: object
     properties:
       k8s.pod.cpu_time:
-        description: "K8sPodCPUTimeConfig provides config for the k8s.pod.cpu_time metric."
+        description: "K8sPodCPUTimeMetricConfig provides config for the k8s.pod.cpu_time metric."
         type: object
         properties:
           enabled:
             type: boolean
             default: true
       k8s.pod.phase:
-        description: "K8sPodPhaseConfig provides config for the k8s.pod.phase metric."
+        description: "K8sPodPhaseMetricConfig provides config for the k8s.pod.phase metric."
         type: object
         properties:
           enabled:
             type: boolean
             default: true
       k8s.replicaset.desired:
-        description: "K8sReplicasetDesiredConfig provides config for the k8s.replicaset.desired metric."
+        description: "K8sReplicasetDesiredMetricConfig provides config for the k8s.replicaset.desired metric."
         type: object
         properties:
           enabled:

--- a/cmd/mdatagen/internal/samplereceiver/config.schema.json
+++ b/cmd/mdatagen/internal/samplereceiver/config.schema.json
@@ -13,7 +13,7 @@
           "type": "object",
           "properties": {
             "default.metric": {
-              "description": "DefaultMetricConfig provides config for the default.metric metric.",
+              "description": "DefaultMetricMetricConfig provides config for the default.metric metric.",
               "type": "object",
               "properties": {
                 "aggregation_strategy": {
@@ -58,7 +58,7 @@
               }
             },
             "default.metric.to_be_removed": {
-              "description": "DefaultMetricToBeRemovedConfig provides config for the default.metric.to_be_removed metric.",
+              "description": "DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric.",
               "type": "object",
               "properties": {
                 "enabled": {
@@ -68,7 +68,7 @@
               }
             },
             "metric.input_type": {
-              "description": "MetricInputTypeConfig provides config for the metric.input_type metric.",
+              "description": "MetricInputTypeMetricConfig provides config for the metric.input_type metric.",
               "type": "object",
               "properties": {
                 "aggregation_strategy": {
@@ -108,7 +108,7 @@
               }
             },
             "optional.metric": {
-              "description": "OptionalMetricConfig provides config for the optional.metric metric.",
+              "description": "OptionalMetricMetricConfig provides config for the optional.metric metric.",
               "type": "object",
               "properties": {
                 "aggregation_strategy": {
@@ -146,7 +146,7 @@
               }
             },
             "optional.metric.empty_unit": {
-              "description": "OptionalMetricEmptyUnitConfig provides config for the optional.metric.empty_unit metric.",
+              "description": "OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric.",
               "type": "object",
               "properties": {
                 "aggregation_strategy": {
@@ -180,7 +180,7 @@
               }
             },
             "reaggregate.metric": {
-              "description": "ReaggregateMetricConfig provides config for the reaggregate.metric metric.",
+              "description": "ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric.",
               "type": "object",
               "properties": {
                 "aggregation_strategy": {
@@ -214,7 +214,7 @@
               }
             },
             "reaggregate.metric.with_required": {
-              "description": "ReaggregateMetricWithRequiredConfig provides config for the reaggregate.metric.with_required metric.",
+              "description": "ReaggregateMetricWithRequiredMetricConfig provides config for the reaggregate.metric.with_required metric.",
               "type": "object",
               "properties": {
                 "aggregation_strategy": {
@@ -250,7 +250,7 @@
               }
             },
             "system.cpu.time": {
-              "description": "SystemCPUTimeConfig provides config for the system.cpu.time metric.",
+              "description": "SystemCPUTimeMetricConfig provides config for the system.cpu.time metric.",
               "type": "object",
               "properties": {
                 "enabled": {

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/config.schema.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/config.schema.yaml
@@ -5,7 +5,7 @@ $defs:
     type: object
     properties:
       default.metric:
-        description: "DefaultMetricConfig provides config for the default.metric metric."
+        description: "DefaultMetricMetricConfig provides config for the default.metric metric."
         type: object
         properties:
           enabled:
@@ -41,14 +41,14 @@ $defs:
               - "conditional_int_attr"
               - "conditional_string_attr"
       default.metric.to_be_removed:
-        description: "DefaultMetricToBeRemovedConfig provides config for the default.metric.to_be_removed metric."
+        description: "DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric."
         type: object
         properties:
           enabled:
             type: boolean
             default: true
       metric.input_type:
-        description: "MetricInputTypeConfig provides config for the metric.input_type metric."
+        description: "MetricInputTypeMetricConfig provides config for the metric.input_type metric."
         type: object
         properties:
           enabled:
@@ -79,7 +79,7 @@ $defs:
               - "slice_attr"
               - "map_attr"
       optional.metric:
-        description: "OptionalMetricConfig provides config for the optional.metric metric."
+        description: "OptionalMetricMetricConfig provides config for the optional.metric metric."
         type: object
         properties:
           enabled:
@@ -108,7 +108,7 @@ $defs:
               - "boolean_attr2"
               - "conditional_string_attr"
       optional.metric.empty_unit:
-        description: "OptionalMetricEmptyUnitConfig provides config for the optional.metric.empty_unit metric."
+        description: "OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric."
         type: object
         properties:
           enabled:
@@ -133,7 +133,7 @@ $defs:
               - "string_attr"
               - "boolean_attr"
       reaggregate.metric:
-        description: "ReaggregateMetricConfig provides config for the reaggregate.metric metric."
+        description: "ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric."
         type: object
         properties:
           enabled:
@@ -158,7 +158,7 @@ $defs:
               - "string_attr"
               - "boolean_attr"
       reaggregate.metric.with_required:
-        description: "ReaggregateMetricWithRequiredConfig provides config for the reaggregate.metric.with_required metric."
+        description: "ReaggregateMetricWithRequiredMetricConfig provides config for the reaggregate.metric.with_required metric."
         type: object
         properties:
           enabled:
@@ -185,7 +185,7 @@ $defs:
               - "string_attr"
               - "boolean_attr"
       system.cpu.time:
-        description: "SystemCPUTimeConfig provides config for the system.cpu.time metric."
+        description: "SystemCPUTimeMetricConfig provides config for the system.cpu.time metric."
         type: object
         properties:
           enabled:

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
@@ -10,30 +10,30 @@ import (
 	"go.opentelemetry.io/collector/filter"
 )
 
-// DefaultMetricAttributeKey specifies the key of an attribute for the default.metric metric.
-type DefaultMetricAttributeKey string
+// DefaultMetricMetricAttributeKey specifies the key of an attribute for the default.metric metric.
+type DefaultMetricMetricAttributeKey string
 
 const (
-	DefaultMetricAttributeKeyStringAttr            DefaultMetricAttributeKey = "string_attr"
-	DefaultMetricAttributeKeyOverriddenIntAttr     DefaultMetricAttributeKey = "state"
-	DefaultMetricAttributeKeyEnumAttr              DefaultMetricAttributeKey = "enum_attr"
-	DefaultMetricAttributeKeySliceAttr             DefaultMetricAttributeKey = "slice_attr"
-	DefaultMetricAttributeKeyMapAttr               DefaultMetricAttributeKey = "map_attr"
-	DefaultMetricAttributeKeyConditionalIntAttr    DefaultMetricAttributeKey = "conditional_int_attr"
-	DefaultMetricAttributeKeyConditionalStringAttr DefaultMetricAttributeKey = "conditional_string_attr"
-	DefaultMetricAttributeKeyOptInBoolAttr         DefaultMetricAttributeKey = "opt_in_bool_attr"
+	DefaultMetricMetricAttributeKeyStringAttr            DefaultMetricMetricAttributeKey = "string_attr"
+	DefaultMetricMetricAttributeKeyOverriddenIntAttr     DefaultMetricMetricAttributeKey = "state"
+	DefaultMetricMetricAttributeKeyEnumAttr              DefaultMetricMetricAttributeKey = "enum_attr"
+	DefaultMetricMetricAttributeKeySliceAttr             DefaultMetricMetricAttributeKey = "slice_attr"
+	DefaultMetricMetricAttributeKeyMapAttr               DefaultMetricMetricAttributeKey = "map_attr"
+	DefaultMetricMetricAttributeKeyConditionalIntAttr    DefaultMetricMetricAttributeKey = "conditional_int_attr"
+	DefaultMetricMetricAttributeKeyConditionalStringAttr DefaultMetricMetricAttributeKey = "conditional_string_attr"
+	DefaultMetricMetricAttributeKeyOptInBoolAttr         DefaultMetricMetricAttributeKey = "opt_in_bool_attr"
 )
 
-// DefaultMetricConfig provides config for the default.metric metric.
-type DefaultMetricConfig struct {
+// DefaultMetricMetricConfig provides config for the default.metric metric.
+type DefaultMetricMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                      `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []DefaultMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []DefaultMetricMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *DefaultMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *DefaultMetricMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -47,10 +47,10 @@ func (ms *DefaultMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *DefaultMetricConfig) Validate() error {
+func (ms *DefaultMetricMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr, DefaultMetricAttributeKeyConditionalIntAttr, DefaultMetricAttributeKeyConditionalStringAttr, DefaultMetricAttributeKeyOptInBoolAttr:
+		case DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr, DefaultMetricMetricAttributeKeyConditionalIntAttr, DefaultMetricMetricAttributeKeyConditionalStringAttr, DefaultMetricMetricAttributeKeyOptInBoolAttr:
 		default:
 			return fmt.Errorf("metric default.metric doesn't have an attribute %v, valid attributes: [string_attr, state, enum_attr, slice_attr, map_attr, conditional_int_attr, conditional_string_attr, opt_in_bool_attr]", val)
 		}
@@ -65,13 +65,13 @@ func (ms *DefaultMetricConfig) Validate() error {
 	return nil
 }
 
-// DefaultMetricToBeRemovedConfig provides config for the default.metric.to_be_removed metric.
-type DefaultMetricToBeRemovedConfig struct {
+// DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric.
+type DefaultMetricToBeRemovedMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *DefaultMetricToBeRemovedConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *DefaultMetricToBeRemovedMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -85,27 +85,27 @@ func (ms *DefaultMetricToBeRemovedConfig) Unmarshal(parser *confmap.Conf) error 
 	return nil
 }
 
-// MetricInputTypeAttributeKey specifies the key of an attribute for the metric.input_type metric.
-type MetricInputTypeAttributeKey string
+// MetricInputTypeMetricAttributeKey specifies the key of an attribute for the metric.input_type metric.
+type MetricInputTypeMetricAttributeKey string
 
 const (
-	MetricInputTypeAttributeKeyStringAttr        MetricInputTypeAttributeKey = "string_attr"
-	MetricInputTypeAttributeKeyOverriddenIntAttr MetricInputTypeAttributeKey = "state"
-	MetricInputTypeAttributeKeyEnumAttr          MetricInputTypeAttributeKey = "enum_attr"
-	MetricInputTypeAttributeKeySliceAttr         MetricInputTypeAttributeKey = "slice_attr"
-	MetricInputTypeAttributeKeyMapAttr           MetricInputTypeAttributeKey = "map_attr"
+	MetricInputTypeMetricAttributeKeyStringAttr        MetricInputTypeMetricAttributeKey = "string_attr"
+	MetricInputTypeMetricAttributeKeyOverriddenIntAttr MetricInputTypeMetricAttributeKey = "state"
+	MetricInputTypeMetricAttributeKeyEnumAttr          MetricInputTypeMetricAttributeKey = "enum_attr"
+	MetricInputTypeMetricAttributeKeySliceAttr         MetricInputTypeMetricAttributeKey = "slice_attr"
+	MetricInputTypeMetricAttributeKeyMapAttr           MetricInputTypeMetricAttributeKey = "map_attr"
 )
 
-// MetricInputTypeConfig provides config for the metric.input_type metric.
-type MetricInputTypeConfig struct {
+// MetricInputTypeMetricConfig provides config for the metric.input_type metric.
+type MetricInputTypeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                        `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []MetricInputTypeAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MetricInputTypeMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *MetricInputTypeConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricInputTypeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -119,10 +119,10 @@ func (ms *MetricInputTypeConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *MetricInputTypeConfig) Validate() error {
+func (ms *MetricInputTypeMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr:
+		case MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr:
 		default:
 			return fmt.Errorf("metric metric.input_type doesn't have an attribute %v, valid attributes: [string_attr, state, enum_attr, slice_attr, map_attr]", val)
 		}
@@ -137,26 +137,26 @@ func (ms *MetricInputTypeConfig) Validate() error {
 	return nil
 }
 
-// OptionalMetricAttributeKey specifies the key of an attribute for the optional.metric metric.
-type OptionalMetricAttributeKey string
+// OptionalMetricMetricAttributeKey specifies the key of an attribute for the optional.metric metric.
+type OptionalMetricMetricAttributeKey string
 
 const (
-	OptionalMetricAttributeKeyStringAttr            OptionalMetricAttributeKey = "string_attr"
-	OptionalMetricAttributeKeyBooleanAttr           OptionalMetricAttributeKey = "boolean_attr"
-	OptionalMetricAttributeKeyBooleanAttr2          OptionalMetricAttributeKey = "boolean_attr2"
-	OptionalMetricAttributeKeyConditionalStringAttr OptionalMetricAttributeKey = "conditional_string_attr"
+	OptionalMetricMetricAttributeKeyStringAttr            OptionalMetricMetricAttributeKey = "string_attr"
+	OptionalMetricMetricAttributeKeyBooleanAttr           OptionalMetricMetricAttributeKey = "boolean_attr"
+	OptionalMetricMetricAttributeKeyBooleanAttr2          OptionalMetricMetricAttributeKey = "boolean_attr2"
+	OptionalMetricMetricAttributeKeyConditionalStringAttr OptionalMetricMetricAttributeKey = "conditional_string_attr"
 )
 
-// OptionalMetricConfig provides config for the optional.metric metric.
-type OptionalMetricConfig struct {
+// OptionalMetricMetricConfig provides config for the optional.metric metric.
+type OptionalMetricMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                       `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OptionalMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OptionalMetricMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OptionalMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OptionalMetricMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -170,10 +170,10 @@ func (ms *OptionalMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *OptionalMetricConfig) Validate() error {
+func (ms *OptionalMetricMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2, OptionalMetricAttributeKeyConditionalStringAttr:
+		case OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2, OptionalMetricMetricAttributeKeyConditionalStringAttr:
 		default:
 			return fmt.Errorf("metric optional.metric doesn't have an attribute %v, valid attributes: [string_attr, boolean_attr, boolean_attr2, conditional_string_attr]", val)
 		}
@@ -188,24 +188,24 @@ func (ms *OptionalMetricConfig) Validate() error {
 	return nil
 }
 
-// OptionalMetricEmptyUnitAttributeKey specifies the key of an attribute for the optional.metric.empty_unit metric.
-type OptionalMetricEmptyUnitAttributeKey string
+// OptionalMetricEmptyUnitMetricAttributeKey specifies the key of an attribute for the optional.metric.empty_unit metric.
+type OptionalMetricEmptyUnitMetricAttributeKey string
 
 const (
-	OptionalMetricEmptyUnitAttributeKeyStringAttr  OptionalMetricEmptyUnitAttributeKey = "string_attr"
-	OptionalMetricEmptyUnitAttributeKeyBooleanAttr OptionalMetricEmptyUnitAttributeKey = "boolean_attr"
+	OptionalMetricEmptyUnitMetricAttributeKeyStringAttr  OptionalMetricEmptyUnitMetricAttributeKey = "string_attr"
+	OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr OptionalMetricEmptyUnitMetricAttributeKey = "boolean_attr"
 )
 
-// OptionalMetricEmptyUnitConfig provides config for the optional.metric.empty_unit metric.
-type OptionalMetricEmptyUnitConfig struct {
+// OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric.
+type OptionalMetricEmptyUnitMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OptionalMetricEmptyUnitAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OptionalMetricEmptyUnitMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OptionalMetricEmptyUnitConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OptionalMetricEmptyUnitMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -219,10 +219,10 @@ func (ms *OptionalMetricEmptyUnitConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *OptionalMetricEmptyUnitConfig) Validate() error {
+func (ms *OptionalMetricEmptyUnitMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr:
+		case OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr:
 		default:
 			return fmt.Errorf("metric optional.metric.empty_unit doesn't have an attribute %v, valid attributes: [string_attr, boolean_attr]", val)
 		}
@@ -237,24 +237,24 @@ func (ms *OptionalMetricEmptyUnitConfig) Validate() error {
 	return nil
 }
 
-// ReaggregateMetricAttributeKey specifies the key of an attribute for the reaggregate.metric metric.
-type ReaggregateMetricAttributeKey string
+// ReaggregateMetricMetricAttributeKey specifies the key of an attribute for the reaggregate.metric metric.
+type ReaggregateMetricMetricAttributeKey string
 
 const (
-	ReaggregateMetricAttributeKeyStringAttr  ReaggregateMetricAttributeKey = "string_attr"
-	ReaggregateMetricAttributeKeyBooleanAttr ReaggregateMetricAttributeKey = "boolean_attr"
+	ReaggregateMetricMetricAttributeKeyStringAttr  ReaggregateMetricMetricAttributeKey = "string_attr"
+	ReaggregateMetricMetricAttributeKeyBooleanAttr ReaggregateMetricMetricAttributeKey = "boolean_attr"
 )
 
-// ReaggregateMetricConfig provides config for the reaggregate.metric metric.
-type ReaggregateMetricConfig struct {
+// ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric.
+type ReaggregateMetricMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                          `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []ReaggregateMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ReaggregateMetricMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *ReaggregateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *ReaggregateMetricMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -268,10 +268,10 @@ func (ms *ReaggregateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *ReaggregateMetricConfig) Validate() error {
+func (ms *ReaggregateMetricMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr:
+		case ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr:
 		default:
 			return fmt.Errorf("metric reaggregate.metric doesn't have an attribute %v, valid attributes: [string_attr, boolean_attr]", val)
 		}
@@ -286,25 +286,25 @@ func (ms *ReaggregateMetricConfig) Validate() error {
 	return nil
 }
 
-// ReaggregateMetricWithRequiredAttributeKey specifies the key of an attribute for the reaggregate.metric.with_required metric.
-type ReaggregateMetricWithRequiredAttributeKey string
+// ReaggregateMetricWithRequiredMetricAttributeKey specifies the key of an attribute for the reaggregate.metric.with_required metric.
+type ReaggregateMetricWithRequiredMetricAttributeKey string
 
 const (
-	ReaggregateMetricWithRequiredAttributeKeyRequiredStringAttr ReaggregateMetricWithRequiredAttributeKey = "required_string_attr"
-	ReaggregateMetricWithRequiredAttributeKeyStringAttr         ReaggregateMetricWithRequiredAttributeKey = "string_attr"
-	ReaggregateMetricWithRequiredAttributeKeyBooleanAttr        ReaggregateMetricWithRequiredAttributeKey = "boolean_attr"
+	ReaggregateMetricWithRequiredMetricAttributeKeyRequiredStringAttr ReaggregateMetricWithRequiredMetricAttributeKey = "required_string_attr"
+	ReaggregateMetricWithRequiredMetricAttributeKeyStringAttr         ReaggregateMetricWithRequiredMetricAttributeKey = "string_attr"
+	ReaggregateMetricWithRequiredMetricAttributeKeyBooleanAttr        ReaggregateMetricWithRequiredMetricAttributeKey = "boolean_attr"
 )
 
-// ReaggregateMetricWithRequiredConfig provides config for the reaggregate.metric.with_required metric.
-type ReaggregateMetricWithRequiredConfig struct {
+// ReaggregateMetricWithRequiredMetricConfig provides config for the reaggregate.metric.with_required metric.
+type ReaggregateMetricWithRequiredMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []ReaggregateMetricWithRequiredAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ReaggregateMetricWithRequiredMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *ReaggregateMetricWithRequiredConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *ReaggregateMetricWithRequiredMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -318,15 +318,15 @@ func (ms *ReaggregateMetricWithRequiredConfig) Unmarshal(parser *confmap.Conf) e
 	return nil
 }
 
-func (ms *ReaggregateMetricWithRequiredConfig) Validate() error {
+func (ms *ReaggregateMetricWithRequiredMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case ReaggregateMetricWithRequiredAttributeKeyRequiredStringAttr, ReaggregateMetricWithRequiredAttributeKeyStringAttr, ReaggregateMetricWithRequiredAttributeKeyBooleanAttr:
+		case ReaggregateMetricWithRequiredMetricAttributeKeyRequiredStringAttr, ReaggregateMetricWithRequiredMetricAttributeKeyStringAttr, ReaggregateMetricWithRequiredMetricAttributeKeyBooleanAttr:
 		default:
 			return fmt.Errorf("metric reaggregate.metric.with_required doesn't have an attribute %v, valid attributes: [required_string_attr, string_attr, boolean_attr]", val)
 		}
 	}
-	if !slices.Contains(ms.EnabledAttributes, ReaggregateMetricWithRequiredAttributeKeyRequiredStringAttr) {
+	if !slices.Contains(ms.EnabledAttributes, ReaggregateMetricWithRequiredMetricAttributeKeyRequiredStringAttr) {
 		return fmt.Errorf("required_string_attr is a required attribute for reaggregate.metric.with_required metric and must be included")
 	}
 
@@ -339,13 +339,13 @@ func (ms *ReaggregateMetricWithRequiredConfig) Validate() error {
 	return nil
 }
 
-// SystemCPUTimeConfig provides config for the system.cpu.time metric.
-type SystemCPUTimeConfig struct {
+// SystemCPUTimeMetricConfig provides config for the system.cpu.time metric.
+type SystemCPUTimeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *SystemCPUTimeConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *SystemCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -361,52 +361,52 @@ func (ms *SystemCPUTimeConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for sample metrics.
 type MetricsConfig struct {
-	DefaultMetric                 DefaultMetricConfig                 `mapstructure:"default.metric"`
-	DefaultMetricToBeRemoved      DefaultMetricToBeRemovedConfig      `mapstructure:"default.metric.to_be_removed"`
-	MetricInputType               MetricInputTypeConfig               `mapstructure:"metric.input_type"`
-	OptionalMetric                OptionalMetricConfig                `mapstructure:"optional.metric"`
-	OptionalMetricEmptyUnit       OptionalMetricEmptyUnitConfig       `mapstructure:"optional.metric.empty_unit"`
-	ReaggregateMetric             ReaggregateMetricConfig             `mapstructure:"reaggregate.metric"`
-	ReaggregateMetricWithRequired ReaggregateMetricWithRequiredConfig `mapstructure:"reaggregate.metric.with_required"`
-	SystemCPUTime                 SystemCPUTimeConfig                 `mapstructure:"system.cpu.time"`
+	DefaultMetric                 DefaultMetricMetricConfig                 `mapstructure:"default.metric"`
+	DefaultMetricToBeRemoved      DefaultMetricToBeRemovedMetricConfig      `mapstructure:"default.metric.to_be_removed"`
+	MetricInputType               MetricInputTypeMetricConfig               `mapstructure:"metric.input_type"`
+	OptionalMetric                OptionalMetricMetricConfig                `mapstructure:"optional.metric"`
+	OptionalMetricEmptyUnit       OptionalMetricEmptyUnitMetricConfig       `mapstructure:"optional.metric.empty_unit"`
+	ReaggregateMetric             ReaggregateMetricMetricConfig             `mapstructure:"reaggregate.metric"`
+	ReaggregateMetricWithRequired ReaggregateMetricWithRequiredMetricConfig `mapstructure:"reaggregate.metric.with_required"`
+	SystemCPUTime                 SystemCPUTimeMetricConfig                 `mapstructure:"system.cpu.time"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		DefaultMetric: DefaultMetricConfig{
+		DefaultMetric: DefaultMetricMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []DefaultMetricAttributeKey{DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr, DefaultMetricAttributeKeyConditionalIntAttr, DefaultMetricAttributeKeyConditionalStringAttr},
+			EnabledAttributes:   []DefaultMetricMetricAttributeKey{DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr, DefaultMetricMetricAttributeKeyConditionalIntAttr, DefaultMetricMetricAttributeKeyConditionalStringAttr},
 		},
-		DefaultMetricToBeRemoved: DefaultMetricToBeRemovedConfig{
+		DefaultMetricToBeRemoved: DefaultMetricToBeRemovedMetricConfig{
 			Enabled: true,
 		},
-		MetricInputType: MetricInputTypeConfig{
+		MetricInputType: MetricInputTypeMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []MetricInputTypeAttributeKey{MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr},
+			EnabledAttributes:   []MetricInputTypeMetricAttributeKey{MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr},
 		},
-		OptionalMetric: OptionalMetricConfig{
+		OptionalMetric: OptionalMetricMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OptionalMetricAttributeKey{OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2, OptionalMetricAttributeKeyConditionalStringAttr},
+			EnabledAttributes:   []OptionalMetricMetricAttributeKey{OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2, OptionalMetricMetricAttributeKeyConditionalStringAttr},
 		},
-		OptionalMetricEmptyUnit: OptionalMetricEmptyUnitConfig{
+		OptionalMetricEmptyUnit: OptionalMetricEmptyUnitMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OptionalMetricEmptyUnitAttributeKey{OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr},
+			EnabledAttributes:   []OptionalMetricEmptyUnitMetricAttributeKey{OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr},
 		},
-		ReaggregateMetric: ReaggregateMetricConfig{
+		ReaggregateMetric: ReaggregateMetricMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []ReaggregateMetricAttributeKey{ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr},
+			EnabledAttributes:   []ReaggregateMetricMetricAttributeKey{ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr},
 		},
-		ReaggregateMetricWithRequired: ReaggregateMetricWithRequiredConfig{
+		ReaggregateMetricWithRequired: ReaggregateMetricWithRequiredMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []ReaggregateMetricWithRequiredAttributeKey{ReaggregateMetricWithRequiredAttributeKeyRequiredStringAttr, ReaggregateMetricWithRequiredAttributeKeyStringAttr, ReaggregateMetricWithRequiredAttributeKeyBooleanAttr},
+			EnabledAttributes:   []ReaggregateMetricWithRequiredMetricAttributeKey{ReaggregateMetricWithRequiredMetricAttributeKeyRequiredStringAttr, ReaggregateMetricWithRequiredMetricAttributeKeyStringAttr, ReaggregateMetricWithRequiredMetricAttributeKeyBooleanAttr},
 		},
-		SystemCPUTime: SystemCPUTimeConfig{
+		SystemCPUTime: SystemCPUTimeMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
@@ -27,40 +27,40 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					DefaultMetric: DefaultMetricConfig{
+					DefaultMetric: DefaultMetricMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []DefaultMetricAttributeKey{DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr, DefaultMetricAttributeKeyConditionalIntAttr, DefaultMetricAttributeKeyConditionalStringAttr, DefaultMetricAttributeKeyOptInBoolAttr},
+						EnabledAttributes:   []DefaultMetricMetricAttributeKey{DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr, DefaultMetricMetricAttributeKeyConditionalIntAttr, DefaultMetricMetricAttributeKeyConditionalStringAttr, DefaultMetricMetricAttributeKeyOptInBoolAttr},
 					},
-					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedConfig{
+					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedMetricConfig{
 						Enabled: true,
 					},
-					MetricInputType: MetricInputTypeConfig{
+					MetricInputType: MetricInputTypeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MetricInputTypeAttributeKey{MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr},
+						EnabledAttributes:   []MetricInputTypeMetricAttributeKey{MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr},
 					},
-					OptionalMetric: OptionalMetricConfig{
+					OptionalMetric: OptionalMetricMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricAttributeKey{OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2, OptionalMetricAttributeKeyConditionalStringAttr},
+						EnabledAttributes:   []OptionalMetricMetricAttributeKey{OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2, OptionalMetricMetricAttributeKeyConditionalStringAttr},
 					},
-					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitConfig{
+					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricEmptyUnitAttributeKey{OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr},
+						EnabledAttributes:   []OptionalMetricEmptyUnitMetricAttributeKey{OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr},
 					},
-					ReaggregateMetric: ReaggregateMetricConfig{
+					ReaggregateMetric: ReaggregateMetricMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []ReaggregateMetricAttributeKey{ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr},
+						EnabledAttributes:   []ReaggregateMetricMetricAttributeKey{ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr},
 					},
-					ReaggregateMetricWithRequired: ReaggregateMetricWithRequiredConfig{
+					ReaggregateMetricWithRequired: ReaggregateMetricWithRequiredMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []ReaggregateMetricWithRequiredAttributeKey{ReaggregateMetricWithRequiredAttributeKeyRequiredStringAttr, ReaggregateMetricWithRequiredAttributeKeyStringAttr, ReaggregateMetricWithRequiredAttributeKeyBooleanAttr},
+						EnabledAttributes:   []ReaggregateMetricWithRequiredMetricAttributeKey{ReaggregateMetricWithRequiredMetricAttributeKeyRequiredStringAttr, ReaggregateMetricWithRequiredMetricAttributeKeyStringAttr, ReaggregateMetricWithRequiredMetricAttributeKeyBooleanAttr},
 					},
-					SystemCPUTime: SystemCPUTimeConfig{
+					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -80,40 +80,40 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					DefaultMetric: DefaultMetricConfig{
+					DefaultMetric: DefaultMetricMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []DefaultMetricAttributeKey{DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr, DefaultMetricAttributeKeyConditionalIntAttr, DefaultMetricAttributeKeyConditionalStringAttr, DefaultMetricAttributeKeyOptInBoolAttr},
+						EnabledAttributes:   []DefaultMetricMetricAttributeKey{DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr, DefaultMetricMetricAttributeKeyConditionalIntAttr, DefaultMetricMetricAttributeKeyConditionalStringAttr, DefaultMetricMetricAttributeKeyOptInBoolAttr},
 					},
-					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedConfig{
+					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedMetricConfig{
 						Enabled: false,
 					},
-					MetricInputType: MetricInputTypeConfig{
+					MetricInputType: MetricInputTypeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MetricInputTypeAttributeKey{MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr},
+						EnabledAttributes:   []MetricInputTypeMetricAttributeKey{MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr},
 					},
-					OptionalMetric: OptionalMetricConfig{
+					OptionalMetric: OptionalMetricMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricAttributeKey{OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2, OptionalMetricAttributeKeyConditionalStringAttr},
+						EnabledAttributes:   []OptionalMetricMetricAttributeKey{OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2, OptionalMetricMetricAttributeKeyConditionalStringAttr},
 					},
-					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitConfig{
+					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricEmptyUnitAttributeKey{OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr},
+						EnabledAttributes:   []OptionalMetricEmptyUnitMetricAttributeKey{OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr},
 					},
-					ReaggregateMetric: ReaggregateMetricConfig{
+					ReaggregateMetric: ReaggregateMetricMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []ReaggregateMetricAttributeKey{ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr},
+						EnabledAttributes:   []ReaggregateMetricMetricAttributeKey{ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr},
 					},
-					ReaggregateMetricWithRequired: ReaggregateMetricWithRequiredConfig{
+					ReaggregateMetricWithRequired: ReaggregateMetricWithRequiredMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []ReaggregateMetricWithRequiredAttributeKey{ReaggregateMetricWithRequiredAttributeKeyRequiredStringAttr, ReaggregateMetricWithRequiredAttributeKeyStringAttr, ReaggregateMetricWithRequiredAttributeKeyBooleanAttr},
+						EnabledAttributes:   []ReaggregateMetricWithRequiredMetricAttributeKey{ReaggregateMetricWithRequiredMetricAttributeKeyRequiredStringAttr, ReaggregateMetricWithRequiredMetricAttributeKeyStringAttr, ReaggregateMetricWithRequiredMetricAttributeKeyBooleanAttr},
 					},
-					SystemCPUTime: SystemCPUTimeConfig{
+					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -133,7 +133,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(DefaultMetricConfig{}, DefaultMetricToBeRemovedConfig{}, MetricInputTypeConfig{}, OptionalMetricConfig{}, OptionalMetricEmptyUnitConfig{}, ReaggregateMetricConfig{}, ReaggregateMetricWithRequiredConfig{}, SystemCPUTimeConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(DefaultMetricMetricConfig{}, DefaultMetricToBeRemovedMetricConfig{}, MetricInputTypeMetricConfig{}, OptionalMetricMetricConfig{}, OptionalMetricEmptyUnitMetricConfig{}, ReaggregateMetricMetricConfig{}, ReaggregateMetricWithRequiredMetricConfig{}, SystemCPUTimeMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
@@ -119,10 +119,10 @@ func WithConditionalStringAttrMetricAttribute(conditionalStringAttrAttributeValu
 }
 
 type metricDefaultMetric struct {
-	data          pmetric.Metric      // data buffer for generated metric.
-	config        DefaultMetricConfig // metric config provided by user.
-	capacity      int                 // max observed number of data points added to the metric.
-	aggDataPoints []int64             // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric            // data buffer for generated metric.
+	config        DefaultMetricMetricConfig // metric config provided by user.
+	capacity      int                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                   // slice containing number of aggregated datapoints at each index
 }
 
 // init fills default.metric metric with initial data.
@@ -145,22 +145,22 @@ func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyOverriddenIntAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyOverriddenIntAttr) {
 		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyEnumAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyEnumAttr) {
 		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeySliceAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeySliceAttr) {
 		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyMapAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyMapAttr) {
 		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyOptInBoolAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyOptInBoolAttr) {
 		dp.Attributes().PutBool("opt_in_bool_attr", optInBoolAttrAttributeValue)
 	}
 	for _, op := range options {
@@ -217,7 +217,7 @@ func (m *metricDefaultMetric) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricDefaultMetric(cfg DefaultMetricConfig) metricDefaultMetric {
+func newMetricDefaultMetric(cfg DefaultMetricMetricConfig) metricDefaultMetric {
 	m := metricDefaultMetric{config: cfg}
 
 	if cfg.Enabled {
@@ -228,9 +228,9 @@ func newMetricDefaultMetric(cfg DefaultMetricConfig) metricDefaultMetric {
 }
 
 type metricDefaultMetricToBeRemoved struct {
-	data     pmetric.Metric                 // data buffer for generated metric.
-	config   DefaultMetricToBeRemovedConfig // metric config provided by user.
-	capacity int                            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   DefaultMetricToBeRemovedMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills default.metric.to_be_removed metric with initial data.
@@ -269,7 +269,7 @@ func (m *metricDefaultMetricToBeRemoved) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricDefaultMetricToBeRemoved(cfg DefaultMetricToBeRemovedConfig) metricDefaultMetricToBeRemoved {
+func newMetricDefaultMetricToBeRemoved(cfg DefaultMetricToBeRemovedMetricConfig) metricDefaultMetricToBeRemoved {
 	m := metricDefaultMetricToBeRemoved{config: cfg}
 
 	if cfg.Enabled {
@@ -280,10 +280,10 @@ func newMetricDefaultMetricToBeRemoved(cfg DefaultMetricToBeRemovedConfig) metri
 }
 
 type metricMetricInputType struct {
-	data          pmetric.Metric        // data buffer for generated metric.
-	config        MetricInputTypeConfig // metric config provided by user.
-	capacity      int                   // max observed number of data points added to the metric.
-	aggDataPoints []int64               // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric              // data buffer for generated metric.
+	config        MetricInputTypeMetricConfig // metric config provided by user.
+	capacity      int                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills metric.input_type metric with initial data.
@@ -306,19 +306,19 @@ func (m *metricMetricInputType) recordDataPoint(start pcommon.Timestamp, ts pcom
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyOverriddenIntAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyOverriddenIntAttr) {
 		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyEnumAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyEnumAttr) {
 		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeySliceAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeySliceAttr) {
 		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyMapAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyMapAttr) {
 		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
 	}
 
@@ -372,7 +372,7 @@ func (m *metricMetricInputType) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMetricInputType(cfg MetricInputTypeConfig) metricMetricInputType {
+func newMetricMetricInputType(cfg MetricInputTypeMetricConfig) metricMetricInputType {
 	m := metricMetricInputType{config: cfg}
 
 	if cfg.Enabled {
@@ -383,10 +383,10 @@ func newMetricMetricInputType(cfg MetricInputTypeConfig) metricMetricInputType {
 }
 
 type metricOptionalMetric struct {
-	data          pmetric.Metric       // data buffer for generated metric.
-	config        OptionalMetricConfig // metric config provided by user.
-	capacity      int                  // max observed number of data points added to the metric.
-	aggDataPoints []float64            // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric             // data buffer for generated metric.
+	config        OptionalMetricMetricConfig // metric config provided by user.
+	capacity      int                        // max observed number of data points added to the metric.
+	aggDataPoints []float64                  // slice containing number of aggregated datapoints at each index
 }
 
 // init fills optional.metric metric with initial data.
@@ -407,13 +407,13 @@ func (m *metricOptionalMetric) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricAttributeKeyBooleanAttr2) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricMetricAttributeKeyBooleanAttr2) {
 		dp.Attributes().PutBool("boolean_attr2", booleanAttr2AttributeValue)
 	}
 	for _, op := range options {
@@ -470,7 +470,7 @@ func (m *metricOptionalMetric) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOptionalMetric(cfg OptionalMetricConfig) metricOptionalMetric {
+func newMetricOptionalMetric(cfg OptionalMetricMetricConfig) metricOptionalMetric {
 	m := metricOptionalMetric{config: cfg}
 
 	if cfg.Enabled {
@@ -481,10 +481,10 @@ func newMetricOptionalMetric(cfg OptionalMetricConfig) metricOptionalMetric {
 }
 
 type metricOptionalMetricEmptyUnit struct {
-	data          pmetric.Metric                // data buffer for generated metric.
-	config        OptionalMetricEmptyUnitConfig // metric config provided by user.
-	capacity      int                           // max observed number of data points added to the metric.
-	aggDataPoints []float64                     // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        OptionalMetricEmptyUnitMetricConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []float64                           // slice containing number of aggregated datapoints at each index
 }
 
 // init fills optional.metric.empty_unit metric with initial data.
@@ -505,10 +505,10 @@ func (m *metricOptionalMetricEmptyUnit) recordDataPoint(start pcommon.Timestamp,
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
 
@@ -562,7 +562,7 @@ func (m *metricOptionalMetricEmptyUnit) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOptionalMetricEmptyUnit(cfg OptionalMetricEmptyUnitConfig) metricOptionalMetricEmptyUnit {
+func newMetricOptionalMetricEmptyUnit(cfg OptionalMetricEmptyUnitMetricConfig) metricOptionalMetricEmptyUnit {
 	m := metricOptionalMetricEmptyUnit{config: cfg}
 
 	if cfg.Enabled {
@@ -573,10 +573,10 @@ func newMetricOptionalMetricEmptyUnit(cfg OptionalMetricEmptyUnitConfig) metricO
 }
 
 type metricReaggregateMetric struct {
-	data          pmetric.Metric          // data buffer for generated metric.
-	config        ReaggregateMetricConfig // metric config provided by user.
-	capacity      int                     // max observed number of data points added to the metric.
-	aggDataPoints []float64               // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        ReaggregateMetricMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []float64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills reaggregate.metric metric with initial data.
@@ -597,10 +597,10 @@ func (m *metricReaggregateMetric) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
 
@@ -654,7 +654,7 @@ func (m *metricReaggregateMetric) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricReaggregateMetric(cfg ReaggregateMetricConfig) metricReaggregateMetric {
+func newMetricReaggregateMetric(cfg ReaggregateMetricMetricConfig) metricReaggregateMetric {
 	m := metricReaggregateMetric{config: cfg}
 
 	if cfg.Enabled {
@@ -665,10 +665,10 @@ func newMetricReaggregateMetric(cfg ReaggregateMetricConfig) metricReaggregateMe
 }
 
 type metricReaggregateMetricWithRequired struct {
-	data          pmetric.Metric                      // data buffer for generated metric.
-	config        ReaggregateMetricWithRequiredConfig // metric config provided by user.
-	capacity      int                                 // max observed number of data points added to the metric.
-	aggDataPoints []float64                           // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        ReaggregateMetricWithRequiredMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []float64                                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills reaggregate.metric.with_required metric with initial data.
@@ -689,13 +689,13 @@ func (m *metricReaggregateMetricWithRequired) recordDataPoint(start pcommon.Time
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricWithRequiredAttributeKeyRequiredStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricWithRequiredMetricAttributeKeyRequiredStringAttr) {
 		dp.Attributes().PutStr("required_string_attr", requiredStringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricWithRequiredAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricWithRequiredMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricWithRequiredAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricWithRequiredMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
 
@@ -749,7 +749,7 @@ func (m *metricReaggregateMetricWithRequired) emit(metrics pmetric.MetricSlice) 
 	}
 }
 
-func newMetricReaggregateMetricWithRequired(cfg ReaggregateMetricWithRequiredConfig) metricReaggregateMetricWithRequired {
+func newMetricReaggregateMetricWithRequired(cfg ReaggregateMetricWithRequiredMetricConfig) metricReaggregateMetricWithRequired {
 	m := metricReaggregateMetricWithRequired{config: cfg}
 
 	if cfg.Enabled {
@@ -760,9 +760,9 @@ func newMetricReaggregateMetricWithRequired(cfg ReaggregateMetricWithRequiredCon
 }
 
 type metricSystemCPUTime struct {
-	data     pmetric.Metric      // data buffer for generated metric.
-	config   SystemCPUTimeConfig // metric config provided by user.
-	capacity int                 // max observed number of data points added to the metric.
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   SystemCPUTimeMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
 }
 
 // init fills system.cpu.time metric with initial data.
@@ -801,7 +801,7 @@ func (m *metricSystemCPUTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricSystemCPUTime(cfg SystemCPUTimeConfig) metricSystemCPUTime {
+func newMetricSystemCPUTime(cfg SystemCPUTimeMetricConfig) metricSystemCPUTime {
 	m := metricSystemCPUTime{config: cfg}
 
 	if cfg.Enabled {

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/config.schema.yaml
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/config.schema.yaml
@@ -5,7 +5,7 @@ $defs:
     type: object
     properties:
       default.metric:
-        description: "DefaultMetricConfig provides config for the default.metric metric."
+        description: "DefaultMetricMetricConfig provides config for the default.metric metric."
         type: object
         properties:
           enabled:
@@ -36,14 +36,14 @@ $defs:
               - "slice_attr"
               - "map_attr"
       default.metric.to_be_removed:
-        description: "DefaultMetricToBeRemovedConfig provides config for the default.metric.to_be_removed metric."
+        description: "DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric."
         type: object
         properties:
           enabled:
             type: boolean
             default: true
       metric.input_type:
-        description: "MetricInputTypeConfig provides config for the metric.input_type metric."
+        description: "MetricInputTypeMetricConfig provides config for the metric.input_type metric."
         type: object
         properties:
           enabled:
@@ -74,7 +74,7 @@ $defs:
               - "slice_attr"
               - "map_attr"
       optional.metric:
-        description: "OptionalMetricConfig provides config for the optional.metric metric."
+        description: "OptionalMetricMetricConfig provides config for the optional.metric metric."
         type: object
         properties:
           enabled:
@@ -101,7 +101,7 @@ $defs:
               - "boolean_attr"
               - "boolean_attr2"
       optional.metric.empty_unit:
-        description: "OptionalMetricEmptyUnitConfig provides config for the optional.metric.empty_unit metric."
+        description: "OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric."
         type: object
         properties:
           enabled:
@@ -126,7 +126,7 @@ $defs:
               - "string_attr"
               - "boolean_attr"
       reaggregate.metric:
-        description: "ReaggregateMetricConfig provides config for the reaggregate.metric metric."
+        description: "ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric."
         type: object
         properties:
           enabled:
@@ -151,7 +151,7 @@ $defs:
               - "string_attr"
               - "boolean_attr"
       system.cpu.time:
-        description: "SystemCPUTimeConfig provides config for the system.cpu.time metric."
+        description: "SystemCPUTimeMetricConfig provides config for the system.cpu.time metric."
         type: object
         properties:
           enabled:

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
@@ -9,27 +9,27 @@ import (
 	"go.opentelemetry.io/collector/filter"
 )
 
-// DefaultMetricAttributeKey specifies the key of an attribute for the default.metric metric.
-type DefaultMetricAttributeKey string
+// DefaultMetricMetricAttributeKey specifies the key of an attribute for the default.metric metric.
+type DefaultMetricMetricAttributeKey string
 
 const (
-	DefaultMetricAttributeKeyStringAttr        DefaultMetricAttributeKey = "string_attr"
-	DefaultMetricAttributeKeyOverriddenIntAttr DefaultMetricAttributeKey = "state"
-	DefaultMetricAttributeKeyEnumAttr          DefaultMetricAttributeKey = "enum_attr"
-	DefaultMetricAttributeKeySliceAttr         DefaultMetricAttributeKey = "slice_attr"
-	DefaultMetricAttributeKeyMapAttr           DefaultMetricAttributeKey = "map_attr"
+	DefaultMetricMetricAttributeKeyStringAttr        DefaultMetricMetricAttributeKey = "string_attr"
+	DefaultMetricMetricAttributeKeyOverriddenIntAttr DefaultMetricMetricAttributeKey = "state"
+	DefaultMetricMetricAttributeKeyEnumAttr          DefaultMetricMetricAttributeKey = "enum_attr"
+	DefaultMetricMetricAttributeKeySliceAttr         DefaultMetricMetricAttributeKey = "slice_attr"
+	DefaultMetricMetricAttributeKeyMapAttr           DefaultMetricMetricAttributeKey = "map_attr"
 )
 
-// DefaultMetricConfig provides config for the default.metric metric.
-type DefaultMetricConfig struct {
+// DefaultMetricMetricConfig provides config for the default.metric metric.
+type DefaultMetricMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                      `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []DefaultMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []DefaultMetricMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *DefaultMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *DefaultMetricMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -43,10 +43,10 @@ func (ms *DefaultMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *DefaultMetricConfig) Validate() error {
+func (ms *DefaultMetricMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr:
+		case DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr:
 		default:
 			return fmt.Errorf("metric default.metric doesn't have an attribute %v, valid attributes: [string_attr, state, enum_attr, slice_attr, map_attr]", val)
 		}
@@ -61,13 +61,13 @@ func (ms *DefaultMetricConfig) Validate() error {
 	return nil
 }
 
-// DefaultMetricToBeRemovedConfig provides config for the default.metric.to_be_removed metric.
-type DefaultMetricToBeRemovedConfig struct {
+// DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric.
+type DefaultMetricToBeRemovedMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *DefaultMetricToBeRemovedConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *DefaultMetricToBeRemovedMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -81,27 +81,27 @@ func (ms *DefaultMetricToBeRemovedConfig) Unmarshal(parser *confmap.Conf) error 
 	return nil
 }
 
-// MetricInputTypeAttributeKey specifies the key of an attribute for the metric.input_type metric.
-type MetricInputTypeAttributeKey string
+// MetricInputTypeMetricAttributeKey specifies the key of an attribute for the metric.input_type metric.
+type MetricInputTypeMetricAttributeKey string
 
 const (
-	MetricInputTypeAttributeKeyStringAttr        MetricInputTypeAttributeKey = "string_attr"
-	MetricInputTypeAttributeKeyOverriddenIntAttr MetricInputTypeAttributeKey = "state"
-	MetricInputTypeAttributeKeyEnumAttr          MetricInputTypeAttributeKey = "enum_attr"
-	MetricInputTypeAttributeKeySliceAttr         MetricInputTypeAttributeKey = "slice_attr"
-	MetricInputTypeAttributeKeyMapAttr           MetricInputTypeAttributeKey = "map_attr"
+	MetricInputTypeMetricAttributeKeyStringAttr        MetricInputTypeMetricAttributeKey = "string_attr"
+	MetricInputTypeMetricAttributeKeyOverriddenIntAttr MetricInputTypeMetricAttributeKey = "state"
+	MetricInputTypeMetricAttributeKeyEnumAttr          MetricInputTypeMetricAttributeKey = "enum_attr"
+	MetricInputTypeMetricAttributeKeySliceAttr         MetricInputTypeMetricAttributeKey = "slice_attr"
+	MetricInputTypeMetricAttributeKeyMapAttr           MetricInputTypeMetricAttributeKey = "map_attr"
 )
 
-// MetricInputTypeConfig provides config for the metric.input_type metric.
-type MetricInputTypeConfig struct {
+// MetricInputTypeMetricConfig provides config for the metric.input_type metric.
+type MetricInputTypeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                        `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []MetricInputTypeAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MetricInputTypeMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *MetricInputTypeConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricInputTypeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -115,10 +115,10 @@ func (ms *MetricInputTypeConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *MetricInputTypeConfig) Validate() error {
+func (ms *MetricInputTypeMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr:
+		case MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr:
 		default:
 			return fmt.Errorf("metric metric.input_type doesn't have an attribute %v, valid attributes: [string_attr, state, enum_attr, slice_attr, map_attr]", val)
 		}
@@ -133,25 +133,25 @@ func (ms *MetricInputTypeConfig) Validate() error {
 	return nil
 }
 
-// OptionalMetricAttributeKey specifies the key of an attribute for the optional.metric metric.
-type OptionalMetricAttributeKey string
+// OptionalMetricMetricAttributeKey specifies the key of an attribute for the optional.metric metric.
+type OptionalMetricMetricAttributeKey string
 
 const (
-	OptionalMetricAttributeKeyStringAttr   OptionalMetricAttributeKey = "string_attr"
-	OptionalMetricAttributeKeyBooleanAttr  OptionalMetricAttributeKey = "boolean_attr"
-	OptionalMetricAttributeKeyBooleanAttr2 OptionalMetricAttributeKey = "boolean_attr2"
+	OptionalMetricMetricAttributeKeyStringAttr   OptionalMetricMetricAttributeKey = "string_attr"
+	OptionalMetricMetricAttributeKeyBooleanAttr  OptionalMetricMetricAttributeKey = "boolean_attr"
+	OptionalMetricMetricAttributeKeyBooleanAttr2 OptionalMetricMetricAttributeKey = "boolean_attr2"
 )
 
-// OptionalMetricConfig provides config for the optional.metric metric.
-type OptionalMetricConfig struct {
+// OptionalMetricMetricConfig provides config for the optional.metric metric.
+type OptionalMetricMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                       `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OptionalMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OptionalMetricMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OptionalMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OptionalMetricMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -165,10 +165,10 @@ func (ms *OptionalMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *OptionalMetricConfig) Validate() error {
+func (ms *OptionalMetricMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2:
+		case OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2:
 		default:
 			return fmt.Errorf("metric optional.metric doesn't have an attribute %v, valid attributes: [string_attr, boolean_attr, boolean_attr2]", val)
 		}
@@ -183,24 +183,24 @@ func (ms *OptionalMetricConfig) Validate() error {
 	return nil
 }
 
-// OptionalMetricEmptyUnitAttributeKey specifies the key of an attribute for the optional.metric.empty_unit metric.
-type OptionalMetricEmptyUnitAttributeKey string
+// OptionalMetricEmptyUnitMetricAttributeKey specifies the key of an attribute for the optional.metric.empty_unit metric.
+type OptionalMetricEmptyUnitMetricAttributeKey string
 
 const (
-	OptionalMetricEmptyUnitAttributeKeyStringAttr  OptionalMetricEmptyUnitAttributeKey = "string_attr"
-	OptionalMetricEmptyUnitAttributeKeyBooleanAttr OptionalMetricEmptyUnitAttributeKey = "boolean_attr"
+	OptionalMetricEmptyUnitMetricAttributeKeyStringAttr  OptionalMetricEmptyUnitMetricAttributeKey = "string_attr"
+	OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr OptionalMetricEmptyUnitMetricAttributeKey = "boolean_attr"
 )
 
-// OptionalMetricEmptyUnitConfig provides config for the optional.metric.empty_unit metric.
-type OptionalMetricEmptyUnitConfig struct {
+// OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric.
+type OptionalMetricEmptyUnitMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OptionalMetricEmptyUnitAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OptionalMetricEmptyUnitMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OptionalMetricEmptyUnitConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OptionalMetricEmptyUnitMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -214,10 +214,10 @@ func (ms *OptionalMetricEmptyUnitConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *OptionalMetricEmptyUnitConfig) Validate() error {
+func (ms *OptionalMetricEmptyUnitMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr:
+		case OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr:
 		default:
 			return fmt.Errorf("metric optional.metric.empty_unit doesn't have an attribute %v, valid attributes: [string_attr, boolean_attr]", val)
 		}
@@ -232,24 +232,24 @@ func (ms *OptionalMetricEmptyUnitConfig) Validate() error {
 	return nil
 }
 
-// ReaggregateMetricAttributeKey specifies the key of an attribute for the reaggregate.metric metric.
-type ReaggregateMetricAttributeKey string
+// ReaggregateMetricMetricAttributeKey specifies the key of an attribute for the reaggregate.metric metric.
+type ReaggregateMetricMetricAttributeKey string
 
 const (
-	ReaggregateMetricAttributeKeyStringAttr  ReaggregateMetricAttributeKey = "string_attr"
-	ReaggregateMetricAttributeKeyBooleanAttr ReaggregateMetricAttributeKey = "boolean_attr"
+	ReaggregateMetricMetricAttributeKeyStringAttr  ReaggregateMetricMetricAttributeKey = "string_attr"
+	ReaggregateMetricMetricAttributeKeyBooleanAttr ReaggregateMetricMetricAttributeKey = "boolean_attr"
 )
 
-// ReaggregateMetricConfig provides config for the reaggregate.metric metric.
-type ReaggregateMetricConfig struct {
+// ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric.
+type ReaggregateMetricMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                          `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []ReaggregateMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ReaggregateMetricMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *ReaggregateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *ReaggregateMetricMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -263,10 +263,10 @@ func (ms *ReaggregateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-func (ms *ReaggregateMetricConfig) Validate() error {
+func (ms *ReaggregateMetricMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr:
+		case ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr:
 		default:
 			return fmt.Errorf("metric reaggregate.metric doesn't have an attribute %v, valid attributes: [string_attr, boolean_attr]", val)
 		}
@@ -281,13 +281,13 @@ func (ms *ReaggregateMetricConfig) Validate() error {
 	return nil
 }
 
-// SystemCPUTimeConfig provides config for the system.cpu.time metric.
-type SystemCPUTimeConfig struct {
+// SystemCPUTimeMetricConfig provides config for the system.cpu.time metric.
+type SystemCPUTimeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *SystemCPUTimeConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *SystemCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -303,46 +303,46 @@ func (ms *SystemCPUTimeConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for sample metrics.
 type MetricsConfig struct {
-	DefaultMetric            DefaultMetricConfig            `mapstructure:"default.metric"`
-	DefaultMetricToBeRemoved DefaultMetricToBeRemovedConfig `mapstructure:"default.metric.to_be_removed"`
-	MetricInputType          MetricInputTypeConfig          `mapstructure:"metric.input_type"`
-	OptionalMetric           OptionalMetricConfig           `mapstructure:"optional.metric"`
-	OptionalMetricEmptyUnit  OptionalMetricEmptyUnitConfig  `mapstructure:"optional.metric.empty_unit"`
-	ReaggregateMetric        ReaggregateMetricConfig        `mapstructure:"reaggregate.metric"`
-	SystemCPUTime            SystemCPUTimeConfig            `mapstructure:"system.cpu.time"`
+	DefaultMetric            DefaultMetricMetricConfig            `mapstructure:"default.metric"`
+	DefaultMetricToBeRemoved DefaultMetricToBeRemovedMetricConfig `mapstructure:"default.metric.to_be_removed"`
+	MetricInputType          MetricInputTypeMetricConfig          `mapstructure:"metric.input_type"`
+	OptionalMetric           OptionalMetricMetricConfig           `mapstructure:"optional.metric"`
+	OptionalMetricEmptyUnit  OptionalMetricEmptyUnitMetricConfig  `mapstructure:"optional.metric.empty_unit"`
+	ReaggregateMetric        ReaggregateMetricMetricConfig        `mapstructure:"reaggregate.metric"`
+	SystemCPUTime            SystemCPUTimeMetricConfig            `mapstructure:"system.cpu.time"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		DefaultMetric: DefaultMetricConfig{
+		DefaultMetric: DefaultMetricMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []DefaultMetricAttributeKey{DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr},
+			EnabledAttributes:   []DefaultMetricMetricAttributeKey{DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr},
 		},
-		DefaultMetricToBeRemoved: DefaultMetricToBeRemovedConfig{
+		DefaultMetricToBeRemoved: DefaultMetricToBeRemovedMetricConfig{
 			Enabled: true,
 		},
-		MetricInputType: MetricInputTypeConfig{
+		MetricInputType: MetricInputTypeMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []MetricInputTypeAttributeKey{MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr},
+			EnabledAttributes:   []MetricInputTypeMetricAttributeKey{MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr},
 		},
-		OptionalMetric: OptionalMetricConfig{
+		OptionalMetric: OptionalMetricMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OptionalMetricAttributeKey{OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2},
+			EnabledAttributes:   []OptionalMetricMetricAttributeKey{OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2},
 		},
-		OptionalMetricEmptyUnit: OptionalMetricEmptyUnitConfig{
+		OptionalMetricEmptyUnit: OptionalMetricEmptyUnitMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OptionalMetricEmptyUnitAttributeKey{OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr},
+			EnabledAttributes:   []OptionalMetricEmptyUnitMetricAttributeKey{OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr},
 		},
-		ReaggregateMetric: ReaggregateMetricConfig{
+		ReaggregateMetric: ReaggregateMetricMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []ReaggregateMetricAttributeKey{ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr},
+			EnabledAttributes:   []ReaggregateMetricMetricAttributeKey{ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr},
 		},
-		SystemCPUTime: SystemCPUTimeConfig{
+		SystemCPUTime: SystemCPUTimeMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config_test.go
@@ -27,35 +27,35 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					DefaultMetric: DefaultMetricConfig{
+					DefaultMetric: DefaultMetricMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []DefaultMetricAttributeKey{DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr},
+						EnabledAttributes:   []DefaultMetricMetricAttributeKey{DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr},
 					},
-					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedConfig{
+					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedMetricConfig{
 						Enabled: true,
 					},
-					MetricInputType: MetricInputTypeConfig{
+					MetricInputType: MetricInputTypeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MetricInputTypeAttributeKey{MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr},
+						EnabledAttributes:   []MetricInputTypeMetricAttributeKey{MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr},
 					},
-					OptionalMetric: OptionalMetricConfig{
+					OptionalMetric: OptionalMetricMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricAttributeKey{OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2},
+						EnabledAttributes:   []OptionalMetricMetricAttributeKey{OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2},
 					},
-					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitConfig{
+					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricEmptyUnitAttributeKey{OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr},
+						EnabledAttributes:   []OptionalMetricEmptyUnitMetricAttributeKey{OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr},
 					},
-					ReaggregateMetric: ReaggregateMetricConfig{
+					ReaggregateMetric: ReaggregateMetricMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []ReaggregateMetricAttributeKey{ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr},
+						EnabledAttributes:   []ReaggregateMetricMetricAttributeKey{ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr},
 					},
-					SystemCPUTime: SystemCPUTimeConfig{
+					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -75,35 +75,35 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					DefaultMetric: DefaultMetricConfig{
+					DefaultMetric: DefaultMetricMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []DefaultMetricAttributeKey{DefaultMetricAttributeKeyStringAttr, DefaultMetricAttributeKeyOverriddenIntAttr, DefaultMetricAttributeKeyEnumAttr, DefaultMetricAttributeKeySliceAttr, DefaultMetricAttributeKeyMapAttr},
+						EnabledAttributes:   []DefaultMetricMetricAttributeKey{DefaultMetricMetricAttributeKeyStringAttr, DefaultMetricMetricAttributeKeyOverriddenIntAttr, DefaultMetricMetricAttributeKeyEnumAttr, DefaultMetricMetricAttributeKeySliceAttr, DefaultMetricMetricAttributeKeyMapAttr},
 					},
-					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedConfig{
+					DefaultMetricToBeRemoved: DefaultMetricToBeRemovedMetricConfig{
 						Enabled: false,
 					},
-					MetricInputType: MetricInputTypeConfig{
+					MetricInputType: MetricInputTypeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MetricInputTypeAttributeKey{MetricInputTypeAttributeKeyStringAttr, MetricInputTypeAttributeKeyOverriddenIntAttr, MetricInputTypeAttributeKeyEnumAttr, MetricInputTypeAttributeKeySliceAttr, MetricInputTypeAttributeKeyMapAttr},
+						EnabledAttributes:   []MetricInputTypeMetricAttributeKey{MetricInputTypeMetricAttributeKeyStringAttr, MetricInputTypeMetricAttributeKeyOverriddenIntAttr, MetricInputTypeMetricAttributeKeyEnumAttr, MetricInputTypeMetricAttributeKeySliceAttr, MetricInputTypeMetricAttributeKeyMapAttr},
 					},
-					OptionalMetric: OptionalMetricConfig{
+					OptionalMetric: OptionalMetricMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricAttributeKey{OptionalMetricAttributeKeyStringAttr, OptionalMetricAttributeKeyBooleanAttr, OptionalMetricAttributeKeyBooleanAttr2},
+						EnabledAttributes:   []OptionalMetricMetricAttributeKey{OptionalMetricMetricAttributeKeyStringAttr, OptionalMetricMetricAttributeKeyBooleanAttr, OptionalMetricMetricAttributeKeyBooleanAttr2},
 					},
-					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitConfig{
+					OptionalMetricEmptyUnit: OptionalMetricEmptyUnitMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OptionalMetricEmptyUnitAttributeKey{OptionalMetricEmptyUnitAttributeKeyStringAttr, OptionalMetricEmptyUnitAttributeKeyBooleanAttr},
+						EnabledAttributes:   []OptionalMetricEmptyUnitMetricAttributeKey{OptionalMetricEmptyUnitMetricAttributeKeyStringAttr, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr},
 					},
-					ReaggregateMetric: ReaggregateMetricConfig{
+					ReaggregateMetric: ReaggregateMetricMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []ReaggregateMetricAttributeKey{ReaggregateMetricAttributeKeyStringAttr, ReaggregateMetricAttributeKeyBooleanAttr},
+						EnabledAttributes:   []ReaggregateMetricMetricAttributeKey{ReaggregateMetricMetricAttributeKeyStringAttr, ReaggregateMetricMetricAttributeKeyBooleanAttr},
 					},
-					SystemCPUTime: SystemCPUTimeConfig{
+					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -123,7 +123,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(DefaultMetricConfig{}, DefaultMetricToBeRemovedConfig{}, MetricInputTypeConfig{}, OptionalMetricConfig{}, OptionalMetricEmptyUnitConfig{}, ReaggregateMetricConfig{}, SystemCPUTimeConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(DefaultMetricMetricConfig{}, DefaultMetricToBeRemovedMetricConfig{}, MetricInputTypeMetricConfig{}, OptionalMetricMetricConfig{}, OptionalMetricEmptyUnitMetricConfig{}, ReaggregateMetricMetricConfig{}, SystemCPUTimeMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics.go
@@ -93,10 +93,10 @@ type metricInfo struct {
 }
 
 type metricDefaultMetric struct {
-	data          pmetric.Metric      // data buffer for generated metric.
-	config        DefaultMetricConfig // metric config provided by user.
-	capacity      int                 // max observed number of data points added to the metric.
-	aggDataPoints []int64             // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric            // data buffer for generated metric.
+	config        DefaultMetricMetricConfig // metric config provided by user.
+	capacity      int                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                   // slice containing number of aggregated datapoints at each index
 }
 
 // init fills default.metric metric with initial data.
@@ -119,19 +119,19 @@ func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyOverriddenIntAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyOverriddenIntAttr) {
 		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyEnumAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyEnumAttr) {
 		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeySliceAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeySliceAttr) {
 		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, DefaultMetricAttributeKeyMapAttr) {
+	if slices.Contains(m.config.EnabledAttributes, DefaultMetricMetricAttributeKeyMapAttr) {
 		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
 	}
 
@@ -185,7 +185,7 @@ func (m *metricDefaultMetric) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricDefaultMetric(cfg DefaultMetricConfig) metricDefaultMetric {
+func newMetricDefaultMetric(cfg DefaultMetricMetricConfig) metricDefaultMetric {
 	m := metricDefaultMetric{config: cfg}
 
 	if cfg.Enabled {
@@ -196,9 +196,9 @@ func newMetricDefaultMetric(cfg DefaultMetricConfig) metricDefaultMetric {
 }
 
 type metricDefaultMetricToBeRemoved struct {
-	data     pmetric.Metric                 // data buffer for generated metric.
-	config   DefaultMetricToBeRemovedConfig // metric config provided by user.
-	capacity int                            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   DefaultMetricToBeRemovedMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills default.metric.to_be_removed metric with initial data.
@@ -237,7 +237,7 @@ func (m *metricDefaultMetricToBeRemoved) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricDefaultMetricToBeRemoved(cfg DefaultMetricToBeRemovedConfig) metricDefaultMetricToBeRemoved {
+func newMetricDefaultMetricToBeRemoved(cfg DefaultMetricToBeRemovedMetricConfig) metricDefaultMetricToBeRemoved {
 	m := metricDefaultMetricToBeRemoved{config: cfg}
 
 	if cfg.Enabled {
@@ -248,10 +248,10 @@ func newMetricDefaultMetricToBeRemoved(cfg DefaultMetricToBeRemovedConfig) metri
 }
 
 type metricMetricInputType struct {
-	data          pmetric.Metric        // data buffer for generated metric.
-	config        MetricInputTypeConfig // metric config provided by user.
-	capacity      int                   // max observed number of data points added to the metric.
-	aggDataPoints []int64               // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric              // data buffer for generated metric.
+	config        MetricInputTypeMetricConfig // metric config provided by user.
+	capacity      int                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills metric.input_type metric with initial data.
@@ -274,19 +274,19 @@ func (m *metricMetricInputType) recordDataPoint(start pcommon.Timestamp, ts pcom
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyOverriddenIntAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyOverriddenIntAttr) {
 		dp.Attributes().PutInt("state", overriddenIntAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyEnumAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyEnumAttr) {
 		dp.Attributes().PutStr("enum_attr", enumAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeySliceAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeySliceAttr) {
 		dp.Attributes().PutEmptySlice("slice_attr").FromRaw(sliceAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeAttributeKeyMapAttr) {
+	if slices.Contains(m.config.EnabledAttributes, MetricInputTypeMetricAttributeKeyMapAttr) {
 		dp.Attributes().PutEmptyMap("map_attr").FromRaw(mapAttrAttributeValue)
 	}
 
@@ -340,7 +340,7 @@ func (m *metricMetricInputType) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMetricInputType(cfg MetricInputTypeConfig) metricMetricInputType {
+func newMetricMetricInputType(cfg MetricInputTypeMetricConfig) metricMetricInputType {
 	m := metricMetricInputType{config: cfg}
 
 	if cfg.Enabled {
@@ -351,10 +351,10 @@ func newMetricMetricInputType(cfg MetricInputTypeConfig) metricMetricInputType {
 }
 
 type metricOptionalMetric struct {
-	data          pmetric.Metric       // data buffer for generated metric.
-	config        OptionalMetricConfig // metric config provided by user.
-	capacity      int                  // max observed number of data points added to the metric.
-	aggDataPoints []float64            // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric             // data buffer for generated metric.
+	config        OptionalMetricMetricConfig // metric config provided by user.
+	capacity      int                        // max observed number of data points added to the metric.
+	aggDataPoints []float64                  // slice containing number of aggregated datapoints at each index
 }
 
 // init fills optional.metric metric with initial data.
@@ -375,13 +375,13 @@ func (m *metricOptionalMetric) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricAttributeKeyBooleanAttr2) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricMetricAttributeKeyBooleanAttr2) {
 		dp.Attributes().PutBool("boolean_attr2", booleanAttr2AttributeValue)
 	}
 
@@ -435,7 +435,7 @@ func (m *metricOptionalMetric) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOptionalMetric(cfg OptionalMetricConfig) metricOptionalMetric {
+func newMetricOptionalMetric(cfg OptionalMetricMetricConfig) metricOptionalMetric {
 	m := metricOptionalMetric{config: cfg}
 
 	if cfg.Enabled {
@@ -446,10 +446,10 @@ func newMetricOptionalMetric(cfg OptionalMetricConfig) metricOptionalMetric {
 }
 
 type metricOptionalMetricEmptyUnit struct {
-	data          pmetric.Metric                // data buffer for generated metric.
-	config        OptionalMetricEmptyUnitConfig // metric config provided by user.
-	capacity      int                           // max observed number of data points added to the metric.
-	aggDataPoints []float64                     // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        OptionalMetricEmptyUnitMetricConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []float64                           // slice containing number of aggregated datapoints at each index
 }
 
 // init fills optional.metric.empty_unit metric with initial data.
@@ -470,10 +470,10 @@ func (m *metricOptionalMetricEmptyUnit) recordDataPoint(start pcommon.Timestamp,
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, OptionalMetricEmptyUnitMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
 
@@ -527,7 +527,7 @@ func (m *metricOptionalMetricEmptyUnit) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOptionalMetricEmptyUnit(cfg OptionalMetricEmptyUnitConfig) metricOptionalMetricEmptyUnit {
+func newMetricOptionalMetricEmptyUnit(cfg OptionalMetricEmptyUnitMetricConfig) metricOptionalMetricEmptyUnit {
 	m := metricOptionalMetricEmptyUnit{config: cfg}
 
 	if cfg.Enabled {
@@ -538,10 +538,10 @@ func newMetricOptionalMetricEmptyUnit(cfg OptionalMetricEmptyUnitConfig) metricO
 }
 
 type metricReaggregateMetric struct {
-	data          pmetric.Metric          // data buffer for generated metric.
-	config        ReaggregateMetricConfig // metric config provided by user.
-	capacity      int                     // max observed number of data points added to the metric.
-	aggDataPoints []float64               // slice containing number of aggregated datapoints at each index
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        ReaggregateMetricMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []float64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills reaggregate.metric metric with initial data.
@@ -562,10 +562,10 @@ func (m *metricReaggregateMetric) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricAttributeKeyStringAttr) {
+	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricMetricAttributeKeyStringAttr) {
 		dp.Attributes().PutStr("string_attr", stringAttrAttributeValue)
 	}
-	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricAttributeKeyBooleanAttr) {
+	if slices.Contains(m.config.EnabledAttributes, ReaggregateMetricMetricAttributeKeyBooleanAttr) {
 		dp.Attributes().PutBool("boolean_attr", booleanAttrAttributeValue)
 	}
 
@@ -619,7 +619,7 @@ func (m *metricReaggregateMetric) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricReaggregateMetric(cfg ReaggregateMetricConfig) metricReaggregateMetric {
+func newMetricReaggregateMetric(cfg ReaggregateMetricMetricConfig) metricReaggregateMetric {
 	m := metricReaggregateMetric{config: cfg}
 
 	if cfg.Enabled {
@@ -630,9 +630,9 @@ func newMetricReaggregateMetric(cfg ReaggregateMetricConfig) metricReaggregateMe
 }
 
 type metricSystemCPUTime struct {
-	data     pmetric.Metric      // data buffer for generated metric.
-	config   SystemCPUTimeConfig // metric config provided by user.
-	capacity int                 // max observed number of data points added to the metric.
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   SystemCPUTimeMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
 }
 
 // init fills system.cpu.time metric with initial data.
@@ -671,7 +671,7 @@ func (m *metricSystemCPUTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricSystemCPUTime(cfg SystemCPUTimeConfig) metricSystemCPUTime {
+func newMetricSystemCPUTime(cfg SystemCPUTimeMetricConfig) metricSystemCPUTime {
 	m := metricSystemCPUTime{config: cfg}
 
 	if cfg.Enabled {

--- a/cmd/mdatagen/internal/templates/config.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config.go.tmpl
@@ -33,36 +33,36 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 {{- range $name, $metric := .Metrics }}
 {{- if hasAggregatableAttributes $metric.Attributes }}
-// {{ $name.Render }}AttributeKey specifies the key of an attribute for the {{ $name }} metric.
-type {{ $name.Render }}AttributeKey string
+// {{ $name.Render }}MetricAttributeKey specifies the key of an attribute for the {{ $name }} metric.
+type {{ $name.Render }}MetricAttributeKey string
 
 const (
 	{{- range $metric.Attributes }}
-	{{ $name.Render }}AttributeKey{{ .Render }} {{ $name.Render }}AttributeKey = "{{ (attributeInfo .).Name }}"
+	{{ $name.Render }}MetricAttributeKey{{ .Render }} {{ $name.Render }}MetricAttributeKey = "{{ (attributeInfo .).Name }}"
 	{{- end }}
 )
 {{- end }}
 
-// {{ $name.Render }}Config provides config for the {{ $name }} metric.
-type {{ $name.Render }}Config struct {
+// {{ $name.Render }}MetricConfig provides config for the {{ $name }} metric.
+type {{ $name.Render }}MetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 	{{- if hasAggregatableAttributes $metric.Attributes }}
 
-	AggregationStrategy string                           `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []{{ $name.Render }}AttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []{{ $name.Render }}MetricAttributeKey `mapstructure:"attributes"`
 	{{- end }}
 }
 
-func (ms *{{ $name.Render }}Config) Unmarshal(parser *confmap.Conf) error {
+func (ms *{{ $name.Render }}MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	{{- template "metricUnmarshal" "ms" }}
 }
 
 {{ if hasAggregatableAttributes $metric.Attributes -}}
-func (ms *{{ $name.Render }}Config) Validate() error {
+func (ms *{{ $name.Render }}MetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case {{ range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}AttributeKey{{ $element.Render }}{{ end }}:
+		case {{ range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}MetricAttributeKey{{ $element.Render }}{{ end }}:
 		default:
 			return fmt.Errorf("metric {{ $name }} doesn't have an attribute %v, valid attributes: [{{ range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ (attributeInfo $element).Name }}{{ end }}]", val)
 		}
@@ -70,7 +70,7 @@ func (ms *{{ $name.Render }}Config) Validate() error {
 
 	{{- range $element := $metric.Attributes }}
 	{{- if (attributeInfo $element).IsRequired }}
-	if !slices.Contains(ms.EnabledAttributes, {{ $name.Render }}AttributeKey{{ $element.Render }}) {
+	if !slices.Contains(ms.EnabledAttributes, {{ $name.Render }}MetricAttributeKey{{ $element.Render }}) {
 		return fmt.Errorf("{{ (attributeInfo $element).Name }} is a required attribute for {{ $name }} metric and must be included")
 	}
 	{{- end }}
@@ -91,7 +91,7 @@ func (ms *{{ $name.Render }}Config) Validate() error {
 // MetricsConfig provides config for {{ .Type }} metrics.
 type MetricsConfig struct {
 	{{- range $name, $metric := .Metrics }}
-	{{ $name.Render }} {{ if $reag }}{{ $name.Render }}Config{{ else }}MetricConfig{{ end }} `mapstructure:"{{ $name }}"`
+	{{ $name.Render }} {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig `mapstructure:"{{ $name }}"`
 	{{- end }}
 }
 
@@ -99,11 +99,11 @@ func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		{{- range $name, $metric := .Metrics }}
 		{{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
-		{{ $name.Render }}: {{ if $reag }}{{ $name.Render }}{{ else }}Metric{{ end }}Config{
+		{{ $name.Render }}: {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig{
 			Enabled: {{ $metric.Enabled }},
 			{{- if $metricReag }}
 			AggregationStrategy: AggregationStrategy{{ if eq $metric.Data.Type "Sum" }}Sum{{ else }}Avg{{ end }},
-			EnabledAttributes:   []{{ $name.Render }}AttributeKey{ {{- range $element := $metric.Attributes -}}{{- if (attributeInfo $element).IsNotOptIn }}{{ $name.Render }}AttributeKey{{ $element.Render }}, {{ end }}{{- end -}} },
+			EnabledAttributes:   []{{ $name.Render }}MetricAttributeKey{ {{- range $element := $metric.Attributes -}}{{- if (attributeInfo $element).IsNotOptIn }}{{ $name.Render }}MetricAttributeKey{{ $element.Render }}, {{ end }}{{- end -}} },
 			{{- end }}
 		},
 		{{- end }}

--- a/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
+++ b/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
@@ -9,7 +9,7 @@ $defs:
       {{- range $name, $metric := .Metrics }}
       {{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
       {{ $name }}:
-        description: "{{ $name.Render }}Config provides config for the {{ $name }} metric."
+        description: "{{ $name.Render }}MetricConfig provides config for the {{ $name }} metric."
         type: object
         properties:
           enabled:

--- a/cmd/mdatagen/internal/templates/config_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_test.go.tmpl
@@ -32,11 +32,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				Metrics: MetricsConfig{
 					{{- range $name, $metric := .Metrics }}
 					{{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
-					{{ $name.Render }}: {{ if $reag }}{{ $name.Render }}{{ else }}Metric{{ end }}Config{
+					{{ $name.Render }}: {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig{
 						Enabled: true,
 						{{- if $metricReag }}
 						AggregationStrategy: AggregationStrategy{{ if eq $metric.Data.Type "Sum" }}Sum{{ else }}Avg{{ end }},
-						EnabledAttributes:   []{{ $name.Render }}AttributeKey{ {{- range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}AttributeKey{{ $element.Render }}{{ end -}} },
+						EnabledAttributes:   []{{ $name.Render }}MetricAttributeKey{ {{- range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}MetricAttributeKey{{ $element.Render }}{{ end -}} },
 						{{- end }}
 					},
 					{{- end }}
@@ -56,11 +56,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				Metrics: MetricsConfig{
 					{{- range $name, $metric := .Metrics }}
 					{{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
-					{{ $name.Render }}: {{ if $reag }}{{ $name.Render }}{{ else }}Metric{{ end }}Config{
+					{{ $name.Render }}: {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig{
 						Enabled: false,
 						{{- if $metricReag }}
 						AggregationStrategy: AggregationStrategy{{ if eq $metric.Data.Type "Sum" }}Sum{{ else }}Avg{{ end }},
-						EnabledAttributes:   []{{ $name.Render }}AttributeKey{ {{- range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}AttributeKey{{ $element.Render }}{{ end -}} },
+						EnabledAttributes:   []{{ $name.Render }}MetricAttributeKey{ {{- range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}MetricAttributeKey{{ $element.Render }}{{ end -}} },
 						{{- end }}
 					},
 					{{- end }}
@@ -80,7 +80,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
 			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(
 				{{- if $reag }}
-				{{- range $name, $metric := .Metrics }}{{ $name.Render }}Config{}, {{ end }}
+				{{- range $name, $metric := .Metrics }}{{ $name.Render }}MetricConfig{}, {{ end }}
 				{{- else }}MetricConfig{},{{ end }}
 				{{- if .ResourceAttributes }}ResourceAttributeConfig{},{{ end }}
 			))

--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -113,7 +113,7 @@ func With{{ .Render }}MetricAttribute({{ .RenderUnexported }}AttributeValue {{ (
 {{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) -}}
 type metric{{ $name.Render }} struct {
 	data                     pmetric.Metric // data buffer for generated metric.
-	config                   {{ if $reag }}{{ $name.Render }}Config{{ else }}MetricConfig{{ end }} // metric config provided by user.
+	config                   {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig // metric config provided by user.
 	capacity                 int // max observed number of data points added to the metric.
 	{{- if $metricReag }}
 	aggDataPoints            []{{ $metric.Data.MetricValueType.BasicType }} // slice containing number of aggregated datapoints at each index
@@ -153,7 +153,7 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetTimestamp(ts)
 	{{- range $metric.Attributes }}
 	{{- if not (attributeInfo .).IsConditional }}
-	if slices.Contains(m.config.EnabledAttributes, {{ $name.Render }}AttributeKey{{ .Render }}) {
+	if slices.Contains(m.config.EnabledAttributes, {{ $name.Render }}MetricAttributeKey{{ .Render }}) {
 		{{- template "putAttribute" . }}
 	}
 	{{- end }}
@@ -242,7 +242,7 @@ func (m *metric{{ $name.Render }}) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetric{{ $name.Render }}(cfg {{ if $reag }}{{ $name.Render }}Config{{ else }}MetricConfig{{ end }}) metric{{ $name.Render }} {
+func newMetric{{ $name.Render }}(cfg {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig) metric{{ $name.Render }} {
 	m := metric{{ $name.Render }}{config: cfg}
 
 	if cfg.Enabled {


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-collector/pull/14724. No need for chanagelog item if merged before the release

Rename generated types for per-metric reaggregation config to make the category explicit and avoid future name collisions:

- `{MetricName}Config` -> `{MetricName}MetricConfig`
- `{MetricName}AttributeKey` -> `{MetricName}MetricAttributeKey`

For example, for the `system.cpu.frequency` metric:
- `SystemCPUFrequencyConfig` -> `SystemCPUFrequencyMetricConfig`
- `SystemCPUFrequencyAttributeKey` -> `SystemCPUFrequencyMetricAttributeKey`