### PR TITLE
use Unref to request created by OnError

### DIFF
--- a/.chloggen/reduce-memory-usage.yaml
+++ b/.chloggen/reduce-memory-usage.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporter/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reduce memory usage of request created by OnError.
+
+# One or more tracking issues or pull requests related to the change
+issues: [14776]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -73,7 +73,7 @@ func NewBaseExporter(set exporter.Settings, signal pipeline.Signal, pusher sende
 	}
 
 	if be.retryCfg.Enabled {
-		be.RetrySender = newRetrySender(be.retryCfg, set, be.firstSender)
+		be.RetrySender = newRetrySender(be.retryCfg, set, be.firstSender, be.queueBatchSettings.ReferenceCounter)
 		be.firstSender = be.RetrySender
 	}
 

--- a/exporter/exporterhelper/internal/queuebatch/logs.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs.go
@@ -94,7 +94,6 @@ func (logsReferenceCounter) Unref(req request.Request) {
 func (req *logsRequest) OnError(err error) request.Request {
 	var logError consumererror.Logs
 	if errors.As(err, &logError) {
-		// TODO: Add logic to unref the new request created here.
 		return newLogsRequest(logError.Data())
 	}
 	return req

--- a/exporter/exporterhelper/internal/queuebatch/metrics.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics.go
@@ -90,7 +90,6 @@ func (metricsReferenceCounter) Unref(req request.Request) {
 func (req *metricsRequest) OnError(err error) request.Request {
 	var metricsError consumererror.Metrics
 	if errors.As(err, &metricsError) {
-		// TODO: Add logic to unref the new request created here.
 		return newMetricsRequest(metricsError.Data())
 	}
 	return req

--- a/exporter/exporterhelper/internal/queuebatch/traces.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces.go
@@ -93,7 +93,6 @@ func (tracesReferenceCounter) Unref(req request.Request) {
 func (req *tracesRequest) OnError(err error) request.Request {
 	var traceError consumererror.Traces
 	if errors.As(err, &traceError) {
-		// TODO: Add logic to unref the new request created here.
 		return newTracesRequest(traceError.Data())
 	}
 	return req

--- a/exporter/exporterhelper/internal/retry_sender.go
+++ b/exporter/exporterhelper/internal/retry_sender.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/experr"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
 )
@@ -47,18 +48,20 @@ func NewThrottleRetry(err error, delay time.Duration) error {
 
 type retrySender struct {
 	component.StartFunc
-	cfg    configretry.BackOffConfig
-	stopCh chan struct{}
-	logger *zap.Logger
-	next   sender.Sender[request.Request]
+	cfg        configretry.BackOffConfig
+	stopCh     chan struct{}
+	logger     *zap.Logger
+	next       sender.Sender[request.Request]
+	refCounter queue.ReferenceCounter[request.Request]
 }
 
-func newRetrySender(config configretry.BackOffConfig, set exporter.Settings, next sender.Sender[request.Request]) *retrySender {
+func newRetrySender(config configretry.BackOffConfig, set exporter.Settings, next sender.Sender[request.Request], refCounter queue.ReferenceCounter[request.Request]) *retrySender {
 	return &retrySender{
-		cfg:    config,
-		stopCh: make(chan struct{}),
-		logger: set.Logger,
-		next:   next,
+		cfg:        config,
+		stopCh:     make(chan struct{}),
+		logger:     set.Logger,
+		next:       next,
+		refCounter: refCounter,
 	}
 }
 
@@ -69,6 +72,13 @@ func (rs *retrySender) Shutdown(context.Context) error {
 
 // Send implements the requestSender interface
 func (rs *retrySender) Send(ctx context.Context, req request.Request) error {
+	originalReq := req
+	defer func() {
+		if originalReq != req && rs.refCounter != nil {
+			rs.refCounter.Unref(req)
+		}
+	}()
+
 	// Do not use NewExponentialBackOff since it calls Reset and the code here must
 	// call Reset after changing the InitialInterval (this saves an unnecessary call to Now).
 	expBackoff := backoff.ExponentialBackOff{
@@ -99,7 +109,13 @@ func (rs *retrySender) Send(ctx context.Context, req request.Request) error {
 		}
 
 		if errReq, ok := req.(request.ErrorHandler); ok {
-			req = errReq.OnError(err)
+			newReq := errReq.OnError(err)
+			if newReq != req {
+				if originalReq != req && rs.refCounter != nil {
+					rs.refCounter.Unref(req)
+				}
+				req = newReq
+			}
 		}
 
 		backoffDelay := expBackoff.NextBackOff()

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,11 +25,26 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 )
 
+type fakeRefCounter struct {
+	mu         sync.Mutex
+	unrefCount int
+	unreffed   []request.Request
+}
+
+func (f *fakeRefCounter) Ref(request.Request) {}
+
+func (f *fakeRefCounter) Unref(req request.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.unrefCount++
+	f.unreffed = append(f.unreffed, req)
+}
+
 func TestRetrySenderDropOnPermanentError(t *testing.T) {
 	rCfg := configretry.NewDefaultBackOffConfig()
 	sink := requesttest.NewSink()
 	expErr := consumererror.NewPermanent(errors.New("bad data"))
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export))
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export), nil)
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	sink.SetExportErr(expErr)
 	require.ErrorIs(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2}), expErr)
@@ -44,7 +60,7 @@ func TestRetrySenderSimpleRetry(t *testing.T) {
 	rCfg.InitialInterval = 0
 	sink := requesttest.NewSink()
 	expErr := errors.New("transient error")
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export))
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export), nil)
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	sink.SetExportErr(expErr)
 	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2}))
@@ -57,7 +73,7 @@ func TestRetrySenderRetryPartial(t *testing.T) {
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = 0
 	sink := requesttest.NewSink()
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export))
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export), nil)
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 5, Partial: 3}))
 	assert.Equal(t, 5, sink.ItemsCount())
@@ -70,7 +86,7 @@ func TestRetrySenderMaxElapsedTime(t *testing.T) {
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 100 * time.Millisecond
 	expErr := errors.New("transient error")
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(func(context.Context, request.Request) error { return expErr }))
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(func(context.Context, request.Request) error { return expErr }), nil)
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	require.ErrorIs(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2}), expErr)
 	require.NoError(t, rs.Shutdown(context.Background()))
@@ -80,7 +96,7 @@ func TestRetrySenderThrottleError(t *testing.T) {
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = 10 * time.Millisecond
 	sink := requesttest.NewSink()
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export))
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export), nil)
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	retry := fmt.Errorf("wrappe error: %w", NewThrottleRetry(errors.New("throttle error"), 100*time.Millisecond))
 	start := time.Now()
@@ -105,7 +121,7 @@ func TestRetrySenderWithContextTimeout(t *testing.T) {
 	set := exportertest.NewNopSettings(exportertest.NopType)
 	logger, observed := observer.New(zap.InfoLevel)
 	set.Logger = zap.New(logger)
-	rs := newRetrySender(rCfg, set, sender.NewSender(func(context.Context, request.Request) error { return errors.New("transient error") }))
+	rs := newRetrySender(rCfg, set, sender.NewSender(func(context.Context, request.Request) error { return errors.New("transient error") }), nil)
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
@@ -124,7 +140,7 @@ func TestRetrySenderWithCancelledContext(t *testing.T) {
 	rCfg.Enabled = true
 	// First attempt after 1s is attempted
 	rCfg.InitialInterval = 1 * time.Second
-	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(func(context.Context, request.Request) error { return errors.New("transient error") }))
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(func(context.Context, request.Request) error { return errors.New("transient error") }), nil)
 	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
 	start := time.Now()
 	ctx, cancel := context.WithCancelCause(context.Background())
@@ -136,5 +152,35 @@ func TestRetrySenderWithCancelledContext(t *testing.T) {
 		rs.Send(ctx, &requesttest.FakeRequest{Items: 2}),
 		"request is cancelled or timed out: transient error")
 	require.Less(t, time.Since(start), 1*time.Second)
+	require.NoError(t, rs.Shutdown(context.Background()))
+}
+
+func TestRetrySenderRetryPartialUnref(t *testing.T) {
+	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg.InitialInterval = 0
+	sink := requesttest.NewSink()
+	rc := &fakeRefCounter{}
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export), rc)
+	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 5, Partial: 3}))
+	assert.Equal(t, 5, sink.ItemsCount())
+	assert.Equal(t, 2, sink.RequestsCount())
+	// The replacement request created by OnError should be Unref'd exactly once.
+	assert.Equal(t, 1, rc.unrefCount)
+	assert.Equal(t, 3, rc.unreffed[0].ItemsCount())
+	require.NoError(t, rs.Shutdown(context.Background()))
+}
+
+func TestRetrySenderSimpleRetryNoUnref(t *testing.T) {
+	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg.InitialInterval = 0
+	sink := requesttest.NewSink()
+	rc := &fakeRefCounter{}
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(sink.Export), rc)
+	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2}))
+	assert.Equal(t, 2, sink.ItemsCount())
+	// No replacement happened, so Unref should not be called.
+	assert.Equal(t, 0, rc.unrefCount)
 	require.NoError(t, rs.Shutdown(context.Background()))
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

use Unref to reduce memory usage to create request in OnError.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
