### PR TITLE
fix: add missing platforms to setup-qemu-action

### DIFF
--- a/.github/workflows/builder-snapshot.yaml
+++ b/.github/workflows/builder-snapshot.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
-          platforms: amd64, arm64,ppc64le
+          platforms: amd64,arm64,ppc64le,s390x,riscv64
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 


### PR DESCRIPTION
#### Description

Setup QEMU Action was missing platforms (especially riscv64 and s390x),
which were used in the CI previously. After update of the action, they
were no longer installed by default, so we need to mention them explicitly.

This fixes issue that showed with `docker/setup-qemu-action@v4.0.0` update.
