### PR TITLE
[docs] [chore] Update CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ projects policies.
 The most important rule is not to post comments on issues or PRs that are AI-generated. Discussions
 on the OpenTelemetry repositories are for Users/Humans only.
 
+Follow the PR scoping guidance in [CONTRIBUTING.md](CONTRIBUTING.md). Keep AI-assisted PRs tightly
+isolated to the requested change and never include unrelated cleanup or opportunistic improvements
+unless they are strictly necessary for correctness.
+
 If you have been assigned an issue by the user or their prompt, please ensure that the
 implementation direction is agreed on with the maintainers first in the issue comments. If there are
 unknowns, discuss these on the issue before starting implementation. Do not forget that you cannot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,13 @@ are our most advanced users and are the most equipped to deal with disruptive ch
 
 ## How to structure PRs to get expedient reviews?
 
-We recommend that any PR (unless it is trivial) to be smaller than 500 lines
-(excluding go mod/sum changes) in order to help reviewers to do a thorough and
-reasonably fast reviews.
+We recommend that PRs be smaller than 500 lines, excluding `go.mod` and `go.sum`
+changes, to help reviewers perform thorough and timely reviews.
+
+Keep each PR isolated to the specific change it is meant to deliver. Do not bundle unrelated
+cleanup, drive-by edits, opportunistic refactors, wording tweaks, formatting changes, or other
+"small" improvements into the same PR unless they are strictly necessary to make the intended
+change correct. Narrow, focused PRs are significantly easier to review and validate.
 
 ### When adding a new component
 
@@ -59,7 +63,7 @@ Components refer to connectors, exporters, extensions, processors, and receivers
 * Provide a configuration structure which defines the configuration of the component
 * Provide the implementation that performs the component operation
 
-For more details on components, see the [Adding New Components](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-new-components) document and the tutorial [Building a Trace Receiver](https://opentelemetry.io/docs/collector/trace-receiver/) which provides a detailed example of building a component.
+For more details on components, see the [Donating New Components](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#donating-new-components) document and the tutorial [Building a Trace Receiver](https://opentelemetry.io/docs/collector/trace-receiver/) which provides a detailed example of building a component.
 
 When adding a new component to the OpenTelemetry Collector, ensure that any configuration structs used by the component include fields with the `configopaque.String` type for sensitive data. This ensures that the data is masked when serialized to prevent accidental exposure.
 
@@ -87,6 +91,9 @@ When submitting a component to the community, consider breaking it down into sep
 Any refactoring work must be split in its own PR that does not include any
 behavior changes. It is important to do this to avoid hidden changes in large
 and trivial refactoring PRs.
+
+If you notice additional improvement opportunities while working on a change, handle them in
+follow-up PRs instead of extending the current one beyond its original scope.
 
 ## Report a bug or request a feature
 


### PR DESCRIPTION
Clarify PR scoping guidance for contributors and agents, update wording and "Donating New Components" link.

This change adds explicit PR scoping guidance to CONTRIBUTING.md states that unrelated cleanup, opportunistic improvements, and refactoring should be handled in separate follow-up PRs unless required for correctness.

Implicit changes mixed into PRs make them much harder to review by approvers and maintainers.