### PR TITLE
exporterhelper/queuebatch: add requests sizer support for batching with persistent queues

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -125,9 +125,9 @@ func (cfg *BatchConfig) Validate() error {
 		return nil
 	}
 
-	// Only support items or bytes sizer for batch at this moment.
-	if cfg.Sizer != request.SizerTypeItems && cfg.Sizer != request.SizerTypeBytes {
-		return fmt.Errorf("`batch` supports only `items` or `bytes` sizer, found %q", cfg.Sizer.String())
+	// Only support items, bytes, or requests sizer for batch.
+	if cfg.Sizer != request.SizerTypeItems && cfg.Sizer != request.SizerTypeBytes && cfg.Sizer != request.SizerTypeRequests {
+		return fmt.Errorf("`batch` supports only `items`, `bytes`, or `requests` sizer, found %q", cfg.Sizer.String())
 	}
 
 	if cfg.FlushTimeout <= 0 {

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -45,7 +45,7 @@ func TestConfig_Validate(t *testing.T) {
 
 	cfg = newTestConfig()
 	cfg.Batch.Get().Sizer = request.SizerType{}
-	require.EqualError(t, xconfmap.Validate(cfg), "batch: `batch` supports only `items` or `bytes` sizer, found \"\"")
+	require.EqualError(t, xconfmap.Validate(cfg), "batch: `batch` supports only `items`, `bytes`, or `requests` sizer, found \"\"")
 
 	cfg = newTestConfig()
 	cfg.Sizer = request.SizerTypeBytes
@@ -109,11 +109,11 @@ func TestBatchConfig_Validate(t *testing.T) {
 
 	cfg = newTestBatchConfig()
 	cfg.Sizer = request.SizerTypeRequests
-	require.EqualError(t, xconfmap.Validate(cfg), "`batch` supports only `items` or `bytes` sizer, found \"requests\"")
+	require.NoError(t, xconfmap.Validate(cfg))
 
 	cfg = newTestBatchConfig()
 	cfg.Sizer = request.SizerType{}
-	require.EqualError(t, xconfmap.Validate(cfg), "`batch` supports only `items` or `bytes` sizer, found \"\"")
+	require.EqualError(t, xconfmap.Validate(cfg), "`batch` supports only `items`, `bytes`, or `requests` sizer, found \"\"")
 
 	cfg = newTestBatchConfig()
 	cfg.MinSize = 2048

--- a/exporter/exporterhelper/internal/queuebatch/logs_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_batch.go
@@ -16,6 +16,24 @@ import (
 // MergeSplit splits and/or merges the provided logs request and the current request into one or more requests
 // conforming with the MaxSizeConfig.
 func (req *logsRequest) MergeSplit(_ context.Context, maxSize int, szt request.SizerType, r2 request.Request) ([]request.Request, error) {
+	if szt == request.SizerTypeRequests {
+		if r2 == nil {
+			return []request.Request{req}, nil
+		}
+
+		req2, ok := r2.(*logsRequest)
+		if !ok {
+			return nil, errors.New("invalid input type")
+		}
+
+		if maxSize == 1 {
+			return []request.Request{req, req2}, nil
+		}
+
+		req2.mergeTo(req, nil)
+		return []request.Request{req}, nil
+	}
+
 	var sz sizer.LogsSizer
 	switch szt {
 	case request.SizerTypeItems:

--- a/exporter/exporterhelper/internal/queuebatch/logs_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_batch_test.go
@@ -273,6 +273,67 @@ func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
 	}
 }
 
+func TestMergeSplitLogsBasedOnRequestSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		szt      request.SizerType
+		maxSize  int
+		lr1      request.Request
+		lr2      request.Request
+		expected []request.Request
+	}{
+		{
+			name:     "first_request_only",
+			szt:      request.SizerTypeRequests,
+			maxSize:  1,
+			lr1:      newLogsRequest(testdata.GenerateLogs(5)),
+			lr2:      nil,
+			expected: []request.Request{newLogsRequest(testdata.GenerateLogs(5))},
+		},
+		{
+			name:    "cannot_merge_when_max_size_is_one",
+			szt:     request.SizerTypeRequests,
+			maxSize: 1,
+			lr1:     newLogsRequest(testdata.GenerateLogs(2)),
+			lr2:     newLogsRequest(testdata.GenerateLogs(3)),
+			expected: []request.Request{
+				newLogsRequest(testdata.GenerateLogs(2)),
+				newLogsRequest(testdata.GenerateLogs(3)),
+			},
+		},
+		{
+			name:    "merge_when_max_size_is_two",
+			szt:     request.SizerTypeRequests,
+			maxSize: 2,
+			lr1:     newLogsRequest(testdata.GenerateLogs(2)),
+			lr2:     newLogsRequest(testdata.GenerateLogs(3)),
+			expected: []request.Request{newLogsRequest(func() plog.Logs {
+				ld := testdata.GenerateLogs(2)
+				testdata.GenerateLogs(3).ResourceLogs().MoveAndAppendTo(ld.ResourceLogs())
+				return ld
+			}())},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.lr1.MergeSplit(context.Background(), tt.maxSize, tt.szt, tt.lr2)
+			require.NoError(t, err)
+			require.Len(t, res, len(tt.expected))
+			for i := range res {
+				assert.Equal(t, tt.expected[i].(*logsRequest).ld, res[i].(*logsRequest).ld)
+			}
+		})
+	}
+}
+
+func TestMergeSplitLogsRequestsInvalidInput(t *testing.T) {
+	r1 := newLogsRequest(testdata.GenerateLogs(2))
+	r2 := newTracesRequest(testdata.GenerateTraces(3))
+
+	_, err := r1.MergeSplit(context.Background(), 1, request.SizerTypeRequests, r2)
+	require.EqualError(t, err, "invalid input type")
+}
+
 func TestMergeSplitLogsInputNotModifiedIfErrorReturned(t *testing.T) {
 	r1 := newLogsRequest(testdata.GenerateLogs(18))
 	r2 := newTracesRequest(testdata.GenerateTraces(3))

--- a/exporter/exporterhelper/internal/queuebatch/metrics_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_batch.go
@@ -16,6 +16,23 @@ import (
 // MergeSplit splits and/or merges the provided metrics request and the current request into one or more requests
 // conforming with the MaxSizeConfig.
 func (req *metricsRequest) MergeSplit(_ context.Context, maxSize int, szt request.SizerType, r2 request.Request) ([]request.Request, error) {
+	if szt == request.SizerTypeRequests {
+		if r2 == nil {
+			return []request.Request{req}, nil
+		}
+
+		req2, ok := r2.(*metricsRequest)
+		if !ok {
+			return nil, errors.New("invalid input type")
+		}
+
+		if maxSize == 1 {
+			return []request.Request{req, req2}, nil
+		}
+		req2.mergeTo(req, nil)
+		return []request.Request{req}, nil
+	}
+
 	var sz sizer.MetricsSizer
 	switch szt {
 	case request.SizerTypeItems:

--- a/exporter/exporterhelper/internal/queuebatch/metrics_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_batch_test.go
@@ -476,6 +476,67 @@ func TestMergeSplitMetricsBasedOnByteSize(t *testing.T) {
 	}
 }
 
+func TestMergeSplitMetricsBasedOnRequestSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		szt      request.SizerType
+		maxSize  int
+		mr1      request.Request
+		mr2      request.Request
+		expected []request.Request
+	}{
+		{
+			name:     "first_request_only",
+			szt:      request.SizerTypeRequests,
+			maxSize:  1,
+			mr1:      newMetricsRequest(testdata.GenerateMetrics(5)),
+			mr2:      nil,
+			expected: []request.Request{newMetricsRequest(testdata.GenerateMetrics(5))},
+		},
+		{
+			name:    "cannot_merge_when_max_size_is_one",
+			szt:     request.SizerTypeRequests,
+			maxSize: 1,
+			mr1:     newMetricsRequest(testdata.GenerateMetrics(2)),
+			mr2:     newMetricsRequest(testdata.GenerateMetrics(3)),
+			expected: []request.Request{
+				newMetricsRequest(testdata.GenerateMetrics(2)),
+				newMetricsRequest(testdata.GenerateMetrics(3)),
+			},
+		},
+		{
+			name:    "merge_when_max_size_is_two",
+			szt:     request.SizerTypeRequests,
+			maxSize: 2,
+			mr1:     newMetricsRequest(testdata.GenerateMetrics(2)),
+			mr2:     newMetricsRequest(testdata.GenerateMetrics(3)),
+			expected: []request.Request{newMetricsRequest(func() pmetric.Metrics {
+				md := testdata.GenerateMetrics(2)
+				testdata.GenerateMetrics(3).ResourceMetrics().MoveAndAppendTo(md.ResourceMetrics())
+				return md
+			}())},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.mr1.MergeSplit(context.Background(), tt.maxSize, tt.szt, tt.mr2)
+			require.NoError(t, err)
+			require.Len(t, res, len(tt.expected))
+			for i := range res {
+				assert.Equal(t, tt.expected[i].(*metricsRequest).md, res[i].(*metricsRequest).md)
+			}
+		})
+	}
+}
+
+func TestMergeSplitMetricsRequestsInvalidInput(t *testing.T) {
+	r1 := newMetricsRequest(testdata.GenerateMetrics(2))
+	r2 := newLogsRequest(testdata.GenerateLogs(3))
+
+	_, err := r1.MergeSplit(context.Background(), 1, request.SizerTypeRequests, r2)
+	require.EqualError(t, err, "invalid input type")
+}
+
 func TestExtractGaugeDataPoints(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/exporter/exporterhelper/internal/queuebatch/traces_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_batch.go
@@ -16,6 +16,24 @@ import (
 // MergeSplit splits and/or merges the provided traces request and the current request into one or more requests
 // conforming with the MaxSizeConfig.
 func (req *tracesRequest) MergeSplit(_ context.Context, maxSize int, szt request.SizerType, r2 request.Request) ([]request.Request, error) {
+	if szt == request.SizerTypeRequests {
+		if r2 == nil {
+			return []request.Request{req}, nil
+		}
+
+		req2, ok := r2.(*tracesRequest)
+		if !ok {
+			return nil, errors.New("invalid input type")
+		}
+
+		if maxSize == 1 {
+			return []request.Request{req, req2}, nil
+		}
+
+		req2.mergeTo(req, nil)
+		return []request.Request{req}, nil
+	}
+
 	var sz sizer.TracesSizer
 	switch szt {
 	case request.SizerTypeItems:

--- a/exporter/exporterhelper/internal/queuebatch/traces_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_batch_test.go
@@ -286,6 +286,80 @@ func TestMergeSplitTracesBasedOnByteSize(t *testing.T) {
 	}
 }
 
+func TestMergeSplitTracesBasedOnRequestSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		szt      request.SizerType
+		maxSize  int
+		tr1      request.Request
+		tr2      request.Request
+		expected []request.Request
+	}{
+		{
+			name:     "first_request_only",
+			szt:      request.SizerTypeRequests,
+			maxSize:  1,
+			tr1:      newTracesRequest(testdata.GenerateTraces(5)),
+			tr2:      nil,
+			expected: []request.Request{newTracesRequest(testdata.GenerateTraces(5))},
+		},
+		{
+			name:    "cannot_merge_when_max_size_is_one",
+			szt:     request.SizerTypeRequests,
+			maxSize: 1,
+			tr1:     newTracesRequest(testdata.GenerateTraces(2)),
+			tr2:     newTracesRequest(testdata.GenerateTraces(3)),
+			expected: []request.Request{
+				newTracesRequest(testdata.GenerateTraces(2)),
+				newTracesRequest(testdata.GenerateTraces(3)),
+			},
+		},
+		{
+			name:    "merge_when_max_size_is_two",
+			szt:     request.SizerTypeRequests,
+			maxSize: 2,
+			tr1:     newTracesRequest(testdata.GenerateTraces(2)),
+			tr2:     newTracesRequest(testdata.GenerateTraces(3)),
+			expected: []request.Request{newTracesRequest(func() ptrace.Traces {
+				td := testdata.GenerateTraces(2)
+				testdata.GenerateTraces(3).ResourceSpans().MoveAndAppendTo(td.ResourceSpans())
+				return td
+			}())},
+		},
+		{
+			name:    "merge_when_max_size_is_zero",
+			szt:     request.SizerTypeRequests,
+			maxSize: 0,
+			tr1:     newTracesRequest(testdata.GenerateTraces(2)),
+			tr2:     newTracesRequest(testdata.GenerateTraces(3)),
+			expected: []request.Request{newTracesRequest(func() ptrace.Traces {
+				td := testdata.GenerateTraces(2)
+				testdata.GenerateTraces(3).ResourceSpans().MoveAndAppendTo(td.ResourceSpans())
+				return td
+			}())},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.tr1.MergeSplit(context.Background(), tt.maxSize, tt.szt, tt.tr2)
+			require.NoError(t, err)
+			assert.Len(t, res, len(tt.expected))
+			for i := range res {
+				assert.Equal(t, tt.expected[i].(*tracesRequest).td, res[i].(*tracesRequest).td)
+			}
+		})
+	}
+}
+
+func TestMergeSplitTracesRequestsInvalidInput(t *testing.T) {
+	r1 := newTracesRequest(testdata.GenerateTraces(2))
+	r2 := newLogsRequest(testdata.GenerateLogs(3))
+
+	_, err := r1.MergeSplit(context.Background(), 1, request.SizerTypeRequests, r2)
+	require.EqualError(t, err, "invalid input type")
+}
+
 func TestMergeSplitTracesInputNotModifiedIfErrorReturned(t *testing.T) {
 	r1 := newTracesRequest(testdata.GenerateTraces(18))
 	r2 := newLogsRequest(testdata.GenerateLogs(3))


### PR DESCRIPTION
#### Description

This change adds support for `requests` as a sizer type in the `queuebatch` package.

- Extends `MergeSplit` logic for traces, metrics, and logs to handle `SizerTypeRequests`
- Updates `BatchConfig.Validate` to allow `requests` as a valid sizer
- Ensures consistent behavior across all signal types

This resolves the incompatibility between batching and persistent queues, where the queue enforces `requests` as the only supported sizer but the batcher previously rejected or failed on it.

Request-based batching operates at request granularity rather than item/byte size, ensuring compatibility with persistent storage while maintaining predictable batching behavior.

Behavior:
- `maxSize == 0`: treated as unlimited, requests are merged
- `maxSize == 1`: requests are not merged and returned separately
- `maxSize > 1`: requests are merged into a single batch

---

#### Link to tracking issue

Fixes #12880

---

#### Testing

- Added unit tests for request-based batching in:
  - `traces_batch_test.go`
  - `metrics_batch_test.go`
  - `logs_batch_test.go`
- Covered key scenarios:
  - nil input handling
  - merge vs non-merge behavior (`maxSize == 1` vs `>1`)
  - invalid input type handling
- Verified all tests pass with `go test -count=1 ./...`

---

#### Documentation

No documentation changes required.