### PR TITLE
[mdatagen] Ensure no conflict across extta_attributes in entity defs

### DIFF
--- a/.chloggen/mdatagen-ensure-no-extra-attributes-conflict.yaml
+++ b/.chloggen/mdatagen-ensure-no-extra-attributes-conflict.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Validate that no two entity definitions share the same `extra_attributes` resource attribute reference.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -219,6 +219,11 @@ func (md *Metadata) validateEntities() error {
 			if _, ok := md.ResourceAttributes[ref.Ref]; !ok {
 				errs = errors.Join(errs, fmt.Errorf(`entity "%v": extra_attributes refers to undefined resource attribute: %v`, entity.Type, ref.Ref))
 			}
+			if otherEntity, used := usedAttrs[ref.Ref]; used {
+				errs = errors.Join(errs, fmt.Errorf(`entity "%v": extra_attributes attribute %v is already used by entity "%v"`, entity.Type, ref.Ref, otherEntity))
+			} else {
+				usedAttrs[ref.Ref] = entity.Type
+			}
 		}
 	}
 

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -136,6 +136,10 @@ func TestValidate(t *testing.T) {
 			wantErr: `attribute host.name is already used by entity`,
 		},
 		{
+			name:    "testdata/entity_extra_attributes_conflict.yaml",
+			wantErr: `extra_attributes attribute k8s.namespace.name is already used by entity`,
+		},
+		{
 			name:    "testdata/entity_duplicate_types.yaml",
 			wantErr: `duplicate entity type: host`,
 		},

--- a/cmd/mdatagen/internal/testdata/entity_extra_attributes_conflict.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_extra_attributes_conflict.yaml
@@ -1,0 +1,41 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  host.id:
+    description: The host identifier
+    type: string
+    enabled: true
+  host.name:
+    description: The hostname
+    type: string
+    enabled: true
+  process.pid:
+    description: The process identifier
+    type: int
+    enabled: true
+  k8s.namespace.name:
+    description: The name of the Kubernetes Namespace
+    type: string
+    enabled: true
+
+entities:
+  - type: host
+    brief: A host instance.
+    stability: stable
+    identity:
+      - ref: host.id
+    description:
+      - ref: host.name
+    extra_attributes:
+      - ref: k8s.namespace.name
+  - type: process
+    brief: A process instance.
+    stability: stable
+    identity:
+      - ref: process.pid
+    extra_attributes:
+      - ref: k8s.namespace.name


### PR DESCRIPTION
Validate that no two entity definitions share the same `extra_attributes` resource attribute reference.
