### PR TITLE
[chore] batchprocessor: document downstream send failure behavior

### DIFF
--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -75,6 +75,12 @@ processors:
 Refer to [config.yaml](./testdata/config.yaml) for detailed
 examples on using the processor.
 
+## Failure behavior
+
+If sending data to the next consumer fails, the batch processor drops the affected batch and does not retry.
+
+Retry behavior should be configured in downstream components, such as exporters using `retry_on_failure` or `sending_queue`.
+
 ## Batching and client metadata
 
 Batching by metadata enables support for multi-tenant OpenTelemetry


### PR DESCRIPTION
#### Description

This PR documents the batch processor's behavior when downstream sends fail.

It also includes a metric (`otelcol_processor_batch_dropped_items`) to make this failure mode observable. 

Happy to scope this PR down to documentation only if preferred.

#### Link to tracking issue
Related to #12443 

#### Testing
Added unit test verifying dropped items metric on export failure

#### Documentation
Updated README and component documentation to describe failure behavior
