### PR TITLE
feat(processor/memory_limiter): add configured limit gauges

### DIFF
--- a/.chloggen/feat-memory-limiter-limit-metric.yaml
+++ b/.chloggen/feat-memory-limiter-limit-metric.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: processor/memory_limiter
+note: Add `otelcol_processor_memory_limiter_limit_bytes` and `otelcol_processor_memory_limiter_spike_limit_bytes` internal metrics to expose the resolved hard and spike memory limits configured for the memory limiter processor.
+issues: [15006]
+change_logs: [user]

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -21,11 +21,11 @@ type TargetsItem struct {
 func (c *TargetsItem) Validate() error {
 	var err error
 
-	if c.Options == nil || len(c.Options) == 0 {
-		err = errors.Join(err, errors.New("options is required"))
-	}
 	if c.HTTPClient == nil {
 		err = errors.Join(err, errors.New("http_client is required"))
+	}
+	if c.Options == nil || len(c.Options) == 0 {
+		err = errors.Join(err, errors.New("options is required"))
 	}
 
 	return err

--- a/internal/memorylimiter/memorylimiter.go
+++ b/internal/memorylimiter/memorylimiter.go
@@ -130,6 +130,16 @@ func (ml *MemoryLimiter) MustRefuse() bool {
 	return ml.mustRefuse.Load()
 }
 
+// AllocLimit returns the resolved hard memory limit in bytes.
+func (ml *MemoryLimiter) AllocLimit() uint64 {
+	return ml.usageChecker.memAllocLimit
+}
+
+// SpikeLimit returns the resolved spike memory limit in bytes.
+func (ml *MemoryLimiter) SpikeLimit() uint64 {
+	return ml.usageChecker.memSpikeLimit
+}
+
 func getMemUsageChecker(cfg *Config, logger *zap.Logger) (*memUsageChecker, error) {
 	memAllocLimit := uint64(cfg.MemoryLimitMiB) * mibBytes
 	memSpikeLimit := uint64(cfg.MemorySpikeLimitMiB) * mibBytes

--- a/internal/memorylimiter/memorylimiter_test.go
+++ b/internal/memorylimiter/memorylimiter_test.go
@@ -80,6 +80,18 @@ func TestGetDecision(t *testing.T) {
 	})
 }
 
+func TestLimits(t *testing.T) {
+	ml, err := NewMemoryLimiter(&Config{
+		CheckInterval:       time.Minute,
+		MemoryLimitMiB:      100,
+		MemorySpikeLimitMiB: 20,
+	}, zap.NewNop())
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(100*mibBytes), ml.AllocLimit())
+	assert.Equal(t, uint64(20*mibBytes), ml.SpikeLimit())
+}
+
 func TestRefuseDecision(t *testing.T) {
 	decision1000Limit30Spike30 := newPercentageMemUsageChecker(1000, 60, 30)
 	decision1000Limit60Spike50 := newPercentageMemUsageChecker(1000, 60, 50)

--- a/processor/memorylimiterprocessor/documentation.md
+++ b/processor/memorylimiterprocessor/documentation.md
@@ -45,6 +45,22 @@ Number of spans successfully pushed into the next component in the pipeline.
 
 **Deprecation note**: This metric is deprecated
 
+### otelcol_processor_memory_limiter_limit_bytes
+
+The hard memory limit (in bytes) configured on this memory limiter processor instance, derived from limit_mib or limit_percentage * total_memory. Useful as a static denominator for capacity utilization dashboards.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+### otelcol_processor_memory_limiter_spike_limit_bytes
+
+The spike (soft) memory limit (in bytes) configured on this memory limiter processor instance. The processor starts refusing data when Alloc >= (limit - spike). This is the soft threshold.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
 ### otelcol_processor_refused_log_records
 
 Number of log records that were rejected by the next component in the pipeline.

--- a/processor/memorylimiterprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/memorylimiterprocessor/internal/metadata/generated_telemetry.go
@@ -23,15 +23,17 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter                         metric.Meter
-	mu                            sync.Mutex
-	registrations                 []metric.Registration
-	ProcessorAcceptedLogRecords   metric.Int64Counter
-	ProcessorAcceptedMetricPoints metric.Int64Counter
-	ProcessorAcceptedSpans        metric.Int64Counter
-	ProcessorRefusedLogRecords    metric.Int64Counter
-	ProcessorRefusedMetricPoints  metric.Int64Counter
-	ProcessorRefusedSpans         metric.Int64Counter
+	meter                                 metric.Meter
+	mu                                    sync.Mutex
+	registrations                         []metric.Registration
+	ProcessorAcceptedLogRecords           metric.Int64Counter
+	ProcessorAcceptedMetricPoints         metric.Int64Counter
+	ProcessorAcceptedSpans                metric.Int64Counter
+	ProcessorMemoryLimiterLimitBytes      metric.Int64Gauge
+	ProcessorMemoryLimiterSpikeLimitBytes metric.Int64Gauge
+	ProcessorRefusedLogRecords            metric.Int64Counter
+	ProcessorRefusedMetricPoints          metric.Int64Counter
+	ProcessorRefusedSpans                 metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -79,6 +81,18 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_processor_accepted_spans",
 		metric.WithDescription("Number of spans successfully pushed into the next component in the pipeline. [Deprecated]"),
 		metric.WithUnit("{span}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ProcessorMemoryLimiterLimitBytes, err = builder.meter.Int64Gauge(
+		"otelcol_processor_memory_limiter_limit_bytes",
+		metric.WithDescription("The hard memory limit (in bytes) configured on this memory limiter processor instance, derived from limit_mib or limit_percentage * total_memory. Useful as a static denominator for capacity utilization dashboards. [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ProcessorMemoryLimiterSpikeLimitBytes, err = builder.meter.Int64Gauge(
+		"otelcol_processor_memory_limiter_spike_limit_bytes",
+		metric.WithDescription("The spike (soft) memory limit (in bytes) configured on this memory limiter processor instance. The processor starts refusing data when Alloc >= (limit - spike). This is the soft threshold. [Development]"),
+		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorRefusedLogRecords, err = builder.meter.Int64Counter(

--- a/processor/memorylimiterprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/memorylimiterprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -70,6 +70,34 @@ func AssertEqualProcessorAcceptedSpans(t *testing.T, tt *componenttest.Telemetry
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualProcessorMemoryLimiterLimitBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_processor_memory_limiter_limit_bytes",
+		Description: "The hard memory limit (in bytes) configured on this memory limiter processor instance, derived from limit_mib or limit_percentage * total_memory. Useful as a static denominator for capacity utilization dashboards. [Development]",
+		Unit:        "By",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_processor_memory_limiter_limit_bytes")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualProcessorMemoryLimiterSpikeLimitBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_processor_memory_limiter_spike_limit_bytes",
+		Description: "The spike (soft) memory limit (in bytes) configured on this memory limiter processor instance. The processor starts refusing data when Alloc >= (limit - spike). This is the soft threshold. [Development]",
+		Unit:        "By",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_processor_memory_limiter_spike_limit_bytes")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualProcessorRefusedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_refused_log_records",

--- a/processor/memorylimiterprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/memorylimiterprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -22,6 +22,8 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ProcessorAcceptedLogRecords.Add(context.Background(), 1)
 	tb.ProcessorAcceptedMetricPoints.Add(context.Background(), 1)
 	tb.ProcessorAcceptedSpans.Add(context.Background(), 1)
+	tb.ProcessorMemoryLimiterLimitBytes.Record(context.Background(), 1)
+	tb.ProcessorMemoryLimiterSpikeLimitBytes.Record(context.Background(), 1)
 	tb.ProcessorRefusedLogRecords.Add(context.Background(), 1)
 	tb.ProcessorRefusedMetricPoints.Add(context.Background(), 1)
 	tb.ProcessorRefusedSpans.Add(context.Background(), 1)
@@ -32,6 +34,12 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorAcceptedSpans(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualProcessorMemoryLimiterLimitBytes(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualProcessorMemoryLimiterSpikeLimitBytes(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorRefusedLogRecords(t, testTel,

--- a/processor/memorylimiterprocessor/memorylimiter.go
+++ b/processor/memorylimiterprocessor/memorylimiter.go
@@ -17,8 +17,17 @@ import (
 	"go.opentelemetry.io/collector/processor"
 )
 
+type memoryLimiter interface {
+	Start(context.Context, component.Host) error
+	Shutdown(context.Context) error
+	CheckMemLimits()
+	MustRefuse() bool
+	AllocLimit() uint64
+	SpikeLimit() uint64
+}
+
 type memoryLimiterProcessor struct {
-	memlimiter *memorylimiter.MemoryLimiter
+	memlimiter memoryLimiter
 	obsrep     *obsReport
 }
 
@@ -42,7 +51,11 @@ func newMemoryLimiterProcessor(set processor.Settings, cfg *Config) (*memoryLimi
 }
 
 func (p *memoryLimiterProcessor) start(ctx context.Context, host component.Host) error {
-	return p.memlimiter.Start(ctx, host)
+	if err := p.memlimiter.Start(ctx, host); err != nil {
+		return err
+	}
+	p.obsrep.recordLimits(ctx, p.memlimiter.AllocLimit(), p.memlimiter.SpikeLimit())
+	return nil
 }
 
 func (p *memoryLimiterProcessor) shutdown(ctx context.Context) error {

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -5,6 +5,7 @@ package memorylimiterprocessor
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"testing"
 	"time"
@@ -32,6 +33,42 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper"
 	"go.opentelemetry.io/collector/processor/processortest"
 )
+
+type stubMemoryLimiter struct {
+	startErr   error
+	allocLimit uint64
+	spikeLimit uint64
+}
+
+func (s stubMemoryLimiter) Start(context.Context, component.Host) error {
+	return s.startErr
+}
+
+func (stubMemoryLimiter) Shutdown(context.Context) error {
+	return nil
+}
+
+func (stubMemoryLimiter) CheckMemLimits() {}
+
+func (stubMemoryLimiter) MustRefuse() bool {
+	return false
+}
+
+func (s stubMemoryLimiter) AllocLimit() uint64 {
+	return s.allocLimit
+}
+
+func (s stubMemoryLimiter) SpikeLimit() uint64 {
+	return s.spikeLimit
+}
+
+func mustNewObsReport(t *testing.T, set processor.Settings) *obsReport {
+	t.Helper()
+
+	obsrep, err := newObsReport(set)
+	require.NoError(t, err)
+	return obsrep
+}
 
 func TestNoDataLoss(t *testing.T) {
 	// Create an exporter.
@@ -237,6 +274,51 @@ func TestMetricsTelemetry(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp())
 
+	require.NoError(t, tel.Shutdown(context.Background()))
+}
+
+func TestRecordsConfiguredLimitMetricsOnStart(t *testing.T) {
+	tel := componenttest.NewTelemetry()
+	cfg := &Config{
+		CheckInterval:       time.Second,
+		MemoryLimitMiB:      512,
+		MemorySpikeLimitMiB: 128,
+	}
+
+	ml, err := newMemoryLimiterProcessor(metadatatest.NewSettings(tel), cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, ml.start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, ml.shutdown(context.Background()))
+
+	expected := []metricdata.DataPoint[int64]{
+		{
+			Value:      512 * 1024 * 1024,
+			Attributes: attribute.NewSet(attribute.String("processor", "memory_limiter")),
+		},
+	}
+	metadatatest.AssertEqualProcessorMemoryLimiterLimitBytes(t, tel, expected, metricdatatest.IgnoreTimestamp())
+
+	expected = []metricdata.DataPoint[int64]{
+		{
+			Value:      128 * 1024 * 1024,
+			Attributes: attribute.NewSet(attribute.String("processor", "memory_limiter")),
+		},
+	}
+	metadatatest.AssertEqualProcessorMemoryLimiterSpikeLimitBytes(t, tel, expected, metricdatatest.IgnoreTimestamp())
+
+	require.NoError(t, tel.Shutdown(context.Background()))
+}
+
+func TestStartPropagatesMemoryLimiterError(t *testing.T) {
+	tel := componenttest.NewTelemetry()
+	p := &memoryLimiterProcessor{
+		memlimiter: stubMemoryLimiter{startErr: errors.New("start failed")},
+		obsrep:     mustNewObsReport(t, metadatatest.NewSettings(tel)),
+	}
+
+	err := p.start(context.Background(), componenttest.NewNopHost())
+	require.EqualError(t, err, "start failed")
 	require.NoError(t, tel.Shutdown(context.Background()))
 }
 

--- a/processor/memorylimiterprocessor/metadata.yaml
+++ b/processor/memorylimiterprocessor/metadata.yaml
@@ -54,6 +54,22 @@ telemetry:
         value_type: int
         monotonic: true
 
+    processor_memory_limiter_limit_bytes:
+      enabled: true
+      description: The hard memory limit (in bytes) configured on this memory limiter processor instance, derived from limit_mib or limit_percentage * total_memory. Useful as a static denominator for capacity utilization dashboards.
+      stability: development
+      unit: "By"
+      gauge:
+        value_type: int
+
+    processor_memory_limiter_spike_limit_bytes:
+      enabled: true
+      description: The spike (soft) memory limit (in bytes) configured on this memory limiter processor instance. The processor starts refusing data when Alloc >= (limit - spike). This is the soft threshold.
+      stability: development
+      unit: "By"
+      gauge:
+        value_type: int
+
     processor_refused_log_records:
       enabled: true
       description: Number of log records that were rejected by the next component in the pipeline.

--- a/processor/memorylimiterprocessor/obsreport.go
+++ b/processor/memorylimiterprocessor/obsreport.go
@@ -32,6 +32,21 @@ func newObsReport(set processor.Settings) (*obsReport, error) {
 	}, nil
 }
 
+// recordLimits records the configured hard and spike memory limits as gauges.
+// Call this once during processor Start, after the MemoryLimiter is initialized.
+func (or *obsReport) recordLimits(ctx context.Context, allocLimitBytes, spikeLimitBytes uint64) {
+	or.telemetryBuilder.ProcessorMemoryLimiterLimitBytes.Record(
+		ctx,
+		int64(allocLimitBytes),
+		or.otelAttrs,
+	)
+	or.telemetryBuilder.ProcessorMemoryLimiterSpikeLimitBytes.Record(
+		ctx,
+		int64(spikeLimitBytes),
+		or.otelAttrs,
+	)
+}
+
 // accepted reports that the num data was accepted.
 func (or *obsReport) accepted(ctx context.Context, num int, signal pipeline.Signal) {
 	switch signal {


### PR DESCRIPTION
#### Description

Adds two new self-telemetry gauges to the memory limiter processor:

- `otelcol_processor_memory_limiter_limit_bytes`
- `otelcol_processor_memory_limiter_spike_limit_bytes`

These expose the processor's effective hard and spike memory budgets in bytes so dashboards can
compute utilization from resolved absolute limits. This is especially useful when the processor is
configured with percentage-based limits, because the resolved denominator is now available at query
time.

The change adds the metric definitions, records them once during processor startup after the memory
limits are resolved, updates generated telemetry/documentation files, and adds a unit test covering
the new startup metrics.

This also makes utilization queries straightforward. For the hard limit:

```promql
otelcol_process_runtime_heap_alloc_bytes
/
otelcol_processor_memory_limiter_limit_bytes
* 100
```

For the soft threshold:

```promql
otelcol_process_runtime_heap_alloc_bytes
/
(
  otelcol_processor_memory_limiter_limit_bytes
  -
  otelcol_processor_memory_limiter_spike_limit_bytes
)
* 100
```

#### Link to tracking issue
Fixes #

#### Testing

- Ran `go test ./...` in `processor/memorylimiterprocessor`
- Ran `go test ./...` in `internal/memorylimiter`
- Ran `make chlog-validate`
- Ran `make -C processor impi`
- Added a unit test that starts a memory limiter processor configured with `limit_mib: 512` and
  `spike_limit_mib: 128` and verifies the new gauges are recorded in bytes

#### Documentation

- Regenerated `processor/memorylimiterprocessor/documentation.md` to include the two new metrics
- Added a `.chloggen` entry for the new memory limiter self-telemetry metrics