### PR TITLE
[mdatagen] Ensure no conflict across extra_attributes in related entity refs

### DIFF
--- a/.chloggen/mdatagen-ensure-no-extra-attributes-conflict.yaml
+++ b/.chloggen/mdatagen-ensure-no-extra-attributes-conflict.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Validate that no two related entity definitions share the same `extra_attributes` resource attribute reference.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15012]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -178,6 +178,17 @@ func (md *Metadata) validateEntities() error {
 	usedAttrs := make(map[AttributeName]string)
 	seenTypes := make(map[string]bool)
 
+	// Pre-build a set of related entity pairs (undirected) from all relationships.
+	type entityPair struct{ a, b string }
+	relatedPairs := make(map[entityPair]bool)
+	for _, entity := range md.Entities {
+		for _, rel := range entity.Relationships {
+			relatedPairs[entityPair{entity.Type, rel.Target}] = true
+			relatedPairs[entityPair{rel.Target, entity.Type}] = true
+		}
+	}
+	usedExtraAttrs := make(map[AttributeName]string)
+
 	// First pass: collect entity types and validate basic entity properties
 	for _, entity := range md.Entities {
 		if entity.Type == "" {
@@ -218,6 +229,13 @@ func (md *Metadata) validateEntities() error {
 		for _, ref := range entity.ExtraAttributes {
 			if _, ok := md.ResourceAttributes[ref.Ref]; !ok {
 				errs = errors.Join(errs, fmt.Errorf(`entity "%v": extra_attributes refers to undefined resource attribute: %v`, entity.Type, ref.Ref))
+			}
+			if otherEntity, used := usedExtraAttrs[ref.Ref]; used {
+				if relatedPairs[entityPair{entity.Type, otherEntity}] {
+					errs = errors.Join(errs, fmt.Errorf(`entity "%v": extra_attributes attribute %v is already used by related entity "%v"`, entity.Type, ref.Ref, otherEntity))
+				}
+			} else {
+				usedExtraAttrs[ref.Ref] = entity.Type
 			}
 		}
 	}

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -136,6 +136,10 @@ func TestValidate(t *testing.T) {
 			wantErr: `attribute host.name is already used by entity`,
 		},
 		{
+			name:    "testdata/entity_extra_attributes_conflict.yaml",
+			wantErr: `extra_attributes attribute k8s.namespace.name is already used by related entity`,
+		},
+		{
 			name:    "testdata/entity_duplicate_types.yaml",
 			wantErr: `duplicate entity type: host`,
 		},

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -21,11 +21,11 @@ type TargetsItem struct {
 func (c *TargetsItem) Validate() error {
 	var err error
 
-	if c.Options == nil || len(c.Options) == 0 {
-		err = errors.Join(err, errors.New("options is required"))
-	}
 	if c.HTTPClient == nil {
 		err = errors.Join(err, errors.New("http_client is required"))
+	}
+	if c.Options == nil || len(c.Options) == 0 {
+		err = errors.Join(err, errors.New("options is required"))
 	}
 
 	return err

--- a/cmd/mdatagen/internal/testdata/entity_extra_attributes_conflict.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_extra_attributes_conflict.yaml
@@ -1,0 +1,44 @@
+type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+
+resource_attributes:
+  host.id:
+    description: The host identifier
+    type: string
+    enabled: true
+  host.name:
+    description: The hostname
+    type: string
+    enabled: true
+  process.pid:
+    description: The process identifier
+    type: int
+    enabled: true
+  k8s.namespace.name:
+    description: The name of the Kubernetes Namespace
+    type: string
+    enabled: true
+
+entities:
+  - type: host
+    brief: A host instance.
+    stability: stable
+    identity:
+      - ref: host.id
+    description:
+      - ref: host.name
+    extra_attributes:
+      - ref: k8s.namespace.name
+  - type: process
+    brief: A process instance.
+    stability: stable
+    identity:
+      - ref: process.pid
+    extra_attributes:
+      - ref: k8s.namespace.name
+    relationships:
+      - type: runs_on
+        target: host


### PR DESCRIPTION
Validate that no two related entity definitions share the same `extra_attributes` resource attribute reference.
