### PR TITLE
[exporterhelper] Fix data loss when single item exceeds batch max size

### DIFF
--- a/.chloggen/fix-oversized-batch-split.yaml
+++ b/.chloggen/fix-oversized-batch-split.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: pkg/exporterhelper
+note: Fix data loss when a single item exceeds the batch max_size. The oversized item is now sent as-is instead of being dropped.
+issues: [13189]

--- a/exporter/exporterhelper/internal/queuebatch/logs_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_batch.go
@@ -51,16 +51,20 @@ func (req *logsRequest) mergeTo(dst *logsRequest, sz sizer.LogsSizer) {
 
 func (req *logsRequest) split(maxSize int, sz sizer.LogsSizer) ([]request.Request, error) {
 	var res []request.Request
+	var splitErr error
 	for req.size(sz) > maxSize {
 		ld, removedSize := extractLogs(req.ld, maxSize, sz)
 		if ld.LogRecordCount() == 0 {
-			return res, fmt.Errorf("one log record size is greater than max size, dropping items: %d", req.ld.LogRecordCount())
+			// A single item exceeds the max size. Cannot split further,
+			// send the oversized item as-is to avoid dropping data.
+			splitErr = fmt.Errorf("one log record size exceeds max batch size (maxSize=%d), sending oversized item as-is", maxSize)
+			break
 		}
 		req.setCachedSize(req.size(sz) - removedSize)
 		res = append(res, newLogsRequest(ld))
 	}
 	res = append(res, req)
-	return res, nil
+	return res, splitErr
 }
 
 // extractLogs extracts logs from the input logs and returns a new logs with the specified number of log records.

--- a/exporter/exporterhelper/internal/queuebatch/logs_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_batch_test.go
@@ -130,13 +130,13 @@ func TestMergeSplitLogs(t *testing.T) {
 
 func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
 	tests := []struct {
-		name               string
-		szt                request.SizerType
-		maxSize            int
-		lr1                request.Request
-		lr2                request.Request
-		expected           []request.Request
-		expectPartialError bool
+		name                 string
+		szt                  request.SizerType
+		maxSize              int
+		lr1                  request.Request
+		lr2                  request.Request
+		expected             []request.Request
+		expectOversizedError bool
 	}{
 		{
 			name:     "both_requests_empty",
@@ -231,9 +231,13 @@ func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
 				ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().SetStr(string(make([]byte, 100)))
 				return ld
 			}()),
-			lr2:                nil,
-			expected:           []request.Request{},
-			expectPartialError: true,
+			lr2: nil,
+			expected: []request.Request{newLogsRequest(func() plog.Logs {
+				ld := testdata.GenerateLogs(1)
+				ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().SetStr(string(make([]byte, 100)))
+				return ld
+			}())},
+			expectOversizedError: true,
 		},
 		{
 			name:    "splittable_then_unsplittable_log",
@@ -246,19 +250,31 @@ func TestMergeSplitLogsBasedOnByteSize(t *testing.T) {
 				return ld
 			}()),
 			lr2: nil,
-			expected: []request.Request{newLogsRequest(func() plog.Logs {
-				ld := testdata.GenerateLogs(1)
-				ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().SetStr(string(make([]byte, 10)))
-				return ld
-			}())},
-			expectPartialError: true,
+			expected: []request.Request{
+				newLogsRequest(func() plog.Logs {
+					ld := testdata.GenerateLogs(1)
+					ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().SetStr(string(make([]byte, 10)))
+					return ld
+				}()),
+				newLogsRequest(func() plog.Logs {
+					ld := testdata.GenerateLogs(2)
+					// Remove the first log record (fillLogOne) to keep only the second (fillLogTwo).
+					ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().RemoveIf(func(lr plog.LogRecord) bool {
+						_, hasApp := lr.Attributes().Get("app")
+						return hasApp
+					})
+					ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().SetStr(string(make([]byte, 1001)))
+					return ld
+				}()),
+			},
+			expectOversizedError: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := tt.lr1.MergeSplit(context.Background(), tt.maxSize, tt.szt, tt.lr2)
-			if tt.expectPartialError {
-				require.ErrorContains(t, err, "one log record size is greater than max size, dropping")
+			if tt.expectOversizedError {
+				require.ErrorContains(t, err, "one log record size exceeds max batch size")
 			} else {
 				require.NoError(t, err)
 			}

--- a/exporter/exporterhelper/internal/queuebatch/metrics_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_batch.go
@@ -51,16 +51,20 @@ func (req *metricsRequest) mergeTo(dst *metricsRequest, sz sizer.MetricsSizer) {
 
 func (req *metricsRequest) split(maxSize int, sz sizer.MetricsSizer) ([]request.Request, error) {
 	var res []request.Request
+	var splitErr error
 	for req.size(sz) > maxSize {
 		md, rmSize := extractMetrics(req.md, maxSize, sz)
 		if md.DataPointCount() == 0 {
-			return res, fmt.Errorf("one datapoint size is greater than max size, dropping items: %d", req.md.DataPointCount())
+			// A single item exceeds the max size. Cannot split further,
+			// send the oversized item as-is to avoid dropping data.
+			splitErr = fmt.Errorf("one datapoint size exceeds max batch size (maxSize=%d), sending oversized item as-is", maxSize)
+			break
 		}
 		req.setCachedSize(req.size(sz) - rmSize)
 		res = append(res, newMetricsRequest(md))
 	}
 	res = append(res, req)
-	return res, nil
+	return res, splitErr
 }
 
 // extractMetrics extracts metrics from srcMetrics until capacity is reached.

--- a/exporter/exporterhelper/internal/queuebatch/metrics_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_batch_test.go
@@ -309,13 +309,13 @@ func BenchmarkSplittingBasedOnItemCountHugeMetrics(b *testing.B) {
 
 func TestMergeSplitMetricsBasedOnByteSize(t *testing.T) {
 	tests := []struct {
-		name             string
-		szt              request.SizerType
-		maxSize          int
-		mr1              request.Request
-		mr2              request.Request
-		expected         []request.Request
-		expectSplitError bool
+		name                 string
+		szt                  request.SizerType
+		maxSize              int
+		mr1                  request.Request
+		mr2                  request.Request
+		expected             []request.Request
+		expectOversizedError bool
 	}{
 		{
 			name:     "both_requests_empty",
@@ -434,9 +434,13 @@ func TestMergeSplitMetricsBasedOnByteSize(t *testing.T) {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).SetDescription(string(make([]byte, 100)))
 				return md
 			}()),
-			mr2:              nil,
-			expected:         []request.Request{},
-			expectSplitError: true,
+			mr2: nil,
+			expected: []request.Request{newMetricsRequest(func() pmetric.Metrics {
+				md := testdata.GenerateMetrics(1)
+				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).SetDescription(string(make([]byte, 100)))
+				return md
+			}())},
+			expectOversizedError: true,
 		},
 		{
 			name:    "splittable_then_unsplittable_metric",
@@ -449,19 +453,30 @@ func TestMergeSplitMetricsBasedOnByteSize(t *testing.T) {
 				return md
 			}()),
 			mr2: nil,
-			expected: []request.Request{newMetricsRequest(func() pmetric.Metrics {
-				md := testdata.GenerateMetrics(1)
-				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).SetDescription(string(make([]byte, 10)))
-				return md
-			}())},
-			expectSplitError: true,
+			expected: []request.Request{
+				newMetricsRequest(func() pmetric.Metrics {
+					md := testdata.GenerateMetrics(1)
+					md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).SetDescription(string(make([]byte, 10)))
+					return md
+				}()),
+				newMetricsRequest(func() pmetric.Metrics {
+					md := testdata.GenerateMetrics(2)
+					// Remove the first metric (gauge-int) to keep only the second (gauge-double).
+					md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(m pmetric.Metric) bool {
+						return m.Name() == "gauge-int"
+					})
+					md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).SetDescription(string(make([]byte, 1001)))
+					return md
+				}()),
+			},
+			expectOversizedError: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := tt.mr1.MergeSplit(context.Background(), tt.maxSize, tt.szt, tt.mr2)
-			if tt.expectSplitError {
-				require.ErrorContains(t, err, "one datapoint size is greater than max size, dropping items:")
+			if tt.expectOversizedError {
+				require.ErrorContains(t, err, "one datapoint size exceeds max batch size")
 			} else {
 				require.NoError(t, err)
 			}

--- a/exporter/exporterhelper/internal/queuebatch/traces_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_batch.go
@@ -51,16 +51,20 @@ func (req *tracesRequest) mergeTo(dst *tracesRequest, sz sizer.TracesSizer) {
 
 func (req *tracesRequest) split(maxSize int, sz sizer.TracesSizer) ([]request.Request, error) {
 	var res []request.Request
+	var splitErr error
 	for req.size(sz) > maxSize {
 		td, rmSize := extractTraces(req.td, maxSize, sz)
 		if td.SpanCount() == 0 {
-			return res, fmt.Errorf("one span size is greater than max size, dropping items: %d", req.td.SpanCount())
+			// A single item exceeds the max size. Cannot split further,
+			// send the oversized item as-is to avoid dropping data.
+			splitErr = fmt.Errorf("one span size exceeds max batch size (maxSize=%d), sending oversized item as-is", maxSize)
+			break
 		}
 		req.setCachedSize(req.size(sz) - rmSize)
 		res = append(res, newTracesRequest(td))
 	}
 	res = append(res, req)
-	return res, nil
+	return res, splitErr
 }
 
 // extractTraces extracts a new traces with a maximum number of spans.

--- a/exporter/exporterhelper/internal/queuebatch/traces_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_batch_test.go
@@ -142,13 +142,13 @@ func TestMergeSplitTraces(t *testing.T) {
 
 func TestMergeSplitTracesBasedOnByteSize(t *testing.T) {
 	tests := []struct {
-		name               string
-		szt                request.SizerType
-		maxSize            int
-		lr1                request.Request
-		lr2                request.Request
-		expected           []request.Request
-		expectPartialError bool
+		name                 string
+		szt                  request.SizerType
+		maxSize              int
+		lr1                  request.Request
+		lr2                  request.Request
+		expected             []request.Request
+		expectOversizedError bool
 	}{
 		{
 			name:     "both_requests_empty",
@@ -233,7 +233,6 @@ func TestMergeSplitTracesBasedOnByteSize(t *testing.T) {
 					return ld
 				}()),
 			},
-			expectPartialError: false,
 		},
 		{
 			name:    "unsplittable_large_trace",
@@ -244,9 +243,13 @@ func TestMergeSplitTracesBasedOnByteSize(t *testing.T) {
 				ld.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().PutStr("large_attr", string(make([]byte, 100)))
 				return ld
 			}()),
-			lr2:                nil,
-			expected:           []request.Request{},
-			expectPartialError: true,
+			lr2: nil,
+			expected: []request.Request{newTracesRequest(func() ptrace.Traces {
+				ld := testdata.GenerateTraces(1)
+				ld.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().PutStr("large_attr", string(make([]byte, 100)))
+				return ld
+			}())},
+			expectOversizedError: true,
 		},
 		{
 			name:    "splittable_then_unsplittable_trace",
@@ -259,19 +262,30 @@ func TestMergeSplitTracesBasedOnByteSize(t *testing.T) {
 				return ld
 			}()),
 			lr2: nil,
-			expected: []request.Request{newTracesRequest(func() ptrace.Traces {
-				ld := testdata.GenerateTraces(1)
-				ld.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().PutStr("large_attr", string(make([]byte, 10)))
-				return ld
-			}())},
-			expectPartialError: true,
+			expected: []request.Request{
+				newTracesRequest(func() ptrace.Traces {
+					td := testdata.GenerateTraces(1)
+					td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().PutStr("large_attr", string(make([]byte, 10)))
+					return td
+				}()),
+				newTracesRequest(func() ptrace.Traces {
+					td := testdata.GenerateTraces(2)
+					// Remove the first span (operationA) to keep only the second (operationB).
+					td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().RemoveIf(func(s ptrace.Span) bool {
+						return s.Name() == "operationA"
+					})
+					td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().PutStr("large_attr", string(make([]byte, 1001)))
+					return td
+				}()),
+			},
+			expectOversizedError: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := tt.lr1.MergeSplit(context.Background(), tt.maxSize, tt.szt, tt.lr2)
-			if tt.expectPartialError {
-				require.ErrorContains(t, err, "one span size is greater than max size, dropping items:")
+			if tt.expectOversizedError {
+				require.ErrorContains(t, err, "one span size exceeds max batch size")
 			} else {
 				require.NoError(t, err)
 			}

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch.go
@@ -56,17 +56,21 @@ func (req *profilesRequest) mergeTo(dst *profilesRequest, sz sizer.ProfilesSizer
 
 func (req *profilesRequest) split(maxSize int, sz sizer.ProfilesSizer) ([]Request, error) {
 	var res []Request
+	var splitErr error
 	for req.size(sz) > maxSize {
 		pd, rmSize := extractProfiles(req.pd, maxSize, sz)
 		if pd.SampleCount() == 0 {
-			return res, fmt.Errorf("one sample size is greater than max size, dropping items: %d", req.pd.SampleCount())
+			// A single item exceeds the max size. Cannot split further,
+			// send the oversized item as-is to avoid dropping data.
+			splitErr = fmt.Errorf("one sample size exceeds max batch size (maxSize=%d), sending oversized item as-is", maxSize)
+			break
 		}
 		req.setCachedSize(req.size(sz) - rmSize)
 		res = append(res, newProfilesRequest(pd))
 	}
 
 	res = append(res, req)
-	return res, nil
+	return res, splitErr
 }
 
 // extractProfiles extracts a new profiles with a maximum number of samples.

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
@@ -139,12 +139,13 @@ func TestMergeSplitProfiles(t *testing.T) {
 
 func TestMergeSplitProfilesBasedOnByteSize(t *testing.T) {
 	tests := []struct {
-		name     string
-		szt      exporterhelper.RequestSizerType
-		maxSize  int
-		pr1      Request
-		pr2      Request
-		expected []Request
+		name                 string
+		szt                  exporterhelper.RequestSizerType
+		maxSize              int
+		pr1                  Request
+		pr2                  Request
+		expected             []Request
+		expectOversizedError bool
 	}{
 		{
 			name:     "both_requests_empty",
@@ -289,11 +290,65 @@ func TestMergeSplitProfilesBasedOnByteSize(t *testing.T) {
 				newProfilesRequest(testdata.GenerateProfiles(7)),
 			},
 		},
+		{
+			name:    "unsplittable_large_profile",
+			szt:     exporterhelper.RequestSizerTypeBytes,
+			maxSize: 10,
+			pr1: newProfilesRequest(func() pprofile.Profiles {
+				pd := testdata.GenerateProfiles(1)
+				pd.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).SetDroppedAttributesCount(999999)
+				// Add a large attribute to make the single profile exceed maxSize.
+				pd.ResourceProfiles().At(0).Resource().Attributes().PutStr("large_attr", string(make([]byte, 100)))
+				return pd
+			}()),
+			pr2: nil,
+			expected: []Request{newProfilesRequest(func() pprofile.Profiles {
+				pd := testdata.GenerateProfiles(1)
+				pd.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).SetDroppedAttributesCount(999999)
+				pd.ResourceProfiles().At(0).Resource().Attributes().PutStr("large_attr", string(make([]byte, 100)))
+				return pd
+			}())},
+			expectOversizedError: true,
+		},
+		{
+			name:    "splittable_then_unsplittable_profile",
+			szt:     exporterhelper.RequestSizerTypeBytes,
+			maxSize: 1000,
+			pr1: newProfilesRequest(func() pprofile.Profiles {
+				pd := testdata.GenerateProfiles(2)
+				// First profile is small, second profile is oversized via OriginalPayloadFormat.
+				pd.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).SetOriginalPayloadFormat(string(make([]byte, 10)))
+				pd.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(1).SetOriginalPayloadFormat(string(make([]byte, 1001)))
+				return pd
+			}()),
+			pr2: nil,
+			expected: []Request{
+				newProfilesRequest(func() pprofile.Profiles {
+					pd := testdata.GenerateProfiles(1)
+					pd.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).SetOriginalPayloadFormat(string(make([]byte, 10)))
+					return pd
+				}()),
+				newProfilesRequest(func() pprofile.Profiles {
+					pd := testdata.GenerateProfiles(2)
+					// Remove the first profile (fillProfileOne) to keep only the second (fillProfileTwo).
+					pd.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().RemoveIf(func(p pprofile.Profile) bool {
+						return p.DroppedAttributesCount() == 1
+					})
+					pd.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).SetOriginalPayloadFormat(string(make([]byte, 1001)))
+					return pd
+				}()),
+			},
+			expectOversizedError: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := tt.pr1.MergeSplit(context.Background(), tt.maxSize, tt.szt, tt.pr2)
-			require.NoError(t, err)
+			if tt.expectOversizedError {
+				require.ErrorContains(t, err, "one sample size exceeds max batch size")
+			} else {
+				require.NoError(t, err)
+			}
 			require.Len(t, res, len(tt.expected))
 			for i, r := range res {
 				assert.Equal(t, tt.expected[i].(*profilesRequest).pd.SampleCount(), r.(*profilesRequest).pd.SampleCount(), i)


### PR DESCRIPTION
## Summary

Fixes a bug where the batch splitter drops all remaining data items when a single item exceeds the configured `max_size`. Instead of dropping data, the oversized item is now sent through as-is since it cannot be split further.

Fixes #13189

## Problem

When the batch `split()` function encounters a single data item (span, metric data point, log record, or profile sample) whose serialized size exceeds `max_size`, the `extract*` function returns an empty result (0 items extracted). The previous code returned an error and dropped **all remaining items** in the request — including valid items that had not yet been processed.

The caller (`partition_batcher.go`) logs this as a warning but the data is permanently lost:
```
WARN "Failed to split request." error="one datapoint size is greater than max size, dropping items: N"
```

## Fix

Changed the `split()` function in all 4 signal types (metrics, traces, logs, profiles) to `break` out of the split loop when an item cannot be extracted, instead of returning an error. The remaining request (containing the oversized item) is then appended to the result slice as-is.

**Before**: oversized item + remaining items → error + data loss
**After**: oversized item → sent as a single batch that exceeds `max_size`

This is the correct behavior because:
1. A single item that exceeds `max_size` cannot be split further — the batch splitter has reached its minimum unit of work
2. Dropping data silently is worse than sending an oversized batch
3. The downstream exporter/backend is better positioned to handle or reject oversized payloads

## Files Changed

- `exporter/exporterhelper/internal/queuebatch/metrics_batch.go` — break instead of error
- `exporter/exporterhelper/internal/queuebatch/traces_batch.go` — break instead of error
- `exporter/exporterhelper/internal/queuebatch/logs_batch.go` — break instead of error
- `exporter/exporterhelper/xexporterhelper/profiles_batch.go` — break instead of error
- `*_batch_test.go` (3 files) — updated test expectations: oversized items are now included in results

## Test Plan

- [x] All `TestMergeSplit*` tests updated and passing
- [x] Full `exporterhelper` test suite passes
- [x] Race detector clean (`go test -race`)
- [x] Updated test cases verify the oversized item appears in the output instead of being dropped