### PR TITLE
[exporterhelper] Improve retry sender log message clarity

### DIFF
--- a/.chloggen/improve-retry-sender-log-message.yaml
+++ b/.chloggen/improve-retry-sender-log-message.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: exporter/exporterhelper
+note: Improve retry sender log message to clarify the error is transient and include retry count.
+issues: [13943]

--- a/.chloggen/improve-retry-sender-log-message.yaml
+++ b/.chloggen/improve-retry-sender-log-message.yaml
@@ -1,4 +1,4 @@
 change_type: bug_fix
-component: exporter/exporterhelper
+component: pkg/exporterhelper
 note: Improve retry sender log message to clarify the error is transient and include retry count.
 issues: [13943]

--- a/exporter/exporterhelper/internal/retry_sender.go
+++ b/exporter/exporterhelper/internal/retry_sender.go
@@ -124,18 +124,20 @@ func (rs *retrySender) Send(ctx context.Context, req request.Request) error {
 			return fmt.Errorf("request will be cancelled before next retry: %w", err)
 		}
 
+		retryNum++
 		backoffDelayStr := backoffDelay.String()
 		span.AddEvent(
-			"Exporting failed. Will retry the request after interval.",
+			"Transient error, will retry the request after interval.",
 			trace.WithAttributes(
 				attribute.String("interval", backoffDelayStr),
+				attribute.Int64("retry_num", retryNum),
 				attribute.String("error", err.Error())))
 		rs.logger.Info(
-			"Exporting failed. Will retry the request after interval.",
+			"Transient error, will retry the request after interval.",
 			zap.Error(err),
 			zap.String("interval", backoffDelayStr),
+			zap.Int64("retry_num", retryNum),
 		)
-		retryNum++
 
 		// back-off, but get interrupted when shutting down or request is cancelled or timed out.
 		select {

--- a/exporter/exporterhelper/internal/retry_sender.go
+++ b/exporter/exporterhelper/internal/retry_sender.go
@@ -127,13 +127,13 @@ func (rs *retrySender) Send(ctx context.Context, req request.Request) error {
 		retryNum++
 		backoffDelayStr := backoffDelay.String()
 		span.AddEvent(
-			"Transient error, will retry the request after interval.",
+			"Exporting failed. Transient error, will retry the request after interval.",
 			trace.WithAttributes(
 				attribute.String("interval", backoffDelayStr),
 				attribute.Int64("retry_num", retryNum),
 				attribute.String("error", err.Error())))
 		rs.logger.Info(
-			"Transient error, will retry the request after interval.",
+			"Exporting failed. Transient error, will retry the request after interval.",
 			zap.Error(err),
 			zap.String("interval", backoffDelayStr),
 			zap.Int64("retry_num", retryNum),

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -115,6 +115,7 @@ func TestRetrySenderWithContextTimeout(t *testing.T) {
 		"request will be cancelled before next retry: transient error")
 	assert.Len(t, observed.All(), 1)
 	assert.Equal(t, "Transient error, will retry the request after interval.", observed.All()[0].Message)
+	assert.Equal(t, int64(1), observed.All()[0].ContextMap()["retry_num"])
 	require.Less(t, time.Since(start), testTimeout/2)
 	require.NoError(t, rs.Shutdown(context.Background()))
 }

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -114,7 +114,7 @@ func TestRetrySenderWithContextTimeout(t *testing.T) {
 		rs.Send(ctx, &requesttest.FakeRequest{Items: 2}),
 		"request will be cancelled before next retry: transient error")
 	assert.Len(t, observed.All(), 1)
-	assert.Equal(t, "Transient error, will retry the request after interval.", observed.All()[0].Message)
+	assert.Equal(t, "Exporting failed. Transient error, will retry the request after interval.", observed.All()[0].Message)
 	assert.Equal(t, int64(1), observed.All()[0].ContextMap()["retry_num"])
 	require.Less(t, time.Since(start), testTimeout/2)
 	require.NoError(t, rs.Shutdown(context.Background()))

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -114,7 +114,7 @@ func TestRetrySenderWithContextTimeout(t *testing.T) {
 		rs.Send(ctx, &requesttest.FakeRequest{Items: 2}),
 		"request will be cancelled before next retry: transient error")
 	assert.Len(t, observed.All(), 1)
-	assert.Equal(t, "Exporting failed. Will retry the request after interval.", observed.All()[0].Message)
+	assert.Equal(t, "Transient error, will retry the request after interval.", observed.All()[0].Message)
 	require.Less(t, time.Since(start), testTimeout/2)
 	require.NoError(t, rs.Shutdown(context.Background()))
 }


### PR DESCRIPTION
## Summary

Improves the retry sender log message to reduce user confusion about transient export failures.

Fixes #13943

## Problem

The current log message:
```
INFO "Exporting failed. Will retry the request after interval." error="rpc error: code = DeadlineExceeded desc = context deadline exceeded" interval="9.64s"
```

This causes concern because:
- "Exporting failed" sounds alarming — users cannot tell if data is being lost
- No indication that the error is **transient** and will be automatically retried
- No retry count to gauge how long the issue has persisted

## Fix

Changed the log message to:
```
INFO "Transient error, will retry the request after interval." error="..." interval="9.64s" retry_num=3
```

Changes:
1. **Message**: "Exporting failed. Will retry..." → "Transient error, will retry..." — immediately signals this is a recoverable, transient failure
2. **Added `retry_num`**: Shows which retry attempt this is, helping operators gauge severity
3. **Moved `retryNum++` before logging**: So the logged retry number is 1-based (first retry = 1)
4. **Span event updated**: Same improvements applied to the trace span event, plus `retry_num` attribute added

## Test Plan

- [x] `TestRetrySenderWithContextTimeout` updated to expect new message
- [x] All retry sender tests pass with `-race`