### PR TITLE
[service/telemetry] Fix Prometheus config defaults mismatch when host is explicitly set

### DIFF
--- a/.chloggen/fix-prometheus-config-defaults.yaml
+++ b/.chloggen/fix-prometheus-config-defaults.yaml
@@ -1,0 +1,10 @@
+change_type: bug_fix
+component: service/telemetry
+note: Fix Prometheus config defaults mismatch when host is explicitly set in telemetry configuration.
+subtext: |
+  When users explicitly configured the telemetry metrics section (e.g. to change the host),
+  the Prometheus exporter boolean fields (WithoutScopeInfo, WithoutUnits, WithoutTypeSuffix)
+  defaulted to nil/false instead of true, causing metric name format changes compared to the
+  implicit default configuration. This fix applies the correct defaults during config unmarshaling.
+issues: [13867]
+change_logs: [user]

--- a/.chloggen/fix-prometheus-config-defaults.yaml
+++ b/.chloggen/fix-prometheus-config-defaults.yaml
@@ -1,5 +1,5 @@
 change_type: bug_fix
-component: service/telemetry
+component: pkg/service
 note: Fix Prometheus config defaults mismatch when host is explicitly set in telemetry configuration.
 subtext: |
   When users explicitly configured the telemetry metrics section (e.g. to change the host),

--- a/internal/e2e/metric_stability_test.go
+++ b/internal/e2e/metric_stability_test.go
@@ -121,47 +121,47 @@ func TestMetricStability(t *testing.T) {
 			configFile: "metric_stability_test_readers.yaml",
 			expectedMetrics: map[string]bool{
 				// Process metrics
-				"otelcol_process_uptime_seconds_total":            false,
-				"otelcol_process_cpu_seconds_total":               false,
-				"otelcol_process_memory_rss_bytes":                false,
-				"otelcol_process_runtime_heap_alloc_bytes":        false,
-				"otelcol_process_runtime_total_alloc_bytes_total": false,
-				"otelcol_process_runtime_total_sys_memory_bytes":  false,
+				"otelcol_process_uptime":                         false,
+				"otelcol_process_cpu_seconds":                    false,
+				"otelcol_process_memory_rss":                     false,
+				"otelcol_process_runtime_heap_alloc_bytes":       false,
+				"otelcol_process_runtime_total_alloc_bytes":      false,
+				"otelcol_process_runtime_total_sys_memory_bytes": false,
 
 				// Batch processor metrics
-				"otelcol_processor_batch_batch_send_size":            false,
-				"otelcol_processor_batch_batch_send_size_bytes":      false,
-				"otelcol_processor_batch_metadata_cardinality":       false,
-				"otelcol_processor_batch_timeout_trigger_send_total": false,
+				"otelcol_processor_batch_batch_send_size":       false,
+				"otelcol_processor_batch_batch_send_size_bytes": false,
+				"otelcol_processor_batch_metadata_cardinality":  false,
+				"otelcol_processor_batch_timeout_trigger_send":  false,
 
 				// HTTP server metrics
-				"http_server_request_body_size_bytes":  false,
-				"http_server_request_duration_seconds": false,
-				"http_server_response_body_size_bytes": false,
+				"http_server_request_body_size":  false,
+				"http_server_request_duration":   false,
+				"http_server_response_body_size": false,
 
 				// Exporter metrics - Metrics
-				"otelcol_exporter_sent_metric_points_total":        false,
-				"otelcol_exporter_send_failed_metric_points_total": false,
+				"otelcol_exporter_sent_metric_points":        false,
+				"otelcol_exporter_send_failed_metric_points": false,
 
 				// Exporter metrics - Traces
-				"otelcol_exporter_sent_spans_total":        false,
-				"otelcol_exporter_send_failed_spans_total": false,
+				"otelcol_exporter_sent_spans":        false,
+				"otelcol_exporter_send_failed_spans": false,
 
 				// Exporter metrics - Logs
-				"otelcol_exporter_sent_log_records_total":        false,
-				"otelcol_exporter_send_failed_log_records_total": false,
+				"otelcol_exporter_sent_log_records":        false,
+				"otelcol_exporter_send_failed_log_records": false,
 
 				// Receiver metrics
-				"otelcol_receiver_accepted_metric_points_total": false,
-				"otelcol_receiver_refused_metric_points_total":  false,
+				"otelcol_receiver_accepted_metric_points": false,
+				"otelcol_receiver_refused_metric_points":  false,
 
 				// Receiver metrics - Traces
-				"otelcol_receiver_accepted_spans_total": false,
-				"otelcol_receiver_refused_spans_total":  false,
+				"otelcol_receiver_accepted_spans": false,
+				"otelcol_receiver_refused_spans":  false,
 
 				// Receiver metrics - Logs
-				"otelcol_receiver_accepted_log_records_total": false,
-				"otelcol_receiver_refused_log_records_total":  false,
+				"otelcol_receiver_accepted_log_records": false,
+				"otelcol_receiver_refused_log_records":  false,
 
 				// Other metrics
 				"promhttp_metric_handler_errors_total": false,

--- a/service/telemetry/otelconftelemetry/config_test.go
+++ b/service/telemetry/otelconftelemetry/config_test.go
@@ -96,6 +96,24 @@ func TestConfig(t *testing.T) {
 		"config_invalid_metrics_views_level.yaml": {
 			validateErr: `service::telemetry::metrics::views can only be set when service::telemetry::metrics::level is detailed`,
 		},
+		"config_prometheus_host_only.yaml": {
+			config: func() *Config {
+				cfg := createDefaultConfig().(*Config)
+				host := "[::0]"
+				cfg.Metrics.Readers = []config.MetricReader{
+					{
+						Pull: &config.PullMetricReader{Exporter: config.PullMetricExporter{Prometheus: &config.Prometheus{
+							WithoutScopeInfo:  ptr(true),
+							WithoutUnits:      ptr(true),
+							WithoutTypeSuffix: ptr(true),
+							Host:              &host,
+							Port:              ptr(8888),
+						}}},
+					},
+				}
+				return cfg
+			}(),
+		},
 	}
 
 	for filename, test := range tests {

--- a/service/telemetry/otelconftelemetry/internal/migration/testdata/v0.3.0_metrics_marshaled.yaml
+++ b/service/telemetry/otelconftelemetry/internal/migration/testdata/v0.3.0_metrics_marshaled.yaml
@@ -13,3 +13,6 @@ readers:
         prometheus:
           host: 127.0.0.1
           port: 8902
+          without_scope_info: true
+          without_type_suffix: true
+          without_units: true

--- a/service/telemetry/otelconftelemetry/internal/migration/testdata/v0.3.0_metrics_prom_explicit.yaml
+++ b/service/telemetry/otelconftelemetry/internal/migration/testdata/v0.3.0_metrics_prom_explicit.yaml
@@ -1,0 +1,10 @@
+level: normal
+readers:
+  - pull:
+      exporter:
+        prometheus:
+          host: 127.0.0.1
+          port: 8888
+          without_scope_info: false
+          without_units: false
+          without_type_suffix: false

--- a/service/telemetry/otelconftelemetry/internal/migration/v0.3.0.go
+++ b/service/telemetry/otelconftelemetry/internal/migration/v0.3.0.go
@@ -118,6 +118,12 @@ func (c *MetricsConfigV030) Unmarshal(conf *confmap.Conf) error {
 		// change the host), unset *bool fields default to nil which the
 		// Prometheus exporter treats as false. This ensures the defaults
 		// match the implicit/default configuration where these are true.
+		//
+		// This is necessary because specifying any metric readers in the
+		// SDK config completely overwrites the list of readers, so the
+		// Prometheus exporter is treated as a new config without any of
+		// the defaults set in the createDefaultConfig function in
+		// otelconftelemetry. We must re-apply those defaults here.
 		if r.Pull != nil && r.Pull.Exporter.Prometheus != nil {
 			applyPrometheusDefaults(r.Pull.Exporter.Prometheus)
 		}

--- a/service/telemetry/otelconftelemetry/internal/migration/v0.3.0.go
+++ b/service/telemetry/otelconftelemetry/internal/migration/v0.3.0.go
@@ -106,12 +106,20 @@ func (c *MetricsConfigV030) Unmarshal(conf *confmap.Conf) error {
 		c.MigratedFromV02 = true
 		return metricsConfigV02ToV03(v02, c)
 	}
-	// ensure endpoint normalization occurs
 	for _, r := range c.Readers {
+		// ensure endpoint normalization occurs
 		if r.Periodic != nil {
 			if r.Periodic.Exporter.OTLP != nil && r.Periodic.Exporter.OTLP.Endpoint != nil {
 				r.Periodic.Exporter.OTLP.Endpoint = normalizeEndpoint(*r.Periodic.Exporter.OTLP.Endpoint, r.Periodic.Exporter.OTLP.Insecure)
 			}
+		}
+		// Apply Prometheus exporter defaults for fields not explicitly set.
+		// When users explicitly configure the telemetry section (e.g. to
+		// change the host), unset *bool fields default to nil which the
+		// Prometheus exporter treats as false. This ensures the defaults
+		// match the implicit/default configuration where these are true.
+		if r.Pull != nil && r.Pull.Exporter.Prometheus != nil {
+			applyPrometheusDefaults(r.Pull.Exporter.Prometheus)
 		}
 	}
 	return nil
@@ -128,6 +136,24 @@ func (c MetricsConfigV030) Marshal(conf *confmap.Conf) error {
 	sm := conf.ToStringMap()
 	redactHeaders(sm, "readers.*.periodic.exporter.otlp.headers.*.value")
 	return conf.Marshal(sm)
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+// applyPrometheusDefaults sets default values for Prometheus exporter
+// fields that were not explicitly provided in the configuration.
+func applyPrometheusDefaults(p *config.Prometheus) {
+	if p.WithoutScopeInfo == nil {
+		p.WithoutScopeInfo = boolPtr(true)
+	}
+	if p.WithoutUnits == nil {
+		p.WithoutUnits = boolPtr(true)
+	}
+	if p.WithoutTypeSuffix == nil {
+		p.WithoutTypeSuffix = boolPtr(true)
+	}
 }
 
 type LogsConfigV030 struct {

--- a/service/telemetry/otelconftelemetry/internal/migration/v0.3.0_test.go
+++ b/service/telemetry/otelconftelemetry/internal/migration/v0.3.0_test.go
@@ -84,6 +84,35 @@ func TestUnmarshalMetricsConfigV030(t *testing.T) {
 	require.Equal(t, "https://127.0.0.1:4317", *cfg.Readers[0].Periodic.Exporter.OTLP.Endpoint)
 	// ensure migration flag is not set for native v0.3.0 config
 	require.False(t, cfg.MigratedFromV02)
+
+	// check that Prometheus exporter defaults are applied even when not explicitly set
+	prom := cfg.Readers[1].Pull.Exporter.Prometheus
+	require.NotNil(t, prom)
+	require.NotNil(t, prom.WithoutScopeInfo, "WithoutScopeInfo should default to non-nil")
+	require.True(t, *prom.WithoutScopeInfo, "WithoutScopeInfo should default to true")
+	require.NotNil(t, prom.WithoutUnits, "WithoutUnits should default to non-nil")
+	require.True(t, *prom.WithoutUnits, "WithoutUnits should default to true")
+	require.NotNil(t, prom.WithoutTypeSuffix, "WithoutTypeSuffix should default to non-nil")
+	require.True(t, *prom.WithoutTypeSuffix, "WithoutTypeSuffix should default to true")
+}
+
+func TestUnmarshalMetricsConfigV030_PrometheusExplicitFalse(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "v0.3.0_metrics_prom_explicit.yaml"))
+	require.NoError(t, err)
+
+	cfg := MetricsConfigV030{}
+	require.NoError(t, cm.Unmarshal(&cfg))
+	require.Len(t, cfg.Readers, 1)
+
+	// When explicitly set to false, values should remain false
+	prom := cfg.Readers[0].Pull.Exporter.Prometheus
+	require.NotNil(t, prom)
+	require.NotNil(t, prom.WithoutScopeInfo)
+	require.False(t, *prom.WithoutScopeInfo, "WithoutScopeInfo should be false when explicitly set")
+	require.NotNil(t, prom.WithoutUnits)
+	require.False(t, *prom.WithoutUnits, "WithoutUnits should be false when explicitly set")
+	require.NotNil(t, prom.WithoutTypeSuffix)
+	require.False(t, *prom.WithoutTypeSuffix, "WithoutTypeSuffix should be false when explicitly set")
 }
 
 func TestMarshalMetricsConfigV030(t *testing.T) {

--- a/service/telemetry/otelconftelemetry/testdata/config_prometheus_host_only.yaml
+++ b/service/telemetry/otelconftelemetry/testdata/config_prometheus_host_only.yaml
@@ -1,0 +1,21 @@
+logs:
+  level: info
+  development: false
+  encoding: console
+  sampling:
+    enabled: true
+    tick: 10s
+    initial: 10
+    thereafter: 100
+  output_paths:
+    - stderr
+  error_output_paths:
+    - stderr
+metrics:
+  level: normal
+  readers:
+    - pull:
+        exporter:
+          prometheus:
+            host: "[::0]"
+            port: 8888


### PR DESCRIPTION
#### Description

When a user explicitly configures the Prometheus endpoint in internal telemetry (e.g., to change the host), the `without_type_suffix`, `without_units`, and `without_scope_info` fields default to `nil`, which the Prometheus exporter treats as `false`. This diverges from the implicit defaults where all three are `true`.

This PR fixes `MetricsConfigV030.Unmarshal` to apply default values of `true` for those three fields when they are not explicitly set, ensuring the behavior is consistent whether or not the user explicitly configures the Prometheus exporter section.

Resolves #13867