### PR TITLE
enhancement(exporterhelper): include exporter IDs in failure logs

### DIFF
--- a/.chloggen/enhancement-exporterhelper-exporter-id-logs.yaml
+++ b/.chloggen/enhancement-exporterhelper-exporter-id-logs.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: pkg/exporterhelper
+note: Add exporter IDs to exporterhelper error and retry logs so failing exporters are easier to identify.
+issues: [9999]
+subtext: ""
+change_logs:
+  - user

--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -113,6 +113,7 @@ func (be *BaseExporter) Send(ctx context.Context, req request.Request) error {
 	err := be.firstSender.Send(ctx, req)
 	if err != nil {
 		be.Set.Logger.Error("Exporting failed. Rejecting data."+be.ExportFailureMessage,
+			zap.String("exporter", be.Set.ID.String()),
 			zap.Error(err), zap.Int("rejected_items", itemsCount))
 	}
 	return err

--- a/exporter/exporterhelper/internal/base_exporter_test.go
+++ b/exporter/exporterhelper/internal/base_exporter_test.go
@@ -65,6 +65,7 @@ func TestQueueOptionsWithRequestExporter(t *testing.T) {
 
 func TestBaseExporterLogging(t *testing.T) {
 	set := exportertest.NewNopSettings(exportertest.NopType)
+	set.ID = component.MustNewIDWithName(exportertest.NopType.String(), "with_name")
 	logger, observed := observer.New(zap.DebugLevel)
 	set.Logger = zap.New(logger)
 	rCfg := configretry.NewDefaultBackOffConfig()
@@ -83,8 +84,10 @@ func TestBaseExporterLogging(t *testing.T) {
 	errorLogs := observed.FilterLevelExact(zap.ErrorLevel).All()
 	require.Len(t, errorLogs, 2)
 	assert.Contains(t, errorLogs[0].Message, "Exporting failed. Dropping data.")
+	assert.Equal(t, "nop/with_name", errorLogs[0].ContextMap()["exporter"])
 	assert.Equal(t, "my error", errorLogs[0].ContextMap()["error"])
 	assert.Contains(t, errorLogs[1].Message, "Exporting failed. Rejecting data.")
+	assert.Equal(t, "nop/with_name", errorLogs[1].ContextMap()["exporter"])
 	assert.Equal(t, "my error", errorLogs[1].ContextMap()["error"])
 	require.NoError(t, bs.Shutdown(context.Background()))
 }

--- a/exporter/exporterhelper/internal/queue_sender.go
+++ b/exporter/exporterhelper/internal/queue_sender.go
@@ -48,6 +48,7 @@ func NewQueueSender(
 		itemsCount := req.ItemsCount()
 		if errSend := next.Send(ctx, req); errSend != nil {
 			qSet.Telemetry.Logger.Error("Exporting failed. Dropping data."+exportFailureMessage,
+				zap.String("exporter", qSet.ID.String()),
 				zap.Error(errSend), zap.Int("dropped_items", itemsCount))
 			return errSend
 		}

--- a/exporter/exporterhelper/internal/queue_sender_test.go
+++ b/exporter/exporterhelper/internal/queue_sender_test.go
@@ -42,6 +42,7 @@ func TestNewQueueSenderFailedRequestDropped(t *testing.T) {
 	require.NoError(t, be.Shutdown(context.Background()))
 	assert.Len(t, observed.All(), 1)
 	assert.Equal(t, "Exporting failed. Dropping data.", observed.All()[0].Message)
+	assert.Equal(t, "nop", observed.All()[0].ContextMap()["exporter"])
 }
 
 func TestQueueConfig_Validate(t *testing.T) {

--- a/exporter/exporterhelper/internal/retry_sender.go
+++ b/exporter/exporterhelper/internal/retry_sender.go
@@ -47,18 +47,20 @@ func NewThrottleRetry(err error, delay time.Duration) error {
 
 type retrySender struct {
 	component.StartFunc
-	cfg    configretry.BackOffConfig
-	stopCh chan struct{}
-	logger *zap.Logger
-	next   sender.Sender[request.Request]
+	cfg        configretry.BackOffConfig
+	stopCh     chan struct{}
+	exporterID string
+	logger     *zap.Logger
+	next       sender.Sender[request.Request]
 }
 
 func newRetrySender(config configretry.BackOffConfig, set exporter.Settings, next sender.Sender[request.Request]) *retrySender {
 	return &retrySender{
-		cfg:    config,
-		stopCh: make(chan struct{}),
-		logger: set.Logger,
-		next:   next,
+		cfg:        config,
+		stopCh:     make(chan struct{}),
+		exporterID: set.ID.String(),
+		logger:     set.Logger,
+		next:       next,
 	}
 }
 
@@ -132,6 +134,7 @@ func (rs *retrySender) Send(ctx context.Context, req request.Request) error {
 				attribute.String("error", err.Error())))
 		rs.logger.Info(
 			"Exporting failed. Will retry the request after interval.",
+			zap.String("exporter", rs.exporterID),
 			zap.Error(err),
 			zap.String("interval", backoffDelayStr),
 		)

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -103,6 +104,7 @@ func TestRetrySenderWithContextTimeout(t *testing.T) {
 	// Second attempt is at twice the testTimeout
 	rCfg.Multiplier = float64(2 * testTimeout / rCfg.InitialInterval)
 	set := exportertest.NewNopSettings(exportertest.NopType)
+	set.ID = component.MustNewIDWithName(exportertest.NopType.String(), "with_name")
 	logger, observed := observer.New(zap.InfoLevel)
 	set.Logger = zap.New(logger)
 	rs := newRetrySender(rCfg, set, sender.NewSender(func(context.Context, request.Request) error { return errors.New("transient error") }))
@@ -115,6 +117,8 @@ func TestRetrySenderWithContextTimeout(t *testing.T) {
 		"request will be cancelled before next retry: transient error")
 	assert.Len(t, observed.All(), 1)
 	assert.Equal(t, "Exporting failed. Will retry the request after interval.", observed.All()[0].Message)
+	assert.Equal(t, "nop/with_name", observed.All()[0].ContextMap()["exporter"])
+	assert.Equal(t, "100ms", observed.All()[0].ContextMap()["interval"])
 	require.Less(t, time.Since(start), testTimeout/2)
 	require.NoError(t, rs.Shutdown(context.Background()))
 }


### PR DESCRIPTION
#### Description

Add the exporter ID to exporterhelper failure logs so dropped exports and retry loops can be tied back to the failing exporter.

#### Testing

- `go test ./internal/...` in `exporter/exporterhelper`
- `make checklicense`
- `make misspell`
- `make checkdoc`
- `make markdownlint`
- `make chlog-validate`

#### Documentation

No separate documentation changes.