### PR TITLE
[chore] remove the created collector after the init test

### DIFF
--- a/cmd/builder/internal/command_init_test.go
+++ b/cmd/builder/internal/command_init_test.go
@@ -4,6 +4,7 @@
 package internal // import "go.opentelemetry.io/collector/cmd/builder/internal"
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -51,6 +52,8 @@ func TestRunInit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpdir := filepath.Join(t.TempDir(), "init")
 			path := tt.buildPath(tmpdir)
+			defer os.RemoveAll(path)
+
 			err := run(path)
 
 			if tt.wantErr == "" {


### PR DESCRIPTION
Without this, we get a test tmp subpackage that breaks all make commands running on every subpackages.