### PR TITLE
mark the batchprocessor as deprecated

### DIFF
--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -2,11 +2,19 @@
 # Batch Processor
 | Status        |           |
 | ------------- |-----------|
-| Stability     | [beta]: traces, metrics, logs   |
+| Stability     | [deprecated]: traces, metrics, logs   |
+| Deprecation of logs | [Date]: 2026-04-01   |
+|                      | [Migration Note]: migrate to exporter helper   |
+| Deprecation of metrics | [Date]: 2026-04-01   |
+|                      | [Migration Note]: migrate to exporter helper   |
+| Deprecation of traces | [Date]: 2026-04-01   |
+|                      | [Migration Note]: migrate to exporter helper   |
 | Distributions | [core], [contrib], [k8s] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector?query=is%3Aissue%20is%3Aopen%20label%3Aprocessor%2Fbatch%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector/issues?q=is%3Aopen+is%3Aissue+label%3Aprocessor%2Fbatch) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector?query=is%3Aissue%20is%3Aclosed%20label%3Aprocessor%2Fbatch%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector/issues?q=is%3Aclosed+is%3Aissue+label%3Aprocessor%2Fbatch) |
 
-[beta]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#beta
+[deprecated]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#deprecated
+[Date]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#deprecation-information
+[Migration Note]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#deprecation-information
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [k8s]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-k8s

--- a/processor/batchprocessor/internal/metadata/generated_status.go
+++ b/processor/batchprocessor/internal/metadata/generated_status.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	TracesStability  = component.StabilityLevelBeta
-	MetricsStability = component.StabilityLevelBeta
-	LogsStability    = component.StabilityLevelBeta
+	TracesStability  = component.StabilityLevelDeprecated
+	MetricsStability = component.StabilityLevelDeprecated
+	LogsStability    = component.StabilityLevelDeprecated
 )

--- a/processor/batchprocessor/metadata.yaml
+++ b/processor/batchprocessor/metadata.yaml
@@ -6,7 +6,17 @@ status:
   disable_codecov_badge: true
   class: processor
   stability:
-    beta: [traces, metrics, logs]
+    deprecated: [traces, metrics, logs]
+  deprecation:
+    traces:
+      migration: "migrate to exporter helper"
+      date: "2026-04-01"
+    metrics:
+      migration: "migrate to exporter helper"
+      date: "2026-04-01"
+    logs:
+      migration: "migrate to exporter helper"
+      date: "2026-04-01"
   distributions: [core, contrib, k8s]
 
 tests:


### PR DESCRIPTION
This continues the work to deprecate the batch processor in favour of the exporter helper's batching capabilities.

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/12022