### PR TITLE
exporterhelper: Fix batch timeout drift

### DIFF
--- a/.chloggen/fixed_windows_batching.yaml
+++ b/.chloggen/fixed_windows_batching.yaml
@@ -1,6 +1,6 @@
 change_type: enhancement
 
-component: exporterhelper
+component: pkg/exporterhelper
 
 note: Add optional fixed-window batching mode to prevent timeout drift by aligning flushes to fixed time boundaries.
 

--- a/.chloggen/fixed_windows_batching.yaml
+++ b/.chloggen/fixed_windows_batching.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+
+component: exporterhelper
+
+note: Add optional fixed-window batching mode to prevent timeout drift by aligning flushes to fixed time boundaries.
+
+issues: [13717, 15059]

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -42,6 +42,7 @@ Batch settings are available in the sending queue. Batching is disabled, by defa
 batch settings, use `batch: {}`. When `batch` is defined, the settings are:
 
 - `flush_timeout` (default = 200 ms): time after which a batch will be sent regardless of its size. Must be a non-zero value;
+- `fixed_windows` (default = false): if true, batching is aligned to fixed time windows anchored at startup (`startTime + N * flush_timeout`), preventing drift caused by delayed flushes. When false, batching uses a relative timeout from the last flush.
 - `min_size` (default = 8192): the minimum size of a batch; should be less than or equal to the `sending_queue::queue_size` if `sending_queue::batch::sizer` matches `sending_queue::sizer`.
 - `max_size` (default = 0): the maximum size of a batch, enables batch splitting. The maximum size of a batch should be greater than or equal to the minimum size of a batch. If set to zero, there is no maximum size;
 - `sizer`: see below.

--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -92,6 +92,10 @@ type BatchConfig struct {
 	// FlushTimeout sets the time after which a batch will be sent regardless of its size.
 	FlushTimeout time.Duration `mapstructure:"flush_timeout"`
 
+	// FixedWindows enables batching on a fixed schedule anchored at batcher start
+	// time, instead of resetting the flush timeout relative to the last timer reset.
+	FixedWindows bool `mapstructure:"fixed_windows"`
+
 	// Sizer determines the type of size measurement used by the batch.
 	// If not configured, use the same configuration as the queue.
 	// It accepts "requests", "items", or "bytes".

--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -92,8 +92,11 @@ type BatchConfig struct {
 	// FlushTimeout sets the time after which a batch will be sent regardless of its size.
 	FlushTimeout time.Duration `mapstructure:"flush_timeout"`
 
-	// FixedWindows enables batching on a fixed schedule anchored at batcher start
-	// time, instead of resetting the flush timeout relative to the last timer reset.
+	// FixedWindows enables time-aligned batching. When enabled, flushes occur at
+	// fixed intervals anchored to the batcher's start time (startTime + N * FlushTimeout),
+	// preventing drift caused by delayed flushes.
+	//
+	// When disabled (default), flushes occur relative to the previous flush.
 	FixedWindows bool `mapstructure:"fixed_windows"`
 
 	// Sizer determines the type of size measurement used by the batch.

--- a/exporter/exporterhelper/internal/queuebatch/config.schema.yaml
+++ b/exporter/exporterhelper/internal/queuebatch/config.schema.yaml
@@ -8,6 +8,10 @@ $defs:
         type: string
         x-customType: time.Duration
         format: duration
+      fixed_windows:
+        description: If true, batching is aligned to fixed time windows anchored at startup (startTime + N * flush_timeout), preventing drift caused by delayed flushes. When false (default), batching is based on a relative timeout from the last flush.
+        type: boolean
+        default: false
       max_size:
         description: MaxSize defines the configuration for the maximum size of a batch.
         type: integer

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -119,6 +119,10 @@ func TestBatchConfig_Validate(t *testing.T) {
 	cfg.MinSize = 2048
 	cfg.MaxSize = 1024
 	require.EqualError(t, xconfmap.Validate(cfg), "`max_size` (1024) must be greater or equal to `min_size` (2048)")
+
+	cfg = newTestBatchConfig()
+	cfg.FixedWindows = true
+	require.NoError(t, xconfmap.Validate(cfg))
 }
 
 func newTestBatchConfig() BatchConfig {
@@ -199,6 +203,21 @@ func TestUnmarshal(t *testing.T) {
 			path: "batch_unset.yaml",
 			// Batch remains unset, sizer override does not apply.
 			expectedCfg: newBaseCfg,
+		},
+		{
+			path: "batch_set_fixed_windows.yaml",
+			expectedCfg: func() configoptional.Optional[Config] {
+				cfg := newBaseCfg()
+				cfg.Get().Sizer = request.SizerTypeItems
+				cfg.Get().QueueSize = 2000
+				cfg.Get().Batch = configoptional.Some(BatchConfig{
+					FlushTimeout: 200 * time.Millisecond,
+					Sizer:        request.SizerTypeItems,
+					MinSize:      100,
+					FixedWindows: true,
+				})
+				return cfg
+			},
 		},
 	}
 

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
@@ -44,7 +44,9 @@ type partitionBatcher struct {
 	logger         *zap.Logger
 	onEmpty        func()    // callback triggered when partition is idle for given time period.
 	lastDataTime   time.Time // tracks when data was last present
-	active         bool      // indicates if partition is still active i.e timer is running and shutdown is not called yet. If Consume is called on inactive partition then data is flushed sync because timer is not running.
+	active         bool      // indicates if partition is still active i.e timer is running and shutdown is not called yet. If Consume is called on inactive partition then data is flushed sync because timer is not running
+	startTime      time.Time // scheduling anchor for fixed-window mode
+	nextFlushTime  time.Time // next scheduled flush boundary for fixed-window mode
 }
 
 func newPartitionBatcher(
@@ -71,9 +73,25 @@ func newPartitionBatcher(
 }
 
 func (qb *partitionBatcher) resetTimer() {
-	if qb.cfg.FlushTimeout > 0 {
-		qb.timer.Reset(qb.cfg.FlushTimeout)
+	if qb.cfg.FlushTimeout <= 0 {
+		return
 	}
+
+	// Fixed windows disabled: rearm the timer relative to now.
+	if !qb.cfg.FixedWindows {
+		qb.timer.Reset(qb.cfg.FlushTimeout)
+		return
+	}
+
+	// Fixed windows enabled: rearm the timer for the first boundary strictly after now.
+	now := time.Now()
+
+	// Advance to the next boundary strictly AFTER now.
+	elapsed := now.Sub(qb.startTime)
+	intervals := elapsed / qb.cfg.FlushTimeout
+	qb.nextFlushTime = qb.startTime.Add((intervals + 1) * qb.cfg.FlushTimeout)
+
+	qb.timer.Reset(time.Until(qb.nextFlushTime))
 }
 
 func (qb *partitionBatcher) consumeInternal(ctx context.Context, req request.Request, done queue.Done) bool {
@@ -217,7 +235,15 @@ func (qb *partitionBatcher) Start(context.Context, component.Host) error {
 	if qb.cfg.FlushTimeout <= 0 {
 		return nil
 	}
-	qb.timer = time.NewTimer(qb.cfg.FlushTimeout)
+
+	if qb.cfg.FixedWindows {
+		qb.startTime = time.Now()
+		qb.nextFlushTime = qb.startTime.Add(qb.cfg.FlushTimeout)
+		qb.timer = time.NewTimer(time.Until(qb.nextFlushTime))
+	} else {
+		qb.timer = time.NewTimer(qb.cfg.FlushTimeout)
+	}
+
 	qb.stopWG.Go(func() {
 		for {
 			select {

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
@@ -239,6 +239,75 @@ func TestPartitionBatcher_NoSplit_WithTimeout(t *testing.T) {
 	}
 }
 
+func TestPartitionBatcher_NoSplit_WithFixedWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows, see https://github.com/open-telemetry/opentelemetry-collector/issues/11869")
+	}
+
+	tests := []struct {
+		name       string
+		sizerType  request.SizerType
+		sizer      request.Sizer
+		maxWorkers int
+	}{
+		{
+			name:       "items/one_worker",
+			sizerType:  request.SizerTypeItems,
+			sizer:      request.NewItemsSizer(),
+			maxWorkers: 1,
+		},
+		{
+			name:       "items/three_workers",
+			sizerType:  request.SizerTypeItems,
+			sizer:      request.NewItemsSizer(),
+			maxWorkers: 3,
+		},
+		{
+			name:       "bytes/one_worker",
+			sizerType:  request.SizerTypeBytes,
+			sizer:      request.NewBytesSizer(),
+			maxWorkers: 1,
+		},
+		{
+			name:       "bytes/three_workers",
+			sizerType:  request.SizerTypeBytes,
+			sizer:      request.NewBytesSizer(),
+			maxWorkers: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := BatchConfig{
+				FlushTimeout: 50 * time.Millisecond,
+				FixedWindows: true,
+				Sizer:        tt.sizerType,
+				MinSize:      100,
+			}
+
+			sink := requesttest.NewSink()
+			ba := newPartitionBatcher(cfg, tt.sizer, nil, newWorkerPool(tt.maxWorkers), sink.Export, zap.NewNop(), nil)
+			require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+			t.Cleanup(func() {
+				require.NoError(t, ba.Shutdown(context.Background()))
+			})
+
+			done := newFakeDone()
+			ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 8, Bytes: 8}, done)
+			ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 17, Bytes: 17}, done)
+			ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 13, Bytes: 13}, done)
+			ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 35, Bytes: 35}, done)
+			ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 2, Bytes: 2}, done)
+
+			assert.Eventually(t, func() bool {
+				return sink.RequestsCount() == 1 && (sink.ItemsCount() == 75 || sink.BytesCount() == 75)
+			}, 1*time.Second, 10*time.Millisecond)
+
+			assert.EqualValues(t, 0, done.errors.Load())
+			assert.EqualValues(t, 5, done.success.Load())
+		})
+	}
+}
+
 func TestPartitionBatcher_Split_TimeoutDisabled(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows, see https://github.com/open-telemetry/opentelemetry-collector/issues/11847")
@@ -559,6 +628,32 @@ func TestPartitionBatcher_ContextMerging(t *testing.T) {
 			assert.EqualValues(t, 2, done.success.Load())
 		})
 	}
+}
+
+func TestPartitionBatcher_FixedWindows_ResetTimerComputesNextBoundary(t *testing.T) {
+	cfg := BatchConfig{
+		FlushTimeout: 100 * time.Millisecond,
+		FixedWindows: true,
+		Sizer:        request.SizerTypeItems,
+		MinSize:      1,
+	}
+
+	sink := requesttest.NewSink()
+	ba := newPartitionBatcher(cfg, request.NewItemsSizer(), nil, newWorkerPool(1), sink.Export, zap.NewNop(), nil)
+
+	// Preserve the existing lifecycle assumption: timer exists before resetTimer is called.
+	ba.timer = time.NewTimer(time.Hour)
+	t.Cleanup(func() {
+		ba.timer.Stop()
+	})
+
+	now := time.Now()
+	ba.startTime = now.Add(-250 * time.Millisecond)
+
+	ba.resetTimer()
+
+	expected := ba.startTime.Add(300 * time.Millisecond)
+	assert.Equal(t, expected, ba.nextFlushTime)
 }
 
 func TestPartitionBatcher_OnEmptyCallbackTriggered(t *testing.T) {

--- a/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_fixed_windows.yaml
+++ b/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_fixed_windows.yaml
@@ -1,0 +1,7 @@
+sizer: items
+num_consumers: 10
+queue_size: 2000
+batch:
+  flush_timeout: 200ms
+  fixed_windows: true
+  min_size: 100


### PR DESCRIPTION
#### Description

This PR introduces an optional fixed-window batching mode to prevent timeout drift in exporterhelper batching.

Currently, batching is scheduled relative to the previous flush. If a flush is delayed, that delay accumulates over time, causing batching windows to drift and become misaligned with expected time boundaries.

This change adds a new configuration option:

- `batch.fixed_windows` (default: false)

When enabled, flushes are aligned to a fixed schedule anchored at startup:

- startTime + N * flush_timeout (N is the number of elapsed intervals)

This ensures consistent time boundaries and prevents drift accumulation.

The implementation updates the partition batcher to compute the next flush boundary directly based on elapsed time from the start, instead of incrementally resetting the timer.

This behavior is fully opt-in and does not affect existing users.

---

#### Link to tracking issue

Related to #13717

---

#### Testing

- Added config unmarshal and validation tests for `fixed_windows`
- Added partition batcher tests for:
  - fixed-window scheduling behavior
  - next-boundary computation logic
- Verified existing batching behavior remains unchanged when `fixed_windows` is disabled by ensuring all existing tests pass without modification

---

#### Documentation

- Added `fixed_windows` to `config.schema.yaml`
- Documented the option in exporterhelper README
- Added inline documentation in `config.go`