### PR TITLE
[pkg/service] feat: Add `body.bytes.processed` metric to component universal telemetry

### DIFF
--- a/.chloggen/dpaasman00_universal-telemetry-raw-log-bytes.yaml
+++ b/.chloggen/dpaasman00_universal-telemetry-raw-log-bytes.yaml
@@ -7,7 +7,7 @@ change_type: 'enhancement'
 component: service/graph
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Emit a new component universal telemetry metric, `body.size`. Only emitted by log components.
+note: Emit a new component universal telemetry metric, `body.bytes.processed`. Only emitted by log components.
 
 # One or more tracking issues or pull requests related to the change
 issues: [14812]

--- a/.chloggen/dpaasman00_universal-telemetry-raw-log-bytes.yaml
+++ b/.chloggen/dpaasman00_universal-telemetry-raw-log-bytes.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: service/graph
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Emit a new component universal telemetry metric, `body.size`. Only emitted by log components.
+
+# One or more tracking issues or pull requests related to the change
+issues: [14812]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dpaasman00_universal-telemetry-raw-log-bytes.yaml
+++ b/.chloggen/dpaasman00_universal-telemetry-raw-log-bytes.yaml
@@ -4,7 +4,7 @@
 change_type: 'enhancement'
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: service/graph
+component: pkg/service
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Emit a new component universal telemetry metric, `body.bytes.processed`. Only emitted by log components.

--- a/docs/rfcs/component-universal-telemetry.md
+++ b/docs/rfcs/component-universal-telemetry.md
@@ -85,7 +85,7 @@ package is internal, then the scope name should be that of the module which cont
 There are two straightforward measurements that can be made on any pdata:
 
 1. A count of "items" (spans, data points, or log records). These are low cost but broadly useful, so they should be enabled by default.
-2. A measure of size, based on [ProtoMarshaler.Sizer()](https://github.com/open-telemetry/opentelemetry-collector/blob/9907ba50df0d5853c34d2962cf21da42e15a560d/pdata/ptrace/pb.go#l11).
+2. A measure of size, based on [ProtoMarshaler.Sizer()](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/ptrace/pb.go).
   These may be high cost to compute, so by default they should be disabled (and not calculated). This default setting may change in the future if it is demonstrated that the cost is generally acceptable.
 
 Additionally, for log pipelines, there is a signal-specific measurement:

--- a/docs/rfcs/component-universal-telemetry.md
+++ b/docs/rfcs/component-universal-telemetry.md
@@ -197,42 +197,42 @@ Errors should be "tagged as coming from downstream" the same way permanent error
         value_type: int
         monotonic: true
 
-    otelcol.receiver.produced.body.size:
+    otelcol.receiver.produced.body.bytes.processed:
       enabled: false
       description: Total byte size of log record bodies emitted from the receiver.
       unit: "By"
       sum:
         value_type: int
         monotonic: true
-    otelcol.processor.consumed.body.size:
+    otelcol.processor.consumed.body.bytes.processed:
       enabled: false
       description: Total byte size of log record bodies passed to the processor.
       unit: "By"
       sum:
         value_type: int
         monotonic: true
-    otelcol.processor.produced.body.size:
+    otelcol.processor.produced.body.bytes.processed:
       enabled: false
       description: Total byte size of log record bodies emitted from the processor.
       unit: "By"
       sum:
         value_type: int
         monotonic: true
-    otelcol.connector.consumed.body.size:
+    otelcol.connector.consumed.body.bytes.processed:
       enabled: false
       description: Total byte size of log record bodies passed to the connector.
       unit: "By"
       sum:
         value_type: int
         monotonic: true
-    otelcol.connector.produced.body.size:
+    otelcol.connector.produced.body.bytes.processed:
       enabled: false
       description: Total byte size of log record bodies emitted from the connector.
       unit: "By"
       sum:
         value_type: int
         monotonic: true
-    otelcol.exporter.consumed.body.size:
+    otelcol.exporter.consumed.body.bytes.processed:
       enabled: false
       description: Total byte size of log record bodies passed to the exporter.
       unit: "By"

--- a/docs/rfcs/component-universal-telemetry.md
+++ b/docs/rfcs/component-universal-telemetry.md
@@ -88,6 +88,12 @@ There are two straightforward measurements that can be made on any pdata:
 2. A measure of size, based on [ProtoMarshaler.Sizer()](https://github.com/open-telemetry/opentelemetry-collector/blob/9907ba50df0d5853c34d2962cf21da42e15a560d/pdata/ptrace/pb.go#l11).
   These may be high cost to compute, so by default they should be disabled (and not calculated). This default setting may change in the future if it is demonstrated that the cost is generally acceptable.
 
+Additionally, for log pipelines, there is a signal-specific measurement:
+
+3. A measure of "body size", computed by summing the byte size of each log record body across all log records in a batch.
+  This measures the byte size of the underlying log data rather than the OTLP wire-format size, and is useful for capacity planning, billing correlation, and data reduction analysis.
+  Like the size metric, this is disabled by default and gated behind the `detailed` telemetry level. It only applies to log pipelines.
+
 The location of these measurements can be described in terms of whether the data is "consumed" or "produced", from the perspective of the
 component to which the telemetry is attributed. Metrics which contain the term "produced" describe data which is emitted from the component,
 while metrics which contain the term "consumed" describe data which is received by the component.
@@ -186,6 +192,49 @@ Errors should be "tagged as coming from downstream" the same way permanent error
     otelcol.exporter.consumed.size:
       enabled: false
       description: Size of items passed to the exporter.
+      unit: "By"
+      sum:
+        value_type: int
+        monotonic: true
+
+    otelcol.receiver.produced.body.size:
+      enabled: false
+      description: Total byte size of log record bodies emitted from the receiver.
+      unit: "By"
+      sum:
+        value_type: int
+        monotonic: true
+    otelcol.processor.consumed.body.size:
+      enabled: false
+      description: Total byte size of log record bodies passed to the processor.
+      unit: "By"
+      sum:
+        value_type: int
+        monotonic: true
+    otelcol.processor.produced.body.size:
+      enabled: false
+      description: Total byte size of log record bodies emitted from the processor.
+      unit: "By"
+      sum:
+        value_type: int
+        monotonic: true
+    otelcol.connector.consumed.body.size:
+      enabled: false
+      description: Total byte size of log record bodies passed to the connector.
+      unit: "By"
+      sum:
+        value_type: int
+        monotonic: true
+    otelcol.connector.produced.body.size:
+      enabled: false
+      description: Total byte size of log record bodies emitted from the connector.
+      unit: "By"
+      sum:
+        value_type: int
+        monotonic: true
+    otelcol.exporter.consumed.body.size:
+      enabled: false
+      description: Total byte size of log record bodies passed to the exporter.
       unit: "By"
       sum:
         value_type: int

--- a/service/generated_package_test.go
+++ b/service/generated_package_test.go
@@ -3,8 +3,9 @@
 package service
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/service/generated_package_test.go
+++ b/service/generated_package_test.go
@@ -3,9 +3,8 @@
 package service
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/service/internal/graph/connector.go
+++ b/service/internal/graph/connector.go
@@ -93,10 +93,10 @@ func (n *connectorNode) buildTraces(
 		Logger:      set.Logger,
 	}
 	consumedSettings := obsconsumer.Settings{
-		ItemCounter:     tb.ConnectorConsumedItems,
-		SizeCounter:     tb.ConnectorConsumedSize,
-		BodySizeCounter: tb.ConnectorConsumedBodySize,
-		Logger:          set.Logger,
+		ItemCounter:               tb.ConnectorConsumedItems,
+		SizeCounter:               tb.ConnectorConsumedSize,
+		BodyBytesProcessedCounter: tb.ConnectorConsumedBodyBytesProcessed,
+		Logger:                    set.Logger,
 	}
 
 	consumers := make(map[pipeline.ID]consumer.Traces, len(nexts))
@@ -216,7 +216,7 @@ func (n *connectorNode) buildMetrics(
 		n.consumer = obsconsumer.NewTraces(n.Component.(consumer.Traces), consumedSettings)
 		n.consumer = refconsumer.NewTraces(n.consumer.(consumer.Traces))
 	case pipeline.SignalLogs:
-		consumedSettings.BodySizeCounter = tb.ConnectorConsumedBodySize
+		consumedSettings.BodyBytesProcessedCounter = tb.ConnectorConsumedBodyBytesProcessed
 		n.Component, err = builder.CreateLogsToMetrics(ctx, set, next)
 		if err != nil {
 			return err
@@ -246,10 +246,10 @@ func (n *connectorNode) buildLogs(
 	}
 
 	producedSettings := obsconsumer.Settings{
-		ItemCounter:     tb.ConnectorProducedItems,
-		SizeCounter:     tb.ConnectorProducedSize,
-		BodySizeCounter: tb.ConnectorProducedBodySize,
-		Logger:          set.Logger,
+		ItemCounter:               tb.ConnectorProducedItems,
+		SizeCounter:               tb.ConnectorProducedSize,
+		BodyBytesProcessedCounter: tb.ConnectorProducedBodyBytesProcessed,
+		Logger:                    set.Logger,
 	}
 	consumedSettings := obsconsumer.Settings{
 		ItemCounter: tb.ConnectorConsumedItems,
@@ -274,7 +274,7 @@ func (n *connectorNode) buildLogs(
 
 	switch n.exprPipelineType {
 	case pipeline.SignalLogs:
-		consumedSettings.BodySizeCounter = tb.ConnectorConsumedBodySize
+		consumedSettings.BodyBytesProcessedCounter = tb.ConnectorConsumedBodyBytesProcessed
 		n.Component, err = builder.CreateLogsToLogs(ctx, set, next)
 		if err != nil {
 			return err
@@ -382,7 +382,7 @@ func (n *connectorNode) buildProfiles(
 		n.consumer = obsconsumer.NewMetrics(n.Component.(consumer.Metrics), consumedSettings)
 		n.consumer = refconsumer.NewMetrics(n.consumer.(consumer.Metrics))
 	case pipeline.SignalLogs:
-		consumedSettings.BodySizeCounter = tb.ConnectorConsumedBodySize
+		consumedSettings.BodyBytesProcessedCounter = tb.ConnectorConsumedBodyBytesProcessed
 		n.Component, err = builder.CreateLogsToProfiles(ctx, set, next)
 		if err != nil {
 			return err

--- a/service/internal/graph/connector.go
+++ b/service/internal/graph/connector.go
@@ -93,9 +93,10 @@ func (n *connectorNode) buildTraces(
 		Logger:      set.Logger,
 	}
 	consumedSettings := obsconsumer.Settings{
-		ItemCounter: tb.ConnectorConsumedItems,
-		SizeCounter: tb.ConnectorConsumedSize,
-		Logger:      set.Logger,
+		ItemCounter:     tb.ConnectorConsumedItems,
+		SizeCounter:     tb.ConnectorConsumedSize,
+		BodySizeCounter: tb.ConnectorConsumedBodySize,
+		Logger:          set.Logger,
 	}
 
 	consumers := make(map[pipeline.ID]consumer.Traces, len(nexts))
@@ -215,6 +216,7 @@ func (n *connectorNode) buildMetrics(
 		n.consumer = obsconsumer.NewTraces(n.Component.(consumer.Traces), consumedSettings)
 		n.consumer = refconsumer.NewTraces(n.consumer.(consumer.Traces))
 	case pipeline.SignalLogs:
+		consumedSettings.BodySizeCounter = tb.ConnectorConsumedBodySize
 		n.Component, err = builder.CreateLogsToMetrics(ctx, set, next)
 		if err != nil {
 			return err
@@ -244,9 +246,10 @@ func (n *connectorNode) buildLogs(
 	}
 
 	producedSettings := obsconsumer.Settings{
-		ItemCounter: tb.ConnectorProducedItems,
-		SizeCounter: tb.ConnectorProducedSize,
-		Logger:      set.Logger,
+		ItemCounter:     tb.ConnectorProducedItems,
+		SizeCounter:     tb.ConnectorProducedSize,
+		BodySizeCounter: tb.ConnectorProducedBodySize,
+		Logger:          set.Logger,
 	}
 	consumedSettings := obsconsumer.Settings{
 		ItemCounter: tb.ConnectorConsumedItems,
@@ -271,6 +274,7 @@ func (n *connectorNode) buildLogs(
 
 	switch n.exprPipelineType {
 	case pipeline.SignalLogs:
+		consumedSettings.BodySizeCounter = tb.ConnectorConsumedBodySize
 		n.Component, err = builder.CreateLogsToLogs(ctx, set, next)
 		if err != nil {
 			return err
@@ -378,6 +382,7 @@ func (n *connectorNode) buildProfiles(
 		n.consumer = obsconsumer.NewMetrics(n.Component.(consumer.Metrics), consumedSettings)
 		n.consumer = refconsumer.NewMetrics(n.consumer.(consumer.Metrics))
 	case pipeline.SignalLogs:
+		consumedSettings.BodySizeCounter = tb.ConnectorConsumedBodySize
 		n.Component, err = builder.CreateLogsToProfiles(ctx, set, next)
 		if err != nil {
 			return err

--- a/service/internal/graph/exporter.go
+++ b/service/internal/graph/exporter.go
@@ -63,10 +63,10 @@ func (n *exporterNode) buildComponent(
 	}
 
 	consumedSettings := obsconsumer.Settings{
-		ItemCounter:     tb.ExporterConsumedItems,
-		SizeCounter:     tb.ExporterConsumedSize,
-		BodySizeCounter: tb.ExporterConsumedBodySize,
-		Logger:          set.Logger,
+		ItemCounter:               tb.ExporterConsumedItems,
+		SizeCounter:               tb.ExporterConsumedSize,
+		BodyBytesProcessedCounter: tb.ExporterConsumedBodyBytesProcessed,
+		Logger:                    set.Logger,
 	}
 
 	switch n.pipelineType {

--- a/service/internal/graph/exporter.go
+++ b/service/internal/graph/exporter.go
@@ -63,9 +63,10 @@ func (n *exporterNode) buildComponent(
 	}
 
 	consumedSettings := obsconsumer.Settings{
-		ItemCounter: tb.ExporterConsumedItems,
-		SizeCounter: tb.ExporterConsumedSize,
-		Logger:      set.Logger,
+		ItemCounter:     tb.ExporterConsumedItems,
+		SizeCounter:     tb.ExporterConsumedSize,
+		BodySizeCounter: tb.ExporterConsumedBodySize,
+		Logger:          set.Logger,
 	}
 
 	switch n.pipelineType {

--- a/service/internal/graph/obs_test.go
+++ b/service/internal/graph/obs_test.go
@@ -436,7 +436,7 @@ func TestComponentInstrumentation(t *testing.T) {
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 1363,
 			},
-			"otelcol.receiver.produced.body.size": simpleMetric{
+			"otelcol.receiver.produced.body.bytes.processed": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 255, // 4*21("This is a log message") + 3*18("something happened") + 3*21 + 3*18
@@ -468,12 +468,12 @@ func TestComponentInstrumentation(t *testing.T) {
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 1363,
 			},
-			"otelcol.processor.consumed.body.size": simpleMetric{
+			"otelcol.processor.consumed.body.bytes.processed": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 255,
 			},
-			"otelcol.processor.produced.body.size": simpleMetric{
+			"otelcol.processor.produced.body.bytes.processed": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 255,
@@ -515,12 +515,12 @@ func TestComponentInstrumentation(t *testing.T) {
 					attribute.String("otelcol.pipeline.id", "logs/left"),
 				): 626,
 			},
-			"otelcol.connector.consumed.body.size": simpleMetric{
+			"otelcol.connector.consumed.body.bytes.processed": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 255,
 			},
-			"otelcol.connector.produced.body.size": simpleMetric{
+			"otelcol.connector.produced.body.bytes.processed": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 					attribute.String("otelcol.pipeline.id", "logs/right"),
@@ -546,7 +546,7 @@ func TestComponentInstrumentation(t *testing.T) {
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 737,
 			},
-			"otelcol.exporter.consumed.body.size": simpleMetric{
+			"otelcol.exporter.consumed.body.bytes.processed": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 138,
@@ -567,7 +567,7 @@ func TestComponentInstrumentation(t *testing.T) {
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 626,
 			},
-			"otelcol.exporter.consumed.body.size": simpleMetric{
+			"otelcol.exporter.consumed.body.bytes.processed": simpleMetric{
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 117,

--- a/service/internal/graph/obs_test.go
+++ b/service/internal/graph/obs_test.go
@@ -436,6 +436,11 @@ func TestComponentInstrumentation(t *testing.T) {
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 1363,
 			},
+			"otelcol.receiver.produced.body.size": simpleMetric{
+				attribute.NewSet(
+					attribute.String(obsconsumer.ComponentOutcome, "success"),
+				): 255, // 4*21("This is a log message") + 3*18("something happened") + 3*21 + 3*18
+			},
 		},
 		attribute.NewSet(
 			attribute.String("otelcol.component.kind", "processor"),
@@ -462,6 +467,16 @@ func TestComponentInstrumentation(t *testing.T) {
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 1363,
+			},
+			"otelcol.processor.consumed.body.size": simpleMetric{
+				attribute.NewSet(
+					attribute.String(obsconsumer.ComponentOutcome, "success"),
+				): 255,
+			},
+			"otelcol.processor.produced.body.size": simpleMetric{
+				attribute.NewSet(
+					attribute.String(obsconsumer.ComponentOutcome, "success"),
+				): 255,
 			},
 		},
 		attribute.NewSet(
@@ -500,6 +515,21 @@ func TestComponentInstrumentation(t *testing.T) {
 					attribute.String("otelcol.pipeline.id", "logs/left"),
 				): 626,
 			},
+			"otelcol.connector.consumed.body.size": simpleMetric{
+				attribute.NewSet(
+					attribute.String(obsconsumer.ComponentOutcome, "success"),
+				): 255,
+			},
+			"otelcol.connector.produced.body.size": simpleMetric{
+				attribute.NewSet(
+					attribute.String(obsconsumer.ComponentOutcome, "success"),
+					attribute.String("otelcol.pipeline.id", "logs/right"),
+				): 138, // GenerateLogs(7): 4*21 + 3*18
+				attribute.NewSet(
+					attribute.String(obsconsumer.ComponentOutcome, "success"),
+					attribute.String("otelcol.pipeline.id", "logs/left"),
+				): 117, // GenerateLogs(6): 3*21 + 3*18
+			},
 		},
 		attribute.NewSet(
 			attribute.String("otelcol.component.kind", "exporter"),
@@ -516,6 +546,11 @@ func TestComponentInstrumentation(t *testing.T) {
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 737,
 			},
+			"otelcol.exporter.consumed.body.size": simpleMetric{
+				attribute.NewSet(
+					attribute.String(obsconsumer.ComponentOutcome, "success"),
+				): 138,
+			},
 		},
 		attribute.NewSet(
 			attribute.String("otelcol.component.kind", "exporter"),
@@ -531,6 +566,11 @@ func TestComponentInstrumentation(t *testing.T) {
 				attribute.NewSet(
 					attribute.String(obsconsumer.ComponentOutcome, "success"),
 				): 626,
+			},
+			"otelcol.exporter.consumed.body.size": simpleMetric{
+				attribute.NewSet(
+					attribute.String(obsconsumer.ComponentOutcome, "success"),
+				): 117,
 			},
 		},
 

--- a/service/internal/graph/processor.go
+++ b/service/internal/graph/processor.go
@@ -63,14 +63,16 @@ func (n *processorNode) buildComponent(ctx context.Context,
 	}
 
 	producedSettings := obsconsumer.Settings{
-		ItemCounter: tb.ProcessorProducedItems,
-		SizeCounter: tb.ProcessorProducedSize,
-		Logger:      set.Logger,
+		ItemCounter:     tb.ProcessorProducedItems,
+		SizeCounter:     tb.ProcessorProducedSize,
+		BodySizeCounter: tb.ProcessorProducedBodySize,
+		Logger:          set.Logger,
 	}
 	consumedSettings := obsconsumer.Settings{
-		ItemCounter: tb.ProcessorConsumedItems,
-		SizeCounter: tb.ProcessorConsumedSize,
-		Logger:      set.Logger,
+		ItemCounter:     tb.ProcessorConsumedItems,
+		SizeCounter:     tb.ProcessorConsumedSize,
+		BodySizeCounter: tb.ProcessorConsumedBodySize,
+		Logger:          set.Logger,
 	}
 
 	switch n.pipelineID.Signal() {

--- a/service/internal/graph/processor.go
+++ b/service/internal/graph/processor.go
@@ -63,16 +63,16 @@ func (n *processorNode) buildComponent(ctx context.Context,
 	}
 
 	producedSettings := obsconsumer.Settings{
-		ItemCounter:     tb.ProcessorProducedItems,
-		SizeCounter:     tb.ProcessorProducedSize,
-		BodySizeCounter: tb.ProcessorProducedBodySize,
-		Logger:          set.Logger,
+		ItemCounter:               tb.ProcessorProducedItems,
+		SizeCounter:               tb.ProcessorProducedSize,
+		BodyBytesProcessedCounter: tb.ProcessorProducedBodyBytesProcessed,
+		Logger:                    set.Logger,
 	}
 	consumedSettings := obsconsumer.Settings{
-		ItemCounter:     tb.ProcessorConsumedItems,
-		SizeCounter:     tb.ProcessorConsumedSize,
-		BodySizeCounter: tb.ProcessorConsumedBodySize,
-		Logger:          set.Logger,
+		ItemCounter:               tb.ProcessorConsumedItems,
+		SizeCounter:               tb.ProcessorConsumedSize,
+		BodyBytesProcessedCounter: tb.ProcessorConsumedBodyBytesProcessed,
+		Logger:                    set.Logger,
 	}
 
 	switch n.pipelineID.Signal() {

--- a/service/internal/graph/receiver.go
+++ b/service/internal/graph/receiver.go
@@ -56,10 +56,10 @@ func (n *receiverNode) buildComponent(ctx context.Context,
 	}
 
 	producedSettings := obsconsumer.Settings{
-		ItemCounter:     tb.ReceiverProducedItems,
-		SizeCounter:     tb.ReceiverProducedSize,
-		BodySizeCounter: tb.ReceiverProducedBodySize,
-		Logger:          set.Logger,
+		ItemCounter:               tb.ReceiverProducedItems,
+		SizeCounter:               tb.ReceiverProducedSize,
+		BodyBytesProcessedCounter: tb.ReceiverProducedBodyBytesProcessed,
+		Logger:                    set.Logger,
 	}
 
 	switch n.pipelineType {

--- a/service/internal/graph/receiver.go
+++ b/service/internal/graph/receiver.go
@@ -56,9 +56,10 @@ func (n *receiverNode) buildComponent(ctx context.Context,
 	}
 
 	producedSettings := obsconsumer.Settings{
-		ItemCounter: tb.ReceiverProducedItems,
-		SizeCounter: tb.ReceiverProducedSize,
-		Logger:      set.Logger,
+		ItemCounter:     tb.ReceiverProducedItems,
+		SizeCounter:     tb.ReceiverProducedSize,
+		BodySizeCounter: tb.ReceiverProducedBodySize,
+		Logger:          set.Logger,
 	}
 
 	switch n.pipelineType {

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -28,10 +28,13 @@ type TelemetryBuilder struct {
 	meter                             metric.Meter
 	mu                                sync.Mutex
 	registrations                     []metric.Registration
+	ConnectorConsumedBodySize         metric.Int64Counter
 	ConnectorConsumedItems            metric.Int64Counter
 	ConnectorConsumedSize             metric.Int64Counter
+	ConnectorProducedBodySize         metric.Int64Counter
 	ConnectorProducedItems            metric.Int64Counter
 	ConnectorProducedSize             metric.Int64Counter
+	ExporterConsumedBodySize          metric.Int64Counter
 	ExporterConsumedItems             metric.Int64Counter
 	ExporterConsumedSize              metric.Int64Counter
 	ProcessCPUSeconds                 metric.Float64ObservableCounter
@@ -40,10 +43,13 @@ type TelemetryBuilder struct {
 	ProcessRuntimeTotalAllocBytes     metric.Int64ObservableCounter
 	ProcessRuntimeTotalSysMemoryBytes metric.Int64ObservableGauge
 	ProcessUptime                     metric.Float64ObservableCounter
+	ProcessorConsumedBodySize         metric.Int64Counter
 	ProcessorConsumedItems            metric.Int64Counter
 	ProcessorConsumedSize             metric.Int64Counter
+	ProcessorProducedBodySize         metric.Int64Counter
 	ProcessorProducedItems            metric.Int64Counter
 	ProcessorProducedSize             metric.Int64Counter
+	ReceiverProducedBodySize          metric.Int64Counter
 	ReceiverProducedItems             metric.Int64Counter
 	ReceiverProducedSize              metric.Int64Counter
 }
@@ -187,6 +193,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
+	builder.ConnectorConsumedBodySize, err = builder.meter.Int64Counter(
+		"otelcol.connector.consumed.body.size",
+		metric.WithDescription("Total byte size of log record bodies passed to the connector. [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
 	builder.ConnectorConsumedItems, err = builder.meter.Int64Counter(
 		"otelcol.connector.consumed.items",
 		metric.WithDescription("Number of items passed to the connector. [Development]"),
@@ -199,6 +211,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{item}"),
 	)
 	errs = errors.Join(errs, err)
+	builder.ConnectorProducedBodySize, err = builder.meter.Int64Counter(
+		"otelcol.connector.produced.body.size",
+		metric.WithDescription("Total byte size of log record bodies emitted from the connector. [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
 	builder.ConnectorProducedItems, err = builder.meter.Int64Counter(
 		"otelcol.connector.produced.items",
 		metric.WithDescription("Number of items emitted from the connector. [Development]"),
@@ -209,6 +227,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol.connector.produced.size",
 		metric.WithDescription("Size of items emitted from the connector, based on ProtoMarshaler.Sizer. [Development]"),
 		metric.WithUnit("{item}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ExporterConsumedBodySize, err = builder.meter.Int64Counter(
+		"otelcol.exporter.consumed.body.size",
+		metric.WithDescription("Total byte size of log record bodies passed to the exporter. [Development]"),
+		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterConsumedItems, err = builder.meter.Int64Counter(
@@ -259,6 +283,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("s"),
 	)
 	errs = errors.Join(errs, err)
+	builder.ProcessorConsumedBodySize, err = builder.meter.Int64Counter(
+		"otelcol.processor.consumed.body.size",
+		metric.WithDescription("Total byte size of log record bodies passed to the processor. [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
 	builder.ProcessorConsumedItems, err = builder.meter.Int64Counter(
 		"otelcol.processor.consumed.items",
 		metric.WithDescription("Number of items passed to the processor. [Development]"),
@@ -271,6 +301,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{item}"),
 	)
 	errs = errors.Join(errs, err)
+	builder.ProcessorProducedBodySize, err = builder.meter.Int64Counter(
+		"otelcol.processor.produced.body.size",
+		metric.WithDescription("Total byte size of log record bodies emitted from the processor. [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
 	builder.ProcessorProducedItems, err = builder.meter.Int64Counter(
 		"otelcol.processor.produced.items",
 		metric.WithDescription("Number of items emitted from the processor. [Development]"),
@@ -281,6 +317,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol.processor.produced.size",
 		metric.WithDescription("Size of items emitted from the processor, based on ProtoMarshaler.Sizer. [Development]"),
 		metric.WithUnit("{item}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ReceiverProducedBodySize, err = builder.meter.Int64Counter(
+		"otelcol.receiver.produced.body.size",
+		metric.WithDescription("Total byte size of log record bodies emitted from the receiver. [Development]"),
+		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ReceiverProducedItems, err = builder.meter.Int64Counter(

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -25,33 +25,33 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter                             metric.Meter
-	mu                                sync.Mutex
-	registrations                     []metric.Registration
-	ConnectorConsumedBodySize         metric.Int64Counter
-	ConnectorConsumedItems            metric.Int64Counter
-	ConnectorConsumedSize             metric.Int64Counter
-	ConnectorProducedBodySize         metric.Int64Counter
-	ConnectorProducedItems            metric.Int64Counter
-	ConnectorProducedSize             metric.Int64Counter
-	ExporterConsumedBodySize          metric.Int64Counter
-	ExporterConsumedItems             metric.Int64Counter
-	ExporterConsumedSize              metric.Int64Counter
-	ProcessCPUSeconds                 metric.Float64ObservableCounter
-	ProcessMemoryRss                  metric.Int64ObservableGauge
-	ProcessRuntimeHeapAllocBytes      metric.Int64ObservableGauge
-	ProcessRuntimeTotalAllocBytes     metric.Int64ObservableCounter
-	ProcessRuntimeTotalSysMemoryBytes metric.Int64ObservableGauge
-	ProcessUptime                     metric.Float64ObservableCounter
-	ProcessorConsumedBodySize         metric.Int64Counter
-	ProcessorConsumedItems            metric.Int64Counter
-	ProcessorConsumedSize             metric.Int64Counter
-	ProcessorProducedBodySize         metric.Int64Counter
-	ProcessorProducedItems            metric.Int64Counter
-	ProcessorProducedSize             metric.Int64Counter
-	ReceiverProducedBodySize          metric.Int64Counter
-	ReceiverProducedItems             metric.Int64Counter
-	ReceiverProducedSize              metric.Int64Counter
+	meter                               metric.Meter
+	mu                                  sync.Mutex
+	registrations                       []metric.Registration
+	ConnectorConsumedBodyBytesProcessed metric.Int64Counter
+	ConnectorConsumedItems              metric.Int64Counter
+	ConnectorConsumedSize               metric.Int64Counter
+	ConnectorProducedBodyBytesProcessed metric.Int64Counter
+	ConnectorProducedItems              metric.Int64Counter
+	ConnectorProducedSize               metric.Int64Counter
+	ExporterConsumedBodyBytesProcessed  metric.Int64Counter
+	ExporterConsumedItems               metric.Int64Counter
+	ExporterConsumedSize                metric.Int64Counter
+	ProcessCPUSeconds                   metric.Float64ObservableCounter
+	ProcessMemoryRss                    metric.Int64ObservableGauge
+	ProcessRuntimeHeapAllocBytes        metric.Int64ObservableGauge
+	ProcessRuntimeTotalAllocBytes       metric.Int64ObservableCounter
+	ProcessRuntimeTotalSysMemoryBytes   metric.Int64ObservableGauge
+	ProcessUptime                       metric.Float64ObservableCounter
+	ProcessorConsumedBodyBytesProcessed metric.Int64Counter
+	ProcessorConsumedItems              metric.Int64Counter
+	ProcessorConsumedSize               metric.Int64Counter
+	ProcessorProducedBodyBytesProcessed metric.Int64Counter
+	ProcessorProducedItems              metric.Int64Counter
+	ProcessorProducedSize               metric.Int64Counter
+	ReceiverProducedBodyBytesProcessed  metric.Int64Counter
+	ReceiverProducedItems               metric.Int64Counter
+	ReceiverProducedSize                metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -193,8 +193,8 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
-	builder.ConnectorConsumedBodySize, err = builder.meter.Int64Counter(
-		"otelcol.connector.consumed.body.size",
+	builder.ConnectorConsumedBodyBytesProcessed, err = builder.meter.Int64Counter(
+		"otelcol.connector.consumed.body.bytes.processed",
 		metric.WithDescription("Total byte size of log record bodies passed to the connector. [Development]"),
 		metric.WithUnit("By"),
 	)
@@ -211,8 +211,8 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{item}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ConnectorProducedBodySize, err = builder.meter.Int64Counter(
-		"otelcol.connector.produced.body.size",
+	builder.ConnectorProducedBodyBytesProcessed, err = builder.meter.Int64Counter(
+		"otelcol.connector.produced.body.bytes.processed",
 		metric.WithDescription("Total byte size of log record bodies emitted from the connector. [Development]"),
 		metric.WithUnit("By"),
 	)
@@ -229,8 +229,8 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{item}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ExporterConsumedBodySize, err = builder.meter.Int64Counter(
-		"otelcol.exporter.consumed.body.size",
+	builder.ExporterConsumedBodyBytesProcessed, err = builder.meter.Int64Counter(
+		"otelcol.exporter.consumed.body.bytes.processed",
 		metric.WithDescription("Total byte size of log record bodies passed to the exporter. [Development]"),
 		metric.WithUnit("By"),
 	)
@@ -283,8 +283,8 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("s"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorConsumedBodySize, err = builder.meter.Int64Counter(
-		"otelcol.processor.consumed.body.size",
+	builder.ProcessorConsumedBodyBytesProcessed, err = builder.meter.Int64Counter(
+		"otelcol.processor.consumed.body.bytes.processed",
 		metric.WithDescription("Total byte size of log record bodies passed to the processor. [Development]"),
 		metric.WithUnit("By"),
 	)
@@ -301,8 +301,8 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{item}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ProcessorProducedBodySize, err = builder.meter.Int64Counter(
-		"otelcol.processor.produced.body.size",
+	builder.ProcessorProducedBodyBytesProcessed, err = builder.meter.Int64Counter(
+		"otelcol.processor.produced.body.bytes.processed",
 		metric.WithDescription("Total byte size of log record bodies emitted from the processor. [Development]"),
 		metric.WithUnit("By"),
 	)
@@ -319,8 +319,8 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{item}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.ReceiverProducedBodySize, err = builder.meter.Int64Counter(
-		"otelcol.receiver.produced.body.size",
+	builder.ReceiverProducedBodyBytesProcessed, err = builder.meter.Int64Counter(
+		"otelcol.receiver.produced.body.bytes.processed",
 		metric.WithDescription("Total byte size of log record bodies emitted from the receiver. [Development]"),
 		metric.WithUnit("By"),
 	)

--- a/service/internal/metadatatest/generated_telemetrytest.go
+++ b/service/internal/metadatatest/generated_telemetrytest.go
@@ -12,9 +12,9 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 )
 
-func AssertEqualConnectorConsumedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualConnectorConsumedBodyBytesProcessed(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol.connector.consumed.body.size",
+		Name:        "otelcol.connector.consumed.body.bytes.processed",
 		Description: "Total byte size of log record bodies passed to the connector. [Development]",
 		Unit:        "By",
 		Data: metricdata.Sum[int64]{
@@ -23,7 +23,7 @@ func AssertEqualConnectorConsumedBodySize(t *testing.T, tt *componenttest.Teleme
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol.connector.consumed.body.size")
+	got, err := tt.GetMetric("otelcol.connector.consumed.body.bytes.processed")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
@@ -60,9 +60,9 @@ func AssertEqualConnectorConsumedSize(t *testing.T, tt *componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualConnectorProducedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualConnectorProducedBodyBytesProcessed(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol.connector.produced.body.size",
+		Name:        "otelcol.connector.produced.body.bytes.processed",
 		Description: "Total byte size of log record bodies emitted from the connector. [Development]",
 		Unit:        "By",
 		Data: metricdata.Sum[int64]{
@@ -71,7 +71,7 @@ func AssertEqualConnectorProducedBodySize(t *testing.T, tt *componenttest.Teleme
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol.connector.produced.body.size")
+	got, err := tt.GetMetric("otelcol.connector.produced.body.bytes.processed")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
@@ -108,9 +108,9 @@ func AssertEqualConnectorProducedSize(t *testing.T, tt *componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualExporterConsumedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualExporterConsumedBodyBytesProcessed(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol.exporter.consumed.body.size",
+		Name:        "otelcol.exporter.consumed.body.bytes.processed",
 		Description: "Total byte size of log record bodies passed to the exporter. [Development]",
 		Unit:        "By",
 		Data: metricdata.Sum[int64]{
@@ -119,7 +119,7 @@ func AssertEqualExporterConsumedBodySize(t *testing.T, tt *componenttest.Telemet
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol.exporter.consumed.body.size")
+	got, err := tt.GetMetric("otelcol.exporter.consumed.body.bytes.processed")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
@@ -246,9 +246,9 @@ func AssertEqualProcessUptime(t *testing.T, tt *componenttest.Telemetry, dps []m
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorConsumedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorConsumedBodyBytesProcessed(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol.processor.consumed.body.size",
+		Name:        "otelcol.processor.consumed.body.bytes.processed",
 		Description: "Total byte size of log record bodies passed to the processor. [Development]",
 		Unit:        "By",
 		Data: metricdata.Sum[int64]{
@@ -257,7 +257,7 @@ func AssertEqualProcessorConsumedBodySize(t *testing.T, tt *componenttest.Teleme
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol.processor.consumed.body.size")
+	got, err := tt.GetMetric("otelcol.processor.consumed.body.bytes.processed")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
@@ -294,9 +294,9 @@ func AssertEqualProcessorConsumedSize(t *testing.T, tt *componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorProducedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorProducedBodyBytesProcessed(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol.processor.produced.body.size",
+		Name:        "otelcol.processor.produced.body.bytes.processed",
 		Description: "Total byte size of log record bodies emitted from the processor. [Development]",
 		Unit:        "By",
 		Data: metricdata.Sum[int64]{
@@ -305,7 +305,7 @@ func AssertEqualProcessorProducedBodySize(t *testing.T, tt *componenttest.Teleme
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol.processor.produced.body.size")
+	got, err := tt.GetMetric("otelcol.processor.produced.body.bytes.processed")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
@@ -342,9 +342,9 @@ func AssertEqualProcessorProducedSize(t *testing.T, tt *componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualReceiverProducedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualReceiverProducedBodyBytesProcessed(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol.receiver.produced.body.size",
+		Name:        "otelcol.receiver.produced.body.bytes.processed",
 		Description: "Total byte size of log record bodies emitted from the receiver. [Development]",
 		Unit:        "By",
 		Data: metricdata.Sum[int64]{
@@ -353,7 +353,7 @@ func AssertEqualReceiverProducedBodySize(t *testing.T, tt *componenttest.Telemet
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol.receiver.produced.body.size")
+	got, err := tt.GetMetric("otelcol.receiver.produced.body.bytes.processed")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/service/internal/metadatatest/generated_telemetrytest.go
+++ b/service/internal/metadatatest/generated_telemetrytest.go
@@ -6,11 +6,26 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
-
-	"go.opentelemetry.io/collector/component/componenttest"
 )
+
+func AssertEqualConnectorConsumedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol.connector.consumed.body.size",
+		Description: "Total byte size of log record bodies passed to the connector. [Development]",
+		Unit:        "By",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol.connector.consumed.body.size")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
 
 func AssertEqualConnectorConsumedItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
@@ -44,6 +59,22 @@ func AssertEqualConnectorConsumedSize(t *testing.T, tt *componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualConnectorProducedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol.connector.produced.body.size",
+		Description: "Total byte size of log record bodies emitted from the connector. [Development]",
+		Unit:        "By",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol.connector.produced.body.size")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualConnectorProducedItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol.connector.produced.items",
@@ -72,6 +103,22 @@ func AssertEqualConnectorProducedSize(t *testing.T, tt *componenttest.Telemetry,
 		},
 	}
 	got, err := tt.GetMetric("otelcol.connector.produced.size")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualExporterConsumedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol.exporter.consumed.body.size",
+		Description: "Total byte size of log record bodies passed to the exporter. [Development]",
+		Unit:        "By",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol.exporter.consumed.body.size")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
@@ -198,6 +245,22 @@ func AssertEqualProcessUptime(t *testing.T, tt *componenttest.Telemetry, dps []m
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualProcessorConsumedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol.processor.consumed.body.size",
+		Description: "Total byte size of log record bodies passed to the processor. [Development]",
+		Unit:        "By",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol.processor.consumed.body.size")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualProcessorConsumedItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol.processor.consumed.items",
@@ -230,6 +293,22 @@ func AssertEqualProcessorConsumedSize(t *testing.T, tt *componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualProcessorProducedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol.processor.produced.body.size",
+		Description: "Total byte size of log record bodies emitted from the processor. [Development]",
+		Unit:        "By",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol.processor.produced.body.size")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualProcessorProducedItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol.processor.produced.items",
@@ -258,6 +337,22 @@ func AssertEqualProcessorProducedSize(t *testing.T, tt *componenttest.Telemetry,
 		},
 	}
 	got, err := tt.GetMetric("otelcol.processor.produced.size")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualReceiverProducedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol.receiver.produced.body.size",
+		Description: "Total byte size of log record bodies emitted from the receiver. [Development]",
+		Unit:        "By",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol.receiver.produced.body.size")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/service/internal/metadatatest/generated_telemetrytest.go
+++ b/service/internal/metadatatest/generated_telemetrytest.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 func AssertEqualConnectorConsumedBodySize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {

--- a/service/internal/metadatatest/generated_telemetrytest_test.go
+++ b/service/internal/metadatatest/generated_telemetrytest_test.go
@@ -44,28 +44,43 @@ func TestSetupTelemetry(t *testing.T) {
 		observer.Observe(1)
 		return nil
 	}))
+	tb.ConnectorConsumedBodySize.Add(context.Background(), 1)
 	tb.ConnectorConsumedItems.Add(context.Background(), 1)
 	tb.ConnectorConsumedSize.Add(context.Background(), 1)
+	tb.ConnectorProducedBodySize.Add(context.Background(), 1)
 	tb.ConnectorProducedItems.Add(context.Background(), 1)
 	tb.ConnectorProducedSize.Add(context.Background(), 1)
+	tb.ExporterConsumedBodySize.Add(context.Background(), 1)
 	tb.ExporterConsumedItems.Add(context.Background(), 1)
 	tb.ExporterConsumedSize.Add(context.Background(), 1)
+	tb.ProcessorConsumedBodySize.Add(context.Background(), 1)
 	tb.ProcessorConsumedItems.Add(context.Background(), 1)
 	tb.ProcessorConsumedSize.Add(context.Background(), 1)
+	tb.ProcessorProducedBodySize.Add(context.Background(), 1)
 	tb.ProcessorProducedItems.Add(context.Background(), 1)
 	tb.ProcessorProducedSize.Add(context.Background(), 1)
+	tb.ReceiverProducedBodySize.Add(context.Background(), 1)
 	tb.ReceiverProducedItems.Add(context.Background(), 1)
 	tb.ReceiverProducedSize.Add(context.Background(), 1)
+	AssertEqualConnectorConsumedBodySize(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualConnectorConsumedItems(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualConnectorConsumedSize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
+	AssertEqualConnectorProducedBodySize(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualConnectorProducedItems(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualConnectorProducedSize(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualExporterConsumedBodySize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterConsumedItems(t, testTel,
@@ -92,16 +107,25 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualProcessUptime(t, testTel,
 		[]metricdata.DataPoint[float64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
+	AssertEqualProcessorConsumedBodySize(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorConsumedItems(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorConsumedSize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
+	AssertEqualProcessorProducedBodySize(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorProducedItems(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorProducedSize(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualReceiverProducedBodySize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualReceiverProducedItems(t, testTel,

--- a/service/internal/metadatatest/generated_telemetrytest_test.go
+++ b/service/internal/metadatatest/generated_telemetrytest_test.go
@@ -44,25 +44,25 @@ func TestSetupTelemetry(t *testing.T) {
 		observer.Observe(1)
 		return nil
 	}))
-	tb.ConnectorConsumedBodySize.Add(context.Background(), 1)
+	tb.ConnectorConsumedBodyBytesProcessed.Add(context.Background(), 1)
 	tb.ConnectorConsumedItems.Add(context.Background(), 1)
 	tb.ConnectorConsumedSize.Add(context.Background(), 1)
-	tb.ConnectorProducedBodySize.Add(context.Background(), 1)
+	tb.ConnectorProducedBodyBytesProcessed.Add(context.Background(), 1)
 	tb.ConnectorProducedItems.Add(context.Background(), 1)
 	tb.ConnectorProducedSize.Add(context.Background(), 1)
-	tb.ExporterConsumedBodySize.Add(context.Background(), 1)
+	tb.ExporterConsumedBodyBytesProcessed.Add(context.Background(), 1)
 	tb.ExporterConsumedItems.Add(context.Background(), 1)
 	tb.ExporterConsumedSize.Add(context.Background(), 1)
-	tb.ProcessorConsumedBodySize.Add(context.Background(), 1)
+	tb.ProcessorConsumedBodyBytesProcessed.Add(context.Background(), 1)
 	tb.ProcessorConsumedItems.Add(context.Background(), 1)
 	tb.ProcessorConsumedSize.Add(context.Background(), 1)
-	tb.ProcessorProducedBodySize.Add(context.Background(), 1)
+	tb.ProcessorProducedBodyBytesProcessed.Add(context.Background(), 1)
 	tb.ProcessorProducedItems.Add(context.Background(), 1)
 	tb.ProcessorProducedSize.Add(context.Background(), 1)
-	tb.ReceiverProducedBodySize.Add(context.Background(), 1)
+	tb.ReceiverProducedBodyBytesProcessed.Add(context.Background(), 1)
 	tb.ReceiverProducedItems.Add(context.Background(), 1)
 	tb.ReceiverProducedSize.Add(context.Background(), 1)
-	AssertEqualConnectorConsumedBodySize(t, testTel,
+	AssertEqualConnectorConsumedBodyBytesProcessed(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualConnectorConsumedItems(t, testTel,
@@ -71,7 +71,7 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualConnectorConsumedSize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	AssertEqualConnectorProducedBodySize(t, testTel,
+	AssertEqualConnectorProducedBodyBytesProcessed(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualConnectorProducedItems(t, testTel,
@@ -80,7 +80,7 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualConnectorProducedSize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	AssertEqualExporterConsumedBodySize(t, testTel,
+	AssertEqualExporterConsumedBodyBytesProcessed(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterConsumedItems(t, testTel,
@@ -107,7 +107,7 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualProcessUptime(t, testTel,
 		[]metricdata.DataPoint[float64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	AssertEqualProcessorConsumedBodySize(t, testTel,
+	AssertEqualProcessorConsumedBodyBytesProcessed(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorConsumedItems(t, testTel,
@@ -116,7 +116,7 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualProcessorConsumedSize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	AssertEqualProcessorProducedBodySize(t, testTel,
+	AssertEqualProcessorProducedBodyBytesProcessed(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorProducedItems(t, testTel,
@@ -125,7 +125,7 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualProcessorProducedSize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	AssertEqualReceiverProducedBodySize(t, testTel,
+	AssertEqualReceiverProducedBodyBytesProcessed(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualReceiverProducedItems(t, testTel,

--- a/service/internal/metricviews/views.go
+++ b/service/internal/metricviews/views.go
@@ -140,6 +140,14 @@ func DefaultViews(level configtelemetry.Level) []config.View {
 			dropViewOption(&config.ViewSelector{
 				MeterName:      graphScope,
 				InstrumentName: ptr("otelcol.*.produced.size"),
+			}),
+			dropViewOption(&config.ViewSelector{
+				MeterName:      graphScope,
+				InstrumentName: ptr("otelcol.*.consumed.body.size"),
+			}),
+			dropViewOption(&config.ViewSelector{
+				MeterName:      graphScope,
+				InstrumentName: ptr("otelcol.*.produced.body.size"),
 			}))
 	}
 

--- a/service/internal/metricviews/views.go
+++ b/service/internal/metricviews/views.go
@@ -143,11 +143,11 @@ func DefaultViews(level configtelemetry.Level) []config.View {
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      graphScope,
-				InstrumentName: ptr("otelcol.*.consumed.body.size"),
+				InstrumentName: ptr("otelcol.*.consumed.body.bytes.processed"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      graphScope,
-				InstrumentName: ptr("otelcol.*.produced.body.size"),
+				InstrumentName: ptr("otelcol.*.produced.body.bytes.processed"),
 			}))
 	}
 

--- a/service/internal/metricviews/views_test.go
+++ b/service/internal/metricviews/views_test.go
@@ -22,17 +22,17 @@ func TestDefaultViews(t *testing.T) {
 		{
 			name:           "None",
 			level:          configtelemetry.LevelNone,
-			wantViewsCount: 18,
+			wantViewsCount: 20,
 		},
 		{
 			name:           "Basic",
 			level:          configtelemetry.LevelBasic,
-			wantViewsCount: 18,
+			wantViewsCount: 20,
 		},
 		{
 			name:           "Normal",
 			level:          configtelemetry.LevelNormal,
-			wantViewsCount: 15,
+			wantViewsCount: 17,
 		},
 		{
 			name:           "Detailed",

--- a/service/internal/obsconsumer/consumer_test.go
+++ b/service/internal/obsconsumer/consumer_test.go
@@ -75,15 +75,19 @@ func TestConsumeRefused(t *testing.T) {
 	require.NoError(t, err)
 	receivedSizeCounter, err := meter.Int64Counter("received.size")
 	require.NoError(t, err)
+	receivedBodySizeCounter, err := meter.Int64Counter("received.body.size")
+	require.NoError(t, err)
 
 	producedItemsCounter, err := meter.Int64Counter("produced.items")
 	require.NoError(t, err)
 	producedSizeConter, err := meter.Int64Counter("produced.size")
 	require.NoError(t, err)
+	producedBodySizeCounter, err := meter.Int64Counter("produced.body.size")
+	require.NoError(t, err)
 
 	logger := zap.NewNop()
-	receivedSettings := obsconsumer.Settings{ItemCounter: receivedItemsCounter, SizeCounter: receivedSizeCounter, Logger: logger}
-	producedSettings := obsconsumer.Settings{ItemCounter: producedItemsCounter, SizeCounter: producedSizeConter, Logger: logger}
+	receivedSettings := obsconsumer.Settings{ItemCounter: receivedItemsCounter, SizeCounter: receivedSizeCounter, BodySizeCounter: newDisabledCounter(receivedBodySizeCounter), Logger: logger}
+	producedSettings := obsconsumer.Settings{ItemCounter: producedItemsCounter, SizeCounter: producedSizeConter, BodySizeCounter: newDisabledCounter(producedBodySizeCounter), Logger: logger}
 
 	type testCase struct {
 		name         string

--- a/service/internal/obsconsumer/consumer_test.go
+++ b/service/internal/obsconsumer/consumer_test.go
@@ -75,19 +75,19 @@ func TestConsumeRefused(t *testing.T) {
 	require.NoError(t, err)
 	receivedSizeCounter, err := meter.Int64Counter("received.size")
 	require.NoError(t, err)
-	receivedBodySizeCounter, err := meter.Int64Counter("received.body.size")
+	receivedBodyBytesProcessedCounter, err := meter.Int64Counter("received.body.bytes.processed")
 	require.NoError(t, err)
 
 	producedItemsCounter, err := meter.Int64Counter("produced.items")
 	require.NoError(t, err)
 	producedSizeConter, err := meter.Int64Counter("produced.size")
 	require.NoError(t, err)
-	producedBodySizeCounter, err := meter.Int64Counter("produced.body.size")
+	producedBodyBytesProcessedCounter, err := meter.Int64Counter("produced.body.bytes.processed")
 	require.NoError(t, err)
 
 	logger := zap.NewNop()
-	receivedSettings := obsconsumer.Settings{ItemCounter: receivedItemsCounter, SizeCounter: receivedSizeCounter, BodySizeCounter: newDisabledCounter(receivedBodySizeCounter), Logger: logger}
-	producedSettings := obsconsumer.Settings{ItemCounter: producedItemsCounter, SizeCounter: producedSizeConter, BodySizeCounter: newDisabledCounter(producedBodySizeCounter), Logger: logger}
+	receivedSettings := obsconsumer.Settings{ItemCounter: receivedItemsCounter, SizeCounter: receivedSizeCounter, BodyBytesProcessedCounter: newDisabledCounter(receivedBodyBytesProcessedCounter), Logger: logger}
+	producedSettings := obsconsumer.Settings{ItemCounter: producedItemsCounter, SizeCounter: producedSizeConter, BodyBytesProcessedCounter: newDisabledCounter(producedBodyBytesProcessedCounter), Logger: logger}
 
 	type testCase struct {
 		name         string

--- a/service/internal/obsconsumer/logs.go
+++ b/service/internal/obsconsumer/logs.go
@@ -32,10 +32,10 @@ func NewLogs(cons consumer.Logs, set Settings, opts ...Option) consumer.Logs {
 	}
 
 	consumerSet := Settings{
-		ItemCounter:     set.ItemCounter,
-		SizeCounter:     set.SizeCounter,
-		BodySizeCounter: set.BodySizeCounter,
-		Logger:          set.Logger.With(telemetry.ToZapFields(o.staticDataPointAttributes)...),
+		ItemCounter:               set.ItemCounter,
+		SizeCounter:               set.SizeCounter,
+		BodyBytesProcessedCounter: set.BodyBytesProcessedCounter,
+		Logger:                    set.Logger.With(telemetry.ToZapFields(o.staticDataPointAttributes)...),
 	}
 
 	return obsLogs{
@@ -68,10 +68,10 @@ func (c obsLogs) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		}()
 	}
 
-	if isEnabled(ctx, c.set.BodySizeCounter) {
+	if isEnabled(ctx, c.set.BodyBytesProcessedCounter) {
 		bodySize := logBodySize(ld)
 		defer func() {
-			c.set.BodySizeCounter.Add(ctx, bodySize, *attrs)
+			c.set.BodyBytesProcessedCounter.Add(ctx, bodySize, *attrs)
 		}()
 	}
 

--- a/service/internal/obsconsumer/logs.go
+++ b/service/internal/obsconsumer/logs.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/internal/telemetry"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/service/internal/metadata"
 )
@@ -31,9 +32,10 @@ func NewLogs(cons consumer.Logs, set Settings, opts ...Option) consumer.Logs {
 	}
 
 	consumerSet := Settings{
-		ItemCounter: set.ItemCounter,
-		SizeCounter: set.SizeCounter,
-		Logger:      set.Logger.With(telemetry.ToZapFields(o.staticDataPointAttributes)...),
+		ItemCounter:     set.ItemCounter,
+		SizeCounter:     set.SizeCounter,
+		BodySizeCounter: set.BodySizeCounter,
+		Logger:          set.Logger.With(telemetry.ToZapFields(o.staticDataPointAttributes)...),
 	}
 
 	return obsLogs{
@@ -66,6 +68,13 @@ func (c obsLogs) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		}()
 	}
 
+	if isEnabled(ctx, c.set.BodySizeCounter) {
+		bodySize := logBodySize(ld)
+		defer func() {
+			c.set.BodySizeCounter.Add(ctx, bodySize, *attrs)
+		}()
+	}
+
 	err := c.consumer.ConsumeLogs(ctx, ld)
 	if err != nil {
 		if consumererror.IsDownstream(err) {
@@ -83,4 +92,54 @@ func (c obsLogs) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 
 func (c obsLogs) Capabilities() consumer.Capabilities {
 	return c.consumer.Capabilities()
+}
+
+func logBodySize(ld plog.Logs) int64 {
+	var total int64
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rl := ld.ResourceLogs().At(i)
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				total += valueSize(sl.LogRecords().At(k).Body())
+			}
+		}
+	}
+	return total
+}
+
+// valueSize estimates the byte size of a pcommon.Value without allocating.
+// For string and bytes values it returns the exact length. For numeric and
+// boolean types it returns the fixed in-memory size. For maps and slices it
+// recursively sums leaf sizes (including map keys). This avoids the
+// json.Marshal path that AsString() takes for structured types.
+func valueSize(v pcommon.Value) int64 {
+	switch v.Type() {
+	case pcommon.ValueTypeStr:
+		return int64(len(v.Str()))
+	case pcommon.ValueTypeBytes:
+		return int64(v.Bytes().Len())
+	case pcommon.ValueTypeInt:
+		return 8
+	case pcommon.ValueTypeDouble:
+		return 8
+	case pcommon.ValueTypeBool:
+		return 1
+	case pcommon.ValueTypeMap:
+		var size int64
+		v.Map().Range(func(k string, val pcommon.Value) bool {
+			size += int64(len(k)) + valueSize(val)
+			return true
+		})
+		return size
+	case pcommon.ValueTypeSlice:
+		var size int64
+		sl := v.Slice()
+		for i := 0; i < sl.Len(); i++ {
+			size += valueSize(sl.At(i))
+		}
+		return size
+	default:
+		return 0
+	}
 }

--- a/service/internal/obsconsumer/logs_test.go
+++ b/service/internal/obsconsumer/logs_test.go
@@ -495,8 +495,8 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 			failureBodySizeDP = dp
 		}
 	}
-	require.Equal(t, int64(8), successBodySizeDP.Value)  // 2*2 + 2*2 = 8 bytes ("ab" * 4)
-	require.Equal(t, int64(6), failureBodySizeDP.Value)   // 3 + 3 = 6 bytes ("abc" * 2)
+	require.Equal(t, int64(8), successBodySizeDP.Value) // 2*2 + 2*2 = 8 bytes ("ab" * 4)
+	require.Equal(t, int64(6), failureBodySizeDP.Value) // 3 + 3 = 6 bytes ("abc" * 2)
 
 	// Check that the logger was called for errors
 	require.Len(t, logs.All(), 2)
@@ -888,10 +888,10 @@ func TestLogsBodySizeStructuredBodies(t *testing.T) {
 			require.NoError(t, err)
 
 			consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{
-				ItemCounter:        itemCounter,
-				SizeCounter:        sizeCounterDisabled,
+				ItemCounter:     itemCounter,
+				SizeCounter:     sizeCounterDisabled,
 				BodySizeCounter: bodySizeCounter,
-				Logger:             zap.NewNop(),
+				Logger:          zap.NewNop(),
 			})
 
 			ld := plog.NewLogs()

--- a/service/internal/obsconsumer/logs_test.go
+++ b/service/internal/obsconsumer/logs_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/service/internal/obsconsumer"
 )
@@ -45,9 +46,11 @@ func TestLogsNopWhenGateDisabled(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
+	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	require.NoError(t, err)
 
 	cons := consumertest.NewNop()
-	require.Equal(t, cons, obsconsumer.NewLogs(cons, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, Logger: zap.NewNop()}))
+	require.Equal(t, cons, obsconsumer.NewLogs(cons, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: zap.NewNop()}))
 }
 
 func TestLogsItemsOnly(t *testing.T) {
@@ -64,10 +67,13 @@ func TestLogsItemsOnly(t *testing.T) {
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
 	sizeCounterDisabled := newDisabledCounter(sizeCounter)
+	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	require.NoError(t, err)
+	bodySizeCounterDisabled := newDisabledCounter(bodySizeCounter)
 
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounterDisabled, Logger: logger})
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounterDisabled, BodySizeCounter: bodySizeCounterDisabled, Logger: logger})
 
 	ld := plog.NewLogs()
 	r := ld.ResourceLogs().AppendEmpty()
@@ -114,15 +120,17 @@ func TestLogsConsumeSuccess(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
+	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	require.NoError(t, err)
 
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, Logger: logger})
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: logger})
 
 	ld := plog.NewLogs()
 	r := ld.ResourceLogs().AppendEmpty()
 	sl := r.ScopeLogs().AppendEmpty()
-	sl.LogRecords().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("hello")
 
 	err = consumer.ConsumeLogs(ctx, ld)
 	require.NoError(t, err)
@@ -131,19 +139,22 @@ func TestLogsConsumeSuccess(t *testing.T) {
 	err = reader.Collect(ctx, &rm)
 	require.NoError(t, err)
 	require.Len(t, rm.ScopeMetrics, 1)
-	require.Len(t, rm.ScopeMetrics[0].Metrics, 2)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 3)
 
-	var itemMetric, sizeMetric metricdata.Metrics
+	var itemMetric, sizeMetric, bodySizeMetric metricdata.Metrics
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		switch m.Name {
 		case "item_counter":
 			itemMetric = m
 		case "size_counter":
 			sizeMetric = m
+		case "body_size_counter":
+			bodySizeMetric = m
 		}
 	}
 	require.NotNil(t, itemMetric)
 	require.NotNil(t, sizeMetric)
+	require.NotNil(t, bodySizeMetric)
 
 	itemData := itemMetric.Data.(metricdata.Sum[int64])
 	require.Len(t, itemData.DataPoints, 1)
@@ -162,6 +173,16 @@ func TestLogsConsumeSuccess(t *testing.T) {
 	sizeAttrs := sizeData.DataPoints[0].Attributes
 	require.Equal(t, 1, sizeAttrs.Len())
 	val, ok = sizeAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
+	require.True(t, ok)
+	require.Equal(t, "success", val.Emit())
+
+	bodySizeData := bodySizeMetric.Data.(metricdata.Sum[int64])
+	require.Len(t, bodySizeData.DataPoints, 1)
+	require.Equal(t, int64(5), bodySizeData.DataPoints[0].Value) // len("hello") == 5
+
+	bodySizeAttrs := bodySizeData.DataPoints[0].Attributes
+	require.Equal(t, 1, bodySizeAttrs.Len())
+	val, ok = bodySizeAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 
@@ -185,15 +206,17 @@ func TestLogsConsumeFailure(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
+	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	require.NoError(t, err)
 
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, Logger: logger})
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: logger})
 
 	ld := plog.NewLogs()
 	r := ld.ResourceLogs().AppendEmpty()
 	sl := r.ScopeLogs().AppendEmpty()
-	sl.LogRecords().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("hello")
 
 	err = consumer.ConsumeLogs(ctx, ld)
 	assert.Equal(t, downstreamErr, err)
@@ -202,19 +225,22 @@ func TestLogsConsumeFailure(t *testing.T) {
 	err = reader.Collect(ctx, &rm)
 	require.NoError(t, err)
 	require.Len(t, rm.ScopeMetrics, 1)
-	require.Len(t, rm.ScopeMetrics[0].Metrics, 2)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 3)
 
-	var itemMetric, sizeMetric metricdata.Metrics
+	var itemMetric, sizeMetric, bodySizeMetric metricdata.Metrics
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		switch m.Name {
 		case "item_counter":
 			itemMetric = m
 		case "size_counter":
 			sizeMetric = m
+		case "body_size_counter":
+			bodySizeMetric = m
 		}
 	}
 	require.NotNil(t, itemMetric)
 	require.NotNil(t, sizeMetric)
+	require.NotNil(t, bodySizeMetric)
 
 	itemData := itemMetric.Data.(metricdata.Sum[int64])
 	require.Len(t, itemData.DataPoints, 1)
@@ -237,6 +263,16 @@ func TestLogsConsumeFailure(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "failure", val.Emit())
 
+	bodySizeData := bodySizeMetric.Data.(metricdata.Sum[int64])
+	require.Len(t, bodySizeData.DataPoints, 1)
+	require.Equal(t, int64(5), bodySizeData.DataPoints[0].Value) // len("hello") == 5
+
+	bodySizeAttrs := bodySizeData.DataPoints[0].Attributes
+	require.Equal(t, 1, bodySizeAttrs.Len())
+	val, ok = bodySizeAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
+	require.True(t, ok)
+	require.Equal(t, "failure", val.Emit())
+
 	// Check that the logger was called with an error
 	require.Len(t, logs.All(), 1)
 	assert.Contains(t, logs.All()[0].Message, "Logs pipeline component had an error")
@@ -256,17 +292,19 @@ func TestLogsWithStaticAttributes(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
+	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	require.NoError(t, err)
 
 	staticAttr := attribute.String("test", "value")
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, Logger: logger},
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: logger},
 		obsconsumer.WithStaticDataPointAttribute(staticAttr))
 
 	ld := plog.NewLogs()
 	r := ld.ResourceLogs().AppendEmpty()
 	sl := r.ScopeLogs().AppendEmpty()
-	sl.LogRecords().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("hello")
 
 	err = consumer.ConsumeLogs(ctx, ld)
 	require.NoError(t, err)
@@ -275,15 +313,17 @@ func TestLogsWithStaticAttributes(t *testing.T) {
 	err = reader.Collect(ctx, &rm)
 	require.NoError(t, err)
 	require.Len(t, rm.ScopeMetrics, 1)
-	require.Len(t, rm.ScopeMetrics[0].Metrics, 2)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 3)
 
-	var itemMetric, sizeMetric metricdata.Metrics
+	var itemMetric, sizeMetric, bodySizeMetric metricdata.Metrics
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		switch m.Name {
 		case "item_counter":
 			itemMetric = m
 		case "size_counter":
 			sizeMetric = m
+		case "body_size_counter":
+			bodySizeMetric = m
 		}
 	}
 	require.NotNil(t, itemMetric)
@@ -314,6 +354,19 @@ func TestLogsWithStaticAttributes(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 
+	bodySizeData := bodySizeMetric.Data.(metricdata.Sum[int64])
+	require.Len(t, bodySizeData.DataPoints, 1)
+	require.Equal(t, int64(5), bodySizeData.DataPoints[0].Value) // len("hello") == 5
+
+	bodySizeAttrs := bodySizeData.DataPoints[0].Attributes
+	require.Equal(t, 2, bodySizeAttrs.Len())
+	val, ok = bodySizeAttrs.Value(attribute.Key("test"))
+	require.True(t, ok)
+	require.Equal(t, "value", val.Emit())
+	val, ok = bodySizeAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
+	require.True(t, ok)
+	require.Equal(t, "success", val.Emit())
+
 	// Check that the logger was not called
 	assert.Empty(t, logs.All())
 }
@@ -334,47 +387,49 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
+	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	require.NoError(t, err)
 
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, Logger: logger})
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: logger})
 
-	// First batch: 2 successful items
+	// First batch: 2 successful items with body "ab" (2 bytes each)
 	ld1 := plog.NewLogs()
 	for range 2 {
 		r := ld1.ResourceLogs().AppendEmpty()
 		sl := r.ScopeLogs().AppendEmpty()
-		sl.LogRecords().AppendEmpty()
+		sl.LogRecords().AppendEmpty().Body().SetStr("ab")
 	}
 	err = consumer.ConsumeLogs(ctx, ld1)
 	require.NoError(t, err)
 
-	// Second batch: 1 failed item
+	// Second batch: 1 failed item with body "abc" (3 bytes)
 	mockConsumer.err = expectedErr
 	ld2 := plog.NewLogs()
 	r := ld2.ResourceLogs().AppendEmpty()
 	sl := r.ScopeLogs().AppendEmpty()
-	sl.LogRecords().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("abc")
 	err = consumer.ConsumeLogs(ctx, ld2)
 	assert.Equal(t, downstreamErr, err)
 
-	// Third batch: 2 successful items
+	// Third batch: 2 successful items with body "ab" (2 bytes each)
 	mockConsumer.err = nil
 	ld3 := plog.NewLogs()
 	for range 2 {
 		r = ld3.ResourceLogs().AppendEmpty()
 		sl = r.ScopeLogs().AppendEmpty()
-		sl.LogRecords().AppendEmpty()
+		sl.LogRecords().AppendEmpty().Body().SetStr("ab")
 	}
 	err = consumer.ConsumeLogs(ctx, ld3)
 	require.NoError(t, err)
 
-	// Fourth batch: 1 failed item
+	// Fourth batch: 1 failed item with body "abc" (3 bytes)
 	mockConsumer.err = expectedErr
 	ld4 := plog.NewLogs()
 	r = ld4.ResourceLogs().AppendEmpty()
 	sl = r.ScopeLogs().AppendEmpty()
-	sl.LogRecords().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("abc")
 	err = consumer.ConsumeLogs(ctx, ld4)
 	assert.Equal(t, downstreamErr, err)
 
@@ -382,24 +437,29 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 	err = reader.Collect(ctx, &rm)
 	require.NoError(t, err)
 	require.Len(t, rm.ScopeMetrics, 1)
-	require.Len(t, rm.ScopeMetrics[0].Metrics, 2)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 3)
 
-	var itemMetric, sizeMetric metricdata.Metrics
+	var itemMetric, sizeMetric, bodySizeMetric metricdata.Metrics
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		switch m.Name {
 		case "item_counter":
 			itemMetric = m
 		case "size_counter":
 			sizeMetric = m
+		case "body_size_counter":
+			bodySizeMetric = m
 		}
 	}
 	require.NotNil(t, itemMetric)
 	require.NotNil(t, sizeMetric)
+	require.NotNil(t, bodySizeMetric)
 
 	itemData := itemMetric.Data.(metricdata.Sum[int64])
 	require.Len(t, itemData.DataPoints, 2)
 	sizeData := sizeMetric.Data.(metricdata.Sum[int64])
 	require.Len(t, sizeData.DataPoints, 2)
+	bodySizeData := bodySizeMetric.Data.(metricdata.Sum[int64])
+	require.Len(t, bodySizeData.DataPoints, 2)
 
 	var successDP, failureDP metricdata.DataPoint[int64]
 	for _, dp := range itemData.DataPoints {
@@ -422,13 +482,440 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 			failureSizeDP = dp
 		}
 	}
-	require.Equal(t, int64(64), successSizeDP.Value)
-	require.Equal(t, int64(32), failureSizeDP.Value)
+	// Size values change because we now set body strings on log records
+	require.Positive(t, successSizeDP.Value)
+	require.Positive(t, failureSizeDP.Value)
+
+	var successBodySizeDP, failureBodySizeDP metricdata.DataPoint[int64]
+	for _, dp := range bodySizeData.DataPoints {
+		val, ok := dp.Attributes.Value(attribute.Key(obsconsumer.ComponentOutcome))
+		if ok && val.Emit() == "success" {
+			successBodySizeDP = dp
+		} else {
+			failureBodySizeDP = dp
+		}
+	}
+	require.Equal(t, int64(8), successBodySizeDP.Value)  // 2*2 + 2*2 = 8 bytes ("ab" * 4)
+	require.Equal(t, int64(6), failureBodySizeDP.Value)   // 3 + 3 = 6 bytes ("abc" * 2)
 
 	// Check that the logger was called for errors
 	require.Len(t, logs.All(), 2)
 	for _, log := range logs.All() {
 		assert.Contains(t, log.Message, "Logs pipeline component had an error")
+	}
+}
+
+func TestLogsBodySizeDisabled(t *testing.T) {
+	setGateForTest(t, true)
+
+	ctx := context.Background()
+	mockConsumer := &mockLogsConsumer{}
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := mp.Meter("test")
+
+	itemCounter, err := meter.Int64Counter("item_counter")
+	require.NoError(t, err)
+	sizeCounter, err := meter.Int64Counter("size_counter")
+	require.NoError(t, err)
+	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	require.NoError(t, err)
+	bodySizeCounterDisabled := newDisabledCounter(bodySizeCounter)
+
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{
+		ItemCounter:     itemCounter,
+		SizeCounter:     sizeCounter,
+		BodySizeCounter: bodySizeCounterDisabled,
+		Logger:          zap.NewNop(),
+	})
+
+	ld := plog.NewLogs()
+	r := ld.ResourceLogs().AppendEmpty()
+	sl := r.ScopeLogs().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("hello")
+
+	err = consumer.ConsumeLogs(ctx, ld)
+	require.NoError(t, err)
+
+	var rm metricdata.ResourceMetrics
+	err = reader.Collect(ctx, &rm)
+	require.NoError(t, err)
+	require.Len(t, rm.ScopeMetrics, 1)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 2) // only item_counter and size_counter
+
+	for _, m := range rm.ScopeMetrics[0].Metrics {
+		require.NotEqual(t, "body_size_counter", m.Name)
+	}
+}
+
+func TestLogsBodySizeStructuredBodies(t *testing.T) {
+	setGateForTest(t, true)
+
+	type bodySetup func(body pcommon.Value)
+
+	tests := []struct {
+		name     string
+		setup    bodySetup
+		expected int64
+	}{
+		// Primitive types
+		{
+			name:     "empty",
+			setup:    func(_ pcommon.Value) {},
+			expected: 0,
+		},
+		{
+			name:     "string",
+			setup:    func(v pcommon.Value) { v.SetStr("hello") },
+			expected: 5,
+		},
+		{
+			name:     "empty_string",
+			setup:    func(v pcommon.Value) { v.SetStr("") },
+			expected: 0,
+		},
+		{
+			name:     "int",
+			setup:    func(v pcommon.Value) { v.SetInt(42) },
+			expected: 8,
+		},
+		{
+			name:     "double",
+			setup:    func(v pcommon.Value) { v.SetDouble(3.14) },
+			expected: 8,
+		},
+		{
+			name:     "bool",
+			setup:    func(v pcommon.Value) { v.SetBool(true) },
+			expected: 1,
+		},
+		{
+			name: "bytes",
+			setup: func(v pcommon.Value) {
+				v.SetEmptyBytes().FromRaw([]byte{1, 2, 3})
+			},
+			expected: 3,
+		},
+		{
+			name:     "empty_bytes",
+			setup:    func(v pcommon.Value) { v.SetEmptyBytes() },
+			expected: 0,
+		},
+
+		// Flat map and slice
+		{
+			name:     "empty_map",
+			setup:    func(v pcommon.Value) { v.SetEmptyMap() },
+			expected: 0,
+		},
+		{
+			name:     "empty_slice",
+			setup:    func(v pcommon.Value) { v.SetEmptySlice() },
+			expected: 0,
+		},
+		{
+			name: "flat_map_string_values",
+			setup: func(v pcommon.Value) {
+				// key "msg" (3) + value "hello world" (11) + key "level" (5) + value "info" (4) = 23
+				m := v.SetEmptyMap()
+				m.PutStr("msg", "hello world")
+				m.PutStr("level", "info")
+			},
+			expected: 23,
+		},
+		{
+			name: "flat_map_mixed_value_types",
+			setup: func(v pcommon.Value) {
+				// key "name" (4) + "alice" (5)
+				// + key "age" (3) + int (8)
+				// + key "active" (6) + bool (1)
+				// + key "score" (5) + double (8) = 40
+				m := v.SetEmptyMap()
+				m.PutStr("name", "alice")
+				m.PutInt("age", 30)
+				m.PutBool("active", true)
+				m.PutDouble("score", 99.5)
+			},
+			expected: 40,
+		},
+		{
+			name: "flat_slice",
+			setup: func(v pcommon.Value) {
+				// "a" (1) + "bb" (2) + "ccc" (3) = 6
+				s := v.SetEmptySlice()
+				s.AppendEmpty().SetStr("a")
+				s.AppendEmpty().SetStr("bb")
+				s.AppendEmpty().SetStr("ccc")
+			},
+			expected: 6,
+		},
+		{
+			name: "slice_mixed_types",
+			setup: func(v pcommon.Value) {
+				// "hello" (5) + int (8) + bool (1) + double (8) = 22
+				s := v.SetEmptySlice()
+				s.AppendEmpty().SetStr("hello")
+				s.AppendEmpty().SetInt(1)
+				s.AppendEmpty().SetBool(false)
+				s.AppendEmpty().SetDouble(2.0)
+			},
+			expected: 22,
+		},
+
+		// Nested: map containing map
+		{
+			name: "nested_map_in_map",
+			setup: func(v pcommon.Value) {
+				// key "outer" (5) + nested map:
+				//   key "inner" (5) + "value" (5) = 10
+				// total = 5 + 10 = 15
+				outer := v.SetEmptyMap()
+				inner := outer.PutEmptyMap("outer")
+				inner.PutStr("inner", "value")
+			},
+			expected: 15,
+		},
+		{
+			name: "nested_map_three_levels",
+			setup: func(v pcommon.Value) {
+				// "a" (1) + map:
+				//   "b" (1) + map:
+				//     "c" (1) + "deep" (4)
+				// total = 1 + 1 + 1 + 4 = 7
+				l1 := v.SetEmptyMap()
+				l2 := l1.PutEmptyMap("a")
+				l3 := l2.PutEmptyMap("b")
+				l3.PutStr("c", "deep")
+			},
+			expected: 7,
+		},
+
+		// Nested: map containing slice
+		{
+			name: "map_containing_slice",
+			setup: func(v pcommon.Value) {
+				// key "tags" (4) + slice:
+				//   "x" (1) + "yy" (2) = 3
+				// total = 4 + 3 = 7
+				m := v.SetEmptyMap()
+				s := m.PutEmptySlice("tags")
+				s.AppendEmpty().SetStr("x")
+				s.AppendEmpty().SetStr("yy")
+			},
+			expected: 7,
+		},
+
+		// Nested: slice containing map
+		{
+			name: "slice_containing_map",
+			setup: func(v pcommon.Value) {
+				// element 0 map: key "k" (1) + "v" (1) = 2
+				// element 1 map: key "ab" (2) + int (8) = 10
+				// total = 12
+				s := v.SetEmptySlice()
+				m0 := s.AppendEmpty().SetEmptyMap()
+				m0.PutStr("k", "v")
+				m1 := s.AppendEmpty().SetEmptyMap()
+				m1.PutInt("ab", 7)
+			},
+			expected: 12,
+		},
+
+		// Nested: slice containing slice
+		{
+			name: "slice_containing_slice",
+			setup: func(v pcommon.Value) {
+				// inner slice 0: "aa" (2) + "bb" (2) = 4
+				// inner slice 1: "c" (1) = 1
+				// total = 5
+				outer := v.SetEmptySlice()
+				inner0 := outer.AppendEmpty().SetEmptySlice()
+				inner0.AppendEmpty().SetStr("aa")
+				inner0.AppendEmpty().SetStr("bb")
+				inner1 := outer.AppendEmpty().SetEmptySlice()
+				inner1.AppendEmpty().SetStr("c")
+			},
+			expected: 5,
+		},
+
+		// Deeply nested: 5 levels of maps
+		{
+			name: "five_level_nested_map",
+			setup: func(v pcommon.Value) {
+				// "1" (1) -> "2" (1) -> "3" (1) -> "4" (1) -> "5" (1) + "leaf" (4)
+				// total = 1 + 1 + 1 + 1 + 1 + 4 = 9
+				l1 := v.SetEmptyMap()
+				l2 := l1.PutEmptyMap("1")
+				l3 := l2.PutEmptyMap("2")
+				l4 := l3.PutEmptyMap("3")
+				l5 := l4.PutEmptyMap("4")
+				l5.PutStr("5", "leaf")
+			},
+			expected: 9,
+		},
+
+		// Deeply nested: alternating maps and slices
+		{
+			name: "alternating_map_slice_nesting",
+			setup: func(v pcommon.Value) {
+				// map: key "items" (5) -> slice -> [map: key "id" (2) + int (8)] = 15
+				m := v.SetEmptyMap()
+				s := m.PutEmptySlice("items")
+				inner := s.AppendEmpty().SetEmptyMap()
+				inner.PutInt("id", 1)
+			},
+			expected: 15,
+		},
+
+		// Map with empty nested containers
+		{
+			name: "map_with_empty_nested_containers",
+			setup: func(v pcommon.Value) {
+				// key "a" (1) + empty map (0) + key "b" (1) + empty slice (0) + key "c" (1) + "val" (3) = 6
+				m := v.SetEmptyMap()
+				m.PutEmptyMap("a")
+				m.PutEmptySlice("b")
+				m.PutStr("c", "val")
+			},
+			expected: 6,
+		},
+
+		// Slice with empty nested containers
+		{
+			name: "slice_with_empty_nested_containers",
+			setup: func(v pcommon.Value) {
+				// empty map (0) + empty slice (0) + "data" (4) = 4
+				s := v.SetEmptySlice()
+				s.AppendEmpty().SetEmptyMap()
+				s.AppendEmpty().SetEmptySlice()
+				s.AppendEmpty().SetStr("data")
+			},
+			expected: 4,
+		},
+
+		// Complex realistic structure: JSON-parsed log body
+		{
+			name: "realistic_structured_log",
+			setup: func(v pcommon.Value) {
+				// Simulates a parsed JSON log:
+				// {
+				//   "message": "request completed",    key(7) + val(17) = 24
+				//   "status": 200,                     key(6) + int(8)  = 14
+				//   "duration_ms": 42.5,               key(11) + dbl(8) = 19
+				//   "success": true,                   key(7) + bool(1) = 8
+				//   "headers": {                       key(7)
+				//     "content-type": "application/json",  key(12) + val(16) = 28
+				//     "x-request-id": "abc123"             key(12) + val(6) = 18
+				//   },                                                    = 53
+				//   "tags": ["web", "api"]             key(4) + "web"(3) + "api"(3) = 10
+				// }
+				// total = 24 + 14 + 19 + 8 + 53 + 10 = 128
+				m := v.SetEmptyMap()
+				m.PutStr("message", "request completed")
+				m.PutInt("status", 200)
+				m.PutDouble("duration_ms", 42.5)
+				m.PutBool("success", true)
+				headers := m.PutEmptyMap("headers")
+				headers.PutStr("content-type", "application/json")
+				headers.PutStr("x-request-id", "abc123")
+				tags := m.PutEmptySlice("tags")
+				tags.AppendEmpty().SetStr("web")
+				tags.AppendEmpty().SetStr("api")
+			},
+			expected: 128,
+		},
+
+		// Map with bytes value
+		{
+			name: "map_with_bytes_value",
+			setup: func(v pcommon.Value) {
+				// key "data" (4) + 5 bytes = 9
+				m := v.SetEmptyMap()
+				m.PutEmptyBytes("data").FromRaw([]byte{0, 1, 2, 3, 4})
+			},
+			expected: 9,
+		},
+
+		// Deeply nested slices (4 levels)
+		{
+			name: "four_level_nested_slices",
+			setup: func(v pcommon.Value) {
+				// [[["abc"]]] = "abc" (3)
+				l1 := v.SetEmptySlice()
+				l2 := l1.AppendEmpty().SetEmptySlice()
+				l3 := l2.AppendEmpty().SetEmptySlice()
+				l3.AppendEmpty().SetStr("abc")
+			},
+			expected: 3,
+		},
+
+		// Wide and deep: map with multiple nested branches
+		{
+			name: "wide_and_deep_tree",
+			setup: func(v pcommon.Value) {
+				// "left" (4) -> "ll" (2) -> "x" (1)        = 4 + 2 + 1 = 7
+				// "right" (5) -> "rr" (2) -> int(8)         = 5 + 2 + 8 = 15
+				// "mid" (3) -> "mm" (2) -> bool(1)           = 3 + 2 + 1 = 6
+				// total = 28
+				root := v.SetEmptyMap()
+				left := root.PutEmptyMap("left")
+				left.PutStr("ll", "x")
+				right := root.PutEmptyMap("right")
+				right.PutInt("rr", 99)
+				mid := root.PutEmptyMap("mid")
+				mid.PutBool("mm", true)
+			},
+			expected: 28,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockConsumer := &mockLogsConsumer{}
+
+			reader := sdkmetric.NewManualReader()
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			meter := mp.Meter("test")
+
+			itemCounter, err := meter.Int64Counter("item_counter")
+			require.NoError(t, err)
+			sizeCounter, err := meter.Int64Counter("size_counter")
+			require.NoError(t, err)
+			sizeCounterDisabled := newDisabledCounter(sizeCounter)
+			bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+			require.NoError(t, err)
+
+			consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{
+				ItemCounter:        itemCounter,
+				SizeCounter:        sizeCounterDisabled,
+				BodySizeCounter: bodySizeCounter,
+				Logger:             zap.NewNop(),
+			})
+
+			ld := plog.NewLogs()
+			lr := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+			tt.setup(lr.Body())
+
+			err = consumer.ConsumeLogs(ctx, ld)
+			require.NoError(t, err)
+
+			var rm metricdata.ResourceMetrics
+			err = reader.Collect(ctx, &rm)
+			require.NoError(t, err)
+			require.Len(t, rm.ScopeMetrics, 1)
+
+			for _, m := range rm.ScopeMetrics[0].Metrics {
+				if m.Name == "body_size_counter" {
+					data := m.Data.(metricdata.Sum[int64])
+					require.Len(t, data.DataPoints, 1)
+					assert.Equal(t, tt.expected, data.DataPoints[0].Value)
+					return
+				}
+			}
+			t.Fatal("body_size_counter metric not found")
+		})
 	}
 }
 

--- a/service/internal/obsconsumer/logs_test.go
+++ b/service/internal/obsconsumer/logs_test.go
@@ -46,11 +46,11 @@ func TestLogsNopWhenGateDisabled(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
-	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	bodyBytesProcessedCounter, err := meter.Int64Counter("body_bytes_processed_counter")
 	require.NoError(t, err)
 
 	cons := consumertest.NewNop()
-	require.Equal(t, cons, obsconsumer.NewLogs(cons, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: zap.NewNop()}))
+	require.Equal(t, cons, obsconsumer.NewLogs(cons, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodyBytesProcessedCounter: bodyBytesProcessedCounter, Logger: zap.NewNop()}))
 }
 
 func TestLogsItemsOnly(t *testing.T) {
@@ -67,13 +67,13 @@ func TestLogsItemsOnly(t *testing.T) {
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
 	sizeCounterDisabled := newDisabledCounter(sizeCounter)
-	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	bodyBytesProcessedCounter, err := meter.Int64Counter("body_bytes_processed_counter")
 	require.NoError(t, err)
-	bodySizeCounterDisabled := newDisabledCounter(bodySizeCounter)
+	bodyBytesProcessedCounterDisabled := newDisabledCounter(bodyBytesProcessedCounter)
 
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounterDisabled, BodySizeCounter: bodySizeCounterDisabled, Logger: logger})
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounterDisabled, BodyBytesProcessedCounter: bodyBytesProcessedCounterDisabled, Logger: logger})
 
 	ld := plog.NewLogs()
 	r := ld.ResourceLogs().AppendEmpty()
@@ -120,12 +120,12 @@ func TestLogsConsumeSuccess(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
-	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	bodyBytesProcessedCounter, err := meter.Int64Counter("body_bytes_processed_counter")
 	require.NoError(t, err)
 
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: logger})
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodyBytesProcessedCounter: bodyBytesProcessedCounter, Logger: logger})
 
 	ld := plog.NewLogs()
 	r := ld.ResourceLogs().AppendEmpty()
@@ -141,20 +141,20 @@ func TestLogsConsumeSuccess(t *testing.T) {
 	require.Len(t, rm.ScopeMetrics, 1)
 	require.Len(t, rm.ScopeMetrics[0].Metrics, 3)
 
-	var itemMetric, sizeMetric, bodySizeMetric metricdata.Metrics
+	var itemMetric, sizeMetric, bodyBytesProcessedMetric metricdata.Metrics
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		switch m.Name {
 		case "item_counter":
 			itemMetric = m
 		case "size_counter":
 			sizeMetric = m
-		case "body_size_counter":
-			bodySizeMetric = m
+		case "body_bytes_processed_counter":
+			bodyBytesProcessedMetric = m
 		}
 	}
 	require.NotNil(t, itemMetric)
 	require.NotNil(t, sizeMetric)
-	require.NotNil(t, bodySizeMetric)
+	require.NotNil(t, bodyBytesProcessedMetric)
 
 	itemData := itemMetric.Data.(metricdata.Sum[int64])
 	require.Len(t, itemData.DataPoints, 1)
@@ -176,13 +176,13 @@ func TestLogsConsumeSuccess(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 
-	bodySizeData := bodySizeMetric.Data.(metricdata.Sum[int64])
-	require.Len(t, bodySizeData.DataPoints, 1)
-	require.Equal(t, int64(5), bodySizeData.DataPoints[0].Value) // len("hello") == 5
+	bodyBytesProcessedData := bodyBytesProcessedMetric.Data.(metricdata.Sum[int64])
+	require.Len(t, bodyBytesProcessedData.DataPoints, 1)
+	require.Equal(t, int64(5), bodyBytesProcessedData.DataPoints[0].Value) // len("hello") == 5
 
-	bodySizeAttrs := bodySizeData.DataPoints[0].Attributes
-	require.Equal(t, 1, bodySizeAttrs.Len())
-	val, ok = bodySizeAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
+	bodyBytesProcessedAttrs := bodyBytesProcessedData.DataPoints[0].Attributes
+	require.Equal(t, 1, bodyBytesProcessedAttrs.Len())
+	val, ok = bodyBytesProcessedAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 
@@ -206,12 +206,12 @@ func TestLogsConsumeFailure(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
-	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	bodyBytesProcessedCounter, err := meter.Int64Counter("body_bytes_processed_counter")
 	require.NoError(t, err)
 
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: logger})
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodyBytesProcessedCounter: bodyBytesProcessedCounter, Logger: logger})
 
 	ld := plog.NewLogs()
 	r := ld.ResourceLogs().AppendEmpty()
@@ -227,20 +227,20 @@ func TestLogsConsumeFailure(t *testing.T) {
 	require.Len(t, rm.ScopeMetrics, 1)
 	require.Len(t, rm.ScopeMetrics[0].Metrics, 3)
 
-	var itemMetric, sizeMetric, bodySizeMetric metricdata.Metrics
+	var itemMetric, sizeMetric, bodyBytesProcessedMetric metricdata.Metrics
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		switch m.Name {
 		case "item_counter":
 			itemMetric = m
 		case "size_counter":
 			sizeMetric = m
-		case "body_size_counter":
-			bodySizeMetric = m
+		case "body_bytes_processed_counter":
+			bodyBytesProcessedMetric = m
 		}
 	}
 	require.NotNil(t, itemMetric)
 	require.NotNil(t, sizeMetric)
-	require.NotNil(t, bodySizeMetric)
+	require.NotNil(t, bodyBytesProcessedMetric)
 
 	itemData := itemMetric.Data.(metricdata.Sum[int64])
 	require.Len(t, itemData.DataPoints, 1)
@@ -263,13 +263,13 @@ func TestLogsConsumeFailure(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "failure", val.Emit())
 
-	bodySizeData := bodySizeMetric.Data.(metricdata.Sum[int64])
-	require.Len(t, bodySizeData.DataPoints, 1)
-	require.Equal(t, int64(5), bodySizeData.DataPoints[0].Value) // len("hello") == 5
+	bodyBytesProcessedData := bodyBytesProcessedMetric.Data.(metricdata.Sum[int64])
+	require.Len(t, bodyBytesProcessedData.DataPoints, 1)
+	require.Equal(t, int64(5), bodyBytesProcessedData.DataPoints[0].Value) // len("hello") == 5
 
-	bodySizeAttrs := bodySizeData.DataPoints[0].Attributes
-	require.Equal(t, 1, bodySizeAttrs.Len())
-	val, ok = bodySizeAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
+	bodyBytesProcessedAttrs := bodyBytesProcessedData.DataPoints[0].Attributes
+	require.Equal(t, 1, bodyBytesProcessedAttrs.Len())
+	val, ok = bodyBytesProcessedAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "failure", val.Emit())
 
@@ -292,13 +292,13 @@ func TestLogsWithStaticAttributes(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
-	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	bodyBytesProcessedCounter, err := meter.Int64Counter("body_bytes_processed_counter")
 	require.NoError(t, err)
 
 	staticAttr := attribute.String("test", "value")
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: logger},
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodyBytesProcessedCounter: bodyBytesProcessedCounter, Logger: logger},
 		obsconsumer.WithStaticDataPointAttribute(staticAttr))
 
 	ld := plog.NewLogs()
@@ -315,15 +315,15 @@ func TestLogsWithStaticAttributes(t *testing.T) {
 	require.Len(t, rm.ScopeMetrics, 1)
 	require.Len(t, rm.ScopeMetrics[0].Metrics, 3)
 
-	var itemMetric, sizeMetric, bodySizeMetric metricdata.Metrics
+	var itemMetric, sizeMetric, bodyBytesProcessedMetric metricdata.Metrics
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		switch m.Name {
 		case "item_counter":
 			itemMetric = m
 		case "size_counter":
 			sizeMetric = m
-		case "body_size_counter":
-			bodySizeMetric = m
+		case "body_bytes_processed_counter":
+			bodyBytesProcessedMetric = m
 		}
 	}
 	require.NotNil(t, itemMetric)
@@ -354,16 +354,16 @@ func TestLogsWithStaticAttributes(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 
-	bodySizeData := bodySizeMetric.Data.(metricdata.Sum[int64])
-	require.Len(t, bodySizeData.DataPoints, 1)
-	require.Equal(t, int64(5), bodySizeData.DataPoints[0].Value) // len("hello") == 5
+	bodyBytesProcessedData := bodyBytesProcessedMetric.Data.(metricdata.Sum[int64])
+	require.Len(t, bodyBytesProcessedData.DataPoints, 1)
+	require.Equal(t, int64(5), bodyBytesProcessedData.DataPoints[0].Value) // len("hello") == 5
 
-	bodySizeAttrs := bodySizeData.DataPoints[0].Attributes
-	require.Equal(t, 2, bodySizeAttrs.Len())
-	val, ok = bodySizeAttrs.Value(attribute.Key("test"))
+	bodyBytesProcessedAttrs := bodyBytesProcessedData.DataPoints[0].Attributes
+	require.Equal(t, 2, bodyBytesProcessedAttrs.Len())
+	val, ok = bodyBytesProcessedAttrs.Value(attribute.Key("test"))
 	require.True(t, ok)
 	require.Equal(t, "value", val.Emit())
-	val, ok = bodySizeAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
+	val, ok = bodyBytesProcessedAttrs.Value(attribute.Key(obsconsumer.ComponentOutcome))
 	require.True(t, ok)
 	require.Equal(t, "success", val.Emit())
 
@@ -387,12 +387,12 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
-	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	bodyBytesProcessedCounter, err := meter.Int64Counter("body_bytes_processed_counter")
 	require.NoError(t, err)
 
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodySizeCounter: bodySizeCounter, Logger: logger})
+	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{ItemCounter: itemCounter, SizeCounter: sizeCounter, BodyBytesProcessedCounter: bodyBytesProcessedCounter, Logger: logger})
 
 	// First batch: 2 successful items with body "ab" (2 bytes each)
 	ld1 := plog.NewLogs()
@@ -439,27 +439,27 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 	require.Len(t, rm.ScopeMetrics, 1)
 	require.Len(t, rm.ScopeMetrics[0].Metrics, 3)
 
-	var itemMetric, sizeMetric, bodySizeMetric metricdata.Metrics
+	var itemMetric, sizeMetric, bodyBytesProcessedMetric metricdata.Metrics
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		switch m.Name {
 		case "item_counter":
 			itemMetric = m
 		case "size_counter":
 			sizeMetric = m
-		case "body_size_counter":
-			bodySizeMetric = m
+		case "body_bytes_processed_counter":
+			bodyBytesProcessedMetric = m
 		}
 	}
 	require.NotNil(t, itemMetric)
 	require.NotNil(t, sizeMetric)
-	require.NotNil(t, bodySizeMetric)
+	require.NotNil(t, bodyBytesProcessedMetric)
 
 	itemData := itemMetric.Data.(metricdata.Sum[int64])
 	require.Len(t, itemData.DataPoints, 2)
 	sizeData := sizeMetric.Data.(metricdata.Sum[int64])
 	require.Len(t, sizeData.DataPoints, 2)
-	bodySizeData := bodySizeMetric.Data.(metricdata.Sum[int64])
-	require.Len(t, bodySizeData.DataPoints, 2)
+	bodyBytesProcessedData := bodyBytesProcessedMetric.Data.(metricdata.Sum[int64])
+	require.Len(t, bodyBytesProcessedData.DataPoints, 2)
 
 	var successDP, failureDP metricdata.DataPoint[int64]
 	for _, dp := range itemData.DataPoints {
@@ -486,17 +486,17 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 	require.Positive(t, successSizeDP.Value)
 	require.Positive(t, failureSizeDP.Value)
 
-	var successBodySizeDP, failureBodySizeDP metricdata.DataPoint[int64]
-	for _, dp := range bodySizeData.DataPoints {
+	var successBodyBytesProcessedDP, failureBodyBytesProcessedDP metricdata.DataPoint[int64]
+	for _, dp := range bodyBytesProcessedData.DataPoints {
 		val, ok := dp.Attributes.Value(attribute.Key(obsconsumer.ComponentOutcome))
 		if ok && val.Emit() == "success" {
-			successBodySizeDP = dp
+			successBodyBytesProcessedDP = dp
 		} else {
-			failureBodySizeDP = dp
+			failureBodyBytesProcessedDP = dp
 		}
 	}
-	require.Equal(t, int64(8), successBodySizeDP.Value) // 2*2 + 2*2 = 8 bytes ("ab" * 4)
-	require.Equal(t, int64(6), failureBodySizeDP.Value) // 3 + 3 = 6 bytes ("abc" * 2)
+	require.Equal(t, int64(8), successBodyBytesProcessedDP.Value) // 2*2 + 2*2 = 8 bytes ("ab" * 4)
+	require.Equal(t, int64(6), failureBodyBytesProcessedDP.Value) // 3 + 3 = 6 bytes ("abc" * 2)
 
 	// Check that the logger was called for errors
 	require.Len(t, logs.All(), 2)
@@ -505,7 +505,7 @@ func TestLogsMultipleItemsMixedOutcomes(t *testing.T) {
 	}
 }
 
-func TestLogsBodySizeDisabled(t *testing.T) {
+func TestLogsBodyBytesProcessedDisabled(t *testing.T) {
 	setGateForTest(t, true)
 
 	ctx := context.Background()
@@ -519,15 +519,15 @@ func TestLogsBodySizeDisabled(t *testing.T) {
 	require.NoError(t, err)
 	sizeCounter, err := meter.Int64Counter("size_counter")
 	require.NoError(t, err)
-	bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+	bodyBytesProcessedCounter, err := meter.Int64Counter("body_bytes_processed_counter")
 	require.NoError(t, err)
-	bodySizeCounterDisabled := newDisabledCounter(bodySizeCounter)
+	bodyBytesProcessedCounterDisabled := newDisabledCounter(bodyBytesProcessedCounter)
 
 	consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{
-		ItemCounter:     itemCounter,
-		SizeCounter:     sizeCounter,
-		BodySizeCounter: bodySizeCounterDisabled,
-		Logger:          zap.NewNop(),
+		ItemCounter:               itemCounter,
+		SizeCounter:               sizeCounter,
+		BodyBytesProcessedCounter: bodyBytesProcessedCounterDisabled,
+		Logger:                    zap.NewNop(),
 	})
 
 	ld := plog.NewLogs()
@@ -545,11 +545,11 @@ func TestLogsBodySizeDisabled(t *testing.T) {
 	require.Len(t, rm.ScopeMetrics[0].Metrics, 2) // only item_counter and size_counter
 
 	for _, m := range rm.ScopeMetrics[0].Metrics {
-		require.NotEqual(t, "body_size_counter", m.Name)
+		require.NotEqual(t, "body_bytes_processed_counter", m.Name)
 	}
 }
 
-func TestLogsBodySizeStructuredBodies(t *testing.T) {
+func TestLogsBodyBytesProcessedStructuredBodies(t *testing.T) {
 	setGateForTest(t, true)
 
 	type bodySetup func(body pcommon.Value)
@@ -884,14 +884,14 @@ func TestLogsBodySizeStructuredBodies(t *testing.T) {
 			sizeCounter, err := meter.Int64Counter("size_counter")
 			require.NoError(t, err)
 			sizeCounterDisabled := newDisabledCounter(sizeCounter)
-			bodySizeCounter, err := meter.Int64Counter("body_size_counter")
+			bodyBytesProcessedCounter, err := meter.Int64Counter("body_bytes_processed_counter")
 			require.NoError(t, err)
 
 			consumer := obsconsumer.NewLogs(mockConsumer, obsconsumer.Settings{
-				ItemCounter:     itemCounter,
-				SizeCounter:     sizeCounterDisabled,
-				BodySizeCounter: bodySizeCounter,
-				Logger:          zap.NewNop(),
+				ItemCounter:               itemCounter,
+				SizeCounter:               sizeCounterDisabled,
+				BodyBytesProcessedCounter: bodyBytesProcessedCounter,
+				Logger:                    zap.NewNop(),
 			})
 
 			ld := plog.NewLogs()
@@ -907,14 +907,14 @@ func TestLogsBodySizeStructuredBodies(t *testing.T) {
 			require.Len(t, rm.ScopeMetrics, 1)
 
 			for _, m := range rm.ScopeMetrics[0].Metrics {
-				if m.Name == "body_size_counter" {
+				if m.Name == "body_bytes_processed_counter" {
 					data := m.Data.(metricdata.Sum[int64])
 					require.Len(t, data.DataPoints, 1)
 					assert.Equal(t, tt.expected, data.DataPoints[0].Value)
 					return
 				}
 			}
-			t.Fatal("body_size_counter metric not found")
+			t.Fatal("body_bytes_processed_counter metric not found")
 		})
 	}
 }

--- a/service/internal/obsconsumer/telemetry.go
+++ b/service/internal/obsconsumer/telemetry.go
@@ -16,6 +16,10 @@ type Settings struct {
 	// SizeCounter is the metric to count the size of items processed.
 	SizeCounter metric.Int64Counter
 
+	// BodySizeCounter is the metric to count the total byte size of log record bodies.
+	// Only used for log signal consumers; nil for other signal types.
+	BodySizeCounter metric.Int64Counter
+
 	// Logger is the logger for the obsconsumer package.
 	Logger *zap.Logger
 }

--- a/service/internal/obsconsumer/telemetry.go
+++ b/service/internal/obsconsumer/telemetry.go
@@ -16,9 +16,9 @@ type Settings struct {
 	// SizeCounter is the metric to count the size of items processed.
 	SizeCounter metric.Int64Counter
 
-	// BodySizeCounter is the metric to count the total byte size of log record bodies.
+	// BodyBytesProcessedCounter is the metric to count the total byte size of log record bodies.
 	// Only used for log signal consumers; nil for other signal types.
-	BodySizeCounter metric.Int64Counter
+	BodyBytesProcessedCounter metric.Int64Counter
 
 	// Logger is the logger for the obsconsumer package.
 	Logger *zap.Logger

--- a/service/metadata.yaml
+++ b/service/metadata.yaml
@@ -11,6 +11,16 @@ status:
 
 telemetry:
   metrics:
+    connector.consumed.body.size:
+      prefix: otelcol.
+      enabled: false
+      stability: development
+      description: Total byte size of log record bodies passed to the connector.
+      unit: By
+      sum:
+        value_type: int
+        monotonic: true
+
     connector.consumed.items:
       prefix: otelcol.
       enabled: true
@@ -31,6 +41,16 @@ telemetry:
         value_type: int
         monotonic: true
 
+    connector.produced.body.size:
+      prefix: otelcol.
+      enabled: false
+      stability: development
+      description: Total byte size of log record bodies emitted from the connector.
+      unit: By
+      sum:
+        value_type: int
+        monotonic: true
+
     connector.produced.items:
       prefix: otelcol.
       enabled: true
@@ -47,6 +67,16 @@ telemetry:
       stability: development
       description: Size of items emitted from the connector, based on ProtoMarshaler.Sizer.
       unit: "{item}"
+      sum:
+        value_type: int
+        monotonic: true
+
+    exporter.consumed.body.size:
+      prefix: otelcol.
+      enabled: false
+      stability: development
+      description: Total byte size of log record bodies passed to the exporter.
+      unit: By
       sum:
         value_type: int
         monotonic: true
@@ -128,6 +158,16 @@ telemetry:
         value_type: double
         monotonic: true
 
+    processor.consumed.body.size:
+      prefix: otelcol.
+      enabled: false
+      stability: development
+      description: Total byte size of log record bodies passed to the processor.
+      unit: By
+      sum:
+        value_type: int
+        monotonic: true
+
     processor.consumed.items:
       prefix: otelcol.
       enabled: true
@@ -148,6 +188,16 @@ telemetry:
         value_type: int
         monotonic: true
 
+    processor.produced.body.size:
+      prefix: otelcol.
+      enabled: false
+      stability: development
+      description: Total byte size of log record bodies emitted from the processor.
+      unit: By
+      sum:
+        value_type: int
+        monotonic: true
+
     processor.produced.items:
       prefix: otelcol.
       enabled: true
@@ -164,6 +214,16 @@ telemetry:
       stability: development
       description: Size of items emitted from the processor, based on ProtoMarshaler.Sizer.
       unit: "{item}"
+      sum:
+        value_type: int
+        monotonic: true
+
+    receiver.produced.body.size:
+      prefix: otelcol.
+      enabled: false
+      stability: development
+      description: Total byte size of log record bodies emitted from the receiver.
+      unit: By
       sum:
         value_type: int
         monotonic: true

--- a/service/metadata.yaml
+++ b/service/metadata.yaml
@@ -11,7 +11,7 @@ status:
 
 telemetry:
   metrics:
-    connector.consumed.body.size:
+    connector.consumed.body.bytes.processed:
       prefix: otelcol.
       enabled: false
       stability: development
@@ -41,7 +41,7 @@ telemetry:
         value_type: int
         monotonic: true
 
-    connector.produced.body.size:
+    connector.produced.body.bytes.processed:
       prefix: otelcol.
       enabled: false
       stability: development
@@ -71,7 +71,7 @@ telemetry:
         value_type: int
         monotonic: true
 
-    exporter.consumed.body.size:
+    exporter.consumed.body.bytes.processed:
       prefix: otelcol.
       enabled: false
       stability: development
@@ -158,7 +158,7 @@ telemetry:
         value_type: double
         monotonic: true
 
-    processor.consumed.body.size:
+    processor.consumed.body.bytes.processed:
       prefix: otelcol.
       enabled: false
       stability: development
@@ -188,7 +188,7 @@ telemetry:
         value_type: int
         monotonic: true
 
-    processor.produced.body.size:
+    processor.produced.body.bytes.processed:
       prefix: otelcol.
       enabled: false
       stability: development
@@ -218,7 +218,7 @@ telemetry:
         value_type: int
         monotonic: true
 
-    receiver.produced.body.size:
+    receiver.produced.body.bytes.processed:
       prefix: otelcol.
       enabled: false
       stability: development


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds a new metric to component universal telemetry, `body.bytes.processed`, that measures the size of log body for log pipelines.

This is feature gated behind `telemetry.newPipelineTelemetry` and requires telemetry level set to `detailed`.

<!-- Issue number if applicable -->
#### Link to tracking issue
Closes #14812 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Unit tests updated

**Performance testing:**
Did performance testing using a OTLP receiver -> nop exporter. OTLP receiver was ingesting JSON logs at a rate of ~50k/second with each log body averaging 244 bytes. Ran this pipeline for 60 seconds in two tests, one with the feature gate & detailed metrics configured and one without either. **Running the collector with the feature gate & detailed metrics saw a 7% increase in CPU when compared to the test without either configured.** Other stats such as memory usage were negligible. Happy to talk more about this.

<!--Describe the documentation added.-->
#### Documentation
- RFC updated
- `service` metadata.yaml updated

<!--Please delete paragraphs that you did not use before submitting.-->
