### PR TITLE
[pdata/pprofile] Fix data corruption when batching profiles in exporter queue

### DIFF
--- a/.chloggen/fix-profiles-data-corruption-15084.yaml
+++ b/.chloggen/fix-profiles-data-corruption-15084.yaml
@@ -1,0 +1,26 @@
+change_type: bug_fix
+
+component: pdata/pprofile
+
+note: Fix data corruption of Profiles data when batching in the exporter queue
+
+issues: [15084]
+
+subtext: |
+  Fix two data corruption bugs in the Profiles MergeTo/switchDictionary path:
+
+  1. Dictionary index 0 was never remapped during MergeTo because all
+     switchDictionary methods used `> 0` guards. This caused samples
+     referencing StackIndex=0 (and similarly for LinkIndex, MappingIndex,
+     FunctionIndex, and all Strindex fields) to silently point to the wrong
+     entry in the destination dictionary after merging.
+
+  2. Resource and scope attribute KeyStrindex values became stale after
+     MergeTo because resolveProfilesReferences kept KeyStrindex set after
+     unmarshaling, but MergeTo did not update these references.
+     convertKeyValueToReferences then skipped re-indexing when KeyStrindex
+     was already non-zero, causing the stale indices to be serialized.
+     On the next unmarshal, keys resolved to wrong strings from the merged
+     dictionary.
+
+change_logs: [user]

--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -120,8 +120,11 @@ func convertKeyValueToReferences(getStringIndex func(string) int32, kvs []intern
 	for i := range kvs {
 		kv := &kvs[i]
 
-		// Convert key to reference
-		if kv.Key != "" && kv.KeyStrindex == 0 {
+		// Convert key to reference. Always re-index when Key is set,
+		// because KeyStrindex may be stale after a MergeTo that changed
+		// the dictionary (resolveProfilesReferences keeps KeyStrindex
+		// set after unmarshal, but MergeTo does not update it).
+		if kv.Key != "" {
 			kv.KeyStrindex = getStringIndex(kv.Key)
 			kv.Key = ""
 		}

--- a/pdata/pprofile/dictionary_helpers_test.go
+++ b/pdata/pprofile/dictionary_helpers_test.go
@@ -417,9 +417,11 @@ func TestConvertMapToReferencesExistingKeyRef(t *testing.T) {
 
 	convertKeyValueToReferences(getStringIndex, mapKeyValues(attrs))
 
-	// KeyStrindex should remain unchanged
+	// Key is set, so KeyStrindex should be updated to the new index
 	kv := &(*mapOrig)[0]
-	assert.Equal(t, int32(5), kv.KeyStrindex)
+	assert.Equal(t, int32(99), kv.KeyStrindex)
+	// Key must be cleared when KeyStrindex is set
+	assert.Empty(t, kv.Key)
 }
 
 func TestResolveAnyValueReferenceNonStringTypes(t *testing.T) {

--- a/pdata/pprofile/function.go
+++ b/pdata/pprofile/function.go
@@ -16,41 +16,35 @@ func (fn Function) Equal(val Function) bool {
 // switchDictionary updates the Function, switching its indices from one
 // dictionary to another.
 func (fn Function) switchDictionary(src, dst ProfilesDictionary) error {
-	if fn.NameStrindex() > 0 {
-		if src.StringTable().Len() <= int(fn.NameStrindex()) {
-			return fmt.Errorf("invalid name index %d", fn.NameStrindex())
-		}
-
-		idx, err := SetString(dst.StringTable(), src.StringTable().At(int(fn.NameStrindex())))
-		if err != nil {
-			return fmt.Errorf("couldn't set name: %w", err)
-		}
-		fn.SetNameStrindex(idx)
+	if src.StringTable().Len() <= int(fn.NameStrindex()) {
+		return fmt.Errorf("invalid name index %d", fn.NameStrindex())
 	}
 
-	if fn.SystemNameStrindex() > 0 {
-		if src.StringTable().Len() <= int(fn.SystemNameStrindex()) {
-			return fmt.Errorf("invalid system name index %d", fn.SystemNameStrindex())
-		}
+	nameIdx, err := SetString(dst.StringTable(), src.StringTable().At(int(fn.NameStrindex())))
+	if err != nil {
+		return fmt.Errorf("couldn't set name: %w", err)
+	}
+	fn.SetNameStrindex(nameIdx)
 
-		idx, err := SetString(dst.StringTable(), src.StringTable().At(int(fn.SystemNameStrindex())))
-		if err != nil {
-			return fmt.Errorf("couldn't set system name: %w", err)
-		}
-		fn.SetSystemNameStrindex(idx)
+	if src.StringTable().Len() <= int(fn.SystemNameStrindex()) {
+		return fmt.Errorf("invalid system name index %d", fn.SystemNameStrindex())
 	}
 
-	if fn.FilenameStrindex() > 0 {
-		if src.StringTable().Len() <= int(fn.FilenameStrindex()) {
-			return fmt.Errorf("invalid filename index %d", fn.FilenameStrindex())
-		}
-
-		idx, err := SetString(dst.StringTable(), src.StringTable().At(int(fn.FilenameStrindex())))
-		if err != nil {
-			return fmt.Errorf("couldn't set filename: %w", err)
-		}
-		fn.SetFilenameStrindex(idx)
+	sysIdx, err := SetString(dst.StringTable(), src.StringTable().At(int(fn.SystemNameStrindex())))
+	if err != nil {
+		return fmt.Errorf("couldn't set system name: %w", err)
 	}
+	fn.SetSystemNameStrindex(sysIdx)
+
+	if src.StringTable().Len() <= int(fn.FilenameStrindex()) {
+		return fmt.Errorf("invalid filename index %d", fn.FilenameStrindex())
+	}
+
+	fileIdx, err := SetString(dst.StringTable(), src.StringTable().At(int(fn.FilenameStrindex())))
+	if err != nil {
+		return fmt.Errorf("couldn't set filename: %w", err)
+	}
+	fn.SetFilenameStrindex(fileIdx)
 
 	return nil
 }

--- a/pdata/pprofile/function_test.go
+++ b/pdata/pprofile/function_test.go
@@ -83,11 +83,23 @@ func TestFunctionSwitchDictionary(t *testing.T) {
 			name:     "with an empty key value and unit",
 			function: NewFunction(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
-			wantFunction:   NewFunction(),
-			wantDictionary: NewProfilesDictionary(),
+			wantFunction: NewFunction(),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 		},
 		{
 			name: "with an existing name",
@@ -199,16 +211,28 @@ func TestFunctionSwitchDictionary(t *testing.T) {
 				return fn
 			}(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantFunction: func() Function {
 				fn := NewFunction()
 				fn.SetSystemNameStrindex(1)
 				return fn
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid system name index 1"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid system name index 1"),
 		},
 		{
 			name: "with a system name index equal to the source table length (boundary condition)",
@@ -223,15 +247,23 @@ func TestFunctionSwitchDictionary(t *testing.T) {
 				d.StringTable().Append("", "test")
 				return d
 			}(),
-			dst: NewProfilesDictionary(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantFunction: func() Function {
 				fn := NewFunction()
 				fn.SetSystemNameStrindex(2)
 				return fn
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid system name index 2"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid system name index 2"),
 		},
 		{
 			name: "with an existing filename",
@@ -271,16 +303,28 @@ func TestFunctionSwitchDictionary(t *testing.T) {
 				return fn
 			}(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantFunction: func() Function {
 				fn := NewFunction()
 				fn.SetFilenameStrindex(1)
 				return fn
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid filename index 1"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid filename index 1"),
 		},
 		{
 			name: "with a filename index equal to the source table length (boundary condition)",
@@ -295,15 +339,23 @@ func TestFunctionSwitchDictionary(t *testing.T) {
 				d.StringTable().Append("", "test")
 				return d
 			}(),
-			dst: NewProfilesDictionary(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantFunction: func() Function {
 				fn := NewFunction()
 				fn.SetFilenameStrindex(2)
 				return fn
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid filename index 2"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid filename index 2"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pdata/pprofile/keyvalueandunit.go
+++ b/pdata/pprofile/keyvalueandunit.go
@@ -16,29 +16,25 @@ func (ms KeyValueAndUnit) Equal(val KeyValueAndUnit) bool {
 // switchDictionary updates the KeyValueAndUnit, switching its indices from one
 // dictionary to another.
 func (ms KeyValueAndUnit) switchDictionary(src, dst ProfilesDictionary) error {
-	if ms.KeyStrindex() > 0 {
-		if src.StringTable().Len() <= int(ms.KeyStrindex()) {
-			return fmt.Errorf("invalid key index %d", ms.KeyStrindex())
-		}
-
-		idx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.KeyStrindex())))
-		if err != nil {
-			return fmt.Errorf("couldn't set key: %w", err)
-		}
-		ms.SetKeyStrindex(idx)
+	if src.StringTable().Len() <= int(ms.KeyStrindex()) {
+		return fmt.Errorf("invalid key index %d", ms.KeyStrindex())
 	}
 
-	if ms.UnitStrindex() > 0 {
-		if src.StringTable().Len() <= int(ms.UnitStrindex()) {
-			return fmt.Errorf("invalid unit index %d", ms.UnitStrindex())
-		}
-
-		idx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.UnitStrindex())))
-		if err != nil {
-			return fmt.Errorf("couldn't set unit: %w", err)
-		}
-		ms.SetUnitStrindex(idx)
+	keyIdx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.KeyStrindex())))
+	if err != nil {
+		return fmt.Errorf("couldn't set key: %w", err)
 	}
+	ms.SetKeyStrindex(keyIdx)
+
+	if src.StringTable().Len() <= int(ms.UnitStrindex()) {
+		return fmt.Errorf("invalid unit index %d", ms.UnitStrindex())
+	}
+
+	unitIdx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.UnitStrindex())))
+	if err != nil {
+		return fmt.Errorf("couldn't set unit: %w", err)
+	}
+	ms.SetUnitStrindex(unitIdx)
 
 	return nil
 }

--- a/pdata/pprofile/keyvalueandunit_test.go
+++ b/pdata/pprofile/keyvalueandunit_test.go
@@ -78,11 +78,23 @@ func TestKeyValueAndUnitSwitchDictionary(t *testing.T) {
 			name:            "with an empty key value and unit",
 			keyValueAndUnit: NewKeyValueAndUnit(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantKeyValueAndUnit: NewKeyValueAndUnit(),
-			wantDictionary:      NewProfilesDictionary(),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 		},
 		{
 			name: "with an existing key",
@@ -194,16 +206,28 @@ func TestKeyValueAndUnitSwitchDictionary(t *testing.T) {
 				return kvu
 			}(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantKeyValueAndUnit: func() KeyValueAndUnit {
 				kvu := NewKeyValueAndUnit()
 				kvu.SetUnitStrindex(1)
 				return kvu
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid unit index 1"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid unit index 1"),
 		},
 		{
 			name: "with a unit index equal to the source table length (boundary condition)",
@@ -218,15 +242,23 @@ func TestKeyValueAndUnitSwitchDictionary(t *testing.T) {
 				d.StringTable().Append("", "test")
 				return d
 			}(),
-			dst: NewProfilesDictionary(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantKeyValueAndUnit: func() KeyValueAndUnit {
 				kvu := NewKeyValueAndUnit()
 				kvu.SetUnitStrindex(2)
 				return kvu
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid unit index 2"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid unit index 2"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pdata/pprofile/line.go
+++ b/pdata/pprofile/line.go
@@ -30,18 +30,16 @@ func (l Line) Equal(val Line) bool {
 // switchDictionary updates the Line, switching its indices from one
 // dictionary to another.
 func (l Line) switchDictionary(src, dst ProfilesDictionary) error {
-	if l.FunctionIndex() > 0 {
-		if src.FunctionTable().Len() <= int(l.FunctionIndex()) {
-			return fmt.Errorf("invalid function index %d", l.FunctionIndex())
-		}
-
-		fn := src.FunctionTable().At(int(l.FunctionIndex()))
-		idx, err := SetFunction(dst.FunctionTable(), fn)
-		if err != nil {
-			return fmt.Errorf("couldn't set function: %w", err)
-		}
-		l.SetFunctionIndex(idx)
+	if src.FunctionTable().Len() <= int(l.FunctionIndex()) {
+		return fmt.Errorf("invalid function index %d", l.FunctionIndex())
 	}
+
+	fn := src.FunctionTable().At(int(l.FunctionIndex()))
+	idx, err := SetFunction(dst.FunctionTable(), fn)
+	if err != nil {
+		return fmt.Errorf("couldn't set function: %w", err)
+	}
+	l.SetFunctionIndex(idx)
 
 	return nil
 }

--- a/pdata/pprofile/line_test.go
+++ b/pdata/pprofile/line_test.go
@@ -139,11 +139,26 @@ func TestLineSwitchDictionary(t *testing.T) {
 			name: "with an empty line",
 			line: NewLine(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.FunctionTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.FunctionTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
 
-			wantLine:       NewLine(),
-			wantDictionary: NewProfilesDictionary(),
+			wantLine: NewLine(),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.FunctionTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
 		},
 		{
 			name: "with an existing function",

--- a/pdata/pprofile/location.go
+++ b/pdata/pprofile/location.go
@@ -16,18 +16,16 @@ func (ms Location) Equal(val Location) bool {
 // switchDictionary updates the Location, switching its indices from one
 // dictionary to another.
 func (ms Location) switchDictionary(src, dst ProfilesDictionary) error {
-	if ms.MappingIndex() > 0 {
-		if src.MappingTable().Len() <= int(ms.MappingIndex()) {
-			return fmt.Errorf("invalid mapping index %d", ms.MappingIndex())
-		}
-
-		mapping := src.MappingTable().At(int(ms.MappingIndex()))
-		idx, err := SetMapping(dst.MappingTable(), mapping)
-		if err != nil {
-			return fmt.Errorf("couldn't set mapping: %w", err)
-		}
-		ms.SetMappingIndex(idx)
+	if src.MappingTable().Len() <= int(ms.MappingIndex()) {
+		return fmt.Errorf("invalid mapping index %d", ms.MappingIndex())
 	}
+
+	mapping := src.MappingTable().At(int(ms.MappingIndex()))
+	idx, err := SetMapping(dst.MappingTable(), mapping)
+	if err != nil {
+		return fmt.Errorf("couldn't set mapping: %w", err)
+	}
+	ms.SetMappingIndex(idx)
 
 	for i, v := range ms.AttributeIndices().All() {
 		if src.AttributeTable().Len() <= int(v) {

--- a/pdata/pprofile/location_test.go
+++ b/pdata/pprofile/location_test.go
@@ -83,11 +83,26 @@ func TestLocationSwitchDictionary(t *testing.T) {
 			name:     "with an empty location",
 			location: NewLocation(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.MappingTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.MappingTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
 
-			wantLocation:   NewLocation(),
-			wantDictionary: NewProfilesDictionary(),
+			wantLocation: NewLocation(),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.MappingTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
 		},
 		{
 			name: "with an existing mapping",
@@ -190,6 +205,8 @@ func TestLocationSwitchDictionary(t *testing.T) {
 				a := d.AttributeTable().AppendEmpty()
 				a.SetKeyStrindex(1)
 
+				d.MappingTable().AppendEmpty()
+
 				return d
 			}(),
 			dst: func() ProfilesDictionary {
@@ -199,6 +216,8 @@ func TestLocationSwitchDictionary(t *testing.T) {
 				d.AttributeTable().AppendEmpty()
 				a := d.AttributeTable().AppendEmpty()
 				a.SetKeyStrindex(1)
+
+				d.MappingTable().AppendEmpty()
 
 				return d
 			}(),
@@ -215,6 +234,8 @@ func TestLocationSwitchDictionary(t *testing.T) {
 				d.AttributeTable().AppendEmpty()
 				a := d.AttributeTable().AppendEmpty()
 				a.SetKeyStrindex(1)
+
+				d.MappingTable().AppendEmpty()
 				return d
 			}(),
 		},
@@ -226,16 +247,31 @@ func TestLocationSwitchDictionary(t *testing.T) {
 				return l
 			}(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.MappingTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.MappingTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantLocation: func() Location {
 				l := NewLocation()
 				l.AttributeIndices().Append(1)
 				return l
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid attribute index 1"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.MappingTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid attribute index 1"),
 		},
 		{
 			name: "with an attribute index equal to the source table length (boundary condition)",
@@ -249,17 +285,29 @@ func TestLocationSwitchDictionary(t *testing.T) {
 				d := NewProfilesDictionary()
 				d.AttributeTable().AppendEmpty()
 				d.AttributeTable().AppendEmpty()
+				d.MappingTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
-			dst: NewProfilesDictionary(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.MappingTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantLocation: func() Location {
 				l := NewLocation()
 				l.AttributeIndices().Append(2)
 				return l
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid attribute index 2"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.MappingTable().AppendEmpty()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid attribute index 2"),
 		},
 		{
 			name: "with an existing line",
@@ -277,6 +325,8 @@ func TestLocationSwitchDictionary(t *testing.T) {
 				f := d.FunctionTable().AppendEmpty()
 				f.SetNameStrindex(1)
 
+				d.MappingTable().AppendEmpty()
+
 				return d
 			}(),
 			dst: func() ProfilesDictionary {
@@ -286,6 +336,8 @@ func TestLocationSwitchDictionary(t *testing.T) {
 				d.FunctionTable().AppendEmpty()
 				f := d.FunctionTable().AppendEmpty()
 				f.SetNameStrindex(1)
+
+				d.MappingTable().AppendEmpty()
 
 				return d
 			}(),
@@ -302,6 +354,8 @@ func TestLocationSwitchDictionary(t *testing.T) {
 				d.FunctionTable().AppendEmpty()
 				f := d.FunctionTable().AppendEmpty()
 				f.SetNameStrindex(1)
+
+				d.MappingTable().AppendEmpty()
 				return d
 			}(),
 		},

--- a/pdata/pprofile/mapping.go
+++ b/pdata/pprofile/mapping.go
@@ -17,17 +17,15 @@ func (ms Mapping) Equal(val Mapping) bool {
 // switchDictionary updates the Mapping, switching its indices from one
 // dictionary to another.
 func (ms Mapping) switchDictionary(src, dst ProfilesDictionary) error {
-	if ms.FilenameStrindex() > 0 {
-		if src.StringTable().Len() <= int(ms.FilenameStrindex()) {
-			return fmt.Errorf("invalid filename index %d", ms.FilenameStrindex())
-		}
-
-		idx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.FilenameStrindex())))
-		if err != nil {
-			return fmt.Errorf("couldn't set filename: %w", err)
-		}
-		ms.SetFilenameStrindex(idx)
+	if src.StringTable().Len() <= int(ms.FilenameStrindex()) {
+		return fmt.Errorf("invalid filename index %d", ms.FilenameStrindex())
 	}
+
+	idx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.FilenameStrindex())))
+	if err != nil {
+		return fmt.Errorf("couldn't set filename: %w", err)
+	}
+	ms.SetFilenameStrindex(idx)
 
 	for i, v := range ms.AttributeIndices().All() {
 		if src.AttributeTable().Len() <= int(v) {

--- a/pdata/pprofile/mapping_test.go
+++ b/pdata/pprofile/mapping_test.go
@@ -89,11 +89,23 @@ func TestMappingSwitchDictionary(t *testing.T) {
 			name:    "with an empty mapping",
 			mapping: NewMapping(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
-			wantMapping:    NewMapping(),
-			wantDictionary: NewProfilesDictionary(),
+			wantMapping: NewMapping(),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 		},
 		{
 			name: "with an existing filename",
@@ -219,16 +231,28 @@ func TestMappingSwitchDictionary(t *testing.T) {
 				return m
 			}(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantMapping: func() Mapping {
 				m := NewMapping()
 				m.AttributeIndices().Append(1)
 				return m
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid attribute index 1"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid attribute index 1"),
 		},
 		{
 			name: "with an attribute index equal to the source table length (boundary condition)",
@@ -242,17 +266,26 @@ func TestMappingSwitchDictionary(t *testing.T) {
 				d := NewProfilesDictionary()
 				d.AttributeTable().AppendEmpty()
 				d.AttributeTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
-			dst: NewProfilesDictionary(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantMapping: func() Mapping {
 				m := NewMapping()
 				m.AttributeIndices().Append(2)
 				return m
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid attribute index 2"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid attribute index 2"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pdata/pprofile/profile_test.go
+++ b/pdata/pprofile/profile_test.go
@@ -30,11 +30,23 @@ func TestProfileSwitchDictionary(t *testing.T) {
 			name:    "with an empty profile",
 			profile: NewProfile(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
-			wantProfile:    NewProfile(),
-			wantDictionary: NewProfilesDictionary(),
+			wantProfile: NewProfile(),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 		},
 		{
 			name: "with an existing attribute",
@@ -135,12 +147,18 @@ func TestProfileSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 			dst: func() ProfilesDictionary {
 				d := NewProfilesDictionary()
 				d.LinkTable().AppendEmpty()
 				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 
@@ -155,6 +173,9 @@ func TestProfileSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 		},

--- a/pdata/pprofile/profiles_merge_test.go
+++ b/pdata/pprofile/profiles_merge_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 func TestProfilesMergeTo(t *testing.T) {
@@ -617,4 +619,178 @@ func TestProfilesMergeToError(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Equal(t, 0, dest.ResourceProfiles().Len())
+}
+
+// TestProfilesMergeTo_StackIndexZero verifies that samples referencing
+// StackIndex=0 are correctly remapped during MergeTo, rather than being
+// silently skipped (which causes data corruption).
+func TestProfilesMergeTo_StackIndexZero(t *testing.T) {
+	// Source: sample with StackIndex=0 pointing to a real stack.
+	src := NewProfiles()
+	src.Dictionary().StringTable().Append("")            // 0
+	src.Dictionary().StringTable().Append("srcFuncName") // 1
+	src.Dictionary().StringTable().Append("srcFileName") // 2
+	src.Dictionary().AttributeTable().AppendEmpty()      // 0: sentinel
+	src.Dictionary().LinkTable().AppendEmpty()           // 0: sentinel
+	src.Dictionary().MappingTable().AppendEmpty()        // 0: sentinel
+
+	srcFn := src.Dictionary().FunctionTable().AppendEmpty() // 0: real function
+	srcFn.SetNameStrindex(1)
+	srcFn.SetFilenameStrindex(2)
+
+	srcLoc := src.Dictionary().LocationTable().AppendEmpty() // 0: real location
+	srcLoc.SetAddress(42)
+	srcLine := srcLoc.Lines().AppendEmpty()
+	srcLine.SetFunctionIndex(0) // refs function at index 0
+
+	srcStack := src.Dictionary().StackTable().AppendEmpty() // 0: real stack
+	srcStack.LocationIndices().Append(0)                    // refs location at index 0
+
+	rp := src.ResourceProfiles().AppendEmpty()
+	rp.Resource().Attributes().PutStr("service.name", "src-service")
+	sp := rp.ScopeProfiles().AppendEmpty()
+	p := sp.Profiles().AppendEmpty()
+	sample := p.Samples().AppendEmpty()
+	sample.SetStackIndex(0) // Points to real stack at index 0
+
+	// Destination: has different data at index 0.
+	dst := NewProfiles()
+	dst.Dictionary().StringTable().Append("")            // 0
+	dst.Dictionary().StringTable().Append("dstFuncName") // 1
+	dst.Dictionary().StringTable().Append("dstFileName") // 2
+	dst.Dictionary().AttributeTable().AppendEmpty()      // 0: sentinel
+	dst.Dictionary().LinkTable().AppendEmpty()           // 0: sentinel
+	dst.Dictionary().MappingTable().AppendEmpty()        // 0: sentinel
+
+	dstFn := dst.Dictionary().FunctionTable().AppendEmpty() // 0: different function
+	dstFn.SetNameStrindex(1)
+	dstFn.SetFilenameStrindex(2)
+
+	dstLoc := dst.Dictionary().LocationTable().AppendEmpty() // 0: different location
+	dstLoc.SetAddress(99)
+	dstLine := dstLoc.Lines().AppendEmpty()
+	dstLine.SetFunctionIndex(0)
+
+	dstStack := dst.Dictionary().StackTable().AppendEmpty() // 0: different stack
+	dstStack.LocationIndices().Append(0)
+
+	err := src.MergeTo(dst)
+	require.NoError(t, err)
+
+	// After merge, the source's sample should reference a stack whose
+	// location has Address=42 (from src), NOT Address=99 (from dst).
+	require.Equal(t, 1, dst.ResourceProfiles().Len())
+	mergedSample := dst.ResourceProfiles().At(0).
+		ScopeProfiles().At(0).
+		Profiles().At(0).
+		Samples().At(0)
+
+	stackIdx := mergedSample.StackIndex()
+	stack := dst.Dictionary().StackTable().At(int(stackIdx))
+	locIdx := stack.LocationIndices().At(0)
+	loc := dst.Dictionary().LocationTable().At(int(locIdx))
+
+	assert.Equal(t, uint64(42), loc.Address(),
+		"source sample's stack should reference the original location with address 42, not destination's 99")
+
+	// Also verify the function name resolves to srcFuncName, not dstFuncName.
+	line := loc.Lines().At(0)
+	fn := dst.Dictionary().FunctionTable().At(int(line.FunctionIndex()))
+	fnName := dst.Dictionary().StringTable().At(int(fn.NameStrindex()))
+	assert.Equal(t, "srcFuncName", fnName,
+		"source sample's function should be srcFuncName, not dstFuncName")
+}
+
+// TestProfilesMergeTo_ResourceAttributeRoundTrip verifies that resource
+// attributes survive a marshal→unmarshal→merge→marshal→unmarshal round-trip
+// without corruption of KeyStrindex references.
+func TestProfilesMergeTo_ResourceAttributeRoundTrip(t *testing.T) {
+	marshaler := &ProtoMarshaler{}
+	unmarshaler := &ProtoUnmarshaler{}
+
+	// Create two profiles with DIFFERENT string tables so that after merge
+	// the destination string table differs from the source's original indices.
+	profileA := NewProfiles()
+	profileA.Dictionary().StringTable().Append("")
+	profileA.Dictionary().StringTable().Append("cpu")
+	profileA.Dictionary().StringTable().Append("nanoseconds")
+	profileA.Dictionary().AttributeTable().AppendEmpty()
+	profileA.Dictionary().StackTable().AppendEmpty()
+	profileA.Dictionary().LocationTable().AppendEmpty()
+	profileA.Dictionary().FunctionTable().AppendEmpty()
+	profileA.Dictionary().MappingTable().AppendEmpty()
+	profileA.Dictionary().LinkTable().AppendEmpty()
+	rpA := profileA.ResourceProfiles().AppendEmpty()
+	rpA.Resource().Attributes().PutStr("service.name", "service-A")
+	rpA.Resource().Attributes().PutStr("deployment", "prod")
+	spA := rpA.ScopeProfiles().AppendEmpty()
+	pA := spA.Profiles().AppendEmpty()
+	pA.PeriodType().SetTypeStrindex(1)
+	pA.PeriodType().SetUnitStrindex(2)
+
+	profileB := NewProfiles()
+	profileB.Dictionary().StringTable().Append("")
+	profileB.Dictionary().StringTable().Append("memory")
+	profileB.Dictionary().StringTable().Append("bytes")
+	profileB.Dictionary().AttributeTable().AppendEmpty()
+	profileB.Dictionary().StackTable().AppendEmpty()
+	profileB.Dictionary().LocationTable().AppendEmpty()
+	profileB.Dictionary().FunctionTable().AppendEmpty()
+	profileB.Dictionary().MappingTable().AppendEmpty()
+	profileB.Dictionary().LinkTable().AppendEmpty()
+	rpB := profileB.ResourceProfiles().AppendEmpty()
+	rpB.Resource().Attributes().PutStr("host.name", "host-1")
+	rpB.Resource().Attributes().PutStr("cluster.name", "us-east")
+	spB := rpB.ScopeProfiles().AppendEmpty()
+	pB := spB.Profiles().AppendEmpty()
+	pB.PeriodType().SetTypeStrindex(1)
+	pB.PeriodType().SetUnitStrindex(2)
+
+	// Record original resource attributes.
+	origAttrsA := attrMapToStrings(rpA.Resource().Attributes())
+	origAttrsB := attrMapToStrings(rpB.Resource().Attributes())
+
+	// Marshal → Unmarshal (simulates Kafka write/read).
+	bytesA, err := marshaler.MarshalProfiles(profileA)
+	require.NoError(t, err)
+	bytesB, err := marshaler.MarshalProfiles(profileB)
+	require.NoError(t, err)
+
+	dstProfiles, err := unmarshaler.UnmarshalProfiles(bytesA)
+	require.NoError(t, err)
+	srcProfiles, err := unmarshaler.UnmarshalProfiles(bytesB)
+	require.NoError(t, err)
+
+	// MergeTo — merges src into dst.
+	err = srcProfiles.MergeTo(dstProfiles)
+	require.NoError(t, err)
+
+	// Re-marshal the merged result.
+	mergedBytes, err := marshaler.MarshalProfiles(dstProfiles)
+	require.NoError(t, err)
+
+	// Re-unmarshal (simulates consumer reading from Kafka).
+	finalProfiles, err := unmarshaler.UnmarshalProfiles(mergedBytes)
+	require.NoError(t, err)
+
+	// After the full round-trip, resource attributes must still match.
+	require.Equal(t, 2, finalProfiles.ResourceProfiles().Len(),
+		"final profiles should have 2 resource profiles")
+
+	finalAttrsA := attrMapToStrings(finalProfiles.ResourceProfiles().At(0).Resource().Attributes())
+	finalAttrsB := attrMapToStrings(finalProfiles.ResourceProfiles().At(1).Resource().Attributes())
+
+	assert.Equal(t, origAttrsA, finalAttrsA,
+		"destination resource attributes corrupted after round-trip")
+	assert.Equal(t, origAttrsB, finalAttrsB,
+		"source resource attributes corrupted after round-trip")
+}
+
+func attrMapToStrings(m pcommon.Map) map[string]string {
+	result := make(map[string]string, m.Len())
+	m.Range(func(k string, v pcommon.Value) bool {
+		result[k] = v.AsString()
+		return true
+	})
+	return result
 }

--- a/pdata/pprofile/profiles_test.go
+++ b/pdata/pprofile/profiles_test.go
@@ -163,12 +163,18 @@ func TestProfilesSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 			dst: func() ProfilesDictionary {
 				d := NewProfilesDictionary()
 				d.LinkTable().AppendEmpty()
 				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 
@@ -184,6 +190,9 @@ func TestProfilesSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 		},

--- a/pdata/pprofile/resourceprofiles_test.go
+++ b/pdata/pprofile/resourceprofiles_test.go
@@ -49,12 +49,18 @@ func TestResourceProfilesSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 			dst: func() ProfilesDictionary {
 				d := NewProfilesDictionary()
 				d.LinkTable().AppendEmpty()
 				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 
@@ -70,6 +76,9 @@ func TestResourceProfilesSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 		},

--- a/pdata/pprofile/sample.go
+++ b/pdata/pprofile/sample.go
@@ -21,30 +21,26 @@ func (ms Sample) switchDictionary(src, dst ProfilesDictionary) error {
 		ms.AttributeIndices().SetAt(i, idx)
 	}
 
-	if ms.LinkIndex() > 0 {
-		if src.LinkTable().Len() <= int(ms.LinkIndex()) {
-			return fmt.Errorf("invalid link index %d", ms.LinkIndex())
-		}
-
-		idx, err := SetLink(dst.LinkTable(), src.LinkTable().At(int(ms.LinkIndex())))
-		if err != nil {
-			return fmt.Errorf("couldn't set link: %w", err)
-		}
-		ms.SetLinkIndex(idx)
+	if src.LinkTable().Len() <= int(ms.LinkIndex()) {
+		return fmt.Errorf("invalid link index %d", ms.LinkIndex())
 	}
 
-	if ms.StackIndex() > 0 {
-		if src.StackTable().Len() <= int(ms.StackIndex()) {
-			return fmt.Errorf("invalid stack index %d", ms.StackIndex())
-		}
-
-		stack := src.StackTable().At(int(ms.StackIndex()))
-		idx, err := SetStack(dst.StackTable(), stack)
-		if err != nil {
-			return fmt.Errorf("couldn't set stack: %w", err)
-		}
-		ms.SetStackIndex(idx)
+	idx, err := SetLink(dst.LinkTable(), src.LinkTable().At(int(ms.LinkIndex())))
+	if err != nil {
+		return fmt.Errorf("couldn't set link: %w", err)
 	}
+	ms.SetLinkIndex(idx)
+
+	if src.StackTable().Len() <= int(ms.StackIndex()) {
+		return fmt.Errorf("invalid stack index %d", ms.StackIndex())
+	}
+
+	stack := src.StackTable().At(int(ms.StackIndex()))
+	sidx, err := SetStack(dst.StackTable(), stack)
+	if err != nil {
+		return fmt.Errorf("couldn't set stack: %w", err)
+	}
+	ms.SetStackIndex(sidx)
 
 	return nil
 }

--- a/pdata/pprofile/sample_test.go
+++ b/pdata/pprofile/sample_test.go
@@ -30,11 +30,29 @@ func TestSampleSwitchDictionary(t *testing.T) {
 			name:   "with an empty sample",
 			sample: NewSample(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				return d
+			}(),
 
-			wantSample:     NewSample(),
-			wantDictionary: NewProfilesDictionary(),
+			wantSample: NewSample(),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				return d
+			}(),
 		},
 		{
 			name: "with an existing attribute",
@@ -52,6 +70,10 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				a := d.AttributeTable().AppendEmpty()
 				a.SetKeyStrindex(1)
 
+				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+
 				return d
 			}(),
 			dst: func() ProfilesDictionary {
@@ -62,6 +84,10 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				d.AttributeTable().AppendEmpty()
 				a := d.AttributeTable().AppendEmpty()
 				a.SetKeyStrindex(1)
+
+				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
 				return d
 			}(),
 
@@ -78,6 +104,10 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				d.AttributeTable().AppendEmpty()
 				a := d.AttributeTable().AppendEmpty()
 				a.SetKeyStrindex(1)
+
+				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
 				return d
 			}(),
 		},
@@ -137,12 +167,16 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
 				return d
 			}(),
 			dst: func() ProfilesDictionary {
 				d := NewProfilesDictionary()
 				d.LinkTable().AppendEmpty()
 				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
 				return d
 			}(),
 
@@ -157,6 +191,8 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
 				return d
 			}(),
 		},
@@ -219,6 +255,8 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				d.StackTable().AppendEmpty()
 				s := d.StackTable().AppendEmpty()
 				s.LocationIndices().Append(1)
+
+				d.LinkTable().AppendEmpty()
 				return d
 			}(),
 			dst: func() ProfilesDictionary {
@@ -230,6 +268,8 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				d.StackTable().AppendEmpty()
 				s := d.StackTable().AppendEmpty()
 				s.LocationIndices().Append(1)
+
+				d.LinkTable().AppendEmpty()
 				return d
 			}(),
 
@@ -247,6 +287,8 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				d.StackTable().AppendEmpty()
 				s := d.StackTable().AppendEmpty()
 				s.LocationIndices().Append(1)
+
+				d.LinkTable().AppendEmpty()
 				return d
 			}(),
 		},
@@ -258,16 +300,28 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				return s
 			}(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.LinkTable().AppendEmpty()
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.LinkTable().AppendEmpty()
+				return d
+			}(),
 
 			wantSample: func() Sample {
 				s := NewSample()
 				s.SetStackIndex(1)
 				return s
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid stack index 1"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.LinkTable().AppendEmpty()
+				return d
+			}(),
+			wantErr: errors.New("invalid stack index 1"),
 		},
 		{
 			name: "with a stack index equal to the source table length (boundary condition)",
@@ -281,17 +335,26 @@ func TestSampleSwitchDictionary(t *testing.T) {
 				d := NewProfilesDictionary()
 				d.StackTable().AppendEmpty()
 				d.StackTable().AppendEmpty()
+				d.LinkTable().AppendEmpty()
 				return d
 			}(),
-			dst: NewProfilesDictionary(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.LinkTable().AppendEmpty()
+				return d
+			}(),
 
 			wantSample: func() Sample {
 				s := NewSample()
 				s.SetStackIndex(2)
 				return s
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid stack index 2"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.LinkTable().AppendEmpty()
+				return d
+			}(),
+			wantErr: errors.New("invalid stack index 2"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pdata/pprofile/scopeprofiles_test.go
+++ b/pdata/pprofile/scopeprofiles_test.go
@@ -49,12 +49,18 @@ func TestScopeProfilesSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 			dst: func() ProfilesDictionary {
 				d := NewProfilesDictionary()
 				d.LinkTable().AppendEmpty()
 				d.LinkTable().AppendEmpty()
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 
@@ -70,6 +76,9 @@ func TestScopeProfilesSwitchDictionary(t *testing.T) {
 				d.LinkTable().AppendEmpty()
 				l := d.LinkTable().AppendEmpty()
 				l.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+				d.StackTable().AppendEmpty()
+				d.LocationTable().AppendEmpty()
+				d.StringTable().Append("")
 				return d
 			}(),
 		},

--- a/pdata/pprofile/valuetype.go
+++ b/pdata/pprofile/valuetype.go
@@ -8,29 +8,25 @@ import "fmt"
 // switchDictionary updates the ValueType, switching its indices from one
 // dictionary to another.
 func (ms ValueType) switchDictionary(src, dst ProfilesDictionary) error {
-	if ms.TypeStrindex() > 0 {
-		if src.StringTable().Len() <= int(ms.TypeStrindex()) {
-			return fmt.Errorf("invalid type index %d", ms.TypeStrindex())
-		}
-
-		idx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.TypeStrindex())))
-		if err != nil {
-			return fmt.Errorf("couldn't set type: %w", err)
-		}
-		ms.SetTypeStrindex(idx)
+	if src.StringTable().Len() <= int(ms.TypeStrindex()) {
+		return fmt.Errorf("invalid type index %d", ms.TypeStrindex())
 	}
 
-	if ms.UnitStrindex() > 0 {
-		if src.StringTable().Len() <= int(ms.UnitStrindex()) {
-			return fmt.Errorf("invalid unit index %d", ms.UnitStrindex())
-		}
-
-		idx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.UnitStrindex())))
-		if err != nil {
-			return fmt.Errorf("couldn't set unit: %w", err)
-		}
-		ms.SetUnitStrindex(idx)
+	typeIdx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.TypeStrindex())))
+	if err != nil {
+		return fmt.Errorf("couldn't set type: %w", err)
 	}
+	ms.SetTypeStrindex(typeIdx)
+
+	if src.StringTable().Len() <= int(ms.UnitStrindex()) {
+		return fmt.Errorf("invalid unit index %d", ms.UnitStrindex())
+	}
+
+	unitIdx, err := SetString(dst.StringTable(), src.StringTable().At(int(ms.UnitStrindex())))
+	if err != nil {
+		return fmt.Errorf("couldn't set unit: %w", err)
+	}
+	ms.SetUnitStrindex(unitIdx)
 
 	return nil
 }

--- a/pdata/pprofile/valuetype_test.go
+++ b/pdata/pprofile/valuetype_test.go
@@ -29,11 +29,23 @@ func TestValueTypeSwitchDictionary(t *testing.T) {
 			name:      "with an empty value type",
 			valueType: NewValueType(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
-			wantValueType:  NewValueType(),
-			wantDictionary: NewProfilesDictionary(),
+			wantValueType: NewValueType(),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 		},
 		{
 			name: "with an existing type",
@@ -145,16 +157,28 @@ func TestValueTypeSwitchDictionary(t *testing.T) {
 				return vt
 			}(),
 
-			src: NewProfilesDictionary(),
-			dst: NewProfilesDictionary(),
+			src: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantValueType: func() ValueType {
 				vt := NewValueType()
 				vt.SetUnitStrindex(1)
 				return vt
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid unit index 1"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid unit index 1"),
 		},
 		{
 			name: "with a unit index equal to the source table length (boundary condition)",
@@ -169,15 +193,23 @@ func TestValueTypeSwitchDictionary(t *testing.T) {
 				d.StringTable().Append("", "test")
 				return d
 			}(),
-			dst: NewProfilesDictionary(),
+			dst: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
 
 			wantValueType: func() ValueType {
 				vt := NewValueType()
 				vt.SetUnitStrindex(2)
 				return vt
 			}(),
-			wantDictionary: NewProfilesDictionary(),
-			wantErr:        errors.New("invalid unit index 2"),
+			wantDictionary: func() ProfilesDictionary {
+				d := NewProfilesDictionary()
+				d.StringTable().Append("")
+				return d
+			}(),
+			wantErr: errors.New("invalid unit index 2"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix two data corruption bugs in the Profiles `MergeTo`/`switchDictionary` path that cause silent data loss when profiles are batched in the exporter queue:

1. **Dictionary index 0 never remapped:** All `switchDictionary` methods used `> 0` guards that skipped remapping when a field (StackIndex, LinkIndex, MappingIndex, FunctionIndex, or any `*Strindex`) pointed to index 0. After merging, these fields silently pointed to the wrong entry in the destination dictionary.

2. **Resource/scope attribute keys corrupted after round-trip:** `resolveProfilesReferences` keeps `KeyStrindex` set after unmarshaling, but `MergeTo` changes the dictionary without updating `KeyStrindex`. `convertKeyValueToReferences` then skipped re-indexing when `KeyStrindex != 0`, causing stale indices to be serialized. On the next unmarshal, keys resolved to wrong strings.

### Root Cause

The `switchDictionary` pattern assumed index 0 was always a sentinel/empty value that didn't need remapping. While the OpenTelemetry Profiles spec uses index 0 as a sentinel by convention, after a `MergeTo` the destination dictionary may have different entries at index 0, making the assumption incorrect.

For the `KeyStrindex` bug, the condition `kv.Key != "" && kv.KeyStrindex == 0` in `convertKeyValueToReferences` was wrong — it should always re-index when `kv.Key` is set, regardless of the current `KeyStrindex` value, because `MergeTo` may have changed the string table.

### Changes

- Removed `> 0` guards from all `switchDictionary` methods in `sample.go`, `location.go`, `line.go`, `function.go`, `mapping.go`, `valuetype.go`, and `keyvalueandunit.go`
- Fixed `convertKeyValueToReferences` in `dictionary_helpers.go` to always re-index when `Key` is set
- Added sentinel entries to all existing test dictionaries so index-0 lookups succeed
- Added two new reproduction tests:
  - `TestProfilesMergeTo_StackIndexZero` — verifies index-0 stack data survives merge
  - `TestProfilesMergeTo_ResourceAttributeRoundTrip` — verifies resource attribute keys survive marshal→unmarshal→merge→marshal→unmarshal

Fixes #15084

## Test plan

- [x] `go test ./pdata/pprofile/...` — all existing tests pass
- [x] `gofmt -l .` — no formatting issues
- [x] `go vet ./...` — no issues
- [x] `TestProfilesMergeTo_StackIndexZero` reproduces bug 1 and verifies the fix
- [x] `TestProfilesMergeTo_ResourceAttributeRoundTrip` reproduces bug 2 and verifies the fix
- [x] All 12 updated test files verified with sentinel entries