### PR TITLE
[memorylimiter] Add disable_gc configuration option

### DIFF
--- a/.chloggen/memorylimiter-disable-gc.yaml
+++ b/.chloggen/memorylimiter-disable-gc.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: processor/memory_limiter
+
+note: Add `disable_gc` option to allow disabling forced garbage collection.
+
+issues: [15081]
+
+change_logs: [user]

--- a/.chloggen/memorylimiter-disable-gc.yaml
+++ b/.chloggen/memorylimiter-disable-gc.yaml
@@ -2,7 +2,7 @@ change_type: enhancement
 
 component: processor/memory_limiter
 
-note: Add `disable_gc` option to allow disabling forced garbage collection.
+note: Add `garbage_collector` config section to allow disabling forced garbage collection via `enabled` field.
 
 issues: [15081]
 

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -43,6 +43,8 @@ require (
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/config/configoptional v1.60.0 // indirect
+	go.opentelemetry.io/collector/confmap/xconfmap v0.154.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.60.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.154.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.60.0 // indirect
@@ -82,3 +84,7 @@ replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testut
 replace go.opentelemetry.io/collector/extension/extensionmiddleware => ../../extension/extensionmiddleware
 
 replace go.opentelemetry.io/collector/internal/componentalias => ../../internal/componentalias
+
+replace go.opentelemetry.io/collector/config/configoptional => ../../config/configoptional
+
+replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap

--- a/internal/memorylimiter/config.go
+++ b/internal/memorylimiter/config.go
@@ -8,7 +8,11 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configoptional"
 )
+
+// GarbageCollectorConfig defines configuration for garbage collection.
+type GarbageCollectorConfig struct{}
 
 var (
 	errCheckIntervalOutOfRange        = errors.New("'check_interval' must be greater than zero")
@@ -37,8 +41,8 @@ type Config struct {
 	// GCs is a CPU-heavy operation and executing it too frequently may affect the recovery capabilities of the collector.
 	MinGCIntervalWhenHardLimited time.Duration `mapstructure:"min_gc_interval_when_hard_limited"`
 
-	// DisableGC disables forced garbage collection.
-	DisableGC bool `mapstructure:"disable_gc"`
+	// GarbageCollector configuration section. Use enabled: false to disable forced garbage collection.
+	GarbageCollector configoptional.Optional[GarbageCollectorConfig] `mapstructure:"garbage_collector"`
 
 	// MemoryLimitMiB is the maximum amount of memory, in MiB, targeted to be
 	// allocated by the process.
@@ -62,6 +66,7 @@ var _ component.Config = (*Config)(nil)
 func NewDefaultConfig() *Config {
 	return &Config{
 		MinGCIntervalWhenSoftLimited: 10 * time.Second,
+		GarbageCollector:             configoptional.Some(GarbageCollectorConfig{}),
 	}
 }
 

--- a/internal/memorylimiter/config.go
+++ b/internal/memorylimiter/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	// GCs is a CPU-heavy operation and executing it too frequently may affect the recovery capabilities of the collector.
 	MinGCIntervalWhenHardLimited time.Duration `mapstructure:"min_gc_interval_when_hard_limited"`
 
+	// DisableGC disables forced garbage collection.
+	DisableGC bool `mapstructure:"disable_gc"`
+
 	// MemoryLimitMiB is the maximum amount of memory, in MiB, targeted to be
 	// allocated by the process.
 	MemoryLimitMiB uint32 `mapstructure:"limit_mib"`

--- a/internal/memorylimiter/config_test.go
+++ b/internal/memorylimiter/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 
@@ -24,7 +25,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			CheckInterval:       5 * time.Second,
 			MemoryLimitMiB:      4000,
 			MemorySpikeLimitMiB: 500,
-			DisableGC:           true,
+			GarbageCollector:    configoptional.Some(GarbageCollectorConfig{}),
 		}, cfg)
 }
 

--- a/internal/memorylimiter/config_test.go
+++ b/internal/memorylimiter/config_test.go
@@ -24,6 +24,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			CheckInterval:       5 * time.Second,
 			MemoryLimitMiB:      4000,
 			MemorySpikeLimitMiB: 500,
+			DisableGC:           true,
 		}, cfg)
 }
 

--- a/internal/memorylimiter/go.mod
+++ b/internal/memorylimiter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.5
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.60.0
+	go.opentelemetry.io/collector/config/configoptional v1.60.0
 	go.opentelemetry.io/collector/confmap v1.60.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
@@ -33,6 +34,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	go.opentelemetry.io/collector/confmap/xconfmap v0.154.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.60.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.60.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
@@ -53,3 +55,7 @@ replace go.opentelemetry.io/collector/pdata => ../../pdata
 replace go.opentelemetry.io/collector/featuregate => ../../featuregate
 
 replace go.opentelemetry.io/collector/internal/testutil => ../testutil
+
+replace go.opentelemetry.io/collector/config/configoptional => ../../config/configoptional
+
+replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap

--- a/internal/memorylimiter/memorylimiter.go
+++ b/internal/memorylimiter/memorylimiter.go
@@ -81,7 +81,7 @@ func NewMemoryLimiter(cfg *Config, logger *zap.Logger) (*MemoryLimiter, error) {
 		minGCIntervalWhenSoftLimited: cfg.MinGCIntervalWhenSoftLimited,
 		minGCIntervalWhenHardLimited: cfg.MinGCIntervalWhenHardLimited,
 		lastGCDone:                   time.Now(),
-		gcDisabled:                   cfg.DisableGC,
+		gcDisabled:                   !cfg.GarbageCollector.HasValue(),
 		readMemStatsFn:               ReadMemStatsFn,
 		runGCFn:                      runtime.GC,
 		logger:                       logger,

--- a/internal/memorylimiter/memorylimiter.go
+++ b/internal/memorylimiter/memorylimiter.go
@@ -46,6 +46,7 @@ type MemoryLimiter struct {
 	minGCIntervalWhenSoftLimited time.Duration
 	minGCIntervalWhenHardLimited time.Duration
 	lastGCDone                   time.Time
+	gcDisabled                   bool
 
 	// The functions to read the mem values and run GC are set as a reference to help with
 	// testing different values.
@@ -80,6 +81,7 @@ func NewMemoryLimiter(cfg *Config, logger *zap.Logger) (*MemoryLimiter, error) {
 		minGCIntervalWhenSoftLimited: cfg.MinGCIntervalWhenSoftLimited,
 		minGCIntervalWhenHardLimited: cfg.MinGCIntervalWhenHardLimited,
 		lastGCDone:                   time.Now(),
+		gcDisabled:                   cfg.DisableGC,
 		readMemStatsFn:               ReadMemStatsFn,
 		runGCFn:                      runtime.GC,
 		logger:                       logger,
@@ -186,7 +188,7 @@ func (ml *MemoryLimiter) CheckMemLimits() {
 	if ml.usageChecker.aboveHardLimit(ms) {
 		// We are above hard limit, do a GC if it wasn't done recently and see if
 		// it brings memory usage below the soft limit.
-		if time.Since(ml.lastGCDone) > ml.minGCIntervalWhenHardLimited {
+		if !ml.gcDisabled && time.Since(ml.lastGCDone) > ml.minGCIntervalWhenHardLimited {
 			ml.logger.Warn("Memory usage is above hard limit. Forcing a GC.", memstatToZapField(ms))
 			ms = ml.doGCandReadMemStats()
 			// Check the limit again to see if GC helped.
@@ -195,7 +197,7 @@ func (ml *MemoryLimiter) CheckMemLimits() {
 	} else {
 		// We are above soft limit, do a GC if it wasn't done recently and see if
 		// it brings memory usage below the soft limit.
-		if time.Since(ml.lastGCDone) > ml.minGCIntervalWhenSoftLimited {
+		if !ml.gcDisabled && time.Since(ml.lastGCDone) > ml.minGCIntervalWhenSoftLimited {
 			ml.logger.Info("Memory usage is above soft limit. Forcing a GC.", memstatToZapField(ms))
 			ms = ml.doGCandReadMemStats()
 			// Check the limit again to see if GC helped.

--- a/internal/memorylimiter/memorylimiter_test.go
+++ b/internal/memorylimiter/memorylimiter_test.go
@@ -196,6 +196,30 @@ func TestCallGCWhenSoftLimit(t *testing.T) {
 			memAllocMiB: [2]uint64{45, 55},
 			numGCs:      2,
 		},
+		{
+			name: "No GC when soft limited and GC disabled",
+			mlCfg: &Config{
+				CheckInterval:                1 * time.Minute,
+				MinGCIntervalWhenSoftLimited: 0,
+				MemoryLimitMiB:               50,
+				MemorySpikeLimitMiB:          10,
+				DisableGC:                    true,
+			},
+			memAllocMiB: [2]uint64{45, 45},
+			numGCs:      0,
+		},
+		{
+			name: "No GC when hard limited and GC disabled",
+			mlCfg: &Config{
+				CheckInterval:                1 * time.Minute,
+				MinGCIntervalWhenHardLimited: 0,
+				MemoryLimitMiB:               50,
+				MemorySpikeLimitMiB:          10,
+				DisableGC:                    true,
+			},
+			memAllocMiB: [2]uint64{55, 55},
+			numGCs:      0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/memorylimiter/memorylimiter_test.go
+++ b/internal/memorylimiter/memorylimiter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/internal/memorylimiter/iruntime"
 )
 
@@ -23,6 +24,7 @@ func TestMemoryPressureResponse(t *testing.T) {
 		CheckInterval:       1 * time.Minute,
 		MemoryLimitMiB:      1024,
 		MemorySpikeLimitMiB: 0,
+		GarbageCollector:    configoptional.Some(GarbageCollectorConfig{}),
 	}
 	ml, err := NewMemoryLimiter(cfg, zap.NewNop())
 	require.NoError(t, err)
@@ -147,6 +149,7 @@ func TestCallGCWhenSoftLimit(t *testing.T) {
 				MinGCIntervalWhenSoftLimited: 10 * time.Second,
 				MemoryLimitMiB:               50,
 				MemorySpikeLimitMiB:          10,
+				GarbageCollector:             configoptional.Some(GarbageCollectorConfig{}),
 			},
 			memAllocMiB: [2]uint64{45, 45},
 			numGCs:      1,
@@ -158,6 +161,7 @@ func TestCallGCWhenSoftLimit(t *testing.T) {
 				MinGCIntervalWhenSoftLimited: 0,
 				MemoryLimitMiB:               50,
 				MemorySpikeLimitMiB:          10,
+				GarbageCollector:             configoptional.Some(GarbageCollectorConfig{}),
 			},
 			memAllocMiB: [2]uint64{45, 45},
 			numGCs:      2,
@@ -169,6 +173,7 @@ func TestCallGCWhenSoftLimit(t *testing.T) {
 				MinGCIntervalWhenHardLimited: 10 * time.Second,
 				MemoryLimitMiB:               50,
 				MemorySpikeLimitMiB:          10,
+				GarbageCollector:             configoptional.Some(GarbageCollectorConfig{}),
 			},
 			memAllocMiB: [2]uint64{55, 55},
 			numGCs:      1,
@@ -180,6 +185,7 @@ func TestCallGCWhenSoftLimit(t *testing.T) {
 				MinGCIntervalWhenHardLimited: 0,
 				MemoryLimitMiB:               50,
 				MemorySpikeLimitMiB:          10,
+				GarbageCollector:             configoptional.Some(GarbageCollectorConfig{}),
 			},
 			memAllocMiB: [2]uint64{55, 55},
 			numGCs:      2,
@@ -192,6 +198,7 @@ func TestCallGCWhenSoftLimit(t *testing.T) {
 				MinGCIntervalWhenHardLimited: 0,
 				MemoryLimitMiB:               50,
 				MemorySpikeLimitMiB:          10,
+				GarbageCollector:             configoptional.Some(GarbageCollectorConfig{}),
 			},
 			memAllocMiB: [2]uint64{45, 55},
 			numGCs:      2,
@@ -203,7 +210,7 @@ func TestCallGCWhenSoftLimit(t *testing.T) {
 				MinGCIntervalWhenSoftLimited: 0,
 				MemoryLimitMiB:               50,
 				MemorySpikeLimitMiB:          10,
-				DisableGC:                    true,
+				GarbageCollector:             configoptional.None[GarbageCollectorConfig](),
 			},
 			memAllocMiB: [2]uint64{45, 45},
 			numGCs:      0,
@@ -215,7 +222,7 @@ func TestCallGCWhenSoftLimit(t *testing.T) {
 				MinGCIntervalWhenHardLimited: 0,
 				MemoryLimitMiB:               50,
 				MemorySpikeLimitMiB:          10,
-				DisableGC:                    true,
+				GarbageCollector:             configoptional.None[GarbageCollectorConfig](),
 			},
 			memAllocMiB: [2]uint64{55, 55},
 			numGCs:      0,

--- a/internal/memorylimiter/testdata/config.yaml
+++ b/internal/memorylimiter/testdata/config.yaml
@@ -11,3 +11,6 @@ limit_mib: 4000
 
 # The maximum, in MiB, spike expected between the measurements of memory usage.
 spike_limit_mib: 500
+
+# When set to true, disables forced garbage collection.
+disable_gc: true

--- a/internal/memorylimiter/testdata/config.yaml
+++ b/internal/memorylimiter/testdata/config.yaml
@@ -12,5 +12,6 @@ limit_mib: 4000
 # The maximum, in MiB, spike expected between the measurements of memory usage.
 spike_limit_mib: 500
 
-# When set to true, disables forced garbage collection.
-disable_gc: true
+# Set enabled: false to disable forced garbage collection.
+garbage_collector:
+  enabled: true

--- a/processor/memorylimiterprocessor/README.md
+++ b/processor/memorylimiterprocessor/README.md
@@ -135,8 +135,8 @@ measurements of memory usage. The value must be less than `limit_percentage`.
 This option is used to calculate `spike_limit_mib` from the total available memory.
 For instance setting of 25% with the total memory of 1GiB will result in the spike limit of 250MiB.
 This option is intended to be used only with `limit_percentage`.
-- `disable_gc` (default = false): When set to true, disables forced garbage collection.
-The processor will still refuse data when memory limits are exceeded but will not trigger GC.
+- `garbage_collector` (optional section, enabled by default): Controls forced garbage collection.
+Set `enabled: false` to disable GC. The processor will still refuse data when memory limits are exceeded.
 
 Examples:
 

--- a/processor/memorylimiterprocessor/README.md
+++ b/processor/memorylimiterprocessor/README.md
@@ -135,6 +135,8 @@ measurements of memory usage. The value must be less than `limit_percentage`.
 This option is used to calculate `spike_limit_mib` from the total available memory.
 For instance setting of 25% with the total memory of 1GiB will result in the spike limit of 250MiB.
 This option is intended to be used only with `limit_percentage`.
+- `disable_gc` (default = false): When set to true, disables forced garbage collection.
+The processor will still refuse data when memory limits are exceeded but will not trigger GC.
 
 Examples:
 

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -57,6 +57,8 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.154.0 // indirect
+	go.opentelemetry.io/collector/config/configoptional v1.60.0 // indirect
+	go.opentelemetry.io/collector/confmap/xconfmap v0.154.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.60.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.154.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.154.0 // indirect
@@ -121,3 +123,7 @@ replace go.opentelemetry.io/collector/pipeline/xpipeline => ../../pipeline/xpipe
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil
 
 replace go.opentelemetry.io/collector/internal/componentalias => ../../internal/componentalias
+
+replace go.opentelemetry.io/collector/config/configoptional => ../../config/configoptional
+
+replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap


### PR DESCRIPTION
Adds a disable_gc configuration option to the memory_limiter processor. This allows users to opt out of forced garbage collection while maintaining logic for data refusal when memory limits are exceeded, supporting scenarios where multiple memory limiters are composed across pipelines.

Fixes #15081