### PR TITLE
[mdatagen] Make display name required in metadata.yaml

### DIFF
--- a/.chloggen/make-display-required.yaml
+++ b/.chloggen/make-display-required.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make the `display_name` field required in metadata.yaml files used by mdatagen
+
+# One or more tracking issues or pull requests related to the change
+issues: [14114]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -589,6 +589,7 @@ func TestLoadMetadata(t *testing.T) {
 			name: "testdata/parent.yaml",
 			want: Metadata{
 				Type:                 "subcomponent",
+				DisplayName:          "Subcomponent",
 				Parent:               "parentComponent",
 				GeneratedPackageName: "metadata",
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
@@ -601,6 +602,7 @@ func TestLoadMetadata(t *testing.T) {
 			name: "testdata/generated_package_name.yaml",
 			want: Metadata{
 				Type:                 "custom",
+				DisplayName:          "Custom Receiver",
 				GeneratedPackageName: "customname",
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
@@ -620,6 +622,7 @@ func TestLoadMetadata(t *testing.T) {
 			name: "testdata/empty_test_config.yaml",
 			want: Metadata{
 				Type:                 "test",
+				DisplayName:          "Test Receiver",
 				GeneratedPackageName: "metadata",
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
@@ -726,22 +729,8 @@ func TestLoadMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "testdata/no_display_name.yaml",
-			want: Metadata{
-				Type:                 "nodisplayname",
-				DisplayName:          "",
-				GeneratedPackageName: "metadata",
-				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
-				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
-				ShortFolderName:      "testdata",
-				Tests:                Tests{Host: "newMdatagenNopHost()"},
-				Status: &Status{
-					Class: "receiver",
-					Stability: map[component.StabilityLevel][]string{
-						component.StabilityLevelBeta: {"logs"},
-					},
-				},
-			},
+			name:    "testdata/no_display_name.yaml",
+			wantErr: "missing display_name",
 		},
 		{
 			name: "testdata/with_description.yaml",
@@ -766,6 +755,7 @@ func TestLoadMetadata(t *testing.T) {
 			name: "testdata/with_underscore_in_semconv_ref_anchor_tag.yaml",
 			want: Metadata{
 				Type:                 "metricreceiver",
+				DisplayName:          "Metric Receiver",
 				GeneratedPackageName: "metadata",
 				SemConvVersion:       "1.40.0",
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -103,6 +103,10 @@ func (md *Metadata) Validate() error {
 		errs = errors.Join(errs, err)
 	}
 
+	if err := md.validateDisplayName(); err != nil {
+		errs = errors.Join(errs, err)
+	}
+
 	if md.Parent != "" {
 		if md.Status != nil {
 			// status is not required for subcomponents.
@@ -154,6 +158,13 @@ func (md *Metadata) validateType() error {
 
 	if !typeRegexp.MatchString(md.Type) {
 		return fmt.Errorf("invalid character(s) in type %q", md.Type)
+	}
+	return nil
+}
+
+func (md *Metadata) validateDisplayName() error {
+	if md.DisplayName == "" {
+		return errors.New("missing display_name")
 	}
 	return nil
 }

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -611,7 +611,8 @@ func TestValidateConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			md := &Metadata{
-				Type: "test",
+				Type:        "test",
+				DisplayName: "Test Component",
 				Status: &Status{
 					Class: "exporter",
 					Stability: StabilityMap{

--- a/cmd/mdatagen/internal/testdata/async_metric.yaml
+++ b/cmd/mdatagen/internal/testdata/async_metric.yaml
@@ -1,4 +1,5 @@
 type: metricreceiver
+display_name: Metric Receiver
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/basic_connector.yaml
+++ b/cmd/mdatagen/internal/testdata/basic_connector.yaml
@@ -1,4 +1,5 @@
 type: test
+display_name: Test Component
 
 status:
   class: connector

--- a/cmd/mdatagen/internal/testdata/basic_pkg.yaml
+++ b/cmd/mdatagen/internal/testdata/basic_pkg.yaml
@@ -1,4 +1,5 @@
 type: test
+display_name: Test Component
 
 status:
   class: pkg

--- a/cmd/mdatagen/internal/testdata/basic_receiver.yaml
+++ b/cmd/mdatagen/internal/testdata/basic_receiver.yaml
@@ -1,4 +1,5 @@
 type: test
+display_name: Test Component
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/custom_generated_package_name.yaml
+++ b/cmd/mdatagen/internal/testdata/custom_generated_package_name.yaml
@@ -1,4 +1,5 @@
 type: metricreceiver
+display_name: Metric Receiver
 
 generated_package_name: custom
 

--- a/cmd/mdatagen/internal/testdata/empty_test_config.yaml
+++ b/cmd/mdatagen/internal/testdata/empty_test_config.yaml
@@ -1,4 +1,5 @@
 type: test
+display_name: Test Receiver
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/entity_duplicate_attributes.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_duplicate_attributes.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_duplicate_types.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_duplicate_types.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_empty_id_attributes.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_empty_id_attributes.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_event_missing_association.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_event_missing_association.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_metric_missing_association.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_metric_missing_association.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_metrics_events_valid.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_metrics_events_valid.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_relationships_bidirectional.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_bidirectional.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_relationships_empty_target.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_empty_target.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_relationships_empty_type.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_empty_type.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_relationships_undefined_target.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_undefined_target.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_relationships_valid.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_relationships_valid.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_single_metric_missing_association.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_single_metric_missing_association.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_undefined_description_attribute.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_undefined_description_attribute.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_undefined_id_attribute.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_undefined_id_attribute.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_undefined_reference.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_undefined_reference.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/entity_valid.yaml
+++ b/cmd/mdatagen/internal/testdata/entity_valid.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/events/basic_event.yaml
+++ b/cmd/mdatagen/internal/testdata/events/basic_event.yaml
@@ -1,4 +1,5 @@
 type: receiver
+display_name: Test Receiver
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/feature_gates.yaml
+++ b/cmd/mdatagen/internal/testdata/feature_gates.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 status:
   class: receiver
   stability:

--- a/cmd/mdatagen/internal/testdata/generated_package_name.yaml
+++ b/cmd/mdatagen/internal/testdata/generated_package_name.yaml
@@ -1,4 +1,5 @@
 type: custom
+display_name: Custom Receiver
 
 generated_package_name: customname
 

--- a/cmd/mdatagen/internal/testdata/metrics_and_type.yaml
+++ b/cmd/mdatagen/internal/testdata/metrics_and_type.yaml
@@ -1,4 +1,5 @@
 type: metricreceiver
+display_name: Metric Receiver
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/parent.yaml
+++ b/cmd/mdatagen/internal/testdata/parent.yaml
@@ -1,3 +1,4 @@
 type: subcomponent
+display_name: Subcomponent
 
 parent: parentComponent

--- a/cmd/mdatagen/internal/testdata/resource_attributes_only.yaml
+++ b/cmd/mdatagen/internal/testdata/resource_attributes_only.yaml
@@ -1,4 +1,5 @@
 type: test
+display_name: Test Component
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/status_only.yaml
+++ b/cmd/mdatagen/internal/testdata/status_only.yaml
@@ -1,4 +1,5 @@
 type: metricreceiver
+display_name: Metric Receiver
 status:
   class: exporter
   stability:

--- a/cmd/mdatagen/internal/testdata/unsorted_rattr.yaml
+++ b/cmd/mdatagen/internal/testdata/unsorted_rattr.yaml
@@ -1,4 +1,5 @@
 type: sample
+display_name: Sample Component
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/with_conditional_attribute.yaml
+++ b/cmd/mdatagen/internal/testdata/with_conditional_attribute.yaml
@@ -1,4 +1,5 @@
 type: receiver
+display_name: Test Receiver
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/with_config.yaml
+++ b/cmd/mdatagen/internal/testdata/with_config.yaml
@@ -1,4 +1,5 @@
 type: receiver
+display_name: Test Receiver
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/with_goleak_ignores.yaml
+++ b/cmd/mdatagen/internal/testdata/with_goleak_ignores.yaml
@@ -1,4 +1,5 @@
 type: foobar
+display_name: Foobar Component
 
 status:
   disable_codecov_badge: true

--- a/cmd/mdatagen/internal/testdata/with_goleak_setup.yaml
+++ b/cmd/mdatagen/internal/testdata/with_goleak_setup.yaml
@@ -1,4 +1,5 @@
 type: foobar
+display_name: Foobar Component
 
 status:
   disable_codecov_badge: true

--- a/cmd/mdatagen/internal/testdata/with_goleak_skip.yaml
+++ b/cmd/mdatagen/internal/testdata/with_goleak_skip.yaml
@@ -1,4 +1,5 @@
 type: foobar
+display_name: Foobar Component
 
 status:
   disable_codecov_badge: true

--- a/cmd/mdatagen/internal/testdata/with_goleak_teardown.yaml
+++ b/cmd/mdatagen/internal/testdata/with_goleak_teardown.yaml
@@ -1,4 +1,5 @@
 type: foobar
+display_name: Foobar Component
 
 status:
   disable_codecov_badge: true

--- a/cmd/mdatagen/internal/testdata/with_invalid_config_ref.yaml
+++ b/cmd/mdatagen/internal/testdata/with_invalid_config_ref.yaml
@@ -1,4 +1,5 @@
 type: receiver
+display_name: Test Receiver
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/with_telemetry.yaml
+++ b/cmd/mdatagen/internal/testdata/with_telemetry.yaml
@@ -1,4 +1,5 @@
 type: metric
+display_name: Metric Component
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/with_tests_connector.yaml
+++ b/cmd/mdatagen/internal/testdata/with_tests_connector.yaml
@@ -1,4 +1,5 @@
 type: foobar
+display_name: Foobar Component
 
 status:
   disable_codecov_badge: true

--- a/cmd/mdatagen/internal/testdata/with_tests_exporter.yaml
+++ b/cmd/mdatagen/internal/testdata/with_tests_exporter.yaml
@@ -1,4 +1,5 @@
 type: metric
+display_name: Metric Component
 
 status:
   class: exporter

--- a/cmd/mdatagen/internal/testdata/with_tests_extension.yaml
+++ b/cmd/mdatagen/internal/testdata/with_tests_extension.yaml
@@ -1,4 +1,5 @@
 type: metric
+display_name: Metric Component
 
 status:
   class: extension

--- a/cmd/mdatagen/internal/testdata/with_tests_processor.yaml
+++ b/cmd/mdatagen/internal/testdata/with_tests_processor.yaml
@@ -1,4 +1,5 @@
 type: metric
+display_name: Metric Component
 
 status:
   class: processor

--- a/cmd/mdatagen/internal/testdata/with_tests_profiles_connector.yaml
+++ b/cmd/mdatagen/internal/testdata/with_tests_profiles_connector.yaml
@@ -1,4 +1,5 @@
 type: foobar
+display_name: Foobar Component
 
 status:
   disable_codecov_badge: true

--- a/cmd/mdatagen/internal/testdata/with_tests_receiver.yaml
+++ b/cmd/mdatagen/internal/testdata/with_tests_receiver.yaml
@@ -1,4 +1,5 @@
 type: metric
+display_name: Metric Component
 
 status:
   class: receiver

--- a/cmd/mdatagen/internal/testdata/with_underscore_in_semconv_ref_anchor_tag.yaml
+++ b/cmd/mdatagen/internal/testdata/with_underscore_in_semconv_ref_anchor_tag.yaml
@@ -1,4 +1,5 @@
 type: metricreceiver
+display_name: Metric Receiver
 
 status:
   class: receiver

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -4,7 +4,7 @@ type:
 # Optional: A deprecated type that is still available as an alias.
 deprecated_type: string
 
-# Optional: Human-readable display name for the component. Used as the title in generated README files.
+# Required: Human-readable display name for the component. Used as the title in generated README files.
 display_name: string
 
 # Optional: Brief description of the component that will be included in the generated README.


### PR DESCRIPTION
The `display_name` attribute was added in #14115, and I have since gone through and added display names to all [core](https://github.com/open-telemetry/opentelemetry-collector/pull/14400) and [contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Ajaydeluca+is%3Aclosed) components.

@mx-psi [raised the idea](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47572#pullrequestreview-4097917275) that we could switch this field from optional to required to now ensure all modules going forward include this.

