### PR TITLE
Fix panic in EndTracesOp with typed nil errors

### DIFF
--- a/receiver/receiverhelper/obsreport.go
+++ b/receiver/receiverhelper/obsreport.go
@@ -7,6 +7,7 @@ package receiverhelper // import "go.opentelemetry.io/collector/receiver/receive
 
 import (
 	"context"
+	"reflect"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -178,6 +179,17 @@ func (rec *ObsReport) endOp(
 	err error,
 	signal pipeline.Signal,
 ) {
+	// Normalize typed nil errors to avoid nil pointer dereference when calling err.Error().
+	if err != nil {
+		v := reflect.ValueOf(err)
+		switch v.Kind() {
+		case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice:
+			if v.IsNil() {
+				err = nil
+			}
+		}
+	}
+
 	numAccepted := numReceivedItems
 	numRefused := 0
 	numFailedErrors := 0

--- a/receiver/receiverhelper/obsreport_test.go
+++ b/receiver/receiverhelper/obsreport_test.go
@@ -779,3 +779,43 @@ func testTelemetry(t *testing.T, testFunc func(t *testing.T, tt *componenttest.T
 
 	testFunc(t, tt)
 }
+
+// typedNilErr is a concrete error type used to construct typed nil errors in tests.
+type typedNilErr struct{}
+
+func (*typedNilErr) Error() string { panic("must not be called") }
+
+func TestTypedNilError(t *testing.T) {
+	tt := componenttest.NewTelemetry()
+	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+
+	settings := ObsReportSettings{
+		ReceiverID:             receiverID,
+		Transport:              transport,
+		ReceiverCreateSettings: receiver.Settings{ID: receiverID, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()},
+	}
+
+	var typedNil *typedNilErr
+	// Wrap typed nil pointer as error interface — non-nil interface, nil data.
+	var typedNilAsErr error = typedNil
+
+	rec, err := newReceiver(settings)
+	require.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		ctx := rec.StartTracesOp(context.Background())
+		rec.EndTracesOp(ctx, format, 1, typedNilAsErr)
+	})
+	assert.NotPanics(t, func() {
+		ctx := rec.StartLogsOp(context.Background())
+		rec.EndLogsOp(ctx, format, 1, typedNilAsErr)
+	})
+	assert.NotPanics(t, func() {
+		ctx := rec.StartMetricsOp(context.Background())
+		rec.EndMetricsOp(ctx, format, 1, typedNilAsErr)
+	})
+	assert.NotPanics(t, func() {
+		ctx := rec.StartProfilesOp(context.Background())
+		rec.EndProfilesOp(ctx, format, 1, typedNilAsErr)
+	})
+}


### PR DESCRIPTION
#### Description

Downstream components might return errors that are typed nils (a pointer wrapped in an error interface but with a nil underlying value). When we call .Error() on these, it panics. Added a reflection check in endOp to detect and normalize these to actual nil.

#### Link to tracking issue
Fixes #15117

#### Testing

Added a test that passes a typed nil error through the End*Op methods for all signal types and verifies no panic occurs.

#### Documentation

N/A