### PR TITLE
[ci] Add validation for tab-formatted Go templates

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -107,6 +107,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
+      - name: checktemplates
+        run: make checktemplates
       - name: checklicense
         run: make checklicense
       - name: misspell

--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,10 @@ chlog-preview:
 chlog-update:
 	$(GO_TOOL) chloggen update --config $(CHLOGGEN_CONFIG) --version $(VERSION)
 
+.PHONY: checktemplates
+checktemplates:
+	@./internal/buildscripts/check-templates.sh
+
 .PHONY: builder-integration-test
 builder-integration-test:
 	cd ./cmd/builder && ./test/test.sh

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -7,152 +7,152 @@ package {{ .Package }}
 
 import (
 {{- if $validators }}
-    "errors"
+	"errors"
 {{- end }}
 {{- range $imports }}
 	"{{ . }}"
 {{- end }}
-    "go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component"
 )
 
 {{ define "struct" }}
-    {{- if .AllOf }}
-    {{- range .AllOf }}
-        {{- if .Description }}
-    // {{ .Description }}
-        {{- end }}
-    	{{ .ResolvedFrom | publicType }} `mapstructure:",squash"`
-    {{- end }}
-    {{- end }}
-    {{- range $propName, $prop := .Properties }}
-        {{- if $prop.Description }}
-    // {{ $prop.Description }}
-        {{- end }}
-    	{{ $propName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}"`
-    {{- end }}
+	{{- if .AllOf }}
+	{{- range .AllOf }}
+		{{- if .Description }}
+	// {{ .Description }}
+		{{- end }}
+		{{ .ResolvedFrom | publicType }} `mapstructure:",squash"`
+	{{- end }}
+	{{- end }}
+	{{- range $propName, $prop := .Properties }}
+		{{- if $prop.Description }}
+	// {{ $prop.Description }}
+		{{- end }}
+		{{ $propName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}"`
+	{{- end }}
 {{ end }}
 
 {{- $defs := extractDefs .Metadata.Config }}
 {{ range $defName, $def := $defs }}
-    {{- if $def.Description }}
-        // {{ $defName | publicVar }} {{ $def.Description }}
-    {{- end }}
-    {{- $typeName := $defName | publicVar }}
-    type {{ $typeName }} struct {
-        {{- template "struct" $def }}
-    }
+	{{- if $def.Description }}
+		// {{ $defName | publicVar }} {{ $def.Description }}
+	{{- end }}
+	{{- $typeName := $defName | publicVar }}
+	type {{ $typeName }} struct {
+		{{- template "struct" $def }}
+	}
 
-    {{ $defValidators := extractValidators $def }}
-    {{- if $defValidators }}
-        // Validate validates the {{$typeName}} fields according to schema annotations.
-        func (c *{{ $typeName }}) Validate() error {
-            var err error
-            {{ range $validator := $defValidators -}}
-                {{- template "validation" $validator }}
-            {{- end }}
+	{{ $defValidators := extractValidators $def }}
+	{{- if $defValidators }}
+		// Validate validates the {{$typeName}} fields according to schema annotations.
+		func (c *{{ $typeName }}) Validate() error {
+			var err error
+			{{ range $validator := $defValidators -}}
+				{{- template "validation" $validator }}
+			{{- end }}
 
-            return err
-        }
-    {{- end }}
+			return err
+		}
+	{{- end }}
 
-    // NewDefault{{ $typeName }} returns a new {{ $typeName }} with default values consistent with the annotations in the schema.
-    {{- if hasDefaultValue $def }}
-    func NewDefault{{ $typeName }}() {{ $typeName }} {
-    cfg := {{ $typeName }}{}
+	// NewDefault{{ $typeName }} returns a new {{ $typeName }} with default values consistent with the annotations in the schema.
+	{{- if hasDefaultValue $def }}
+	func NewDefault{{ $typeName }}() {{ $typeName }} {
+	cfg := {{ $typeName }}{}
 
-    {{- template "defaultValueSetter" $def }}
+	{{- template "defaultValueSetter" $def }}
 
-    return cfg
-    }
-    {{- end }}
+	return cfg
+	}
+	{{- end }}
 
 {{ end }}
 
 {{- if .Metadata.Config.Description }}
-    // {{ .Metadata.Config.Description }}
+	// {{ .Metadata.Config.Description }}
 {{- else }}
-    // Config defines the configuration for {{ .Metadata.DisplayName }} component.
+	// Config defines the configuration for {{ .Metadata.DisplayName }} component.
 {{- end }}
 type Config struct {
-    {{- template "struct" .Metadata.Config }}
+	{{- template "struct" .Metadata.Config }}
 }
 
 {{ define "customValidator" -}}
-    {{ $name := .FieldName | publicVar -}}
-    {{ $value := "c" }}
-    {{- if ne .FieldName "." }}
-        {{ $value = printf "c.%s" $name -}}
-    {{ end }}
-    if inner_err := {{ .CustomValidator }}({{ $value }}); inner_err != nil {
-        err = errors.Join(err, inner_err)
-    }
+	{{ $name := .FieldName | publicVar -}}
+	{{ $value := "c" }}
+	{{- if ne .FieldName "." }}
+		{{ $value = printf "c.%s" $name -}}
+	{{ end }}
+	if inner_err := {{ .CustomValidator }}({{ $value }}); inner_err != nil {
+		err = errors.Join(err, inner_err)
+	}
 {{- end }}
 
 {{ define "requiredValidator" -}}
-    {{ $name := .FieldName | publicVar -}}
-    {{- if .IsPointer }}
-        {{- if or (eq .FieldType "array") (eq .FieldType "map") }}
-        if c.{{ $name }} == nil || len(*c.{{ $name }}) == 0 {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-        {{- else }}
-        if c.{{ $name }} == nil {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-        {{- end }}
-    {{- else if eq .FieldType "string" }}
-        if c.{{ $name }} == "" {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-    {{- else if eq .FieldType "array" }}
-        if len(c.{{ $name }}) == 0 {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-    {{- else if eq .FieldType "map" }}
-        if c.{{ $name }} == nil || len(c.{{ $name }}) == 0 {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-    {{- end -}}
+	{{ $name := .FieldName | publicVar -}}
+	{{- if .IsPointer }}
+		{{- if or (eq .FieldType "array") (eq .FieldType "map") }}
+		if c.{{ $name }} == nil || len(*c.{{ $name }}) == 0 {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+		{{- else }}
+		if c.{{ $name }} == nil {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+		{{- end }}
+	{{- else if eq .FieldType "string" }}
+		if c.{{ $name }} == "" {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+	{{- else if eq .FieldType "array" }}
+		if len(c.{{ $name }}) == 0 {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+	{{- else if eq .FieldType "map" }}
+		if c.{{ $name }} == nil || len(c.{{ $name }}) == 0 {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+	{{- end -}}
 {{- end }}
 
 {{- define "validation" -}}
-    {{- if .IsRequired -}}
-        {{ template "requiredValidator" . }}
-    {{- end -}}
-    {{- if .CustomValidator }}
-        {{ template "customValidator" . }}
-    {{- end -}}
+	{{- if .IsRequired -}}
+		{{ template "requiredValidator" . }}
+	{{- end -}}
+	{{- if .CustomValidator }}
+		{{ template "customValidator" . }}
+	{{- end -}}
 {{- end }}
 
 {{- if $validators }}
-    // Validate validates the Config fields.
-    func (c *Config) Validate() error {
-        var err error
-        {{ range $validator := $validators -}}
-            {{- template "validation" $validator }}
-        {{- end }}
+	// Validate validates the Config fields.
+	func (c *Config) Validate() error {
+		var err error
+		{{ range $validator := $validators -}}
+			{{- template "validation" $validator }}
+		{{- end }}
 
-        return err
-    }
+		return err
+	}
 {{- end }}
 
 {{- define "defaultValueSetter" }}
-    {{- range $propName, $prop := .Properties }}
-        {{- $defaultValue := formatDefaultValue $prop $propName $prop.Default }}
-        {{- if $defaultValue }}
-        cfg.{{ $propName | publicVar }} = {{ $defaultValue }}
-        {{- end }}
-        {{- $exprs := mapCustomDefaults $prop $prop.Default }}
-        {{- range $expr := $exprs }}
-            cfg.{{ $propName | publicVar }}{{ $expr }}
-        {{- end }}
-    {{- end }}
+	{{- range $propName, $prop := .Properties }}
+		{{- $defaultValue := formatDefaultValue $prop $propName $prop.Default }}
+		{{- if $defaultValue }}
+		cfg.{{ $propName | publicVar }} = {{ $defaultValue }}
+		{{- end }}
+		{{- $exprs := mapCustomDefaults $prop $prop.Default }}
+		{{- range $expr := $exprs }}
+			cfg.{{ $propName | publicVar }}{{ $expr }}
+		{{- end }}
+	{{- end }}
 {{- end }}
 
 func createDefaultConfig() component.Config {
-    cfg := Config{}
+	cfg := Config{}
 
-    {{- template "defaultValueSetter" .Metadata.Config }}
+	{{- template "defaultValueSetter" .Metadata.Config }}
 
-    return &cfg
+	return &cfg
 }

--- a/internal/buildscripts/check-templates.sh
+++ b/internal/buildscripts/check-templates.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks that Go template files (.go.tmpl) use tabs for indentation,
+# not spaces. Go source code must be tab-indented (per gofmt), and
+# templates that generate Go code should follow the same convention.
+
+set -euo pipefail
+
+failed=0
+
+while IFS= read -r -d '' file; do
+    # Find lines that begin with one or more spaces (space-indented).
+    # We use grep -n to show line numbers for actionable output.
+    if grep -n '^ ' "$file" > /dev/null 2>&1; then
+        echo "ERROR: $file contains space indentation (expected tabs):"
+        grep -n '^ ' "$file" | head -10
+        echo ""
+        failed=1
+    fi
+done < <(find . -name '*.go.tmpl' -type f -print0)
+
+if [ "$failed" -eq 1 ]; then
+    echo "FAILED: Some Go template files use spaces for indentation instead of tabs."
+    echo "Please convert all leading spaces to tabs in the listed files."
+    exit 1
+fi
+
+echo "OK: All Go template files use tab indentation."

--- a/internal/cmd/pdatagen/internal/pdata/templates/message.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/message.go.tmpl
@@ -64,7 +64,7 @@ func (ms {{ .structName }}) MoveTo(dest {{ .structName }}) {
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms {{ .structName }}) CopyTo(dest {{ .structName }}) {
 	dest.{{ .stateAccessor }}.AssertMutable()
-    internal.Copy{{ .originName }}(dest.{{ .origAccessor }}, ms.{{ .origAccessor }})
+	internal.Copy{{ .originName }}(dest.{{ .origAccessor }}, ms.{{ .origAccessor }})
 }
 
 {{ if .hasWrapper -}}

--- a/internal/cmd/pdatagen/internal/pdata/templates/message_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/message_internal.go.tmpl
@@ -30,5 +30,5 @@ func New{{ .structName }}Wrapper(orig *{{ .originName }}, state *State) {{ .stru
 }
 
 func GenTest{{ .structName }}Wrapper() {{ .structName }}Wrapper {
-    return New{{ .structName }}Wrapper(GenTest{{ .originName }}(), NewState())
+	return New{{ .structName }}Wrapper(GenTest{{ .originName }}(), NewState())
 }

--- a/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice.go.tmpl
@@ -115,15 +115,15 @@ func (ms {{ .structName }}) MoveTo(dest {{ .structName }}) {
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (ms {{ .structName }}) MoveAndAppendTo(dest {{ .structName }}) {
-  ms.getState().AssertMutable()
-  dest.getState().AssertMutable()
-  if *dest.getOrig() == nil {
-    // We can simply move the entire vector and avoid any allocations.
-    *dest.getOrig() = *ms.getOrig()
-  } else {
-    *dest.getOrig() = append(*dest.getOrig(), *ms.getOrig()...)
-  }
-  *ms.getOrig() = nil
+	ms.getState().AssertMutable()
+	dest.getState().AssertMutable()
+	if *dest.getOrig() == nil {
+		// We can simply move the entire vector and avoid any allocations.
+		*dest.getOrig() = *ms.getOrig()
+	} else {
+		*dest.getOrig() = append(*dest.getOrig(), *ms.getOrig()...)
+	}
+	*ms.getOrig() = nil
 }
 
 // RemoveIf calls f sequentially for each element present in the slice.

--- a/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice_internal.go.tmpl
@@ -35,5 +35,5 @@ func GenTest{{ .structName }}Wrapper() {{ .structName }}Wrapper {
 }
 
 func GenTest{{ .elementOriginName }}Slice() []{{ .itemType }} {
-    return []{{ .itemType }}{ {{ .testOrigVal }} }
+	return []{{ .itemType }}{ {{ .testOrigVal }} }
 }

--- a/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice_test.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/primitive_slice_test.go.tmpl
@@ -135,22 +135,22 @@ func Test{{ .structName }}All(t *testing.T) {
 
 
 func Test{{ .structName }}MoveAndAppendTo(t *testing.T) {
-  // Test moving from an empty slice
-  ms := New{{ .structName }}()
-  ms2 := New{{ .structName }}()
-  ms.MoveAndAppendTo(ms2)
-  assert.Equal(t, New{{ .structName }}(), ms2)
-  assert.Equal(t, ms.Len(), 0)
+	// Test moving from an empty slice
+	ms := New{{ .structName }}()
+	ms2 := New{{ .structName }}()
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, New{{ .structName }}(), ms2)
+	assert.Equal(t, ms.Len(), 0)
 
-  // Test moving to empty slice
-  ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
-  ms.MoveAndAppendTo(ms2)
-  assert.Equal(t, ms2.Len(), 3)
+	// Test moving to empty slice
+	ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 3)
 
-  // Test moving to a non empty slice
-  ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
-  ms.MoveAndAppendTo(ms2)
-  assert.Equal(t, ms2.Len(), 6)
+	// Test moving to a non empty slice
+	ms.FromRaw([]{{ .itemType }}{ {{ .testOrigVal }} })
+	ms.MoveAndAppendTo(ms2)
+	assert.Equal(t, ms2.Len(), 6)
 }
 
 func Test{{ .structName }}RemoveIf(t *testing.T) {

--- a/internal/cmd/pdatagen/internal/pdata/templates/slice_internal.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/slice_internal.go.tmpl
@@ -30,6 +30,6 @@ func New{{ .structName }}Wrapper(orig *[]{{ if .elementNullable }}*{{ end }}{{ .
 }
 
 func GenTest{{ .structName }}Wrapper() {{ .structName }}Wrapper {
-    orig := GenTest{{ .elementOriginName }}{{ if .elementNullable }}Ptr{{ end }}Slice()
-    return New{{ .structName }}Wrapper(&orig, NewState())
+	orig := GenTest{{ .elementOriginName }}{{ if .elementNullable }}Ptr{{ end }}Slice()
+	return New{{ .structName }}Wrapper(&orig, NewState())
 }

--- a/internal/cmd/pdatagen/internal/pdata/templates/slice_test.go.tmpl
+++ b/internal/cmd/pdatagen/internal/pdata/templates/slice_test.go.tmpl
@@ -31,7 +31,7 @@ func Test{{ .structName }}(t *testing.T) {
 	for i := 0; i < 7; i++ {
 		es.AppendEmpty()
 		assert.Equal(t, emptyVal, es.At(i))
-        (*es.{{ .origAccessor }})[i] = {{ if not .elementNullable }}*{{ end }}internal.GenTest{{ .elementOriginName }}()
+		(*es.{{ .origAccessor }})[i] = {{ if not .elementNullable }}*{{ end }}internal.GenTest{{ .elementOriginName }}()
 		assert.Equal(t, testVal, es.At(i))
 	}
 	assert.Equal(t, 7, es.Len())
@@ -56,8 +56,8 @@ func Test{{ .structName }}_CopyTo(t *testing.T) {
 	src := generateTest{{ .structName }}()
 	src.CopyTo(dest)
 	assert.Equal(t, generateTest{{ .structName }}(), dest)
-    dest.CopyTo(dest)
-    assert.Equal(t, generateTest{{ .structName }}(), dest)
+	dest.CopyTo(dest)
+	assert.Equal(t, generateTest{{ .structName }}(), dest)
 }
 
 func Test{{ .structName }}_EnsureCapacity(t *testing.T) {

--- a/internal/cmd/pdatagen/internal/proto/templates/message.go.tmpl
+++ b/internal/cmd/pdatagen/internal/proto/templates/message.go.tmpl
@@ -19,10 +19,10 @@ import (
 {{ .description }}
 type {{ .messageName }} struct {
 {{- range .fields }}
-    {{ .GenMessageField }}
+	{{ .GenMessageField }}
 {{- end }}
 {{ if gt .metadataSize 0 -}}
-    metadata [{{ .metadataSize }}]uint64
+	metadata [{{ .metadataSize }}]uint64
 {{ end -}}
 }
 
@@ -31,52 +31,52 @@ var (
 	    New: func() any {
 		    return &{{ .messageName }}{}
 	    },
-    }
-    {{- range .fields }}{{ .GenPool }}{{- end }}
+	}
+	{{- range .fields }}{{ .GenPool }}{{- end }}
 )
 
 
 func New{{ .messageName }}() *{{ .messageName }} {
-    if !metadata.PdataUseProtoPoolingFeatureGate.IsEnabled() {
-        return &{{ .messageName }}{}
-    }
-    return protoPool{{ .messageName }}.Get().(*{{ .messageName }})
+	if !metadata.PdataUseProtoPoolingFeatureGate.IsEnabled() {
+		return &{{ .messageName }}{}
+	}
+	return protoPool{{ .messageName }}.Get().(*{{ .messageName }})
 }
 
 func Delete{{ .messageName }}(orig *{{ .messageName }}, nullable bool) {
-    if orig == nil {
-        return
-    }
+	if orig == nil {
+		return
+	}
 
-    if !metadata.PdataUseProtoPoolingFeatureGate.IsEnabled() {
-        orig.Reset()
-        return
-    }
+	if !metadata.PdataUseProtoPoolingFeatureGate.IsEnabled() {
+		orig.Reset()
+		return
+	}
 
-    {{- range .fields }}
-        {{ .GenDelete }}
-    {{- end }}
-    orig.Reset()
-    if nullable {
-        protoPool{{ .messageName }}.Put(orig)
-    }
+	{{- range .fields }}
+		{{ .GenDelete }}
+	{{- end }}
+	orig.Reset()
+	if nullable {
+		protoPool{{ .messageName }}.Put(orig)
+	}
 }
 
 func Copy{{ .messageName }}(dest, src *{{ .messageName }}) *{{ .messageName }}{
 	// If copying to same object, just return.
 	if src == dest {
 		return dest
-    }
+	}
 
-    if src == nil {
-        return nil;
-    }
+	if src == nil {
+		return nil;
+	}
 
-    if dest == nil {
-        dest = New{{ .messageName }}();
-    }
+	if dest == nil {
+		dest = New{{ .messageName }}();
+	}
 
-    {{- range .fields }}
+	{{- range .fields }}
 	{{ .GenCopy }}
 	{{- end }}
 
@@ -84,51 +84,51 @@ func Copy{{ .messageName }}(dest, src *{{ .messageName }}) *{{ .messageName }}{
 }
 
 func Copy{{ .messageName }}Slice(dest, src []{{ .messageName }}) []{{ .messageName }} {
-    var newDest []{{ .messageName }}
-    if cap(dest) < len(src) {
-        newDest = make([]{{ .messageName }}, len(src))
-    } else {
-        newDest = dest[:len(src)]
-        // Cleanup the rest of the elements so GC can free the memory.
-        // This can happen when len(src) < len(dest) < cap(dest).
-        for i := len(src); i < len(dest); i++ {
-            Delete{{ .messageName }}(&dest[i], false)
-        }
-    }
-    for i := range src {
-        Copy{{ .messageName }}(&newDest[i], &src[i])
-    }
-    return newDest
+	var newDest []{{ .messageName }}
+	if cap(dest) < len(src) {
+		newDest = make([]{{ .messageName }}, len(src))
+	} else {
+		newDest = dest[:len(src)]
+		// Cleanup the rest of the elements so GC can free the memory.
+		// This can happen when len(src) < len(dest) < cap(dest).
+		for i := len(src); i < len(dest); i++ {
+			Delete{{ .messageName }}(&dest[i], false)
+		}
+	}
+	for i := range src {
+		Copy{{ .messageName }}(&newDest[i], &src[i])
+	}
+	return newDest
 }
 
 func Copy{{ .messageName }}PtrSlice(dest, src []*{{ .messageName }}) []*{{ .messageName }} {
-    var newDest []*{{ .messageName }}
-    if cap(dest) < len(src) {
-        newDest = make([]*{{ .messageName }}, len(src))
-        // Copy old pointers to re-use.
-        copy(newDest, dest)
-        // Add new pointers for missing elements from len(dest) to len(srt).
-        for i := len(dest); i < len(src); i++ {
-            newDest[i] = New{{ .messageName }}()
-        }
+	var newDest []*{{ .messageName }}
+	if cap(dest) < len(src) {
+		newDest = make([]*{{ .messageName }}, len(src))
+		// Copy old pointers to re-use.
+		copy(newDest, dest)
+		// Add new pointers for missing elements from len(dest) to len(srt).
+		for i := len(dest); i < len(src); i++ {
+			newDest[i] = New{{ .messageName }}()
+		}
 	} else {
-        newDest = dest[:len(src)]
-        // Cleanup the rest of the elements so GC can free the memory.
-        // This can happen when len(src) < len(dest) < cap(dest).
-        for i := len(src); i < len(dest); i++ {
-            Delete{{ .messageName }}(dest[i], true)
-            dest[i] = nil
-        }
-        // Add new pointers for missing elements.
-        // This can happen when len(dest) < len(src) < cap(dest).
-        for i := len(dest); i < len(src); i++ {
-            newDest[i] = New{{ .messageName }}()
-        }
-    }
-    for i := range src {
-        Copy{{ .messageName }}(newDest[i], src[i])
-    }
-    return newDest
+		newDest = dest[:len(src)]
+		// Cleanup the rest of the elements so GC can free the memory.
+		// This can happen when len(src) < len(dest) < cap(dest).
+		for i := len(src); i < len(dest); i++ {
+			Delete{{ .messageName }}(dest[i], true)
+			dest[i] = nil
+		}
+		// Add new pointers for missing elements.
+		// This can happen when len(dest) < len(src) < cap(dest).
+		for i := len(dest); i < len(src); i++ {
+			newDest[i] = New{{ .messageName }}()
+		}
+	}
+	for i := range src {
+		Copy{{ .messageName }}(newDest[i], src[i])
+	}
+	return newDest
 }
 
 
@@ -210,26 +210,26 @@ func (orig *{{ .messageName }}) UnmarshalProto(buf []byte) error {
 {{ end -}}
 
 func GenTest{{ .messageName }}() *{{ .messageName }} {
-    orig := New{{ .messageName }}()
-    {{- range .fields }}
-    {{ .GenTest }}
-    {{- end }}
-    return orig
+	orig := New{{ .messageName }}()
+	{{- range .fields }}
+	{{ .GenTest }}
+	{{- end }}
+	return orig
 }
 
 func GenTest{{ .messageName }}PtrSlice() []*{{ .messageName }} {
-    orig := make([]*{{ .messageName }}, 5)
-    orig[0] = New{{ .messageName }}()
-    orig[1] = GenTest{{ .messageName }}()
-    orig[2] = New{{ .messageName }}()
-    orig[3] = GenTest{{ .messageName }}()
-    orig[4] = New{{ .messageName }}()
-    return orig
+	orig := make([]*{{ .messageName }}, 5)
+	orig[0] = New{{ .messageName }}()
+	orig[1] = GenTest{{ .messageName }}()
+	orig[2] = New{{ .messageName }}()
+	orig[3] = GenTest{{ .messageName }}()
+	orig[4] = New{{ .messageName }}()
+	return orig
 }
 
 func GenTest{{ .messageName }}Slice() []{{ .messageName }} {
-    orig := make([]{{ .messageName }}, 5)
-    orig[1] = *GenTest{{ .messageName }}()
-    orig[3] = *GenTest{{ .messageName }}()
-    return orig
+	orig := make([]{{ .messageName }}, 5)
+	orig[1] = *GenTest{{ .messageName }}()
+	orig[3] = *GenTest{{ .messageName }}()
+	return orig
 }

--- a/internal/cmd/pdatagen/internal/proto/templates/message_test.go.tmpl
+++ b/internal/cmd/pdatagen/internal/proto/templates/message_test.go.tmpl
@@ -13,119 +13,119 @@ import (
 )
 
 func TestCopy{{ .messageName }}(t *testing.T) {
-    for name, src := range genTestEncodingValues{{ .messageName }}() {
-        for _, pooling := range []bool{true, false} {
-            t.Run(name+"/Pooling="+strconv.FormatBool(pooling), func(t *testing.T) {
-                prevPooling := metadata.PdataUseProtoPoolingFeatureGate.IsEnabled()
-                require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), pooling))
-                defer func() {
-                    require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), prevPooling))
-                }()
+	for name, src := range genTestEncodingValues{{ .messageName }}() {
+		for _, pooling := range []bool{true, false} {
+			t.Run(name+"/Pooling="+strconv.FormatBool(pooling), func(t *testing.T) {
+				prevPooling := metadata.PdataUseProtoPoolingFeatureGate.IsEnabled()
+				require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), pooling))
+				defer func() {
+					require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), prevPooling))
+				}()
 
-                dest := New{{ .messageName }}()
-                Copy{{ .messageName }}(dest, src)
-                assert.Equal(t, src, dest)
-                Copy{{ .messageName }}(dest, dest)
-                assert.Equal(t, src, dest)
-            })
-        }
-    }
+				dest := New{{ .messageName }}()
+				Copy{{ .messageName }}(dest, src)
+				assert.Equal(t, src, dest)
+				Copy{{ .messageName }}(dest, dest)
+				assert.Equal(t, src, dest)
+			})
+		}
+	}
 }
 
 func TestCopy{{ .messageName }}Slice(t *testing.T) {
-    src := []{{ .messageName }}{}
-    dest := []{{ .messageName }}{}
-    // Test CopyTo empty
-    dest = Copy{{ .messageName }}Slice(dest, src)
-    assert.Equal(t, []{{ .messageName }}{}, dest)
+	src := []{{ .messageName }}{}
+	dest := []{{ .messageName }}{}
+	// Test CopyTo empty
+	dest = Copy{{ .messageName }}Slice(dest, src)
+	assert.Equal(t, []{{ .messageName }}{}, dest)
 
-    // Test CopyTo larger slice
-    src = GenTest{{ .messageName }}Slice()
-    dest = Copy{{ .messageName }}Slice(dest, src)
-    assert.Equal(t, GenTest{{ .messageName }}Slice(), dest)
+	// Test CopyTo larger slice
+	src = GenTest{{ .messageName }}Slice()
+	dest = Copy{{ .messageName }}Slice(dest, src)
+	assert.Equal(t, GenTest{{ .messageName }}Slice(), dest)
 
-    // Test CopyTo same size slice
-    dest = Copy{{ .messageName }}Slice(dest, src)
-    assert.Equal(t, GenTest{{ .messageName }}Slice(), dest)
+	// Test CopyTo same size slice
+	dest = Copy{{ .messageName }}Slice(dest, src)
+	assert.Equal(t, GenTest{{ .messageName }}Slice(), dest)
 
-    // Test CopyTo smaller size slice
-    dest = Copy{{ .messageName }}Slice(dest, []{{ .messageName }}{})
-    assert.Len(t, dest, 0)
+	// Test CopyTo smaller size slice
+	dest = Copy{{ .messageName }}Slice(dest, []{{ .messageName }}{})
+	assert.Len(t, dest, 0)
 
-    // Test CopyTo larger slice with enough capacity
-    dest = Copy{{ .messageName }}Slice(dest, src)
-    assert.Equal(t, GenTest{{ .messageName }}Slice(), dest)
+	// Test CopyTo larger slice with enough capacity
+	dest = Copy{{ .messageName }}Slice(dest, src)
+	assert.Equal(t, GenTest{{ .messageName }}Slice(), dest)
 }
 
 func TestCopy{{ .messageName }}PtrSlice(t *testing.T) {
-    src := []*{{ .messageName }}{}
-    dest := []*{{ .messageName }}{}
-    // Test CopyTo empty
-    dest = Copy{{ .messageName }}PtrSlice(dest, src)
-    assert.Equal(t, []*{{ .messageName }}{}, dest)
+	src := []*{{ .messageName }}{}
+	dest := []*{{ .messageName }}{}
+	// Test CopyTo empty
+	dest = Copy{{ .messageName }}PtrSlice(dest, src)
+	assert.Equal(t, []*{{ .messageName }}{}, dest)
 
-    // Test CopyTo larger slice
-    src = GenTest{{ .messageName }}PtrSlice()
-    dest = Copy{{ .messageName }}PtrSlice(dest, src)
-    assert.Equal(t, GenTest{{ .messageName }}PtrSlice(), dest)
+	// Test CopyTo larger slice
+	src = GenTest{{ .messageName }}PtrSlice()
+	dest = Copy{{ .messageName }}PtrSlice(dest, src)
+	assert.Equal(t, GenTest{{ .messageName }}PtrSlice(), dest)
 
-    // Test CopyTo same size slice
-    dest = Copy{{ .messageName }}PtrSlice(dest, src)
-    assert.Equal(t, GenTest{{ .messageName }}PtrSlice(), dest)
+	// Test CopyTo same size slice
+	dest = Copy{{ .messageName }}PtrSlice(dest, src)
+	assert.Equal(t, GenTest{{ .messageName }}PtrSlice(), dest)
 
-    // Test CopyTo smaller size slice
-    dest = Copy{{ .messageName }}PtrSlice(dest, []*{{ .messageName }}{})
-    assert.Len(t, dest, 0)
+	// Test CopyTo smaller size slice
+	dest = Copy{{ .messageName }}PtrSlice(dest, []*{{ .messageName }}{})
+	assert.Len(t, dest, 0)
 
-    // Test CopyTo larger slice with enough capacity
-    dest = Copy{{ .messageName }}PtrSlice(dest, src)
-    assert.Equal(t, GenTest{{ .messageName }}PtrSlice(), dest)
+	// Test CopyTo larger slice with enough capacity
+	dest = Copy{{ .messageName }}PtrSlice(dest, src)
+	assert.Equal(t, GenTest{{ .messageName }}PtrSlice(), dest)
 }
 
 func TestMarshalAndUnmarshalJSON{{ .messageName }}Unknown(t *testing.T) {
 	iter := json.BorrowIterator([]byte(`{"unknown": "string"}`))
 	defer json.ReturnIterator(iter)
 	dest := New{{ .messageName }}()
-    dest.UnmarshalJSON(iter)
+	dest.UnmarshalJSON(iter)
 	require.NoError(t, iter.Error())
 	assert.Equal(t, New{{ .messageName }}(), dest)
 }
 
 func TestMarshalAndUnmarshalJSON{{ .messageName }}(t *testing.T) {
 	for name, src := range genTestEncodingValues{{ .messageName }}() {
-        for _, pooling := range []bool{true, false} {
-            t.Run(name+"/Pooling="+strconv.FormatBool(pooling), func(t *testing.T) {
-                prevPooling := metadata.PdataUseProtoPoolingFeatureGate.IsEnabled()
-                require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), pooling))
-                defer func() {
-                    require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), prevPooling))
-                }()
+		for _, pooling := range []bool{true, false} {
+			t.Run(name+"/Pooling="+strconv.FormatBool(pooling), func(t *testing.T) {
+				prevPooling := metadata.PdataUseProtoPoolingFeatureGate.IsEnabled()
+				require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), pooling))
+				defer func() {
+					require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), prevPooling))
+				}()
 
-                stream := json.BorrowStream(nil)
-                defer json.ReturnStream(stream)
-                src.MarshalJSON(stream)
-                require.NoError(t, stream.Error())
+				stream := json.BorrowStream(nil)
+				defer json.ReturnStream(stream)
+				src.MarshalJSON(stream)
+				require.NoError(t, stream.Error())
 
-                iter := json.BorrowIterator(stream.Buffer())
-                defer json.ReturnIterator(iter)
-                dest := New{{ .messageName }}()
-                dest.UnmarshalJSON(iter)
-                require.NoError(t, iter.Error())
+				iter := json.BorrowIterator(stream.Buffer())
+				defer json.ReturnIterator(iter)
+				dest := New{{ .messageName }}()
+				dest.UnmarshalJSON(iter)
+				require.NoError(t, iter.Error())
 
-                assert.Equal(t, src, dest)
-                Delete{{ .messageName }}(dest, true)
-            })
-        }
+				assert.Equal(t, src, dest)
+				Delete{{ .messageName }}(dest, true)
+			})
+		}
 	}
 }
 
 func TestMarshalAndUnmarshalProto{{ .messageName }}Failing(t *testing.T) {
-    for name, buf := range genTestFailingUnmarshalProtoValues{{ .messageName }}() {
-        t.Run(name, func(t *testing.T) {
-            dest := New{{ .messageName }}()
-            require.Error(t, dest.UnmarshalProto(buf))
-        })
-    }
+	for name, buf := range genTestFailingUnmarshalProtoValues{{ .messageName }}() {
+		t.Run(name, func(t *testing.T) {
+			dest := New{{ .messageName }}()
+			require.Error(t, dest.UnmarshalProto(buf))
+		})
+	}
 }
 
 func TestMarshalAndUnmarshalProto{{ .messageName }}Unknown(t *testing.T) {
@@ -137,53 +137,53 @@ func TestMarshalAndUnmarshalProto{{ .messageName }}Unknown(t *testing.T) {
 
 func TestMarshalAndUnmarshalProto{{ .messageName }}(t *testing.T) {
 	for name, src := range genTestEncodingValues{{ .messageName }}(){
-        for _, pooling := range []bool{true, false} {
-            t.Run(name+"/Pooling="+strconv.FormatBool(pooling), func(t *testing.T) {
-                prevPooling := metadata.PdataUseProtoPoolingFeatureGate.IsEnabled()
-                require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), pooling))
-                defer func() {
-                    require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), prevPooling))
-                }()
+		for _, pooling := range []bool{true, false} {
+			t.Run(name+"/Pooling="+strconv.FormatBool(pooling), func(t *testing.T) {
+				prevPooling := metadata.PdataUseProtoPoolingFeatureGate.IsEnabled()
+				require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), pooling))
+				defer func() {
+					require.NoError(t, featuregate.GlobalRegistry().Set(metadata.PdataUseProtoPoolingFeatureGate.ID(), prevPooling))
+				}()
 
-                buf := make([]byte, src.SizeProto())
-                gotSize := src.MarshalProto(buf)
-                assert.Equal(t, len(buf), gotSize)
+				buf := make([]byte, src.SizeProto())
+				gotSize := src.MarshalProto(buf)
+				assert.Equal(t, len(buf), gotSize)
 
-                dest := New{{ .messageName }}()
-                require.NoError(t, dest.UnmarshalProto(buf))
+				dest := New{{ .messageName }}()
+				require.NoError(t, dest.UnmarshalProto(buf))
 
-                assert.Equal(t, src, dest)
-                Delete{{ .messageName }}(dest, true)
-            })
-        }
+				assert.Equal(t, src, dest)
+				Delete{{ .messageName }}(dest, true)
+			})
+		}
 	}
 }
 
 func TestMarshalAndUnmarshalProtoViaProtobuf{{ .messageName }}(t *testing.T) {
 	for name, src := range genTestEncodingValues{{ .messageName }}(){
 		t.Run(name, func(t *testing.T) {
-            buf := make([]byte, src.SizeProto())
-            gotSize := src.MarshalProto(buf)
-            assert.Equal(t, len(buf), gotSize)
+			buf := make([]byte, src.SizeProto())
+			gotSize := src.MarshalProto(buf)
+			assert.Equal(t, len(buf), gotSize)
 
-            goDest := &{{ .upstreamMessage }}{}
-            require.NoError(t, proto.Unmarshal(buf, goDest))
+			goDest := &{{ .upstreamMessage }}{}
+			require.NoError(t, proto.Unmarshal(buf, goDest))
 
-            goBuf, err := proto.Marshal(goDest)
-            require.NoError(t, err)
+			goBuf, err := proto.Marshal(goDest)
+			require.NoError(t, err)
 
-            dest := New{{ .messageName }}()
-            require.NoError(t, dest.UnmarshalProto(goBuf))
-            assert.Equal(t, src, dest)
-        })
+			dest := New{{ .messageName }}()
+			require.NoError(t, dest.UnmarshalProto(goBuf))
+			assert.Equal(t, src, dest)
+		})
 	}
 }
 
 func genTestFailingUnmarshalProtoValues{{ .messageName }}() map[string][]byte {
-    return map[string][]byte{
+	return map[string][]byte{
 		"invalid_field": { 0x02 },
-        {{- range .fields }}{{ .GenTestFailingUnmarshalProtoValues }}{{- end }}
-    }
+		{{- range .fields }}{{ .GenTestFailingUnmarshalProtoValues }}{{- end }}
+	}
 }
 
 func genTestEncodingValues{{ .messageName }}() map[string]*{{ .messageName }} {


### PR DESCRIPTION
#### Description

Add a CI check that ensures all Go template files (`.go.tmpl`) use tabs for indentation instead of spaces, consistent with Go formatting conventions (`gofmt`).

This adds:
- A shell script (`internal/buildscripts/check-templates.sh`) that scans all `.go.tmpl` files for lines with leading-space indentation
- A Makefile target (`checktemplates`) that runs the check
- A CI step in the `checks` job of `build-and-test.yml` that runs the check on every PR

As part of this change, all existing template files that had space indentation are fixed:
- `cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl` (4-space to tabs)
- `internal/cmd/pdatagen/internal/proto/templates/message.go.tmpl` (4-space to tabs)
- `internal/cmd/pdatagen/internal/proto/templates/message_test.go.tmpl` (4-space to tabs)
- 7 files in `internal/cmd/pdatagen/internal/pdata/templates/` (2-space and 4-space to tabs)

#### Link to tracking issue

Fixes #14698

#### Testing

- Ran the check script locally; it passes with all template files now using tab indentation
- Verified the check correctly detects space indentation by testing against the original files

#### Documentation

N/A