### PR TITLE
Always retry on ResourceExhausted to prevent data loss

### DIFF
--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 
 	"go.uber.org/zap"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -186,7 +185,7 @@ func processError(err error) error {
 	// Now, this is a real error.
 	retryInfo := statusutil.GetRetryInfo(st)
 
-	if !shouldRetry(st.Code(), retryInfo) {
+	if !shouldRetry(st.Code()) {
 		// It is not a retryable error, we should not retry.
 		return consumererror.NewPermanent(err)
 	}
@@ -202,20 +201,17 @@ func processError(err error) error {
 	return err
 }
 
-func shouldRetry(code codes.Code, retryInfo *errdetails.RetryInfo) bool {
+func shouldRetry(code codes.Code) bool {
 	switch code {
 	case codes.Canceled,
 		codes.DeadlineExceeded,
 		codes.Aborted,
 		codes.OutOfRange,
 		codes.Unavailable,
-		codes.DataLoss:
+		codes.DataLoss,
+		codes.ResourceExhausted:
 		// These are retryable errors.
 		return true
-	case codes.ResourceExhausted:
-		// Retry only if RetryInfo was supplied by the server.
-		// This indicates that the server can still recover from resource exhaustion.
-		return retryInfo != nil
 	}
 	// Don't retry on any other code.
 	return false

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -723,9 +723,9 @@ func TestSendTracesOnResourceExhaustion(t *testing.T) {
 	td := ptrace.NewTraces()
 	require.NoError(t, exp.ConsumeTraces(context.Background(), td))
 
-	assert.Never(t, func() bool {
+	assert.Eventually(t, func() bool {
 		return rcv.requestCount.Load() > 1
-	}, 1*time.Second, 5*time.Millisecond, "Should not retry if RetryInfo is not included into status details by the server.")
+	}, 10*time.Second, 5*time.Millisecond, "Should retry on ResourceExhausted even without RetryInfo.")
 
 	rcv.requestCount.Swap(0)
 

--- a/extension/memorylimiterextension/memorylimiter.go
+++ b/extension/memorylimiterextension/memorylimiter.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"go.uber.org/zap"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -69,16 +70,24 @@ func (ml *memoryLimiterExtension) GetGRPCServerOptions(_ context.Context) ([]grp
 		grpc.ChainUnaryInterceptor(
 			func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 				if ml.MustRefuse() {
-					return nil, status.Errorf(codes.ResourceExhausted, "RESOURCE_EXHAUSTED")
+					return nil, resourceExhaustedStatus()
 				}
 				return handler(ctx, req)
 			}),
 		grpc.ChainStreamInterceptor(
 			func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 				if ml.MustRefuse() {
-					return status.Errorf(codes.ResourceExhausted, "RESOURCE_EXHAUSTED")
+					return resourceExhaustedStatus()
 				}
 				return handler(srv, ss)
 			}),
 	}, nil
+}
+
+func resourceExhaustedStatus() error {
+	st, err := status.New(codes.ResourceExhausted, "RESOURCE_EXHAUSTED").WithDetails(&errdetails.RetryInfo{})
+	if err != nil {
+		return status.Errorf(codes.ResourceExhausted, "RESOURCE_EXHAUSTED")
+	}
+	return st.Err()
 }


### PR DESCRIPTION
#### Description

Found that when downstream collectors hit resource limits and return ResourceExhausted, we're only retrying if they include RetryInfo in the error details. If they skip it, we just drop the data. ResourceExhausted is almost always temporary anyway, so we should retry regardless.

Simplified the retry logic to unconditionally retry on ResourceExhausted. Removed the RetryInfo dependency since we don't need it. Moved the errdetails import over to memorylimiter since the exporter doesn't use it anymore.

#### Link to tracking issue
Fixes #15126

#### Testing

Updated the ResourceExhausted test that was asserting we never retry. Changed it to verify we actually do retry now, with a reasonable timeout window to let retries happen.

#### Documentation

N/A