### PR TITLE
[pdata] Use spec-compliant string representation for NaN and Infinity

### DIFF
--- a/.chloggen/fix-float64-nan-infinity-string.yaml
+++ b/.chloggen/fix-float64-nan-infinity-string.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pkg/pdata
+note: "Use spec-compliant string representation for NaN, Infinity, and -Infinity in Value.AsString()."
+issues: [14487]
+change_logs: [user]

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -419,8 +419,14 @@ func (v Value) AsString() string {
 // See https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/encoding/json/encode.go;l=585.
 // This allows us to avoid using reflection.
 func float64AsString(f float64) string {
-	if math.IsInf(f, 0) || math.IsNaN(f) {
-		return "json: unsupported value: " + strconv.FormatFloat(f, 'g', -1, 64)
+	if math.IsNaN(f) {
+		return "NaN"
+	}
+	if math.IsInf(f, 1) {
+		return "Infinity"
+	}
+	if math.IsInf(f, -1) {
+		return "-Infinity"
 	}
 
 	// Convert as if by ES6 number to string conversion.

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -303,9 +303,19 @@ func TestValueAsString(t *testing.T) {
 			expected: "9e-9",
 		},
 		{
-			name:     "bad float64",
+			name:     "float64_positive_infinity",
 			input:    NewValueDouble(math.Inf(1)),
-			expected: "json: unsupported value: +Inf",
+			expected: "Infinity",
+		},
+		{
+			name:     "float64_negative_infinity",
+			input:    NewValueDouble(math.Inf(-1)),
+			expected: "-Infinity",
+		},
+		{
+			name:     "float64_nan",
+			input:    NewValueDouble(math.NaN()),
+			expected: "NaN",
 		},
 		{
 			name:     "boolean",


### PR DESCRIPTION
## Summary

Update `float64AsString` to return `"NaN"`, `"Infinity"`, and `"-Infinity"` instead of `"json: unsupported value: ..."` for special float values.

Fixes #14487

## Problem

The current `Value.AsString()` for double values containing `NaN`, `+Inf`, or `-Inf` returns strings like:
```
json: unsupported value: +Inf
json: unsupported value: NaN
```

The [OpenTelemetry specification's suggested string representation](https://github.com/open-telemetry/opentelemetry-specification/pull/4848) for non-OTLP protocols specifies these should be `"NaN"`, `"Infinity"`, and `"-Infinity"`.

## Fix

Updated `float64AsString` in `pdata/pcommon/value.go` to return spec-compliant strings:
- `math.NaN()` → `"NaN"`
- `math.Inf(1)` → `"Infinity"`
- `math.Inf(-1)` → `"-Infinity"`

## Test Plan

- [x] Updated existing `"bad float64"` test case and added `NaN` and `-Infinity` cases
- [x] Full `pdata` test suite passes with `-race`