### PR TITLE
[config/configgrpc] Add `DefaultLoadBalancerName` constant

### DIFF
--- a/.chloggen/configgrpc-balancername.yaml
+++ b/.chloggen/configgrpc-balancername.yaml
@@ -10,7 +10,7 @@ component: pkg/config/configgrpc
 note: Add a `DefaultBalancerName` constant for the name of the default load balancer
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [15139]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/configgrpc-balancername.yaml
+++ b/.chloggen/configgrpc-balancername.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: config/configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a `DefaultBalancerName` constant for the name of the default load balancer
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This replaces the `BalancerName` function.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/configgrpc-balancername.yaml
+++ b/.chloggen/configgrpc-balancername.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: config/configgrpc
+component: pkg/config/configgrpc
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add a `DefaultBalancerName` constant for the name of the default load balancer

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -44,6 +44,9 @@ import (
 
 var errMetadataNotFound = errors.New("no request metadata found")
 
+// DefaultBalancerName is the name of the default load balancer.
+const DefaultBalancerName = "round_robin"
+
 // KeepaliveClientConfig exposes the keepalive.ClientParameters to be used by the exporter.
 // Refer to the original data-structure for the meaning of each parameter:
 // https://godoc.org/google.golang.org/grpc/keepalive#ClientParameters
@@ -64,8 +67,10 @@ func NewDefaultKeepaliveClientConfig() KeepaliveClientConfig {
 }
 
 // BalancerName returns a string with default load balancer value
+//
+// Deprecated[v0.151.0]: Use the DefaultBalancerName constant instead.
 func BalancerName() string {
-	return "round_robin"
+	return DefaultBalancerName
 }
 
 // ClientConfig defines common settings for a gRPC client configuration.
@@ -120,7 +125,7 @@ func NewDefaultClientConfig() ClientConfig {
 	return ClientConfig{
 		TLS:          configtls.NewDefaultClientConfig(),
 		Keepalive:    configoptional.Some(NewDefaultKeepaliveClientConfig()),
-		BalancerName: BalancerName(),
+		BalancerName: DefaultBalancerName,
 	}
 }
 

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -65,7 +65,7 @@ func TestNewDefaultClientConfig(t *testing.T) {
 	expected := ClientConfig{
 		TLS:          configtls.NewDefaultClientConfig(),
 		Keepalive:    configoptional.Some(keepalive),
-		BalancerName: BalancerName(),
+		BalancerName: DefaultBalancerName,
 	}
 
 	result := NewDefaultClientConfig()

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -36,7 +36,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, configoptional.Some(exporterhelper.NewDefaultQueueConfig()), ocfg.QueueConfig)
 	assert.Equal(t, exporterhelper.NewDefaultTimeoutConfig(), ocfg.TimeoutConfig)
 	assert.Equal(t, configcompression.TypeGzip, ocfg.ClientConfig.Compression)
-	assert.Equal(t, configgrpc.BalancerName(), ocfg.ClientConfig.BalancerName)
+	assert.Equal(t, configgrpc.DefaultBalancerName, ocfg.ClientConfig.BalancerName)
 }
 
 func TestCreateMetrics(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The name of the function (and fact it is a function) are slightly off to me, so this is a minor improvement to make before stabilizing the module.

<!-- Issue number if applicable -->
#### Link to tracking issue

Works toward https://github.com/open-telemetry/opentelemetry-collector/issues/9477

