### PR TITLE
[service/telemetry] Warn on deprecated v0.2.0 telemetry config format during migration 

### DIFF
--- a/service/telemetry/otelconftelemetry/internal/migration/v0.2.0_test.go
+++ b/service/telemetry/otelconftelemetry/internal/migration/v0.2.0_test.go
@@ -9,12 +9,18 @@ import (
 
 	"github.com/stretchr/testify/require"
 	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 
 func TestUnmarshalLogsConfigV020(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	undo := zap.ReplaceGlobals(zap.New(core))
+	defer undo()
+
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "v0.2.0_logs.yaml"))
 	require.NoError(t, err)
 
@@ -29,9 +35,16 @@ func TestUnmarshalLogsConfigV020(t *testing.T) {
 	require.Equal(t, "http://127.0.0.1:4317", *cfg.Processors[2].Simple.Exporter.OTLP.Endpoint)
 	// ensure defaults set in the original config object are not lost
 	require.Equal(t, "console", cfg.Encoding)
+	// ensure a deprecation warning was emitted
+	require.Equal(t, 1, logs.Len())
+	require.Contains(t, logs.All()[0].Message, "v0.2.0")
 }
 
 func TestUnmarshalTracesConfigV020(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	undo := zap.ReplaceGlobals(zap.New(core))
+	defer undo()
+
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "v0.2.0_traces.yaml"))
 	require.NoError(t, err)
 
@@ -46,9 +59,16 @@ func TestUnmarshalTracesConfigV020(t *testing.T) {
 	require.Equal(t, "http://127.0.0.1:4317", *cfg.Processors[2].Simple.Exporter.OTLP.Endpoint)
 	// ensure defaults set in the original config object are not lost
 	require.Equal(t, configtelemetry.LevelNone, cfg.Level)
+	// ensure a deprecation warning was emitted
+	require.Equal(t, 1, logs.Len())
+	require.Contains(t, logs.All()[0].Message, "v0.2.0")
 }
 
 func TestUnmarshalMetricsConfigV020(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	undo := zap.ReplaceGlobals(zap.New(core))
+	defer undo()
+
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "v0.2.0_metrics.yaml"))
 	require.NoError(t, err)
 
@@ -62,6 +82,9 @@ func TestUnmarshalMetricsConfigV020(t *testing.T) {
 	require.ElementsMatch(t, []config.NameStringValuePair{{Name: "key1", Value: ptr("value1")}, {Name: "key2", Value: ptr("value2")}}, cfg.Readers[0].Periodic.Exporter.OTLP.Headers)
 	// ensure defaults set in the original config object are not lost
 	require.Equal(t, configtelemetry.LevelBasic, cfg.Level)
+	// ensure a deprecation warning was emitted
+	require.Equal(t, 1, logs.Len())
+	require.Contains(t, logs.All()[0].Message, "v0.2.0")
 }
 
 func ptr[T any](v T) *T {

--- a/service/telemetry/otelconftelemetry/internal/migration/v0.3.0.go
+++ b/service/telemetry/otelconftelemetry/internal/migration/v0.3.0.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
@@ -40,7 +41,7 @@ func (c *TracesConfigV030) Unmarshal(conf *confmap.Conf) error {
 			// compatibility attempts
 			return err
 		}
-		// TODO: add a warning log to tell users to migrate their config
+		zap.L().Warn("Deprecated telemetry traces configuration format (v0.2.0) detected; auto-migrating to v0.3.0. Please update your configuration.")
 		return tracesConfigV02ToV03(v2TracesConfig, c)
 	}
 	// ensure endpoint normalization occurs
@@ -95,7 +96,7 @@ func (c *MetricsConfigV030) Unmarshal(conf *confmap.Conf) error {
 			// compatibility attempts
 			return err
 		}
-		// TODO: add a warning log to tell users to migrate their config
+		zap.L().Warn("Deprecated telemetry metrics configuration format (v0.2.0) detected; auto-migrating to v0.3.0. Please update your configuration.")
 		return metricsConfigV02ToV03(v02, c)
 	}
 	// ensure endpoint normalization occurs
@@ -229,7 +230,7 @@ func (c *LogsConfigV030) Unmarshal(conf *confmap.Conf) error {
 			// compatibility attempts
 			return err
 		}
-		// TODO: add a warning log to tell users to migrate their config
+		zap.L().Warn("Deprecated telemetry logs configuration format (v0.2.0) detected; auto-migrating to v0.3.0. Please update your configuration.")
 		return logsConfigV02ToV03(v02, c)
 	}
 	// ensure endpoint normalization occurs


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
- Fixes three TODOs in `v0.3.0.go` that flagged missing deprecation warnings.                                                    
- The collector was silently auto-migrating deprecated v0.2.0 telemetry configs (traces, metrics, logs) without notifying operators.                                                                                                     
- Added `zap.L().Warn()` at each of the three migration paths so operators know their config is outdated and needs updating.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Updated `TestUnmarshalTracesConfigV020`, `TestUnmarshalMetricsConfigV020`, and `TestUnmarshalLogsConfigV020` to assert exactly one deprecation warning containing `v0.2.0` is emitted when migration is triggered.
- All 9 tests in the migration package pass