### PR TITLE
confmap/envprovider: fix empty default resolving to nil instead of empty string

### DIFF
--- a/.chloggen/fix-empty-env-default-nil.yaml
+++ b/.chloggen/fix-empty-env-default-nil.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: confmap/provider/envprovider
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix empty default in env var expansion resolving to nil instead of empty string
+
+# One or more tracking issues or pull requests related to the change
+issues: [14587]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When using ${env:VAR:-} with an unset variable, the empty default value was
+  passed through YAML unmarshaling which turned it into nil. This caused
+  downstream components to treat the field as missing rather than explicitly
+  empty. The empty default is now returned directly as an empty string.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/confmap/provider/envprovider/provider.go
+++ b/confmap/provider/envprovider/provider.go
@@ -57,6 +57,12 @@ func (emp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFu
 	if !exists {
 		if defaultValuePtr != nil {
 			val = *defaultValuePtr
+			// When the default value is empty (e.g. ${env:VAR:-}), return it
+			// directly as an empty string instead of passing it through YAML
+			// parsing, which would turn "" into nil.
+			if val == "" {
+				return confmap.NewRetrieved(val)
+			}
 		} else {
 			emp.logger.Warn("Configuration references unset environment variable", zap.String("name", envVarName))
 		}

--- a/confmap/provider/envprovider/provider_test.go
+++ b/confmap/provider/envprovider/provider_test.go
@@ -190,6 +190,25 @@ func TestEnvWithDefaultValue(t *testing.T) {
 	assert.NoError(t, env.Shutdown(context.Background()))
 }
 
+func TestEmptyDefaultValueResolvesToEmptyString(t *testing.T) {
+	// Regression test for https://github.com/open-telemetry/opentelemetry-collector/issues/14587
+	// ${env:VAR:-} with an unset VAR should resolve to "" (empty string), not nil.
+	env := createProvider()
+	ret, err := env.Retrieve(context.Background(), "env:UNSET_VAR_FOR_TEST:-", nil)
+	require.NoError(t, err)
+
+	raw, err := ret.AsRaw()
+	require.NoError(t, err)
+	assert.Equal(t, "", raw, "empty default should resolve to empty string, not nil")
+	assert.IsType(t, "", raw, "empty default should be a string type, not nil")
+
+	str, err := ret.AsString()
+	require.NoError(t, err)
+	assert.Equal(t, "", str)
+
+	assert.NoError(t, env.Shutdown(context.Background()))
+}
+
 func createProvider() confmap.Provider {
 	return NewFactory().Create(confmaptest.NewNopProviderSettings())
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #14587.

When using `${env:VAR:-}` with an unset `VAR`, the empty default value gets passed to `NewRetrievedFromYAML([]byte(""))`. The YAML unmarshaler turns an empty byte slice into Go `nil`, so the resolved config value ends up as `nil` rather than `""`.

This matters because downstream components distinguish between "field not set" (`nil`) and "field explicitly set to empty" (`""`). The resource processor in contrib, for example, checks `if a.Value != nil` and rejects the config when it sees `nil`, even though the user explicitly provided a default via `:-`.

## The fix

When the env var is unset and the default value from `:-` is empty, return it directly through `confmap.NewRetrieved(val)` instead of routing it through YAML parsing. This keeps the empty string as a real `""`.

The change is scoped to the one case that is broken: unset variable + explicit empty default. All other paths (set variables, non-empty defaults, no default at all) still go through `NewRetrievedFromYAML` as before.

## How to reproduce the original bug

```yaml
processors:
  resource/foo:
    attributes:
      - key: foo
        value: "${env:UNSET_VAR:-}"
        action: upsert
```

Without the fix, this fails at startup:
```
error creating AttrProc. Either field "value", "from_attribute", "from_context", or "default_value" must be specified
```

## Code path

1. `envprovider/provider.go` `Retrieve()` — `parseEnvVarURI("UNSET_VAR:-")` returns `("UNSET_VAR", ptr to "")`
2. `VAR` is unset, so `val = *defaultValuePtr` → `val = ""`
3. `confmap.NewRetrievedFromYAML([]byte(""))` → `yaml.Unmarshal` produces `nil`
4. `nil` propagates into the config tree → validation fails

After the fix, step 3 is skipped for this case and `confmap.NewRetrieved("")` returns a proper empty string.

## Testing

Added `TestEmptyDefaultValueResolvesToEmptyString` which checks that `AsRaw()` returns `""` (not `nil`) for `${env:UNSET_VAR:-}`. The existing `TestEnvWithDefaultValue/unset2` already checked `AsString()` which happened to work due to the string representation fallback, but `AsRaw()` was the broken path.

## Changelog

Added `.chloggen/fix-empty-env-default-nil.yaml`.

---

> This change was developed with assistance from AI tooling (Claude Opus 4.6), disclosed per project policy.