### PR TITLE
[cmd/mdatagen] Fix ExtractDefs to handle allOf internal references

### DIFF
--- a/.chloggen/fix_allof_mdatagen.yaml
+++ b/.chloggen/fix_allof_mdatagen.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a bug in mdatagen where the `allOf` field was not being properly handled, resulting in incorrect generation of data models.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15153]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -276,6 +276,7 @@ func collectDefs(md *ConfigMetadata, defs map[string]*ConfigMetadata) {
 		if !refDesc.isInternal() {
 			return
 		}
+		defs[md.ResolvedFrom] = md
 	}
 
 	for _, name := range slices.Sorted(maps.Keys(md.Defs)) {

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -898,6 +898,103 @@ func TestExtractDefs_EmptyInput(t *testing.T) {
 	require.Empty(t, result)
 }
 
+func TestExtractDefs_AllOfInternalRef(t *testing.T) {
+	// Mirrors the schema:
+	//   type: object
+	//   $defs:
+	//     embedded_type:
+	//       type: object
+	//       properties:
+	//         field: {type: string}
+	//   allOf:
+	//     - $ref: embedded_type
+	//
+	// After resolver runs, the allOf entry carries ResolvedFrom: "embedded_type".
+	// ExtractDefs must emit "embedded_type" so that EmbeddedType struct is generated.
+	embeddedType := &ConfigMetadata{
+		Type: "object",
+		Properties: map[string]*ConfigMetadata{
+			"field": {Type: "string"},
+		},
+		ResolvedFrom: "embedded_type",
+	}
+	md := &ConfigMetadata{
+		Type:  "object",
+		AllOf: []*ConfigMetadata{embeddedType},
+	}
+
+	result := ExtractDefs(md)
+	require.Len(t, result, 1)
+	require.Contains(t, result, "embedded_type")
+	require.Same(t, embeddedType, result["embedded_type"])
+}
+
+func TestExtractDefs_AllOfMultipleInternalRefs(t *testing.T) {
+	// Two allOf entries, each resolving from a distinct internal definition.
+	typeA := &ConfigMetadata{
+		Type:         "object",
+		ResolvedFrom: "type_a",
+		Properties:   map[string]*ConfigMetadata{"x": {Type: "string"}},
+	}
+	typeB := &ConfigMetadata{
+		Type:         "object",
+		ResolvedFrom: "type_b",
+		Properties:   map[string]*ConfigMetadata{"y": {Type: "integer"}},
+	}
+	md := &ConfigMetadata{
+		Type:  "object",
+		AllOf: []*ConfigMetadata{typeA, typeB},
+	}
+
+	result := ExtractDefs(md)
+	require.Len(t, result, 2)
+	require.Same(t, typeA, result["type_a"])
+	require.Same(t, typeB, result["type_b"])
+}
+
+func TestExtractDefs_AllOfExternalRefSkipped(t *testing.T) {
+	// An allOf entry that resolved from an external reference must NOT be emitted
+	// (there is nothing to generate for it locally).
+	md := &ConfigMetadata{
+		Type: "object",
+		AllOf: []*ConfigMetadata{
+			{
+				Type:         "object",
+				ResolvedFrom: "go.opentelemetry.io/collector/scraper/scraperhelper.ControllerConfig",
+				Properties:   map[string]*ConfigMetadata{"timeout": {Type: "string"}},
+			},
+		},
+	}
+
+	result := ExtractDefs(md)
+	require.Empty(t, result)
+}
+
+func TestExtractDefs_AllOfInternalRefWithNestedProperties(t *testing.T) {
+	// An allOf-referenced type that itself contains an inline nested object must
+	// also emit the nested type definition.
+	embedded := &ConfigMetadata{
+		Type:         "object",
+		ResolvedFrom: "embedded_type",
+		Properties: map[string]*ConfigMetadata{
+			"nested": {
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"value": {Type: "string"},
+				},
+			},
+		},
+	}
+	md := &ConfigMetadata{
+		Type:  "object",
+		AllOf: []*ConfigMetadata{embedded},
+	}
+
+	result := ExtractDefs(md)
+	require.Contains(t, result, "embedded_type")
+	require.Contains(t, result, "nested")
+}
+
 func TestNewCfgFns_ExtractImports(t *testing.T) {
 	fns := NewCfgFns("go.opentelemetry.io/collector", "go.opentelemetry.io/collector/comp")
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix a regression in mdatagen where `allOf` entries referencing internal `$defs` definitions did not produce a struct declaration in the generated config code.

When a schema uses `allOf` with a `$ref` pointing to a type defined in the same schema's `$defs` section, the referenced type is resolved and stored with ResolvedFrom set to the definition name. `collectDefs` correctly identified such entries as internal but was missing the `defs[md.ResolvedFrom] = md` assignment, so the type was never registered and no Go struct was emitted for it.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15153

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added corresponding unit tests to avoid same regression in the future.