### PR TITLE
[cmd/mdatagen]Allow custom mapstructure tags for generated config struct fields

### DIFF
--- a/.chloggen/mdatagen_custom_config_tags.yaml
+++ b/.chloggen/mdatagen_custom_config_tags.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow custom mapstructure tags for generated config struct fields
+
+# One or more tracking issues or pull requests related to the change
+issues: [15155]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/cfggen/model.go
+++ b/cmd/mdatagen/internal/cfggen/model.go
@@ -58,6 +58,7 @@ type ConfigMetadata struct {
 }
 
 type GoStructConfig struct {
+	Mapstructure    string                 `mapstructure:"mapstructure" json:"-"`
 	CustomValidator *CustomValidatorConfig `mapstructure:"custom_validator" json:"-"`
 }
 
@@ -66,7 +67,11 @@ type CustomValidatorConfig struct {
 }
 
 func (g *GoStructConfig) Unmarshal(parser *confmap.Conf) error {
+	if err := parser.Unmarshal(g); err != nil {
+		return err
+	}
 	if !parser.IsSet("custom_validator") {
+		g.CustomValidator = nil
 		return nil
 	}
 	sub, err := parser.Sub("custom_validator")

--- a/cmd/mdatagen/internal/cfggen/model_test.go
+++ b/cmd/mdatagen/internal/cfggen/model_test.go
@@ -328,6 +328,8 @@ func TestGoStructConfig_Unmarshal(t *testing.T) {
 		name                  string
 		input                 map[string]any
 		expectCustomValidator bool
+		expectMapstructure    string
+		expectErr             bool
 	}{
 		{
 			name:                  "custom_validator present with empty map",
@@ -345,9 +347,25 @@ func TestGoStructConfig_Unmarshal(t *testing.T) {
 			expectCustomValidator: false,
 		},
 		{
-			name:                  "unrelated keys only",
-			input:                 map[string]any{"something_else": true},
-			expectCustomValidator: false,
+			name:      "unknown key returns error",
+			input:     map[string]any{"something_else": true},
+			expectErr: true,
+		},
+		{
+			name:               "mapstructure tag set",
+			input:              map[string]any{"mapstructure": "protocols"},
+			expectMapstructure: "protocols",
+		},
+		{
+			name:                  "mapstructure tag and custom_validator both set",
+			input:                 map[string]any{"mapstructure": "protocols", "custom_validator": map[string]any{"name": "validateProtocols"}},
+			expectMapstructure:    "protocols",
+			expectCustomValidator: true,
+		},
+		{
+			name:               "mapstructure tag empty string when absent",
+			input:              map[string]any{},
+			expectMapstructure: "",
 		},
 	}
 
@@ -356,12 +374,17 @@ func TestGoStructConfig_Unmarshal(t *testing.T) {
 			parser := confmap.NewFromStringMap(tt.input)
 			var g GoStructConfig
 			err := g.Unmarshal(parser)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			if tt.expectCustomValidator {
 				assert.NotNil(t, g.CustomValidator, "CustomValidator should be non-nil when key is present")
 			} else {
 				assert.Nil(t, g.CustomValidator, "CustomValidator should be nil when key is absent")
 			}
+			assert.Equal(t, tt.expectMapstructure, g.Mapstructure)
 		})
 	}
 }

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -669,6 +669,105 @@ func TestGenerateConfigGoStruct_InternalResolvedRefGeneratesLocalType(t *testing
 	require.Contains(t, generated, "cfg.Config = NewDefaultPlainConfig()")
 }
 
+func TestGenerateConfigGoStruct_AllOfCustomMapstructureTag(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "shortname")
+	require.NoError(t, os.MkdirAll(outputDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmodule\n"), 0o600))
+
+	md := Metadata{
+		Type:        "test",
+		PackageName: "testmodule/shortname",
+		Status:      &Status{Class: "receiver"},
+		Config: &cfggen.ConfigMetadata{
+			Type: "object",
+			AllOf: []*cfggen.ConfigMetadata{
+				{
+					Type:         "object",
+					ResolvedFrom: "go.opentelemetry.io/collector/scraper/scraperhelper.ControllerConfig",
+					GoStruct:     cfggen.GoStructConfig{Mapstructure: "protocols"},
+				},
+			},
+		},
+	}
+
+	err := generateConfigGoStruct(md, outputDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "generated_config.go")) // #nosec G304
+	require.NoError(t, err)
+
+	generated := string(content)
+	// Custom tag "protocols" must be used instead of the default ",squash"
+	require.Contains(t, generated, "`mapstructure:\"protocols\"`")
+	require.NotContains(t, generated, `mapstructure:",squash"`)
+}
+
+func TestGenerateConfigGoStruct_AllOfDefaultSquashTag(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "shortname")
+	require.NoError(t, os.MkdirAll(outputDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmodule\n"), 0o600))
+
+	md := Metadata{
+		Type:        "test",
+		PackageName: "testmodule/shortname",
+		Status:      &Status{Class: "receiver"},
+		Config: &cfggen.ConfigMetadata{
+			Type: "object",
+			AllOf: []*cfggen.ConfigMetadata{
+				{
+					Type:         "object",
+					ResolvedFrom: "go.opentelemetry.io/collector/scraper/scraperhelper.ControllerConfig",
+					// No custom GoStruct.Mapstructure — should default to ",squash"
+				},
+			},
+		},
+	}
+
+	err := generateConfigGoStruct(md, outputDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "generated_config.go")) // #nosec G304
+	require.NoError(t, err)
+
+	require.Contains(t, string(content), "`mapstructure:\",squash\"`")
+}
+
+func TestGenerateConfigGoStruct_PropertyCustomMapstructureTag(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "shortname")
+	require.NoError(t, os.MkdirAll(outputDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmodule\n"), 0o600))
+
+	md := Metadata{
+		Type:        "test",
+		PackageName: "testmodule/shortname",
+		Status:      &Status{Class: "receiver"},
+		Config: &cfggen.ConfigMetadata{
+			Type: "object",
+			Properties: map[string]*cfggen.ConfigMetadata{
+				"timeout": {
+					Type:     "string",
+					GoType:   "time.Duration",
+					GoStruct: cfggen.GoStructConfig{Mapstructure: "interval"},
+				},
+			},
+		},
+	}
+
+	err := generateConfigGoStruct(md, outputDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "generated_config.go")) // #nosec G304
+	require.NoError(t, err)
+
+	generated := string(content)
+	// Custom tag "interval" must be used instead of the property name "timeout"
+	require.Contains(t, generated, "`mapstructure:\"interval\"`")
+	require.NotContains(t, generated, "`mapstructure:\"timeout\"`")
+}
+
 func TestGenerateConfigFiles_GoStructError(t *testing.T) {
 	// generateConfigGoStruct fails because tmpdir has no go.mod in any ancestor
 	md := Metadata{

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -21,14 +21,14 @@ import (
         {{- if .Description }}
     // {{ .Description }}
         {{- end }}
-    	{{ .ResolvedFrom | publicType }} `mapstructure:",squash"`
+    	{{ .ResolvedFrom | publicType }} `mapstructure:"{{ or .GoStruct.Mapstructure ",squash" }}"`
     {{- end }}
     {{- end }}
     {{- range $propName, $prop := .Properties }}
         {{- if $prop.Description }}
     // {{ $prop.Description }}
         {{- end }}
-    	{{ $propName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}"`
+    	{{ $propName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ or .GoStruct.Mapstructure $propName }}"`
     {{- end }}
 {{ end }}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Adds a mapstructure field to the go_struct schema annotation, allowing schema authors to override the generated mapstructure struct tag for both allOf entries and named properties.
- Without a custom tag, allOf entries still default to `mapstructure:",squash"` and properties use the property name — no change to existing behavior.
- Enables use cases like the OTLP receiver pattern where an embedded struct should be exposed as a named field (e.g. `mapstructure:"protocols"`) rather than squashed.

Example:
```yaml
  config:
    type: object
    allOf:
      - $ref: protocols
        go_struct:
          mapstructure: "protocols"
```

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15155

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Covered change with corresponding unit tests