### PR TITLE
[chore] Update config schema references to use relative paths

### DIFF
--- a/config/configgrpc/config.schema.yaml
+++ b/config/configgrpc/config.schema.yaml
@@ -6,7 +6,7 @@ $defs:
       auth:
         description: Auth configuration for outgoing RPCs.
         x-optional: true
-        $ref: go.opentelemetry.io/collector/config/configauth.config
+        $ref: /config/configauth.config
       authority:
         description: WithAuthority parameter configures client to rewrite ":authority" header (godoc.org/google.golang.org/grpc#WithAuthority)
         type: string
@@ -15,13 +15,13 @@ $defs:
         type: string
       compression:
         description: The compression key for supported compression types within collector.
-        $ref: go.opentelemetry.io/collector/config/configcompression.type
+        $ref: /config/configcompression.type
       endpoint:
         description: The target to which the exporter is going to send traces or metrics, using the gRPC protocol. The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md.
         type: string
       headers:
         description: The headers associated with gRPC requests.
-        $ref: go.opentelemetry.io/collector/config/configopaque.map_list
+        $ref: /config/configopaque.map_list
       keepalive:
         description: The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams. (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
         x-optional: true
@@ -30,13 +30,13 @@ $defs:
         description: Middlewares for the gRPC client.
         type: array
         items:
-          $ref: go.opentelemetry.io/collector/config/configmiddleware.config
+          $ref: /config/configmiddleware.config
       read_buffer_size:
         description: ReadBufferSize for gRPC client. See grpc.WithReadBufferSize. (https://godoc.org/google.golang.org/grpc#WithReadBufferSize).
         type: integer
       tls:
         description: TLS struct exposes TLS client configuration.
-        $ref: go.opentelemetry.io/collector/config/configtls.client_config
+        $ref: /config/configtls.client_config
       wait_for_ready:
         description: WaitForReady parameter configures client to wait for ready state before sending data. (https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md)
         type: boolean
@@ -108,7 +108,7 @@ $defs:
       auth:
         description: Auth for this receiver
         x-optional: true
-        $ref: go.opentelemetry.io/collector/config/configauth.config
+        $ref: /config/configauth.config
       include_metadata:
         description: Include propagates the incoming connection's metadata to downstream consumers.
         type: boolean
@@ -127,16 +127,16 @@ $defs:
         description: Middlewares for the gRPC server.
         type: array
         items:
-          $ref: go.opentelemetry.io/collector/config/configmiddleware.config
+          $ref: /config/configmiddleware.config
       read_buffer_size:
         description: ReadBufferSize for gRPC server. See grpc.ReadBufferSize. (https://godoc.org/google.golang.org/grpc#ReadBufferSize).
         type: integer
       tls:
         description: Configures the protocol to use TLS. The default value is nil, which will cause the protocol to not use TLS.
         x-optional: true
-        $ref: go.opentelemetry.io/collector/config/configtls.server_config
+        $ref: /config/configtls.server_config
       write_buffer_size:
         description: WriteBufferSize for gRPC server. See grpc.WriteBufferSize. (https://godoc.org/google.golang.org/grpc#WriteBufferSize).
         type: integer
     allOf:
-      - $ref: go.opentelemetry.io/collector/config/confignet.addr_config
+      - $ref: /config/confignet.addr_config

--- a/pdata/plog/config.schema.yaml
+++ b/pdata/plog/config.schema.yaml
@@ -5,7 +5,7 @@ $defs:
     x-customType: uint32
   logs:
     description: 'Logs is the top-level struct that is propagated through the logs pipeline. Use NewLogs to create new instance, zero-initialized instance is not valid for use. This is a reference type, if passed by value and callee modifies it the caller will see the modification. Must use NewLogs function to create new instances. Important: zero-initialized instance is not valid for use.'
-    $ref: go.opentelemetry.io/collector/pdata/internal.logs_wrapper
+    $ref: /pdata/internal.logs_wrapper
   severity_number:
     description: SeverityNumber represents severity number of a log record.
     type: integer


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Updates $ref paths in config schema YAML files (configgrpc, plog) from fully-qualified Go module paths (e.g., go.opentelemetry.io/collector/config/configauth.config) to repository-relative paths (e.g., /config/configauth.config)

<!-- Issue number if applicable -->
#### Link to tracking issue
#15158
