### PR TITLE
docs: clarify processor ordering for batch vs transform/filter

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -30,8 +30,17 @@ processor documentation for more information.
 1. [memory_limiter](memorylimiterprocessor/README.md)
 2. Any sampling or initial filtering processors
 3. Any processor relying on sending source from `Context` (e.g. `k8sattributes`)
-3. [batch](batchprocessor/README.md), although prefer using the exporter's batching capabilities
-4. Any other processors
+4. Any processors that transform, enrich, or filter data (e.g. `transform`, `attributes`, `filter`)
+5. [batch](batchprocessor/README.md), although prefer using the exporter's batching capabilities
+
+Placing filtering and transformation processors **before** `batch` is
+preferred because it avoids batching data that may be discarded or modified.
+The `batch` processor works most efficiently as the last processor before
+the exporter, operating on data that is already in its final form.
+
+The `batch` processor should still come **after** `memory_limiter` and
+context-dependent processors (like `k8sattributes`), which need to run
+early in the pipeline to function correctly.
 
 ## Data Ownership
 
@@ -106,6 +115,18 @@ data cloning described in Exclusive Ownership section.
 
 The order processors are specified in a pipeline is important as this is the
 order in which each processor is applied.
+
+As a general rule:
+- **Protection first**: `memory_limiter` should always be first to prevent
+  out-of-memory situations.
+- **Context-dependent processors early**: Processors that rely on connection
+  or context metadata (e.g. `k8sattributes`) must run before any processor
+  that might decouple data from the original request context.
+- **Filter and transform before batching**: Running filtering and
+  transformation before `batch` avoids unnecessary work on data that will be
+  dropped and keeps batches consistent.
+- **Batch last** (when used): The `batch` processor is most effective as the
+  last step before export, grouping finalized data for efficient transmission.
 
 ## Creating Custom Processors
 


### PR DESCRIPTION
#### Description

The recommended processor ordering in the README was a bit unclear about where `batch` should go relative to transform/filter processors like `attributes` or `filter`. A few people got tripped up by this (see #15075).

Updated the ordering list to explicitly put filtering and transformation processors before `batch`. Also added a short section in the pipeline ordering docs explaining the reasoning, basically: filter/transform first so you don't batch stuff that gets dropped anyway, and batch last right before export.

Nothing controversial here, just making the docs match what most people already do in practice.

#### Link to tracking issue
Fixes #15075

#### Testing
Docs only change, no code affected.

#### Documentation
All changes are in `processor/README.md`. Updated the recommended ordering list and added a general rule summary further down in the ordering section.