### PR TITLE
[cmd/mdatagen] Rename DefaultMetricsBuilderConfig to NewDefaultMetricsBuilderConfig

### DIFF
--- a/.chloggen/metrics_builder_constructor.yaml
+++ b/.chloggen/metrics_builder_constructor.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "The `DefaultMetricsBuilderConfig` function is deprecated. Use `NewDefaultMetricsBuilderConfig` instead."
+
+# One or more tracking issues or pull requests related to the change
+issues: [15165]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The generated `DefaultMetricsBuilderConfig` function has been renamed to `NewDefaultMetricsBuilderConfig`
+  to follow Go naming conventions. The old function is kept as a deprecated wrapper and will be removed
+  in a future release.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
@@ -397,9 +397,14 @@ type MetricsBuilderConfig struct {
 	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
 		Metrics:            DefaultMetricsConfig(),
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
+}
+
+// Deprecated: Use NewDefaultMetricsBuilderConfig.
+func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+	return NewDefaultMetricsBuilderConfig()
 }

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config_test.go
@@ -21,7 +21,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	}{
 		{
 			name: "default",
-			want: DefaultMetricsBuilderConfig(),
+			want: NewDefaultMetricsBuilderConfig(),
 		},
 		{
 			name: "all_set",
@@ -128,7 +128,7 @@ func loadMetricsBuilderConfig(t *testing.T, name string) MetricsBuilderConfig {
 	require.NoError(t, err)
 	sub, err := cm.Sub(name)
 	require.NoError(t, err)
-	cfg := DefaultMetricsBuilderConfig()
+	cfg := NewDefaultMetricsBuilderConfig()
 	require.NoError(t, sub.Unmarshal(&cfg, confmap.WithIgnoreUnused()))
 	return cfg
 }

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_entity_metrics_test.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_entity_metrics_test.go
@@ -17,7 +17,7 @@ func TestEntityBuilders(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
 	settings := connectortest.NewNopSettings(connectortest.NopType)
-	mb := NewMetricsBuilder(DefaultMetricsBuilderConfig(), settings, WithStartTime(start))
+	mb := NewMetricsBuilder(NewDefaultMetricsBuilderConfig(), settings, WithStartTime(start))
 
 	t.Run("test.entity", func(t *testing.T) {
 		e := NewTestEntityEntity("string.resource.attr-val")
@@ -52,7 +52,7 @@ func TestEntityBuilders(t *testing.T) {
 	t.Run("test.entity/disabled_identity_attr", func(t *testing.T) {
 		// When an identity attribute is disabled, the entity is not produced but
 		// other enabled attributes are still added to the resource directly.
-		cfg := DefaultMetricsBuilderConfig()
+		cfg := NewDefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.StringResourceAttr.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
@@ -81,7 +81,7 @@ func TestEntityBuilders(t *testing.T) {
 	t.Run("test.entity/disabled_descriptive_attr", func(t *testing.T) {
 		// When a descriptive attribute is disabled, the entity is still produced
 		// with its identity but the disabled attribute is not added.
-		cfg := DefaultMetricsBuilderConfig()
+		cfg := NewDefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.MapResourceAttr.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 

--- a/cmd/mdatagen/internal/sampleconnector/metrics_test.go
+++ b/cmd/mdatagen/internal/sampleconnector/metrics_test.go
@@ -17,7 +17,7 @@ import (
 
 // TestGeneratedMetrics verifies that the internal/metadata API is generated correctly.
 func TestGeneratedMetrics(t *testing.T) {
-	mb := metadata.NewMetricsBuilder(metadata.DefaultMetricsBuilderConfig(), connectortest.NewNopSettings(metadata.Type))
+	mb := metadata.NewMetricsBuilder(metadata.NewDefaultMetricsBuilderConfig(), connectortest.NewNopSettings(metadata.Type))
 	m := mb.Emit()
 	require.Equal(t, 0, m.ResourceMetrics().Len())
 }

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config.go
@@ -109,9 +109,14 @@ type MetricsBuilderConfig struct {
 	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
 		Metrics:            DefaultMetricsConfig(),
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
+}
+
+// Deprecated: Use NewDefaultMetricsBuilderConfig.
+func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+	return NewDefaultMetricsBuilderConfig()
 }

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config_test.go
@@ -21,7 +21,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	}{
 		{
 			name: "default",
-			want: DefaultMetricsBuilderConfig(),
+			want: NewDefaultMetricsBuilderConfig(),
 		},
 		{
 			name: "all_set",
@@ -84,7 +84,7 @@ func loadMetricsBuilderConfig(t *testing.T, name string) MetricsBuilderConfig {
 	require.NoError(t, err)
 	sub, err := cm.Sub(name)
 	require.NoError(t, err)
-	cfg := DefaultMetricsBuilderConfig()
+	cfg := NewDefaultMetricsBuilderConfig()
 	require.NoError(t, sub.Unmarshal(&cfg, confmap.WithIgnoreUnused()))
 	return cfg
 }

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_entity_metrics_test.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_entity_metrics_test.go
@@ -17,7 +17,7 @@ func TestEntityBuilders(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
 	settings := receivertest.NewNopSettings(receivertest.NopType)
-	mb := NewMetricsBuilder(DefaultMetricsBuilderConfig(), settings, WithStartTime(start))
+	mb := NewMetricsBuilder(NewDefaultMetricsBuilderConfig(), settings, WithStartTime(start))
 
 	t.Run("k8s.replicaset", func(t *testing.T) {
 		e := NewK8sReplicasetEntity("k8s.replicaset.uid-val")
@@ -47,7 +47,7 @@ func TestEntityBuilders(t *testing.T) {
 	t.Run("k8s.replicaset/disabled_identity_attr", func(t *testing.T) {
 		// When an identity attribute is disabled, the entity is not produced but
 		// other enabled attributes are still added to the resource directly.
-		cfg := DefaultMetricsBuilderConfig()
+		cfg := NewDefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sReplicasetUID.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
@@ -71,7 +71,7 @@ func TestEntityBuilders(t *testing.T) {
 	t.Run("k8s.replicaset/disabled_descriptive_attr", func(t *testing.T) {
 		// When a descriptive attribute is disabled, the entity is still produced
 		// with its identity but the disabled attribute is not added.
-		cfg := DefaultMetricsBuilderConfig()
+		cfg := NewDefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sReplicasetName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
@@ -133,7 +133,7 @@ func TestEntityBuilders(t *testing.T) {
 	t.Run("k8s.pod/disabled_identity_attr", func(t *testing.T) {
 		// When an identity attribute is disabled, the entity is not produced but
 		// other enabled attributes are still added to the resource directly.
-		cfg := DefaultMetricsBuilderConfig()
+		cfg := NewDefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sPodUID.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
@@ -158,7 +158,7 @@ func TestEntityBuilders(t *testing.T) {
 	t.Run("k8s.pod/disabled_descriptive_attr", func(t *testing.T) {
 		// When a descriptive attribute is disabled, the entity is still produced
 		// with its identity but the disabled attribute is not added.
-		cfg := DefaultMetricsBuilderConfig()
+		cfg := NewDefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sPodName.Enabled = false
 		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))

--- a/cmd/mdatagen/internal/samplefactoryreceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplefactoryreceiver/internal/metadata/generated_config.go
@@ -175,11 +175,17 @@ type MetricsBuilderConfig struct {
 	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+// NewDefaultMetricsBuilderConfig returns a MetricsBuilderConfig with default values.
+func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
 		Metrics:            DefaultMetricsConfig(),
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
+}
+
+// Deprecated: Use NewDefaultMetricsBuilderConfig.
+func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+	return NewDefaultMetricsBuilderConfig()
 }
 
 // LogsBuilderConfig is a configuration for sample logs builder.
@@ -188,9 +194,15 @@ type LogsBuilderConfig struct {
 	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
-func DefaultLogsBuilderConfig() LogsBuilderConfig {
+// NewDefaultLogsBuilderConfig returns a LogsBuilderConfig with default values.
+func NewDefaultLogsBuilderConfig() LogsBuilderConfig {
 	return LogsBuilderConfig{
 		Events:             DefaultEventsConfig(),
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
+}
+
+// Deprecated: Use NewDefaultLogsBuilderConfig.
+func DefaultLogsBuilderConfig() LogsBuilderConfig {
+	return NewDefaultLogsBuilderConfig()
 }

--- a/cmd/mdatagen/internal/samplefactoryreceiver/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplefactoryreceiver/internal/metadata/generated_config_test.go
@@ -21,7 +21,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	}{
 		{
 			name: "default",
-			want: DefaultMetricsBuilderConfig(),
+			want: NewDefaultMetricsBuilderConfig(),
 		},
 		{
 			name: "all_set",
@@ -82,7 +82,7 @@ func loadMetricsBuilderConfig(t *testing.T, name string) MetricsBuilderConfig {
 	require.NoError(t, err)
 	sub, err := cm.Sub(name)
 	require.NoError(t, err)
-	cfg := DefaultMetricsBuilderConfig()
+	cfg := NewDefaultMetricsBuilderConfig()
 	require.NoError(t, sub.Unmarshal(&cfg, confmap.WithIgnoreUnused()))
 	return cfg
 }
@@ -92,7 +92,7 @@ func loadLogsBuilderConfig(t *testing.T, name string) LogsBuilderConfig {
 	require.NoError(t, err)
 	sub, err := cm.Sub(name)
 	require.NoError(t, err)
-	cfg := DefaultLogsBuilderConfig()
+	cfg := NewDefaultLogsBuilderConfig()
 	require.NoError(t, sub.Unmarshal(&cfg, confmap.WithIgnoreUnused()))
 	return cfg
 }

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
@@ -620,11 +620,16 @@ type MetricsBuilderConfig struct {
 	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
 		Metrics:            DefaultMetricsConfig(),
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
+}
+
+// Deprecated: Use NewDefaultMetricsBuilderConfig.
+func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+	return NewDefaultMetricsBuilderConfig()
 }
 
 // LogsBuilderConfig is a configuration for sample logs builder.

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
@@ -21,7 +21,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	}{
 		{
 			name: "default",
-			want: DefaultMetricsBuilderConfig(),
+			want: NewDefaultMetricsBuilderConfig(),
 		},
 		{
 			name: "all_set",
@@ -160,7 +160,7 @@ func loadMetricsBuilderConfig(t *testing.T, name string) MetricsBuilderConfig {
 	require.NoError(t, err)
 	sub, err := cm.Sub(name)
 	require.NoError(t, err)
-	cfg := DefaultMetricsBuilderConfig()
+	cfg := NewDefaultMetricsBuilderConfig()
 	require.NoError(t, sub.Unmarshal(&cfg, confmap.WithIgnoreUnused()))
 	return cfg
 }

--- a/cmd/mdatagen/internal/samplereceiver/metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/metrics_test.go
@@ -20,7 +20,7 @@ import (
 
 // TestGeneratedMetrics verifies that the internal/metadata API is generated correctly.
 func TestGeneratedMetrics(t *testing.T) {
-	mb := metadata.NewMetricsBuilder(metadata.DefaultMetricsBuilderConfig(), receivertest.NewNopSettings(metadata.Type))
+	mb := metadata.NewMetricsBuilder(metadata.NewDefaultMetricsBuilderConfig(), receivertest.NewNopSettings(metadata.Type))
 	m := mb.Emit()
 	require.Equal(t, 0, m.ResourceMetrics().Len())
 }

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
@@ -421,9 +421,14 @@ type MetricsBuilderConfig struct {
 	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
 		Metrics:            DefaultMetricsConfig(),
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
+}
+
+// Deprecated: Use NewDefaultMetricsBuilderConfig.
+func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+	return NewDefaultMetricsBuilderConfig()
 }

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config_test.go
@@ -21,7 +21,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	}{
 		{
 			name: "default",
-			want: DefaultMetricsBuilderConfig(),
+			want: NewDefaultMetricsBuilderConfig(),
 		},
 		{
 			name: "all_set",
@@ -134,7 +134,7 @@ func loadMetricsBuilderConfig(t *testing.T, name string) MetricsBuilderConfig {
 	require.NoError(t, err)
 	sub, err := cm.Sub(name)
 	require.NoError(t, err)
-	cfg := DefaultMetricsBuilderConfig()
+	cfg := NewDefaultMetricsBuilderConfig()
 	require.NoError(t, sub.Unmarshal(&cfg, confmap.WithIgnoreUnused()))
 	return cfg
 }

--- a/cmd/mdatagen/internal/templates/config.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config.go.tmpl
@@ -214,13 +214,18 @@ type MetricsBuilderConfig struct {
 	{{- end }}
 }
 
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig {
 		Metrics: DefaultMetricsConfig(),
 		{{- if .ResourceAttributes }}
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 		{{- end }}
 	}
+}
+
+// Deprecated: Use NewDefaultMetricsBuilderConfig.
+func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
+	return NewDefaultMetricsBuilderConfig()
 }
 {{- end }}
 

--- a/cmd/mdatagen/internal/templates/config_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_test.go.tmpl
@@ -24,7 +24,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	}{
 		{
 			name: "default",
-			want: DefaultMetricsBuilderConfig(),
+			want: NewDefaultMetricsBuilderConfig(),
 		},
 		{
 			name: "all_set",
@@ -94,7 +94,7 @@ func loadMetricsBuilderConfig(t *testing.T, name string) MetricsBuilderConfig {
 	require.NoError(t, err)
 	sub, err := cm.Sub(name)
 	require.NoError(t, err)
-	cfg := DefaultMetricsBuilderConfig()
+	cfg := NewDefaultMetricsBuilderConfig()
 	require.NoError(t, sub.Unmarshal(&cfg, confmap.WithIgnoreUnused()))
 	return cfg
 }

--- a/cmd/mdatagen/internal/templates/entity_metrics_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/entity_metrics_test.go.tmpl
@@ -18,7 +18,7 @@ func TestEntityBuilders(t *testing.T) {
 	start := pcommon.Timestamp(1_000_000_000)
 	ts := pcommon.Timestamp(1_000_001_000)
 	settings := {{ .Status.Class }}test.NewNopSettings({{ .Status.Class }}test.NopType)
-	mb := NewMetricsBuilder(DefaultMetricsBuilderConfig(), settings, WithStartTime(start))
+	mb := NewMetricsBuilder(NewDefaultMetricsBuilderConfig(), settings, WithStartTime(start))
 
 	{{- range $ent := .Entities }}
 	{{ $entityType := $ent.Type }}
@@ -137,7 +137,7 @@ func TestEntityBuilders(t *testing.T) {
 	t.Run("{{ $entityType }}/disabled_identity_attr", func(t *testing.T) {
 		// When an identity attribute is disabled, the entity is not produced but
 		// other enabled attributes are still added to the resource directly.
-		cfg := DefaultMetricsBuilderConfig()
+		cfg := NewDefaultMetricsBuilderConfig()
 		{{- range $idAttr := $ent.Identity }}
 		cfg.ResourceAttributes.{{ publicVar $idAttr.Ref.Render }}.Enabled = false
 		{{- end }}
@@ -190,7 +190,7 @@ func TestEntityBuilders(t *testing.T) {
 	t.Run("{{ $entityType }}/disabled_descriptive_attr", func(t *testing.T) {
 		// When a descriptive attribute is disabled, the entity is still produced
 		// with its identity but the disabled attribute is not added.
-		cfg := DefaultMetricsBuilderConfig()
+		cfg := NewDefaultMetricsBuilderConfig()
 		{{- range $descAttr := $ent.Description }}
 		cfg.ResourceAttributes.{{ publicVar $descAttr.Ref.Render }}.Enabled = false
 		{{- end }}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds NewDefaultMetricsBuilderConfig() as the canonical constructor function in mdatagen-generated generated_config.go files. The existing DefaultMetricsBuilderConfig() is kept as deprecated wrapper that delegate to the new New* variant, preserving full backward compatibility.                       
                                                                                                                                                                                                     
The New* prefix follows the idiomatic Go convention for constructor functions that return a populated struct. This also unblocks the cfggen layer (#14560), which needs to detect and call New*-prefixed constructors to resolve default config values.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15165

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Existing TestMetricsBuilderConfig and TestResourceAttributesConfig tests in each sample component's generated_config_test.go cover the new constructors. `make mdatagen-test` pass.