### PR TITLE
Introduce configurable per-signal collection intervals for metrics and events

### DIFF
--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/config.schema.yaml
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/config.schema.yaml
@@ -11,6 +11,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -42,6 +47,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
       metric.input_type:
         description: "MetricInputTypeMetricConfig provides config for the metric.input_type metric."
         type: object
@@ -49,6 +59,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -80,6 +95,11 @@ $defs:
           enabled:
             type: boolean
             default: false
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -107,6 +127,11 @@ $defs:
           enabled:
             type: boolean
             default: false
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -132,6 +157,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -165,12 +195,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       optional.resource.attr:
         description: ResourceAttributeConfig provides common config for a optional.resource.attr resource attribute.
         type: object
@@ -182,12 +212,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       slice.resource.attr:
         description: ResourceAttributeConfig provides common config for a slice.resource.attr resource attribute.
         type: object
@@ -199,12 +229,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.enum.resource.attr:
         description: ResourceAttributeConfig provides common config for a string.enum.resource.attr resource attribute.
         type: object
@@ -216,12 +246,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr:
         description: ResourceAttributeConfig provides common config for a string.resource.attr resource attribute.
         type: object
@@ -233,12 +263,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr_disable_warning:
         description: ResourceAttributeConfig provides common config for a string.resource.attr_disable_warning resource attribute.
         type: object
@@ -250,12 +280,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr_remove_warning:
         description: ResourceAttributeConfig provides common config for a string.resource.attr_remove_warning resource attribute.
         type: object
@@ -267,12 +297,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr_to_be_removed:
         description: ResourceAttributeConfig provides common config for a string.resource.attr_to_be_removed resource attribute.
         type: object
@@ -284,12 +314,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
   metrics_builder_config:
     description: MetricsBuilderConfig is a configuration for sample metrics builder.
     type: object

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
@@ -22,8 +23,11 @@ const (
 
 // DefaultMetricMetricConfig provides config for the default.metric metric.
 type DefaultMetricMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []DefaultMetricMetricAttributeKey `mapstructure:"attributes"`
@@ -63,8 +67,11 @@ func (ms *DefaultMetricMetricConfig) Validate() error {
 
 // DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric.
 type DefaultMetricToBeRemovedMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 }
 
 func (ms *DefaultMetricToBeRemovedMetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -94,8 +101,11 @@ const (
 
 // MetricInputTypeMetricConfig provides config for the metric.input_type metric.
 type MetricInputTypeMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                              `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []MetricInputTypeMetricAttributeKey `mapstructure:"attributes"`
@@ -144,8 +154,11 @@ const (
 
 // OptionalMetricMetricConfig provides config for the optional.metric metric.
 type OptionalMetricMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                             `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []OptionalMetricMetricAttributeKey `mapstructure:"attributes"`
@@ -193,8 +206,11 @@ const (
 
 // OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric.
 type OptionalMetricEmptyUnitMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []OptionalMetricEmptyUnitMetricAttributeKey `mapstructure:"attributes"`
@@ -242,8 +258,11 @@ const (
 
 // ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric.
 type ReaggregateMetricMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []ReaggregateMetricMetricAttributeKey `mapstructure:"attributes"`

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/config.schema.yaml
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/config.schema.yaml
@@ -11,6 +11,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
       k8s.pod.phase:
         description: "K8sPodPhaseMetricConfig provides config for the k8s.pod.phase metric."
         type: object
@@ -18,6 +23,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
       k8s.replicaset.desired:
         description: "K8sReplicasetDesiredMetricConfig provides config for the k8s.replicaset.desired metric."
         type: object
@@ -25,6 +35,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
   resource_attributes_config:
     description: ResourceAttributesConfig provides config for sampleentity resource attributes.
     type: object
@@ -40,12 +55,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       k8s.pod.name:
         description: ResourceAttributeConfig provides common config for a k8s.pod.name resource attribute.
         type: object
@@ -57,12 +72,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       k8s.pod.uid:
         description: ResourceAttributeConfig provides common config for a k8s.pod.uid resource attribute.
         type: object
@@ -74,12 +89,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       k8s.replicaset.name:
         description: ResourceAttributeConfig provides common config for a k8s.replicaset.name resource attribute.
         type: object
@@ -91,12 +106,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       k8s.replicaset.uid:
         description: ResourceAttributeConfig provides common config for a k8s.replicaset.uid resource attribute.
         type: object
@@ -108,12 +123,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
   metrics_builder_config:
     description: MetricsBuilderConfig is a configuration for sampleentity metrics builder.
     type: object

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config.go
@@ -3,14 +3,19 @@
 package metadata
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
 // MetricConfig provides common config for a particular metric.
 type MetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 }
 
 func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {

--- a/cmd/mdatagen/internal/samplereceiver/config.schema.json
+++ b/cmd/mdatagen/internal/samplereceiver/config.schema.json
@@ -51,6 +51,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true
@@ -61,6 +66,11 @@
               "description": "DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric.",
               "type": "object",
               "properties": {
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true
@@ -101,6 +111,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true
@@ -139,6 +154,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": false
@@ -173,6 +193,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": false
@@ -206,6 +231,11 @@
                       "boolean_attr"
                     ]
                   }
+                },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
                 },
                 "enabled": {
                   "type": "boolean",
@@ -243,6 +273,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true
@@ -275,6 +310,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true
@@ -306,6 +346,11 @@
                       "state"
                     ]
                   }
+                },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
                 },
                 "enabled": {
                   "type": "boolean",

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/config.schema.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/config.schema.yaml
@@ -11,6 +11,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -47,6 +52,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
       metric.input_type:
         description: "MetricInputTypeMetricConfig provides config for the metric.input_type metric."
         type: object
@@ -54,6 +64,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -85,6 +100,11 @@ $defs:
           enabled:
             type: boolean
             default: false
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -114,6 +134,11 @@ $defs:
           enabled:
             type: boolean
             default: false
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -139,6 +164,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -164,6 +194,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -191,6 +226,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -214,6 +254,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -241,6 +286,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this event; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
       default.event.to_be_removed:
         description: EventConfig provides common config for a  default.event.to_be_removed event.
         type: object
@@ -248,6 +298,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this event; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
       default.event.to_be_renamed:
         description: EventConfig provides common config for a  default.event.to_be_renamed event.
         type: object
@@ -255,6 +310,11 @@ $defs:
           enabled:
             type: boolean
             default: false
+          collection_interval:
+            description: Optional scrape interval for this event; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
   resource_attributes_config:
     description: ResourceAttributesConfig provides config for sample resource attributes.
     type: object
@@ -270,22 +330,22 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       optional.resource.attr:
         description: ResourceAttributeConfig provides common config for a optional.resource.attr resource attribute.
         type: object
@@ -297,22 +357,22 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       slice.resource.attr:
         description: ResourceAttributeConfig provides common config for a slice.resource.attr resource attribute.
         type: object
@@ -324,22 +384,22 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.enum.resource.attr:
         description: ResourceAttributeConfig provides common config for a string.enum.resource.attr resource attribute.
         type: object
@@ -351,22 +411,22 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr:
         description: ResourceAttributeConfig provides common config for a string.resource.attr resource attribute.
         type: object
@@ -378,22 +438,22 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr_disable_warning:
         description: ResourceAttributeConfig provides common config for a string.resource.attr_disable_warning resource attribute.
         type: object
@@ -405,22 +465,22 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr_remove_warning:
         description: ResourceAttributeConfig provides common config for a string.resource.attr_remove_warning resource attribute.
         type: object
@@ -432,22 +492,22 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr_to_be_removed:
         description: ResourceAttributeConfig provides common config for a string.resource.attr_to_be_removed resource attribute.
         type: object
@@ -459,22 +519,22 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.disabled_attr_to_be_removed:
         description: ResourceAttributeConfig provides common config for a string.resource.disabled_attr_to_be_removed resource attribute.
         type: object
@@ -486,22 +546,22 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
   metrics_builder_config:
     description: MetricsBuilderConfig is a configuration for sample metrics builder.
     type: object

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
@@ -4,7 +4,7 @@ package metadata
 
 import (
 	"fmt"
-	"slices"
+	"time"
 
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
@@ -26,8 +26,11 @@ const (
 
 // DefaultMetricMetricConfig provides config for the default.metric metric.
 type DefaultMetricMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []DefaultMetricMetricAttributeKey `mapstructure:"attributes"`
@@ -67,8 +70,11 @@ func (ms *DefaultMetricMetricConfig) Validate() error {
 
 // DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric.
 type DefaultMetricToBeRemovedMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 }
 
 func (ms *DefaultMetricToBeRemovedMetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -98,8 +104,11 @@ const (
 
 // MetricInputTypeMetricConfig provides config for the metric.input_type metric.
 type MetricInputTypeMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                              `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []MetricInputTypeMetricAttributeKey `mapstructure:"attributes"`
@@ -149,8 +158,11 @@ const (
 
 // OptionalMetricMetricConfig provides config for the optional.metric metric.
 type OptionalMetricMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                             `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []OptionalMetricMetricAttributeKey `mapstructure:"attributes"`
@@ -198,8 +210,11 @@ const (
 
 // OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric.
 type OptionalMetricEmptyUnitMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []OptionalMetricEmptyUnitMetricAttributeKey `mapstructure:"attributes"`
@@ -247,8 +262,11 @@ const (
 
 // ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric.
 type ReaggregateMetricMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []ReaggregateMetricMetricAttributeKey `mapstructure:"attributes"`
@@ -297,8 +315,11 @@ const (
 
 // ReaggregateMetricWithRequiredMetricConfig provides config for the reaggregate.metric.with_required metric.
 type ReaggregateMetricWithRequiredMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []ReaggregateMetricWithRequiredMetricAttributeKey `mapstructure:"attributes"`
@@ -326,8 +347,17 @@ func (ms *ReaggregateMetricWithRequiredMetricConfig) Validate() error {
 			return fmt.Errorf("metric reaggregate.metric.with_required doesn't have an attribute %v, valid attributes: [required_string_attr, string_attr, boolean_attr]", val)
 		}
 	}
-	if !slices.Contains(ms.EnabledAttributes, ReaggregateMetricWithRequiredMetricAttributeKeyRequiredStringAttr) {
-		return fmt.Errorf("required_string_attr is a required attribute for reaggregate.metric.with_required metric and must be included")
+	{
+		var found bool
+		for _, a := range ms.EnabledAttributes {
+			if a == ReaggregateMetricWithRequiredMetricAttributeKeyRequiredStringAttr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("required_string_attr is a required attribute for reaggregate.metric.with_required metric and must be included")
+		}
 	}
 
 	switch ms.AggregationStrategy {
@@ -348,8 +378,11 @@ const (
 
 // SystemCPUTimeMetricConfig provides config for the system.cpu.time metric.
 type SystemCPUTimeMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []SystemCPUTimeMetricAttributeKey `mapstructure:"attributes"`
@@ -396,8 +429,11 @@ const (
 
 // SystemMemoryUsageMetricConfig provides config for the system.memory.usage metric.
 type SystemMemoryUsageMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []SystemMemoryUsageMetricAttributeKey `mapstructure:"attributes"`
@@ -499,6 +535,9 @@ func DefaultMetricsConfig() MetricsConfig {
 // EventConfig provides common config for a particular event.
 type EventConfig struct {
 	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this event is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
 
 	enabledSetByUser bool
 }

--- a/cmd/mdatagen/internal/samplescraper/config.schema.json
+++ b/cmd/mdatagen/internal/samplescraper/config.schema.json
@@ -47,6 +47,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true
@@ -57,6 +62,11 @@
               "description": "DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric.",
               "type": "object",
               "properties": {
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true
@@ -97,6 +107,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true
@@ -133,6 +148,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": false
@@ -166,6 +186,11 @@
                       "boolean_attr"
                     ]
                   }
+                },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
                 },
                 "enabled": {
                   "type": "boolean",
@@ -201,6 +226,11 @@
                     ]
                   }
                 },
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true
@@ -211,6 +241,11 @@
               "description": "SystemCPUTimeMetricConfig provides config for the system.cpu.time metric.",
               "type": "object",
               "properties": {
+                "collection_interval": {
+                  "description": "Optional scrape interval for this metric; zero uses the receiver collection_interval.",
+                  "type": "string",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+                },
                 "enabled": {
                   "type": "boolean",
                   "default": true

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -4,14 +4,14 @@ package samplescraper
 
 import (
 	"errors"
+	"oracle-loadgen/config/confighttp"
+	"oracle-loadgen/scraper/scraperhelper"
 	"regexp"
 	"time"
 
 	"go.opentelemetry.io/collector/cmd/mdatagen/internal/samplescraper/internal/metadata"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configoptional"
-	"go.opentelemetry.io/collector/scraper/scraperhelper"
 )
 
 type TargetsItem struct {

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/config.schema.yaml
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/config.schema.yaml
@@ -11,6 +11,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -42,6 +47,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
       metric.input_type:
         description: "MetricInputTypeMetricConfig provides config for the metric.input_type metric."
         type: object
@@ -49,6 +59,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -80,6 +95,11 @@ $defs:
           enabled:
             type: boolean
             default: false
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -107,6 +127,11 @@ $defs:
           enabled:
             type: boolean
             default: false
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -132,6 +157,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           aggregation_strategy:
             type: string
             enum:
@@ -157,6 +187,11 @@ $defs:
           enabled:
             type: boolean
             default: true
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
   resource_attributes_config:
     description: ResourceAttributesConfig provides config for sample resource attributes.
     type: object
@@ -172,12 +207,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       optional.resource.attr:
         description: ResourceAttributeConfig provides common config for a optional.resource.attr resource attribute.
         type: object
@@ -189,12 +224,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       slice.resource.attr:
         description: ResourceAttributeConfig provides common config for a slice.resource.attr resource attribute.
         type: object
@@ -206,12 +241,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.enum.resource.attr:
         description: ResourceAttributeConfig provides common config for a string.enum.resource.attr resource attribute.
         type: object
@@ -223,12 +258,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr:
         description: ResourceAttributeConfig provides common config for a string.resource.attr resource attribute.
         type: object
@@ -240,12 +275,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr_disable_warning:
         description: ResourceAttributeConfig provides common config for a string.resource.attr_disable_warning resource attribute.
         type: object
@@ -257,12 +292,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr_remove_warning:
         description: ResourceAttributeConfig provides common config for a string.resource.attr_remove_warning resource attribute.
         type: object
@@ -274,12 +309,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
       string.resource.attr_to_be_removed:
         description: ResourceAttributeConfig provides common config for a string.resource.attr_to_be_removed resource attribute.
         type: object
@@ -291,12 +326,12 @@ $defs:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
             type: array
             items:
-              $ref: /filter.config
+              $ref: go.opentelemetry.io/collector/filter.config
   metrics_builder_config:
     description: MetricsBuilderConfig is a configuration for sample metrics builder.
     type: object

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
@@ -22,8 +23,11 @@ const (
 
 // DefaultMetricMetricConfig provides config for the default.metric metric.
 type DefaultMetricMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []DefaultMetricMetricAttributeKey `mapstructure:"attributes"`
@@ -63,8 +67,11 @@ func (ms *DefaultMetricMetricConfig) Validate() error {
 
 // DefaultMetricToBeRemovedMetricConfig provides config for the default.metric.to_be_removed metric.
 type DefaultMetricToBeRemovedMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 }
 
 func (ms *DefaultMetricToBeRemovedMetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -94,8 +101,11 @@ const (
 
 // MetricInputTypeMetricConfig provides config for the metric.input_type metric.
 type MetricInputTypeMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                              `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []MetricInputTypeMetricAttributeKey `mapstructure:"attributes"`
@@ -144,8 +154,11 @@ const (
 
 // OptionalMetricMetricConfig provides config for the optional.metric metric.
 type OptionalMetricMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                             `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []OptionalMetricMetricAttributeKey `mapstructure:"attributes"`
@@ -193,8 +206,11 @@ const (
 
 // OptionalMetricEmptyUnitMetricConfig provides config for the optional.metric.empty_unit metric.
 type OptionalMetricEmptyUnitMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []OptionalMetricEmptyUnitMetricAttributeKey `mapstructure:"attributes"`
@@ -242,8 +258,11 @@ const (
 
 // ReaggregateMetricMetricConfig provides config for the reaggregate.metric metric.
 type ReaggregateMetricMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 
 	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
 	EnabledAttributes   []ReaggregateMetricMetricAttributeKey `mapstructure:"attributes"`
@@ -283,8 +302,11 @@ func (ms *ReaggregateMetricMetricConfig) Validate() error {
 
 // SystemCPUTimeMetricConfig provides config for the system.cpu.time metric.
 type SystemCPUTimeMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
+	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	enabledSetByUser   bool
 }
 
 func (ms *SystemCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {

--- a/cmd/mdatagen/internal/templates/config.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config.go.tmpl
@@ -9,7 +9,9 @@ package {{ .Package }}
 import (
 	{{- if $hasReagMetrics }}
 	"fmt"
-	"slices"
+	{{- end }}
+	{{- if or .Metrics .Events }}
+	"time"
 	{{- end }}
 
 	"go.opentelemetry.io/collector/confmap"
@@ -23,6 +25,9 @@ import (
 // MetricConfig provides common config for a particular metric.
 type MetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
 	enabledSetByUser bool
 }
 
@@ -46,6 +51,9 @@ const (
 // {{ $name.Render }}MetricConfig provides config for the {{ $name }} metric.
 type {{ $name.Render }}MetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this metric is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
 	enabledSetByUser bool
 	{{- if hasAggregatableAttributes $metric.Attributes }}
 
@@ -70,8 +78,17 @@ func (ms *{{ $name.Render }}MetricConfig) Validate() error {
 
 	{{- range $element := $metric.Attributes }}
 	{{- if (attributeInfo $element).IsRequired }}
-	if !slices.Contains(ms.EnabledAttributes, {{ $name.Render }}MetricAttributeKey{{ $element.Render }}) {
-		return fmt.Errorf("{{ (attributeInfo $element).Name }} is a required attribute for {{ $name }} metric and must be included")
+	{
+		var found bool
+		for _, a := range ms.EnabledAttributes {
+			if a == {{ $name.Render }}MetricAttributeKey{{ $element.Render }} {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("{{ (attributeInfo $element).Name }} is a required attribute for {{ $name }} metric and must be included")
+		}
 	}
 	{{- end }}
 	{{- end }}
@@ -115,6 +132,9 @@ func DefaultMetricsConfig() MetricsConfig {
 // EventConfig provides common config for a particular event.
 type EventConfig struct {
 	Enabled bool `mapstructure:"enabled"`
+	// CollectionInterval sets how frequently this event is scraped when using a scraper controller.
+	// Zero uses the receiver-level collection_interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
 
 	enabledSetByUser bool
 }

--- a/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
+++ b/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
@@ -15,6 +15,11 @@ $defs:
           enabled:
             type: boolean
             default: {{ $metric.Enabled }}
+          collection_interval:
+            description: Optional scrape interval for this metric; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
           {{- if $metricReag }}
           aggregation_strategy:
             type: string
@@ -58,6 +63,11 @@ $defs:
           enabled:
             type: boolean
             default: {{ $event.Enabled }}
+          collection_interval:
+            description: Optional scrape interval for this event; zero uses the receiver collection_interval.
+            type: string
+            x-customType: time.Duration
+            format: duration
       {{- end }}
 {{- end }}
 {{- if .ResourceAttributes }}

--- a/scraper/scraperhelper/controller.go
+++ b/scraper/scraperhelper/controller.go
@@ -72,6 +72,20 @@ func AddFactoryWithConfig(f scraper.Factory, cfg component.Config) ControllerOpt
 	})
 }
 
+// AddFactoryWithCollectionInterval configures the scraper.Factory like
+// [AddFactoryWithConfig] but overrides the collection interval for this scraper
+// only. When collectionInterval is zero, the controller-level
+// [ControllerConfig.CollectionInterval] is used.
+func AddFactoryWithCollectionInterval(f scraper.Factory, cfg component.Config, collectionInterval time.Duration) ControllerOption {
+	return optionFunc(func(o *controllerOptions) {
+		o.factoriesWithConfig = append(o.factoriesWithConfig, factoryWithConfig{
+			f:                  f,
+			cfg:                cfg,
+			collectionInterval: collectionInterval,
+		})
+	})
+}
+
 // WithTickerChannel allows you to override the scraper controller's ticker
 // channel to specify when scrape is called. This is only expected to be
 // used by tests.
@@ -84,6 +98,8 @@ func WithTickerChannel(tickerCh <-chan time.Time) ControllerOption {
 type factoryWithConfig struct {
 	f   scraper.Factory
 	cfg component.Config
+	// collectionInterval, when positive, overrides ControllerConfig.CollectionInterval for this scraper.
+	collectionInterval time.Duration
 }
 
 type controllerOptions struct {
@@ -99,6 +115,7 @@ func NewLogsController(cfg *ControllerConfig,
 ) (receiver.Logs, error) {
 	co := getOptions(options)
 	scrapers := make([]scraper.Logs, 0, len(co.factoriesWithConfig))
+	intervals := make([]time.Duration, 0, len(co.factoriesWithConfig))
 	for _, fwc := range co.factoriesWithConfig {
 		set := controller.GetSettings(fwc.f.Type(), rSet)
 		s, err := fwc.f.CreateLogs(context.Background(), set, fwc.cfg)
@@ -110,9 +127,18 @@ func NewLogsController(cfg *ControllerConfig,
 			return nil, err
 		}
 		scrapers = append(scrapers, s)
+		intervals = append(intervals, fwc.collectionInterval)
 	}
 	return controller.NewController[scraper.Logs](
-		cfg, rSet, scrapers, func(c *controller.Controller[scraper.Logs]) { scrapeLogs(c, nextConsumer) }, co.tickerCh)
+		cfg,
+		rSet,
+		scrapers,
+		func(c *controller.Controller[scraper.Logs], indices []int) {
+			scrapeLogs(c, nextConsumer, indices)
+		},
+		co.tickerCh,
+		intervals,
+	)
 }
 
 // NewMetricsController creates a receiver.Metrics with the configured options, that can control multiple scraper.Metrics.
@@ -123,6 +149,7 @@ func NewMetricsController(cfg *ControllerConfig,
 ) (receiver.Metrics, error) {
 	co := getOptions(options)
 	scrapers := make([]scraper.Metrics, 0, len(co.factoriesWithConfig))
+	intervals := make([]time.Duration, 0, len(co.factoriesWithConfig))
 	for _, fwc := range co.factoriesWithConfig {
 		set := controller.GetSettings(fwc.f.Type(), rSet)
 		s, err := fwc.f.CreateMetrics(context.Background(), set, fwc.cfg)
@@ -134,22 +161,42 @@ func NewMetricsController(cfg *ControllerConfig,
 			return nil, err
 		}
 		scrapers = append(scrapers, s)
+		intervals = append(intervals, fwc.collectionInterval)
 	}
 	return controller.NewController[scraper.Metrics](
-		cfg, rSet, scrapers, func(c *controller.Controller[scraper.Metrics]) { scrapeMetrics(c, nextConsumer) }, co.tickerCh)
+		cfg,
+		rSet,
+		scrapers,
+		func(c *controller.Controller[scraper.Metrics], indices []int) {
+			scrapeMetrics(c, nextConsumer, indices)
+		},
+		co.tickerCh,
+		intervals,
+	)
 }
 
-func scrapeLogs(c *controller.Controller[scraper.Logs], nextConsumer consumer.Logs) {
+func scrapeLogs(c *controller.Controller[scraper.Logs], nextConsumer consumer.Logs, indices []int) {
 	ctx, done := controller.WithScrapeContext(c.Timeout)
 	defer done()
 
 	logs := plog.NewLogs()
-	for i := range c.Scrapers {
+	scrapeAt := func(i int) {
 		md, err := c.Scrapers[i].ScrapeLogs(ctx)
 		if err != nil && !scrapererror.IsPartialScrapeError(err) {
-			continue
+			return
 		}
 		md.ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
+	}
+	if indices == nil {
+		for i := range c.Scrapers {
+			scrapeAt(i)
+		}
+	} else {
+		for _, i := range indices {
+			if i >= 0 && i < len(c.Scrapers) {
+				scrapeAt(i)
+			}
+		}
 	}
 
 	logRecordCount := logs.LogRecordCount()
@@ -158,17 +205,28 @@ func scrapeLogs(c *controller.Controller[scraper.Logs], nextConsumer consumer.Lo
 	c.Obsrecv.EndLogsOp(ctx, "", logRecordCount, err)
 }
 
-func scrapeMetrics(c *controller.Controller[scraper.Metrics], nextConsumer consumer.Metrics) {
+func scrapeMetrics(c *controller.Controller[scraper.Metrics], nextConsumer consumer.Metrics, indices []int) {
 	ctx, done := controller.WithScrapeContext(c.Timeout)
 	defer done()
 
 	metrics := pmetric.NewMetrics()
-	for i := range c.Scrapers {
+	scrapeAt := func(i int) {
 		md, err := c.Scrapers[i].ScrapeMetrics(ctx)
 		if err != nil && !scrapererror.IsPartialScrapeError(err) {
-			continue
+			return
 		}
 		md.ResourceMetrics().MoveAndAppendTo(metrics.ResourceMetrics())
+	}
+	if indices == nil {
+		for i := range c.Scrapers {
+			scrapeAt(i)
+		}
+	} else {
+		for _, i := range indices {
+			if i >= 0 && i < len(c.Scrapers) {
+				scrapeAt(i)
+			}
+		}
 	}
 
 	dataPointCount := metrics.DataPointCount()

--- a/scraper/scraperhelper/internal/controller/controller.go
+++ b/scraper/scraperhelper/internal/controller/controller.go
@@ -7,6 +7,9 @@ package controller // import "go.opentelemetry.io/collector/scraper/scraperhelpe
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -24,9 +27,12 @@ type Controller[T component.Component] struct {
 	initialDelay       time.Duration
 	Timeout            time.Duration
 
-	Scrapers   []T
-	scrapeFunc func(*Controller[T])
-	tickerCh   <-chan time.Time
+	Scrapers []T
+	// scraperCollectionIntervals holds optional per-scraper collection intervals.
+	// A value of zero means use collectionInterval for that scraper.
+	scraperCollectionIntervals []time.Duration
+	scrapeFunc                 func(*Controller[T], []int)
+	tickerCh                   <-chan time.Time
 
 	done chan struct{}
 	wg   sync.WaitGroup
@@ -38,9 +44,21 @@ func NewController[T component.Component](
 	cfg *ControllerConfig,
 	rSet receiver.Settings,
 	scrapers []T,
-	scrapeFunc func(*Controller[T]),
+	scrapeFunc func(*Controller[T], []int),
 	tickerCh <-chan time.Time,
+	scraperCollectionIntervals []time.Duration,
 ) (*Controller[T], error) {
+	if len(scraperCollectionIntervals) == 0 {
+		scraperCollectionIntervals = make([]time.Duration, len(scrapers))
+	} else if len(scraperCollectionIntervals) != len(scrapers) {
+		return nil, fmt.Errorf("scraperhelper: scraper collection intervals length %d must match scrapers length %d", len(scraperCollectionIntervals), len(scrapers))
+	}
+	for _, d := range scraperCollectionIntervals {
+		if d < 0 {
+			return nil, errors.New("scraperhelper: per-scraper collection_interval must not be negative")
+		}
+	}
+
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
 		ReceiverID:             rSet.ID,
 		Transport:              "",
@@ -51,14 +69,15 @@ func NewController[T component.Component](
 	}
 
 	cs := &Controller[T]{
-		collectionInterval: cfg.CollectionInterval,
-		initialDelay:       cfg.InitialDelay,
-		Timeout:            cfg.Timeout,
-		Scrapers:           scrapers,
-		scrapeFunc:         scrapeFunc,
-		done:               make(chan struct{}),
-		tickerCh:           tickerCh,
-		Obsrecv:            obsrecv,
+		collectionInterval:         cfg.CollectionInterval,
+		initialDelay:               cfg.InitialDelay,
+		Timeout:                    cfg.Timeout,
+		Scrapers:                   scrapers,
+		scraperCollectionIntervals: scraperCollectionIntervals,
+		scrapeFunc:                 scrapeFunc,
+		done:                       make(chan struct{}),
+		tickerCh:                   tickerCh,
+		Obsrecv:                    obsrecv,
 	}
 
 	return cs, nil
@@ -89,8 +108,9 @@ func (sc *Controller[T]) Shutdown(ctx context.Context) error {
 	return errs
 }
 
-// startScraping initiates a ticker that calls Scrape based on the configured
-// collection interval.
+// startScraping initiates tickers that call Scrape based on the configured
+// collection intervals. When tickerCh is set (tests), every tick scrapes all
+// scrapers and per-scraper intervals are ignored for scheduling.
 func (sc *Controller[T]) startScraping() {
 	sc.wg.Go(func() {
 		if sc.initialDelay > 0 {
@@ -101,24 +121,55 @@ func (sc *Controller[T]) startScraping() {
 			}
 		}
 
-		if sc.tickerCh == nil {
-			ticker := time.NewTicker(sc.collectionInterval)
-			defer ticker.Stop()
-
-			sc.tickerCh = ticker.C
-		}
-		// Call scrape method during initialization to ensure
-		// that scrapers start from when the component starts
-		// instead of waiting for the full duration to start.
-		sc.scrapeFunc(sc)
-		for {
-			select {
-			case <-sc.tickerCh:
-				sc.scrapeFunc(sc)
-			case <-sc.done:
-				return
+		// Test hook: a single external channel drives full scrapes.
+		if sc.tickerCh != nil {
+			sc.scrapeFunc(sc, nil)
+			for {
+				select {
+				case <-sc.tickerCh:
+					sc.scrapeFunc(sc, nil)
+				case <-sc.done:
+					return
+				}
 			}
 		}
+
+		// Initial scrape includes all scrapers.
+		sc.scrapeFunc(sc, nil)
+
+		effective := make([]time.Duration, len(sc.Scrapers))
+		for i := range sc.Scrapers {
+			d := sc.scraperCollectionIntervals[i]
+			if d <= 0 {
+				d = sc.collectionInterval
+			}
+			effective[i] = d
+		}
+
+		groups := map[time.Duration][]int{}
+		for i, d := range effective {
+			groups[d] = append(groups[d], i)
+		}
+
+		var inner sync.WaitGroup
+		for interval, groupIndices := range groups {
+			inner.Add(1)
+			clonedIndices := slices.Clone(groupIndices)
+			go func() {
+				defer inner.Done()
+				ticker := time.NewTicker(interval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ticker.C:
+						sc.scrapeFunc(sc, clonedIndices)
+					case <-sc.done:
+						return
+					}
+				}
+			}()
+		}
+		inner.Wait()
 	})
 }
 

--- a/scraper/scraperhelper/internal/controller/controller_test.go
+++ b/scraper/scraperhelper/internal/controller/controller_test.go
@@ -30,8 +30,9 @@ func newTestController(t *testing.T, cfg *ControllerConfig, scrapers []component
 		cfg,
 		receivertest.NewNopSettings(receivertest.NopType),
 		scrapers,
-		func(*Controller[component.Component]) {},
+		func(*Controller[component.Component], []int) {},
 		tickerCh,
+		nil,
 	)
 	require.NoError(t, err)
 	return ctrl
@@ -40,7 +41,7 @@ func newTestController(t *testing.T, cfg *ControllerConfig, scrapers []component
 func TestNewController(t *testing.T) {
 	t.Parallel()
 
-	scrapeFunc := func(*Controller[component.Component]) {}
+	scrapeFunc := func(*Controller[component.Component], []int) {}
 
 	for _, tc := range []struct {
 		name     string
@@ -86,6 +87,7 @@ func TestNewController(t *testing.T) {
 				scrapers,
 				scrapeFunc,
 				tc.tickerCh,
+				nil,
 			)
 
 			require.NoError(t, err)
@@ -145,19 +147,23 @@ func TestStartScrapingWithNilTickerCh(t *testing.T) {
 	t.Parallel()
 
 	var scrapeCount atomic.Int32
-	scrapeFunc := func(*Controller[component.Component]) {
+	scrapeFunc := func(*Controller[component.Component], []int) {
 		scrapeCount.Add(1)
 	}
 
 	cfg := &ControllerConfig{
 		CollectionInterval: 50 * time.Millisecond,
 	}
+	scrapers := []component.Component{
+		&mockScraper{},
+	}
 	ctrl, err := NewController(
 		cfg,
 		receivertest.NewNopSettings(receivertest.NopType),
-		[]component.Component{},
+		scrapers,
 		scrapeFunc,
-		nil, // nil tickerCh — will create a real ticker internally.
+		nil, // nil tickerCh — per-scraper tickers use collection_interval.
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -226,7 +232,7 @@ func TestStartScraping(t *testing.T) {
 
 	tickerCh := make(chan time.Time)
 	var scrapeCount atomic.Int32
-	scrapeFunc := func(*Controller[component.Component]) {
+	scrapeFunc := func(*Controller[component.Component], []int) {
 		scrapeCount.Add(1)
 	}
 
@@ -239,6 +245,7 @@ func TestStartScraping(t *testing.T) {
 		[]component.Component{},
 		scrapeFunc,
 		tickerCh,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -263,7 +270,7 @@ func TestStartScrapingWithInitialDelay(t *testing.T) {
 
 	tickerCh := make(chan time.Time)
 	var scrapeCount atomic.Int32
-	scrapeFunc := func(*Controller[component.Component]) {
+	scrapeFunc := func(*Controller[component.Component], []int) {
 		scrapeCount.Add(1)
 	}
 
@@ -277,6 +284,7 @@ func TestStartScrapingWithInitialDelay(t *testing.T) {
 		[]component.Component{},
 		scrapeFunc,
 		tickerCh,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -294,7 +302,7 @@ func TestStartScrapingShutdownDuringInitialDelay(t *testing.T) {
 	t.Parallel()
 
 	var scraped atomic.Bool
-	scrapeFunc := func(*Controller[component.Component]) {
+	scrapeFunc := func(*Controller[component.Component], []int) {
 		scraped.Store(true)
 	}
 
@@ -308,6 +316,7 @@ func TestStartScrapingShutdownDuringInitialDelay(t *testing.T) {
 		[]component.Component{},
 		scrapeFunc,
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -316,6 +325,49 @@ func TestStartScrapingShutdownDuringInitialDelay(t *testing.T) {
 	require.NoError(t, ctrl.Shutdown(context.Background()))
 
 	assert.False(t, scraped.Load(), "scrapeFunc should not have been called")
+}
+
+func TestPerScraperCollectionIntervals(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ControllerConfig{
+		CollectionInterval: 200 * time.Millisecond,
+	}
+	var fullCalls, idx0Calls, idx1Calls atomic.Int32
+	scrapeFunc := func(_ *Controller[component.Component], indices []int) {
+		if indices == nil {
+			fullCalls.Add(1)
+			return
+		}
+		for _, i := range indices {
+			switch i {
+			case 0:
+				idx0Calls.Add(1)
+			case 1:
+				idx1Calls.Add(1)
+			}
+		}
+	}
+	scrapers := []component.Component{&mockScraper{}, &mockScraper{}}
+	intervals := []time.Duration{40 * time.Millisecond, 120 * time.Millisecond}
+	ctrl, err := NewController(
+		cfg,
+		receivertest.NewNopSettings(receivertest.NopType),
+		scrapers,
+		scrapeFunc,
+		nil,
+		intervals,
+	)
+	require.NoError(t, err)
+	require.NoError(t, ctrl.Start(context.Background(), componenttest.NewNopHost()))
+
+	require.Eventually(t, func() bool { return fullCalls.Load() >= 1 }, time.Second, 5*time.Millisecond)
+
+	time.Sleep(300 * time.Millisecond)
+	require.NoError(t, ctrl.Shutdown(context.Background()))
+
+	assert.GreaterOrEqual(t, idx0Calls.Load(), int32(4), "faster scraper should run more often")
+	assert.Greater(t, idx0Calls.Load(), idx1Calls.Load(), "faster interval should produce more scrapes than slower")
 }
 
 func TestGetSettings(t *testing.T) {

--- a/scraper/scraperhelper/xscraperhelper/controller.go
+++ b/scraper/scraperhelper/xscraperhelper/controller.go
@@ -31,8 +31,9 @@ const (
 )
 
 type factoryWithConfig struct {
-	f   xscraper.Factory
-	cfg component.Config
+	f                  xscraper.Factory
+	cfg                component.Config
+	collectionInterval time.Duration
 }
 
 type controllerOptions struct {
@@ -76,6 +77,20 @@ func AddFactoryWithConfig(f xscraper.Factory, cfg component.Config) ControllerOp
 	})
 }
 
+// AddFactoryWithCollectionInterval configures the xscraper.Factory like
+// [AddFactoryWithConfig] but overrides the collection interval for this scraper
+// only. When collectionInterval is zero, the controller-level
+// [scraperhelper.ControllerConfig.CollectionInterval] is used.
+func AddFactoryWithCollectionInterval(f xscraper.Factory, cfg component.Config, collectionInterval time.Duration) ControllerOption {
+	return optionFunc(func(o *controllerOptions) {
+		o.factoriesWithConfig = append(o.factoriesWithConfig, factoryWithConfig{
+			f:                  f,
+			cfg:                cfg,
+			collectionInterval: collectionInterval,
+		})
+	})
+}
+
 // WithTickerChannel allows you to override the scraper controller's ticker
 // channel to specify when scrape is called. This is only expected to be
 // used by tests.
@@ -93,6 +108,7 @@ func NewProfilesController(cfg *scraperhelper.ControllerConfig,
 ) (xreceiver.Profiles, error) {
 	co := getOptions(options)
 	scrapers := make([]xscraper.Profiles, 0, len(co.factoriesWithConfig))
+	intervals := make([]time.Duration, 0, len(co.factoriesWithConfig))
 	for _, fwc := range co.factoriesWithConfig {
 		set := controller.GetSettings(fwc.f.Type(), rSet)
 		s, err := fwc.f.CreateProfiles(context.Background(), set, fwc.cfg)
@@ -104,9 +120,18 @@ func NewProfilesController(cfg *scraperhelper.ControllerConfig,
 			return nil, err
 		}
 		scrapers = append(scrapers, s)
+		intervals = append(intervals, fwc.collectionInterval)
 	}
 	return controller.NewController[xscraper.Profiles](
-		cfg, rSet, scrapers, func(c *controller.Controller[xscraper.Profiles]) { scrapeProfiles(c, nextConsumer) }, co.tickerCh)
+		cfg,
+		rSet,
+		scrapers,
+		func(c *controller.Controller[xscraper.Profiles], indices []int) {
+			scrapeProfiles(c, nextConsumer, indices)
+		},
+		co.tickerCh,
+		intervals,
+	)
 }
 
 func getOptions(options []ControllerOption) controllerOptions {
@@ -117,17 +142,28 @@ func getOptions(options []ControllerOption) controllerOptions {
 	return co
 }
 
-func scrapeProfiles(c *controller.Controller[xscraper.Profiles], nextConsumer xconsumer.Profiles) {
+func scrapeProfiles(c *controller.Controller[xscraper.Profiles], nextConsumer xconsumer.Profiles, indices []int) {
 	ctx, done := controller.WithScrapeContext(c.Timeout)
 	defer done()
 
 	profiles := pprofile.NewProfiles()
-	for i := range c.Scrapers {
+	scrapeAt := func(i int) {
 		md, err := c.Scrapers[i].ScrapeProfiles(ctx)
 		if err != nil && !scrapererror.IsPartialScrapeError(err) {
-			continue
+			return
 		}
 		md.ResourceProfiles().MoveAndAppendTo(profiles.ResourceProfiles())
+	}
+	if indices == nil {
+		for i := range c.Scrapers {
+			scrapeAt(i)
+		}
+	} else {
+		for _, i := range indices {
+			if i >= 0 && i < len(c.Scrapers) {
+				scrapeAt(i)
+			}
+		}
 	}
 
 	// TODO: Add proper receiver observability for profiles when receiverhelper supports it


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
##### scraper/scraperhelper
- Extend the scraper controller so each registered scraper can have an optional per-scraper collection_interval (zero = use the receiver’s ControllerConfig.collection_interval).
- Scheduling: After a one-time full initial scrape, scrapers are grouped by effective interval; each distinct interval gets its own time.Ticker; ticks invoke only the scrapers in that group. WithTickerChannel (tests) unchanged: one channel, full scrapes, ignores per-scraper scheduling.
- API: AddFactoryWithCollectionInterval(factory, config, collectionInterval); factoryWithConfig carries the optional duration.
- scrapeMetrics / scrapeLogs: support subset scrapes via an index list; nil = all scrapers.

##### scraper/scraperhelper/xscraperhelper
- Same per-scraper interval + scrapeProfiles subset behavior for the profiles path.

##### cmd/mdatagen

- Add optional collection_interval to generated metric and event config structs; update config schema; add time import where needed.
- Replace slices.Contains in reaggregated Validate with an explicit loop so slices is not imported when unused.
<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45700

<!--Describe what testing was performed and which tests were added.-->
#### Testing
unit tests updated.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
