### PR TITLE
 [receiver/otlp] Make Protocols field in Config struct not anonymous

### DIFF
--- a/.chloggen/otlpreceiver-named-protocols-field.yaml
+++ b/.chloggen/otlpreceiver-named-protocols-field.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: receiver/otlp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`Config.Protocols` is now a named field instead of an anonymous embedded field."
+
+# One or more tracking issues or pull requests related to the change
+issues: [15178]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Access to `cfg.GRPC` and `cfg.HTTP` must be updated to `cfg.Protocols.GRPC` and `cfg.Protocols.HTTP`.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/internal/e2e/consume_contract_test.go
+++ b/internal/e2e/consume_contract_test.go
@@ -37,7 +37,7 @@ func testExporterConfig(endpoint string) component.Config {
 
 func testReceiverConfig(endpoint string) component.Config {
 	cfg := otlpreceiver.NewFactory().CreateDefaultConfig()
-	cfg.(*otlpreceiver.Config).GRPC.GetOrInsertDefault().NetAddr.Endpoint = endpoint
+	cfg.(*otlpreceiver.Config).Protocols.GRPC.GetOrInsertDefault().NetAddr.Endpoint = endpoint
 	return cfg
 }
 

--- a/internal/e2e/error_propagation_test.go
+++ b/internal/e2e/error_propagation_test.go
@@ -224,7 +224,7 @@ func assertOnGRPCCode(t *testing.T, l consumer.Logs, s *status.Status) {
 
 	rf := otlpreceiver.NewFactory()
 	rcfg := rf.CreateDefaultConfig().(*otlpreceiver.Config)
-	rcfg.GRPC = configoptional.Some(
+	rcfg.Protocols.GRPC = configoptional.Some(
 		configgrpc.ServerConfig{
 			NetAddr: confignet.AddrConfig{
 				Endpoint:  testutil.GetAvailableLocalAddress(t),
@@ -243,7 +243,7 @@ func assertOnGRPCCode(t *testing.T, l consumer.Logs, s *status.Status) {
 		require.NoError(t, r.Shutdown(context.Background()))
 	})
 
-	conn, err := grpc.NewClient(rcfg.GRPC.Get().NetAddr.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(rcfg.Protocols.GRPC.Get().NetAddr.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, conn.Close())
@@ -275,7 +275,7 @@ func assertOnHTTPCode(t *testing.T, l consumer.Logs, code int) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	rf := otlpreceiver.NewFactory()
 	rcfg := rf.CreateDefaultConfig().(*otlpreceiver.Config)
-	rcfg.HTTP = configoptional.Some(
+	rcfg.Protocols.HTTP = configoptional.Some(
 		otlpreceiver.HTTPConfig{
 			ServerConfig: confighttp.ServerConfig{
 				NetAddr: confignet.AddrConfig{

--- a/internal/e2e/otlphttp_test.go
+++ b/internal/e2e/otlphttp_test.go
@@ -422,7 +422,7 @@ func startLogsReceiver(t *testing.T, addr string, next consumer.Logs) {
 
 func createReceiverConfig(addr string, defaultCfg component.Config) *otlpreceiver.Config {
 	cfg := defaultCfg.(*otlpreceiver.Config)
-	cfg.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = addr
+	cfg.Protocols.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = addr
 	return cfg
 }
 

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -61,7 +61,7 @@ type Protocols struct {
 // Config defines configuration for OTLP receiver.
 type Config struct {
 	// Protocols is the configuration for the supported protocols, currently gRPC and HTTP (Proto and JSON).
-	Protocols `mapstructure:"protocols"`
+	Protocols Protocols `mapstructure:"protocols"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -70,7 +70,7 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {
-	if !cfg.GRPC.HasValue() && !cfg.HTTP.HasValue() {
+	if !cfg.Protocols.GRPC.HasValue() && !cfg.Protocols.HTTP.HasValue() {
 		return errors.New("must specify at least one protocol when using the OTLP receiver")
 	}
 	return nil

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -30,8 +30,8 @@ func TestUnmarshalDefaultConfig(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	require.NoError(t, cm.Unmarshal(&cfg))
 	expectedCfg := factory.CreateDefaultConfig().(*Config)
-	expectedCfg.GRPC.GetOrInsertDefault()
-	expectedCfg.HTTP.GetOrInsertDefault()
+	expectedCfg.Protocols.GRPC.GetOrInsertDefault()
+	expectedCfg.Protocols.HTTP.GetOrInsertDefault()
 	assert.Equal(t, expectedCfg, cfg)
 }
 
@@ -43,7 +43,7 @@ func TestUnmarshalConfigOnlyGRPC(t *testing.T) {
 	require.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyGRPC := factory.CreateDefaultConfig().(*Config)
-	defaultOnlyGRPC.GRPC.GetOrInsertDefault()
+	defaultOnlyGRPC.Protocols.GRPC.GetOrInsertDefault()
 	assert.Equal(t, defaultOnlyGRPC, cfg)
 }
 
@@ -55,7 +55,7 @@ func TestUnmarshalConfigOnlyHTTP(t *testing.T) {
 	require.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyHTTP := factory.CreateDefaultConfig().(*Config)
-	defaultOnlyHTTP.HTTP.GetOrInsertDefault()
+	defaultOnlyHTTP.Protocols.HTTP.GetOrInsertDefault()
 	assert.Equal(t, defaultOnlyHTTP, cfg)
 }
 
@@ -67,7 +67,7 @@ func TestUnmarshalConfigOnlyHTTPNull(t *testing.T) {
 	require.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyHTTP := factory.CreateDefaultConfig().(*Config)
-	defaultOnlyHTTP.HTTP.GetOrInsertDefault()
+	defaultOnlyHTTP.Protocols.HTTP.GetOrInsertDefault()
 	assert.Equal(t, defaultOnlyHTTP, cfg)
 }
 
@@ -79,7 +79,7 @@ func TestUnmarshalConfigOnlyHTTPEmptyMap(t *testing.T) {
 	require.NoError(t, cm.Unmarshal(&cfg))
 
 	defaultOnlyHTTP := factory.CreateDefaultConfig().(*Config)
-	defaultOnlyHTTP.HTTP.GetOrInsertDefault()
+	defaultOnlyHTTP.Protocols.HTTP.GetOrInsertDefault()
 	assert.Equal(t, defaultOnlyHTTP, cfg)
 }
 

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -36,8 +36,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateSameReceiver(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPC.GetOrInsertDefault().NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
-	cfg.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.Protocols.GRPC.GetOrInsertDefault().NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.Protocols.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	creationSet := receivertest.NewNopSettings(factory.Type())
 	var droppedAttrs []string

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -87,11 +87,11 @@ func newOtlpReceiver(cfg *Config, set *receiver.Settings) (*otlpReceiver, error)
 
 func (r *otlpReceiver) startGRPCServer(ctx context.Context, host component.Host) error {
 	// If GRPC is not enabled, nothing to start.
-	if !r.cfg.GRPC.HasValue() {
+	if !r.cfg.Protocols.GRPC.HasValue() {
 		return nil
 	}
 
-	grpcCfg := r.cfg.GRPC.Get()
+	grpcCfg := r.cfg.Protocols.GRPC.Get()
 	var err error
 	if r.serverGRPC, err = grpcCfg.ToServer(ctx, host.GetExtensions(), r.settings.TelemetrySettings); err != nil {
 		return err
@@ -129,11 +129,11 @@ func (r *otlpReceiver) startGRPCServer(ctx context.Context, host component.Host)
 
 func (r *otlpReceiver) startHTTPServer(ctx context.Context, host component.Host) error {
 	// If HTTP is not enabled, nothing to start.
-	if !r.cfg.HTTP.HasValue() {
+	if !r.cfg.Protocols.HTTP.HasValue() {
 		return nil
 	}
 
-	httpCfg := r.cfg.HTTP.Get()
+	httpCfg := r.cfg.Protocols.HTTP.Get()
 	httpMux := http.NewServeMux()
 	if r.nextTraces != nil {
 		httpTracesReceiver := trace.New(r.nextTraces, r.obsrepHTTP)

--- a/receiver/otlpreceiver/otlp_benchmark_test.go
+++ b/receiver/otlpreceiver/otlp_benchmark_test.go
@@ -47,7 +47,7 @@ func startLogsReceiver(b *testing.B, cfg *Config, sink *consumertest.LogsSink) {
 func BenchmarkGRPCLogsSequential(b *testing.B) {
 	endpoint := testutil.GetAvailableLocalAddress(b)
 	cfg := createDefaultConfig().(*Config)
-	cfg.GRPC.GetOrInsertDefault().NetAddr.Endpoint = endpoint
+	cfg.Protocols.GRPC.GetOrInsertDefault().NetAddr.Endpoint = endpoint
 	var sink consumertest.LogsSink
 	startLogsReceiver(b, cfg, &sink)
 
@@ -71,7 +71,7 @@ func BenchmarkGRPCLogsSequential(b *testing.B) {
 func BenchmarkHTTPProtoLogsSequential(b *testing.B) {
 	endpoint := testutil.GetAvailableLocalAddress(b)
 	cfg := createDefaultConfig().(*Config)
-	cfg.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = endpoint
+	cfg.Protocols.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = endpoint
 	var sink consumertest.LogsSink
 	startLogsReceiver(b, cfg, &sink)
 

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -869,7 +869,7 @@ func TestGRPCMaxRecvSize(t *testing.T) {
 	sink := newErrOrSinkConsumer()
 
 	cfg := createDefaultConfig().(*Config)
-	cfg.GRPC.GetOrInsertDefault().NetAddr.Endpoint = addr
+	cfg.Protocols.GRPC.GetOrInsertDefault().NetAddr.Endpoint = addr
 	recv := newReceiver(t, componenttest.NewNopTelemetrySettings(), cfg, otlpReceiverID, sink)
 	require.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -882,7 +882,7 @@ func TestGRPCMaxRecvSize(t *testing.T) {
 	assert.NoError(t, cc.Close())
 	require.NoError(t, recv.Shutdown(context.Background()))
 
-	cfg.GRPC.Get().MaxRecvMsgSizeMiB = 100
+	cfg.Protocols.GRPC.Get().MaxRecvMsgSizeMiB = 100
 	recv = newReceiver(t, componenttest.NewNopTelemetrySettings(), cfg, otlpReceiverID, sink)
 	require.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, recv.Shutdown(context.Background())) })
@@ -980,13 +980,13 @@ func TestHTTPMaxRequestBodySize(t *testing.T) {
 
 func newGRPCReceiver(t *testing.T, settings component.TelemetrySettings, endpoint string, c consumertest.Consumer) component.Component {
 	cfg := createDefaultConfig().(*Config)
-	cfg.GRPC.GetOrInsertDefault().NetAddr.Endpoint = endpoint
+	cfg.Protocols.GRPC.GetOrInsertDefault().NetAddr.Endpoint = endpoint
 	return newReceiver(t, settings, cfg, otlpReceiverID, c)
 }
 
 func newHTTPReceiver(t *testing.T, settings component.TelemetrySettings, endpoint string, c consumertest.Consumer) component.Component {
 	cfg := createDefaultConfig().(*Config)
-	cfg.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = endpoint
+	cfg.Protocols.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = endpoint
 	return newReceiver(t, settings, cfg, otlpReceiverID, c)
 }
 
@@ -1166,8 +1166,8 @@ func TestShutdown(t *testing.T) {
 	// Create OTLP receiver with gRPC and HTTP protocols.
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPC.GetOrInsertDefault().NetAddr.Endpoint = endpointGrpc
-	cfg.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = endpointHTTP
+	cfg.Protocols.GRPC.GetOrInsertDefault().NetAddr.Endpoint = endpointGrpc
+	cfg.Protocols.HTTP.GetOrInsertDefault().ServerConfig.NetAddr.Endpoint = endpointHTTP
 	set := receivertest.NewNopSettings(metadata.Type)
 	set.ID = otlpReceiverID
 	r, err := NewFactory().CreateTraces(


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/15178

`Config.Protocols` is now a named field instead of an anonymous embedded field according to our [coding guidelines](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/coding-guidelines.md#avoid-embedded-structs)

Access to `cfg.GRPC` and `cfg.HTTP` must be updated to `cfg.Protocols.GRPC` and `cfg.Protocols.HTTP`.
