### PR TITLE
Mdatagen support versioning of metrics

### DIFF
--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -25,6 +25,18 @@ func setAttributeDefaultFields(attrs map[AttributeName]Attribute) {
 	}
 }
 
+func setMetricDefaultFields(metrics map[MetricName]Metric) {
+	for k, v := range metrics {
+		if v.Name == "" {
+			keyStr := string(k)
+			if idx := strings.Index(keyStr, "/"); idx != -1 {
+				v.Name = keyStr[:idx]
+				metrics[k] = v
+			}
+		}
+	}
+}
+
 type TemplateContext struct {
 	Metadata
 	// Package name for generated code.
@@ -66,6 +78,8 @@ func LoadMetadata(filePath string) (Metadata, error) {
 
 	setAttributeDefaultFields(md.Attributes)
 	setAttributeDefaultFields(md.ResourceAttributes)
+	setMetricDefaultFields(md.Metrics)
+	setMetricDefaultFields(md.Telemetry.Metrics)
 
 	return md, nil
 }

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -27,12 +27,13 @@ func setAttributeDefaultFields(attrs map[AttributeName]Attribute) {
 
 func setMetricDefaultFields(metrics map[MetricName]Metric) {
 	for k, v := range metrics {
-		if v.Name == "" {
-			keyStr := string(k)
-			if idx := strings.Index(keyStr, "/"); idx != -1 {
-				v.Name = keyStr[:idx]
-				metrics[k] = v
+		keyStr := string(k)
+		if withoutSlash, _, found := strings.Cut(keyStr, "/"); found {
+			v.Versioned = true
+			if v.Name == "" {
+				v.Name = withoutSlash
 			}
+			metrics[k] = v
 		}
 	}
 }

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -688,7 +688,7 @@ func TestSetMetricDefaultFields(t *testing.T) {
 				"system.cpu.time/v2": {Signal: Signal{Description: "test"}},
 			},
 			expected: map[MetricName]Metric{
-				"system.cpu.time/v2": {Name: "system.cpu.time", Signal: Signal{Description: "test"}},
+				"system.cpu.time/v2": {Name: "system.cpu.time", Signal: Signal{Description: "test"}, Versioned: true},
 			},
 		},
 		{

--- a/cmd/mdatagen/internal/metric.go
+++ b/cmd/mdatagen/internal/metric.go
@@ -32,6 +32,11 @@ func (mn MetricName) RenderUnexported() (string, error) {
 type Metric struct {
 	Signal `mapstructure:",squash"`
 
+	// Name overrides the emitted metric name. If not set, the map key is used.
+	// This is useful for versioned metrics where the config key is "metric.name/v2"
+	// but the emitted metric name should be "metric.name".
+	Name string `mapstructure:"name"`
+
 	// Optional can be used to specify metrics that may
 	// or may not be present in all cases, depending on configuration.
 	Optional bool `mapstructure:"optional"`
@@ -48,6 +53,13 @@ type Metric struct {
 
 	// Override the default prefix for the metric name.
 	Prefix string `mapstructure:"prefix"`
+}
+
+func (m Metric) EmittedMetricName(mapKey MetricName) string {
+	if m.Name != "" {
+		return m.Name
+	}
+	return string(mapKey)
 }
 
 type Stability struct {

--- a/cmd/mdatagen/internal/metric.go
+++ b/cmd/mdatagen/internal/metric.go
@@ -37,6 +37,10 @@ type Metric struct {
 	// but the emitted metric name should be "metric.name".
 	Name string `mapstructure:"name"`
 
+	// This indicates if the metric is versioned are not. This helps with generated code.
+	// The reason for this is if the metric is versioned a metric name can be duplicated.
+	Versioned bool `mapstructure:"-"`
+
 	// Optional can be used to specify metrics that may
 	// or may not be present in all cases, depending on configuration.
 	Optional bool `mapstructure:"optional"`

--- a/cmd/mdatagen/internal/sampleconnector/documentation.md
+++ b/cmd/mdatagen/internal/sampleconnector/documentation.md
@@ -12,6 +12,7 @@ metrics:
     enabled: false
 ```
 
+
 ### default.metric
 
 Monotonic cumulative sum int metric enabled by default.
@@ -32,6 +33,7 @@ The metric will be become optional soon.
 | slice_attr | Attribute with a slice value. | Any Slice | Recommended |
 | map_attr | Attribute with a map value. | Any Map | Recommended |
 
+
 ### default.metric.to_be_removed
 
 [DEPRECATED] Non-monotonic delta sum double metric enabled by default.
@@ -41,6 +43,7 @@ The metric will be removed soon.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Double | Delta | false | Deprecated |
+
 
 ### metric.input_type
 
@@ -59,6 +62,7 @@ Monotonic cumulative sum int metric with string input_type enabled by default.
 | enum_attr | Attribute with a known set of string values. | Str: ``red``, ``green``, ``blue`` | Recommended |
 | slice_attr | Attribute with a slice value. | Any Slice | Recommended |
 | map_attr | Attribute with a map value. | Any Map | Recommended |
+
 
 ### reaggregate.metric
 
@@ -85,6 +89,7 @@ metrics:
     enabled: true
 ```
 
+
 ### optional.metric
 
 [DEPRECATED] Gauge double metric disabled by default.
@@ -100,6 +105,7 @@ metrics:
 | string_attr | Attribute with any string value. | Any Str | Recommended |
 | boolean_attr | Attribute with a boolean value. | Any Bool | Recommended |
 | boolean_attr2 | Another attribute with a boolean value. | Any Bool | Recommended |
+
 
 ### optional.metric.empty_unit
 

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_metrics_test.go
@@ -110,21 +110,18 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordDefaultMetricDataPoint(ts, 1, "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"})
 			if tt.name == "reaggregate_set" {
 				mb.RecordDefaultMetricDataPoint(ts, 3, "string_attr-val-2", 20, AttributeEnumAttrGreen, []any{"slice_attr-item3", "slice_attr-item4"}, map[string]any{"key3": "map_attr-val3", "key4": "map_attr-val4"})
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordDefaultMetricToBeRemovedDataPoint(ts, 1)
 			if tt.name == "reaggregate_set" {
 				mb.RecordDefaultMetricToBeRemovedDataPoint(ts, 3)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMetricInputTypeDataPoint(ts, "1", "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"})
@@ -143,7 +140,6 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordOptionalMetricEmptyUnitDataPoint(ts, 3, "string_attr-val-2", false)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordReaggregateMetricDataPoint(ts, 1, "string_attr-val", true)

--- a/cmd/mdatagen/internal/samplereceiver/documentation.md
+++ b/cmd/mdatagen/internal/samplereceiver/documentation.md
@@ -12,6 +12,7 @@ metrics:
     enabled: false
 ```
 
+
 ### default.metric
 
 Monotonic cumulative sum int metric enabled by default.
@@ -35,6 +36,7 @@ The metric will be become optional soon.
 | conditional_string_attr | A conditional attribute with any string value | Any Str | Conditionally Required |
 | opt_in_bool_attr | An opt-in attribute with a boolean value | Any Bool | Opt-In |
 
+
 ### default.metric.to_be_removed
 
 [DEPRECATED] Non-monotonic delta sum double metric enabled by default.
@@ -44,6 +46,7 @@ The metric will be removed soon.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Double | Delta | false | Deprecated |
+
 
 ### metric.input_type
 
@@ -63,6 +66,7 @@ Monotonic cumulative sum int metric with string input_type enabled by default.
 | slice_attr | Attribute with a slice value. | Any Slice | Recommended |
 | map_attr | Attribute with a map value. | Any Map | Recommended |
 
+
 ### reaggregate.metric
 
 Metric for testing spatial reaggregation
@@ -77,6 +81,7 @@ Metric for testing spatial reaggregation
 | ---- | ----------- | ------ | -------- |
 | string_attr | Attribute with any string value. | Any Str | Recommended |
 | boolean_attr | Attribute with a boolean value. | Any Bool | Recommended |
+
 
 ### reaggregate.metric.with_required
 
@@ -93,6 +98,7 @@ Metric for testing spatial reaggregation with required attributes
 | required_string_attr | A required attribute with a string value | Any Str | Required |
 | string_attr | Attribute with any string value. | Any Str | Recommended |
 | boolean_attr | Attribute with a boolean value. | Any Bool | Recommended |
+
 
 ### system.cpu.time
 
@@ -114,6 +120,7 @@ metrics:
     enabled: true
 ```
 
+
 ### optional.metric
 
 [DEPRECATED] Gauge double metric disabled by default.
@@ -130,6 +137,7 @@ metrics:
 | boolean_attr | Attribute with a boolean value. | Any Bool | Recommended |
 | boolean_attr2 | Another attribute with a boolean value. | Any Bool | Recommended |
 | conditional_string_attr | A conditional attribute with any string value | Any Str | Conditionally Required |
+
 
 ### optional.metric.empty_unit
 

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics_test.go
@@ -112,21 +112,18 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordDefaultMetricDataPoint(ts, 1, "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"}, true, WithConditionalIntAttrMetricAttribute(20), WithConditionalStringAttrMetricAttribute("conditional_string_attr-val"))
 			if tt.name == "reaggregate_set" {
 				mb.RecordDefaultMetricDataPoint(ts, 3, "string_attr-val-2", 20, AttributeEnumAttrGreen, []any{"slice_attr-item3", "slice_attr-item4"}, map[string]any{"key3": "map_attr-val3", "key4": "map_attr-val4"}, false, WithConditionalIntAttrMetricAttribute(20), WithConditionalStringAttrMetricAttribute("conditional_string_attr-val"))
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordDefaultMetricToBeRemovedDataPoint(ts, 1)
 			if tt.name == "reaggregate_set" {
 				mb.RecordDefaultMetricToBeRemovedDataPoint(ts, 3)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMetricInputTypeDataPoint(ts, "1", "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"})
@@ -145,21 +142,18 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordOptionalMetricEmptyUnitDataPoint(ts, 3, "string_attr-val-2", false)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordReaggregateMetricDataPoint(ts, 1, "string_attr-val", true)
 			if tt.name == "reaggregate_set" {
 				mb.RecordReaggregateMetricDataPoint(ts, 3, "string_attr-val-2", false)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordReaggregateMetricWithRequiredDataPoint(ts, 1, "required_string_attr-val", "string_attr-val", true)
 			if tt.name == "reaggregate_set" {
 				mb.RecordReaggregateMetricWithRequiredDataPoint(ts, 3, "required_string_attr-val", "string_attr-val-2", false)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemCPUTimeDataPoint(ts, 1)

--- a/cmd/mdatagen/internal/samplescraper/documentation.md
+++ b/cmd/mdatagen/internal/samplescraper/documentation.md
@@ -12,6 +12,7 @@ metrics:
     enabled: false
 ```
 
+
 ### default.metric
 
 Monotonic cumulative sum int metric enabled by default.
@@ -32,6 +33,7 @@ The metric will be become optional soon.
 | slice_attr | Attribute with a slice value. | Any Slice | Recommended |
 | map_attr | Attribute with a map value. | Any Map | Recommended |
 
+
 ### default.metric.to_be_removed
 
 [DEPRECATED] Non-monotonic delta sum double metric enabled by default.
@@ -41,6 +43,7 @@ The metric will be removed soon.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Double | Delta | false | Deprecated |
+
 
 ### metric.input_type
 
@@ -60,6 +63,7 @@ Monotonic cumulative sum int metric with string input_type enabled by default.
 | slice_attr | Attribute with a slice value. | Any Slice | Recommended |
 | map_attr | Attribute with a map value. | Any Map | Recommended |
 
+
 ### reaggregate.metric
 
 Metric for testing spacial reaggregation
@@ -74,6 +78,7 @@ Metric for testing spacial reaggregation
 | ---- | ----------- | ------ | -------- |
 | string_attr | Attribute with any string value. | Any Str | Recommended |
 | boolean_attr | Attribute with a boolean value. | Any Bool | Recommended |
+
 
 ### system.cpu.time
 
@@ -95,6 +100,7 @@ metrics:
     enabled: true
 ```
 
+
 ### optional.metric
 
 [DEPRECATED] Gauge double metric disabled by default.
@@ -110,6 +116,7 @@ metrics:
 | string_attr | Attribute with any string value. | Any Str | Recommended |
 | boolean_attr | Attribute with a boolean value. | Any Bool | Recommended |
 | boolean_attr2 | Another attribute with a boolean value. | Any Bool | Recommended |
+
 
 ### optional.metric.empty_unit
 

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_metrics_test.go
@@ -111,21 +111,18 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordDefaultMetricDataPoint(ts, 1, "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"})
 			if tt.name == "reaggregate_set" {
 				mb.RecordDefaultMetricDataPoint(ts, 3, "string_attr-val-2", 20, AttributeEnumAttrGreen, []any{"slice_attr-item3", "slice_attr-item4"}, map[string]any{"key3": "map_attr-val3", "key4": "map_attr-val4"})
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordDefaultMetricToBeRemovedDataPoint(ts, 1)
 			if tt.name == "reaggregate_set" {
 				mb.RecordDefaultMetricToBeRemovedDataPoint(ts, 3)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMetricInputTypeDataPoint(ts, "1", "string_attr-val", 19, AttributeEnumAttrRed, []any{"slice_attr-item1", "slice_attr-item2"}, map[string]any{"key1": "map_attr-val1", "key2": "map_attr-val2"})
@@ -144,14 +141,12 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordOptionalMetricEmptyUnitDataPoint(ts, 3, "string_attr-val-2", false)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordReaggregateMetricDataPoint(ts, 1, "string_attr-val", true)
 			if tt.name == "reaggregate_set" {
 				mb.RecordReaggregateMetricDataPoint(ts, 3, "string_attr-val-2", false)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemCPUTimeDataPoint(ts, 1)

--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -2,7 +2,12 @@
 {{- $metricName := . }}
 {{- $metric := $metricName | metricInfo -}}
 
+{{- if $metric.Name }}
+### {{ $metric.Name }}
+Configuration key: `{{ $metricName }}`
+{{- else }}
 ### {{ $metricName }}
+{{- end }}
 
 {{ $metric.Description }}
 

--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -71,11 +71,15 @@ var MapAttribute{{ $name.Render }} = map[string]Attribute{{ $name.Render }}{
 {{- end }}
 
 var MetricsInfo = metricsInfo{
-    {{- range $name, $metric := .Metrics }}
-    {{ $name.Render }}: metricInfo{
-        Name: "{{ $name }}",
-    },
-    {{- end }}
+  {{- range $name, $metric := .Metrics }}
+  {{ $name.Render }}: metricInfo{
+      {{- if $metric.Name }}
+      Name: "{{ $metric.Name }}",
+      {{- else }}
+      Name: "{{ $name }}",
+      {{- end }}
+  },
+  {{- end }}
 }
 
 type metricsInfo struct {
@@ -120,7 +124,11 @@ type metric{{ $name.Render }} struct {
 
 // init fills {{ $name }} metric with initial data.
 func (m *metric{{ $name.Render }}) init() {
-	m.data.SetName("{{ $name }}")
+  {{- if $metric.Name }}
+  m.data.SetName("{{ $metric.Name }}")
+  {{- else }}
+  m.data.SetName("{{ $name }}")
+  {{- end }}
 	m.data.SetDescription("{{ $metric.Description }}")
 	m.data.SetUnit("{{ $metric.Unit }}")
 	m.data.SetEmpty{{ $metric.Data.Type }}()

--- a/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
@@ -140,6 +140,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount := 0
 			{{- range $name, $metric := .Metrics }}
 
+      {{- if not $metric.Versioned }}
 				{{ if $metric.Enabled }}defaultMetricsCount++{{ end }}
 				allMetricsCount++
 				mb.Record{{ $name.Render }}DataPoint(ts, {{ if $metric.Data.HasMetricInputType }}"1"{{ else }}1{{ end }}
@@ -175,6 +176,7 @@ func TestMetricsBuilder(t *testing.T) {
         }
         {{- end }}
 			{{- end }}
+      {{- end }}
 
 			{{ if .ResourceAttributes }}
 			rb := mb.NewResourceBuilder()
@@ -211,7 +213,8 @@ func TestMetricsBuilder(t *testing.T) {
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
 				{{- range $name, $metric := .Metrics }}
-				case "{{ $name }}":
+        {{- if not $metric.Versioned }}
+        case "{{- if $metric.Name }}{{ $metric.Name }}{{ else }}{{ $name }}{{ end }}":
           {{- if $reag }}
           if tt.name != "reaggregate_set" {
             assert.False(t, validatedMetrics["{{ $name }}"], "Found a duplicate in the metrics slice: {{ $name }}")
@@ -351,6 +354,7 @@ func TestMetricsBuilder(t *testing.T) {
 					{{- if or (eq (attributeInfo $attr).Type.String "Slice") (eq (attributeInfo $attr).Type.String "Map")}}.AsRaw(){{ end }})
 					{{- end }}
           {{- end }}
+        {{- end }}
 				{{- end }}
 				}
 			}

--- a/cmd/mdatagen/internal/testdata/versioned_metric.yaml
+++ b/cmd/mdatagen/internal/testdata/versioned_metric.yaml
@@ -1,0 +1,50 @@
+type: test_versioned
+sem_conv_version: 1.9.0
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: []
+attributes:
+  state:
+    description: CPU state
+    type: string
+    enum: [idle, user, system]
+metrics:
+  # Legacy metric - uses map key as emitted name
+  system.cpu.time:
+    enabled: true
+    description: Legacy CPU time metric
+    stability:
+      level: deprecated
+    unit: s
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [state]
+    warnings:
+      if_enabled: This metric is deprecated, use system.cpu.time/v2 instead.
+  # New semconv metric - different config key, same emitted name
+  system.cpu.time/v2:
+    name: system.cpu.time
+    enabled: false
+    description: CPU time metric per new semantic conventions
+    stability:
+      level: beta
+    unit: s
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [state]
+  # Metric with explicit name override (different from key)
+  custom.metric.key:
+    name: actual.metric.name
+    enabled: true
+    description: Metric with custom name
+    stability:
+      level: alpha
+    unit: "1"
+    gauge:
+      value_type: int

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -112,6 +112,10 @@ attributes:
 # being described below.
 metrics:
   <metric.name>:
+    # Optional: overrides the emitted metric name. If not set, the map key is used.
+    # Useful for versioned metrics where the config key differs from the emitted name.
+    # Example: key "system.cpu.frequency/v2" with name "system.cpu.frequency"
+    name: string
     # Required: whether the metric is collected by default.
     enabled: bool
     # Required: metric description.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This POC shows how to handle versioned metrics in mdatagen.

Here we introduce the concept of the `name` field on the metrics struct. This allows us to override the name.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
