### PR TITLE
exporter/otlphttp: use byte-based batching with default max request size

### DIFF
--- a/.chloggen/otlphttp-batch-maxsize-bytes.yaml
+++ b/.chloggen/otlphttp-batch-maxsize-bytes.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporter/otlp_http
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+   Change default batching strategy from item-based to byte-based and
+   introduce a default max request size (20 MiB) to align with OTLP HTTP
+   receiver limits, preventing HTTP 400 errors due to oversized payloads.
+
+
+# One or more tracking issues or pull requests related to the change
+issues: [15177]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -57,10 +57,11 @@ func TestUnmarshalConfig(t *testing.T) {
 				Sizer:        exporterhelper.RequestSizerTypeRequests,
 				NumConsumers: 2,
 				QueueSize:    10,
-				Batch: configoptional.Default(exporterhelper.BatchConfig{
-					Sizer:        exporterhelper.RequestSizerTypeItems,
+				Batch: configoptional.Some(exporterhelper.BatchConfig{
+					Sizer:        exporterhelper.RequestSizerTypeBytes,
 					FlushTimeout: 200 * time.Millisecond,
-					MinSize:      8192,
+					MinSize:      0,
+					MaxSize:      defaultMaxRequestBodySize,
 				}),
 			}),
 			Encoding: EncodingProto,

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -27,6 +27,14 @@ import (
 	"go.opentelemetry.io/collector/exporter/xexporter"
 )
 
+const (
+	// defaultMaxRequestBodySize is the default maximum size of a batch in bytes.
+	// It matches the default MaxRequestBodySize of the otlpreceiver (20 MiB),
+	// preventing permanent HTTP 400 errors when sending to a default otlp/http receiver.
+	// See https://github.com/open-telemetry/opentelemetry-collector/issues/15177
+	defaultMaxRequestBodySize = 20 * 1024 * 1024 // 20 MiB
+)
+
 // NewFactory creates a factory for OTLP exporter.
 func NewFactory() exporter.Factory {
 	return xexporter.NewFactory(
@@ -48,9 +56,17 @@ func createDefaultConfig() component.Config {
 	// We almost read 0 bytes, so no need to tune ReadBufferSize.
 	clientConfig.WriteBufferSize = 512 * 1024
 
+	queueCfg := exporterhelper.NewDefaultQueueConfig()
+
+	queueCfg.Batch = configoptional.Some(exporterhelper.BatchConfig{
+		FlushTimeout: 200 * time.Millisecond,
+		Sizer:        exporterhelper.RequestSizerTypeBytes,
+		MinSize:      0,
+		MaxSize:      defaultMaxRequestBodySize,
+	})
 	return &Config{
 		RetryConfig:  configretry.NewDefaultBackOffConfig(),
-		QueueConfig:  configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+		QueueConfig:  configoptional.Some(queueCfg),
 		Encoding:     EncodingProto,
 		ClientConfig: clientConfig,
 	}

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -20,11 +20,26 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/xexporter"
 	"go.opentelemetry.io/collector/internal/testutil"
 )
 
+func TestCreateDefaultConfig_BatchMaxSizeBytes(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+
+	require.True(t, cfg.QueueConfig.HasValue(), "QueueConfig should have a value")
+	queueCfg := cfg.QueueConfig.Get()
+
+	require.True(t, queueCfg.Batch.HasValue(), "Batch should be set")
+	batchCfg := queueCfg.Batch.Get()
+	require.NotNil(t, batchCfg)
+
+	assert.Equal(t, exporterhelper.RequestSizerTypeBytes, batchCfg.Sizer)
+	assert.Equal(t, int64(defaultMaxRequestBodySize), batchCfg.MaxSize)
+	assert.Greater(t, batchCfg.FlushTimeout, time.Duration(0))
+}
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -40,6 +40,7 @@ func TestCreateDefaultConfig_BatchMaxSizeBytes(t *testing.T) {
 	assert.Equal(t, int64(defaultMaxRequestBodySize), batchCfg.MaxSize)
 	assert.Greater(t, batchCfg.FlushTimeout, time.Duration(0))
 }
+
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()


### PR DESCRIPTION
## Description

This change updates the default batching configuration for the OTLP HTTP exporter:

- Switches batch sizer from `items` to `bytes`
- Introduces `defaultMaxRequestBodySize` (20 MiB)
- Aligns exporter defaults with OTLP HTTP receiver limits

Previously, batching was based on item count, which could produce payloads exceeding
the OTLP HTTP receiver’s default `MaxRequestBodySize` (20 MiB). This resulted in
permanent HTTP 400 errors.

By switching to byte-based batching and enforcing a max size aligned with the receiver,
we prevent oversized requests and improve reliability out-of-the-box.

## Changes

- Added `defaultMaxRequestBodySize` constant (20 MiB)
- Updated default queue batch config:
  - `Sizer: bytes`
  - `MaxSize: 20 MiB`
  - `MinSize: 0`
- Updated config tests
- Added `TestCreateDefaultConfig_BatchMaxSizeBytes`

## Testing

- Updated existing tests
- Added validation for:
  - batch sizer type
  - max size
  - flush timeout > 0

## Related Issues

Fixes #15177