### PR TITLE
[chore] [exporterhelper] fix flaky test

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/disabled_batcher_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/disabled_batcher_test.go
@@ -6,6 +6,7 @@ package queuebatch
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -35,7 +36,15 @@ func TestDisabledBatcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := requesttest.NewSink()
-			ba := newDisabledBatcher(sink.Export)
+			var exportCalls atomic.Int64
+			var attemptedItemCount atomic.Int64
+			exportFunc := func(ctx context.Context, req request.Request) error {
+				err := sink.Export(ctx, req)
+				attemptedItemCount.Add(int64(req.ItemsCount()))
+				exportCalls.Add(1)
+				return err
+			}
+			ba := newDisabledBatcher(exportFunc)
 
 			q, err := queue.NewQueue(queue.Settings[request.Request]{
 				Capacity:        1000,
@@ -52,16 +61,32 @@ func TestDisabledBatcher(t *testing.T) {
 				require.NoError(t, ba.Shutdown(context.Background()))
 			})
 
-			require.NoError(t, q.Offer(context.Background(), &requesttest.FakeRequest{Items: 8}))
+			var offers int
+			var offeredItemCount int
+			offerItems := func(items int) {
+				offers++
+				offeredItemCount += items
+				require.NoError(t, q.Offer(context.Background(), &requesttest.FakeRequest{Items: items}))
+			}
+
+			// Create batches of 8 items per num_consumers, and arrange for one to fail.
 			sink.SetExportErr(errors.New("transient error"))
-			require.NoError(t, q.Offer(context.Background(), &requesttest.FakeRequest{Items: 8}))
-			require.NoError(t, q.Offer(context.Background(), &requesttest.FakeRequest{Items: 17}))
-			require.NoError(t, q.Offer(context.Background(), &requesttest.FakeRequest{Items: 13}))
-			require.NoError(t, q.Offer(context.Background(), &requesttest.FakeRequest{Items: 35}))
-			require.NoError(t, q.Offer(context.Background(), &requesttest.FakeRequest{Items: 2}))
-			assert.Eventually(t, func() bool {
-				return sink.RequestsCount() == 5 && sink.ItemsCount() == 75
-			}, 1*time.Second, 10*time.Millisecond)
+			for range tt.maxWorkers {
+				offerItems(8)
+			}
+			offerItems(17)
+			offerItems(13)
+			offerItems(35)
+			offerItems(2)
+
+			assert.EventuallyWithT(t, func(t *assert.CollectT) {
+				assert.Equal(t, int64(offers), exportCalls.Load())
+				assert.Equal(t, int64(offeredItemCount), attemptedItemCount.Load())
+			}, time.Second, 10*time.Millisecond)
+
+			// One of the 8-item requests failed,
+			assert.Equal(t, offers-1, sink.RequestsCount())
+			assert.Equal(t, offeredItemCount-8, sink.ItemsCount())
 		})
 	}
 }


### PR DESCRIPTION
#### Description

Fixes a race in TestDisabledBatcher/three_workers.

It was possible for the first two 8-item requests to be dequeued, and then the third request to be dequeued and hit the exporter error case. We fix this by sending as many 8-item requests as there are workers, and then verifying that one of them doesn't get counted in the successfully exported request stats.

#### Link to tracking issue

None

#### Testing

Ran the test in a loop.

#### Documentation

N/A