### PR TITLE
[xextension/storage] Add Walker interface for storage extensions

### DIFF
--- a/.chloggen/storage-walker-interface.yaml
+++ b/.chloggen/storage-walker-interface.yaml
@@ -1,0 +1,11 @@
+# Use this changelog template to create an entry for release notes.
+
+change_type: enhancement
+component: pkg/xextension/storage
+note: Add Walker interface, WalkFunc type, and SkipAll error value to support iterating over storage key/value entries.
+issues: [15190, 15191]
+subtext: |
+  A storage Client may optionally implement the Walker interface to allow
+  consumers to range through all stored entries. This enables use cases such
+  as storage migrations and TTL-based garbage collection.
+change_logs: [api]

--- a/extension/xextension/storage/README.md
+++ b/extension/xextension/storage/README.md
@@ -36,3 +36,23 @@ Get operation results are stored in-place into the given Operation and can be re
 Note: All methods should return error only if a problem occurred. (For example, if a file is no longer accessible, or if a remote service is unavailable.)
 
 Note: It is the responsibility of each component to `Close` a storage client that it has requested.
+
+## Walking storage entries
+
+A `storage.Client` may optionally implement the `storage.Walker` interface to support iterating over all key/value entries:
+```
+Walk(context.Context, WalkFunc) error
+```
+
+The `WalkFunc` callback is called for every key/value pair. Key order is not guaranteed.
+
+The callback returns a slice of `Operation` and an error:
+```
+WalkFunc = func(key string, value []byte) ([]*Operation, error)
+```
+
+Operations returned by `WalkFunc` are collected during the walk and applied in order when the walk completes successfully or when `SkipAll` is returned. Returning a `nil` slice is valid and contributes no operations.
+
+All operation types (`Get`, `Set`, `Delete`) are valid in the returned slice. `Get` operations work as usual — the result is stored in the `Operation` instance.
+
+If `WalkFunc` returns the `SkipAll` error, the walk stops early and all collected operations are still applied. If `WalkFunc` returns any other non-nil error, or if the walk encounters an internal error, the walk stops and no collected operations are applied.

--- a/extension/xextension/storage/storage.go
+++ b/extension/xextension/storage/storage.go
@@ -54,6 +54,49 @@ type Client interface {
 	Close(ctx context.Context) error
 }
 
+// WalkFunc is the type of the function called by Walk to visit each entry in the storage.
+//
+// The key argument contains the key of the stored entry.
+// Key order is not guaranteed and may vary between storage implementations.
+//
+// The value bytes are only valid for the duration of the
+// function call and need to be copied if later access is needed.
+//
+// The function may return operations that are collected and applied in order
+// either when the end of the Walk is reached or after SkipAll is returned.
+// Returning a nil slice is valid and simply contributes no operations.
+// All operation types (Get, Set, Delete) are valid in the returned slice.
+// Get operations work as usual — the result is stored in the Operation instance.
+//
+// If the storage supports transactions, all returned operations must be
+// applied in the same transaction the key/value entries for WalkFunc were obtained from.
+//
+// The error result returned by the function controls how Walk continues:
+//
+// If the function returns the special value SkipAll, Walk skips all remaining
+// storage entries and all collected operations still get applied in order.
+//
+// Otherwise, if the function returns a non-nil error,
+// Walk stops entirely and returns that error without applying
+// any of the collected operations.
+type WalkFunc func(key string, value []byte) ([]*Operation, error)
+
+// SkipAll is used as a return value from WalkFunc to indicate that
+// all remaining storage entries are to be skipped.
+// The pending operations are still applied.
+var SkipAll = errors.New("skip everything and stop the walk")
+
+// Walker is the interface that a storage extension Client may implement
+// in order to support ranging through the storage entries.
+type Walker interface {
+	// Walk calls fn for every key/value pair in the storage.
+	//
+	// If fn returns a non-nil error other than SkipAll, or if Walk
+	// encounters an internal error, ranging stops immediately and no
+	// collected operations are applied.
+	Walk(ctx context.Context, fn WalkFunc) error
+}
+
 type OpType int
 
 const (

--- a/extension/xextension/storage/storage.go
+++ b/extension/xextension/storage/storage.go
@@ -84,7 +84,7 @@ type WalkFunc func(key string, value []byte) ([]*Operation, error)
 // SkipAll is used as a return value from WalkFunc to indicate that
 // all remaining storage entries are to be skipped.
 // The pending operations are still applied.
-var SkipAll = errors.New("skip everything and stop the walk") //nolint // mimics the existing API in the standard library, see filepath
+var SkipAll = errors.New("skip everything and stop the walk") //nolint:revive // mimics the existing API in the standard library, see filepath
 
 // Walker is the interface that a storage extension Client may implement
 // in order to support ranging through the storage entries.

--- a/extension/xextension/storage/storage.go
+++ b/extension/xextension/storage/storage.go
@@ -84,7 +84,7 @@ type WalkFunc func(key string, value []byte) ([]*Operation, error)
 // SkipAll is used as a return value from WalkFunc to indicate that
 // all remaining storage entries are to be skipped.
 // The pending operations are still applied.
-var SkipAll = errors.New("skip everything and stop the walk")
+var SkipAll = errors.New("skip everything and stop the walk") // nolint // mimics the existing API in the standard library, see filepath
 
 // Walker is the interface that a storage extension Client may implement
 // in order to support ranging through the storage entries.

--- a/extension/xextension/storage/storage.go
+++ b/extension/xextension/storage/storage.go
@@ -84,7 +84,7 @@ type WalkFunc func(key string, value []byte) ([]*Operation, error)
 // SkipAll is used as a return value from WalkFunc to indicate that
 // all remaining storage entries are to be skipped.
 // The pending operations are still applied.
-var SkipAll = errors.New("skip everything and stop the walk") // nolint // mimics the existing API in the standard library, see filepath
+var SkipAll = errors.New("skip everything and stop the walk") //nolint // mimics the existing API in the standard library, see filepath
 
 // Walker is the interface that a storage extension Client may implement
 // in order to support ranging through the storage entries.

--- a/extension/xextension/storage/storage.go
+++ b/extension/xextension/storage/storage.go
@@ -84,7 +84,7 @@ type WalkFunc func(key string, value []byte) ([]*Operation, error)
 // SkipAll is used as a return value from WalkFunc to indicate that
 // all remaining storage entries are to be skipped.
 // The pending operations are still applied.
-var SkipAll = errors.New("skip everything and stop the walk") //nolint:revive // mimics the existing API in the standard library, see filepath
+var SkipAll = errors.New("skip everything and stop the walk") //nolint:revive,staticcheck // mimics the existing API in the standard library, see filepath
 
 // Walker is the interface that a storage extension Client may implement
 // in order to support ranging through the storage entries.


### PR DESCRIPTION
#### Description

Introduce `Walker` interface, `WalkFunc` type, and `SkipAll` error value to support iterating over storage key/value entries.

This enables consumers to implement storage migrations or any functionality that involves ranging through the storage entries.

One of the examples of such functionality may be a TTL-based garbage collection. Values can have a TTL marker, a routine runs with an interval iterating through entries searching for expired entries. `WalkFunc` produces `Delete` operations for each expired entry.

The type names and the interface is close to the ones in [`filepath`](https://pkg.go.dev/path/filepath#WalkFunc) package of the standard library.

Example: TTL-based garbage collection using `Walker`

This example shows how to use the `Walker` interface to implement a TTL-based
garbage collection routine. Each stored value carries a TTL marker (an expiration
timestamp prefix). A periodic routine walks all entries, and the `WalkFunc`
produces `Delete` operations for every expired entry.

Values are prefixed with an 8-byte big-endian Unix timestamp (seconds) that
represents the expiration time. The rest of the bytes are the actual payload.

```go
import (
	"encoding/binary"
	"time"
)

func encodeWithTTL(value []byte, ttl time.Duration) []byte {
	expireAt := time.Now().Add(ttl).Unix()
	buf := make([]byte, 8+len(value))
	binary.BigEndian.PutUint64(buf[:8], uint64(expireAt))
	copy(buf[8:], value)
	return buf
}

func decodeExpiration(value []byte) (time.Time, []byte) {
	ts := binary.BigEndian.Uint64(value[:8])
	return time.Unix(int64(ts), 0), value[8:]
}
```

Garbage collection with `Walk`:

```go
import (
	"context"
	"fmt"
	"time"

	"go.opentelemetry.io/collector/extension/xextension/storage"
)

func collectExpired(ctx context.Context, client storage.Client) error {
	walker, ok := client.(storage.Walker)
	if !ok {
		return fmt.Errorf("storage client does not implement Walker")
	}

	now := time.Now()
	return walker.Walk(ctx, func(key string, value []byte) ([]*storage.Operation, error) {
		if len(value) < 8 {
			return nil, nil
		}
		expireAt, _ := decodeExpiration(value)
		if now.After(expireAt) {
			return []*storage.Operation{storage.DeleteOperation(key)}, nil
		}
		return nil, nil
	})
}
```

All `Delete` operations returned by the `WalkFunc` are collected during the walk
and applied atomically once the iteration completes. If the callback returns a
non-nil error (other than `SkipAll`), or if the walk encounters an internal
error, no operations are applied.

<!--Describe the documentation added.-->
#### Documentation

The package's README.md has been updated. The new types have been fully documented.


Closes https://github.com/open-telemetry/opentelemetry-collector/issues/15191
