### PR TITLE
Update mdatagen to handle nested projects

### DIFF
--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -86,13 +86,47 @@ var componentTypes = []string{
 }
 
 func shortFolderName(filePath string) string {
-	parentFolder := filepath.Base(filepath.Dir(filePath))
-	for _, cType := range componentTypes {
-		if before, ok := strings.CutSuffix(parentFolder, cType); ok {
-			return before
+	// Get the directory containing metadata.yaml
+	componentDir := filepath.Dir(filePath)
+
+	// Split the path into parts to find the component type folder
+	parts := strings.Split(filepath.ToSlash(componentDir), "/")
+
+	// Find the component type in the path (e.g., "extension", "receiver")
+	var componentTypeIndex = -1
+	for i, part := range parts {
+		for _, cType := range componentTypes {
+			if part == cType {
+				componentTypeIndex = i
+				break
+			}
+		}
+		if componentTypeIndex != -1 {
+			break
 		}
 	}
-	return parentFolder
+
+	// If we found a component type folder, get everything after it
+	var pathAfterComponentType string
+	if componentTypeIndex != -1 && componentTypeIndex < len(parts)-1 {
+		pathAfterComponentType = strings.Join(parts[componentTypeIndex+1:], "/")
+	} else {
+		// Fallback to just the parent folder name
+		pathAfterComponentType = filepath.Base(componentDir)
+	}
+
+	// Strip component type suffix from the final directory name only
+	pathParts := strings.Split(pathAfterComponentType, "/")
+	lastPart := pathParts[len(pathParts)-1]
+
+	for _, cType := range componentTypes {
+		if before, ok := strings.CutSuffix(lastPart, cType); ok {
+			pathParts[len(pathParts)-1] = before
+			return strings.Join(pathParts, "/")
+		}
+	}
+
+	return pathAfterComponentType
 }
 
 func packageName(filePath string) (string, error) {

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -36,6 +36,57 @@ func TestTwoPackagesInDirectory(t *testing.T) {
 	require.ErrorContains(t, err, "unable to determine package name: [go list -f {{.ImportPath}}] failed: (stderr) found packages package1 (package1.go) and package2 (package2.go)")
 }
 
+func TestShortFolderName(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		want     string
+	}{
+		{
+			name:     "simple receiver",
+			filePath: "receiver/samplereceiver/metadata.yaml",
+			want:     "sample",
+		},
+		{
+			name:     "simple extension",
+			filePath: "extension/filestorage/metadata.yaml",
+			want:     "filestorage",
+		},
+		{
+			name:     "extension with suffix",
+			filePath: "extension/filestorageextension/metadata.yaml",
+			want:     "filestorage",
+		},
+		{
+			name:     "nested storage extension",
+			filePath: "extension/storage/filestorage/metadata.yaml",
+			want:     "storage/filestorage",
+		},
+		{
+			name:     "nested storage extension with suffix",
+			filePath: "extension/storage/redisstorageextension/metadata.yaml",
+			want:     "storage/redisstorage",
+		},
+		{
+			name:     "deeply nested",
+			filePath: "receiver/hostmetrics/cpu/cpureceiver/metadata.yaml",
+			want:     "hostmetrics/cpu/cpu",
+		},
+		{
+			name:     "no component type in path",
+			filePath: "testdata/metadata.yaml",
+			want:     "testdata",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shortFolderName(tt.filePath)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestLoadMetadata(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Update mdatagen to handle nested projects.

#### Description
Extensions like filestorage, dbstorage and redisstorage in otelcollector-contrib all are nested under a second directory storage. The issue labels in github correctly represents that (extension/storage/filestorage). The generated README.md does not.

#### Testing
New unit tests have been added to make sure previous behavior and new behavior cohabit.
Ran a script to identify other potential errors in opencollector-contrib and found 21 README.md that would be fixed by this change.
