### PR TITLE
feat(confignet): add Unix domain socket lifecycle management

### DIFF
--- a/.chloggen/confignet-unix-socket-lifecycle.yaml
+++ b/.chloggen/confignet-unix-socket-lifecycle.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/config/confignet
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Automatically manage Unix domain socket lifecycle in AddrConfig.Listen()
+
+# One or more tracking issues or pull requests related to the change
+issues: [15189]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  For filesystem-based Unix domain sockets, Listen() now automatically:
+  - Removes stale socket files before binding (refuses to remove non-socket files)
+  - Sets socket permissions to 0722 so any local process can connect
+  - Cleans up socket files on Close()
+  Abstract sockets (@ prefix) are unaffected. No configuration is needed.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -5,8 +5,10 @@ package confignet // import "go.opentelemetry.io/collector/config/confignet"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 )
@@ -88,6 +90,7 @@ type AddrConfig struct {
 
 	// DialerConfig contains options for connecting to an address.
 	DialerConfig DialerConfig `mapstructure:"dialer,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -113,8 +116,36 @@ func (na *AddrConfig) Listen(ctx context.Context) (net.Listener, error) {
 	if na.Transport == TransportTypeNpipe {
 		return listenNpipe(na.Endpoint)
 	}
+
+	// Filesystem-based Unix sockets need lifecycle handling:
+	// remove any stale socket before binding and clean up on close.
+	// Abstract sockets (@ prefix) live in kernel memory and need none of this.
+	isFsSocket := na.isUnixTransport() && !isAbstractSocket(na.Endpoint)
+
+	if isFsSocket {
+		if err := removeStaleSocket(na.Endpoint); err != nil {
+			return nil, fmt.Errorf("failed to clean up stale socket %q: %w", na.Endpoint, err)
+		}
+	}
+
 	lc := net.ListenConfig{}
-	return lc.Listen(ctx, string(na.Transport), na.Endpoint)
+	ln, err := lc.Listen(ctx, string(na.Transport), na.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if isFsSocket {
+		// Allow any local process to connect to the socket (owner rwx, group/other write).
+		// The write bit on a Unix socket controls connect access.
+		if err := os.Chmod(na.Endpoint, socketFileMode); err != nil {
+			_ = ln.Close()
+			_ = os.Remove(na.Endpoint)
+			return nil, fmt.Errorf("failed to set socket permissions on %q: %w", na.Endpoint, err)
+		}
+		ln = &unixListener{Listener: ln, path: na.Endpoint}
+	}
+
+	return ln, nil
 }
 
 func (na *AddrConfig) Validate() error {
@@ -137,6 +168,61 @@ func (na *AddrConfig) Validate() error {
 	default:
 		return fmt.Errorf("invalid transport type %q", na.Transport)
 	}
+}
+
+func (na *AddrConfig) isUnixTransport() bool {
+	switch na.Transport {
+	case TransportTypeUnix, TransportTypeUnixgram, TransportTypeUnixPacket:
+		return true
+	default:
+		return false
+	}
+}
+
+// socketFileMode is the permission set on Unix domain socket files.
+// Owner rwx (7), group write (2), other write (2). The write bit on a
+// Unix socket controls connect access, so 0o722 allows any local process
+// to connect while only the owner can manage the socket.
+const socketFileMode os.FileMode = 0o722
+
+// isAbstractSocket reports whether path refers to a Linux abstract Unix socket.
+// Abstract sockets live in kernel memory and have no filesystem representation.
+func isAbstractSocket(path string) bool {
+	return strings.HasPrefix(path, "@")
+}
+
+// removeStaleSocket removes a leftover socket file at path so a new
+// listener can bind. It refuses to remove non-socket files.
+// Note: there is an inherent TOCTOU race between the Stat and Remove
+// calls; this is acceptable for a startup-time code path.
+func removeStaleSocket(path string) error {
+	fi, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if fi.Mode().Type()&os.ModeSocket == 0 {
+		return fmt.Errorf("path %q exists but is not a socket (mode: %s)", path, fi.Mode())
+	}
+
+	return os.Remove(path)
+}
+
+// unixListener wraps a net.Listener for Unix domain sockets and removes
+// the socket file on Close.
+type unixListener struct {
+	net.Listener
+	path string
+}
+
+func (u *unixListener) Close() error {
+	err := u.Listener.Close()
+	// Best-effort cleanup of the socket file.
+	_ = os.Remove(u.path)
+	return err
 }
 
 // validateNpipePath validates a Windows named pipe path.

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -7,10 +7,7 @@ import (
 	"context"
 	"errors"
 	"net"
-	"os"
-	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -202,167 +199,11 @@ func Test_TransportType_UnmarshalText(t *testing.T) {
 	require.Error(t, err)
 }
 
-func Test_removeStaleSocket(t *testing.T) {
-	t.Parallel()
-	t.Run("path does not exist", func(t *testing.T) {
-		t.Parallel()
-		err := removeStaleSocket(filepath.Join(t.TempDir(), "nonexistent.sock"))
-		assert.NoError(t, err)
-	})
-
-	t.Run("path is a regular file", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "regular.txt")
-		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
-
-		err := removeStaleSocket(path)
-		assert.ErrorContains(t, err, "not a socket")
-		// File should still exist.
-		_, statErr := os.Stat(path)
-		assert.NoError(t, statErr)
-	})
-
-	t.Run("path is a stale socket", func(t *testing.T) {
-		t.Parallel()
-		// Use os.MkdirTemp with an empty base so the OS chooses a short path,
-		// avoiding the 104-character Unix socket path limit on macOS/BSD.
-		dir, err := os.MkdirTemp("", "confignet-sock-test-*")
-		require.NoError(t, err)
-		t.Cleanup(func() { os.RemoveAll(dir) })
-		path := filepath.Join(dir, "stale.sock")
-		// Create a socket file directly via syscall so it is not auto-removed
-		// when closed (Go's net.Listener.Close removes socket files on some OSes).
-		fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-		require.NoError(t, err)
-		err = syscall.Bind(fd, &syscall.SockaddrUnix{Name: path})
-		require.NoError(t, err)
-		require.NoError(t, syscall.Close(fd))
-		// Socket file should still exist after closing the fd.
-		_, err = os.Stat(path)
-		require.NoError(t, err)
-
-		err = removeStaleSocket(path)
-		assert.NoError(t, err)
-		// Socket file should be removed.
-		_, err = os.Stat(path)
-		assert.True(t, os.IsNotExist(err))
-	})
-
-}
-
 func Test_isAbstractSocket(t *testing.T) {
 	t.Parallel()
 	assert.True(t, isAbstractSocket("@abstract"))
 	assert.False(t, isAbstractSocket("/var/run/test.sock"))
 	assert.False(t, isAbstractSocket(""))
-}
-
-func Test_unixListener_Close(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "listener.sock")
-
-	ln, err := net.Listen("unix", path)
-	require.NoError(t, err)
-
-	// Socket file exists after listen.
-	_, err = os.Stat(path)
-	require.NoError(t, err)
-
-	uln := &unixListener{Listener: ln, path: path}
-	require.NoError(t, uln.Close())
-
-	// Socket file should be removed after close.
-	_, err = os.Stat(path)
-	assert.True(t, os.IsNotExist(err))
-}
-
-func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "stale.sock")
-
-	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
-	fd, sysErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-	require.NoError(t, sysErr)
-	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
-	require.NoError(t, syscall.Close(fd))
-	_, sysErr = os.Stat(path)
-	require.NoError(t, sysErr)
-
-	// Listen should succeed despite stale socket.
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, ln.Close()) })
-}
-
-func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "regular.txt")
-	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	_, err = na.Listen(context.Background())
-	assert.ErrorContains(t, err, "not a socket")
-}
-
-func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "perms.sock")
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, ln.Close()) })
-
-	fi, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
-}
-
-func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "cleanup.sock")
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-
-	_, err = os.Stat(path)
-	require.NoError(t, err)
-
-	require.NoError(t, ln.Close())
-
-	// Socket file should be removed after close.
-	_, err = os.Stat(path)
-	assert.True(t, os.IsNotExist(err))
 }
 
 func Test_AddrConfig_isUnixTransport(t *testing.T) {

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -7,7 +7,10 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -197,4 +200,195 @@ func Test_TransportType_UnmarshalText(t *testing.T) {
 	assert.Equal(t, TransportTypeNpipe, tt)
 	err = tt.UnmarshalText([]byte("invalid"))
 	require.Error(t, err)
+}
+
+func Test_removeStaleSocket(t *testing.T) {
+	t.Parallel()
+	t.Run("path does not exist", func(t *testing.T) {
+		t.Parallel()
+		err := removeStaleSocket(filepath.Join(t.TempDir(), "nonexistent.sock"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("path is a regular file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "regular.txt")
+		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+
+		err := removeStaleSocket(path)
+		assert.ErrorContains(t, err, "not a socket")
+		// File should still exist.
+		_, statErr := os.Stat(path)
+		assert.NoError(t, statErr)
+	})
+
+	t.Run("path is a stale socket", func(t *testing.T) {
+		t.Parallel()
+		// Use os.MkdirTemp with an empty base so the OS chooses a short path,
+		// avoiding the 104-character Unix socket path limit on macOS/BSD.
+		dir, err := os.MkdirTemp("", "confignet-sock-test-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		path := filepath.Join(dir, "stale.sock")
+		// Create a socket file directly via syscall so it is not auto-removed
+		// when closed (Go's net.Listener.Close removes socket files on some OSes).
+		fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+		require.NoError(t, err)
+		err = syscall.Bind(fd, &syscall.SockaddrUnix{Name: path})
+		require.NoError(t, err)
+		require.NoError(t, syscall.Close(fd))
+		// Socket file should still exist after closing the fd.
+		_, err = os.Stat(path)
+		require.NoError(t, err)
+
+		err = removeStaleSocket(path)
+		assert.NoError(t, err)
+		// Socket file should be removed.
+		_, err = os.Stat(path)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+}
+
+func Test_isAbstractSocket(t *testing.T) {
+	t.Parallel()
+	assert.True(t, isAbstractSocket("@abstract"))
+	assert.False(t, isAbstractSocket("/var/run/test.sock"))
+	assert.False(t, isAbstractSocket(""))
+}
+
+func Test_unixListener_Close(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "listener.sock")
+
+	ln, err := net.Listen("unix", path)
+	require.NoError(t, err)
+
+	// Socket file exists after listen.
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	uln := &unixListener{Listener: ln, path: path}
+	require.NoError(t, uln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "stale.sock")
+
+	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
+	fd, sysErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	require.NoError(t, sysErr)
+	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
+	require.NoError(t, syscall.Close(fd))
+	_, sysErr = os.Stat(path)
+	require.NoError(t, sysErr)
+
+	// Listen should succeed despite stale socket.
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+}
+
+func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "regular.txt")
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	_, err = na.Listen(context.Background())
+	assert.ErrorContains(t, err, "not a socket")
+}
+
+func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "perms.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
+}
+
+func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "cleanup.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	require.NoError(t, ln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func Test_AddrConfig_isUnixTransport(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		transport TransportType
+		expected  bool
+	}{
+		{TransportTypeTCP, false},
+		{TransportTypeTCP4, false},
+		{TransportTypeTCP6, false},
+		{TransportTypeUDP, false},
+		{TransportTypeUDP4, false},
+		{TransportTypeUDP6, false},
+		{TransportTypeIP, false},
+		{TransportTypeIP4, false},
+		{TransportTypeIP6, false},
+		{TransportTypeUnix, true},
+		{TransportTypeUnixgram, true},
+		{TransportTypeUnixPacket, true},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.transport), func(t *testing.T) {
+			t.Parallel()
+			na := &AddrConfig{Transport: tt.transport}
+			assert.Equal(t, tt.expected, na.isUnixTransport())
+		})
+	}
 }

--- a/config/confignet/confignet_unix_test.go
+++ b/config/confignet/confignet_unix_test.go
@@ -151,6 +151,75 @@ func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
 	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
 }
 
+func TestAddrConfig_Listen_UnixInvalidEndpoint(t *testing.T) {
+	t.Parallel()
+	na := &AddrConfig{
+		Endpoint:  "/nonexistent/dir/deep/socket.sock",
+		Transport: TransportTypeUnix,
+	}
+	_, err := na.Listen(context.Background())
+	assert.Error(t, err)
+}
+
+func TestAddrConfig_Listen_UnixChmodFailure(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "chmod.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+
+	// Remove the socket file behind the listener's back so that the
+	// Chmod in a second Listen call fails (socket won't exist to chmod).
+	require.NoError(t, ln.Close())
+
+	// Now make the directory read-only so Listen succeeds at binding
+	// but Chmod fails due to permission denied.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o700))
+	subPath := filepath.Join(dir, "sub", "chmod.sock")
+	na2 := &AddrConfig{
+		Endpoint:  subPath,
+		Transport: TransportTypeUnix,
+	}
+	ln2, err := na2.Listen(context.Background())
+	require.NoError(t, err)
+	// Verify listener works, then close
+	require.NoError(t, ln2.Close())
+
+	// Make dir read-only to cause Chmod failure
+	require.NoError(t, os.Chmod(filepath.Join(dir, "sub"), 0o444))       //nolint:gosec // intentional for test
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "sub"), 0o700) }) //nolint:gosec // restore perms for cleanup
+
+	_, err = na2.Listen(context.Background())
+	// On some systems this fails at Listen (can't bind), on others at Chmod.
+	// Either way it should error.
+	assert.Error(t, err)
+}
+
+func Test_removeStaleSocket_StatError(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700); os.RemoveAll(dir) }) //nolint:gosec // restore perms for cleanup
+	path := filepath.Join(dir, "socket.sock")
+
+	// Create a file so the path exists.
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+	// Remove permission on the directory so Stat fails with permission denied.
+	require.NoError(t, os.Chmod(dir, 0o000))
+
+	err = removeStaleSocket(path)
+	assert.Error(t, err)
+}
+
 func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
 	t.Parallel()
 	//nolint:usetesting // short path needed for Unix socket limit

--- a/config/confignet/confignet_unix_test.go
+++ b/config/confignet/confignet_unix_test.go
@@ -1,0 +1,177 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package confignet
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_removeStaleSocket(t *testing.T) {
+	t.Parallel()
+	t.Run("path does not exist", func(t *testing.T) {
+		t.Parallel()
+		err := removeStaleSocket(filepath.Join(t.TempDir(), "nonexistent.sock"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("path is a regular file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "regular.txt")
+		require.NoError(t, os.WriteFile(path, []byte("data"), 0o600))
+
+		err := removeStaleSocket(path)
+		require.ErrorContains(t, err, "not a socket")
+		// File should still exist.
+		_, statErr := os.Stat(path)
+		assert.NoError(t, statErr)
+	})
+
+	t.Run("path is a stale socket", func(t *testing.T) {
+		t.Parallel()
+		//nolint:usetesting // short path needed for Unix socket limit
+		dir, err := os.MkdirTemp("", "confignet-sock-test-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		path := filepath.Join(dir, "stale.sock")
+		// Create a socket file directly via syscall so it is not auto-removed
+		// when closed (Go's net.Listener.Close removes socket files on some OSes).
+		fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+		require.NoError(t, err)
+		err = syscall.Bind(fd, &syscall.SockaddrUnix{Name: path})
+		require.NoError(t, err)
+		require.NoError(t, syscall.Close(fd))
+		// Socket file should still exist after closing the fd.
+		_, err = os.Stat(path)
+		require.NoError(t, err)
+
+		err = removeStaleSocket(path)
+		require.NoError(t, err)
+		// Socket file should be removed.
+		_, err = os.Stat(path)
+		assert.True(t, os.IsNotExist(err))
+	})
+}
+
+func Test_unixListener_Close(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "listener.sock")
+
+	ln, err := net.Listen("unix", path)
+	require.NoError(t, err)
+
+	// Socket file exists after listen.
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	uln := &unixListener{Listener: ln, path: path}
+	require.NoError(t, uln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "stale.sock")
+
+	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
+	fd, sysErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	require.NoError(t, sysErr)
+	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
+	require.NoError(t, syscall.Close(fd))
+	_, sysErr = os.Stat(path)
+	require.NoError(t, sysErr)
+
+	// Listen should succeed despite stale socket.
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+}
+
+func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "regular.txt")
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o600))
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	_, err = na.Listen(context.Background())
+	assert.ErrorContains(t, err, "not a socket")
+}
+
+func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "perms.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
+}
+
+func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "cleanup.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	require.NoError(t, ln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}


### PR DESCRIPTION
## Summary

- `AddrConfig.Listen()` now automatically manages the full lifecycle of filesystem-based Unix domain sockets:
  - Removes stale socket files before binding (refuses to remove non-socket files for safety)
  - Sets socket permissions to `0722` so any local process can connect
  - Cleans up socket files on `Close()`
- Abstract sockets (`@` prefix) are unaffected — they live in kernel memory and need no filesystem handling
- No configuration needed — the behavior is automatic for all Unix transport types

Closes #15189

## Test plan

- [x] Unit tests for `removeStaleSocket` (nonexistent path, regular file, stale socket)
- [x] Unit tests for `isAbstractSocket` helper
- [x] Unit tests for `unixListener.Close` removing socket file
- [x] Integration test: `Listen` succeeds despite pre-existing stale socket
- [x] Integration test: `Listen` refuses to remove a non-socket file
- [x] Integration test: socket gets `0722` permissions after `Listen`
- [x] Integration test: socket file removed after `Close`
- [x] All tests pass locally (`go test ./... -count=1`)