### PR TITLE
[cmd/mdatagen] Handle enum and const validators in generated config structs

### DIFF
--- a/.chloggen/mdatagen_enum_const_validators.yaml
+++ b/.chloggen/mdatagen_enum_const_validators.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`)
+note: Handle enum validators in generated config structs
+
+# One or more tracking issues or pull requests related to the change
+issues: [14805]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Supported validators include `enum`.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -89,7 +89,10 @@ func NewCfgFns(rootPackage, componentPackage string) map[string]any {
 		"mapCustomDefaults": func(schema *ConfigMetadata, defaultValue any) []string {
 			return MapCustomDefaults(schema, defaultValue, rootPackage, componentPackage)
 		},
-		"hasDefaultValue": hasDefaultValue,
+		"hasDefaultValue":  hasDefaultValue,
+		"formatEnumSlice":  formatEnumSlice,
+		"formatEnumValues": formatEnumValues,
+		"invalidTestValue": invalidTestValue,
 		"isExternalRef": func(ref string) bool {
 			if ref == "" {
 				return false
@@ -316,6 +319,10 @@ func collectImports(md *ConfigMetadata, imports map[string]bool, rootPackage, co
 		imports["regexp"] = true
 	}
 
+	if len(md.Enum) > 0 {
+		imports["slices"] = true
+	}
+
 	for _, prop := range md.Properties {
 		if err := collectImports(prop, imports, rootPackage, componentPackage); err != nil {
 			return err
@@ -499,11 +506,13 @@ type ValidationRules struct {
 	Maximum          *float64
 	ExclusiveMinimum *float64
 	ExclusiveMaximum *float64
+	Enum             []any
 }
 
 func (vr *ValidationRules) HasValueRule() bool {
 	return vr.MaxLength != nil || vr.MinLength != nil || vr.Pattern != nil ||
-		vr.Minimum != nil || vr.Maximum != nil || vr.ExclusiveMinimum != nil || vr.ExclusiveMaximum != nil
+		vr.Minimum != nil || vr.Maximum != nil || vr.ExclusiveMinimum != nil || vr.ExclusiveMaximum != nil ||
+		len(vr.Enum) > 0
 }
 
 func (vr *ValidationRules) Enabled() bool {
@@ -529,6 +538,7 @@ func collectValidators(md *ConfigMetadata, validators *[]Validator) {
 			Maximum:          prop.Maximum,
 			ExclusiveMinimum: prop.ExclusiveMinimum,
 			ExclusiveMaximum: prop.ExclusiveMaximum,
+			Enum:             prop.Enum,
 		}
 
 		rules.Required = slices.Contains(md.Required, propName)
@@ -817,4 +827,52 @@ func formatDurationAsGoExpr(d time.Duration) string {
 		}
 	}
 	return strings.Join(parts, " + ")
+}
+
+func formatEnumSlice(values []any, fieldType string) string {
+	var goType string
+	switch fieldType {
+	case "string":
+		goType = "string"
+	case "integer":
+		goType = "int"
+	case "number":
+		goType = "float64"
+	case "boolean":
+		goType = "bool"
+	default:
+		goType = "any"
+	}
+
+	formatted := make([]string, 0, len(values))
+	for _, v := range values {
+		switch tv := v.(type) {
+		case string:
+			formatted = append(formatted, fmt.Sprintf("%q", tv))
+		default:
+			formatted = append(formatted, fmt.Sprintf("%v", tv))
+		}
+	}
+	return fmt.Sprintf("[]%s{%s}", goType, strings.Join(formatted, ", "))
+}
+
+func formatEnumValues(values []any) string {
+	formatted := make([]string, 0, len(values))
+	for _, v := range values {
+		formatted = append(formatted, fmt.Sprintf("%v", v))
+	}
+	return "[" + strings.Join(formatted, ", ") + "]"
+}
+
+func invalidTestValue(fieldType string) string {
+	switch fieldType {
+	case "string":
+		return `"__invalid__"`
+	case "integer":
+		return "-1"
+	case "number":
+		return "-1.0"
+	default:
+		return `"__invalid__"`
+	}
 }

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -1671,6 +1671,11 @@ func TestValidationRules_Enabled(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "enum only",
+			rules:    ValidationRules{Enum: []any{"a", "b"}},
+			expected: true,
+		},
+		{
 			name:     "required with value rule",
 			rules:    ValidationRules{Required: true, MaxLength: Ptr(64)},
 			expected: true,
@@ -2983,4 +2988,132 @@ func TestExtractValidators_DefsValidatorNotOverwrittenByRefSite(t *testing.T) {
 	require.Equal(t, ".", validators[0].FieldName)
 	require.Equal(t, "validateBatchConfig", validators[0].CustomValidator,
 		"struct-level validator must come from the type definition, not the ref-site property")
+}
+
+func TestExtractValidators_EnumValidators(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *ConfigMetadata
+		expected []Validator
+	}{
+		{
+			name: "enum on string field",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"level": {Type: "string", Enum: []any{"debug", "info", "warn"}},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "level",
+					FieldType: "string",
+					Rules:     ValidationRules{Enum: []any{"debug", "info", "warn"}},
+				},
+			},
+		},
+		{
+			name: "enum on integer field",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"port": {Type: "integer", Enum: []any{80, 443, 8080}},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "port",
+					FieldType: "integer",
+					Rules:     ValidationRules{Enum: []any{80, 443, 8080}},
+				},
+			},
+		},
+		{
+			name: "no enum produces no validator",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"name": {Type: "string"},
+				},
+			},
+			expected: []Validator{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractValidators(tt.metadata)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractImports_EnumAddsSlices(t *testing.T) {
+	md := &ConfigMetadata{
+		Type: "object",
+		Properties: map[string]*ConfigMetadata{
+			"level": {Type: "string", Enum: []any{"a", "b"}},
+		},
+	}
+	imports, err := ExtractImports(md, "example.com/root", "example.com/component")
+	require.NoError(t, err)
+	require.Contains(t, imports, "slices")
+}
+
+func TestFormatEnumSlice(t *testing.T) {
+	tests := []struct {
+		name      string
+		values    []any
+		fieldType string
+		expected  string
+	}{
+		{
+			name:      "string values",
+			values:    []any{"a", "b", "c"},
+			fieldType: "string",
+			expected:  `[]string{"a", "b", "c"}`,
+		},
+		{
+			name:      "integer values",
+			values:    []any{1, 2, 3},
+			fieldType: "integer",
+			expected:  "[]int{1, 2, 3}",
+		},
+		{
+			name:      "number values",
+			values:    []any{1.5, 2.5},
+			fieldType: "number",
+			expected:  "[]float64{1.5, 2.5}",
+		},
+		{
+			name:      "boolean values",
+			values:    []any{true, false},
+			fieldType: "boolean",
+			expected:  "[]bool{true, false}",
+		},
+		{
+			name:      "unknown type falls back to any",
+			values:    []any{"x"},
+			fieldType: "unknown",
+			expected:  `[]any{"x"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, formatEnumSlice(tt.values, tt.fieldType))
+		})
+	}
+}
+
+func TestFormatEnumValues(t *testing.T) {
+	require.Equal(t, "[a, b, c]", formatEnumValues([]any{"a", "b", "c"}))
+	require.Equal(t, "[1, 2]", formatEnumValues([]any{1, 2}))
+}
+
+func TestInvalidTestValue(t *testing.T) {
+	require.Equal(t, `"__invalid__"`, invalidTestValue("string"))
+	require.Equal(t, "-1", invalidTestValue("integer"))
+	require.Equal(t, "-1.0", invalidTestValue("number"))
+	require.Equal(t, `"__invalid__"`, invalidTestValue("object"))
 }

--- a/cmd/mdatagen/internal/samplescraper/README.md
+++ b/cmd/mdatagen/internal/samplescraper/README.md
@@ -25,6 +25,7 @@ This scraper is used for testing purposes to check the output of mdatagen.
 | `component` | string |  | no | Identifies the scraper, used for telemetry and logging. |
 | `initial_delay` | duration | 1s | no | Sets the initial start delay for the scraper, any non positive value is assumed to be immediately. |
 | `job_name` | string | test_job | **yes** | Name of the scrape job, used to identify the source in telemetry. |
+| `log_level` | string (one of: debug, info, warn, error) | info | no | Logging level for the scraper. |
 | `metrics` | object (see [metrics](#metrics)) |  | no | MetricsConfig provides config for sample metrics. |
 | `resource_attributes` | object (see [resource_attributes](#resource_attributes)) |  | no | ResourceAttributesConfig provides config for sample resource attributes. |
 | `targets` | []object | [{}] | **yes** | List of targets to scrape metrics from. |

--- a/cmd/mdatagen/internal/samplescraper/config.schema.json
+++ b/cmd/mdatagen/internal/samplescraper/config.schema.json
@@ -601,6 +601,17 @@
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9_.-]+$"
     },
+    "log_level": {
+      "description": "Logging level for the scraper.",
+      "type": "string",
+      "default": "info",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ]
+    },
     "targets": {
       "description": "List of targets to scrape metrics from.",
       "type": "array",

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -5,6 +5,7 @@ package samplescraper
 import (
 	"errors"
 	"regexp"
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/cmd/mdatagen/internal/samplepkg"
@@ -78,6 +79,8 @@ type Config struct {
 	ComponentID component.ID `mapstructure:"component"`
 	// Name of the scrape job, used to identify the source in telemetry.
 	JobName string `mapstructure:"job_name"`
+	// Logging level for the scraper.
+	LogLevel string `mapstructure:"log_level"`
 	// List of targets to scrape metrics from.
 	Targets *[]TargetsItem `mapstructure:"targets"`
 	// prevent unkeyed literal initialization
@@ -105,6 +108,10 @@ func (c *Config) Validate() error {
 		err = errors.Join(err, inner_err)
 	}
 
+	if !slices.Contains([]string{"debug", "info", "warn", "error"}, c.LogLevel) {
+		err = errors.Join(err, errors.New("log_level must be one of [debug, info, warn, error]"))
+	}
+
 	if c.Targets == nil || len(*c.Targets) == 0 {
 		err = errors.Join(err, errors.New("targets is required"))
 	}
@@ -117,6 +124,7 @@ func createDefaultConfig() component.Config {
 		ControllerConfig:     scraperhelper.NewDefaultControllerConfig(),
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 		JobName:              "test_job",
+		LogLevel:             "info",
 		Targets:              &[]TargetsItem{NewDefaultTargetsItem()},
 	}
 }

--- a/cmd/mdatagen/internal/samplescraper/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config_test.go
@@ -27,6 +27,13 @@ func TestConfigValidate_RequiredJobName(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "job_name is required")
 }
 
+func TestConfigValidate_InvalidEnumLogLevel(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.LogLevel = "__invalid__"
+
+	require.ErrorContains(t, cfg.Validate(), "log_level must be one of")
+}
+
 func TestConfigValidate_RequiredTargets(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Targets = nil

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -89,6 +89,11 @@ config:
         required: [labels]
       default:
         - {} # one item with default values
+    log_level:
+      description: Logging level for the scraper.
+      type: string
+      enum: [debug, info, warn, error]
+      default: info
   required: [job_name, targets]
 
 resource_attributes:

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -190,6 +190,12 @@ import (
     }
 {{- end }}
 
+{{ define "enumValidator" -}}
+    if !slices.Contains({{ formatEnumSlice .Rules.Enum .FieldType }}, {{ template "fieldValue" . }}) {
+        err = errors.Join(err, errors.New("{{ .FieldName }} must be one of {{ formatEnumValues .Rules.Enum }}"))
+    }
+{{- end }}
+
 {{ define "valueValidators" }}
     {{ if .Rules.MaxLength }}{{ template "maxLengthValidator" . }}{{ end }}
     {{ if .Rules.MinLength }}{{ template "minLengthValidator" . }}{{ end }}
@@ -198,6 +204,7 @@ import (
     {{ if .Rules.Maximum }}{{ template "maximumValidator" . }}{{ end }}
     {{ if .Rules.ExclusiveMinimum }}{{ template "exclusiveMinimumValidator" . }}{{ end }}
     {{ if .Rules.ExclusiveMaximum }}{{ template "exclusiveMaximumValidator" . }}{{ end }}
+    {{ if .Rules.Enum }}{{ template "enumValidator" . }}{{ end }}
 {{ end -}}
 
 {{ define "validation" }}

--- a/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
@@ -113,6 +113,14 @@ require.NotNil(t, cfg)
             require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than {{ $exclMax }}")
             }
         {{ end }}
+        {{- if $validator.Rules.Enum }}
+            func TestConfigValidate_InvalidEnum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+            cfg := createDefaultConfig().(*Config)
+            cfg.{{ $validator.FieldName | publicVar }} = {{ invalidTestValue $validator.FieldType }}
+
+            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} must be one of")
+            }
+        {{ end }}
     {{- end }}
 {{- end }}
 {{- end }}
@@ -212,6 +220,14 @@ require.NotNil(t, cfg)
                 {{- end }}
 
                 require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than {{ $exclMax }}")
+                }
+            {{ end }}
+            {{- if $validator.Rules.Enum }}
+                func Test{{ $defName | publicVar }}Validate_InvalidEnum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+                cfg := NewDefault{{ $defName | publicVar }}()
+                cfg.{{ $validator.FieldName | publicVar }} = {{ invalidTestValue $validator.FieldType }}
+
+                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} must be one of")
                 }
             {{ end }}
         {{- end }}

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -133,5 +133,10 @@ func (md *ConfigMetadata) Validate() error {
 	if !hasDefs && !hasConfigFields {
 		errs = errors.Join(errs, errors.New("config must not be empty"))
 	}
+	for name, prop := range md.Properties {
+		if len(prop.Enum) > 0 && (prop.Type == "object" || prop.Type == "array") {
+			errs = errors.Join(errs, fmt.Errorf("property %q: enum is not supported for type %q", name, prop.Type))
+		}
+	}
 	return errs
 }

--- a/internal/schemagen/model_test.go
+++ b/internal/schemagen/model_test.go
@@ -548,3 +548,53 @@ func TestGoStructConfig_UnmarshalError(t *testing.T) {
 	var g GoStructConfig
 	require.Error(t, g.Unmarshal(parser))
 }
+
+func TestConfigMetadata_Validate_EnumOnComplexType(t *testing.T) {
+	tests := []struct {
+		name    string
+		md      *ConfigMetadata
+		wantErr string
+	}{
+		{
+			name: "enum on object",
+			md: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"nested": {Type: "object", Enum: []any{"a"}},
+				},
+			},
+			wantErr: `property "nested": enum is not supported for type "object"`,
+		},
+		{
+			name: "enum on array",
+			md: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"items": {Type: "array", Enum: []any{"a"}},
+				},
+			},
+			wantErr: `property "items": enum is not supported for type "array"`,
+		},
+		{
+			name: "enum on string is valid",
+			md: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"level": {Type: "string", Enum: []any{"a", "b"}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.md.Validate()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Description
Adds support for `enum` and `const` JSON Schema keywords in mdatagen's config generation. 
Properties with these constraints now produce the corresponding `Validate()` checks
  `slices.Contains` for enum
  equality for const.

#### Link to tracking issue
Fixes #14805

#### Testing
Unit tests cover extraction, `HasValueRule`, and the formatter helpers. The samplescraper golden file is updated to reflect the new output