### PR TITLE
Add next processor attribute to pipeline metrics

### DIFF
--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -302,8 +302,8 @@ func (g *Graph) buildComponents(ctx context.Context, set Settings) error {
 		case *receiverNode:
 			err = n.buildComponent(ctx, set.Telemetry, set.BuildInfo, set.ReceiverBuilder, g.nextConsumers(n.ID()))
 		case *processorNode:
-			// nextConsumers is guaranteed to be length 1.  Either it is the next processor or it is the fanout node for the exporters.
-			err = n.buildComponent(ctx, set.Telemetry, set.BuildInfo, set.ProcessorBuilder, g.nextConsumers(n.ID())[0])
+			// nextNodes is guaranteed to be length 1.  Either it is the next processor or it is the fanout node for the exporters.
+			err = n.buildComponent(ctx, set.Telemetry, set.BuildInfo, set.ProcessorBuilder, g.nextNodes(n.ID())[0])
 		case *exporterNode:
 			err = n.buildComponent(ctx, set.Telemetry, set.BuildInfo, set.ExporterBuilder)
 		case *connectorNode:
@@ -377,6 +377,15 @@ func (g *Graph) nextConsumers(nodeID int64) []baseConsumer {
 	nexts := make([]baseConsumer, 0, nextNodes.Len())
 	for nextNodes.Next() {
 		nexts = append(nexts, nextNodes.Node().(consumerNode).getConsumer())
+	}
+	return nexts
+}
+
+func (g *Graph) nextNodes(nodeID int64) []graph.Node {
+	nextNodes := g.componentGraph.From(nodeID)
+	nexts := make([]graph.Node, 0, nextNodes.Len())
+	for nextNodes.Next() {
+		nexts = append(nexts, nextNodes.Node())
 	}
 	return nexts
 }

--- a/service/internal/graph/processor.go
+++ b/service/internal/graph/processor.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"fmt"
 
+	otelattr "go.opentelemetry.io/otel/attribute"
+	"gonum.org/v1/gonum/graph"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/xconsumer"
@@ -20,6 +23,8 @@ import (
 	"go.opentelemetry.io/collector/service/internal/obsconsumer"
 	"go.opentelemetry.io/collector/service/internal/refconsumer"
 )
+
+const peerComponentIDAttrKey = "otelcol.peer.component.id"
 
 var _ consumerNode = (*processorNode)(nil)
 
@@ -49,8 +54,10 @@ func (n *processorNode) buildComponent(ctx context.Context,
 	tel component.TelemetrySettings,
 	info component.BuildInfo,
 	builder *builders.ProcessorBuilder,
-	next baseConsumer,
+	next graph.Node,
 ) error {
+	nextConsumer := next.(consumerNode).getConsumer()
+
 	set := processor.Settings{
 		ID:                n.componentID,
 		TelemetrySettings: componentattribute.TelemetrySettingsWithAttributes(tel, *n.Set()),
@@ -73,10 +80,15 @@ func (n *processorNode) buildComponent(ctx context.Context,
 		Logger:      set.Logger,
 	}
 
+	var opts []obsconsumer.Option
+	if n, ok := next.(*processorNode); ok {
+		opts = []obsconsumer.Option{obsconsumer.WithStaticDataPointAttribute(otelattr.String(peerComponentIDAttrKey, n.componentID.String()))}
+	}
+
 	switch n.pipelineID.Signal() {
 	case pipeline.SignalTraces:
 		n.Component, err = builder.CreateTraces(ctx, set,
-			obsconsumer.NewTraces(next.(consumer.Traces), producedSettings),
+			obsconsumer.NewTraces(nextConsumer.(consumer.Traces), producedSettings, opts...),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create %q processor, in pipeline %q: %w", set.ID, n.pipelineID.String(), err)
@@ -85,7 +97,7 @@ func (n *processorNode) buildComponent(ctx context.Context,
 		n.consumer = refconsumer.NewTraces(n.consumer.(consumer.Traces))
 	case pipeline.SignalMetrics:
 		n.Component, err = builder.CreateMetrics(ctx, set,
-			obsconsumer.NewMetrics(next.(consumer.Metrics), producedSettings))
+			obsconsumer.NewMetrics(nextConsumer.(consumer.Metrics), producedSettings, opts...))
 		if err != nil {
 			return fmt.Errorf("failed to create %q processor, in pipeline %q: %w", set.ID, n.pipelineID.String(), err)
 		}
@@ -93,7 +105,7 @@ func (n *processorNode) buildComponent(ctx context.Context,
 		n.consumer = refconsumer.NewMetrics(n.consumer.(consumer.Metrics))
 	case pipeline.SignalLogs:
 		n.Component, err = builder.CreateLogs(ctx, set,
-			obsconsumer.NewLogs(next.(consumer.Logs), producedSettings))
+			obsconsumer.NewLogs(nextConsumer.(consumer.Logs), producedSettings, opts...))
 		if err != nil {
 			return fmt.Errorf("failed to create %q processor, in pipeline %q: %w", set.ID, n.pipelineID.String(), err)
 		}
@@ -101,7 +113,7 @@ func (n *processorNode) buildComponent(ctx context.Context,
 		n.consumer = refconsumer.NewLogs(n.consumer.(consumer.Logs))
 	case xpipeline.SignalProfiles:
 		n.Component, err = builder.CreateProfiles(ctx, set,
-			obsconsumer.NewProfiles(next.(xconsumer.Profiles), producedSettings))
+			obsconsumer.NewProfiles(nextConsumer.(xconsumer.Profiles), producedSettings, opts...))
 		if err != nil {
 			return fmt.Errorf("failed to create %q processor, in pipeline %q: %w", set.ID, n.pipelineID.String(), err)
 		}


### PR DESCRIPTION
#### Description
This PR adds the `otelcol.peer.component.id` attribute to the [new unified pipeline telemetry](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md) allowing users to reconstruct processor order when debugging pipelines.

Use cases include:
- Building a visual graph based on telemetry alone
- Find out which component is dropping/filtering data

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15001

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tested with custom build including a variety of processors.
Automatic tests to be added once we know if this is the approach to be used.

<!--Describe the documentation added.-->
#### Documentation

As the final approach has not been fully defined, I've not yet documented the new attributes
