### PR TITLE
Add OpenSSL Library as a required tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,6 +231,7 @@ Working with the project sources requires the following tools:
 2. [Go](https://go.dev/) (version 1.25 and up)
 3. [GNU Make](https://www.gnu.org/software/make/)
 4. [Docker](https://www.docker.com/)
+5. [OpenSSL Library](https://openssl-library.org/) (for the  `config/configtls` component)
 
 ## Repository Setup
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds OpenSSL Library as a required tool to the [`CONTRIBUTING.md`](https://github.com/open-telemetry/opentelemetry-collector/blob/346b0657a8e837bbf82f009bde9838a3712ae141/CONTRIBUTING.md) file. The OpenSSL Library is required to run for the project `make` successfully, as it's a dependency of `github.com/google/go-tpm/tpm2/transport`.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15233 

<!--Describe the documentation added.-->
#### Documentation
As mentioned above, I added the [OpenSSL Library](https://openssl-library.org/) as a required tool to work with the project sources. This might be pre-installed on some systems, but is not on others which require a manual installation of the correct devel package or downloading the OpenSSL sources manually.

<!--Please delete paragraphs that you did not use before submitting.-->
