### PR TITLE
[grpccompression/snappy]: avoid sync.Once reuse on pooled snappy compressors

### DIFF
--- a/.chloggen/fix-grpccompression-snappy-panic.yaml
+++ b/.chloggen/fix-grpccompression-snappy-panic.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: config/configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Prevent panic on snappy gRPC compression during concurrent use.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15237]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Reusing pooled wrapper objects carried `sync.Once` state across calls, which
+  could panic under concurrent snappy compression. The fix returns only the
+  underlying snappy reader and writer to the pool and creates fresh wrappers for
+  each use.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/grpccompression/snappy/snappy.go
+++ b/internal/grpccompression/snappy/snappy.go
@@ -38,23 +38,27 @@ type compressor struct {
 func newCompressor() *compressor {
 	c := &compressor{}
 	c.poolCompressor.New = func() any {
-		return &writer{
-			Writer: snappylib.NewBufferedWriter(io.Discard),
-			pool:   &c.poolCompressor,
-		}
+		return snappylib.NewBufferedWriter(io.Discard)
 	}
 	return c
 }
 
 func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {
-	z := c.poolCompressor.Get().(*writer)
-	z.once = sync.Once{}
-	z.Reset(w)
-	return z, nil
+	z, ok := c.poolCompressor.Get().(*snappylib.Writer)
+	if !ok {
+		z = snappylib.NewBufferedWriter(w)
+	} else {
+		z.Reset(w)
+	}
+
+	return &writer{
+		Writer: z,
+		pool:   &c.poolCompressor,
+	}, nil
 }
 
 func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
-	z, ok := c.poolDecompressor.Get().(*reader)
+	z, ok := c.poolDecompressor.Get().(*snappylib.Reader)
 	if !ok {
 		return &reader{
 			Reader: snappylib.NewReader(r),
@@ -62,9 +66,11 @@ func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
 		}, nil
 	}
 
-	z.once = sync.Once{}
 	z.Reset(r)
-	return z, nil
+	return &reader{
+		Reader: z,
+		pool:   &c.poolDecompressor,
+	}, nil
 }
 
 func (c *compressor) Name() string {
@@ -79,10 +85,15 @@ type writer struct {
 
 func (z *writer) Close() error {
 	err := z.Writer.Close()
-	z.once.Do(func() {
-		z.pool.Put(z)
-	})
+	z.release()
 	return err
+}
+
+// release returns the underlying writer to the pool exactly once per wrapper.
+func (z *writer) release() {
+	z.once.Do(func() {
+		z.pool.Put(z.Writer)
+	})
 }
 
 type reader struct {
@@ -94,9 +105,14 @@ type reader struct {
 func (z *reader) Read(p []byte) (int, error) {
 	n, err := z.Reader.Read(p)
 	if err != nil {
-		z.once.Do(func() {
-			z.pool.Put(z)
-		})
+		z.release()
 	}
 	return n, err
+}
+
+// release returns the underlying reader to the pool exactly once per wrapper.
+func (z *reader) release() {
+	z.once.Do(func() {
+		z.pool.Put(z.Reader)
+	})
 }

--- a/internal/grpccompression/snappy/snappy_test.go
+++ b/internal/grpccompression/snappy/snappy_test.go
@@ -7,6 +7,7 @@ package snappy
 import (
 	"bytes"
 	"io"
+	"runtime"
 	"testing"
 
 	snappylib "github.com/golang/snappy"
@@ -67,10 +68,8 @@ func TestRegisterCompressor(t *testing.T) {
 
 func TestDecompressReusesPooledReader(t *testing.T) {
 	c := newCompressor()
-	seed := &reader{
-		Reader: snappylib.NewReader(bytes.NewReader(nil)),
-		pool:   &c.poolDecompressor,
-	}
+	seed := snappylib.NewReader(bytes.NewReader(nil))
+
 	c.poolDecompressor.New = func() any { return seed }
 
 	compressed := compressPayload(t, c, []byte("snappy reuse check"))
@@ -79,11 +78,34 @@ func TestDecompressReusesPooledReader(t *testing.T) {
 	require.NoError(t, err)
 	got, ok := r.(*reader)
 	require.True(t, ok)
-	assert.Same(t, seed, got)
+	assert.Same(t, seed, got.Reader)
 
 	out, err := io.ReadAll(got)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("snappy reuse check"), out)
+}
+
+func TestCompressReusesPooledWriter(t *testing.T) {
+	c := newCompressor()
+	seed := snappylib.NewBufferedWriter(io.Discard)
+	c.poolCompressor.New = func() any { return seed }
+	payload := []byte("snappy writer reuse check")
+
+	var buf bytes.Buffer
+	w, err := c.Compress(&buf)
+	require.NoError(t, err)
+	got, ok := w.(*writer)
+	require.True(t, ok)
+	assert.Same(t, seed, got.Writer)
+	_, err = got.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, got.Close())
+
+	r, err := c.Decompress(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, payload, out)
 }
 
 func compressPayload(t *testing.T, comp encoding.Compressor, payload []byte) []byte {
@@ -111,4 +133,89 @@ func roundTripCompression(t *testing.T, comp encoding.Compressor, payload []byte
 	got, err := io.ReadAll(r)
 	require.NoError(t, err)
 	return got
+}
+
+func TestConcurrentWriterReuseDoesNotPanic(t *testing.T) {
+	prev := runtime.GOMAXPROCS(runtime.NumCPU())
+	defer runtime.GOMAXPROCS(prev)
+
+	comp := newCompressor()
+	payload := bytes.Repeat([]byte("snappy payload "), 32)
+
+	const workers = 6
+	const iterations = 100
+
+	start := make(chan struct{})
+	errCh := make(chan error, workers)
+
+	for range workers {
+		go func() {
+			<-start
+			for range iterations {
+				var buf bytes.Buffer
+				w, err := comp.Compress(&buf)
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				if _, err = w.Write(payload); err != nil {
+					errCh <- err
+					return
+				}
+
+				if err = w.Close(); err != nil {
+					errCh <- err
+					return
+				}
+			}
+			errCh <- nil
+		}()
+	}
+
+	close(start)
+
+	for range workers {
+		require.NoError(t, <-errCh)
+	}
+}
+
+func TestConcurrentReaderReuseDoesNotPanic(t *testing.T) {
+	prev := runtime.GOMAXPROCS(runtime.NumCPU())
+	defer runtime.GOMAXPROCS(prev)
+
+	comp := newCompressor()
+	payload := bytes.Repeat([]byte("snappy payload "), 32)
+	compressed := compressPayload(t, comp, payload)
+
+	const workers = 8
+	const iterations = 50
+
+	start := make(chan struct{})
+	errCh := make(chan error, workers)
+
+	for range workers {
+		go func() {
+			<-start
+			for range iterations {
+				r, err := comp.Decompress(bytes.NewReader(compressed))
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				if _, err = io.ReadAll(r); err != nil {
+					errCh <- err
+					return
+				}
+			}
+			errCh <- nil
+		}()
+	}
+
+	close(start)
+
+	for range workers {
+		require.NoError(t, <-errCh)
+	}
 }


### PR DESCRIPTION

#### Description
Fixes [15237](https://github.com/open-telemetry/opentelemetry-collector/issues/15237).

Moves the one-time release guard off pooled reader/writer objects and onto per-use wrappers.
Added regression tests covering pooled reuse and concurrent writer reuse, passing `-race` validation.

Assisted-by: OpenAI GPT 5.4
