### PR TITLE
[confighttp] Enforce max_request_body_size before snappy decompression

### DIFF
--- a/.chloggen/confighttp-snappy-decompression-limit.yaml
+++ b/.chloggen/confighttp-snappy-decompression-limit.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enforce `max_request_body_size` on `Content-Encoding: snappy` requests before the decoded buffer is allocated."
+
+# One or more tracking issues or pull requests related to the change
+issues: [15252]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -99,7 +99,7 @@ var availableDecoders = map[string]func(body io.ReadCloser) (io.ReadCloser, erro
 		}
 		return zr, nil
 	},
-	"snappy": snappyHandler,
+	"snappy": newSnappyHandler(0),
 	//nolint:unparam // Ignoring the linter request to remove error return since it needs to match the method signature
 	"lz4": func(body io.ReadCloser) (io.ReadCloser, error) {
 		return &compressReadCloser{
@@ -122,7 +122,7 @@ var snappyFramingHeader = []byte{
 	0x73, 0x4e, 0x61, 0x50, 0x70, 0x59, // "sNaPpY"
 }
 
-// snappyHandler returns an io.ReadCloser that auto-detects the snappy format.
+// newSnappyHandler returns a factory for io.ReadCloser that auto-detects the snappy format.
 // This is necessary because the collector previously used "content-encoding: snappy"
 // but decompressed and compressed the payloads using the snappy framing format.
 // However, "content-encoding: snappy" is uses the block format, and "x-snappy-framed"
@@ -131,31 +131,46 @@ var snappyFramingHeader = []byte{
 //
 // See https://github.com/google/snappy/blob/6af9287fbdb913f0794d0148c6aa43b58e63c8e3/framing_format.txt#L27-L36
 // for more details on the framing format.
-func snappyHandler(body io.ReadCloser) (io.ReadCloser, error) {
-	br := bufio.NewReader(body)
+//
+// maxRequestBodySize bounds the decoded allocation in the block-format path
+// by checking snappy.DecodedLen before snappy.Decode, so a small compressed
+// body cannot amplify into a large in-memory buffer.
+func newSnappyHandler(maxRequestBodySize int64) func(io.ReadCloser) (io.ReadCloser, error) {
+	return func(body io.ReadCloser) (io.ReadCloser, error) {
+		br := bufio.NewReader(body)
 
-	peekBytes, err := br.Peek(len(snappyFramingHeader))
-	if err != nil && !errors.Is(err, io.EOF) {
-		return nil, err
-	}
+		peekBytes, err := br.Peek(len(snappyFramingHeader))
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, err
+		}
 
-	isFramed := len(peekBytes) >= len(snappyFramingHeader) && bytes.Equal(peekBytes[:len(snappyFramingHeader)], snappyFramingHeader)
+		isFramed := len(peekBytes) >= len(snappyFramingHeader) && bytes.Equal(peekBytes[:len(snappyFramingHeader)], snappyFramingHeader)
+		if isFramed {
+			return &compressReadCloser{
+				Reader: snappy.NewReader(br),
+				orig:   body,
+			}, nil
+		}
 
-	if isFramed {
-		return &compressReadCloser{
-			Reader: snappy.NewReader(br),
-			orig:   body,
-		}, nil
+		compressed, err := io.ReadAll(br)
+		if err != nil {
+			return nil, err
+		}
+		if maxRequestBodySize > 0 {
+			decodedLen, decErr := snappy.DecodedLen(compressed)
+			if decErr != nil {
+				return nil, decErr
+			}
+			if int64(decodedLen) > maxRequestBodySize {
+				return nil, errors.New("snappy: decoded size exceeds max request body size")
+			}
+		}
+		decoded, err := snappy.Decode(nil, compressed)
+		if err != nil {
+			return nil, err
+		}
+		return io.NopCloser(bytes.NewReader(decoded)), nil
 	}
-	compressed, err := io.ReadAll(br)
-	if err != nil {
-		return nil, err
-	}
-	decoded, err := snappy.Decode(nil, compressed)
-	if err != nil {
-		return nil, err
-	}
-	return io.NopCloser(bytes.NewReader(decoded)), nil
 }
 
 func newCompressionParams(level configcompression.Level) configcompression.CompressionParams {
@@ -228,6 +243,9 @@ func httpContentDecompressor(h http.Handler, maxRequestBodySize int64, eh func(w
 
 		if dec == "deflate" {
 			enabled["deflate"] = availableDecoders["zlib"]
+		}
+		if dec == "snappy" {
+			enabled["snappy"] = newSnappyHandler(maxRequestBodySize)
 		}
 	}
 

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -929,6 +929,38 @@ func TestDecompressorAvoidDecompressionBomb(t *testing.T) {
 	}
 }
 
+func TestSnappyBlockRejectsOversizedDecodedLen(t *testing.T) {
+	t.Parallel()
+
+	const maxBody = 1024
+
+	// Build a small compressed payload that decodes to more than maxBody.
+	// 8 KiB of zeros compresses to a handful of bytes with snappy block format.
+	payload := snappy.Encode(nil, make([]byte, 8*1024))
+	require.Less(t, len(payload), maxBody, "compressed payload must be smaller than limit to prove amplification")
+
+	downstreamCalled := false
+	h := httpContentDecompressor(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			downstreamCalled = true
+		}),
+		maxBody,
+		defaultErrorHandler,
+		defaultCompressionAlgorithms(),
+		nil, // let the decompressor install the size-aware snappy handler
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+	req.Header.Set("Content-Encoding", "snappy")
+
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Contains(t, resp.Body.String(), "decoded size exceeds max request body size")
+	assert.False(t, downstreamCalled, "downstream handler must not run when request is rejected")
+}
+
 func TestPooledZstdReadCloserReadAfterClose(t *testing.T) {
 	h := httpContentDecompressor(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/15252

When a request uses Content-Encoding: snappy (block format), confighttp decompresses the body into a buffer sized by the snappy block's decoded-length header before max_request_body_size is applied. This means a small compressed request can allocate a much larger decoded buffer than the configured limit.

This change applies `snappy.DecodedLen(compressed)` and reject with an error if it exceeds `maxRequestBodySize` before `snappy.Decode`.
