### PR TITLE
Track info metrics for component graph reconstruction

### DIFF
--- a/service/documentation.md
+++ b/service/documentation.md
@@ -30,6 +30,14 @@ Number of items passed to the exporter.
 | ---- | ----------- | ---------- | --------- | --------- |
 | {item} | Sum | Int | true | Development |
 
+### otelcol.graph.edge.connected
+
+Indicates connection between components (1 = connected, 0 = not connected)
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {item} | Gauge | Int | Development |
+
 ### otelcol_process_cpu_seconds
 
 Total CPU user and system time in seconds

--- a/service/internal/graph/component.go
+++ b/service/internal/graph/component.go
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package graph // import "go.opentelemetry.io/collector/service/internal/graph"
+
+import (
+	"go.opentelemetry.io/collector/component"
+)
+
+// componentNode is a utility interface to get the component ID of receivers, exporters, processors and connectors
+type componentNode interface {
+	ComponentID() component.ID
+}

--- a/service/internal/graph/connector.go
+++ b/service/internal/graph/connector.go
@@ -26,7 +26,10 @@ import (
 
 const pipelineIDAttrKey = "otelcol.pipeline.id"
 
-var _ consumerNode = (*connectorNode)(nil)
+var (
+	_ consumerNode  = (*connectorNode)(nil)
+	_ componentNode = (*connectorNode)(nil)
+)
 
 type connectorNode struct {
 	attribute.Attributes
@@ -48,6 +51,10 @@ func newConnectorNode(exprPipelineType, rcvrPipelineType pipeline.Signal, connID
 
 func (n *connectorNode) getConsumer() baseConsumer {
 	return n.consumer
+}
+
+func (n *connectorNode) ComponentID() component.ID {
+	return n.componentID
 }
 
 func (n *connectorNode) buildComponent(

--- a/service/internal/graph/exporter.go
+++ b/service/internal/graph/exporter.go
@@ -21,7 +21,10 @@ import (
 	"go.opentelemetry.io/collector/service/internal/refconsumer"
 )
 
-var _ consumerNode = (*exporterNode)(nil)
+var (
+	_ consumerNode  = (*exporterNode)(nil)
+	_ componentNode = (*exporterNode)(nil)
+)
 
 // An exporter instance can be shared by multiple pipelines of the same type.
 // Therefore, nodeID is derived from "pipeline type" and "component ID".
@@ -43,6 +46,10 @@ func newExporterNode(pipelineType pipeline.Signal, exprID component.ID) *exporte
 
 func (n *exporterNode) getConsumer() baseConsumer {
 	return n.consumer
+}
+
+func (n *exporterNode) ComponentID() component.ID {
+	return n.componentID
 }
 
 func (n *exporterNode) buildComponent(

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -25,6 +25,9 @@ import (
 	"gonum.org/v1/gonum/graph/simple"
 	"gonum.org/v1/gonum/graph/topo"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/connector"
@@ -32,11 +35,14 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/collector/internal/fanoutconsumer"
+	"go.opentelemetry.io/collector/internal/telemetry"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/pipeline/xpipeline"
 	"go.opentelemetry.io/collector/service/hostcapabilities"
 	"go.opentelemetry.io/collector/service/internal/builders"
 	"go.opentelemetry.io/collector/service/internal/capabilityconsumer"
+	"go.opentelemetry.io/collector/service/internal/componentattribute"
+	"go.opentelemetry.io/collector/service/internal/metadata"
 	"go.opentelemetry.io/collector/service/internal/status"
 	"go.opentelemetry.io/collector/service/pipelines"
 )
@@ -88,7 +94,10 @@ func Build(ctx context.Context, set Settings) (*Graph, error) {
 	if err := pipelines.createNodes(set); err != nil {
 		return nil, err
 	}
-	pipelines.createEdges()
+
+	if err := pipelines.createEdges(ctx, set.Telemetry); err != nil {
+		return nil, err
+	}
 	err := pipelines.buildComponents(ctx, set)
 	return pipelines, err
 }
@@ -262,11 +271,36 @@ func (g *Graph) createConnector(exprPipelineID, rcvrPipelineID pipeline.ID, conn
 }
 
 // Iterates through the pipelines and creates edges between components.
-func (g *Graph) createEdges() {
-	for _, pg := range g.pipelines {
+func (g *Graph) createEdges(ctx context.Context, set component.TelemetrySettings) error {
+	for id, pg := range g.pipelines {
+		tb, err := metadata.NewTelemetryBuilder(componentattribute.TelemetrySettingsWithAttributes(set, attribute.NewSet(
+			attribute.String(telemetry.PipelineIDKey, id.String()),
+		)))
+		if err != nil {
+			return fmt.Errorf("initializing telemetrybuilder: %w", err)
+		}
+
+		infoMetric := tb.GraphEdgeConnected
+		var receiverTarget componentNode
+		if len(pg.processors) > 0 {
+			receiverTarget = pg.processors[0].(componentNode)
+		}
 		// Draw edges from each receiver to the capability node.
 		for _, receiver := range pg.receivers {
 			g.componentGraph.SetEdge(g.componentGraph.NewEdge(receiver, pg.capabilitiesNode))
+			if receiverTarget != nil {
+				infoMetric.Record(ctx, 1, metric.WithAttributes(
+					attribute.String("from", receiver.(componentNode).ComponentID().String()),
+					attribute.String("to", receiverTarget.ComponentID().String()),
+				))
+			} else if len(pg.exporters) > 0 {
+				for _, exporter := range pg.exporters {
+					infoMetric.Record(ctx, 1, metric.WithAttributes(
+						attribute.String("from", receiver.(componentNode).ComponentID().String()),
+						attribute.String("to", exporter.(componentNode).ComponentID().String()),
+					))
+				}
+			}
 		}
 
 		// Iterates through processors, chaining them together.  starts with the capabilities node.
@@ -275,6 +309,12 @@ func (g *Graph) createEdges() {
 		for _, processor := range pg.processors {
 			to = processor
 			g.componentGraph.SetEdge(g.componentGraph.NewEdge(from, to))
+			if pp, ok := from.(componentNode); ok {
+				infoMetric.Record(ctx, 1, metric.WithAttributes(
+					attribute.String("from", pp.ComponentID().String()),
+					attribute.String("to", to.(componentNode).ComponentID().String()),
+				))
+			}
 			from = processor
 		}
 		// Always inserts a fanout node before any exporters. If there is only one
@@ -284,8 +324,17 @@ func (g *Graph) createEdges() {
 
 		for _, exporter := range pg.exporters {
 			g.componentGraph.SetEdge(g.componentGraph.NewEdge(pg.fanOutNode, exporter))
+			if lastProcessor, ok := from.(componentNode); ok {
+				if exp, ok := exporter.(*exporterNode); ok {
+					infoMetric.Record(ctx, 1, metric.WithAttributes(
+						attribute.String("from", lastProcessor.ComponentID().String()),
+						attribute.String("to", exp.componentID.String()),
+					))
+				}
+			}
 		}
 	}
+	return nil
 }
 
 // Uses the already built graph g to instantiate the actual components for each component of each pipeline.

--- a/service/internal/graph/obs_test.go
+++ b/service/internal/graph/obs_test.go
@@ -192,6 +192,147 @@ func TestComponentInstrumentation(t *testing.T) {
 
 	// TODO fix metric name prefix delimiter
 	expectedScopeMetrics := simpleScopeMetrics{
+		// Graph
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "traces/in"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", rcvrID.String()),
+					attribute.String("to", procID.String()),
+				): 1,
+				attribute.NewSet(
+					attribute.String("from", procID.String()),
+					attribute.String("to", routerID.String()),
+				): 1,
+			},
+		},
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "traces/left"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", routerID.String()),
+					attribute.String("to", expLeftID.String()),
+				): 1,
+			},
+		},
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "traces/right"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", routerID.String()),
+					attribute.String("to", expRightID.String()),
+				): 1,
+			},
+		},
+
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "profiles/in"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", rcvrID.String()),
+					attribute.String("to", procID.String()),
+				): 1,
+				attribute.NewSet(
+					attribute.String("from", procID.String()),
+					attribute.String("to", routerID.String()),
+				): 1,
+			},
+		},
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "profiles/left"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", routerID.String()),
+					attribute.String("to", expLeftID.String()),
+				): 1,
+			},
+		},
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "profiles/right"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", routerID.String()),
+					attribute.String("to", expRightID.String()),
+				): 1,
+			},
+		},
+
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "logs/in"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", rcvrID.String()),
+					attribute.String("to", procID.String()),
+				): 1,
+				attribute.NewSet(
+					attribute.String("from", procID.String()),
+					attribute.String("to", routerID.String()),
+				): 1,
+			},
+		},
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "logs/left"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", routerID.String()),
+					attribute.String("to", expLeftID.String()),
+				): 1,
+			},
+		},
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "logs/right"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", routerID.String()),
+					attribute.String("to", expRightID.String()),
+				): 1,
+			},
+		},
+
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "metrics/in"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", rcvrID.String()),
+					attribute.String("to", procID.String()),
+				): 1,
+				attribute.NewSet(
+					attribute.String("from", procID.String()),
+					attribute.String("to", routerID.String()),
+				): 1,
+			},
+		},
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "metrics/left"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", routerID.String()),
+					attribute.String("to", expLeftID.String()),
+				): 1,
+			},
+		},
+		attribute.NewSet(
+			attribute.String("otelcol.pipeline.id", "metrics/right"),
+		): simpleMetricMap{
+			"otelcol.graph.edge.connected": simpleMetric{
+				attribute.NewSet(
+					attribute.String("from", routerID.String()),
+					attribute.String("to", expRightID.String()),
+				): 1,
+			},
+		},
+
 		// Traces
 		attribute.NewSet(
 			attribute.String("otelcol.component.kind", "receiver"),
@@ -664,13 +805,23 @@ func TestComponentInstrumentation(t *testing.T) {
 
 		for _, actualMetric := range actualScopeMetrics.Metrics {
 			expectedMetric, ok := expectedScopeMetrics[actualMetric.Name]
-			require.True(t, ok)
+			require.True(t, ok, "metric %s not found", actualMetric.Name)
 
-			for _, actualPoint := range actualMetric.Data.(metricdata.Sum[int64]).DataPoints {
-				expectedPoint, ok := expectedMetric[actualPoint.Attributes]
-				require.True(t, ok)
+			if sum, ok := actualMetric.Data.(metricdata.Sum[int64]); ok {
+				for _, actualPoint := range sum.DataPoints {
+					expectedPoint, ok := expectedMetric[actualPoint.Attributes]
+					require.True(t, ok)
 
-				assert.Equal(t, int64(expectedPoint), actualPoint.Value)
+					assert.Equal(t, int64(expectedPoint), actualPoint.Value)
+				}
+			}
+			if gauge, ok := actualMetric.Data.(metricdata.Gauge[int64]); ok {
+				for _, actualPoint := range gauge.DataPoints {
+					expectedPoint, ok := expectedMetric[actualPoint.Attributes]
+					require.True(t, ok)
+
+					assert.Equal(t, int64(expectedPoint), actualPoint.Value)
+				}
 			}
 		}
 	}

--- a/service/internal/graph/processor.go
+++ b/service/internal/graph/processor.go
@@ -21,7 +21,10 @@ import (
 	"go.opentelemetry.io/collector/service/internal/refconsumer"
 )
 
-var _ consumerNode = (*processorNode)(nil)
+var (
+	_ consumerNode  = (*processorNode)(nil)
+	_ componentNode = (*processorNode)(nil)
+)
 
 // Every processor instance is unique to one pipeline.
 // Therefore, nodeID is derived from "pipeline ID" and "component ID".
@@ -43,6 +46,10 @@ func newProcessorNode(pipelineID pipeline.ID, procID component.ID) *processorNod
 
 func (n *processorNode) getConsumer() baseConsumer {
 	return n.consumer
+}
+
+func (n *processorNode) ComponentID() component.ID {
+	return n.componentID
 }
 
 func (n *processorNode) buildComponent(ctx context.Context,

--- a/service/internal/graph/receiver.go
+++ b/service/internal/graph/receiver.go
@@ -21,6 +21,8 @@ import (
 	"go.opentelemetry.io/collector/service/internal/obsconsumer"
 )
 
+var _ componentNode = (*receiverNode)(nil)
+
 // A receiver instance can be shared by multiple pipelines of the same type.
 // Therefore, nodeID is derived from "pipeline type" and "component ID".
 type receiverNode struct {
@@ -36,6 +38,10 @@ func newReceiverNode(pipelineType pipeline.Signal, recvID component.ID) *receive
 		componentID:  recvID,
 		pipelineType: pipelineType,
 	}
+}
+
+func (n *receiverNode) ComponentID() component.ID {
+	return n.componentID
 }
 
 func (n *receiverNode) buildComponent(ctx context.Context,

--- a/service/internal/metadata/generated_telemetry.go
+++ b/service/internal/metadata/generated_telemetry.go
@@ -34,6 +34,7 @@ type TelemetryBuilder struct {
 	ConnectorProducedSize             metric.Int64Counter
 	ExporterConsumedItems             metric.Int64Counter
 	ExporterConsumedSize              metric.Int64Counter
+	GraphEdgeConnected                metric.Int64Gauge
 	ProcessCPUSeconds                 metric.Float64ObservableCounter
 	ProcessMemoryRss                  metric.Int64ObservableGauge
 	ProcessRuntimeHeapAllocBytes      metric.Int64ObservableGauge
@@ -220,6 +221,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.ExporterConsumedSize, err = builder.meter.Int64Counter(
 		"otelcol.exporter.consumed.size",
 		metric.WithDescription("Size of items passed to the exporter, based on ProtoMarshaler.Sizer. [Development]"),
+		metric.WithUnit("{item}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.GraphEdgeConnected, err = builder.meter.Int64Gauge(
+		"otelcol.graph.edge.connected",
+		metric.WithDescription("Indicates connection between components (1 = connected, 0 = not connected) [Development]"),
 		metric.WithUnit("{item}"),
 	)
 	errs = errors.Join(errs, err)

--- a/service/internal/metadatatest/generated_telemetrytest.go
+++ b/service/internal/metadatatest/generated_telemetrytest.go
@@ -108,6 +108,20 @@ func AssertEqualExporterConsumedSize(t *testing.T, tt *componenttest.Telemetry, 
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualGraphEdgeConnected(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol.graph.edge.connected",
+		Description: "Indicates connection between components (1 = connected, 0 = not connected) [Development]",
+		Unit:        "{item}",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol.graph.edge.connected")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualProcessCPUSeconds(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_process_cpu_seconds",

--- a/service/internal/metadatatest/generated_telemetrytest_test.go
+++ b/service/internal/metadatatest/generated_telemetrytest_test.go
@@ -50,6 +50,7 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ConnectorProducedSize.Add(context.Background(), 1)
 	tb.ExporterConsumedItems.Add(context.Background(), 1)
 	tb.ExporterConsumedSize.Add(context.Background(), 1)
+	tb.GraphEdgeConnected.Record(context.Background(), 1)
 	tb.ProcessorConsumedItems.Add(context.Background(), 1)
 	tb.ProcessorConsumedSize.Add(context.Background(), 1)
 	tb.ProcessorProducedItems.Add(context.Background(), 1)
@@ -72,6 +73,9 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterConsumedSize(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualGraphEdgeConnected(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessCPUSeconds(t, testTel,

--- a/service/metadata.yaml
+++ b/service/metadata.yaml
@@ -71,6 +71,15 @@ telemetry:
         value_type: int
         monotonic: true
 
+    graph.edge.connected:
+      prefix: otelcol.
+      enabled: true
+      stability: development
+      description: Indicates connection between components (1 = connected, 0 = not connected)
+      unit: "{item}"
+      gauge:
+        value_type: int
+
     process_cpu_seconds:
       enabled: true
       stability: alpha
@@ -190,22 +199,22 @@ telemetry:
 
 feature_gates:
   - id: service.AllowNoPipelines
-    description: 'Allow starting the Collector without starting any pipelines.'
+    description: "Allow starting the Collector without starting any pipelines."
     stage: alpha
-    from_version: 'v0.122.0'
-    reference_url: 'https://github.com/open-telemetry/opentelemetry-collector/pull/12613'
+    from_version: "v0.122.0"
+    reference_url: "https://github.com/open-telemetry/opentelemetry-collector/pull/12613"
   - id: service.profilesSupport
-    description: 'Controls whether profiles support can be enabled'
+    description: "Controls whether profiles support can be enabled"
     stage: alpha
-    from_version: 'v0.112.0'
-    reference_url: 'https://github.com/open-telemetry/opentelemetry-collector/pull/11477'
+    from_version: "v0.112.0"
+    reference_url: "https://github.com/open-telemetry/opentelemetry-collector/pull/11477"
   - id: telemetry.UseLocalHostAsDefaultMetricsAddress
-    description: 'Controls whether default Prometheus metrics server use localhost as the default host for their endpoints'
+    description: "Controls whether default Prometheus metrics server use localhost as the default host for their endpoints"
     stage: beta
-    from_version: 'v0.111.0'
-    reference_url: 'https://github.com/open-telemetry/opentelemetry-collector/pull/11251'
+    from_version: "v0.111.0"
+    reference_url: "https://github.com/open-telemetry/opentelemetry-collector/pull/11251"
   - id: telemetry.newPipelineTelemetry
-    description: 'Injects component-identifying scope attributes in internal Collector metrics'
+    description: "Injects component-identifying scope attributes in internal Collector metrics"
     stage: alpha
-    from_version: 'v0.123.0'
-    reference_url: 'https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md'
+    from_version: "v0.123.0"
+    reference_url: "https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md"

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -178,6 +178,7 @@ func assertMetrics(t *testing.T, rm metricdata.ResourceMetrics) {
 		"otelcol_process_runtime_total_alloc_bytes",
 		"otelcol_process_runtime_total_sys_memory_bytes",
 		"otelcol_process_uptime",
+		"otelcol.graph.edge.connected",
 	}, actualNames)
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR explores an alternative way to support component graph reconstruction from telemetry alone.
It works by defining a new metric `otelcol.graph.edge.connected` with the `otelcol.pipeline.id`, `from` and `to` attributes. A value of `1` indicates that the component with the id in `from` is connected to the component with the id of `to` in the pipeline with id `otelcol.pipeline.id`

The implementation works but as there has been no formal decision on how to implement this, the primary purpose is to serve as a foundation for follow-up discussions

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15001

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tested with a custom build including this patch and the following telemetry configuration:
```yaml
    metrics:
      level: detailed
      readers:
        - pull:
            exporter:
              prometheus:
                host: "0.0.0.0"
                port: 8888
                without_scope_info: false
                without_units: false
                without_type_suffix: false
```
Combined with `--feature-gates=telemetry.newPipelineTelemetry`, the following PromQL query reconstructs a graph for items produced per pipeline:
```promql
({"otelcol.graph.edge.connected"} * on(from,"otel_scope_otelcol.pipeline.id") group_left  label_replace(
        sum(rate({"otelcol.processor.produced.items_total"}[4m])) by ("otel_scope_otelcol.pipeline.id","otel_scope_otelcol.component.id"),
        "from","$1","otel_scope_otelcol.component.id","(.*)"
        ))
or
({"otelcol.graph.edge.connected"} * on(to,"otel_scope_otelcol.pipeline.id") group_left     label_replace(
        sum(rate({"otelcol.processor.consumed.items_total"}[4m])) by ("otel_scope_otelcol.pipeline.id","otel_scope_otelcol.component.id"),
        "to","$1","otel_scope_otelcol.component.id","(.*)"
        ))
or
({"otelcol.graph.edge.connected"} * on(from,"otel_scope_otelcol.pipeline.id") group_left     label_replace(label_replace(
        sum(rate({"otelcol.connector.produced.items_total"}[4m])) by ("otelcol.pipeline.id","otel_scope_otelcol.component.id"),
        "from","$1","otel_scope_otelcol.component.id","(.*)"
        ),"otel_scope_otelcol.pipeline.id","$1","otelcol.pipeline.id","(.*)"))
```

<!--Describe the documentation added.-->
#### Documentation

_To be done once metric names & attributes are decided_
<!--Please delete paragraphs that you did not use before submitting.-->
