### PR TITLE
[confighttp] Close block snappy request body

### DIFF
--- a/.chloggen/confighttp-close-snappy-block-body.yaml
+++ b/.chloggen/confighttp-close-snappy-block-body.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Close the original request body after reading block-format `Content-Encoding: snappy` requests."
+
+# One or more tracking issues or pull requests related to the change
+issues: [15262]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -151,6 +151,7 @@ func newSnappyHandler(maxRequestBodySize int64) func(io.ReadCloser) (io.ReadClos
 				orig:   body,
 			}, nil
 		}
+		defer body.Close()
 
 		compressed, err := io.ReadAll(br)
 		if err != nil {

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -961,6 +961,46 @@ func TestSnappyBlockRejectsOversizedDecodedLen(t *testing.T) {
 	assert.False(t, downstreamCalled, "downstream handler must not run when request is rejected")
 }
 
+func TestSnappyBlockClosesOriginalBody(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		maxBody   int64
+		payload   []byte
+		wantError string
+	}{
+		{
+			name:    "valid",
+			maxBody: 1024,
+			payload: snappy.Encode(nil, []byte("request body")),
+		},
+		{
+			name:      "oversized",
+			maxBody:   1024,
+			payload:   snappy.Encode(nil, make([]byte, 8*1024)),
+			wantError: "snappy: decoded size exceeds max request body size",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := &closeTrackingReadCloser{Reader: bytes.NewReader(tc.payload)}
+			newBody, err := newSnappyHandler(tc.maxBody)(body)
+
+			assert.True(t, body.closed)
+			if tc.wantError != "" {
+				require.EqualError(t, err, tc.wantError)
+				assert.Nil(t, newBody)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, newBody)
+			require.NoError(t, newBody.Close())
+		})
+	}
+}
+
 func TestPooledZstdReadCloserReadAfterClose(t *testing.T) {
 	h := httpContentDecompressor(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -991,6 +1031,16 @@ func TestPooledZstdReadCloserReadAfterClose(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code, "Must match the expected code")
 	assert.Empty(t, resp.Body.String(), "Must match the returned string")
+}
+
+type closeTrackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (ctrc *closeTrackingReadCloser) Close() error {
+	ctrc.closed = true
+	return nil
 }
 
 func compressGzip(tb testing.TB, body []byte) *bytes.Buffer {


### PR DESCRIPTION
Close the original HTTP request body after confighttp eagerly reads block-format snappy payloads, including oversized reject paths, so resources are released instead of being hidden behind an in-memory NopCloser.