### PR TITLE
cmd/mdatagen: Support config type aliases

### DIFF
--- a/.chloggen/mdatagen-config-type-aliases.yaml
+++ b/.chloggen/mdatagen-config-type-aliases.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: cmd/mdatagen
+
+note: Support generating Go type aliases from pure `$ref` entries under config `$defs`.
+
+issues: [15261]
+
+change_logs: [api]

--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -58,6 +58,14 @@ func NewCfgFns(rootPackage, componentPackage string) map[string]any {
 			}
 			return typeName
 		},
+		"isTypeAlias": IsTypeAlias,
+		"typeAliasTarget": func(md *ConfigMetadata) string {
+			typeName, err := FormatTypeName(TypeAliasTarget(md), rootPackage, componentPackage)
+			if err != nil {
+				panic(err)
+			}
+			return typeName
+		},
 		"embeddedName": func(md *ConfigMetadata) string {
 			id := md.EmbeddedName
 			if id == "" {
@@ -210,6 +218,16 @@ func collectImports(md *ConfigMetadata, imports map[string]bool, rootPackage, co
 		}
 	}
 
+	if aliasTarget := TypeAliasTarget(md); aliasTarget != "" {
+		ref, err := ResolveGoTypeRef(aliasTarget, rootPackage, componentPackage)
+		if err != nil {
+			return fmt.Errorf("failed to resolve import for type alias %q: %w", aliasTarget, err)
+		}
+		if ref.ImportPath != "" {
+			imports[ref.ImportPath] = true
+		}
+	}
+
 	if md.Type == "string" && strings.HasPrefix(md.GoType, "time.") {
 		imports["time"] = true
 	}
@@ -321,6 +339,33 @@ func FormatTypeName(ref, rootPackage, componentPackage string) (string, error) {
 	return tr.String(), nil
 }
 
+// IsTypeAlias reports whether md represents a generated Go type alias.
+func IsTypeAlias(md *ConfigMetadata) bool {
+	return TypeAliasTarget(md) != ""
+}
+
+// TypeAliasTarget returns the raw metadata reference used as a Go type alias target.
+func TypeAliasTarget(md *ConfigMetadata) string {
+	if md == nil {
+		return ""
+	}
+	if md.TypeAlias != "" {
+		return md.TypeAlias
+	}
+	if md.Ref != "" &&
+		md.Type == "" &&
+		md.GoType == "" &&
+		md.ResolvedFrom == "" &&
+		len(md.Properties) == 0 &&
+		len(md.AllOf) == 0 &&
+		md.AdditionalProperties == nil &&
+		md.Items == nil &&
+		len(md.Defs) == 0 {
+		return md.Ref
+	}
+	return ""
+}
+
 // ExtractDefs recursively collects all definitions from the ConfigMetadata, including nested ones,
 // and returns a flat map of definition names to their corresponding ConfigMetadata.
 func ExtractDefs(md *ConfigMetadata) map[string]*ConfigMetadata {
@@ -331,6 +376,9 @@ func ExtractDefs(md *ConfigMetadata) map[string]*ConfigMetadata {
 
 func collectDefs(md *ConfigMetadata, defs map[string]*ConfigMetadata) {
 	if md == nil {
+		return
+	}
+	if IsTypeAlias(md) {
 		return
 	}
 	if md.ResolvedFrom != "" {
@@ -356,7 +404,7 @@ func collectDefs(md *ConfigMetadata, defs map[string]*ConfigMetadata) {
 }
 
 func collectDefsForSchema(propName string, md *ConfigMetadata, defs map[string]*ConfigMetadata) {
-	if md == nil || md.GoType != "" {
+	if md == nil || md.GoType != "" || IsTypeAlias(md) {
 		return
 	}
 
@@ -604,7 +652,11 @@ func formatSimpleValue(md *ConfigMetadata, name string, defaultValue any, rootPa
 	if isReference || isSubStruct {
 		if hasDefaultValue(md) {
 			if isReference {
-				refType, err := ResolveGoTypeRef(md.ResolvedFrom, rootPackage, componentPackage)
+				defaultRef := md.ResolvedFrom
+				if md.TypeAlias != "" {
+					defaultRef = md.TypeAlias
+				}
+				refType, err := ResolveGoTypeRef(defaultRef, rootPackage, componentPackage)
 				if err != nil {
 					panic(err)
 				}

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -718,6 +718,20 @@ func TestExtractImports_Defs(t *testing.T) {
 	require.Contains(t, result, "time")
 }
 
+func TestExtractImports_TypeAlias(t *testing.T) {
+	md := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"helper": {
+				TypeAlias: "/scraper/scraperhelper.controller_config",
+			},
+		},
+	}
+	result, err := ExtractImports(md, "go.opentelemetry.io/collector", "")
+	require.NoError(t, err)
+	require.Contains(t, result, "go.opentelemetry.io/collector/scraper/scraperhelper")
+}
+
 func TestExtractImports_NilInput(t *testing.T) {
 	result, err := ExtractImports(nil, "", "")
 	require.NoError(t, err)
@@ -1000,6 +1014,24 @@ func TestExtractDefs_SkipsExternalResolvedReference(t *testing.T) {
 
 	result := ExtractDefs(md)
 	require.Empty(t, result)
+}
+
+func TestExtractDefs_PreservesTypeAliasDef(t *testing.T) {
+	md := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"helper": {
+				TypeAlias: "go.opentelemetry.io/collector/scraper/scraperhelper.controller_config",
+				Properties: map[string]*ConfigMetadata{
+					"timeout": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	result := ExtractDefs(md)
+	require.Len(t, result, 1)
+	require.Same(t, md.Defs["helper"], result["helper"])
 }
 
 func TestExtractDefs_NilInput(t *testing.T) {

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -714,6 +714,61 @@ func TestGenerateConfigGoStruct_InternalResolvedRefGeneratesLocalType(t *testing
 	require.Contains(t, generated, "Config: config,")
 }
 
+func TestGenerateConfigGoStruct_TypeAliasDef(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "shortname")
+	require.NoError(t, os.MkdirAll(outputDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmodule\n"), 0o600))
+
+	md := Metadata{
+		Type:        "test",
+		PackageName: "testmodule/shortname",
+		Status:      &Status{Class: "receiver"},
+		Config: &cfggen.ConfigMetadata{
+			Type: "object",
+			Defs: map[string]*cfggen.ConfigMetadata{
+				"helper": {
+					Description: "ControllerConfig defines common settings.",
+					TypeAlias:   "/scraper/scraperhelper.controller_config",
+				},
+			},
+			AllOf: []*cfggen.ConfigMetadata{
+				{
+					Type:         "object",
+					ResolvedFrom: "helper",
+					TypeAlias:    "/scraper/scraperhelper.controller_config",
+					EmbeddedName: "controller_config",
+					Default:      map[string]any{"timeout": "30s"},
+					Properties: map[string]*cfggen.ConfigMetadata{
+						"timeout": {
+							Type:    "string",
+							GoType:  "time.Duration",
+							Default: "30s",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := generateConfigGoStruct(md, outputDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "generated_config.go")) // #nosec G304
+	require.NoError(t, err)
+
+	generated := string(content)
+	require.Contains(t, generated, `"testmodule/scraper/scraperhelper"`)
+	require.Contains(t, generated, "// Helper ControllerConfig defines common settings.")
+	require.Contains(t, generated, "type Helper = scraperhelper.ControllerConfig")
+	require.Contains(t, generated, "ControllerConfig Helper `mapstructure:\",squash\"`")
+	require.Contains(t, generated, "helper := scraperhelper.NewDefaultControllerConfig()")
+	require.Contains(t, generated, "helper.Timeout = 30 * time.Second")
+	require.Contains(t, generated, "ControllerConfig: helper,")
+	require.NotContains(t, generated, "type Helper struct")
+	require.NotContains(t, generated, "NewDefaultHelper")
+}
+
 func TestGenerateConfigFiles_GoStructError(t *testing.T) {
 	// generateConfigGoStruct fails because tmpdir has no go.mod in any ancestor
 	md := Metadata{

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -42,6 +42,9 @@ import (
         // {{ $defName | publicVar }} {{ $def.Description }}
     {{- end }}
     {{- $typeName := $defName | publicVar }}
+    {{- if isTypeAlias $def }}
+    type {{ $typeName }} = {{ typeAliasTarget $def }}
+    {{- else }}
     type {{ $typeName }} struct {
         {{- template "struct" $def }}
     }
@@ -69,6 +72,7 @@ import (
     }
     {{- end }}
 
+    {{- end }}
 {{ end }}
 
 {{- if .Metadata.Config.Description }}

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -57,6 +57,7 @@ type ConfigMetadata struct {
 	// internal
 	ResolvedFrom string `mapstructure:"-" json:"-" yaml:"-"`
 	EmbeddedName string `mapstructure:"-" json:"-" yaml:"-"`
+	TypeAlias    string `mapstructure:"-" json:"-" yaml:"-"`
 }
 
 type GoStructConfig struct {

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -60,6 +60,18 @@ func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *
 		if err != nil {
 			return fmt.Errorf("failed to resolve $ref %q: %w", current.Ref, err)
 		}
+		aliasTarget := ""
+		resolvedFromPureRef := isPureRefDefinition(resolved)
+		if resolved.Ref != "" && resolved != current {
+			resolvedTarget := &ConfigMetadata{}
+			if err := r.resolveSchema(root, resolved, resolvedTarget, origin); err != nil {
+				return err
+			}
+			if resolvedFromPureRef {
+				aliasTarget = resolvedTarget.ResolvedFrom
+			}
+			resolved = resolvedTarget
+		}
 
 		// Preserve custom extensions defined on the reference node
 		customGoType := current.GoType
@@ -72,6 +84,7 @@ func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *
 		// Copy the resolved node
 		newCurrent := *resolved
 		newCurrent.ResolvedFrom = current.Ref
+		newCurrent.TypeAlias = aliasTarget
 		newCurrent.GoStruct = current.GoStruct
 		newCurrent.Embed = current.Embed
 
@@ -130,9 +143,16 @@ func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *
 					key := iter.Key()
 					value := iter.Value()
 					if !value.IsNil() {
+						sourceMeta := value.Interface().(*ConfigMetadata)
+						if currRef.Type().Field(i).Name == "Defs" && !isPureRefDefinition(sourceMeta) {
+							continue
+						}
 						newMeta := &ConfigMetadata{}
-						if err := r.resolveSchema(root, value.Interface().(*ConfigMetadata), newMeta, origin); err != nil {
+						if err := r.resolveSchema(root, sourceMeta, newMeta, origin); err != nil {
 							return err
+						}
+						if currRef.Type().Field(i).Name == "Defs" {
+							newMeta.TypeAlias = newMeta.ResolvedFrom
 						}
 						newMap.SetMapIndex(key, reflect.ValueOf(newMeta))
 					}
@@ -164,8 +184,54 @@ func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *
 	}
 	handleEmbeddedStructs(target)
 	enhanceTimeTypes(target)
-	target.Defs = nil // Clear defs after resolution to avoid confusion
+	if len(target.Defs) == 0 {
+		target.Defs = nil // Clear defs after resolution to avoid confusion
+	}
 	return nil
+}
+
+func isPureRefDefinition(md *ConfigMetadata) bool {
+	return md != nil &&
+		md.Ref != "" &&
+		md.Schema == "" &&
+		md.ID == "" &&
+		md.Title == "" &&
+		md.Description == "" &&
+		md.Comment == "" &&
+		md.Type == "" &&
+		md.Default == nil &&
+		len(md.Examples) == 0 &&
+		!md.Deprecated &&
+		len(md.Enum) == 0 &&
+		md.Const == nil &&
+		len(md.AllOf) == 0 &&
+		len(md.Properties) == 0 &&
+		md.AdditionalProperties == nil &&
+		len(md.Required) == 0 &&
+		md.MinProperties == nil &&
+		md.MaxProperties == nil &&
+		md.Items == nil &&
+		md.MinItems == nil &&
+		md.MaxItems == nil &&
+		!md.UniqueItems &&
+		md.MaxLength == nil &&
+		md.MinLength == nil &&
+		md.Pattern == "" &&
+		md.Format == "" &&
+		md.ContentMediaType == "" &&
+		md.ContentEncoding == "" &&
+		md.ContentSchema == nil &&
+		md.MultipleOf == nil &&
+		md.Maximum == nil &&
+		md.ExclusiveMaximum == nil &&
+		md.Minimum == nil &&
+		md.ExclusiveMinimum == nil &&
+		len(md.Defs) == 0 &&
+		md.GoStruct == (GoStructConfig{}) &&
+		md.GoType == "" &&
+		!md.IsPointer &&
+		!md.IsOptional &&
+		!md.Embed
 }
 
 // resolveRef resolves a JSON Schema $ref, handling both internal and external references.

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -63,6 +63,63 @@ func TestResolver_ResolveSchema_InternalReference(t *testing.T) {
 	require.Equal(t, "Target type description", result.Properties["config"].Description)
 }
 
+func TestResolver_ResolveSchema_PreservesPureRefDefsAsAliases(t *testing.T) {
+	helperSchema := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"controller_config": {
+				Type:        "object",
+				Description: "ControllerConfig defines common settings.",
+				Properties: map[string]*ConfigMetadata{
+					"timeout": {
+						Type:    "string",
+						Format:  "duration",
+						Default: "30s",
+					},
+				},
+			},
+		},
+	}
+	resolver := &Resolver{
+		pkgID: "go.opentelemetry.io/collector/test/component",
+		loader: &mockLoader{schemas: map[string]*ConfigMetadata{
+			"/scraper/scraperhelper.controller_config": helperSchema,
+		}},
+	}
+
+	src := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"helper": {
+				Ref: "/scraper/scraperhelper.controller_config",
+			},
+			"scratch": {
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"name": {Type: "string"},
+				},
+			},
+		},
+		Properties: map[string]*ConfigMetadata{
+			"controller_config": {
+				Ref:   "helper",
+				Embed: true,
+			},
+		},
+	}
+
+	result, err := resolver.ResolveSchema(src)
+	require.NoError(t, err)
+	require.Len(t, result.Defs, 1)
+	require.Equal(t, "/scraper/scraperhelper.controller_config", result.Defs["helper"].TypeAlias)
+	require.Equal(t, "ControllerConfig defines common settings.", result.Defs["helper"].Description)
+	require.Empty(t, result.Defs["helper"].Defs)
+	require.Len(t, result.AllOf, 1)
+	require.Equal(t, "helper", result.AllOf[0].ResolvedFrom)
+	require.Equal(t, "/scraper/scraperhelper.controller_config", result.AllOf[0].TypeAlias)
+	require.Equal(t, "time.Duration", result.AllOf[0].Properties["timeout"].GoType)
+}
+
 func TestResolver_ResolveSchema_UnknownInternalReference(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",


### PR DESCRIPTION
#### Description

Adds support for generating Go type aliases from pure `$ref` entries under `config.$defs`.

This allows components to re-export external config types from generated config code while preserving type identity, so values and methods remain interchangeable. Non-emitted scratch definitions continue to be pruned as before.

#### Link to tracking issue

Fixes #15261

#### Testing

Added coverage for:

- preserving pure `$ref` definitions as aliases during schema resolution
- generating Go alias declarations
- importing alias target packages
- using aliases for embedded fields
- keeping default constructors wired to the external target type

Ran full repository `make`.

#### Documentation

Added changelog entry.
