### PR TITLE
[chore][cmd/mdatagen] Fix alias chain resolution for internal $defs referencing external types

### DIFF
--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -82,6 +82,13 @@ func NewCfgFns(rootPackage, componentPackage string) map[string]any {
 			return MapCustomDefaults(schema, defaultValue, rootPackage, componentPackage)
 		},
 		"hasDefaultValue": hasDefaultValue,
+		"isExternalRef": func(ref string) bool {
+			if ref == "" {
+				return false
+			}
+			tr, err := ResolveGoTypeRef(ref, rootPackage, componentPackage)
+			return err == nil && tr.ImportPath != ""
+		},
 	}
 }
 

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -2359,6 +2359,66 @@ func TestMapCustomDefaults_IgnoreDefault(t *testing.T) {
 	require.Empty(t, MapCustomDefaults(md, defaultValue(map[string]any{"host": "localhost"}), "", ""))
 }
 
+func TestIsExternalRef(t *testing.T) {
+	fns := NewCfgFns("go.opentelemetry.io/collector", "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplescraper")
+	isExternalRef := fns["isExternalRef"].(func(string) bool)
+
+	tests := []struct {
+		name     string
+		ref      string
+		expected bool
+	}{
+		{
+			name:     "empty ref",
+			ref:      "",
+			expected: false,
+		},
+		{
+			name:     "internal def name",
+			ref:      "plain_config",
+			expected: false,
+		},
+		{
+			name:     "external ref with namespace",
+			ref:      "go.opentelemetry.io/collector/scraper/scraperhelper.controller_config",
+			expected: true,
+		},
+		{
+			name:     "local absolute ref",
+			ref:      "/scraper/scraperhelper.controller_config",
+			expected: true,
+		},
+		{
+			name:     "local relative ref",
+			ref:      "./internal/metadata.metrics_builder_config",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isExternalRef(tt.ref))
+		})
+	}
+}
+
+func TestMapCustomDefaults_ExternalRefWithProperties(t *testing.T) {
+	md := &ConfigMetadata{
+		Type:         "object",
+		ResolvedFrom: "go.opentelemetry.io/collector/scraper/scraperhelper.controller_config",
+		Properties: map[string]*ConfigMetadata{
+			"timeout": {
+				Type:   "string",
+				GoType: "time.Duration",
+			},
+		},
+	}
+
+	exprs := MapCustomDefaults(md, map[string]any{"timeout": "30s"}, "", "")
+	require.Len(t, exprs, 1)
+	require.Equal(t, ".Timeout = 30*time.Second", exprs[0])
+}
+
 func TestNewCfgFns_DefaultHelpers(t *testing.T) {
 	fns := NewCfgFns("", "")
 

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -14,6 +14,9 @@ import (
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 )
 
+// ControllerConfig ControllerConfig defines common settings for a scraper controller configuration. Scraper controller receivers can embed this struct, instead of receiver.Settings, and extend it with more fields if needed.
+type ControllerConfig = scraperhelper.ControllerConfig
+
 type TargetsItem struct {
 	// HTTP client configuration for the target endpoint.
 	HTTPClient confighttp.ClientConfig                `mapstructure:"http_client"`

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -25,6 +25,9 @@ status:
 config:
   type: object
   description: Configuration for the Sample Scraper.
+  $defs:
+    controller_config:
+      $ref: /scraper/scraperhelper.controller_config
   properties:
     metrics_builder_config:
       $ref: ./internal/metadata.metrics_builder_config
@@ -32,7 +35,7 @@ config:
       go_struct:
         anonymous: true
     controller_config:
-      $ref: /scraper/scraperhelper.controller_config
+      $ref: controller_config
       embed: true
       default:
         timeout: 30s

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -42,9 +42,13 @@ import (
         // {{ $defName | publicVar }} {{ $def.Description }}
     {{- end }}
     {{- $typeName := $defName | publicVar }}
-    type {{ $typeName }} struct {
+    {{- if isExternalRef $def.ResolvedFrom }}
+        type {{ $typeName }} = {{ $def.ResolvedFrom | publicType }}
+    {{- else }}
+        type {{ $typeName }} struct {
         {{- template "struct" $def }}
-    }
+        }
+    {{- end }}
 
     {{ $defValidators := extractValidators $def }}
     {{- if $defValidators }}
@@ -59,8 +63,8 @@ import (
         }
     {{- end }}
 
-    // NewDefault{{ $typeName }} returns a new {{ $typeName }} with default values consistent with the annotations in the schema.
     {{- if hasDefaultValue $def }}
+    // NewDefault{{ $typeName }} returns a new {{ $typeName }} with default values consistent with the annotations in the schema.
     func NewDefault{{ $typeName }}() {{ $typeName }} {
         {{- template "structLiteralVars" $def }}
         return {{ $typeName }}{

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -56,11 +56,6 @@ func (r *Resolver) ResolveSchema(src *ConfigMetadata) (*ConfigMetadata, error) {
 
 func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *Ref) error {
 	if current.Ref != "" {
-		resolved, err := r.resolveRef(root, current, origin)
-		if err != nil {
-			return fmt.Errorf("failed to resolve $ref %q: %w", current.Ref, err)
-		}
-
 		// Preserve custom extensions defined on the reference node
 		customGoType := current.GoType
 		customIsPointer := current.IsPointer
@@ -69,9 +64,31 @@ func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *
 		customDefault := current.Default
 		customEnum := current.Enum
 
+		finalRef := current.Ref
+		resolved, err := r.resolveRef(root, current, origin)
+		if err != nil {
+			return fmt.Errorf("failed to resolve $ref %q: %w", current.Ref, err)
+		}
+
+		// Follow alias chains: an internal $defs entry may itself be a $ref (e.g. to an external type).
+		// Keep resolving until we reach a concrete schema node.
+		// Stop if resolveRef returns the same pointer (unknown-ref fallback sets GoType and returns current).
+		for resolved.Ref != "" {
+			next, err := r.resolveRef(root, resolved, origin)
+			if err != nil {
+				return fmt.Errorf("failed to resolve $ref %q: %w", resolved.Ref, err)
+			}
+			if next == resolved {
+				// fallback "any" case: resolveRef returned the node unchanged
+				break
+			}
+			finalRef = resolved.Ref
+			resolved = next
+		}
+
 		// Copy the resolved node
 		newCurrent := *resolved
-		newCurrent.ResolvedFrom = current.Ref
+		newCurrent.ResolvedFrom = finalRef
 		newCurrent.GoStruct = current.GoStruct
 		newCurrent.Embed = current.Embed
 
@@ -164,7 +181,8 @@ func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *
 	}
 	handleEmbeddedStructs(target)
 	enhanceTimeTypes(target)
-	target.Defs = nil // Clear defs after resolution to avoid confusion
+	cleanupDefs(target)
+
 	return nil
 }
 
@@ -257,4 +275,19 @@ func enhanceTimeTypes(md *ConfigMetadata) {
 			md.GoType = "time.Time"
 		}
 	}
+}
+
+func cleanupDefs(md *ConfigMetadata) {
+	if md.Defs == nil {
+		// nothing to do here
+		return
+	}
+	defs := make(map[string]*ConfigMetadata)
+	for name, def := range md.Defs {
+		// if is an alias
+		if def.ResolvedFrom != "" {
+			defs[name] = def
+		}
+	}
+	md.Defs = defs
 }

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -86,6 +86,115 @@ func TestResolver_ResolveSchema_UnknownInternalReference(t *testing.T) {
 	require.Empty(t, result.Properties["config"].Type)
 }
 
+func TestResolver_ResolveSchema_AliasChain_InternalToExternal(t *testing.T) {
+	externalSchema := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"controller_config": {
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"timeout": {
+						Type:   "string",
+						GoType: "time.Duration",
+					},
+				},
+			},
+		},
+	}
+
+	ml := &mockLoader{
+		schemas: map[string]*ConfigMetadata{
+			"go.opentelemetry.io/collector/scraper/scraperhelper.controller_config": externalSchema,
+		},
+	}
+
+	resolver := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplescraper",
+		class:  "scraper",
+		name:   "sample",
+		loader: ml,
+	}
+
+	src := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			// alias: internal name → external type
+			"helper": {
+				Ref: "go.opentelemetry.io/collector/scraper/scraperhelper.controller_config",
+			},
+		},
+		Properties: map[string]*ConfigMetadata{
+			"controller_config": {
+				Ref:     "helper",
+				Embed:   true,
+				Default: map[string]any{"timeout": "30s"},
+			},
+		},
+	}
+
+	result, err := resolver.ResolveSchema(src)
+	require.NoError(t, err)
+
+	require.Len(t, result.AllOf, 1)
+	embedded := result.AllOf[0]
+
+	require.Equal(t, "go.opentelemetry.io/collector/scraper/scraperhelper.controller_config", embedded.ResolvedFrom)
+	require.NotNil(t, embedded.Properties["timeout"])
+	require.Equal(t, "time.Duration", embedded.Properties["timeout"].GoType)
+	require.Equal(t, map[string]any{"timeout": "30s"}, embedded.Default)
+}
+
+func TestResolver_ResolveSchema_AliasChain_PreservesCustomExtensions(t *testing.T) {
+	externalSchema := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"base": {
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"level": {Type: "integer"},
+				},
+			},
+		},
+	}
+
+	ml := &mockLoader{
+		schemas: map[string]*ConfigMetadata{
+			"go.opentelemetry.io/collector/config/configbase.base": externalSchema,
+		},
+	}
+
+	resolver := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: ml,
+	}
+
+	src := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"alias": {Ref: "go.opentelemetry.io/collector/config/configbase.base"},
+		},
+		Properties: map[string]*ConfigMetadata{
+			"cfg": {
+				Ref:         "alias",
+				Description: "overridden description",
+				Default:     map[string]any{"level": 5},
+			},
+		},
+	}
+
+	result, err := resolver.ResolveSchema(src)
+	require.NoError(t, err)
+
+	cfg := result.Properties["cfg"]
+	require.NotNil(t, cfg)
+	require.Equal(t, "go.opentelemetry.io/collector/config/configbase.base", cfg.ResolvedFrom)
+	require.Equal(t, "overridden description", cfg.Description)
+	require.Equal(t, map[string]any{"level": 5}, cfg.Default)
+	require.NotNil(t, cfg.Properties["level"])
+}
+
 func TestResolver_ResolveSchema_NestedStructures(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When a `$defs` entry in a component schema is itself a `$ref` to an external type (an alias), the resolver previously stopped after one hop. The resolved node retained the unresolved `Ref` field, so `ResolvedFrom` was set to the internal alias name (e.g. `helper`) rather than the concrete external type. Because the `Properties` map was never populated, `MapCustomDefaults` panicked with:
```
  schema does not contain required property: timeout
```
This change fixes the resolver to follow alias chains until a concrete schema node is reached, setting `ResolvedFrom` to the final external ref. It also tightens the template guard that emits `type X = pkg.Y` (type aliases) so it only fires for external refs, not for internal `$defs` that define local struct types.

The `samplescraper` metadata is updated to exercise the alias pattern as a regression guard.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15261

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- Added unit tests
- Regenerated `samplescraper` config to confirm end-to-end generation
  succeeds with the alias pattern.