### PR TITLE
[chore][docs/rfc] Adds 'rfc:approvals-needed' label

### DIFF
--- a/.github/workflows/add-rfc-label.yml
+++ b/.github/workflows/add-rfc-label.yml
@@ -1,0 +1,30 @@
+name: 'Add rfc:approvals-needed label to RFC PRs'
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+    paths:
+      - 'docs/rfcs/*.md'
+
+permissions: read-all
+
+jobs:
+  add-rfc-label:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    if: >-
+      ${{ github.repository_owner == 'open-telemetry'
+          && github.event.pull_request.draft == false
+          && !contains(github.event.pull_request.labels.*.name, 'rfc:approvals-needed')
+          && !contains(github.event.pull_request.labels.*.name, 'rfc:final-comment-period')
+          && !contains(github.event.pull_request.labels.*.name, 'rfc:vote-needed') }}
+    steps:
+      - name: Add rfc:approvals-needed label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.number }}
+        run: gh pr edit "$PR" --repo "$REPO" --add-label "rfc:approvals-needed"

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -45,10 +45,11 @@ We use a [Lazy Consensus](https://www.apache.org/foundation/glossary.html#LazyCo
 
 1. *Quorum*: For an RFC to be mergeable, it needs to have at least **two approvals** from the
    approvers set as well as approvals from any additional stakeholders.
-2. *Waiting period*: Maintainers need to announce their intent to merge the RFC with a GitHub
-   comment. They will need to add a `rfc:final-comment-period` label to the PR, comment on the PR
-   and note the final comment period in the #otel-collector-dev CNCF Slack channel, and wait for at
-   least **4 business days** after making the announcement to merge the RFC.
+2. *Waiting period*: RFC PRs are labeled `rfc:approvals-needed` when opened. Once the RFC has the
+   required approvals, maintainers announce their intent to merge with a GitHub comment, replace
+   `rfc:approvals-needed` with `rfc:final-comment-period`, and note the final comment period in the
+   #otel-collector-dev CNCF Slack channel. They must then wait at least **4 business days** before
+   merging the RFC.
 3. *Objections*: Objections should be communicated as a 'request changes' review. All objections
    must be addressed before merging an RFC. If addressing an objection does not appear feasible, any
    maintainer may call for a vote to be made on the objection (see below). This will be signified by


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->

Adds workflow to add `rfc:approvals-needed` for RFCs that are in need of approvals.

The intent is to add this to our weekly Slack message as a filter to make sure RFCs get more engagement and are surfaced more easily.

Somewhat related to #15172
