### PR TITLE
[cmd/mdatagen] Implement numeric validation in generated Go config code (#14806)

### DIFF
--- a/.chloggen/mdatagen_numeric_validators.yaml
+++ b/.chloggen/mdatagen_numeric_validators.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Handle numeric validators in generated config structs
+
+# One or more tracking issues or pull requests related to the change
+issues: [14806]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Supported validators include `minimum`, `maximum`, `exclusiveMinimum` and `exclusiveMaximum`.
+
+# Optional: The change log or logs in which this entry should be included
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users
+# Include 'api' if there is a change to a library API
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -441,14 +441,19 @@ func ExtractValidators(md *ConfigMetadata) []Validator {
 }
 
 type ValidationRules struct {
-	MaxLength *int
-	MinLength *int
-	Pattern   *string
-	Required  bool
+	MaxLength        *int
+	MinLength        *int
+	Pattern          *string
+	Required         bool
+	Minimum          *float64
+	Maximum          *float64
+	ExclusiveMinimum *float64
+	ExclusiveMaximum *float64
 }
 
 func (vr *ValidationRules) HasValueRule() bool {
-	return vr.MaxLength != nil || vr.MinLength != nil || vr.Pattern != nil
+	return vr.MaxLength != nil || vr.MinLength != nil || vr.Pattern != nil ||
+		vr.Minimum != nil || vr.Maximum != nil || vr.ExclusiveMinimum != nil || vr.ExclusiveMaximum != nil
 }
 
 func (vr *ValidationRules) Enabled() bool {
@@ -468,8 +473,12 @@ func collectValidators(md *ConfigMetadata, validators *[]Validator) {
 	for _, propName := range slices.Sorted(maps.Keys(md.Properties)) {
 		prop := md.Properties[propName]
 		rules := ValidationRules{
-			MaxLength: prop.MaxLength,
-			MinLength: prop.MinLength,
+			MaxLength:        prop.MaxLength,
+			MinLength:        prop.MinLength,
+			Minimum:          prop.Minimum,
+			Maximum:          prop.Maximum,
+			ExclusiveMinimum: prop.ExclusiveMinimum,
+			ExclusiveMaximum: prop.ExclusiveMaximum,
 		}
 
 		rules.Required = slices.Contains(md.Required, propName)

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -1799,6 +1799,150 @@ func TestExtractValidators_StringValidators(t *testing.T) {
 	}
 }
 
+func TestExtractValidators_NumericValidators(t *testing.T) {
+	minVal := 0.0
+	maxVal := 100.0
+	exclMinVal := 5.0
+	exclMaxVal := 10.0
+
+	tests := []struct {
+		name     string
+		metadata *ConfigMetadata
+		expected []Validator
+	}{
+		{
+			name: "minimum only",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"count": {Type: "number", Minimum: &minVal},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "count",
+					FieldType: "number",
+					Rules:     ValidationRules{Minimum: &minVal},
+				},
+			},
+		},
+		{
+			name: "maximum only",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"count": {Type: "number", Maximum: &maxVal},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "count",
+					FieldType: "number",
+					Rules:     ValidationRules{Maximum: &maxVal},
+				},
+			},
+		},
+		{
+			name: "exclusiveMinimum only",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"score": {Type: "number", ExclusiveMinimum: &exclMinVal},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "score",
+					FieldType: "number",
+					Rules:     ValidationRules{ExclusiveMinimum: &exclMinVal},
+				},
+			},
+		},
+		{
+			name: "exclusiveMaximum only",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"score": {Type: "number", ExclusiveMaximum: &exclMaxVal},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "score",
+					FieldType: "number",
+					Rules:     ValidationRules{ExclusiveMaximum: &exclMaxVal},
+				},
+			},
+		},
+		{
+			name: "all numeric validators",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"value": {Type: "number", Minimum: &minVal, Maximum: &maxVal, ExclusiveMinimum: &exclMinVal, ExclusiveMaximum: &exclMaxVal},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "value",
+					FieldType: "number",
+					Rules:     ValidationRules{Minimum: &minVal, Maximum: &maxVal, ExclusiveMinimum: &exclMinVal, ExclusiveMaximum: &exclMaxVal},
+				},
+			},
+		},
+		{
+			name: "integer type with numeric validators",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"retry_count": {Type: "integer", Minimum: &minVal, Maximum: &maxVal},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "retry_count",
+					FieldType: "integer",
+					Rules:     ValidationRules{Minimum: &minVal, Maximum: &maxVal},
+				},
+			},
+		},
+		{
+			name: "nil numeric validators produces no validator",
+			metadata: &ConfigMetadata{
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"value": {Type: "number"},
+				},
+			},
+			expected: []Validator{},
+		},
+		{
+			name: "required combined with numeric validators",
+			metadata: &ConfigMetadata{
+				Type:     "object",
+				Required: []string{"threshold"},
+				Properties: map[string]*ConfigMetadata{
+					"threshold": {Type: "number", Minimum: &minVal, Maximum: &maxVal},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "threshold",
+					FieldType: "number",
+					Rules:     ValidationRules{Required: true, Minimum: &minVal, Maximum: &maxVal},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractValidators(tt.metadata)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestExtractValidators_InternalRefFromDefs_NoValidators(t *testing.T) {
 	md := &ConfigMetadata{
 		Ref: "plain_config",
@@ -1971,6 +2115,36 @@ func TestValidationRules_HasValueRule(t *testing.T) {
 		},
 		{
 			name:     "nil validators map",
+			rules:    ValidationRules{},
+			expected: false,
+		},
+		{
+			name:     "minimum",
+			rules:    ValidationRules{Minimum: Ptr(0.0)},
+			expected: true,
+		},
+		{
+			name:     "maximum",
+			rules:    ValidationRules{Maximum: Ptr(100.0)},
+			expected: true,
+		},
+		{
+			name:     "exclusiveMinimum",
+			rules:    ValidationRules{ExclusiveMinimum: Ptr(5.0)},
+			expected: true,
+		},
+		{
+			name:     "exclusiveMaximum",
+			rules:    ValidationRules{ExclusiveMaximum: Ptr(10.0)},
+			expected: true,
+		},
+		{
+			name:     "all numeric validators",
+			rules:    ValidationRules{Minimum: Ptr(0.0), Maximum: Ptr(100.0), ExclusiveMinimum: Ptr(5.0), ExclusiveMaximum: Ptr(10.0)},
+			expected: true,
+		},
+		{
+			name:     "empty numeric validators",
 			rules:    ValidationRules{},
 			expected: false,
 		},

--- a/cmd/mdatagen/internal/samplescraper/config.schema.json
+++ b/cmd/mdatagen/internal/samplescraper/config.schema.json
@@ -621,6 +621,20 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "retry_count": {
+            "description": "Number of retry attempts for failed scrapes.",
+            "type": "integer",
+            "default": 3,
+            "maximum": 10,
+            "minimum": 0
+          },
+          "timeout_seconds": {
+            "description": "Timeout in seconds for each scrape request.",
+            "type": "number",
+            "default": 5,
+            "exclusiveMaximum": 30,
+            "exclusiveMinimum": 0
           }
         },
         "required": [

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -25,6 +25,10 @@ type TargetsItem struct {
 	Interval configoptional.Optional[time.Duration] `mapstructure:"interval"`
 	// Static key-value labels attached to all metrics from this target.
 	Labels map[string]string `mapstructure:"labels"`
+	// Number of retry attempts for failed scrapes.
+	RetryCount int `mapstructure:"retry_count"`
+	// Timeout in seconds for each scrape request.
+	TimeoutSeconds float64 `mapstructure:"timeout_seconds"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -37,14 +41,30 @@ func (c *TargetsItem) Validate() error {
 		err = errors.Join(err, errors.New("labels is required"))
 	}
 
+	if c.RetryCount < 0 {
+		err = errors.Join(err, errors.New("retry_count value must be greater than or equal to 0"))
+	}
+	if c.RetryCount > 10 {
+		err = errors.Join(err, errors.New("retry_count value must be less than or equal to 10"))
+	}
+
+	if c.TimeoutSeconds <= 0 {
+		err = errors.Join(err, errors.New("timeout_seconds value must be greater than 0"))
+	}
+	if c.TimeoutSeconds >= 30 {
+		err = errors.Join(err, errors.New("timeout_seconds value must be less than 30"))
+	}
+
 	return err
 }
 
 // NewDefaultTargetsItem returns a new TargetsItem with default values consistent with the annotations in the schema.
 func NewDefaultTargetsItem() TargetsItem {
 	return TargetsItem{
-		Interval: configoptional.Some(10 * time.Second),
-		Labels:   map[string]string{"option1": "value1", "option2": "value2"},
+		Interval:       configoptional.Some(10 * time.Second),
+		Labels:         map[string]string{"option1": "value1", "option2": "value2"},
+		RetryCount:     3,
+		TimeoutSeconds: 5,
 	}
 }
 

--- a/cmd/mdatagen/internal/samplescraper/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config_test.go
@@ -66,3 +66,31 @@ func TestConfigValidate_RequiredLabels(t *testing.T) {
 
 	require.ErrorContains(t, cfg.Validate(), "labels is required")
 }
+
+func TestTargetsItemValidate_MinimumRetryCount(t *testing.T) {
+	cfg := NewDefaultTargetsItem()
+	cfg.RetryCount = 0 - 1
+
+	require.ErrorContains(t, cfg.Validate(), "retry_count value must be greater than or equal to 0")
+}
+
+func TestTargetsItemValidate_MaximumRetryCount(t *testing.T) {
+	cfg := NewDefaultTargetsItem()
+	cfg.RetryCount = 10 + 1
+
+	require.ErrorContains(t, cfg.Validate(), "retry_count value must be less than or equal to 10")
+}
+
+func TestTargetsItemValidate_ExclusiveMinimumTimeoutSeconds(t *testing.T) {
+	cfg := NewDefaultTargetsItem()
+	cfg.TimeoutSeconds = 0
+
+	require.ErrorContains(t, cfg.Validate(), "timeout_seconds value must be greater than 0")
+}
+
+func TestTargetsItemValidate_ExclusiveMaximumTimeoutSeconds(t *testing.T) {
+	cfg := NewDefaultTargetsItem()
+	cfg.TimeoutSeconds = 30
+
+	require.ErrorContains(t, cfg.Validate(), "timeout_seconds value must be less than 30")
+}

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -68,6 +68,18 @@ config:
             default:
               option1: value1
               option2: value2
+          retry_count:
+            description: Number of retry attempts for failed scrapes.
+            type: integer
+            default: 3
+            minimum: 0
+            maximum: 10
+          timeout_seconds:
+            description: Timeout in seconds for each scrape request.
+            type: number
+            default: 5.0
+            exclusiveMinimum: 0
+            exclusiveMaximum: 30
         required: [labels]
       default:
         - {} # one item with default values

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -160,10 +160,42 @@ import (
     }
 {{- end }}
 
+{{ define "minimumValidator" -}}
+    {{ $minimum := .Rules.Minimum -}}
+    if {{ template "fieldValue" . }} < {{ $minimum }} {
+        err = errors.Join(err, errors.New("{{ .FieldName }} value must be greater than or equal to {{ $minimum }}"))
+    }
+{{- end }}
+
+{{ define "maximumValidator" -}}
+    {{ $maximum := .Rules.Maximum -}}
+    if {{ template "fieldValue" . }} > {{ $maximum }} {
+        err = errors.Join(err, errors.New("{{ .FieldName }} value must be less than or equal to {{ $maximum }}"))
+    }
+{{- end }}
+
+{{ define "exclusiveMinimumValidator" -}}
+    {{ $exclMin := .Rules.ExclusiveMinimum -}}
+    if {{ template "fieldValue" . }} <= {{ $exclMin }} {
+        err = errors.Join(err, errors.New("{{ .FieldName }} value must be greater than {{ $exclMin }}"))
+    }
+{{- end }}
+
+{{ define "exclusiveMaximumValidator" -}}
+    {{ $exclMax := .Rules.ExclusiveMaximum -}}
+    if {{ template "fieldValue" . }} >= {{ $exclMax }} {
+        err = errors.Join(err, errors.New("{{ .FieldName }} value must be less than {{ $exclMax }}"))
+    }
+{{- end }}
+
 {{ define "valueValidators" }}
     {{ if .Rules.MaxLength }}{{ template "maxLengthValidator" . }}{{ end }}
     {{ if .Rules.MinLength }}{{ template "minLengthValidator" . }}{{ end }}
     {{ if .Rules.Pattern }}{{ template "patternValidator" . }}{{ end }}
+    {{ if .Rules.Minimum }}{{ template "minimumValidator" . }}{{ end }}
+    {{ if .Rules.Maximum }}{{ template "maximumValidator" . }}{{ end }}
+    {{ if .Rules.ExclusiveMinimum }}{{ template "exclusiveMinimumValidator" . }}{{ end }}
+    {{ if .Rules.ExclusiveMaximum }}{{ template "exclusiveMaximumValidator" . }}{{ end }}
 {{ end -}}
 
 {{ define "validation" }}

--- a/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
@@ -49,6 +49,70 @@ require.NotNil(t, cfg)
             require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} is required")
             }
         {{ end }}
+        {{- if $validator.Rules.Minimum }}
+            func TestConfigValidate_Minimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+            cfg := createDefaultConfig().(*Config)
+            {{- $fieldName := $validator.FieldName | publicVar }}
+            {{- $minimum := $validator.Rules.Minimum }}
+            {{- if $validator.IsPointer }}
+                cfg.{{ $fieldName }} = {{ $minimum }} - 1
+            {{- else if $validator.IsOptional }}
+                *cfg.{{ $fieldName }}.Get() = {{ $minimum }} - 1
+            {{- else }}
+                cfg.{{ $fieldName }} = {{ $minimum }} - 1
+            {{- end }}
+
+            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than or equal to {{ $minimum }}")
+            }
+        {{ end }}
+        {{- if $validator.Rules.Maximum }}
+            func TestConfigValidate_Maximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+            cfg := createDefaultConfig().(*Config)
+            {{- $fieldName := $validator.FieldName | publicVar }}
+            {{- $maximum := $validator.Rules.Maximum }}
+            {{- if $validator.IsPointer }}
+                cfg.{{ $fieldName }} = {{ $maximum }} + 1
+            {{- else if $validator.IsOptional }}
+                *cfg.{{ $fieldName }}.Get() = {{ $maximum }} + 1
+            {{- else }}
+                cfg.{{ $fieldName }} = {{ $maximum }} + 1
+            {{- end }}
+
+            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than or equal to {{ $maximum }}")
+            }
+        {{ end }}
+        {{- if $validator.Rules.ExclusiveMinimum }}
+            func TestConfigValidate_ExclusiveMinimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+            cfg := createDefaultConfig().(*Config)
+            {{- $fieldName := $validator.FieldName | publicVar }}
+            {{- $exclMin := $validator.Rules.ExclusiveMinimum }}
+            {{- if $validator.IsPointer }}
+                cfg.{{ $fieldName }} = {{ $exclMin }}
+            {{- else if $validator.IsOptional }}
+                *cfg.{{ $fieldName }}.Get() = {{ $exclMin }}
+            {{- else }}
+                cfg.{{ $fieldName }} = {{ $exclMin }}
+            {{- end }}
+
+            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than {{ $exclMin }}")
+            }
+        {{ end }}
+        {{- if $validator.Rules.ExclusiveMaximum }}
+            func TestConfigValidate_ExclusiveMaximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+            cfg := createDefaultConfig().(*Config)
+            {{- $fieldName := $validator.FieldName | publicVar }}
+            {{- $exclMax := $validator.Rules.ExclusiveMaximum }}
+            {{- if $validator.IsPointer }}
+                cfg.{{ $fieldName }} = {{ $exclMax }}
+            {{- else if $validator.IsOptional }}
+                *cfg.{{ $fieldName }}.Get() = {{ $exclMax }}
+            {{- else }}
+                cfg.{{ $fieldName }} = {{ $exclMax }}
+            {{- end }}
+
+            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than {{ $exclMax }}")
+            }
+        {{ end }}
     {{- end }}
 {{- end }}
 {{- end }}
@@ -84,6 +148,70 @@ require.NotNil(t, cfg)
                 {{- end }}
 
                 require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} is required")
+                }
+            {{ end }}
+            {{- if $validator.Rules.Minimum }}
+                func Test{{ $defName | publicVar }}Validate_Minimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+                cfg := NewDefault{{ $defName | publicVar }}()
+                {{- $fieldName := $validator.FieldName | publicVar }}
+                {{- $minimum := $validator.Rules.Minimum }}
+                {{- if $validator.IsPointer }}
+                    cfg.{{ $fieldName }} = {{ $minimum }} - 1
+                {{- else if $validator.IsOptional }}
+                    *cfg.{{ $fieldName }}.Get() = {{ $minimum }} - 1
+                {{- else }}
+                    cfg.{{ $fieldName }} = {{ $minimum }} - 1
+                {{- end }}
+
+                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than or equal to {{ $minimum }}")
+                }
+            {{ end }}
+            {{- if $validator.Rules.Maximum }}
+                func Test{{ $defName | publicVar }}Validate_Maximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+                cfg := NewDefault{{ $defName | publicVar }}()
+                {{- $fieldName := $validator.FieldName | publicVar }}
+                {{- $maximum := $validator.Rules.Maximum }}
+                {{- if $validator.IsPointer }}
+                    cfg.{{ $fieldName }} = {{ $maximum }} + 1
+                {{- else if $validator.IsOptional }}
+                    *cfg.{{ $fieldName }}.Get() = {{ $maximum }} + 1
+                {{- else }}
+                    cfg.{{ $fieldName }} = {{ $maximum }} + 1
+                {{- end }}
+
+                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than or equal to {{ $maximum }}")
+                }
+            {{ end }}
+            {{- if $validator.Rules.ExclusiveMinimum }}
+                func Test{{ $defName | publicVar }}Validate_ExclusiveMinimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+                cfg := NewDefault{{ $defName | publicVar }}()
+                {{- $fieldName := $validator.FieldName | publicVar }}
+                {{- $exclMin := $validator.Rules.ExclusiveMinimum }}
+                {{- if $validator.IsPointer }}
+                    cfg.{{ $fieldName }} = {{ $exclMin }}
+                {{- else if $validator.IsOptional }}
+                    *cfg.{{ $fieldName }}.Get() = {{ $exclMin }}
+                {{- else }}
+                    cfg.{{ $fieldName }} = {{ $exclMin }}
+                {{- end }}
+
+                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than {{ $exclMin }}")
+                }
+            {{ end }}
+            {{- if $validator.Rules.ExclusiveMaximum }}
+                func Test{{ $defName | publicVar }}Validate_ExclusiveMaximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+                cfg := NewDefault{{ $defName | publicVar }}()
+                {{- $fieldName := $validator.FieldName | publicVar }}
+                {{- $exclMax := $validator.Rules.ExclusiveMaximum }}
+                {{- if $validator.IsPointer }}
+                    cfg.{{ $fieldName }} = {{ $exclMax }}
+                {{- else if $validator.IsOptional }}
+                    *cfg.{{ $fieldName }}.Get() = {{ $exclMax }}
+                {{- else }}
+                    cfg.{{ $fieldName }} = {{ $exclMax }}
+                {{- end }}
+
+                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than {{ $exclMax }}")
                 }
             {{ end }}
         {{- end }}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue. Ex. Adding a feature - Explain what this achieves.-->

Implements support for the JSON Schema numeric validation keywords 'minimum', 'maximum', 'exclusiveMaximum' and 'exclusiveMinimum' in mdatagen config generation pipeline.

<!-- Issue number if applicable -->
Fixes #14806

<!--Describe what testing was performed and which tests were added.-->

* Added unit tests in generation_test.go
* The samplescraper golden file (`generated_config.go`) is updated to reflect the new generated output.
