### PR TITLE
[pkg/confighttp] Check snappy decoded length before read

### DIFF
--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -152,18 +153,24 @@ func newSnappyHandler(maxRequestBodySize int64) func(io.ReadCloser) (io.ReadClos
 			}, nil
 		}
 
-		compressed, err := io.ReadAll(br)
-		if err != nil {
-			return nil, err
-		}
 		if maxRequestBodySize > 0 {
-			decodedLen, decErr := snappy.DecodedLen(compressed)
+			// Peek MaxVarintLen64 bytes so we can read the decoded length
+			// before reading the full compressed request body.
+			lenBytes, peakErr := br.Peek(binary.MaxVarintLen64)
+			if peakErr != nil && !errors.Is(peakErr, io.EOF) {
+				return nil, peakErr
+			}
+			decodedLen, decErr := snappy.DecodedLen(lenBytes)
 			if decErr != nil {
 				return nil, decErr
 			}
 			if int64(decodedLen) > maxRequestBodySize {
 				return nil, errors.New("snappy: decoded size exceeds max request body size")
 			}
+		}
+		compressed, err := io.ReadAll(br)
+		if err != nil {
+			return nil, err
 		}
 		decoded, err := snappy.Decode(nil, compressed)
 		if err != nil {

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	"compress/zlib"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -948,6 +949,41 @@ func TestSnappyBlockRejectsOversizedDecodedLen(t *testing.T) {
 		defaultErrorHandler,
 		defaultCompressionAlgorithms(),
 		nil, // let the decompressor install the size-aware snappy handler
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+	req.Header.Set("Content-Encoding", "snappy")
+
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Contains(t, resp.Body.String(), "decoded size exceeds max request body size")
+	assert.False(t, downstreamCalled, "downstream handler must not run when request is rejected")
+}
+
+func TestSnappyBlockRejectsOversizedDecodedLenBeforeCompressedBodyLimit(t *testing.T) {
+	t.Parallel()
+
+	const maxBody = 1024
+
+	payload := make([]byte, binary.MaxVarintLen64+maxBody+1)
+	n := binary.PutUvarint(payload, maxBody+1)
+	payload = payload[:n+maxBody+1]
+	require.Greater(t, len(payload), maxBody)
+
+	downstreamCalled := false
+	h := maxRequestBodySizeInterceptor(
+		httpContentDecompressor(
+			http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				downstreamCalled = true
+			}),
+			maxBody,
+			defaultErrorHandler,
+			defaultCompressionAlgorithms(),
+			nil,
+		),
+		maxBody,
 	)
 
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -995,6 +995,7 @@ func TestSnappyBlockRejectsOversizedDecodedLenBeforeCompressedBodyLimit(t *testi
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
 	assert.Contains(t, resp.Body.String(), "decoded size exceeds max request body size")
 	assert.False(t, downstreamCalled, "downstream handler must not run when request is rejected")
+}
 
 func TestSnappyBlockClosesOriginalBody(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/opentelemetry-collector/pull/15253. No need for another changelog item 