### PR TITLE
[chore] Add RFCs with approvals needed label to weekly report

### DIFF
--- a/.github/workflows/scripts/weekly-slack-report.sh
+++ b/.github/workflows/scripts/weekly-slack-report.sh
@@ -15,6 +15,8 @@
 # - "opentelemetry_collector_ready_to_merge_count"
 # - "opentelemetry_collector_final_comment_period_url"
 # - "opentelemetry_collector_final_comment_period_count"
+# - "opentelemetry_collector_approvals_needed_url"
+# - "opentelemetry_collector_approvals_needed_count"
 
 
 set -euo pipefail
@@ -31,6 +33,7 @@ fi
 declare -A LABELS=(
     ["ready-to-merge"]="ready_to_merge"
     ["rfc:final-comment-period"]="final_comment_period"
+    ["rfc:approvals-needed"]="approvals_needed"
 )
 
 repo_prefix="${REPO##*/}"


### PR DESCRIPTION
#### Description

Follow-up to #15268 and #15172. Includes RFCs with the `rfc:approvals-needed` label in the weekly Slack report.

> [!WARNING]
> Do not merge before updating the workflow to declare these variables:
> - `opentelemetry_collector_approvals_needed_count`
> - `opentelemetry_collector_approvals_needed_url`
