### PR TITLE
[chore][govuln] requires Go 1.25.10 in govuln check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: oldstable
+          go-version: 1.25.10 # TODO: revert to oldstable once oldstable picks up 1.25.10+
           cache: false
       - name: Cache Go
         id: go-cache


### PR DESCRIPTION
#### Description
Explicitly requires Go 1.25.10 in govuln check rather than oldstable for now

Example CI failure: http://github.com/open-telemetry/opentelemetry-collector/actions/runs/25534202772/job/74946538350 for some reason oldstable picks up `go version go1.25.9 linux/amd64` that has a few known vulnerabilities.