### PR TITLE
feat[pkg/pdata]: Add DisallowUnknownFields option to JSONUnmarshaler

### DIFF
--- a/.chloggen/pdata-json-disallow-unknown-fields.yaml
+++ b/.chloggen/pdata-json-disallow-unknown-fields.yaml
@@ -15,7 +15,9 @@ issues: [15279]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: When `DisallowUnknownFields` is false (the default), unknown fields are silently ignored, matching the previous behavior.
+subtext: |
+  When `DisallowUnknownFields` is false (the default), unknown fields are silently ignored, matching the previous behavior.
+  Warning: enabling this option breaks forwards compatibility with future evolutions of the OTLP format, as fields added to the format in newer versions will be rejected as unknown.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/.chloggen/pdata-json-disallow-unknown-fields.yaml
+++ b/.chloggen/pdata-json-disallow-unknown-fields.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `DisallowUnknownFields` option to `JSONUnmarshaler` in plog, ptrace, pmetric, pprofile, and xpdata to error on JSON fields not defined by the OTLP schema.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15279]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: When `DisallowUnknownFields` is false (the default), unknown fields are silently ignored, matching the previous behavior.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/pdata-json-disallow-unknown-fields.yaml
+++ b/.chloggen/pdata-json-disallow-unknown-fields.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: pdata
+component: pkg/pdata
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add `DisallowUnknownFields` option to `JSONUnmarshaler` in plog, ptrace, pmetric, pprofile, and xpdata to error on JSON fields not defined by the OTLP schema.

--- a/internal/cmd/pdatagen/internal/proto/templates/message.go.tmpl
+++ b/internal/cmd/pdatagen/internal/proto/templates/message.go.tmpl
@@ -153,7 +153,7 @@ func (orig *{{ .messageName }}) UnmarshalJSON(iter *json.Iterator) {
 		{{ .GenUnmarshalJSON }}
 		{{ end -}}
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_anyvalue.go
+++ b/pdata/internal/generated_proto_anyvalue.go
@@ -523,7 +523,7 @@ func (orig *AnyValue) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_arrayvalue.go
+++ b/pdata/internal/generated_proto_arrayvalue.go
@@ -150,7 +150,7 @@ func (orig *ArrayValue) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_entityref.go
+++ b/pdata/internal/generated_proto_entityref.go
@@ -182,7 +182,7 @@ func (orig *EntityRef) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exemplar.go
+++ b/pdata/internal/generated_proto_exemplar.go
@@ -296,7 +296,7 @@ func (orig *Exemplar) UnmarshalJSON(iter *json.Iterator) {
 
 			orig.SpanId.UnmarshalJSON(iter)
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exponentialhistogram.go
+++ b/pdata/internal/generated_proto_exponentialhistogram.go
@@ -162,7 +162,7 @@ func (orig *ExponentialHistogram) UnmarshalJSON(iter *json.Iterator) {
 		case "aggregationTemporality", "aggregation_temporality":
 			orig.AggregationTemporality = AggregationTemporality(iter.ReadEnumValue(AggregationTemporality_value))
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exponentialhistogramdatapoint.go
+++ b/pdata/internal/generated_proto_exponentialhistogramdatapoint.go
@@ -298,7 +298,7 @@ func (orig *ExponentialHistogramDataPoint) UnmarshalJSON(iter *json.Iterator) {
 		case "zeroThreshold", "zero_threshold":
 			orig.ZeroThreshold = iter.ReadFloat64()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exponentialhistogramdatapointbuckets.go
+++ b/pdata/internal/generated_proto_exponentialhistogramdatapointbuckets.go
@@ -156,7 +156,7 @@ func (orig *ExponentialHistogramDataPointBuckets) UnmarshalJSON(iter *json.Itera
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exportlogspartialsuccess.go
+++ b/pdata/internal/generated_proto_exportlogspartialsuccess.go
@@ -146,7 +146,7 @@ func (orig *ExportLogsPartialSuccess) UnmarshalJSON(iter *json.Iterator) {
 		case "errorMessage", "error_message":
 			orig.ErrorMessage = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exportlogsservicerequest.go
+++ b/pdata/internal/generated_proto_exportlogsservicerequest.go
@@ -151,7 +151,7 @@ func (orig *ExportLogsServiceRequest) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exportlogsserviceresponse.go
+++ b/pdata/internal/generated_proto_exportlogsserviceresponse.go
@@ -137,7 +137,7 @@ func (orig *ExportLogsServiceResponse) UnmarshalJSON(iter *json.Iterator) {
 
 			orig.PartialSuccess.UnmarshalJSON(iter)
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exportmetricspartialsuccess.go
+++ b/pdata/internal/generated_proto_exportmetricspartialsuccess.go
@@ -146,7 +146,7 @@ func (orig *ExportMetricsPartialSuccess) UnmarshalJSON(iter *json.Iterator) {
 		case "errorMessage", "error_message":
 			orig.ErrorMessage = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exportmetricsservicerequest.go
+++ b/pdata/internal/generated_proto_exportmetricsservicerequest.go
@@ -151,7 +151,7 @@ func (orig *ExportMetricsServiceRequest) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exportmetricsserviceresponse.go
+++ b/pdata/internal/generated_proto_exportmetricsserviceresponse.go
@@ -137,7 +137,7 @@ func (orig *ExportMetricsServiceResponse) UnmarshalJSON(iter *json.Iterator) {
 
 			orig.PartialSuccess.UnmarshalJSON(iter)
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exportprofilespartialsuccess.go
+++ b/pdata/internal/generated_proto_exportprofilespartialsuccess.go
@@ -146,7 +146,7 @@ func (orig *ExportProfilesPartialSuccess) UnmarshalJSON(iter *json.Iterator) {
 		case "errorMessage", "error_message":
 			orig.ErrorMessage = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exportprofilesservicerequest.go
+++ b/pdata/internal/generated_proto_exportprofilesservicerequest.go
@@ -160,7 +160,7 @@ func (orig *ExportProfilesServiceRequest) UnmarshalJSON(iter *json.Iterator) {
 
 			orig.Dictionary.UnmarshalJSON(iter)
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exportprofilesserviceresponse.go
+++ b/pdata/internal/generated_proto_exportprofilesserviceresponse.go
@@ -137,7 +137,7 @@ func (orig *ExportProfilesServiceResponse) UnmarshalJSON(iter *json.Iterator) {
 
 			orig.PartialSuccess.UnmarshalJSON(iter)
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exporttracepartialsuccess.go
+++ b/pdata/internal/generated_proto_exporttracepartialsuccess.go
@@ -146,7 +146,7 @@ func (orig *ExportTracePartialSuccess) UnmarshalJSON(iter *json.Iterator) {
 		case "errorMessage", "error_message":
 			orig.ErrorMessage = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exporttraceservicerequest.go
+++ b/pdata/internal/generated_proto_exporttraceservicerequest.go
@@ -151,7 +151,7 @@ func (orig *ExportTraceServiceRequest) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_exporttraceserviceresponse.go
+++ b/pdata/internal/generated_proto_exporttraceserviceresponse.go
@@ -137,7 +137,7 @@ func (orig *ExportTraceServiceResponse) UnmarshalJSON(iter *json.Iterator) {
 
 			orig.PartialSuccess.UnmarshalJSON(iter)
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_function.go
+++ b/pdata/internal/generated_proto_function.go
@@ -162,7 +162,7 @@ func (orig *Function) UnmarshalJSON(iter *json.Iterator) {
 		case "startLine", "start_line":
 			orig.StartLine = iter.ReadInt64()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_gauge.go
+++ b/pdata/internal/generated_proto_gauge.go
@@ -150,7 +150,7 @@ func (orig *Gauge) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_histogram.go
+++ b/pdata/internal/generated_proto_histogram.go
@@ -161,7 +161,7 @@ func (orig *Histogram) UnmarshalJSON(iter *json.Iterator) {
 		case "aggregationTemporality", "aggregation_temporality":
 			orig.AggregationTemporality = AggregationTemporality(iter.ReadEnumValue(AggregationTemporality_value))
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_histogramdatapoint.go
+++ b/pdata/internal/generated_proto_histogramdatapoint.go
@@ -289,7 +289,7 @@ func (orig *HistogramDataPoint) UnmarshalJSON(iter *json.Iterator) {
 			orig.SetMax(iter.ReadFloat64())
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_instrumentationscope.go
+++ b/pdata/internal/generated_proto_instrumentationscope.go
@@ -177,7 +177,7 @@ func (orig *InstrumentationScope) UnmarshalJSON(iter *json.Iterator) {
 		case "droppedAttributesCount", "dropped_attributes_count":
 			orig.DroppedAttributesCount = iter.ReadUint32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_ipaddr.go
+++ b/pdata/internal/generated_proto_ipaddr.go
@@ -146,7 +146,7 @@ func (orig *IPAddr) UnmarshalJSON(iter *json.Iterator) {
 		case "zone":
 			orig.Zone = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_keyvalue.go
+++ b/pdata/internal/generated_proto_keyvalue.go
@@ -155,7 +155,7 @@ func (orig *KeyValue) UnmarshalJSON(iter *json.Iterator) {
 		case "keyStrindex", "key_strindex":
 			orig.KeyStrindex = iter.ReadInt32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_keyvalueandunit.go
+++ b/pdata/internal/generated_proto_keyvalueandunit.go
@@ -158,7 +158,7 @@ func (orig *KeyValueAndUnit) UnmarshalJSON(iter *json.Iterator) {
 		case "unitStrindex", "unit_strindex":
 			orig.UnitStrindex = iter.ReadInt32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_keyvaluelist.go
+++ b/pdata/internal/generated_proto_keyvaluelist.go
@@ -150,7 +150,7 @@ func (orig *KeyValueList) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_line.go
+++ b/pdata/internal/generated_proto_line.go
@@ -154,7 +154,7 @@ func (orig *Line) UnmarshalJSON(iter *json.Iterator) {
 		case "column":
 			orig.Column = iter.ReadInt64()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_link.go
+++ b/pdata/internal/generated_proto_link.go
@@ -150,7 +150,7 @@ func (orig *Link) UnmarshalJSON(iter *json.Iterator) {
 
 			orig.SpanId.UnmarshalJSON(iter)
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_location.go
+++ b/pdata/internal/generated_proto_location.go
@@ -187,7 +187,7 @@ func (orig *Location) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_logrecord.go
+++ b/pdata/internal/generated_proto_logrecord.go
@@ -244,7 +244,7 @@ func (orig *LogRecord) UnmarshalJSON(iter *json.Iterator) {
 		case "eventName", "event_name":
 			orig.EventName = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_logsdata.go
+++ b/pdata/internal/generated_proto_logsdata.go
@@ -152,7 +152,7 @@ func (orig *LogsData) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_logsrequest.go
+++ b/pdata/internal/generated_proto_logsrequest.go
@@ -158,7 +158,7 @@ func (orig *LogsRequest) UnmarshalJSON(iter *json.Iterator) {
 		case "formatVersion", "format_version":
 			orig.FormatVersion = iter.ReadUint32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_mapping.go
+++ b/pdata/internal/generated_proto_mapping.go
@@ -180,7 +180,7 @@ func (orig *Mapping) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_metric.go
+++ b/pdata/internal/generated_proto_metric.go
@@ -439,7 +439,7 @@ func (orig *Metric) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_metricsdata.go
+++ b/pdata/internal/generated_proto_metricsdata.go
@@ -152,7 +152,7 @@ func (orig *MetricsData) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_metricsrequest.go
+++ b/pdata/internal/generated_proto_metricsrequest.go
@@ -158,7 +158,7 @@ func (orig *MetricsRequest) UnmarshalJSON(iter *json.Iterator) {
 		case "formatVersion", "format_version":
 			orig.FormatVersion = iter.ReadUint32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_numberdatapoint.go
+++ b/pdata/internal/generated_proto_numberdatapoint.go
@@ -311,7 +311,7 @@ func (orig *NumberDataPoint) UnmarshalJSON(iter *json.Iterator) {
 		case "flags":
 			orig.Flags = iter.ReadUint32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_profile.go
+++ b/pdata/internal/generated_proto_profile.go
@@ -252,7 +252,7 @@ func (orig *Profile) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_profilesdata.go
+++ b/pdata/internal/generated_proto_profilesdata.go
@@ -161,7 +161,7 @@ func (orig *ProfilesData) UnmarshalJSON(iter *json.Iterator) {
 
 			orig.Dictionary.UnmarshalJSON(iter)
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_profilesdictionary.go
+++ b/pdata/internal/generated_proto_profilesdictionary.go
@@ -280,7 +280,7 @@ func (orig *ProfilesDictionary) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_profilesrequest.go
+++ b/pdata/internal/generated_proto_profilesrequest.go
@@ -158,7 +158,7 @@ func (orig *ProfilesRequest) UnmarshalJSON(iter *json.Iterator) {
 		case "formatVersion", "format_version":
 			orig.FormatVersion = iter.ReadUint32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_requestcontext.go
+++ b/pdata/internal/generated_proto_requestcontext.go
@@ -374,7 +374,7 @@ func (orig *RequestContext) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_resource.go
+++ b/pdata/internal/generated_proto_resource.go
@@ -181,7 +181,7 @@ func (orig *Resource) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_resourcelogs.go
+++ b/pdata/internal/generated_proto_resourcelogs.go
@@ -190,7 +190,7 @@ func (orig *ResourceLogs) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_resourcemetrics.go
+++ b/pdata/internal/generated_proto_resourcemetrics.go
@@ -190,7 +190,7 @@ func (orig *ResourceMetrics) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_resourceprofiles.go
+++ b/pdata/internal/generated_proto_resourceprofiles.go
@@ -169,7 +169,7 @@ func (orig *ResourceProfiles) UnmarshalJSON(iter *json.Iterator) {
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_resourcespans.go
+++ b/pdata/internal/generated_proto_resourcespans.go
@@ -190,7 +190,7 @@ func (orig *ResourceSpans) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_sample.go
+++ b/pdata/internal/generated_proto_sample.go
@@ -203,7 +203,7 @@ func (orig *Sample) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_scopelogs.go
+++ b/pdata/internal/generated_proto_scopelogs.go
@@ -169,7 +169,7 @@ func (orig *ScopeLogs) UnmarshalJSON(iter *json.Iterator) {
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_scopemetrics.go
+++ b/pdata/internal/generated_proto_scopemetrics.go
@@ -169,7 +169,7 @@ func (orig *ScopeMetrics) UnmarshalJSON(iter *json.Iterator) {
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_scopeprofiles.go
+++ b/pdata/internal/generated_proto_scopeprofiles.go
@@ -169,7 +169,7 @@ func (orig *ScopeProfiles) UnmarshalJSON(iter *json.Iterator) {
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_scopespans.go
+++ b/pdata/internal/generated_proto_scopespans.go
@@ -169,7 +169,7 @@ func (orig *ScopeSpans) UnmarshalJSON(iter *json.Iterator) {
 		case "schemaUrl", "schema_url":
 			orig.SchemaUrl = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_span.go
+++ b/pdata/internal/generated_proto_span.go
@@ -316,7 +316,7 @@ func (orig *Span) UnmarshalJSON(iter *json.Iterator) {
 
 			orig.Status.UnmarshalJSON(iter)
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_spancontext.go
+++ b/pdata/internal/generated_proto_spancontext.go
@@ -176,7 +176,7 @@ func (orig *SpanContext) UnmarshalJSON(iter *json.Iterator) {
 		case "remote":
 			orig.Remote = iter.ReadBool()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_spanevent.go
+++ b/pdata/internal/generated_proto_spanevent.go
@@ -179,7 +179,7 @@ func (orig *SpanEvent) UnmarshalJSON(iter *json.Iterator) {
 		case "droppedAttributesCount", "dropped_attributes_count":
 			orig.DroppedAttributesCount = iter.ReadUint32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_spanlink.go
+++ b/pdata/internal/generated_proto_spanlink.go
@@ -202,7 +202,7 @@ func (orig *SpanLink) UnmarshalJSON(iter *json.Iterator) {
 		case "flags":
 			orig.Flags = iter.ReadUint32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_stack.go
+++ b/pdata/internal/generated_proto_stack.go
@@ -149,7 +149,7 @@ func (orig *Stack) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_status.go
+++ b/pdata/internal/generated_proto_status.go
@@ -148,7 +148,7 @@ func (orig *Status) UnmarshalJSON(iter *json.Iterator) {
 		case "code":
 			orig.Code = StatusCode(iter.ReadEnumValue(StatusCode_value))
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_sum.go
+++ b/pdata/internal/generated_proto_sum.go
@@ -169,7 +169,7 @@ func (orig *Sum) UnmarshalJSON(iter *json.Iterator) {
 		case "isMonotonic", "is_monotonic":
 			orig.IsMonotonic = iter.ReadBool()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_summary.go
+++ b/pdata/internal/generated_proto_summary.go
@@ -150,7 +150,7 @@ func (orig *Summary) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_summarydatapoint.go
+++ b/pdata/internal/generated_proto_summarydatapoint.go
@@ -217,7 +217,7 @@ func (orig *SummaryDataPoint) UnmarshalJSON(iter *json.Iterator) {
 		case "flags":
 			orig.Flags = iter.ReadUint32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_summarydatapointvalueatquantile.go
+++ b/pdata/internal/generated_proto_summarydatapointvalueatquantile.go
@@ -148,7 +148,7 @@ func (orig *SummaryDataPointValueAtQuantile) UnmarshalJSON(iter *json.Iterator) 
 		case "value":
 			orig.Value = iter.ReadFloat64()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_tcpaddr.go
+++ b/pdata/internal/generated_proto_tcpaddr.go
@@ -154,7 +154,7 @@ func (orig *TCPAddr) UnmarshalJSON(iter *json.Iterator) {
 		case "zone":
 			orig.Zone = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_tracesdata.go
+++ b/pdata/internal/generated_proto_tracesdata.go
@@ -152,7 +152,7 @@ func (orig *TracesData) UnmarshalJSON(iter *json.Iterator) {
 			}
 
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_tracesrequest.go
+++ b/pdata/internal/generated_proto_tracesrequest.go
@@ -158,7 +158,7 @@ func (orig *TracesRequest) UnmarshalJSON(iter *json.Iterator) {
 		case "formatVersion", "format_version":
 			orig.FormatVersion = iter.ReadUint32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_udpaddr.go
+++ b/pdata/internal/generated_proto_udpaddr.go
@@ -154,7 +154,7 @@ func (orig *UDPAddr) UnmarshalJSON(iter *json.Iterator) {
 		case "zone":
 			orig.Zone = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_unixaddr.go
+++ b/pdata/internal/generated_proto_unixaddr.go
@@ -145,7 +145,7 @@ func (orig *UnixAddr) UnmarshalJSON(iter *json.Iterator) {
 		case "net":
 			orig.Net = iter.ReadString()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/generated_proto_valuetype.go
+++ b/pdata/internal/generated_proto_valuetype.go
@@ -146,7 +146,7 @@ func (orig *ValueType) UnmarshalJSON(iter *json.Iterator) {
 		case "unitStrindex", "unit_strindex":
 			orig.UnitStrindex = iter.ReadInt32()
 		default:
-			iter.Skip()
+			iter.HandleUnknownField(f)
 		}
 	}
 }

--- a/pdata/internal/json/iterator.go
+++ b/pdata/internal/json/iterator.go
@@ -20,7 +20,28 @@ func ReturnIterator(s *Iterator) {
 }
 
 type Iterator struct {
-	delegate *jsoniter.Iterator
+	delegate              *jsoniter.Iterator
+	disallowUnknownFields bool
+}
+
+// SetDisallowUnknownFields configures whether unknown fields encountered during
+// JSON unmarshalling cause an error. When set to true, [Iterator.HandleUnknownField]
+// records an error instead of skipping the field.
+func (iter *Iterator) SetDisallowUnknownFields(b bool) *Iterator {
+	iter.disallowUnknownFields = b
+	return iter
+}
+
+// HandleUnknownField is called by generated UnmarshalJSON code when an
+// unrecognized JSON field is encountered. By default the field's value is
+// skipped, but if [Iterator.SetDisallowUnknownFields] was set to true, an
+// error is recorded on the iterator instead.
+func (iter *Iterator) HandleUnknownField(field string) {
+	if iter.disallowUnknownFields {
+		iter.ReportError("UnmarshalJSON", "unknown field \""+field+"\"")
+		return
+	}
+	iter.Skip()
 }
 
 // ReadInt32 unmarshalls JSON data into an int32. Accepts both numbers and strings decimal.

--- a/pdata/internal/json/iterator_test.go
+++ b/pdata/internal/json/iterator_test.go
@@ -436,3 +436,32 @@ func TestReadBytes(t *testing.T) {
 	}
 	require.NoError(t, iter.Error())
 }
+
+func TestHandleUnknownField(t *testing.T) {
+	t.Run("default skips unknown fields", func(t *testing.T) {
+		iter := BorrowIterator([]byte(`{"known":"v","unknown":"value"}`))
+		defer ReturnIterator(iter)
+		var seen []string
+		for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
+			seen = append(seen, f)
+			if f == "known" {
+				iter.ReadString()
+				continue
+			}
+			iter.HandleUnknownField(f)
+		}
+		require.NoError(t, iter.Error())
+		assert.Equal(t, []string{"known", "unknown"}, seen)
+	})
+
+	t.Run("strict mode reports error", func(t *testing.T) {
+		iter := BorrowIterator([]byte(`{"unknown":"value"}`))
+		defer ReturnIterator(iter)
+		iter.SetDisallowUnknownFields(true)
+		for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
+			iter.HandleUnknownField(f)
+		}
+		require.Error(t, iter.Error())
+		assert.Contains(t, iter.Error().Error(), `unknown field "unknown"`)
+	})
+}

--- a/pdata/plog/json.go
+++ b/pdata/plog/json.go
@@ -33,6 +33,10 @@ type JSONUnmarshaler struct {
 	// DisallowUnknownFields causes UnmarshalLogs to return an error when the
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
+	//
+	// Warning: enabling this option breaks forwards compatibility with future
+	// evolutions of the OTLP format, as fields added to the format in newer
+	// versions will be rejected as unknown.
 	DisallowUnknownFields bool
 }
 

--- a/pdata/plog/json.go
+++ b/pdata/plog/json.go
@@ -27,12 +27,18 @@ func (*JSONMarshaler) MarshalLogs(ld Logs) ([]byte, error) {
 var _ Unmarshaler = (*JSONUnmarshaler)(nil)
 
 // JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to Logs.
-type JSONUnmarshaler struct{}
+type JSONUnmarshaler struct {
+	// DisallowUnknownFields causes UnmarshalLogs to return an error when the
+	// input contains JSON object fields that are not defined by the OTLP
+	// schema. When false (the default), unknown fields are silently ignored.
+	DisallowUnknownFields bool
+}
 
 // UnmarshalLogs from OTLP/JSON format into Logs.
-func (*JSONUnmarshaler) UnmarshalLogs(buf []byte) (Logs, error) {
+func (u *JSONUnmarshaler) UnmarshalLogs(buf []byte) (Logs, error) {
 	iter := json.BorrowIterator(buf)
 	defer json.ReturnIterator(iter)
+	iter.SetDisallowUnknownFields(u.DisallowUnknownFields)
 	ld := NewLogs()
 	ld.getOrig().UnmarshalJSON(iter)
 	if iter.Error() != nil {

--- a/pdata/plog/json.go
+++ b/pdata/plog/json.go
@@ -28,12 +28,12 @@ var _ Unmarshaler = (*JSONUnmarshaler)(nil)
 
 // JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to Logs.
 type JSONUnmarshaler struct {
+	// prevent unkeyed literal initialization
+	_ struct{}
 	// DisallowUnknownFields causes UnmarshalLogs to return an error when the
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
 	DisallowUnknownFields bool
-	// prevent unkeyed literal initialization
-	_ struct{}
 }
 
 // UnmarshalLogs from OTLP/JSON format into Logs.

--- a/pdata/plog/json.go
+++ b/pdata/plog/json.go
@@ -32,6 +32,8 @@ type JSONUnmarshaler struct {
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
 	DisallowUnknownFields bool
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // UnmarshalLogs from OTLP/JSON format into Logs.

--- a/pdata/plog/json_test.go
+++ b/pdata/plog/json_test.go
@@ -1,0 +1,47 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package plog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONUnmarshalerDisallowUnknownFields(t *testing.T) {
+	// Input contains a JSON object field ("unexpected") that is not part of
+	// the OTLP/JSON schema for LogsData.
+	input := []byte(`{"resourceLogs":[],"unexpected":"value"}`)
+
+	t.Run("default ignores unknown fields", func(t *testing.T) {
+		u := &JSONUnmarshaler{}
+		ld, err := u.UnmarshalLogs(input)
+		require.NoError(t, err)
+		assert.Equal(t, 0, ld.ResourceLogs().Len())
+	})
+
+	t.Run("strict mode errors on unknown fields", func(t *testing.T) {
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalLogs(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+	})
+
+	t.Run("strict mode errors on nested unknown fields", func(t *testing.T) {
+		nested := []byte(`{"resourceLogs":[{"resource":{},"unexpected":"value"}]}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalLogs(nested)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+	})
+
+	t.Run("strict mode accepts valid OTLP JSON", func(t *testing.T) {
+		valid := []byte(`{"resourceLogs":[{"resource":{}}]}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		ld, err := u.UnmarshalLogs(valid)
+		require.NoError(t, err)
+		assert.Equal(t, 1, ld.ResourceLogs().Len())
+	})
+}

--- a/pdata/plog/json_test.go
+++ b/pdata/plog/json_test.go
@@ -44,4 +44,13 @@ func TestJSONUnmarshalerDisallowUnknownFields(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, ld.ResourceLogs().Len())
 	})
+
+	t.Run("strict mode reports only the first unknown field", func(t *testing.T) {
+		multi := []byte(`{"unexpected1":"a","unexpected2":"b"}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalLogs(multi)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected1"`)
+		assert.NotContains(t, err.Error(), `unknown field "unexpected2"`)
+	})
 }

--- a/pdata/pmetric/json.go
+++ b/pdata/pmetric/json.go
@@ -33,6 +33,10 @@ type JSONUnmarshaler struct {
 	// DisallowUnknownFields causes UnmarshalMetrics to return an error when the
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
+	//
+	// Warning: enabling this option breaks forwards compatibility with future
+	// evolutions of the OTLP format, as fields added to the format in newer
+	// versions will be rejected as unknown.
 	DisallowUnknownFields bool
 }
 

--- a/pdata/pmetric/json.go
+++ b/pdata/pmetric/json.go
@@ -27,12 +27,18 @@ func (*JSONMarshaler) MarshalMetrics(md Metrics) ([]byte, error) {
 }
 
 // JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to Metrics.
-type JSONUnmarshaler struct{}
+type JSONUnmarshaler struct {
+	// DisallowUnknownFields causes UnmarshalMetrics to return an error when the
+	// input contains JSON object fields that are not defined by the OTLP
+	// schema. When false (the default), unknown fields are silently ignored.
+	DisallowUnknownFields bool
+}
 
 // UnmarshalMetrics from OTLP/JSON format into Metrics.
-func (*JSONUnmarshaler) UnmarshalMetrics(buf []byte) (Metrics, error) {
+func (u *JSONUnmarshaler) UnmarshalMetrics(buf []byte) (Metrics, error) {
 	iter := json.BorrowIterator(buf)
 	defer json.ReturnIterator(iter)
+	iter.SetDisallowUnknownFields(u.DisallowUnknownFields)
 	md := NewMetrics()
 	md.getOrig().UnmarshalJSON(iter)
 	if iter.Error() != nil {

--- a/pdata/pmetric/json.go
+++ b/pdata/pmetric/json.go
@@ -28,12 +28,12 @@ func (*JSONMarshaler) MarshalMetrics(md Metrics) ([]byte, error) {
 
 // JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to Metrics.
 type JSONUnmarshaler struct {
+	// prevent unkeyed literal initialization
+	_ struct{}
 	// DisallowUnknownFields causes UnmarshalMetrics to return an error when the
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
 	DisallowUnknownFields bool
-	// prevent unkeyed literal initialization
-	_ struct{}
 }
 
 // UnmarshalMetrics from OTLP/JSON format into Metrics.

--- a/pdata/pmetric/json.go
+++ b/pdata/pmetric/json.go
@@ -32,6 +32,8 @@ type JSONUnmarshaler struct {
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
 	DisallowUnknownFields bool
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // UnmarshalMetrics from OTLP/JSON format into Metrics.

--- a/pdata/pmetric/json_test.go
+++ b/pdata/pmetric/json_test.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pmetric
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONUnmarshalerDisallowUnknownFields(t *testing.T) {
+	input := []byte(`{"resourceMetrics":[],"unexpected":"value"}`)
+
+	t.Run("default ignores unknown fields", func(t *testing.T) {
+		u := &JSONUnmarshaler{}
+		md, err := u.UnmarshalMetrics(input)
+		require.NoError(t, err)
+		assert.Equal(t, 0, md.ResourceMetrics().Len())
+	})
+
+	t.Run("strict mode errors on unknown fields", func(t *testing.T) {
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalMetrics(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+	})
+
+	t.Run("strict mode errors on nested unknown fields", func(t *testing.T) {
+		nested := []byte(`{"resourceMetrics":[{"resource":{},"unexpected":"value"}]}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalMetrics(nested)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+	})
+
+	t.Run("strict mode accepts valid OTLP JSON", func(t *testing.T) {
+		valid := []byte(`{"resourceMetrics":[{"resource":{}}]}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		md, err := u.UnmarshalMetrics(valid)
+		require.NoError(t, err)
+		assert.Equal(t, 1, md.ResourceMetrics().Len())
+	})
+}

--- a/pdata/pmetric/json_test.go
+++ b/pdata/pmetric/json_test.go
@@ -42,4 +42,13 @@ func TestJSONUnmarshalerDisallowUnknownFields(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, md.ResourceMetrics().Len())
 	})
+
+	t.Run("strict mode reports only the first unknown field", func(t *testing.T) {
+		multi := []byte(`{"unexpected1":"a","unexpected2":"b"}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalMetrics(multi)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected1"`)
+		assert.NotContains(t, err.Error(), `unknown field "unexpected2"`)
+	})
 }

--- a/pdata/pprofile/json.go
+++ b/pdata/pprofile/json.go
@@ -38,12 +38,18 @@ func (*JSONMarshaler) MarshalProfiles(pd Profiles) ([]byte, error) {
 }
 
 // JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to pprofile.Profiles.
-type JSONUnmarshaler struct{}
+type JSONUnmarshaler struct {
+	// DisallowUnknownFields causes UnmarshalProfiles to return an error when the
+	// input contains JSON object fields that are not defined by the OTLP
+	// schema. When false (the default), unknown fields are silently ignored.
+	DisallowUnknownFields bool
+}
 
 // UnmarshalProfiles from OTLP/JSON format into pprofile.Profiles.
-func (*JSONUnmarshaler) UnmarshalProfiles(buf []byte) (Profiles, error) {
+func (u *JSONUnmarshaler) UnmarshalProfiles(buf []byte) (Profiles, error) {
 	iter := json.BorrowIterator(buf)
 	defer json.ReturnIterator(iter)
+	iter.SetDisallowUnknownFields(u.DisallowUnknownFields)
 	pd := NewProfiles()
 	pd.getOrig().UnmarshalJSON(iter)
 	if iter.Error() != nil {

--- a/pdata/pprofile/json.go
+++ b/pdata/pprofile/json.go
@@ -43,6 +43,8 @@ type JSONUnmarshaler struct {
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
 	DisallowUnknownFields bool
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // UnmarshalProfiles from OTLP/JSON format into pprofile.Profiles.

--- a/pdata/pprofile/json.go
+++ b/pdata/pprofile/json.go
@@ -42,6 +42,10 @@ type JSONUnmarshaler struct {
 	// DisallowUnknownFields causes UnmarshalProfiles to return an error when the
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
+	//
+	// Warning: enabling this option breaks forwards compatibility with future
+	// evolutions of the OTLP format, as fields added to the format in newer
+	// versions will be rejected as unknown.
 	DisallowUnknownFields bool
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/pdata/pprofile/json_test.go
+++ b/pdata/pprofile/json_test.go
@@ -42,4 +42,13 @@ func TestJSONUnmarshalerDisallowUnknownFields(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, pd.ResourceProfiles().Len())
 	})
+
+	t.Run("strict mode reports only the first unknown field", func(t *testing.T) {
+		multi := []byte(`{"unexpected1":"a","unexpected2":"b"}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalProfiles(multi)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected1"`)
+		assert.NotContains(t, err.Error(), `unknown field "unexpected2"`)
+	})
 }

--- a/pdata/pprofile/json_test.go
+++ b/pdata/pprofile/json_test.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pprofile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONUnmarshalerDisallowUnknownFields(t *testing.T) {
+	input := []byte(`{"resourceProfiles":[],"unexpected":"value"}`)
+
+	t.Run("default ignores unknown fields", func(t *testing.T) {
+		u := &JSONUnmarshaler{}
+		pd, err := u.UnmarshalProfiles(input)
+		require.NoError(t, err)
+		assert.Equal(t, 0, pd.ResourceProfiles().Len())
+	})
+
+	t.Run("strict mode errors on unknown fields", func(t *testing.T) {
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalProfiles(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+	})
+
+	t.Run("strict mode errors on nested unknown fields", func(t *testing.T) {
+		nested := []byte(`{"resourceProfiles":[{"resource":{},"unexpected":"value"}]}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalProfiles(nested)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+	})
+
+	t.Run("strict mode accepts valid OTLP JSON", func(t *testing.T) {
+		valid := []byte(`{"resourceProfiles":[{"resource":{}}]}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		pd, err := u.UnmarshalProfiles(valid)
+		require.NoError(t, err)
+		assert.Equal(t, 1, pd.ResourceProfiles().Len())
+	})
+}

--- a/pdata/ptrace/json.go
+++ b/pdata/ptrace/json.go
@@ -25,12 +25,18 @@ func (*JSONMarshaler) MarshalTraces(td Traces) ([]byte, error) {
 }
 
 // JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to Traces.
-type JSONUnmarshaler struct{}
+type JSONUnmarshaler struct {
+	// DisallowUnknownFields causes UnmarshalTraces to return an error when the
+	// input contains JSON object fields that are not defined by the OTLP
+	// schema. When false (the default), unknown fields are silently ignored.
+	DisallowUnknownFields bool
+}
 
 // UnmarshalTraces from OTLP/JSON format into Traces.
-func (*JSONUnmarshaler) UnmarshalTraces(buf []byte) (Traces, error) {
+func (u *JSONUnmarshaler) UnmarshalTraces(buf []byte) (Traces, error) {
 	iter := json.BorrowIterator(buf)
 	defer json.ReturnIterator(iter)
+	iter.SetDisallowUnknownFields(u.DisallowUnknownFields)
 	td := NewTraces()
 	td.getOrig().UnmarshalJSON(iter)
 	if iter.Error() != nil {

--- a/pdata/ptrace/json.go
+++ b/pdata/ptrace/json.go
@@ -30,6 +30,8 @@ type JSONUnmarshaler struct {
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
 	DisallowUnknownFields bool
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // UnmarshalTraces from OTLP/JSON format into Traces.

--- a/pdata/ptrace/json.go
+++ b/pdata/ptrace/json.go
@@ -26,12 +26,12 @@ func (*JSONMarshaler) MarshalTraces(td Traces) ([]byte, error) {
 
 // JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to Traces.
 type JSONUnmarshaler struct {
+	// prevent unkeyed literal initialization
+	_ struct{}
 	// DisallowUnknownFields causes UnmarshalTraces to return an error when the
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
 	DisallowUnknownFields bool
-	// prevent unkeyed literal initialization
-	_ struct{}
 }
 
 // UnmarshalTraces from OTLP/JSON format into Traces.

--- a/pdata/ptrace/json.go
+++ b/pdata/ptrace/json.go
@@ -31,6 +31,10 @@ type JSONUnmarshaler struct {
 	// DisallowUnknownFields causes UnmarshalTraces to return an error when the
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
+	//
+	// Warning: enabling this option breaks forwards compatibility with future
+	// evolutions of the OTLP format, as fields added to the format in newer
+	// versions will be rejected as unknown.
 	DisallowUnknownFields bool
 }
 

--- a/pdata/ptrace/json_test.go
+++ b/pdata/ptrace/json_test.go
@@ -42,4 +42,13 @@ func TestJSONUnmarshalerDisallowUnknownFields(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, td.ResourceSpans().Len())
 	})
+
+	t.Run("strict mode reports only the first unknown field", func(t *testing.T) {
+		multi := []byte(`{"unexpected1":"a","unexpected2":"b"}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalTraces(multi)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected1"`)
+		assert.NotContains(t, err.Error(), `unknown field "unexpected2"`)
+	})
 }

--- a/pdata/ptrace/json_test.go
+++ b/pdata/ptrace/json_test.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ptrace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONUnmarshalerDisallowUnknownFields(t *testing.T) {
+	input := []byte(`{"resourceSpans":[],"unexpected":"value"}`)
+
+	t.Run("default ignores unknown fields", func(t *testing.T) {
+		u := &JSONUnmarshaler{}
+		td, err := u.UnmarshalTraces(input)
+		require.NoError(t, err)
+		assert.Equal(t, 0, td.ResourceSpans().Len())
+	})
+
+	t.Run("strict mode errors on unknown fields", func(t *testing.T) {
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalTraces(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+	})
+
+	t.Run("strict mode errors on nested unknown fields", func(t *testing.T) {
+		nested := []byte(`{"resourceSpans":[{"resource":{},"unexpected":"value"}]}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		_, err := u.UnmarshalTraces(nested)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+	})
+
+	t.Run("strict mode accepts valid OTLP JSON", func(t *testing.T) {
+		valid := []byte(`{"resourceSpans":[{"resource":{}}]}`)
+		u := &JSONUnmarshaler{DisallowUnknownFields: true}
+		td, err := u.UnmarshalTraces(valid)
+		require.NoError(t, err)
+		assert.Equal(t, 1, td.ResourceSpans().Len())
+	})
+}

--- a/pdata/xpdata/json.go
+++ b/pdata/xpdata/json.go
@@ -28,6 +28,10 @@ type JSONUnmarshaler struct {
 	// DisallowUnknownFields causes UnmarshalValue to return an error when the
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
+	//
+	// Warning: enabling this option breaks forwards compatibility with future
+	// evolutions of the OTLP format, as fields added to the format in newer
+	// versions will be rejected as unknown.
 	DisallowUnknownFields bool
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/pdata/xpdata/json.go
+++ b/pdata/xpdata/json.go
@@ -29,6 +29,8 @@ type JSONUnmarshaler struct {
 	// input contains JSON object fields that are not defined by the OTLP
 	// schema. When false (the default), unknown fields are silently ignored.
 	DisallowUnknownFields bool
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (u *JSONUnmarshaler) UnmarshalValue(buf []byte) (pcommon.Value, error) {

--- a/pdata/xpdata/json.go
+++ b/pdata/xpdata/json.go
@@ -24,11 +24,17 @@ func (*JSONMarshaler) MarshalValue(value pcommon.Value) ([]byte, error) {
 	return slices.Clone(dest.Buffer()), nil
 }
 
-type JSONUnmarshaler struct{}
+type JSONUnmarshaler struct {
+	// DisallowUnknownFields causes UnmarshalValue to return an error when the
+	// input contains JSON object fields that are not defined by the OTLP
+	// schema. When false (the default), unknown fields are silently ignored.
+	DisallowUnknownFields bool
+}
 
-func (*JSONUnmarshaler) UnmarshalValue(buf []byte) (pcommon.Value, error) {
+func (u *JSONUnmarshaler) UnmarshalValue(buf []byte) (pcommon.Value, error) {
 	iter := json.BorrowIterator(buf)
 	defer json.ReturnIterator(iter)
+	iter.SetDisallowUnknownFields(u.DisallowUnknownFields)
 	value := &internal.AnyValue{}
 	value.UnmarshalJSON(iter)
 	if iter.Error() != nil {

--- a/pdata/xpdata/json_test.go
+++ b/pdata/xpdata/json_test.go
@@ -36,6 +36,14 @@ func TestUnmarshalValueUnknown(t *testing.T) {
 	assert.Equal(t, pcommon.NewValueEmpty(), b)
 }
 
+func TestUnmarshalValueDisallowUnknownFields(t *testing.T) {
+	m := &JSONUnmarshaler{DisallowUnknownFields: true}
+
+	_, err := m.UnmarshalValue([]byte(`{"unknown": "string"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown field "unknown"`)
+}
+
 func genTestEncodingValues() map[string]pcommon.Value {
 	return map[string]pcommon.Value{
 		"empty":               pcommon.NewValueEmpty(),

--- a/pdata/xpdata/json_test.go
+++ b/pdata/xpdata/json_test.go
@@ -44,6 +44,15 @@ func TestUnmarshalValueDisallowUnknownFields(t *testing.T) {
 	assert.Contains(t, err.Error(), `unknown field "unknown"`)
 }
 
+func TestUnmarshalValueDisallowUnknownFieldsReportsOnlyFirst(t *testing.T) {
+	m := &JSONUnmarshaler{DisallowUnknownFields: true}
+
+	_, err := m.UnmarshalValue([]byte(`{"unexpected1":"a","unexpected2":"b"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown field "unexpected1"`)
+	assert.NotContains(t, err.Error(), `unknown field "unexpected2"`)
+}
+
 func genTestEncodingValues() map[string]pcommon.Value {
 	return map[string]pcommon.Value{
 		"empty":               pcommon.NewValueEmpty(),


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds an opt-in strict mode on the plog, ptrace, pmetric, pprofile, and xpdata JSONUnmarshaler types so callers can reject input that contains JSON fields not defined by the OTLP schema. The default preserves the existing behavior of silently skipping unknown fields.

The unknown-field check is plumbed through pdata/internal/json.Iterator via a new HandleUnknownField helper; the generator template now emits calls to it in place of iter.Skip() for the default UnmarshalJSON case.

Assisted-by: Claude Opus 4.7

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15279.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit test coverage added for new functionality, all existing tests still pass.

<!--Please delete paragraphs that you did not use before submitting.-->
