### PR TITLE
[chore][cmd/mdatagen] Implement external default call for config generation

### DIFF
--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -89,7 +89,28 @@ func NewCfgFns(rootPackage, componentPackage string) map[string]any {
 			tr, err := ResolveGoTypeRef(ref, rootPackage, componentPackage)
 			return err == nil && tr.ImportPath != ""
 		},
+		"externalDefaultCall": func(ref string) string {
+			call, err := ExternalDefaultCall(ref, rootPackage, componentPackage)
+			if err != nil {
+				panic(err)
+			}
+			return call
+		},
 	}
+}
+
+// ExternalDefaultCall returns the Go expression that delegates to the upstream package's
+// NewDefault constructor for an external type reference (e.g. "controller.NewDefaultControllerConfig()").
+func ExternalDefaultCall(ref, rootPackage, componentPackage string) (string, error) {
+	tr, err := ResolveGoTypeRef(ref, rootPackage, componentPackage)
+	if err != nil {
+		return "", err
+	}
+	fnCall := fmt.Sprintf("NewDefault%s()", tr.TypeName)
+	if tr.Qualifier() != "" {
+		fnCall = tr.Qualifier() + "." + fnCall
+	}
+	return fnCall, nil
 }
 
 // WithCfgFns merges config generation template functions into the given function map.

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -2050,6 +2050,51 @@ func Ptr[T any](v T) *T {
 	return &v
 }
 
+func TestExternalDefaultCall(t *testing.T) {
+	rootPkg := "go.opentelemetry.io/collector"
+	compPkg := "go.opentelemetry.io/collector/scraper/scraperhelper"
+
+	tests := []struct {
+		name     string
+		ref      string
+		expected string
+	}{
+		{
+			name:     "fully qualified external ref",
+			ref:      "go.opentelemetry.io/collector/scraper/scraperhelper/internal/controller.controller_config",
+			expected: "controller.NewDefaultControllerConfig()",
+		},
+		{
+			name:     "relative local ref",
+			ref:      "./internal/controller.controller_config",
+			expected: "controller.NewDefaultControllerConfig()",
+		},
+		{
+			name:     "absolute local ref",
+			ref:      "/config/confighttp.client_config",
+			expected: "confighttp.NewDefaultClientConfig()",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ExternalDefaultCall(tt.ref, rootPkg, compPkg)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewCfgFns_ExternalDefaultCall(t *testing.T) {
+	rootPkg := "go.opentelemetry.io/collector"
+	compPkg := "go.opentelemetry.io/collector/scraper/scraperhelper"
+	fns := NewCfgFns(rootPkg, compPkg)
+	externalDefaultCall := fns["externalDefaultCall"].(func(string) string)
+
+	require.Equal(t, "controller.NewDefaultControllerConfig()", externalDefaultCall("./internal/controller.controller_config"))
+	require.Panics(t, func() { externalDefaultCall("github.com/pkg.") })
+}
+
 func TestFormatDefaultValue_ScalarDefaults(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -69,10 +69,14 @@ import (
     {{- if hasDefaultValue $def }}
     // NewDefault{{ $typeName }} returns a new {{ $typeName }} with default values consistent with the annotations in the schema.
     func NewDefault{{ $typeName }}() {{ $typeName }} {
+        {{- if isExternalRef $def.ResolvedFrom }}
+        return {{ externalDefaultCall $def.ResolvedFrom }}
+        {{- else }}
         {{- template "structLiteralVars" $def }}
         return {{ $typeName }}{
             {{- template "structLiteralFields" $def }}
         }
+        {{- end }}
     }
     {{- end }}
 

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -47,7 +47,7 @@ type ConfigMetadata struct {
 	ExclusiveMaximum     *float64                   `mapstructure:"exclusiveMaximum,omitempty" json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
 	Minimum              *float64                   `mapstructure:"minimum,omitempty" json:"minimum,omitempty" yaml:"minimum,omitempty"`
 	ExclusiveMinimum     *float64                   `mapstructure:"exclusiveMinimum,omitempty" json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
-	Defs                 map[string]*ConfigMetadata `mapstructure:"$defs,omitempty" json:"-" yaml:"$defs,omitempty"`
+	Defs                 map[string]*ConfigMetadata `mapstructure:"$defs,omitempty" json:"$defs,omitempty" yaml:"$defs,omitempty"`
 	// Additional custom fields
 	GoStruct   GoStructConfig `mapstructure:"go_struct,omitempty" json:"-" yaml:"go_struct,omitempty"`
 	GoType     string         `mapstructure:"x-customType,omitempty" json:"-" yaml:"x-customType,omitempty"`


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When mdatagen generates a `NewDefault*()` constructor for a type that is a schema-level alias to an external type (e.g. `type ControllerConfig = controller.ControllerConfig`), the generated function previously attempted to inline a struct literal. This fails or produces incorrect code because the fields of the external type are not available in the local schema definition.

This PR fixes the generated code so that when the def is an external ref (`isExternalRef`), the NewDefault*()` body delegates to the upstream package's own constructor instead:
```go
  // Before (broken/incomplete)                                                                                                                                                                      
  func NewDefaultControllerConfig() ControllerConfig {                                                                                                                                               
      return ControllerConfig{}                                                                                                                                                                      
  }                                                                                                                                                                                                  
                                                                                                                                                                                                     
  // After (correct delegation)                                                                                                                                                                      
  func NewDefaultControllerConfig() ControllerConfig {         
      return controller.NewDefaultControllerConfig()                                                                                                                                                 
  }
```

<!-- Issue number if applicable -->
#### Link to tracking issue
Related to #14560

