### PR TITLE
exporterhelper: fix duplicated "the" in Partitioner doc comment

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/partitioner.go
+++ b/exporter/exporterhelper/internal/queuebatch/partitioner.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 )
 
-// Partitioner is an interface that returns the the partition key of the given element.
+// Partitioner is an interface that returns the partition key of the given element.
 type Partitioner[T any] interface {
 	GetKey(context.Context, T) string
 }


### PR DESCRIPTION
Removes a doubled `the the` in the doc comment for `Partitioner` in `exporter/exporterhelper/internal/queuebatch/partitioner.go`. Comment-only, no behavior change.