### PR TITLE
[chore][cmd/mdatagen] Fix config schema alias resolution

### DIFF
--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -203,21 +203,11 @@ func (r *Resolver) resolveRef(root, current *ConfigMetadata, origin *Ref) (*Conf
 		return nil, fmt.Errorf("invalid reference format %q: %w", current.Ref, err)
 	}
 
-	if ref.IsInternal() {
-		if root.Defs != nil {
-			if val, ok := root.Defs[ref.DefName()]; ok {
-				return val, nil
-			}
-		}
+	if def, ok := lookupRootDef(root, current, ref); ok {
+		return def, nil
 	}
 
 	if ref.IsLocal() {
-		// Local refs whose def is already in root.$defs (injected by the caller) can be resolved without loading a file.
-		if root.Defs != nil {
-			if val, ok := root.Defs[ref.DefName()]; ok {
-				return val, nil
-			}
-		}
 		return r.loadExternalRef(ref)
 	}
 
@@ -230,6 +220,17 @@ func (r *Resolver) resolveRef(root, current *ConfigMetadata, origin *Ref) (*Conf
 	current.GoType = current.Ref
 	current.Comment = "Uses `any` type."
 	return current, nil
+}
+
+func lookupRootDef(root, current *ConfigMetadata, ref *Ref) (*ConfigMetadata, bool) {
+	if root.Defs == nil || (!ref.IsInternal() && !ref.IsLocal()) {
+		return nil, false
+	}
+	def, ok := root.Defs[ref.DefName()]
+	if !ok || def == current {
+		return nil, false
+	}
+	return def, ok
 }
 
 // loadExternalRef uses SchemaLoader to load external references

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -223,6 +223,142 @@ func TestResolver_ResolveSchema_AliasChain_PreservesCustomExtensions(t *testing.
 	require.NotNil(t, cfg.Properties["level"])
 }
 
+func TestResolver_ResolveSchema_InternalAliasChain(t *testing.T) {
+	resolver := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: &mockLoader{schemas: map[string]*ConfigMetadata{}},
+	}
+
+	src := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"alias": {Ref: "base"},
+			"base": {
+				Type:        "object",
+				Description: "Base configuration",
+				Properties: map[string]*ConfigMetadata{
+					"endpoint": {Type: "string"},
+				},
+			},
+		},
+		Properties: map[string]*ConfigMetadata{
+			"cfg": {
+				Ref: "alias",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveSchema(src)
+	require.NoError(t, err)
+
+	cfg := result.Properties["cfg"]
+	require.NotNil(t, cfg)
+	require.Equal(t, "base", cfg.ResolvedFrom)
+	require.Equal(t, "object", cfg.Type)
+	require.Equal(t, "Base configuration", cfg.Description)
+	require.Contains(t, cfg.Properties, "endpoint")
+}
+
+func TestResolver_ResolveSchema_DefsOnlyLocalAliasWithSameDefName(t *testing.T) {
+	controllerSchema := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"controller_config": {
+				Type:        "object",
+				Description: "Controller configuration",
+				Properties: map[string]*ConfigMetadata{
+					"collection_interval": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	resolver := &Resolver{
+		pkgID: "go.opentelemetry.io/collector/scraper/scraperhelper",
+		class: "pkg",
+		name:  "scraperhelper",
+		loader: &mockLoader{schemas: map[string]*ConfigMetadata{
+			"./internal/controller.controller_config": controllerSchema,
+		}},
+	}
+
+	src := &ConfigMetadata{
+		Defs: map[string]*ConfigMetadata{
+			"controller_config": {
+				Ref: "./internal/controller.controller_config",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveSchema(src)
+	require.NoError(t, err)
+
+	controller := result.Defs["controller_config"]
+	require.NotNil(t, controller)
+	require.Equal(t, "./internal/controller.controller_config", controller.ResolvedFrom)
+	require.Equal(t, "object", controller.Type)
+	require.Equal(t, "Controller configuration", controller.Description)
+	require.Contains(t, controller.Properties, "collection_interval")
+}
+
+func TestResolver_ResolveSchema_ExternalRefDoesNotUseRootDefWithSameName(t *testing.T) {
+	externalSchema := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"shared_config": {
+				Type:        "object",
+				Description: "External shared config",
+				Properties: map[string]*ConfigMetadata{
+					"external": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	ml := &mockLoader{
+		schemas: map[string]*ConfigMetadata{
+			"go.opentelemetry.io/collector/config/shared.shared_config": externalSchema,
+		},
+	}
+
+	resolver := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: ml,
+	}
+
+	src := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"shared_config": {
+				Type:        "object",
+				Description: "Local shared config",
+				Properties: map[string]*ConfigMetadata{
+					"local": {Type: "string"},
+				},
+			},
+		},
+		Properties: map[string]*ConfigMetadata{
+			"cfg": {
+				Ref: "go.opentelemetry.io/collector/config/shared.shared_config",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveSchema(src)
+	require.NoError(t, err)
+
+	cfg := result.Properties["cfg"]
+	require.NotNil(t, cfg)
+	require.Equal(t, "go.opentelemetry.io/collector/config/shared.shared_config", cfg.ResolvedFrom)
+	require.Equal(t, "External shared config", cfg.Description)
+	require.Contains(t, cfg.Properties, "external")
+	require.NotContains(t, cfg.Properties, "local")
+}
+
 func TestResolver_ResolveSchema_NestedStructures(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes alias resolution in internal/schemagen so config schemas resolve $defs aliases instead of emitting empty schema objects.

This specifically fixes the scraper/scraperhelper case where:
```yaml
controller_config:
  $ref: ./internal/controller.controller_config
```
could produce:
```json
"controller_config": {}
```

Changes:
- Keep root $defs lookup scoped to internal/local refs.
- Avoid resolving a $defs entry to itself, so same-name local aliases fall through to the loader.
- Prevent external refs from being shadowed by root $defs entries with the same definition name.
- Add regression coverage for internal alias chains, same-name local aliases, and external ref shadowing.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15299
