### PR TITLE
Enable mdatagen reaggregation by default

### DIFF
--- a/.chloggen/mdatagen-reaggregation-default.yaml
+++ b/.chloggen/mdatagen-reaggregation-default.yaml
@@ -1,0 +1,5 @@
+change_type: breaking
+component: cmd/mdatagen
+note: "Enable reaggregation config generation by default; set `reaggregation_enabled: false` to keep generating metric config with only the `enabled` field."
+issues: [14689]
+change_logs: [api]

--- a/cmd/mdatagen/README.md
+++ b/cmd/mdatagen/README.md
@@ -142,12 +142,11 @@ This lets users:
 
 ### Metric Reaggregation Configuration
 
-Set `reaggregation_enabled: true` to let users reduce metric cardinality by dropping selected metric
-attributes and aggregating the resulting datapoints.
+By default, `mdatagen` lets users reduce metric cardinality by dropping selected metric
+attributes and aggregating the resulting datapoints. Set `reaggregation_enabled: false`
+to generate metric config with only the `enabled` field.
 
 ```yaml
-reaggregation_enabled: true
-
 attributes:
   transport:
     description: Transport used by the request.

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -44,7 +44,11 @@ func LoadMetadata(filePath string) (Metadata, error) {
 		return Metadata{}, err
 	}
 
-	md := Metadata{ShortFolderName: shortFolderName(filePath), Tests: Tests{Host: "newMdatagenNopHost()"}}
+	md := Metadata{
+		ShortFolderName:      shortFolderName(filePath),
+		ReaggregationEnabled: true,
+		Tests:                Tests{Host: "newMdatagenNopHost()"},
+	}
 	err = conf.Unmarshal(&md)
 	if err != nil {
 		return md, err

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -38,9 +38,10 @@ func TestTwoPackagesInDirectory(t *testing.T) {
 
 func TestLoadMetadata(t *testing.T) {
 	tests := []struct {
-		name    string
-		want    Metadata
-		wantErr string
+		name                     string
+		want                     Metadata
+		wantErr                  string
+		wantReaggregationEnabled *bool
 	}{
 		{
 			name: "samplereceiver/metadata.yaml",
@@ -638,6 +639,24 @@ func TestLoadMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "testdata/reaggregation_disabled.yaml",
+			want: Metadata{
+				Type:                 "test",
+				GeneratedPackageName: "metadata",
+				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
+				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
+				ShortFolderName:      "testdata",
+				Tests:                Tests{Host: "newMdatagenNopHost()"},
+				Status: &Status{
+					Class: "receiver",
+					Stability: map[component.StabilityLevel][]string{
+						component.StabilityLevelBeta: {"logs"},
+					},
+				},
+			},
+			wantReaggregationEnabled: boolPtr(false),
+		},
+		{
 			name:    "testdata/invalid_type_rattr.yaml",
 			want:    Metadata{},
 			wantErr: "decoding failed due to the following error(s):\n\n'resource_attributes[string.resource.attr].type' invalid type: \"invalidtype\"",
@@ -815,7 +834,13 @@ func TestLoadMetadata(t *testing.T) {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.want, got)
+				want := tt.want
+				wantReaggregationEnabled := boolPtr(true)
+				if tt.wantReaggregationEnabled != nil {
+					wantReaggregationEnabled = tt.wantReaggregationEnabled
+				}
+				want.ReaggregationEnabled = *wantReaggregationEnabled
+				require.Equal(t, want, got)
 			}
 		})
 	}

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -33,7 +33,7 @@ type Metadata struct {
 	Parent string `mapstructure:"parent"`
 	// Status information for the component.
 	Status *Status `mapstructure:"status"`
-	// Spatial Re-aggregation featuregate.
+	// ReaggregationEnabled enables spatial re-aggregation configuration generation. Defaults to true.
 	ReaggregationEnabled bool `mapstructure:"reaggregation_enabled"`
 	// Override value featuregate for resource attributes.
 	OverrideValueEnabled bool `mapstructure:"override_value_enabled"`

--- a/cmd/mdatagen/internal/sampleconnector/metadata.yaml
+++ b/cmd/mdatagen/internal/sampleconnector/metadata.yaml
@@ -4,7 +4,6 @@ type: sample
 display_name: Sample Connector
 description: This connector is used for testing purposes to check the output of mdatagen.
 github_project: open-telemetry/opentelemetry-collector
-reaggregation_enabled: true
 override_value_enabled: true
 
 sem_conv_version: 1.9.0

--- a/cmd/mdatagen/internal/sampleentityreceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/sampleentityreceiver/metadata.yaml
@@ -3,6 +3,7 @@
 type: sampleentity
 display_name: Sample Entity Receiver
 description: This receiver demonstrates entity-based metrics builder API.
+reaggregation_enabled: false
 override_value_enabled: true
 scope_name: go.opentelemetry.io/collector/internal/receiver/sampleentityreceiver
 sem_conv_version: 1.40.0

--- a/cmd/mdatagen/internal/samplefactoryreceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplefactoryreceiver/metadata.yaml
@@ -3,6 +3,7 @@
 type: sample
 display_name: Sample Factory Receiver
 description: This receiver is used for testing purposes to check the output of mdatagen.
+reaggregation_enabled: false
 scope_name: go.opentelemetry.io/collector/internal/receiver/samplefactoryreceiver
 github_project: open-telemetry/opentelemetry-collector
 
@@ -26,4 +27,3 @@ status:
     active: [dmitryax]
   warnings:
     - Any additional information that should be brought to the consumer's attention
-

--- a/cmd/mdatagen/internal/sampleprocessor/metadata.yaml
+++ b/cmd/mdatagen/internal/sampleprocessor/metadata.yaml
@@ -3,7 +3,6 @@
 type: sample
 display_name: Sample Processor
 description: This processor is used for testing purposes to check the output of mdatagen.
-reaggregation_enabled: true
 override_value_enabled: true
 scope_name: go.opentelemetry.io/collector/internal/receiver/samplereceiver
 github_project: open-telemetry/opentelemetry-collector

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -3,7 +3,6 @@
 type: sample
 display_name: Sample Receiver
 description: This receiver is used for testing purposes to check the output of mdatagen.
-reaggregation_enabled: true
 override_value_enabled: true
 scope_name: go.opentelemetry.io/collector/internal/receiver/samplereceiver
 github_project: open-telemetry/opentelemetry-collector

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -3,7 +3,6 @@
 type: sample
 display_name: Sample Scraper
 description: This scraper is used for testing purposes to check the output of mdatagen.
-reaggregation_enabled: true
 override_value_enabled: true
 github_project: open-telemetry/opentelemetry-collector
 

--- a/cmd/mdatagen/internal/testdata/reaggregation_disabled.yaml
+++ b/cmd/mdatagen/internal/testdata/reaggregation_disabled.yaml
@@ -1,0 +1,7 @@
+type: test
+reaggregation_enabled: false
+
+status:
+  class: receiver
+  stability:
+    beta: [logs]

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -20,6 +20,8 @@ scope_name: string
 generated_package_name: string
 
 # Optional: Enables per-metric reaggregation config generation for metrics with attributes.
+# Enabled by default. Set to false to generate metric config with only the `enabled`
+# field.
 # When enabled, generated metrics config includes `aggregation_strategy` and `attributes`
 # fields that let users reduce metric cardinality by choosing which dimensions are kept.
 reaggregation_enabled: bool


### PR DESCRIPTION
Enables mdatagen reaggregation config generation by default while preserving `reaggregation_enabled: false` as the opt-out for fixtures that need legacy metric config.