### PR TITLE
Fix memory corruption and fatal error in Snappy (#15321)

### DIFF
--- a/.chloggen/fix-snappy.yaml
+++ b/.chloggen/fix-snappy.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/config/configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix memory corruption and fatal error in Snappy
+
+# One or more tracking issues or pull requests related to the change
+issues: [15237, 15320]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/grpccompression/snappy/snappy.go
+++ b/internal/grpccompression/snappy/snappy.go
@@ -30,41 +30,35 @@ func registerCompressor(get func(string) encoding.Compressor, register func(enco
 	return true
 }
 
-type compressor struct {
-	poolCompressor   sync.Pool
-	poolDecompressor sync.Pool
-}
+var (
+	writerPool = sync.Pool{
+		New: func() any {
+			return snappylib.NewBufferedWriter(io.Discard)
+		},
+	}
+	readerPool = sync.Pool{
+		New: func() any {
+			return snappylib.NewReader(nil)
+		},
+	}
+)
+
+type compressor struct{}
 
 func newCompressor() *compressor {
-	c := &compressor{}
-	c.poolCompressor.New = func() any {
-		return &writer{
-			Writer: snappylib.NewBufferedWriter(io.Discard),
-			pool:   &c.poolCompressor,
-		}
-	}
-	return c
+	return &compressor{}
 }
 
-func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {
-	z := c.poolCompressor.Get().(*writer)
-	z.once = sync.Once{}
+func (*compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	z := writerPool.Get().(*snappylib.Writer)
 	z.Reset(w)
-	return z, nil
+	return &writer{Writer: z}, nil
 }
 
 func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
-	z, ok := c.poolDecompressor.Get().(*reader)
-	if !ok {
-		return &reader{
-			Reader: snappylib.NewReader(r),
-			pool:   &c.poolDecompressor,
-		}, nil
-	}
-
-	z.once = sync.Once{}
+	z := readerPool.Get().(*snappylib.Reader)
 	z.Reset(r)
-	return z, nil
+	return &reader{Reader: z}, nil
 }
 
 func (c *compressor) Name() string {
@@ -73,30 +67,24 @@ func (c *compressor) Name() string {
 
 type writer struct {
 	*snappylib.Writer
-	pool *sync.Pool
-	once sync.Once
 }
 
 func (z *writer) Close() error {
 	err := z.Writer.Close()
-	z.once.Do(func() {
-		z.pool.Put(z)
-	})
+	writerPool.Put(z.Writer)
+	z.Writer = nil
 	return err
 }
 
 type reader struct {
 	*snappylib.Reader
-	pool *sync.Pool
-	once sync.Once
 }
 
 func (z *reader) Read(p []byte) (int, error) {
 	n, err := z.Reader.Read(p)
 	if err != nil {
-		z.once.Do(func() {
-			z.pool.Put(z)
-		})
+		readerPool.Put(z.Reader)
+		z.Reader = nil
 	}
 	return n, err
 }

--- a/internal/grpccompression/snappy/snappy_test.go
+++ b/internal/grpccompression/snappy/snappy_test.go
@@ -7,9 +7,9 @@ package snappy
 import (
 	"bytes"
 	"io"
+	"runtime"
 	"testing"
 
-	snappylib "github.com/golang/snappy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/encoding"
@@ -65,25 +65,89 @@ func TestRegisterCompressor(t *testing.T) {
 	})
 }
 
-func TestDecompressReusesPooledReader(t *testing.T) {
-	c := newCompressor()
-	seed := &reader{
-		Reader: snappylib.NewReader(bytes.NewReader(nil)),
-		pool:   &c.poolDecompressor,
+func TestConcurrentWriterReuseDoesNotPanic(t *testing.T) {
+	prev := runtime.GOMAXPROCS(runtime.NumCPU())
+	defer runtime.GOMAXPROCS(prev)
+
+	comp := newCompressor()
+	payload := bytes.Repeat([]byte("snappy payload "), 32)
+
+	const workers = 6
+	const iterations = 100
+
+	start := make(chan struct{})
+	errCh := make(chan error, workers)
+
+	for range workers {
+		go func() {
+			<-start
+			for range iterations {
+				var buf bytes.Buffer
+				w, err := comp.Compress(&buf)
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				if _, err = w.Write(payload); err != nil {
+					errCh <- err
+					return
+				}
+
+				if err = w.Close(); err != nil {
+					errCh <- err
+					return
+				}
+			}
+			errCh <- nil
+		}()
 	}
-	c.poolDecompressor.New = func() any { return seed }
 
-	compressed := compressPayload(t, c, []byte("snappy reuse check"))
+	close(start)
 
-	r, err := c.Decompress(bytes.NewReader(compressed))
-	require.NoError(t, err)
-	got, ok := r.(*reader)
-	require.True(t, ok)
-	assert.Same(t, seed, got)
+	for range workers {
+		require.NoError(t, <-errCh)
+	}
+}
 
-	out, err := io.ReadAll(got)
-	require.NoError(t, err)
-	assert.Equal(t, []byte("snappy reuse check"), out)
+func TestConcurrentReaderReuseDoesNotPanic(t *testing.T) {
+	prev := runtime.GOMAXPROCS(runtime.NumCPU())
+	defer runtime.GOMAXPROCS(prev)
+
+	comp := newCompressor()
+	payload := bytes.Repeat([]byte("snappy payload "), 32)
+	compressed := compressPayload(t, comp, payload)
+
+	const workers = 8
+	const iterations = 50
+
+	start := make(chan struct{})
+	errCh := make(chan error, workers)
+
+	for range workers {
+		go func() {
+			<-start
+			for range iterations {
+				r, err := comp.Decompress(bytes.NewReader(compressed))
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				if _, err = io.ReadAll(r); err != nil {
+					errCh <- err
+					return
+				}
+			}
+			errCh <- nil
+		}()
+	}
+
+	close(start)
+
+	for range workers {
+		require.NoError(t, <-errCh)
+	}
 }
 
 func compressPayload(t *testing.T, comp encoding.Compressor, payload []byte) []byte {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue. Ex. Adding a feature - Explain what this achieves.--> #### Description

The problem happens because:

T1: Executes `writer.Close()` and gets descheduled after `z.pool.Put(z)` but before leaving the `Do` function.
T2: Executes `compressor.Decompress`, get the latest re-added writer from T1, and overwrites the `once` variable.
T1: Resumes and tries to unlock the overwritten `once` which is not locked.

This is an UB and everything can happen when we corrupt the memory like this.

```
fatal error: sync: unlock of unlocked mutex
goroutine 48499 [running]:
internal/sync.fatal({0xa4032ec?, 0x373e910417c0?})
	GOROOT/src/runtime/panic.go:1191 +0x18
internal/sync.(*Mutex).unlockSlow(0x373e910417d4, 0xffffffff)
	GOROOT/src/internal/sync/mutex.go:204 +0x35
internal/sync.(*Mutex).Unlock(...)
	GOROOT/src/internal/sync/mutex.go:198
sync.(*Mutex).Unlock(...)
	GOROOT/src/sync/mutex.go:65
sync.(*Once).doSlow(0x373e91c44f50?, 0x373eadc29fed?)
	GOROOT/src/sync/once.go:80 +0xe4
sync.(*Once).Do(...)
	GOROOT/src/sync/once.go:69
go.opentelemetry.io/collector/internal/grpccompression/snappy.(*reader).Read(0x373e910417c0, {0x373eadc29fed?, 0x373e4d674300?, 0x8000?})
	external/io_opentelemetry_go_collector/internal/grpccompression/snappy/snappy.go:96 +0x65
io.(*LimitedReader).Read(0x373eaa8bc6c0, {0x373eadc29fed?, 0x373e4d6526c0?, 0x373eaa8bc6c0?})
	GOROOT/src/io/io.go:479 +0x43
google.golang.org/grpc/mem.ReadAll({0xad75ec0, 0x373eaa8bc6c0}, {0xadfedd8, 0x373e4d6526c0})
	external/org_golang_google_grpc/mem/buffer_slice.go:268 +0x188
google.golang.org/grpc.decompress({0xae3eea0, 0x373e4d66a320}, {0x373e4d836c60?, 0x373e68b4c8b0?, 0x425745?}, {0x0?, 0x0?}, 0x40000000, {0xadfedd8, 0x373e4d6526c0})
	external/org_golang_google_grpc/rpc_util.go:999 +0x15c
google.golang.org/grpc.recvAndDecompress(0x373e9e41f170, {0xad7dfa0, 0x373e96992820}, {0x0, 0x0}, 0x40000000, 0x373e91041d00, {0xae3eea0, 0x373e4d66a320}, 0x1)
	external/org_golang_google_grpc/rpc_util.go:947 +0x2ab
google.golang.org/grpc.(*Server).processUnaryRPC(0x373e4f182008, {0xae516e0, 0x373e9e41f0b0}, 0x373e96992820, 0x373e4e86a060, 0x10da6290, 0x0)
	external/org_golang_google_grpc/server.go:1386 +0xf25
google.golang.org/grpc.(*Server).handleStream(0x373e4f182008, {0xae53b28, 0x373e4d859d40}, 0x373e96992820)
	external/org_golang_google_grpc/server.go:1856 +0xc2e
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	external/org_golang_google_grpc/server.go:1065 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 302
	external/org_golang_google_grpc/server.go:1076 +0x11d
```

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15237 
Fixes #15320 

<!--Describe what testing was performed and which tests were added.--> #### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
