### PR TITLE
Support max_retries on BackOffConfig

### DIFF
--- a/.chloggen/configretry-max-retries.yaml
+++ b/.chloggen/configretry-max-retries.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: pkg/config/configretry
+note: "Add `max_retries` to retry-on-failure backoff configuration."
+issues: [15274]
+subtext:
+change_logs: [user, api]

--- a/config/configretry/backoff.go
+++ b/config/configretry/backoff.go
@@ -19,6 +19,7 @@ func NewDefaultBackOffConfig() BackOffConfig {
 		Multiplier:          backoff.DefaultMultiplier,
 		MaxInterval:         30 * time.Second,
 		MaxElapsedTime:      5 * time.Minute,
+		MaxRetryCount:       0,
 	}
 }
 
@@ -38,8 +39,10 @@ type BackOffConfig struct {
 	// consecutive retries will always be `MaxInterval`.
 	MaxInterval time.Duration `mapstructure:"max_interval"`
 	// MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch.
-	// Once this value is reached, the data is discarded. If set to 0, the retries are never stopped.
+	// Once this value is reached, the data is discarded. If set to 0, retries are not limited by elapsed time.
 	MaxElapsedTime time.Duration `mapstructure:"max_elapsed_time"`
+	// MaxRetryCount is the maximum number of retries before giving up. If set to 0, retries are not limited by retry count.
+	MaxRetryCount int64 `mapstructure:"max_retries"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -62,6 +65,9 @@ func (bs *BackOffConfig) Validate() error {
 	}
 	if bs.MaxElapsedTime < 0 {
 		return errors.New("'max_elapsed_time' must be non-negative")
+	}
+	if bs.MaxRetryCount < 0 {
+		return errors.New("'max_retries' must be non-negative")
 	}
 	if bs.MaxElapsedTime > 0 {
 		if bs.MaxElapsedTime < bs.InitialInterval {

--- a/config/configretry/backoff_test.go
+++ b/config/configretry/backoff_test.go
@@ -22,6 +22,7 @@ func TestNewDefaultBackOffSettings(t *testing.T) {
 			Multiplier:          1.5,
 			MaxInterval:         30 * time.Second,
 			MaxElapsedTime:      5 * time.Minute,
+			MaxRetryCount:       0,
 		}, cfg)
 }
 
@@ -81,6 +82,13 @@ func TestInvalidMaxElapsedTime(t *testing.T) {
 	assert.NoError(t, cfg.Validate())
 }
 
+func TestInvalidMaxRetries(t *testing.T) {
+	cfg := NewDefaultBackOffConfig()
+	require.NoError(t, cfg.Validate())
+	cfg.MaxRetryCount = -1
+	assert.Error(t, cfg.Validate())
+}
+
 func TestDisabledWithInvalidValues(t *testing.T) {
 	cfg := BackOffConfig{
 		Enabled:             false,
@@ -89,6 +97,7 @@ func TestDisabledWithInvalidValues(t *testing.T) {
 		Multiplier:          0,
 		MaxInterval:         -1,
 		MaxElapsedTime:      -1,
+		MaxRetryCount:       -1,
 	}
 	assert.NoError(t, cfg.Validate())
 }

--- a/config/configretry/config.schema.yaml
+++ b/config/configretry/config.schema.yaml
@@ -12,7 +12,7 @@ $defs:
         x-customType: time.Duration
         format: duration
       max_elapsed_time:
-        description: MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch. Once this value is reached, the data is discarded. If set to 0, the retries are never stopped.
+        description: MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch. Once this value is reached, the data is discarded. If set to 0, retries are not limited by elapsed time.
         type: string
         x-customType: time.Duration
         format: duration
@@ -21,6 +21,9 @@ $defs:
         type: string
         x-customType: time.Duration
         format: duration
+      max_retries:
+        description: MaxRetryCount is the maximum number of retries before giving up. If set to 0, retries are not limited by retry count.
+        type: integer
       multiplier:
         description: Multiplier is the value multiplied by the backoff interval bounds
         type: number

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -13,7 +13,8 @@ The following configuration options can be modified:
   - `enabled` (default = true)
   - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`
   - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
-  - `max_elapsed_time` (default = 300s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`. If set to 0, the retries are never stopped.
+  - `max_elapsed_time` (default = 300s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`. If set to 0, retries are not limited by elapsed time.
+  - `max_retries` (default = 0): Is the maximum number of retries before giving up; ignored if `enabled` is `false`. If set to 0, retries are not limited by retry count.
   - `multiplier` (default = 1.5): Factor by which the retry interval is multiplied on each attempt; ignored if `enabled` is `false`
 
 ### Sending Queue

--- a/exporter/exporterhelper/internal/retry_sender.go
+++ b/exporter/exporterhelper/internal/retry_sender.go
@@ -102,6 +102,10 @@ func (rs *retrySender) Send(ctx context.Context, req request.Request) error {
 			req = errReq.OnError(err)
 		}
 
+		if rs.cfg.MaxRetryCount > 0 && retryNum >= rs.cfg.MaxRetryCount {
+			return fmt.Errorf("no more retries left: %w", err)
+		}
+
 		backoffDelay := expBackoff.NextBackOff()
 		if backoffDelay == backoff.Stop {
 			return fmt.Errorf("no more retries left: %w", err)

--- a/exporter/exporterhelper/internal/retry_sender_test.go
+++ b/exporter/exporterhelper/internal/retry_sender_test.go
@@ -76,6 +76,22 @@ func TestRetrySenderMaxElapsedTime(t *testing.T) {
 	require.NoError(t, rs.Shutdown(context.Background()))
 }
 
+func TestRetrySenderMaxRetries(t *testing.T) {
+	rCfg := configretry.NewDefaultBackOffConfig()
+	rCfg.InitialInterval = 0
+	rCfg.MaxRetryCount = 2
+	expErr := errors.New("transient error")
+	attempts := 0
+	rs := newRetrySender(rCfg, exportertest.NewNopSettings(exportertest.NopType), sender.NewSender(func(context.Context, request.Request) error {
+		attempts++
+		return expErr
+	}))
+	require.NoError(t, rs.Start(context.Background(), componenttest.NewNopHost()))
+	require.ErrorIs(t, rs.Send(context.Background(), &requesttest.FakeRequest{Items: 2}), expErr)
+	assert.Equal(t, 3, attempts)
+	require.NoError(t, rs.Shutdown(context.Background()))
+}
+
 func TestRetrySenderThrottleError(t *testing.T) {
 	rCfg := configretry.NewDefaultBackOffConfig()
 	rCfg.InitialInterval = 10 * time.Millisecond

--- a/exporter/otlpexporter/cfg-schema.yaml
+++ b/exporter/otlpexporter/cfg-schema.yaml
@@ -65,6 +65,10 @@ fields:
     doc: |
       MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch.
       Once this value is reached, the data is discarded.
+  - name: max_retries
+    kind: int64
+    doc: |
+      MaxRetryCount is the maximum number of retries before giving up. If set to 0, retries are not limited by retry count.
 - name: endpoint
   kind: string
   doc: |

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -49,6 +49,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				Multiplier:          1.3,
 				MaxInterval:         1 * time.Minute,
 				MaxElapsedTime:      10 * time.Minute,
+				MaxRetryCount:       7,
 			},
 			QueueConfig: configoptional.Some(exporterhelper.QueueBatchConfig{
 				Sizer:        exporterhelper.RequestSizerTypeItems,

--- a/exporter/otlpexporter/testdata/config.yaml
+++ b/exporter/otlpexporter/testdata/config.yaml
@@ -19,6 +19,7 @@ retry_on_failure:
   multiplier: 1.3
   max_interval: 60s
   max_elapsed_time: 10m
+  max_retries: 7
 auth:
   authenticator: nop
 headers:

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -51,6 +51,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				Multiplier:          1.3,
 				MaxInterval:         1 * time.Minute,
 				MaxElapsedTime:      10 * time.Minute,
+				MaxRetryCount:       7,
 			},
 			QueueConfig: configoptional.Some(exporterhelper.QueueBatchConfig{
 				Sizer:        exporterhelper.RequestSizerTypeRequests,

--- a/exporter/otlphttpexporter/testdata/config.yaml
+++ b/exporter/otlphttpexporter/testdata/config.yaml
@@ -18,6 +18,7 @@ retry_on_failure:
   multiplier: 1.3
   max_interval: 60s
   max_elapsed_time: 10m
+  max_retries: 7
 headers:
   "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
   header1: "234"


### PR DESCRIPTION
Adds `max_retries` as an additional retry-on-failure limit so retries stop when either `max_retries` or `max_elapsed_time` is reached.

Closes #15274