### PR TITLE
[exporter/exporterhelper] mark exporter.PersistRequestContext as stable

### DIFF
--- a/.chloggen/codeboten_stabilize-exporter.PersistRequestContext.yaml
+++ b/.chloggen/codeboten_stabilize-exporter.PersistRequestContext.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "mark exporter.PersistRequestContext as stable"
+
+# One or more tracking issues or pull requests related to the change
+issues: [15330]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/documentation.md
+++ b/exporter/exporterhelper/documentation.md
@@ -148,6 +148,6 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `exporter.PersistRequestContext` | beta | controls whether context should be stored alongside requests in the persistent queue | v0.128.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector/pull/13188) |
+| `exporter.PersistRequestContext` | stable | controls whether context should be stored alongside requests in the persistent queue | v0.128.0 | v0.154.0 | [Link](https://github.com/open-telemetry/opentelemetry-collector/pull/13188) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/exporter/exporterhelper/internal/metadata/generated_feature_gates.go
+++ b/exporter/exporterhelper/internal/metadata/generated_feature_gates.go
@@ -8,8 +8,9 @@ import (
 
 var ExporterPersistRequestContextFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"exporter.PersistRequestContext",
-	featuregate.StageBeta,
+	featuregate.StageStable,
 	featuregate.WithRegisterDescription("controls whether context should be stored alongside requests in the persistent queue"),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/pull/13188"),
 	featuregate.WithRegisterFromVersion("v0.128.0"),
+	featuregate.WithRegisterToVersion("v0.154.0"),
 )

--- a/exporter/exporterhelper/metadata.yaml
+++ b/exporter/exporterhelper/metadata.yaml
@@ -209,6 +209,7 @@ telemetry:
 feature_gates:
   - id: exporter.PersistRequestContext
     description: 'controls whether context should be stored alongside requests in the persistent queue'
-    stage: beta
+    stage: stable
     from_version: 'v0.128.0'
+    to_version: 'v0.154.0'
     reference_url: 'https://github.com/open-telemetry/opentelemetry-collector/pull/13188'


### PR DESCRIPTION
This feature gate has been in beta for 15 versions, it's time to stabilize it.
