### PR TITLE
[chore]: fix install of mdatagen from the tip of main

### DIFF
--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -20,7 +20,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.152.1
 	go.opentelemetry.io/collector/featuregate v1.58.0
 	go.opentelemetry.io/collector/filter v0.152.1
-	go.opentelemetry.io/collector/internal/schemagen v0.152.1
+	go.opentelemetry.io/collector/internal/schemagen v0.152.1-0.20260521144538-6a86f8609a5c
 	go.opentelemetry.io/collector/pdata v1.58.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.152.1
 	go.opentelemetry.io/collector/pdata/xpdata v0.152.1


### PR DESCRIPTION
#### Description

At the moment `go get go.opentelemetry.io/collector/cmd/mdatagen@main` result in an unbuildable `mdatagen`.

This happens because mdatagen's go.mod on main references `go.opentelemetry.io/collector/internal/schemagen v0.152.1`. `mdatagen` was [updated](https://github.com/open-telemetry/opentelemetry-collector/pull/15304/changes#diff-42498599bf5b805dde7cc8403116834d346c7cbb62150935aeda205a61886661R60) to depend on a new field from `internal/schemagen` (`InternalOnly`) on main and this new field is not in `go.opentelemetry.io/collector/internal/schemagen v0.152.1`. When building externally (without the replace statements) the dependency is resolved to `v0.152.1` and the compile fails because `v0.152.1` does not have the new field.

My fix is to bump `mdatagen`'s dependency to a psuedo version of the tip of main. All of this will get cleaned up with the `v0.153.0` release, but I'd like to do this now so I can bump Contrib's core deps to the tip of main so I can handle the breaking change from https://github.com/open-telemetry/opentelemetry-collector/pull/15310 before the release.

#### Testing

I ran a quick test locally using this commit's psuedo version and confirmed I was able to install mdatagen now