### PR TITLE
[chore][internal/schemagen] split JSON Schema doc from ConfigMetadata

### DIFF
--- a/cmd/mdatagen/internal/cfggen/shared_alias.go
+++ b/cmd/mdatagen/internal/cfggen/shared_alias.go
@@ -7,6 +7,8 @@ import "go.opentelemetry.io/collector/internal/schemagen"
 
 type (
 	ConfigMetadata        = schemagen.ConfigMetadata
+	JSONSchemaDoc         = schemagen.JSONSchemaDoc
+	Metadata              = schemagen.Metadata
 	GoStructConfig        = schemagen.GoStructConfig
 	CustomValidatorConfig = schemagen.CustomValidatorConfig
 	Loader                = schemagen.Loader

--- a/cmd/mdatagen/internal/cfggen/shared_alias.go
+++ b/cmd/mdatagen/internal/cfggen/shared_alias.go
@@ -24,11 +24,12 @@ const (
 )
 
 var (
-	ErrNotFound     = schemagen.ErrNotFound
-	NewLoader       = schemagen.NewLoader
-	NewRef          = schemagen.NewRef
-	WithOrigin      = schemagen.WithOrigin
-	LocalizeRef     = schemagen.LocalizeRef
-	NewResolver     = schemagen.NewResolver
-	WriteJSONSchema = schemagen.WriteJSONSchema
+	ErrNotFound      = schemagen.ErrNotFound
+	NewLoader        = schemagen.NewLoader
+	NewRef           = schemagen.NewRef
+	WithOrigin       = schemagen.WithOrigin
+	LocalizeRef      = schemagen.LocalizeRef
+	NewResolver      = schemagen.NewResolver
+	NewJSONSchemaDoc = schemagen.NewJSONSchemaDoc
+	WriteJSONSchema  = schemagen.WriteJSONSchema
 )

--- a/cmd/mdatagen/internal/command.go
+++ b/cmd/mdatagen/internal/command.go
@@ -674,9 +674,23 @@ func mergeInternalMetadataDefs(raw []byte, src *cfggen.ConfigMetadata) error {
 
 func generateConfigFiles(md Metadata, mdDir, importRootPath string) error {
 	if md.Config != nil || len(md.ExportedConfigs) > 0 {
-		if md.Config == nil {
+		// Deep-clone the schema inputs so injectInternalMetadataDefs and the
+		// resolver below cannot leak mutations back into the caller's Metadata
+		// through shared *ConfigMetadata pointers. `md Metadata` is passed by
+		// value, but Config and ExportedConfigs hold caller-owned pointers.
+		if md.Config != nil {
+			md.Config = md.Config.Clone()
+		} else {
 			md.Config = &cfggen.ConfigMetadata{}
 		}
+		if len(md.ExportedConfigs) > 0 {
+			cloned := make(map[string]*cfggen.ConfigMetadata, len(md.ExportedConfigs))
+			for k, v := range md.ExportedConfigs {
+				cloned[k] = v.Clone()
+			}
+			md.ExportedConfigs = cloned
+		}
+
 		if err := injectInternalMetadataDefs(md, mdDir, md.Config); err != nil {
 			return err
 		}

--- a/cmd/mdatagen/internal/command.go
+++ b/cmd/mdatagen/internal/command.go
@@ -699,25 +699,21 @@ func generateConfigFiles(md Metadata, mdDir, importRootPath string) error {
 			Config:          md.Config,
 			ExportedConfigs: md.ExportedConfigs,
 		}
-		resolvedDoc, err := resolver.Resolve(schemaInput)
+		resolvedConfig, err := resolver.Resolve(schemaInput)
 		if err != nil {
 			return fmt.Errorf("failed to resolve config schema: %w", err)
 		}
 
-		err = cfggen.WriteJSONSchema(mdDir, resolvedDoc)
+		err = cfggen.WriteJSONSchema(mdDir, cfggen.NewJSONSchemaDoc(resolvedConfig))
 		if err != nil {
 			return fmt.Errorf("failed to write config schema: %w", err)
 		}
 
-		// do a shallow copy of Metadata and replace Config with resolved schema
+		// do a shallow copy of Metadata and replace Config with the resolved schema.
+		// The Go-struct templates walk Config (Properties, AllOf, $defs); the resolver
+		// leaves the merged $defs on the node, so no reattach is needed here.
 		mdWithConfig := md
-		mdWithConfig.Config = resolvedDoc.ConfigMetadata
-		// The Go-struct templates iterate over Config.Defs to emit a struct per
-		// exported config. The resolver promotes those into JSONSchemaDoc.Defs for
-		// JSON output, so reattach them here for the templating path.
-		if mdWithConfig.Config != nil && len(resolvedDoc.Defs) > 0 {
-			mdWithConfig.Config.Defs = resolvedDoc.Defs
-		}
+		mdWithConfig.Config = resolvedConfig
 
 		if err = generateConfigGoStruct(mdWithConfig, mdDir); err != nil {
 			return fmt.Errorf("failed to generate config Go struct: %w", err)

--- a/cmd/mdatagen/internal/command.go
+++ b/cmd/mdatagen/internal/command.go
@@ -673,31 +673,37 @@ func mergeInternalMetadataDefs(raw []byte, src *cfggen.ConfigMetadata) error {
 }
 
 func generateConfigFiles(md Metadata, mdDir, importRootPath string) error {
-	if md.ExportedConfigs != nil {
+	if md.Config != nil || len(md.ExportedConfigs) > 0 {
 		if md.Config == nil {
 			md.Config = &cfggen.ConfigMetadata{}
 		}
-		md.Config.Defs = md.ExportedConfigs
-	}
-
-	if md.Config != nil {
 		if err := injectInternalMetadataDefs(md, mdDir, md.Config); err != nil {
 			return err
 		}
 		resolver := cfggen.NewResolver(md.PackageName, md.Status.Class, md.Type, mdDir)
-		resolvedSchema, err := resolver.ResolveSchema(md.Config)
+		schemaInput := &cfggen.Metadata{
+			Config:          md.Config,
+			ExportedConfigs: md.ExportedConfigs,
+		}
+		resolvedDoc, err := resolver.Resolve(schemaInput)
 		if err != nil {
 			return fmt.Errorf("failed to resolve config schema: %w", err)
 		}
 
-		err = cfggen.WriteJSONSchema(mdDir, resolvedSchema)
+		err = cfggen.WriteJSONSchema(mdDir, resolvedDoc)
 		if err != nil {
 			return fmt.Errorf("failed to write config schema: %w", err)
 		}
 
 		// do a shallow copy of Metadata and replace Config with resolved schema
 		mdWithConfig := md
-		mdWithConfig.Config = resolvedSchema
+		mdWithConfig.Config = resolvedDoc.ConfigMetadata
+		// The Go-struct templates iterate over Config.Defs to emit a struct per
+		// exported config. The resolver promotes those into JSONSchemaDoc.Defs for
+		// JSON output, so reattach them here for the templating path.
+		if mdWithConfig.Config != nil && len(resolvedDoc.Defs) > 0 {
+			mdWithConfig.Config.Defs = resolvedDoc.Defs
+		}
 
 		if err = generateConfigGoStruct(mdWithConfig, mdDir); err != nil {
 			return fmt.Errorf("failed to generate config Go struct: %w", err)

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -1797,3 +1797,49 @@ func TestGenerateConfigSchema_LocalizesSameRootRefs(t *testing.T) {
 	require.Contains(t, string(actual), "$ref: /filter.config")
 	require.NotContains(t, string(actual), "$ref: go.opentelemetry.io/collector/filter.config")
 }
+
+func TestGenerateConfigFiles_DoesNotMutateSourceMetadata(t *testing.T) {
+	// Regression: generateConfigFiles takes Metadata by value, but Config and
+	// ExportedConfigs hold caller-owned *ConfigMetadata pointers. Before the
+	// upfront Clone, both injectInternalMetadataDefs (which sets Config.Defs)
+	// and the resolver's recursive walk leaked mutations back into the
+	// caller's source-side data.
+	root := t.TempDir()
+	tmpdir := filepath.Join(root, "shortname")
+	require.NoError(t, os.MkdirAll(tmpdir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmodule\n"), 0o600))
+
+	srcConfig := &cfggen.ConfigMetadata{
+		Type: "object",
+		Properties: map[string]*cfggen.ConfigMetadata{
+			"endpoint": {Type: "string"},
+		},
+	}
+	srcExported := map[string]*cfggen.ConfigMetadata{
+		"sample_config": {
+			Type: "object",
+			Properties: map[string]*cfggen.ConfigMetadata{
+				"host_name": {Type: "string"},
+			},
+		},
+	}
+	md := Metadata{
+		Type:            "test",
+		PackageName:     "testmodule/shortname",
+		Status:          &Status{Class: "receiver"},
+		Config:          srcConfig,
+		ExportedConfigs: srcExported,
+	}
+
+	configSnapshot := srcConfig.Clone()
+	exportedSnapshot := make(map[string]*cfggen.ConfigMetadata, len(srcExported))
+	for k, v := range srcExported {
+		exportedSnapshot[k] = v.Clone()
+	}
+
+	require.NoError(t, generateConfigFiles(md, tmpdir, "testmodule"))
+
+	require.Nil(t, srcConfig.Defs, "Config.Defs must remain nil; injectInternalMetadataDefs leaked Defs onto the caller's Config")
+	require.Equal(t, configSnapshot, srcConfig, "generateConfigFiles must not mutate the caller's Config tree")
+	require.Equal(t, exportedSnapshot, srcExported, "generateConfigFiles must not mutate the caller's ExportedConfigs tree")
+}

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -549,7 +549,7 @@ func TestGenerateConfigFiles(t *testing.T) {
 				Status: &Status{
 					Class: "receiver",
 				},
-				// A local ref without a definition name fails Validate() inside ResolveSchema
+				// A local ref without a definition name fails Validate() inside Resolve
 				Config: &cfggen.ConfigMetadata{
 					Ref: "/config/configauth",
 				},

--- a/internal/schemagen/loader.go
+++ b/internal/schemagen/loader.go
@@ -28,11 +28,11 @@ var ErrNotFound = errors.New("schema not found")
 
 // Loader loads configuration metadata from various sources (file, HTTP).
 type Loader interface {
-	Load(ref Ref) (*ConfigMetadata, error)
+	Load(ref Ref) (*Metadata, error)
 }
 
 type schemaLoader struct {
-	cache      map[string]*ConfigMetadata
+	cache      map[string]*Metadata
 	cd         string
 	rootDir    string
 	httpClient *http.Client
@@ -41,13 +41,13 @@ type schemaLoader struct {
 // NewLoader creates a fully configured loader. Takes current component's directory to determine where to look for local schema files.
 func NewLoader(cwd string) Loader {
 	return &schemaLoader{
-		cache:      make(map[string]*ConfigMetadata),
+		cache:      make(map[string]*Metadata),
 		cd:         cwd,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
-func (sl *schemaLoader) Load(ref Ref) (*ConfigMetadata, error) {
+func (sl *schemaLoader) Load(ref Ref) (*Metadata, error) {
 	if cached, ok := sl.cache[ref.CacheKey()]; ok {
 		return cached, nil
 	}
@@ -61,7 +61,7 @@ func (sl *schemaLoader) Load(ref Ref) (*ConfigMetadata, error) {
 	return metadata, nil
 }
 
-func (sl *schemaLoader) load(ref Ref) (*ConfigMetadata, error) {
+func (sl *schemaLoader) load(ref Ref) (*Metadata, error) {
 	repoRoot, err := sl.repoRoot(sl.cd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine repo root: %w", err)
@@ -80,7 +80,7 @@ func (sl *schemaLoader) load(ref Ref) (*ConfigMetadata, error) {
 	return sl.loadFromHTTP(ref, filepath.Join(repoRoot, ".schemas"))
 }
 
-func (sl *schemaLoader) loadFromFile(filePath string) (*ConfigMetadata, error) {
+func (sl *schemaLoader) loadFromFile(filePath string) (*Metadata, error) {
 	body, err := os.ReadFile(filePath) // #nosec G304
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -94,17 +94,10 @@ func (sl *schemaLoader) loadFromFile(filePath string) (*ConfigMetadata, error) {
 		return nil, fmt.Errorf("failed to parse schema from %s: %w", filePath, err)
 	}
 
-	if metadata.ExportedConfigs != nil {
-		if metadata.Config == nil {
-			metadata.Config = &ConfigMetadata{}
-		}
-		metadata.Config.Defs = metadata.ExportedConfigs
-	}
-
-	return metadata.Config, nil
+	return &metadata, nil
 }
 
-func (sl *schemaLoader) loadFromHTTP(ref Ref, fileCacheDir string) (*ConfigMetadata, error) {
+func (sl *schemaLoader) loadFromHTTP(ref Ref, fileCacheDir string) (*Metadata, error) {
 	version, err := sl.refVersion(&ref)
 	if err != nil {
 		return nil, err
@@ -128,7 +121,7 @@ func (sl *schemaLoader) loadFromHTTP(ref Ref, fileCacheDir string) (*ConfigMetad
 	return metadata, nil
 }
 
-func (sl *schemaLoader) tryLoad(ref Ref, version string) (*ConfigMetadata, error) {
+func (sl *schemaLoader) tryLoad(ref Ref, version string) (*Metadata, error) {
 	url, err := ref.URL(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct URL for %s: %w", ref.CacheKey(), err)
@@ -157,22 +150,15 @@ func (sl *schemaLoader) tryLoad(ref Ref, version string) (*ConfigMetadata, error
 		return nil, fmt.Errorf("failed to parse schema from %s: %w", url, err)
 	}
 
-	if metadata.ExportedConfigs != nil {
-		if metadata.Config == nil {
-			metadata.Config = &ConfigMetadata{}
-		}
-		metadata.Config.Defs = metadata.ExportedConfigs
-	}
-
-	return metadata.Config, nil
+	return &metadata, nil
 }
 
-func (sl *schemaLoader) persistToFile(filePath string, md *ConfigMetadata) error {
+func (sl *schemaLoader) persistToFile(filePath string, md *Metadata) error {
 	if err := os.MkdirAll(filepath.Dir(filePath), 0o750); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	data, err := yaml.Marshal(Metadata{Config: md})
+	data, err := yaml.Marshal(md)
 	if err != nil {
 		return fmt.Errorf("failed to marshal metadata: %w", err)
 	}

--- a/internal/schemagen/loader_test.go
+++ b/internal/schemagen/loader_test.go
@@ -35,9 +35,9 @@ func TestLoader_LoadFromFile_Success(t *testing.T) {
 	// For local refs, the loadFromFile method takes a file path
 	result, err := loader.loadFromFile(schemaFile)
 	require.NoError(t, err)
-	require.Equal(t, "Test Schema", result.Title)
-	require.Equal(t, "A test schema", result.Description)
-	require.Equal(t, "object", result.Type)
+	require.Equal(t, "Test Schema", result.Config.Title)
+	require.Equal(t, "A test schema", result.Config.Description)
+	require.Equal(t, "object", result.Config.Type)
 }
 
 func TestLoader_LoadFromFile_ExportedConfigsOnly(t *testing.T) {
@@ -57,9 +57,9 @@ func TestLoader_LoadFromFile_ExportedConfigsOnly(t *testing.T) {
 	result, err := loader.loadFromFile(schemaFile)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Contains(t, result.Defs, "sample_config")
-	require.Equal(t, "object", result.Defs["sample_config"].Type)
-	require.Contains(t, result.Defs["sample_config"].Properties, "endpoint")
+	require.Contains(t, result.ExportedConfigs, "sample_config")
+	require.Equal(t, "object", result.ExportedConfigs["sample_config"].Type)
+	require.Contains(t, result.ExportedConfigs["sample_config"].Properties, "endpoint")
 }
 
 func TestLoader_LoadFromFile_NotFound(t *testing.T) {
@@ -112,8 +112,8 @@ func TestLoader_LoadFromHTTP_Success(t *testing.T) {
 
 	result, err := loader.loadFromHTTP(ref, filepath.Join(tempDir, ".schemas"))
 	require.NoError(t, err)
-	require.Equal(t, "HTTP Schema", result.Title)
-	require.Equal(t, "string", result.Type)
+	require.Equal(t, "HTTP Schema", result.Config.Title)
+	require.Equal(t, "string", result.Config.Type)
 }
 
 func TestLoader_LoadFromHTTP_NotFound(t *testing.T) {
@@ -178,7 +178,7 @@ func TestLoader_TryLoad_WithVersion(t *testing.T) {
 	// Try to load with version
 	result, err := loader.tryLoad(ref, "v1.0.0")
 	require.NoError(t, err)
-	require.Equal(t, "Versioned Schema", result.Title)
+	require.Equal(t, "Versioned Schema", result.Config.Title)
 }
 
 func TestLoader_TryLoad_ExportedConfigsOnly(t *testing.T) {
@@ -204,18 +204,20 @@ func TestLoader_TryLoad_ExportedConfigsOnly(t *testing.T) {
 	result, err := loader.tryLoad(ref, "v1.0.0")
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Contains(t, result.Defs, "sample_config")
-	require.Equal(t, "object", result.Defs["sample_config"].Type)
-	require.Contains(t, result.Defs["sample_config"].Properties, "endpoint")
+	require.Contains(t, result.ExportedConfigs, "sample_config")
+	require.Equal(t, "object", result.ExportedConfigs["sample_config"].Type)
+	require.Contains(t, result.ExportedConfigs["sample_config"].Properties, "endpoint")
 }
 
 func TestLoader_PersistToFile_Success(t *testing.T) {
 	tempDir := t.TempDir()
 	loader := NewLoader(tempDir).(*schemaLoader)
 
-	metadata := &ConfigMetadata{
-		Title:       "Persisted Schema",
-		Description: "Test persistence",
+	metadata := &Metadata{
+		Config: &ConfigMetadata{
+			Title:       "Persisted Schema",
+			Description: "Test persistence",
+		},
 	}
 
 	filePath := filepath.Join(tempDir, "test", "persisted.yaml")
@@ -227,8 +229,8 @@ func TestLoader_PersistToFile_Success(t *testing.T) {
 
 	roundTripped, err := loader.loadFromFile(filePath)
 	require.NoError(t, err)
-	require.Equal(t, "Persisted Schema", roundTripped.Title)
-	require.Equal(t, "Test persistence", roundTripped.Description)
+	require.Equal(t, "Persisted Schema", roundTripped.Config.Title)
+	require.Equal(t, "Test persistence", roundTripped.Config.Description)
 }
 
 func TestLoader_Load_CacheInteraction(t *testing.T) {
@@ -237,7 +239,7 @@ func TestLoader_Load_CacheInteraction(t *testing.T) {
 	loader := NewLoader(tempDir).(*schemaLoader)
 	ref := *NewRef("go.opentelemetry.io/collector/test/path.config")
 
-	expected := &ConfigMetadata{Title: "Pre-cached Schema"}
+	expected := &Metadata{Config: &ConfigMetadata{Title: "Pre-cached Schema"}}
 	loader.cache[ref.CacheKey()] = expected
 
 	result, err := loader.Load(ref)
@@ -250,23 +252,23 @@ func TestLoader_Integration_MemoryCachePeristence(t *testing.T) {
 	tempDir := t.TempDir()
 
 	loader := &schemaLoader{
-		cache:      make(map[string]*ConfigMetadata),
+		cache:      make(map[string]*Metadata),
 		cd:         tempDir,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
 
 	ref := *NewRef("go.opentelemetry.io/collector/test/path.config")
-	expected := &ConfigMetadata{Title: "Integration Test"}
+	expected := &Metadata{Config: &ConfigMetadata{Title: "Integration Test"}}
 
 	loader.cache[ref.CacheKey()] = expected
 
 	result1, err := loader.Load(ref)
 	require.NoError(t, err)
-	require.Equal(t, "Integration Test", result1.Title)
+	require.Equal(t, "Integration Test", result1.Config.Title)
 
 	result2, err := loader.Load(ref)
 	require.NoError(t, err)
-	require.Equal(t, "Integration Test", result2.Title)
+	require.Equal(t, "Integration Test", result2.Config.Title)
 
 	require.Same(t, result1, result2)
 }
@@ -286,7 +288,7 @@ func TestLoader_Load_CachesOnFirstLoad(t *testing.T) {
 
 	result1, err := loader.Load(ref)
 	require.NoError(t, err)
-	require.Equal(t, "Cached", result1.Title)
+	require.Equal(t, "Cached", result1.Config.Title)
 
 	result2, err := loader.Load(ref)
 	require.NoError(t, err)
@@ -318,7 +320,7 @@ func TestLoader_Load_LocalAbsolutePath(t *testing.T) {
 	ref := Ref{schemaID: "/somepackage", kind: Local}
 	result, err := loader.load(ref)
 	require.NoError(t, err)
-	require.Equal(t, "AbsoluteLocal", result.Title)
+	require.Equal(t, "AbsoluteLocal", result.Config.Title)
 }
 
 func TestLoader_Load_LocalRelativePath(t *testing.T) {
@@ -334,7 +336,7 @@ func TestLoader_Load_LocalRelativePath(t *testing.T) {
 	ref := Ref{schemaID: "subdir", kind: Local}
 	result, err := loader.load(ref)
 	require.NoError(t, err)
-	require.Equal(t, "RelativeLocal", result.Title)
+	require.Equal(t, "RelativeLocal", result.Config.Title)
 }
 
 func TestLoader_LoadFromFile_ReadError(t *testing.T) {
@@ -372,14 +374,14 @@ func TestLoader_LoadFromHTTP_FileCacheHit(t *testing.T) {
 
 	// Use an httpClient that always panics to confirm no HTTP call is made.
 	loader := &schemaLoader{
-		cache:      make(map[string]*ConfigMetadata),
+		cache:      make(map[string]*Metadata),
 		cd:         sgDir,
 		httpClient: &http.Client{},
 	}
 
 	result, err := loader.loadFromHTTP(ref, fileCacheDir)
 	require.NoError(t, err)
-	require.Equal(t, "FileCached", result.Title)
+	require.Equal(t, "FileCached", result.Config.Title)
 }
 
 func TestLoader_LoadFromHTTP_PersistWarning(t *testing.T) {
@@ -411,7 +413,7 @@ func TestLoader_LoadFromHTTP_PersistWarning(t *testing.T) {
 	// Should still return the result even though persist fails (warning only)
 	result, err := loader.loadFromHTTP(ref, cacheDir)
 	require.NoError(t, err)
-	require.Equal(t, "PersistFail", result.Title)
+	require.Equal(t, "PersistFail", result.Config.Title)
 }
 
 func TestLoader_LoadFromHTTP_NonNotFoundFileError(t *testing.T) {
@@ -444,14 +446,14 @@ func TestLoader_LoadFromHTTP_NonNotFoundFileError(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filePath, 0o750))
 
 	loader := &schemaLoader{
-		cache:      make(map[string]*ConfigMetadata),
+		cache:      make(map[string]*Metadata),
 		cd:         sgDir,
 		httpClient: &http.Client{},
 	}
 
 	result, err := loader.loadFromHTTP(ref, cacheDir)
 	require.NoError(t, err)
-	require.Equal(t, "AfterWarning", result.Title)
+	require.Equal(t, "AfterWarning", result.Config.Title)
 }
 
 func TestLoader_TryLoad_URLError(t *testing.T) {
@@ -556,7 +558,7 @@ func TestLoader_PersistToFile_MkdirAllError(t *testing.T) {
 	require.NoError(t, os.Chmod(tempDir, 0o500)) // #nosec G302
 
 	loader := NewLoader(tempDir).(*schemaLoader)
-	err := loader.persistToFile(filepath.Join(tempDir, "newdir", "schema.yaml"), &ConfigMetadata{Title: "X"})
+	err := loader.persistToFile(filepath.Join(tempDir, "newdir", "schema.yaml"), &Metadata{Config: &ConfigMetadata{Title: "X"}})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create directory")
 }
@@ -568,7 +570,7 @@ func TestLoader_PersistToFile_WriteFileError(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filePath, 0o750))
 
 	loader := NewLoader(tempDir).(*schemaLoader)
-	err := loader.persistToFile(filePath, &ConfigMetadata{Title: "X"})
+	err := loader.persistToFile(filePath, &Metadata{Config: &ConfigMetadata{Title: "X"}})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to write file")
 }

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -120,6 +120,14 @@ func (d *JSONSchemaDoc) ToJSON() ([]byte, error) {
 	return json.MarshalIndent(d, "", "  ")
 }
 
+// ToJSON serializes the schema node with indentation. This is the entry point used
+// by callers that operate on a bare ConfigMetadata, such as the combiner output
+// path. The writer-side document path uses JSONSchemaDoc.ToJSON, which additionally
+// emits the top-level $defs.
+func (md *ConfigMetadata) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(md, "", "  ")
+}
+
 // MarshalJSON serializes the document by delegating to the inner ConfigMetadata's
 // MarshalJSON (so PatternProperties / AdditionalPropertiesAllowed handling is
 // preserved) and splicing the top-level $defs into the produced object. Without this
@@ -235,52 +243,52 @@ func (md *Metadata) Clone() *Metadata {
 // reachable from it (Properties, Items, AllOf, AdditionalProperties, ContentSchema,
 // PatternProperties, Defs). Primitive slices are copied; numeric pointer fields
 // (MinLength, MultipleOf, etc.) are shallow-shared since the resolver only reads them.
-func (c *ConfigMetadata) Clone() *ConfigMetadata {
-	if c == nil {
+func (md *ConfigMetadata) Clone() *ConfigMetadata {
+	if md == nil {
 		return nil
 	}
-	out := *c
-	if c.AllOf != nil {
-		out.AllOf = make([]*ConfigMetadata, len(c.AllOf))
-		for i, v := range c.AllOf {
+	out := *md
+	if md.AllOf != nil {
+		out.AllOf = make([]*ConfigMetadata, len(md.AllOf))
+		for i, v := range md.AllOf {
 			out.AllOf[i] = v.Clone()
 		}
 	}
-	if c.Properties != nil {
-		out.Properties = make(map[string]*ConfigMetadata, len(c.Properties))
-		for k, v := range c.Properties {
+	if md.Properties != nil {
+		out.Properties = make(map[string]*ConfigMetadata, len(md.Properties))
+		for k, v := range md.Properties {
 			out.Properties[k] = v.Clone()
 		}
 	}
-	if c.AdditionalProperties != nil {
-		out.AdditionalProperties = c.AdditionalProperties.Clone()
+	if md.AdditionalProperties != nil {
+		out.AdditionalProperties = md.AdditionalProperties.Clone()
 	}
-	if c.PatternProperties != nil {
-		out.PatternProperties = make(map[string]*ConfigMetadata, len(c.PatternProperties))
-		for k, v := range c.PatternProperties {
+	if md.PatternProperties != nil {
+		out.PatternProperties = make(map[string]*ConfigMetadata, len(md.PatternProperties))
+		for k, v := range md.PatternProperties {
 			out.PatternProperties[k] = v.Clone()
 		}
 	}
-	if c.Items != nil {
-		out.Items = c.Items.Clone()
+	if md.Items != nil {
+		out.Items = md.Items.Clone()
 	}
-	if c.ContentSchema != nil {
-		out.ContentSchema = c.ContentSchema.Clone()
+	if md.ContentSchema != nil {
+		out.ContentSchema = md.ContentSchema.Clone()
 	}
-	if c.Defs != nil {
-		out.Defs = make(map[string]*ConfigMetadata, len(c.Defs))
-		for k, v := range c.Defs {
+	if md.Defs != nil {
+		out.Defs = make(map[string]*ConfigMetadata, len(md.Defs))
+		for k, v := range md.Defs {
 			out.Defs[k] = v.Clone()
 		}
 	}
-	if c.Examples != nil {
-		out.Examples = slices.Clone(c.Examples)
+	if md.Examples != nil {
+		out.Examples = slices.Clone(md.Examples)
 	}
-	if c.Enum != nil {
-		out.Enum = slices.Clone(c.Enum)
+	if md.Enum != nil {
+		out.Enum = slices.Clone(md.Enum)
 	}
-	if c.Required != nil {
-		out.Required = slices.Clone(c.Required)
+	if md.Required != nil {
+		out.Required = slices.Clone(md.Required)
 	}
 	return &out
 }

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -4,14 +4,25 @@
 package schemagen // import "go.opentelemetry.io/collector/internal/schemagen"
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"go.opentelemetry.io/collector/confmap"
 )
 
-// ConfigMetadata represents a JSON schema object, draft 2020-12 (limited), with additional custom fields.
+// ConfigMetadata is a single schema node parsed from metadata.yaml's `config` (and from
+// any externally-loaded schema). It mirrors a subset of JSON Schema 2020-12, plus the
+// project-specific x-* and go_struct extensions.
+//
+// It is NOT the type emitted to disk as a JSON Schema document; that is JSONSchemaDoc.
+// The Defs field is kept here only to back the resolver's internal ref-lookup logic for
+// schemas that carry their own nested $defs. Top-level $defs (built from a component's
+// exported_configs) live on JSONSchemaDoc and are produced at write time. The json tag
+// on Defs is "-" so that the embedded *ConfigMetadata inside JSONSchemaDoc cannot
+// shadow the outer Defs field during JSON marshaling.
 type ConfigMetadata struct {
 	Schema               string                     `mapstructure:"$schema,omitempty" json:"$schema,omitempty" yaml:"$schema,omitempty"`
 	ID                   string                     `mapstructure:"$id,omitempty" json:"$id,omitempty" yaml:"$id,omitempty"`
@@ -48,7 +59,7 @@ type ConfigMetadata struct {
 	ExclusiveMaximum     *float64                   `mapstructure:"exclusiveMaximum,omitempty" json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
 	Minimum              *float64                   `mapstructure:"minimum,omitempty" json:"minimum,omitempty" yaml:"minimum,omitempty"`
 	ExclusiveMinimum     *float64                   `mapstructure:"exclusiveMinimum,omitempty" json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
-	Defs                 map[string]*ConfigMetadata `mapstructure:"$defs,omitempty" json:"$defs,omitempty" yaml:"$defs,omitempty"`
+	Defs                 map[string]*ConfigMetadata `mapstructure:"$defs,omitempty" json:"-" yaml:"$defs,omitempty"`
 	// Additional custom fields
 	GoStruct   GoStructConfig `mapstructure:"go_struct,omitempty" json:"-" yaml:"go_struct,omitempty"`
 	GoType     string         `mapstructure:"x-customType,omitempty" json:"-" yaml:"x-customType,omitempty"`
@@ -94,8 +105,70 @@ func (g *GoStructConfig) Unmarshal(parser *confmap.Conf) error {
 	return sub.Unmarshal(g.CustomValidator)
 }
 
-func (md *ConfigMetadata) ToJSON() ([]byte, error) {
-	return json.MarshalIndent(md, "", "  ")
+// JSONSchemaDoc is the writer-side JSON Schema 2020-12 document produced by schemagen.
+// It wraps a resolved ConfigMetadata schema node and owns the top-level $defs map that
+// is built from a component's exported_configs (plus any internal definitions injected
+// by mdatagen). Keeping $defs here avoids mutating the source ConfigMetadata to carry
+// an output-only concern.
+type JSONSchemaDoc struct {
+	*ConfigMetadata
+	Defs map[string]*ConfigMetadata `json:"$defs,omitempty"`
+}
+
+// ToJSON serializes the JSON Schema document with indentation.
+func (d *JSONSchemaDoc) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(d, "", "  ")
+}
+
+// MarshalJSON serializes the document by delegating to the inner ConfigMetadata's
+// MarshalJSON (so PatternProperties / AdditionalPropertiesAllowed handling is
+// preserved) and splicing the top-level $defs into the produced object. Without this
+// override the embedded ConfigMetadata.MarshalJSON would be promoted to JSONSchemaDoc
+// and the outer Defs field would be silently dropped.
+func (d *JSONSchemaDoc) MarshalJSON() ([]byte, error) {
+	if d.ConfigMetadata == nil {
+		if len(d.Defs) == 0 {
+			return []byte("{}"), nil
+		}
+		return json.Marshal(struct {
+			Defs map[string]*ConfigMetadata `json:"$defs"`
+		}{Defs: d.Defs})
+	}
+	base, err := json.Marshal(d.ConfigMetadata)
+	if err != nil {
+		return nil, err
+	}
+	if len(d.Defs) == 0 {
+		return base, nil
+	}
+	defsRaw, err := json.Marshal(d.Defs)
+	if err != nil {
+		return nil, err
+	}
+	inner := bytes.TrimSpace(base)
+	if len(inner) < 2 || inner[0] != '{' || inner[len(inner)-1] != '}' {
+		return nil, fmt.Errorf("unexpected ConfigMetadata JSON encoding: %s", base)
+	}
+	out := make([]byte, 0, len(inner)+len(defsRaw)+10)
+	out = append(out, inner[:len(inner)-1]...)
+	if len(inner) > 2 {
+		out = append(out, ',')
+	}
+	out = append(out, `"$defs":`...)
+	out = append(out, defsRaw...)
+	out = append(out, '}')
+	return out, nil
+}
+
+// AsJSONSchema builds the writer-side JSON Schema document from this source-side
+// Metadata. The resulting doc shares the underlying ConfigMetadata and exported-configs
+// maps; callers that need to mutate the resolved schema should do so before this call.
+func (md *Metadata) AsJSONSchema() *JSONSchemaDoc {
+	doc := &JSONSchemaDoc{ConfigMetadata: md.Config}
+	if len(md.ExportedConfigs) > 0 {
+		doc.Defs = md.ExportedConfigs
+	}
+	return doc
 }
 
 func (md *ConfigMetadata) MarshalJSON() ([]byte, error) {
@@ -139,4 +212,75 @@ func (md *ConfigMetadata) Validate() error {
 		}
 	}
 	return errs
+}
+
+// Clone returns a deep copy of the Metadata. The returned Metadata shares no pointers
+// with the receiver, so callers downstream of Clone() can freely mutate the result
+// without affecting the source.
+func (md *Metadata) Clone() *Metadata {
+	if md == nil {
+		return nil
+	}
+	out := &Metadata{Config: md.Config.Clone()}
+	if md.ExportedConfigs != nil {
+		out.ExportedConfigs = make(map[string]*ConfigMetadata, len(md.ExportedConfigs))
+		for k, v := range md.ExportedConfigs {
+			out.ExportedConfigs[k] = v.Clone()
+		}
+	}
+	return out
+}
+
+// Clone returns a deep copy of the ConfigMetadata node and every pointer-bearing field
+// reachable from it (Properties, Items, AllOf, AdditionalProperties, ContentSchema,
+// PatternProperties, Defs). Primitive slices are copied; numeric pointer fields
+// (MinLength, MultipleOf, etc.) are shallow-shared since the resolver only reads them.
+func (c *ConfigMetadata) Clone() *ConfigMetadata {
+	if c == nil {
+		return nil
+	}
+	out := *c
+	if c.AllOf != nil {
+		out.AllOf = make([]*ConfigMetadata, len(c.AllOf))
+		for i, v := range c.AllOf {
+			out.AllOf[i] = v.Clone()
+		}
+	}
+	if c.Properties != nil {
+		out.Properties = make(map[string]*ConfigMetadata, len(c.Properties))
+		for k, v := range c.Properties {
+			out.Properties[k] = v.Clone()
+		}
+	}
+	if c.AdditionalProperties != nil {
+		out.AdditionalProperties = c.AdditionalProperties.Clone()
+	}
+	if c.PatternProperties != nil {
+		out.PatternProperties = make(map[string]*ConfigMetadata, len(c.PatternProperties))
+		for k, v := range c.PatternProperties {
+			out.PatternProperties[k] = v.Clone()
+		}
+	}
+	if c.Items != nil {
+		out.Items = c.Items.Clone()
+	}
+	if c.ContentSchema != nil {
+		out.ContentSchema = c.ContentSchema.Clone()
+	}
+	if c.Defs != nil {
+		out.Defs = make(map[string]*ConfigMetadata, len(c.Defs))
+		for k, v := range c.Defs {
+			out.Defs[k] = v.Clone()
+		}
+	}
+	if c.Examples != nil {
+		out.Examples = slices.Clone(c.Examples)
+	}
+	if c.Enum != nil {
+		out.Enum = slices.Clone(c.Enum)
+	}
+	if c.Required != nil {
+		out.Required = slices.Clone(c.Required)
+	}
+	return &out
 }

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -105,18 +105,21 @@ func (g *GoStructConfig) Unmarshal(parser *confmap.Conf) error {
 }
 
 // JSONSchemaDoc is the writer-side JSON Schema 2020-12 document produced by schemagen.
-// It is a standalone type, not a wrapper around ConfigMetadata: a component's config
-// root is always an object schema, so the document carries the object-level and
-// identity fields it can actually emit plus the top-level $defs built from the
-// component's exported_configs (and any internal definitions injected by mdatagen).
+// It is a standalone type, not a wrapper around ConfigMetadata, but it mirrors the full
+// set of JSON Schema fields ConfigMetadata can emit (every json-tagged keyword, minus the
+// metadata-only and internal x-*/go_struct fields) plus the top-level $defs built from the
+// component's exported_configs (and any internal definitions injected by mdatagen). A config
+// root is normally an object, but carrying the complete keyword set means a root that uses
+// scalar/array validation, enum/const, or annotation keywords (default, examples, deprecated)
+// is emitted rather than silently dropped.
 //
 // Keeping it separate lets the on-disk JSON Schema evolve independently of the
 // metadata.yaml config representation, which is free to drift away from JSON Schema
 // shape. Standard encoding/json handles serialization; no custom MarshalJSON is needed.
 //
-// Field order mirrors the equivalent fields on ConfigMetadata so the serialized
-// document is byte-identical to the prior embedded-node output: allOf precedes
-// properties, and $defs is emitted last.
+// Field order mirrors the declaration order on ConfigMetadata so the serialized document
+// is byte-identical to the prior embedded-node output: allOf precedes properties, and
+// $defs is emitted last.
 type JSONSchemaDoc struct {
 	Schema      string `json:"$schema,omitempty"`
 	ID          string `json:"$id,omitempty"`
@@ -124,6 +127,12 @@ type JSONSchemaDoc struct {
 	Description string `json:"description,omitempty"`
 	Comment     string `json:"$comment,omitempty"`
 	Type        string `json:"type,omitempty"`
+
+	Default    any   `json:"default,omitempty"`
+	Examples   []any `json:"examples,omitempty"`
+	Deprecated bool  `json:"deprecated,omitempty"`
+	Enum       []any `json:"enum,omitempty"`
+	Const      any   `json:"const,omitempty"`
 
 	AllOf                []*ConfigMetadata          `json:"allOf,omitempty"`
 	Properties           map[string]*ConfigMetadata `json:"properties,omitempty"`
@@ -133,11 +142,31 @@ type JSONSchemaDoc struct {
 	MinProperties        *int                       `json:"minProperties,omitempty"`
 	MaxProperties        *int                       `json:"maxProperties,omitempty"`
 
+	Items       *ConfigMetadata `json:"items,omitempty"`
+	MinItems    *int            `json:"minItems,omitempty"`
+	MaxItems    *int            `json:"maxItems,omitempty"`
+	UniqueItems bool            `json:"uniqueItems,omitempty"`
+
+	MaxLength *int   `json:"maxLength,omitempty"`
+	MinLength *int   `json:"minLength,omitempty"`
+	Pattern   string `json:"pattern,omitempty"`
+	Format    string `json:"format,omitempty"`
+
+	ContentMediaType string          `json:"contentMediaType,omitempty"`
+	ContentEncoding  string          `json:"contentEncoding,omitempty"`
+	ContentSchema    *ConfigMetadata `json:"contentSchema,omitempty"`
+
+	MultipleOf       *float64 `json:"multipleOf,omitempty"`
+	Maximum          *float64 `json:"maximum,omitempty"`
+	ExclusiveMaximum *float64 `json:"exclusiveMaximum,omitempty"`
+	Minimum          *float64 `json:"minimum,omitempty"`
+	ExclusiveMinimum *float64 `json:"exclusiveMinimum,omitempty"`
+
 	Defs map[string]*ConfigMetadata `json:"$defs,omitempty"`
 }
 
 // NewJSONSchemaDoc projects a resolved schema node onto a writer-side JSON Schema
-// document. It copies the document-level fields a config root can carry and the
+// document. It copies every JSON Schema keyword the root node can carry and the
 // resolved $defs. The node's internal AdditionalPropertiesAllowed flag becomes a real
 // additionalProperties boolean on the document. The source node is not retained.
 func NewJSONSchemaDoc(root *ConfigMetadata) *JSONSchemaDoc {
@@ -151,12 +180,33 @@ func NewJSONSchemaDoc(root *ConfigMetadata) *JSONSchemaDoc {
 		Description:       root.Description,
 		Comment:           root.Comment,
 		Type:              root.Type,
+		Default:           root.Default,
+		Examples:          root.Examples,
+		Deprecated:        root.Deprecated,
+		Enum:              root.Enum,
+		Const:             root.Const,
+		AllOf:             root.AllOf,
 		Properties:        root.Properties,
 		PatternProperties: root.PatternProperties,
 		Required:          root.Required,
 		MinProperties:     root.MinProperties,
 		MaxProperties:     root.MaxProperties,
-		AllOf:             root.AllOf,
+		Items:             root.Items,
+		MinItems:          root.MinItems,
+		MaxItems:          root.MaxItems,
+		UniqueItems:       root.UniqueItems,
+		MaxLength:         root.MaxLength,
+		MinLength:         root.MinLength,
+		Pattern:           root.Pattern,
+		Format:            root.Format,
+		ContentMediaType:  root.ContentMediaType,
+		ContentEncoding:   root.ContentEncoding,
+		ContentSchema:     root.ContentSchema,
+		MultipleOf:        root.MultipleOf,
+		Maximum:           root.Maximum,
+		ExclusiveMaximum:  root.ExclusiveMaximum,
+		Minimum:           root.Minimum,
+		ExclusiveMinimum:  root.ExclusiveMinimum,
 		Defs:              root.Defs,
 	}
 	if root.AdditionalPropertiesAllowed != nil {

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -4,7 +4,6 @@
 package schemagen // import "go.opentelemetry.io/collector/internal/schemagen"
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,9 +19,9 @@ import (
 // It is NOT the type emitted to disk as a JSON Schema document; that is JSONSchemaDoc.
 // The Defs field is kept here only to back the resolver's internal ref-lookup logic for
 // schemas that carry their own nested $defs. Top-level $defs (built from a component's
-// exported_configs) live on JSONSchemaDoc and are produced at write time. The json tag
-// on Defs is "-" so that the embedded *ConfigMetadata inside JSONSchemaDoc cannot
-// shadow the outer Defs field during JSON marshaling.
+// exported_configs) are owned by JSONSchemaDoc and emitted at write time. The json tag
+// on Defs is "-" so a resolved node's internal defs are never serialized directly; the
+// document's $defs go through JSONSchemaDoc instead.
 type ConfigMetadata struct {
 	Schema               string                     `mapstructure:"$schema,omitempty" json:"$schema,omitempty" yaml:"$schema,omitempty"`
 	ID                   string                     `mapstructure:"$id,omitempty" json:"$id,omitempty" yaml:"$id,omitempty"`
@@ -106,13 +105,66 @@ func (g *GoStructConfig) Unmarshal(parser *confmap.Conf) error {
 }
 
 // JSONSchemaDoc is the writer-side JSON Schema 2020-12 document produced by schemagen.
-// It wraps a resolved ConfigMetadata schema node and owns the top-level $defs map that
-// is built from a component's exported_configs (plus any internal definitions injected
-// by mdatagen). Keeping $defs here avoids mutating the source ConfigMetadata to carry
-// an output-only concern.
+// It is a standalone type, not a wrapper around ConfigMetadata: a component's config
+// root is always an object schema, so the document carries the object-level and
+// identity fields it can actually emit plus the top-level $defs built from the
+// component's exported_configs (and any internal definitions injected by mdatagen).
+//
+// Keeping it separate lets the on-disk JSON Schema evolve independently of the
+// metadata.yaml config representation, which is free to drift away from JSON Schema
+// shape. Standard encoding/json handles serialization; no custom MarshalJSON is needed.
+//
+// Field order mirrors the equivalent fields on ConfigMetadata so the serialized
+// document is byte-identical to the prior embedded-node output: allOf precedes
+// properties, and $defs is emitted last.
 type JSONSchemaDoc struct {
-	*ConfigMetadata
+	Schema      string `json:"$schema,omitempty"`
+	ID          string `json:"$id,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Comment     string `json:"$comment,omitempty"`
+	Type        string `json:"type,omitempty"`
+
+	AllOf                []*ConfigMetadata          `json:"allOf,omitempty"`
+	Properties           map[string]*ConfigMetadata `json:"properties,omitempty"`
+	AdditionalProperties any                        `json:"additionalProperties,omitempty"`
+	PatternProperties    map[string]*ConfigMetadata `json:"patternProperties,omitempty"`
+	Required             []string                   `json:"required,omitempty"`
+	MinProperties        *int                       `json:"minProperties,omitempty"`
+	MaxProperties        *int                       `json:"maxProperties,omitempty"`
+
 	Defs map[string]*ConfigMetadata `json:"$defs,omitempty"`
+}
+
+// NewJSONSchemaDoc projects a resolved schema node onto a writer-side JSON Schema
+// document. It copies the document-level fields a config root can carry and the
+// resolved $defs. The node's internal AdditionalPropertiesAllowed flag becomes a real
+// additionalProperties boolean on the document. The source node is not retained.
+func NewJSONSchemaDoc(root *ConfigMetadata) *JSONSchemaDoc {
+	if root == nil {
+		return &JSONSchemaDoc{}
+	}
+	doc := &JSONSchemaDoc{
+		Schema:            root.Schema,
+		ID:                root.ID,
+		Title:             root.Title,
+		Description:       root.Description,
+		Comment:           root.Comment,
+		Type:              root.Type,
+		Properties:        root.Properties,
+		PatternProperties: root.PatternProperties,
+		Required:          root.Required,
+		MinProperties:     root.MinProperties,
+		MaxProperties:     root.MaxProperties,
+		AllOf:             root.AllOf,
+		Defs:              root.Defs,
+	}
+	if root.AdditionalPropertiesAllowed != nil {
+		doc.AdditionalProperties = *root.AdditionalPropertiesAllowed
+	} else if root.AdditionalProperties != nil {
+		doc.AdditionalProperties = root.AdditionalProperties
+	}
+	return doc
 }
 
 // ToJSON serializes the JSON Schema document with indentation.
@@ -122,60 +174,21 @@ func (d *JSONSchemaDoc) ToJSON() ([]byte, error) {
 
 // ToJSON serializes the schema node with indentation. This is the entry point used
 // by callers that operate on a bare ConfigMetadata, such as the combiner output
-// path. The writer-side document path uses JSONSchemaDoc.ToJSON, which additionally
+// path. The writer-side document path goes through JSONSchemaDoc, which additionally
 // emits the top-level $defs.
 func (md *ConfigMetadata) ToJSON() ([]byte, error) {
 	return json.MarshalIndent(md, "", "  ")
 }
 
-// MarshalJSON serializes the document by delegating to the inner ConfigMetadata's
-// MarshalJSON (so PatternProperties / AdditionalPropertiesAllowed handling is
-// preserved) and splicing the top-level $defs into the produced object. Without this
-// override the embedded ConfigMetadata.MarshalJSON would be promoted to JSONSchemaDoc
-// and the outer Defs field would be silently dropped.
-func (d *JSONSchemaDoc) MarshalJSON() ([]byte, error) {
-	if d.ConfigMetadata == nil {
-		if len(d.Defs) == 0 {
-			return []byte("{}"), nil
-		}
-		return json.Marshal(struct {
-			Defs map[string]*ConfigMetadata `json:"$defs"`
-		}{Defs: d.Defs})
-	}
-	base, err := json.Marshal(d.ConfigMetadata)
-	if err != nil {
-		return nil, err
-	}
-	if len(d.Defs) == 0 {
-		return base, nil
-	}
-	defsRaw, err := json.Marshal(d.Defs)
-	if err != nil {
-		return nil, err
-	}
-	inner := bytes.TrimSpace(base)
-	if len(inner) < 2 || inner[0] != '{' || inner[len(inner)-1] != '}' {
-		return nil, fmt.Errorf("unexpected ConfigMetadata JSON encoding: %s", base)
-	}
-	out := make([]byte, 0, len(inner)+len(defsRaw)+10)
-	out = append(out, inner[:len(inner)-1]...)
-	if len(inner) > 2 {
-		out = append(out, ',')
-	}
-	out = append(out, `"$defs":`...)
-	out = append(out, defsRaw...)
-	out = append(out, '}')
-	return out, nil
-}
-
-// AsJSONSchema builds the writer-side JSON Schema document from this source-side
-// Metadata. The resulting doc shares the underlying ConfigMetadata and exported-configs
-// maps; callers that need to mutate the resolved schema should do so before this call.
+// AsJSONSchema builds a writer-side document directly from this source Metadata without
+// running the resolver. The document's $defs are the source exported_configs. Used where
+// a document is needed without ref resolution.
 func (md *Metadata) AsJSONSchema() *JSONSchemaDoc {
-	doc := &JSONSchemaDoc{ConfigMetadata: md.Config}
-	if len(md.ExportedConfigs) > 0 {
-		doc.Defs = md.ExportedConfigs
+	if md == nil {
+		return &JSONSchemaDoc{}
 	}
+	doc := NewJSONSchemaDoc(md.Config)
+	doc.Defs = md.ExportedConfigs
 	return doc
 }
 

--- a/internal/schemagen/model_test.go
+++ b/internal/schemagen/model_test.go
@@ -19,13 +19,13 @@ func defaultValue(value any) any {
 }
 
 func TestJSONSchemaDoc_ToJSON(t *testing.T) {
-	doc := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{
+	doc := NewJSONSchemaDoc(&ConfigMetadata{
 		Schema: schemaVersion,
 		Type:   "object",
 		Properties: map[string]*ConfigMetadata{
 			"endpoint": {Type: "string", Description: "The endpoint"},
 		},
-	}}
+	})
 
 	data, err := doc.ToJSON()
 	require.NoError(t, err)
@@ -131,13 +131,19 @@ default:
 }
 
 func TestJSONSchemaDoc_ToJSONDefaultValue(t *testing.T) {
-	absent := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{Type: "string"}}
+	absent := NewJSONSchemaDoc(&ConfigMetadata{
+		Type:       "object",
+		Properties: map[string]*ConfigMetadata{"endpoint": {Type: "string"}},
+	})
 
 	jsonData, err := absent.ToJSON()
 	require.NoError(t, err)
 	require.NotContains(t, string(jsonData), `"default"`)
 
-	withDefault := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{Type: "string", Default: defaultValue("localhost")}}
+	withDefault := NewJSONSchemaDoc(&ConfigMetadata{
+		Type:       "object",
+		Properties: map[string]*ConfigMetadata{"endpoint": {Type: "string", Default: defaultValue("localhost")}},
+	})
 
 	jsonData, err = withDefault.ToJSON()
 	require.NoError(t, err)

--- a/internal/schemagen/model_test.go
+++ b/internal/schemagen/model_test.go
@@ -598,3 +598,14 @@ func TestConfigMetadata_Validate_EnumOnComplexType(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigMetadata_Clone_PreservesExamples(t *testing.T) {
+	src := &ConfigMetadata{
+		Type:     "string",
+		Examples: []any{"a", "b"},
+	}
+	cloned := src.Clone()
+	require.Equal(t, src.Examples, cloned.Examples)
+	cloned.Examples[0] = "mutated"
+	require.Equal(t, "a", src.Examples[0])
+}

--- a/internal/schemagen/model_test.go
+++ b/internal/schemagen/model_test.go
@@ -34,6 +34,45 @@ func TestJSONSchemaDoc_ToJSON(t *testing.T) {
 	assert.Contains(t, string(data), `"The endpoint"`)
 }
 
+func TestNewJSONSchemaDoc_PreservesRootKeywords(t *testing.T) {
+	t.Parallel()
+
+	minItems := 1
+	maximum := 65535.0
+	root := &ConfigMetadata{
+		Type:       "object",
+		Default:    map[string]any{"port": 4317},
+		Examples:   []any{"a", "b"},
+		Deprecated: true,
+		Enum:       []any{"tcp", "udp"},
+		Const:      "fixed",
+		Pattern:    "^a.*$",
+		Format:     "uri",
+		MinItems:   &minItems,
+		Maximum:    &maximum,
+	}
+
+	doc := NewJSONSchemaDoc(root)
+
+	// Keywords carried on the root node must reach the document instead of being
+	// dropped during projection.
+	assert.Equal(t, root.Default, doc.Default)
+	assert.Equal(t, root.Examples, doc.Examples)
+	assert.True(t, doc.Deprecated)
+	assert.Equal(t, root.Enum, doc.Enum)
+	assert.Equal(t, root.Const, doc.Const)
+	assert.Equal(t, root.Pattern, doc.Pattern)
+	assert.Equal(t, root.Format, doc.Format)
+	assert.Equal(t, root.MinItems, doc.MinItems)
+	assert.Equal(t, root.Maximum, doc.Maximum)
+
+	data, err := doc.ToJSON()
+	require.NoError(t, err)
+	for _, want := range []string{`"deprecated"`, `"enum"`, `"const"`, `"pattern"`, `"format"`, `"minItems"`, `"maximum"`} {
+		assert.Contains(t, string(data), want)
+	}
+}
+
 func TestConfigMetadata_MarshalJSON_NoSpecialFieldsUsesStructLayout(t *testing.T) {
 	t.Parallel()
 

--- a/internal/schemagen/model_test.go
+++ b/internal/schemagen/model_test.go
@@ -18,16 +18,16 @@ func defaultValue(value any) any {
 	return value
 }
 
-func TestConfigMetadata_ToJSON(t *testing.T) {
-	md := &ConfigMetadata{
+func TestJSONSchemaDoc_ToJSON(t *testing.T) {
+	doc := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{
 		Schema: schemaVersion,
 		Type:   "object",
 		Properties: map[string]*ConfigMetadata{
 			"endpoint": {Type: "string", Description: "The endpoint"},
 		},
-	}
+	}}
 
-	data, err := md.ToJSON()
+	data, err := doc.ToJSON()
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"$schema"`)
 	assert.Contains(t, string(data), `"endpoint"`)
@@ -130,14 +130,14 @@ default:
 	}
 }
 
-func TestConfigMetadata_ToJSONDefaultValue(t *testing.T) {
-	absent := &ConfigMetadata{Type: "string"}
+func TestJSONSchemaDoc_ToJSONDefaultValue(t *testing.T) {
+	absent := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{Type: "string"}}
 
 	jsonData, err := absent.ToJSON()
 	require.NoError(t, err)
 	require.NotContains(t, string(jsonData), `"default"`)
 
-	withDefault := &ConfigMetadata{Type: "string", Default: defaultValue("localhost")}
+	withDefault := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{Type: "string", Default: defaultValue("localhost")}}
 
 	jsonData, err = withDefault.ToJSON()
 	require.NoError(t, err)

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -36,34 +36,6 @@ func NewResolver(pkgID, class, name, dir string) *Resolver {
 	}
 }
 
-// ResolveSchema takes a source configuration metadata schema and resolves all references ($ref)
-// to produce a fully resolved schema. It handles both internal references (within the same schema) and external references
-// (pointing to other schemas, either locally or remotely). The resolver uses registered loaders to fetch external schemas as needed.
-//
-// Returns a new ConfigMetadata with all references resolved, or an error if resolution fails.
-//
-// Deprecated: prefer Resolve, which takes the full source Metadata (so exported_configs
-// are not coerced into ConfigMetadata.Defs by the caller) and returns the writer-side
-// JSONSchemaDoc. This wrapper is kept for callers that still operate on a bare
-// ConfigMetadata with internal Defs set up.
-func (r *Resolver) ResolveSchema(src *ConfigMetadata) (*ConfigMetadata, error) {
-	target := &ConfigMetadata{}
-	err := r.resolveSchema(src, src, target, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	target.Schema = schemaVersion
-	target.ID = r.pkgID
-	target.Title = fmt.Sprintf("%s/%s", r.class, r.name)
-
-	if len(src.Properties) > 0 {
-		target.Type = "object"
-	}
-
-	return target, nil
-}
-
 // Resolve takes the source Metadata parsed from metadata.yaml and produces a
 // JSONSchemaDoc with all $ref references resolved. exported_configs from the source
 // become the top-level $defs of the output document.

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -36,15 +36,16 @@ func NewResolver(pkgID, class, name, dir string) *Resolver {
 	}
 }
 
-// Resolve takes the source Metadata parsed from metadata.yaml and produces a
-// JSONSchemaDoc with all $ref references resolved. exported_configs from the source
-// become the top-level $defs of the output document.
+// Resolve takes the source Metadata parsed from metadata.yaml and produces a resolved
+// schema node with all $ref references resolved. exported_configs from the source are
+// merged into the node's $defs. Pass the result to NewJSONSchemaDoc to build the
+// writer-side document.
 //
 // The source Metadata is treated as read-only: the inputs are deep-cloned before the
 // recursive resolver walks them, so internal mutations (the "any" fallback in
 // resolveRef, per-node type writes) cannot leak back into the caller's tree through
 // shared *ConfigMetadata pointers.
-func (r *Resolver) Resolve(src *Metadata) (*JSONSchemaDoc, error) {
+func (r *Resolver) Resolve(src *Metadata) (*ConfigMetadata, error) {
 	if src == nil {
 		return nil, errors.New("nil metadata")
 	}
@@ -79,15 +80,11 @@ func (r *Resolver) Resolve(src *Metadata) (*JSONSchemaDoc, error) {
 		target.Type = "object"
 	}
 
-	doc := &JSONSchemaDoc{ConfigMetadata: target}
-	// Defs on the resolved target are the merged exported_configs and any internal
-	// $defs that survived the resolver's cleanup pass. Promote them to the document's
-	// $defs and clear them off the inner node so they are not serialized twice.
-	if len(target.Defs) > 0 {
-		doc.Defs = target.Defs
-		target.Defs = nil
-	}
-	return doc, nil
+	// target.Defs holds the merged exported_configs and any internal $defs that
+	// survived the resolver's cleanup pass. They stay on the node: NewJSONSchemaDoc
+	// promotes them to the document's $defs at write time, and mdatagen's Go-struct
+	// templates read them off the node directly.
+	return target, nil
 }
 
 func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *Ref) error {

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -4,6 +4,7 @@
 package schemagen // import "go.opentelemetry.io/collector/internal/schemagen"
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"maps"
@@ -65,34 +66,35 @@ func (r *Resolver) ResolveSchema(src *ConfigMetadata) (*ConfigMetadata, error) {
 
 // Resolve takes the source Metadata parsed from metadata.yaml and produces a
 // JSONSchemaDoc with all $ref references resolved. exported_configs from the source
-// become the top-level $defs of the output document; the source ConfigMetadata is not
-// mutated.
+// become the top-level $defs of the output document.
+//
+// The source Metadata is treated as read-only: the inputs are deep-cloned before the
+// recursive resolver walks them, so internal mutations (the "any" fallback in
+// resolveRef, per-node type writes) cannot leak back into the caller's tree through
+// shared *ConfigMetadata pointers.
 func (r *Resolver) Resolve(src *Metadata) (*JSONSchemaDoc, error) {
 	if src == nil {
-		return nil, fmt.Errorf("nil metadata")
+		return nil, errors.New("nil metadata")
 	}
-	config := src.Config
+	work := src.Clone()
+	config := work.Config
 	if config == nil {
 		config = &ConfigMetadata{}
 	}
 
-	// For ref-lookup purposes the resolver expects the top-level definitions
-	// (both nested $defs and exported_configs) to be reachable from the root node.
-	// Build a transient root that carries them, without touching the caller's data.
-	root := *config
-	if len(src.ExportedConfigs) > 0 {
-		merged := make(map[string]*ConfigMetadata, len(src.ExportedConfigs)+len(root.Defs))
-		for k, v := range root.Defs {
-			merged[k] = v
-		}
-		for k, v := range src.ExportedConfigs {
-			merged[k] = v
-		}
-		root.Defs = merged
+	// For ref-lookup purposes the recursive resolver expects the top-level
+	// definitions (both nested $defs and exported_configs) to be reachable from
+	// the root node. Merge them onto the owned root. On collision the exported
+	// configs win, matching the legacy behavior.
+	if len(work.ExportedConfigs) > 0 {
+		merged := make(map[string]*ConfigMetadata, len(work.ExportedConfigs)+len(config.Defs))
+		maps.Copy(merged, config.Defs)
+		maps.Copy(merged, work.ExportedConfigs)
+		config.Defs = merged
 	}
 
 	target := &ConfigMetadata{}
-	if err := r.resolveSchema(&root, &root, target, nil); err != nil {
+	if err := r.resolveSchema(config, config, target, nil); err != nil {
 		return nil, err
 	}
 
@@ -341,22 +343,19 @@ func (r *Resolver) loadExternalRef(ref *Ref) (*ConfigMetadata, error) {
 		return nil, fmt.Errorf("no loader could resolve external reference: %s", ref)
 	}
 
-	// Build a synthetic root from the loaded Metadata so the recursive resolveSchema
-	// can still walk nested refs by name. The loaded schema's exported_configs are the
-	// source of named definitions on the external side.
-	root := &ConfigMetadata{}
-	if m.Config != nil {
-		copy := *m.Config
-		root = &copy
+	// Loaders may cache and reuse the same *Metadata across calls, so deep-clone
+	// here. Otherwise mutations performed by the recursive resolveSchema (the "any"
+	// fallback in resolveRef, per-node type writes) would persist into the cache
+	// and contaminate subsequent loads.
+	m = m.Clone()
+	root := m.Config
+	if root == nil {
+		root = &ConfigMetadata{}
 	}
 	if len(m.ExportedConfigs) > 0 {
 		merged := make(map[string]*ConfigMetadata, len(m.ExportedConfigs)+len(root.Defs))
-		for k, v := range root.Defs {
-			merged[k] = v
-		}
-		for k, v := range m.ExportedConfigs {
-			merged[k] = v
-		}
+		maps.Copy(merged, root.Defs)
+		maps.Copy(merged, m.ExportedConfigs)
 		root.Defs = merged
 	}
 

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -40,6 +40,11 @@ func NewResolver(pkgID, class, name, dir string) *Resolver {
 // (pointing to other schemas, either locally or remotely). The resolver uses registered loaders to fetch external schemas as needed.
 //
 // Returns a new ConfigMetadata with all references resolved, or an error if resolution fails.
+//
+// Deprecated: prefer Resolve, which takes the full source Metadata (so exported_configs
+// are not coerced into ConfigMetadata.Defs by the caller) and returns the writer-side
+// JSONSchemaDoc. This wrapper is kept for callers that still operate on a bare
+// ConfigMetadata with internal Defs set up.
 func (r *Resolver) ResolveSchema(src *ConfigMetadata) (*ConfigMetadata, error) {
 	target := &ConfigMetadata{}
 	err := r.resolveSchema(src, src, target, nil)
@@ -56,6 +61,57 @@ func (r *Resolver) ResolveSchema(src *ConfigMetadata) (*ConfigMetadata, error) {
 	}
 
 	return target, nil
+}
+
+// Resolve takes the source Metadata parsed from metadata.yaml and produces a
+// JSONSchemaDoc with all $ref references resolved. exported_configs from the source
+// become the top-level $defs of the output document; the source ConfigMetadata is not
+// mutated.
+func (r *Resolver) Resolve(src *Metadata) (*JSONSchemaDoc, error) {
+	if src == nil {
+		return nil, fmt.Errorf("nil metadata")
+	}
+	config := src.Config
+	if config == nil {
+		config = &ConfigMetadata{}
+	}
+
+	// For ref-lookup purposes the resolver expects the top-level definitions
+	// (both nested $defs and exported_configs) to be reachable from the root node.
+	// Build a transient root that carries them, without touching the caller's data.
+	root := *config
+	if len(src.ExportedConfigs) > 0 {
+		merged := make(map[string]*ConfigMetadata, len(src.ExportedConfigs)+len(root.Defs))
+		for k, v := range root.Defs {
+			merged[k] = v
+		}
+		for k, v := range src.ExportedConfigs {
+			merged[k] = v
+		}
+		root.Defs = merged
+	}
+
+	target := &ConfigMetadata{}
+	if err := r.resolveSchema(&root, &root, target, nil); err != nil {
+		return nil, err
+	}
+
+	target.Schema = schemaVersion
+	target.ID = r.pkgID
+	target.Title = fmt.Sprintf("%s/%s", r.class, r.name)
+	if len(config.Properties) > 0 {
+		target.Type = "object"
+	}
+
+	doc := &JSONSchemaDoc{ConfigMetadata: target}
+	// Defs on the resolved target are the merged exported_configs and any internal
+	// $defs that survived the resolver's cleanup pass. Promote them to the document's
+	// $defs and clear them off the inner node so they are not serialized twice.
+	if len(target.Defs) > 0 {
+		doc.Defs = target.Defs
+		target.Defs = nil
+	}
+	return doc, nil
 }
 
 func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *Ref) error {
@@ -277,22 +333,39 @@ func lookupRootDef(root, current *ConfigMetadata, ref *Ref) (*ConfigMetadata, bo
 
 // loadExternalRef uses SchemaLoader to load external references
 func (r *Resolver) loadExternalRef(ref *Ref) (*ConfigMetadata, error) {
-	md, err := r.loader.Load(*ref)
+	m, err := r.loader.Load(*ref)
 	if err != nil {
 		return nil, err
 	}
-	if md == nil {
+	if m == nil {
 		return nil, fmt.Errorf("no loader could resolve external reference: %s", ref)
 	}
 
-	if md.Defs != nil {
-		if def, ok := md.Defs[ref.DefName()]; ok {
-			resolved := &ConfigMetadata{}
-			if err := r.resolveSchema(md, def, resolved, ref); err != nil {
-				return nil, fmt.Errorf("failed to resolve internal references in external schema %s: %w", ref, err)
-			}
-			return resolved, nil
+	// Build a synthetic root from the loaded Metadata so the recursive resolveSchema
+	// can still walk nested refs by name. The loaded schema's exported_configs are the
+	// source of named definitions on the external side.
+	root := &ConfigMetadata{}
+	if m.Config != nil {
+		copy := *m.Config
+		root = &copy
+	}
+	if len(m.ExportedConfigs) > 0 {
+		merged := make(map[string]*ConfigMetadata, len(m.ExportedConfigs)+len(root.Defs))
+		for k, v := range root.Defs {
+			merged[k] = v
 		}
+		for k, v := range m.ExportedConfigs {
+			merged[k] = v
+		}
+		root.Defs = merged
+	}
+
+	if def, ok := root.Defs[ref.DefName()]; ok {
+		resolved := &ConfigMetadata{}
+		if err := r.resolveSchema(root, def, resolved, ref); err != nil {
+			return nil, fmt.Errorf("failed to resolve internal references in external schema %s: %w", ref, err)
+		}
+		return resolved, nil
 	}
 
 	return nil, fmt.Errorf("type %q not found in loaded schema for reference %s", ref.DefName(), ref)

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -56,12 +56,14 @@ func (r *Resolver) Resolve(src *Metadata) (*JSONSchemaDoc, error) {
 
 	// For ref-lookup purposes the recursive resolver expects the top-level
 	// definitions (both nested $defs and exported_configs) to be reachable from
-	// the root node. Merge them onto the owned root. On collision the exported
-	// configs win, matching the legacy behavior.
+	// the root node. Merge them onto the owned root. On collision the nested
+	// $defs win: the legacy mdatagen path injected internal generated defs over
+	// exported_configs, so a generated name like metrics_builder_config must
+	// resolve to the internal def, not an exported config sharing the name.
 	if len(work.ExportedConfigs) > 0 {
 		merged := make(map[string]*ConfigMetadata, len(work.ExportedConfigs)+len(config.Defs))
-		maps.Copy(merged, config.Defs)
 		maps.Copy(merged, work.ExportedConfigs)
+		maps.Copy(merged, config.Defs)
 		config.Defs = merged
 	}
 
@@ -326,8 +328,8 @@ func (r *Resolver) loadExternalRef(ref *Ref) (*ConfigMetadata, error) {
 	}
 	if len(m.ExportedConfigs) > 0 {
 		merged := make(map[string]*ConfigMetadata, len(m.ExportedConfigs)+len(root.Defs))
-		maps.Copy(merged, root.Defs)
 		maps.Copy(merged, m.ExportedConfigs)
+		maps.Copy(merged, root.Defs)
 		root.Defs = merged
 	}
 

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolver_ResolveSchema_BasicMetadata(t *testing.T) {
+func TestResolver_Resolve_BasicMetadata(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/receiver/otlpreceiver",
 		class:  "receiver",
@@ -23,7 +23,7 @@ func TestResolver_ResolveSchema_BasicMetadata(t *testing.T) {
 		Type:        "object",
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Equal(t, schemaVersion, result.Schema)
 	require.Equal(t, "go.opentelemetry.io/collector/receiver/otlpreceiver", result.ID)
@@ -32,7 +32,7 @@ func TestResolver_ResolveSchema_BasicMetadata(t *testing.T) {
 	require.Equal(t, "object", result.Type)
 }
 
-func TestResolver_ResolveSchema_InternalReference(t *testing.T) {
+func TestResolver_Resolve_InternalReference(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -55,7 +55,7 @@ func TestResolver_ResolveSchema_InternalReference(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Equal(t, "object", result.Type)
 	require.NotNil(t, result.Properties["config"])
@@ -63,7 +63,7 @@ func TestResolver_ResolveSchema_InternalReference(t *testing.T) {
 	require.Equal(t, "Target type description", result.Properties["config"].Description)
 }
 
-func TestResolver_ResolveSchema_InternalReferencePreservesInlineValidationOverrides(t *testing.T) {
+func TestResolver_Resolve_InternalReferencePreservesInlineValidationOverrides(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -90,7 +90,7 @@ func TestResolver_ResolveSchema_InternalReferencePreservesInlineValidationOverri
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	port := result.Properties["port"]
@@ -110,7 +110,7 @@ func TestResolver_ResolveSchema_InternalReferencePreservesInlineValidationOverri
 	require.InEpsilon(t, aliasMaximum, *def.Maximum, 1e-9)
 }
 
-func TestResolver_ResolveSchema_DefsOnlyPreservesDefs(t *testing.T) {
+func TestResolver_Resolve_DefsOnlyPreservesDefs(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/pkg",
 		class:  "pkg",
@@ -129,7 +129,7 @@ func TestResolver_ResolveSchema_DefsOnlyPreservesDefs(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Empty(t, result.Type)
 	require.Empty(t, result.Properties)
@@ -138,7 +138,7 @@ func TestResolver_ResolveSchema_DefsOnlyPreservesDefs(t *testing.T) {
 	require.Contains(t, result.Defs["sample_config"].Properties, "endpoint")
 }
 
-func TestResolver_ResolveSchema_PreservesInlineDefsWithProperties(t *testing.T) {
+func TestResolver_Resolve_PreservesInlineDefsWithProperties(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -161,7 +161,7 @@ func TestResolver_ResolveSchema_PreservesInlineDefsWithProperties(t *testing.T) 
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Contains(t, result.Properties, "endpoint")
 	require.Contains(t, result.Defs, "sample_config")
@@ -169,7 +169,7 @@ func TestResolver_ResolveSchema_PreservesInlineDefsWithProperties(t *testing.T) 
 	require.Contains(t, result.Defs["sample_config"].Properties, "host_name")
 }
 
-func TestResolver_ResolveSchema_DropsInternalOnlyDefs(t *testing.T) {
+func TestResolver_Resolve_DropsInternalOnlyDefs(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -202,7 +202,7 @@ func TestResolver_ResolveSchema_DropsInternalOnlyDefs(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Contains(t, result.Properties, "endpoint")
 	require.NotContains(t, result.Defs, "metrics_builder_config")
@@ -211,7 +211,7 @@ func TestResolver_ResolveSchema_DropsInternalOnlyDefs(t *testing.T) {
 	require.Contains(t, result.Defs["exported_metrics_config"].Properties, "metrics")
 }
 
-func TestResolver_ResolveSchema_UnknownInternalReference(t *testing.T) {
+func TestResolver_Resolve_UnknownInternalReference(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -229,12 +229,12 @@ func TestResolver_ResolveSchema_UnknownInternalReference(t *testing.T) {
 	}
 
 	// Should use "any" type because the internal reference doesn't exist
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Empty(t, result.Properties["config"].Type)
 }
 
-func TestResolver_ResolveSchema_AliasChain_InternalToExternal(t *testing.T) {
+func TestResolver_Resolve_AliasChain_InternalToExternal(t *testing.T) {
 	externalSchema := &ConfigMetadata{
 		Type: "object",
 		Defs: map[string]*ConfigMetadata{
@@ -280,7 +280,7 @@ func TestResolver_ResolveSchema_AliasChain_InternalToExternal(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	require.Len(t, result.AllOf, 1)
@@ -292,7 +292,7 @@ func TestResolver_ResolveSchema_AliasChain_InternalToExternal(t *testing.T) {
 	require.Equal(t, map[string]any{"timeout": "30s"}, embedded.Default)
 }
 
-func TestResolver_ResolveSchema_AliasChain_PreservesCustomExtensions(t *testing.T) {
+func TestResolver_Resolve_AliasChain_PreservesCustomExtensions(t *testing.T) {
 	externalSchema := &ConfigMetadata{
 		Type: "object",
 		Defs: map[string]*ConfigMetadata{
@@ -332,7 +332,7 @@ func TestResolver_ResolveSchema_AliasChain_PreservesCustomExtensions(t *testing.
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	cfg := result.Properties["cfg"]
@@ -343,7 +343,7 @@ func TestResolver_ResolveSchema_AliasChain_PreservesCustomExtensions(t *testing.
 	require.NotNil(t, cfg.Properties["level"])
 }
 
-func TestResolver_ResolveSchema_InternalAliasChain(t *testing.T) {
+func TestResolver_Resolve_InternalAliasChain(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -370,7 +370,7 @@ func TestResolver_ResolveSchema_InternalAliasChain(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	cfg := result.Properties["cfg"]
@@ -381,7 +381,7 @@ func TestResolver_ResolveSchema_InternalAliasChain(t *testing.T) {
 	require.Contains(t, cfg.Properties, "endpoint")
 }
 
-func TestResolver_ResolveSchema_DefsOnlyLocalAliasWithSameDefName(t *testing.T) {
+func TestResolver_Resolve_DefsOnlyLocalAliasWithSameDefName(t *testing.T) {
 	controllerSchema := &ConfigMetadata{
 		Type: "object",
 		Defs: map[string]*ConfigMetadata{
@@ -412,7 +412,7 @@ func TestResolver_ResolveSchema_DefsOnlyLocalAliasWithSameDefName(t *testing.T) 
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	controller := result.Defs["controller_config"]
@@ -423,7 +423,7 @@ func TestResolver_ResolveSchema_DefsOnlyLocalAliasWithSameDefName(t *testing.T) 
 	require.Contains(t, controller.Properties, "collection_interval")
 }
 
-func TestResolver_ResolveSchema_ExternalRefDoesNotUseRootDefWithSameName(t *testing.T) {
+func TestResolver_Resolve_ExternalRefDoesNotUseRootDefWithSameName(t *testing.T) {
 	externalSchema := &ConfigMetadata{
 		Type: "object",
 		Defs: map[string]*ConfigMetadata{
@@ -468,7 +468,7 @@ func TestResolver_ResolveSchema_ExternalRefDoesNotUseRootDefWithSameName(t *test
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	cfg := result.Properties["cfg"]
@@ -479,7 +479,7 @@ func TestResolver_ResolveSchema_ExternalRefDoesNotUseRootDefWithSameName(t *test
 	require.NotContains(t, cfg.Properties, "local")
 }
 
-func TestResolver_ResolveSchema_NestedStructures(t *testing.T) {
+func TestResolver_Resolve_NestedStructures(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -504,7 +504,7 @@ func TestResolver_ResolveSchema_NestedStructures(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Equal(t, "object", result.Type)
 	require.NotNil(t, result.Properties["nested"])
@@ -515,7 +515,7 @@ func TestResolver_ResolveSchema_NestedStructures(t *testing.T) {
 	require.Equal(t, "integer", result.Properties["nested"].Properties["field2"].Type)
 }
 
-func TestResolver_ResolveSchema_AllOf(t *testing.T) {
+func TestResolver_Resolve_AllOf(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -541,14 +541,14 @@ func TestResolver_ResolveSchema_AllOf(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Len(t, result.AllOf, 2)
 	require.NotNil(t, result.AllOf[0].Properties["field1"])
 	require.NotNil(t, result.AllOf[1].Properties["field2"])
 }
 
-func TestResolver_ResolveSchema_EmbeddedProperties(t *testing.T) {
+func TestResolver_Resolve_EmbeddedProperties(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -578,7 +578,7 @@ func TestResolver_ResolveSchema_EmbeddedProperties(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Len(t, result.Properties, 1)
 	require.Contains(t, result.Properties, "regular")
@@ -600,7 +600,7 @@ func TestResolver_ResolveSchema_EmbeddedProperties(t *testing.T) {
 	require.Empty(t, anonymous.EmbeddedName)
 }
 
-func TestResolver_ResolveSchema_EmbeddedReferencePreservesExtensions(t *testing.T) {
+func TestResolver_Resolve_EmbeddedReferencePreservesExtensions(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -628,7 +628,7 @@ func TestResolver_ResolveSchema_EmbeddedReferencePreservesExtensions(t *testing.
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Empty(t, result.Properties)
 	require.Len(t, result.AllOf, 1)
@@ -642,7 +642,7 @@ func TestResolver_ResolveSchema_EmbeddedReferencePreservesExtensions(t *testing.
 	require.Contains(t, embedded.Properties, "endpoint")
 }
 
-func TestResolver_ResolveSchema_ArrayItems(t *testing.T) {
+func TestResolver_Resolve_ArrayItems(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -660,7 +660,7 @@ func TestResolver_ResolveSchema_ArrayItems(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Equal(t, "array", result.Type)
 	require.NotNil(t, result.Items)
@@ -786,7 +786,7 @@ func TestResolver_IsExternalRef(t *testing.T) {
 	}
 }
 
-func TestResolver_ResolveSchema_ExternalReference_Integration(t *testing.T) {
+func TestResolver_Resolve_ExternalReference_Integration(t *testing.T) {
 	// Use mockLoader instead of real file loading to avoid repo root dependency
 	confighttpSchema := &ConfigMetadata{
 		Type: "object",
@@ -829,7 +829,7 @@ func TestResolver_ResolveSchema_ExternalReference_Integration(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.Equal(t, "object", result.Type)
 	require.NotNil(t, result.Properties["http"])
@@ -840,7 +840,7 @@ func TestResolver_ResolveSchema_ExternalReference_Integration(t *testing.T) {
 	require.Equal(t, "Request timeout", result.Properties["http"].Properties["timeout"].Description)
 }
 
-func TestResolver_ResolveSchema_DurationFormat(t *testing.T) {
+func TestResolver_Resolve_DurationFormat(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -863,7 +863,7 @@ func TestResolver_ResolveSchema_DurationFormat(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	// Check timeout field - format should be cleared, GoType and Pattern set
@@ -906,7 +906,7 @@ func (m *mockLoader) Load(ref Ref) (*Metadata, error) {
 	return nil, fmt.Errorf("schema not found for ref: %s", cacheKey)
 }
 
-func TestResolver_ResolveSchema_OriginConvertsLocalRefToExternal(t *testing.T) {
+func TestResolver_Resolve_OriginConvertsLocalRefToExternal(t *testing.T) {
 	// confighttp schema contains a local absolute ref to /config/configauth.config
 	// When loaded as an external ref from the collector namespace, the local ref
 	// should be converted to go.opentelemetry.io/collector/config/configauth.config
@@ -964,7 +964,7 @@ func TestResolver_ResolveSchema_OriginConvertsLocalRefToExternal(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["http"])
 	require.Equal(t, "object", result.Properties["http"].Type)
@@ -977,7 +977,7 @@ func TestResolver_ResolveSchema_OriginConvertsLocalRefToExternal(t *testing.T) {
 	require.NotNil(t, result.Properties["http"].Properties["auth"].Properties["token"])
 }
 
-func TestResolver_ResolveSchema_LocalRefWithOriginConversion(t *testing.T) {
+func TestResolver_Resolve_LocalRefWithOriginConversion(t *testing.T) {
 	// When a local ref is encountered in an externally-loaded schema, it should be converted
 	// using the origin namespace
 	configauthSchema := &ConfigMetadata{
@@ -1029,7 +1029,7 @@ func TestResolver_ResolveSchema_LocalRefWithOriginConversion(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["http"])
 	require.Equal(t, "object", result.Properties["http"].Type)
@@ -1039,7 +1039,7 @@ func TestResolver_ResolveSchema_LocalRefWithOriginConversion(t *testing.T) {
 	require.Equal(t, "Auth config", result.Properties["http"].Properties["auth"].Description)
 }
 
-func TestResolver_ResolveSchema_NestedOriginPropagation(t *testing.T) {
+func TestResolver_Resolve_NestedOriginPropagation(t *testing.T) {
 	// Schema A (remote) → local ref → Schema B (also remote) → local ref → Schema C
 	// Verify the origin propagates through all levels.
 
@@ -1106,7 +1106,7 @@ func TestResolver_ResolveSchema_NestedOriginPropagation(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["http"])
 	// auth should be resolved through origin-aware conversion
@@ -1120,7 +1120,7 @@ func TestResolver_ResolveSchema_NestedOriginPropagation(t *testing.T) {
 	require.Equal(t, "TLS configuration", tls.Description)
 }
 
-func TestResolver_ResolveSchema_RelativeRefWithOrigin(t *testing.T) {
+func TestResolver_Resolve_RelativeRefWithOrigin(t *testing.T) {
 	metadataSchema := &ConfigMetadata{
 		Type: "object",
 		Defs: map[string]*ConfigMetadata{
@@ -1168,7 +1168,7 @@ func TestResolver_ResolveSchema_RelativeRefWithOrigin(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["http"])
 	metrics := result.Properties["http"].Properties["metrics"]
@@ -1177,7 +1177,7 @@ func TestResolver_ResolveSchema_RelativeRefWithOrigin(t *testing.T) {
 	require.Equal(t, "Metrics configuration", metrics.Description)
 }
 
-func TestResolver_ResolveSchema_ParentRelativeRefWithOrigin(t *testing.T) {
+func TestResolver_Resolve_ParentRelativeRefWithOrigin(t *testing.T) {
 	configtlsSchema := &ConfigMetadata{
 		Type: "object",
 		Defs: map[string]*ConfigMetadata{
@@ -1225,7 +1225,7 @@ func TestResolver_ResolveSchema_ParentRelativeRefWithOrigin(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["http"])
 	tls := result.Properties["http"].Properties["tls"]
@@ -1244,7 +1244,7 @@ func TestNewResolver(t *testing.T) {
 	require.NotNil(t, r.loader)
 }
 
-func TestResolver_ResolveSchema_UnknownNamespaceFallback(t *testing.T) {
+func TestResolver_Resolve_UnknownNamespaceFallback(t *testing.T) {
 	// An external ref with an unsupported namespace should fall back to "any" type
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
@@ -1262,14 +1262,14 @@ func TestResolver_ResolveSchema_UnknownNamespaceFallback(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["custom"])
 	require.Equal(t, "github.com/example/custom.config", result.Properties["custom"].GoType)
 	require.Contains(t, result.Properties["custom"].Comment, "any")
 }
 
-func TestResolver_ResolveSchema_LoaderError(t *testing.T) {
+func TestResolver_Resolve_LoaderError(t *testing.T) {
 	ml := &mockLoader{schemas: map[string]*ConfigMetadata{}}
 
 	resolver := &Resolver{
@@ -1288,7 +1288,7 @@ func TestResolver_ResolveSchema_LoaderError(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.Error(t, err)
 	require.Nil(t, result)
 }
@@ -1309,7 +1309,7 @@ func TestResolver_ResolveRef_InvalidRefFormat(t *testing.T) {
 			},
 		},
 	}
-	_, err := resolver.ResolveSchema(src)
+	_, err := resolver.Resolve(&Metadata{Config: src})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid reference format")
 }
@@ -1370,7 +1370,7 @@ func TestResolver_LoadExternalRef_InternalResolutionError(t *testing.T) {
 	require.Nil(t, result)
 }
 
-func TestResolver_ResolveSchema_LocalRef(t *testing.T) {
+func TestResolver_Resolve_LocalRef(t *testing.T) {
 	localSchema := &ConfigMetadata{
 		Type: "object",
 		Defs: map[string]*ConfigMetadata{
@@ -1403,14 +1403,14 @@ func TestResolver_ResolveSchema_LocalRef(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["local"])
 	require.Equal(t, "object", result.Properties["local"].Type)
 	require.Equal(t, "Local target", result.Properties["local"].Description)
 }
 
-func TestResolver_ResolveSchema_LocalRefUsesRootDef(t *testing.T) {
+func TestResolver_Resolve_LocalRefUsesRootDef(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -1438,7 +1438,7 @@ func TestResolver_ResolveSchema_LocalRefUsesRootDef(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	resourceAttributes := result.Properties["resource_attributes"]
@@ -1448,7 +1448,7 @@ func TestResolver_ResolveSchema_LocalRefUsesRootDef(t *testing.T) {
 	require.Equal(t, "string", resourceAttributes.Properties["service.name"].Type)
 }
 
-func TestResolver_ResolveSchema_MapValueError(t *testing.T) {
+func TestResolver_Resolve_MapValueError(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -1466,11 +1466,11 @@ func TestResolver_ResolveSchema_MapValueError(t *testing.T) {
 		},
 	}
 
-	_, err := resolver.ResolveSchema(src)
+	_, err := resolver.Resolve(&Metadata{Config: src})
 	require.Error(t, err)
 }
 
-func TestResolver_ResolveSchema_AllOfError(t *testing.T) {
+func TestResolver_Resolve_AllOfError(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -1487,11 +1487,11 @@ func TestResolver_ResolveSchema_AllOfError(t *testing.T) {
 		},
 	}
 
-	_, err := resolver.ResolveSchema(src)
+	_, err := resolver.Resolve(&Metadata{Config: src})
 	require.Error(t, err)
 }
 
-func TestResolver_ResolveSchema_PtrFieldError(t *testing.T) {
+func TestResolver_Resolve_PtrFieldError(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -1511,11 +1511,11 @@ func TestResolver_ResolveSchema_PtrFieldError(t *testing.T) {
 		},
 	}
 
-	_, err := resolver.ResolveSchema(src)
+	_, err := resolver.Resolve(&Metadata{Config: src})
 	require.Error(t, err)
 }
 
-func TestResolver_ResolveSchema_PointerFields(t *testing.T) {
+func TestResolver_Resolve_PointerFields(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -1537,7 +1537,7 @@ func TestResolver_ResolveSchema_PointerFields(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["tags"])
 	require.Equal(t, "array", result.Properties["tags"].Type)
@@ -1545,7 +1545,7 @@ func TestResolver_ResolveSchema_PointerFields(t *testing.T) {
 	require.Equal(t, "string", result.Properties["tags"].Items.Type)
 }
 
-func TestResolver_ResolveSchema_ContentSchema(t *testing.T) {
+func TestResolver_Resolve_ContentSchema(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -1569,14 +1569,14 @@ func TestResolver_ResolveSchema_ContentSchema(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["body"])
 	require.NotNil(t, result.Properties["body"].ContentSchema)
 	require.Equal(t, "object", result.Properties["body"].ContentSchema.Type)
 }
 
-func TestResolver_ResolveSchema_PreservesCustomExtensions(t *testing.T) {
+func TestResolver_Resolve_PreservesCustomExtensions(t *testing.T) {
 	// When a node has both a $ref and custom extensions (GoType, IsPointer,
 	// IsOptional, Description, Default, Enum), the custom extensions should
 	// be preserved after resolution instead of being overwritten by the
@@ -1620,7 +1620,7 @@ func TestResolver_ResolveSchema_PreservesCustomExtensions(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["timeout"])
 
@@ -1641,7 +1641,7 @@ func TestResolver_ResolveSchema_PreservesCustomExtensions(t *testing.T) {
 	require.Equal(t, "string", timeout.Type)
 }
 
-func TestResolver_ResolveSchema_RefWithoutCustomExtensions(t *testing.T) {
+func TestResolver_Resolve_RefWithoutCustomExtensions(t *testing.T) {
 	// When a node has a $ref but NO custom extensions, the resolved schema's
 	// values should be used as-is (no overriding).
 
@@ -1679,7 +1679,7 @@ func TestResolver_ResolveSchema_RefWithoutCustomExtensions(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 	require.NotNil(t, result.Properties["base"])
 
@@ -1690,7 +1690,7 @@ func TestResolver_ResolveSchema_RefWithoutCustomExtensions(t *testing.T) {
 	require.Equal(t, "BaseConfig", base.GoType)
 }
 
-func TestResolver_ResolveSchema_DecoratesPropNames(t *testing.T) {
+func TestResolver_Resolve_DecoratesPropNames(t *testing.T) {
 	resolver := &Resolver{
 		pkgID:  "go.opentelemetry.io/collector/test/component",
 		class:  "receiver",
@@ -1709,14 +1709,14 @@ func TestResolver_ResolveSchema_DecoratesPropNames(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	require.Equal(t, "endpoint", result.Properties["endpoint"].GoStruct.FieldName)
 	require.Equal(t, "storage", result.Properties["storage"].GoStruct.FieldName)
 }
 
-func TestResolver_ResolveSchema_PreservesIntAndFloatPointers(t *testing.T) {
+func TestResolver_Resolve_PreservesIntAndFloatPointers(t *testing.T) {
 	// Regression test: *int and *float64 pointer fields must be copied by the resolver.
 	// Previously, only *ConfigMetadata pointers were handled; all other pointer types
 	// were silently dropped, causing MinLength, MaxLength, Minimum, Maximum, etc. to be nil.
@@ -1763,7 +1763,7 @@ func TestResolver_ResolveSchema_PreservesIntAndFloatPointers(t *testing.T) {
 		},
 	}
 
-	result, err := resolver.ResolveSchema(src)
+	result, err := resolver.Resolve(&Metadata{Config: src})
 	require.NoError(t, err)
 
 	name := result.Properties["name"]

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -898,10 +898,10 @@ func findSchema(t *testing.T, schemas []*ConfigMetadata, match func(*ConfigMetad
 	return nil
 }
 
-func (m *mockLoader) Load(ref Ref) (*ConfigMetadata, error) {
+func (m *mockLoader) Load(ref Ref) (*Metadata, error) {
 	cacheKey := ref.CacheKey()
 	if md, ok := m.schemas[cacheKey]; ok {
-		return md, nil
+		return &Metadata{Config: md}, nil
 	}
 	return nil, fmt.Errorf("schema not found for ref: %s", cacheKey)
 }
@@ -1333,7 +1333,7 @@ func TestResolver_LoadExternalRef_NilResult(t *testing.T) {
 // nilResultLoader returns (nil, nil) for any ref.
 type nilResultLoader struct{}
 
-func (n *nilResultLoader) Load(_ Ref) (*ConfigMetadata, error) { return nil, nil }
+func (n *nilResultLoader) Load(_ Ref) (*Metadata, error) { return nil, nil }
 
 func TestResolver_LoadExternalRef_InternalResolutionError(t *testing.T) {
 	brokenSchema := &ConfigMetadata{

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -1973,21 +1973,17 @@ func TestMetadata_Clone_HandlesNil(t *testing.T) {
 	require.Nil(t, cloned.ExportedConfigs)
 }
 
-func TestJSONSchemaDoc_MarshalJSON_EmitsDefsWithMarshalJSONInner(t *testing.T) {
-	// JSONSchemaDoc embeds *ConfigMetadata, which now defines its own MarshalJSON
-	// (for PatternProperties / AdditionalPropertiesAllowed). Without an explicit
-	// JSONSchemaDoc.MarshalJSON, the promoted inner method would marshal only the
-	// inner node and silently drop the outer $defs.
-	doc := &JSONSchemaDoc{
-		ConfigMetadata: &ConfigMetadata{
-			Schema: schemaVersion,
-			Type:   "object",
-			Properties: map[string]*ConfigMetadata{
-				"endpoint": {Type: "string"},
-			},
-			// Trigger the inner MarshalJSON's "special fields" branch.
-			AdditionalPropertiesAllowed: boolPtr(false),
+func TestNewJSONSchemaDoc_EmitsDefsAndBody(t *testing.T) {
+	// The standalone document emits both the schema body and the top-level $defs
+	// through plain struct tags, with no custom MarshalJSON. AdditionalPropertiesAllowed
+	// on the resolved node is projected to a real additionalProperties boolean.
+	doc := NewJSONSchemaDoc(&ConfigMetadata{
+		Schema: schemaVersion,
+		Type:   "object",
+		Properties: map[string]*ConfigMetadata{
+			"endpoint": {Type: "string"},
 		},
+		AdditionalPropertiesAllowed: boolPtr(false),
 		Defs: map[string]*ConfigMetadata{
 			"sample_config": {
 				Type: "object",
@@ -1996,7 +1992,7 @@ func TestJSONSchemaDoc_MarshalJSON_EmitsDefsWithMarshalJSONInner(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	data, err := doc.ToJSON()
 	require.NoError(t, err)
@@ -2006,20 +2002,20 @@ func TestJSONSchemaDoc_MarshalJSON_EmitsDefsWithMarshalJSONInner(t *testing.T) {
 	require.Contains(t, string(data), `"endpoint"`)
 }
 
-func TestJSONSchemaDoc_MarshalJSON_DefsOnlyWithoutInner(t *testing.T) {
-	doc := &JSONSchemaDoc{
+func TestNewJSONSchemaDoc_DefsOnly(t *testing.T) {
+	doc := NewJSONSchemaDoc(&ConfigMetadata{
 		Defs: map[string]*ConfigMetadata{
 			"sample": {Type: "string"},
 		},
-	}
+	})
 	data, err := doc.ToJSON()
 	require.NoError(t, err)
 	require.Contains(t, string(data), `"$defs"`)
 	require.Contains(t, string(data), `"sample"`)
 }
 
-func TestJSONSchemaDoc_MarshalJSON_EmptyDoc(t *testing.T) {
-	doc := &JSONSchemaDoc{}
+func TestNewJSONSchemaDoc_NilRoot(t *testing.T) {
+	doc := NewJSONSchemaDoc(nil)
 	data, err := doc.ToJSON()
 	require.NoError(t, err)
 	require.Equal(t, "{}", string(data))
@@ -2056,15 +2052,19 @@ func TestResolver_Resolve_MergesExportedConfigsIntoDefs(t *testing.T) {
 		},
 	}
 
-	doc, err := r.Resolve(src)
+	resolved, err := r.Resolve(src)
 	require.NoError(t, err)
-	require.NotNil(t, doc.ConfigMetadata)
-	require.Equal(t, "object", doc.Type)
+	require.NotNil(t, resolved)
+	require.Equal(t, "object", resolved.Type)
+	require.Contains(t, resolved.Defs, "shared_config")
+	require.Equal(t, "object", resolved.Properties["shared"].Type)
+	require.Contains(t, resolved.Properties["shared"].Properties, "endpoint")
+	// The merged exported_configs are promoted onto the document's $defs at write time.
+	doc := NewJSONSchemaDoc(resolved)
 	require.Contains(t, doc.Defs, "shared_config")
-	require.Equal(t, "object", doc.Properties["shared"].Type)
-	require.Contains(t, doc.Properties["shared"].Properties, "endpoint")
-	// $defs must live on the outer doc, not on the inner ConfigMetadata.
-	require.Nil(t, doc.ConfigMetadata.Defs)
+	data, err := doc.ToJSON()
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"$defs"`)
 }
 
 func TestResolver_Resolve_InternalDefsWinNameCollision(t *testing.T) {

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -2066,3 +2066,133 @@ func TestResolver_Resolve_MergesExportedConfigsIntoDefs(t *testing.T) {
 	// $defs must live on the outer doc, not on the inner ConfigMetadata.
 	require.Nil(t, doc.ConfigMetadata.Defs)
 }
+
+// stubLoader is a Loader test double that returns pre-built *Metadata values verbatim.
+// Unlike mockLoader (which wraps schemas as Metadata{Config: md}), this lets tests
+// exercise loadExternalRef branches that depend on Metadata.ExportedConfigs or on a
+// nil Metadata.Config.
+type stubLoader struct {
+	results map[string]*Metadata
+}
+
+func (s *stubLoader) Load(ref Ref) (*Metadata, error) {
+	if md, ok := s.results[ref.CacheKey()]; ok {
+		return md, nil
+	}
+	return nil, fmt.Errorf("stubLoader: no result for %s", ref.CacheKey())
+}
+
+func TestResolver_Resolve_HandlesNilConfig(t *testing.T) {
+	// A source Metadata with no Config should still produce a well-formed JSON
+	// Schema document (Schema/$id/title populated, no properties) rather than
+	// crashing on the nil-deref path.
+	r := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: &mockLoader{schemas: map[string]*ConfigMetadata{}},
+	}
+	doc, err := r.Resolve(&Metadata{})
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.Equal(t, schemaVersion, doc.Schema)
+	require.Empty(t, doc.Properties)
+}
+
+func TestResolver_Resolve_PropagatesResolveSchemaError(t *testing.T) {
+	// An invalid $ref must surface as an error from Resolve, not be swallowed.
+	r := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: &mockLoader{schemas: map[string]*ConfigMetadata{}},
+	}
+	_, err := r.Resolve(&Metadata{Config: &ConfigMetadata{Ref: "/"}})
+	require.Error(t, err)
+}
+
+func TestResolver_Resolve_EnhancesDateTimeFormat(t *testing.T) {
+	// enhanceTimeTypes maps {string, date-time} to time.Time on the resolved node.
+	r := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: &mockLoader{schemas: map[string]*ConfigMetadata{}},
+	}
+	src := &Metadata{
+		Config: &ConfigMetadata{
+			Type: "object",
+			Properties: map[string]*ConfigMetadata{
+				"ts": {Type: "string", Format: "date-time"},
+			},
+		},
+	}
+	doc, err := r.Resolve(src)
+	require.NoError(t, err)
+	require.Equal(t, "time.Time", doc.Properties["ts"].GoType)
+}
+
+func TestResolver_LoadExternalRef_HandlesNilConfig(t *testing.T) {
+	// A loader returning Metadata{Config: nil, ExportedConfigs: ...} must still
+	// resolve refs that point to entries in ExportedConfigs.
+	external := &Metadata{
+		ExportedConfigs: map[string]*ConfigMetadata{
+			"config": {
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"endpoint": {Type: "string"},
+				},
+			},
+		},
+	}
+	r := &Resolver{
+		pkgID: "go.opentelemetry.io/collector/test/component",
+		class: "receiver",
+		name:  "test",
+		loader: &stubLoader{
+			results: map[string]*Metadata{
+				"go.opentelemetry.io/collector/foo/bar.config": external,
+			},
+		},
+	}
+	resolved, err := r.loadExternalRef(NewRef("go.opentelemetry.io/collector/foo/bar.config"))
+	require.NoError(t, err)
+	require.Equal(t, "object", resolved.Type)
+	require.Contains(t, resolved.Properties, "endpoint")
+}
+
+func TestResolver_LoadExternalRef_MergesLoaderExportedConfigs(t *testing.T) {
+	// When the loader returns ExportedConfigs alongside Config.Defs, both should
+	// be reachable for ref lookup, with ExportedConfigs winning on key collisions.
+	external := &Metadata{
+		Config: &ConfigMetadata{
+			Type: "object",
+			Defs: map[string]*ConfigMetadata{
+				"config": {Type: "object", Description: "from Config.Defs"},
+			},
+		},
+		ExportedConfigs: map[string]*ConfigMetadata{
+			"config": {Type: "object", Description: "from ExportedConfigs"},
+			"extra":  {Type: "string"},
+		},
+	}
+	r := &Resolver{
+		pkgID: "go.opentelemetry.io/collector/test/component",
+		class: "receiver",
+		name:  "test",
+		loader: &stubLoader{
+			results: map[string]*Metadata{
+				"go.opentelemetry.io/collector/foo/bar.config": external,
+				"go.opentelemetry.io/collector/foo/bar.extra":  external,
+			},
+		},
+	}
+
+	winner, err := r.loadExternalRef(NewRef("go.opentelemetry.io/collector/foo/bar.config"))
+	require.NoError(t, err)
+	require.Equal(t, "from ExportedConfigs", winner.Description)
+
+	extra, err := r.loadExternalRef(NewRef("go.opentelemetry.io/collector/foo/bar.extra"))
+	require.NoError(t, err)
+	require.Equal(t, "string", extra.Type)
+}

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -2067,6 +2067,43 @@ func TestResolver_Resolve_MergesExportedConfigsIntoDefs(t *testing.T) {
 	require.Nil(t, doc.ConfigMetadata.Defs)
 }
 
+func TestResolver_Resolve_InternalDefsWinNameCollision(t *testing.T) {
+	// An internal generated def (Config.Defs) and an exported config can share a
+	// generated name such as metrics_builder_config. mdatagen injects the internal
+	// def before Resolve, so the ref must resolve to that internal def, not to the
+	// exported config that happens to reuse the name.
+	r := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: &mockLoader{schemas: map[string]*ConfigMetadata{}},
+	}
+	src := &Metadata{
+		Config: &ConfigMetadata{
+			Type: "object",
+			Properties: map[string]*ConfigMetadata{
+				"shared": {Ref: "metrics_builder_config"},
+			},
+			Defs: map[string]*ConfigMetadata{
+				"metrics_builder_config": {
+					Type:        "object",
+					Description: "internal generated def",
+				},
+			},
+		},
+		ExportedConfigs: map[string]*ConfigMetadata{
+			"metrics_builder_config": {
+				Type:        "object",
+				Description: "exported config",
+			},
+		},
+	}
+
+	doc, err := r.Resolve(src)
+	require.NoError(t, err)
+	require.Equal(t, "internal generated def", doc.Properties["shared"].Description)
+}
+
 // stubLoader is a Loader test double that returns pre-built *Metadata values verbatim.
 // Unlike mockLoader (which wraps schemas as Metadata{Config: md}), this lets tests
 // exercise loadExternalRef branches that depend on Metadata.ExportedConfigs or on a
@@ -2163,7 +2200,7 @@ func TestResolver_LoadExternalRef_HandlesNilConfig(t *testing.T) {
 
 func TestResolver_LoadExternalRef_MergesLoaderExportedConfigs(t *testing.T) {
 	// When the loader returns ExportedConfigs alongside Config.Defs, both should
-	// be reachable for ref lookup, with ExportedConfigs winning on key collisions.
+	// be reachable for ref lookup, with the nested $defs winning on key collisions.
 	external := &Metadata{
 		Config: &ConfigMetadata{
 			Type: "object",
@@ -2190,7 +2227,7 @@ func TestResolver_LoadExternalRef_MergesLoaderExportedConfigs(t *testing.T) {
 
 	winner, err := r.loadExternalRef(NewRef("go.opentelemetry.io/collector/foo/bar.config"))
 	require.NoError(t, err)
-	require.Equal(t, "from ExportedConfigs", winner.Description)
+	require.Equal(t, "from Config.Defs", winner.Description)
 
 	extra, err := r.loadExternalRef(NewRef("go.opentelemetry.io/collector/foo/bar.extra"))
 	require.NoError(t, err)

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -1796,3 +1796,273 @@ func TestResolver_ResolveSchema_PreservesIntAndFloatPointers(t *testing.T) {
 	require.NotNil(t, score.MultipleOf)
 	require.InEpsilon(t, multipleOf, *score.MultipleOf, 1e-9)
 }
+
+func TestResolver_Resolve_DoesNotMutateSourceMetadata(t *testing.T) {
+	// Regression for the writer-side type split: Resolve must treat its *Metadata
+	// argument as read-only. The pre-fix shallow-copy root left every nested
+	// *ConfigMetadata pointer in Properties / Items / Defs / ExportedConfigs
+	// aliased with the caller's tree, so the "any"-fallback in resolveRef leaked
+	// GoType and Comment writes back into the source.
+	resolver := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: &mockLoader{schemas: map[string]*ConfigMetadata{}},
+	}
+
+	// Node that the "any" fallback in resolveRef would mutate.
+	anyFallbackNode := &ConfigMetadata{Ref: "github.com/example/unknown.type"}
+
+	src := &Metadata{
+		Config: &ConfigMetadata{
+			Type: "object",
+			Properties: map[string]*ConfigMetadata{
+				"outer": {
+					Type: "object",
+					Properties: map[string]*ConfigMetadata{
+						"field": anyFallbackNode,
+					},
+				},
+				"items_field": {
+					Type: "array",
+					Items: &ConfigMetadata{
+						Type: "object",
+						Properties: map[string]*ConfigMetadata{
+							"name": {Type: "string"},
+						},
+					},
+				},
+			},
+			Defs: map[string]*ConfigMetadata{
+				"local_alias": {
+					Type:        "string",
+					Description: "shared local def",
+				},
+			},
+		},
+		ExportedConfigs: map[string]*ConfigMetadata{
+			"exp_config": {
+				Type:        "object",
+				Description: "shared exported config",
+				Properties: map[string]*ConfigMetadata{
+					"knob": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	snapshot := src.Clone()
+	_, err := resolver.Resolve(src)
+	require.NoError(t, err)
+
+	// Direct check on the node the "any" fallback would have mutated.
+	require.Empty(t, anyFallbackNode.GoType, "Resolve must not mutate caller's nested ref node (GoType)")
+	require.Empty(t, anyFallbackNode.Comment, "Resolve must not mutate caller's nested ref node (Comment)")
+	// Full deep-equality check across the whole source tree.
+	require.Equal(t, snapshot, src, "Resolve must not mutate caller's source Metadata")
+}
+
+func TestResolver_LoadExternalRef_DoesNotMutateLoaderResult(t *testing.T) {
+	// Loaders cache and reuse *Metadata across calls, so loadExternalRef must own
+	// the tree it walks. Otherwise mutations performed by the recursive
+	// resolveSchema (the "any"-fallback in resolveRef, future per-node writes)
+	// would persist into the cached schema and contaminate subsequent loads.
+	external := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"config": {
+				Type:        "object",
+				Description: "external cached config",
+				Properties: map[string]*ConfigMetadata{
+					"endpoint": {Type: "string"},
+					"nested": {
+						Type: "object",
+						Properties: map[string]*ConfigMetadata{
+							"x": {Type: "integer"},
+						},
+					},
+					"timing": {
+						Type:   "string",
+						Format: "duration",
+					},
+					"items_field": {
+						Type:  "array",
+						Items: &ConfigMetadata{Type: "string"},
+					},
+				},
+			},
+		},
+	}
+	ml := &mockLoader{
+		schemas: map[string]*ConfigMetadata{
+			"go.opentelemetry.io/collector/foo/bar.config": external,
+		},
+	}
+	snapshot := external.Clone()
+
+	resolver := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: ml,
+	}
+	ref := NewRef("go.opentelemetry.io/collector/foo/bar.config")
+
+	// Call twice: a second hit on the cached schema would surface any first-call
+	// mutation that escaped the deep clone.
+	_, err := resolver.loadExternalRef(ref)
+	require.NoError(t, err)
+	_, err = resolver.loadExternalRef(ref)
+	require.NoError(t, err)
+
+	require.Equal(t, snapshot, external, "loadExternalRef must not mutate the loader's returned schema")
+}
+
+func TestConfigMetadata_Clone_DeepCopiesNestedPointers(t *testing.T) {
+	// Verifies the property Resolve relies on: a cloned tree shares no pointers
+	// with the source for the fields the resolver walks (Properties, Items,
+	// AllOf, AdditionalProperties, ContentSchema, PatternProperties, Defs).
+	src := &ConfigMetadata{
+		Type:        "object",
+		Description: "root",
+		Properties: map[string]*ConfigMetadata{
+			"a": {Type: "string"},
+		},
+		Items:                &ConfigMetadata{Type: "integer"},
+		AllOf:                []*ConfigMetadata{{Ref: "x"}},
+		AdditionalProperties: &ConfigMetadata{Type: "string"},
+		ContentSchema:        &ConfigMetadata{Type: "object"},
+		PatternProperties: map[string]*ConfigMetadata{
+			"^p": {Type: "string"},
+		},
+		Defs: map[string]*ConfigMetadata{
+			"d": {Type: "object"},
+		},
+		Required: []string{"a"},
+		Enum:     []any{"x", "y"},
+	}
+
+	cloned := src.Clone()
+	require.Equal(t, src, cloned)
+
+	require.NotSame(t, src, cloned)
+	require.NotSame(t, src.Properties["a"], cloned.Properties["a"])
+	require.NotSame(t, src.Items, cloned.Items)
+	require.NotSame(t, src.AllOf[0], cloned.AllOf[0])
+	require.NotSame(t, src.AdditionalProperties, cloned.AdditionalProperties)
+	require.NotSame(t, src.ContentSchema, cloned.ContentSchema)
+	require.NotSame(t, src.PatternProperties["^p"], cloned.PatternProperties["^p"])
+	require.NotSame(t, src.Defs["d"], cloned.Defs["d"])
+
+	// Mutating the clone must not affect the source.
+	cloned.Properties["a"].Type = "mutated"
+	require.Equal(t, "string", src.Properties["a"].Type)
+}
+
+func TestMetadata_Clone_HandlesNil(t *testing.T) {
+	var nilMd *Metadata
+	require.Nil(t, nilMd.Clone())
+
+	var nilCM *ConfigMetadata
+	require.Nil(t, nilCM.Clone())
+
+	empty := &Metadata{}
+	cloned := empty.Clone()
+	require.NotNil(t, cloned)
+	require.Nil(t, cloned.Config)
+	require.Nil(t, cloned.ExportedConfigs)
+}
+
+func TestJSONSchemaDoc_MarshalJSON_EmitsDefsWithMarshalJSONInner(t *testing.T) {
+	// JSONSchemaDoc embeds *ConfigMetadata, which now defines its own MarshalJSON
+	// (for PatternProperties / AdditionalPropertiesAllowed). Without an explicit
+	// JSONSchemaDoc.MarshalJSON, the promoted inner method would marshal only the
+	// inner node and silently drop the outer $defs.
+	doc := &JSONSchemaDoc{
+		ConfigMetadata: &ConfigMetadata{
+			Schema: schemaVersion,
+			Type:   "object",
+			Properties: map[string]*ConfigMetadata{
+				"endpoint": {Type: "string"},
+			},
+			// Trigger the inner MarshalJSON's "special fields" branch.
+			AdditionalPropertiesAllowed: boolPtr(false),
+		},
+		Defs: map[string]*ConfigMetadata{
+			"sample_config": {
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"endpoint": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	data, err := doc.ToJSON()
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"$defs"`)
+	require.Contains(t, string(data), `"sample_config"`)
+	require.Contains(t, string(data), `"additionalProperties": false`)
+	require.Contains(t, string(data), `"endpoint"`)
+}
+
+func TestJSONSchemaDoc_MarshalJSON_DefsOnlyWithoutInner(t *testing.T) {
+	doc := &JSONSchemaDoc{
+		Defs: map[string]*ConfigMetadata{
+			"sample": {Type: "string"},
+		},
+	}
+	data, err := doc.ToJSON()
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"$defs"`)
+	require.Contains(t, string(data), `"sample"`)
+}
+
+func TestJSONSchemaDoc_MarshalJSON_EmptyDoc(t *testing.T) {
+	doc := &JSONSchemaDoc{}
+	data, err := doc.ToJSON()
+	require.NoError(t, err)
+	require.Equal(t, "{}", string(data))
+}
+
+func TestResolver_Resolve_NilSource(t *testing.T) {
+	r := &Resolver{loader: NewLoader("")}
+	_, err := r.Resolve(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil metadata")
+}
+
+func TestResolver_Resolve_MergesExportedConfigsIntoDefs(t *testing.T) {
+	r := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: &mockLoader{schemas: map[string]*ConfigMetadata{}},
+	}
+	src := &Metadata{
+		Config: &ConfigMetadata{
+			Type: "object",
+			Properties: map[string]*ConfigMetadata{
+				"shared": {Ref: "shared_config"},
+			},
+		},
+		ExportedConfigs: map[string]*ConfigMetadata{
+			"shared_config": {
+				Type: "object",
+				Properties: map[string]*ConfigMetadata{
+					"endpoint": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	doc, err := r.Resolve(src)
+	require.NoError(t, err)
+	require.NotNil(t, doc.ConfigMetadata)
+	require.Equal(t, "object", doc.Type)
+	require.Contains(t, doc.Defs, "shared_config")
+	require.Equal(t, "object", doc.Properties["shared"].Type)
+	require.Contains(t, doc.Properties["shared"].Properties, "endpoint")
+	// $defs must live on the outer doc, not on the inner ConfigMetadata.
+	require.Nil(t, doc.ConfigMetadata.Defs)
+}

--- a/internal/schemagen/writer.go
+++ b/internal/schemagen/writer.go
@@ -10,11 +10,11 @@ import (
 
 const fileName = "config.schema.json"
 
-// WriteJSONSchema writes the given ConfigMetadata as a JSON Schema file
+// WriteJSONSchema writes the given JSONSchemaDoc as a JSON Schema file
 // named "config.schema.json" in the specified directory.
-func WriteJSONSchema(dir string, md *ConfigMetadata) error {
+func WriteJSONSchema(dir string, doc *JSONSchemaDoc) error {
 	filePath := filepath.Join(dir, fileName)
-	data, err := md.ToJSON()
+	data, err := doc.ToJSON()
 	if err != nil {
 		return err
 	}

--- a/internal/schemagen/writer_test.go
+++ b/internal/schemagen/writer_test.go
@@ -13,15 +13,15 @@ import (
 
 func TestWriteJSONSchema(t *testing.T) {
 	dir := t.TempDir()
-	md := &ConfigMetadata{
+	doc := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{
 		Schema: schemaVersion,
 		Type:   "object",
 		Properties: map[string]*ConfigMetadata{
 			"endpoint": {Type: "string"},
 		},
-	}
+	}}
 
-	err := WriteJSONSchema(dir, md)
+	err := WriteJSONSchema(dir, doc)
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(dir, fileName)) // #nosec G304
@@ -32,7 +32,7 @@ func TestWriteJSONSchema(t *testing.T) {
 
 func TestWriteJSONSchema_OmitsInternalResolvedFrom(t *testing.T) {
 	dir := t.TempDir()
-	md := &ConfigMetadata{
+	doc := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{
 		Schema:       schemaVersion,
 		Type:         "object",
 		ResolvedFrom: "go.opentelemetry.io/collector/config/confighttp.ClientConfig",
@@ -42,9 +42,9 @@ func TestWriteJSONSchema_OmitsInternalResolvedFrom(t *testing.T) {
 				ResolvedFrom: "string",
 			},
 		},
-	}
+	}}
 
-	err := WriteJSONSchema(dir, md)
+	err := WriteJSONSchema(dir, doc)
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(dir, fileName)) // #nosec G304
@@ -53,7 +53,29 @@ func TestWriteJSONSchema_OmitsInternalResolvedFrom(t *testing.T) {
 }
 
 func TestWriteJSONSchema_InvalidDir(t *testing.T) {
-	md := &ConfigMetadata{Type: "object"}
-	err := WriteJSONSchema("/nonexistent/path/that/does/not/exist", md)
+	doc := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{Type: "object"}}
+	err := WriteJSONSchema("/nonexistent/path/that/does/not/exist", doc)
 	require.Error(t, err)
+}
+
+func TestJSONSchemaDoc_EmitsDefs(t *testing.T) {
+	dir := t.TempDir()
+	doc := (&Metadata{
+		Config: &ConfigMetadata{Type: "object", Properties: map[string]*ConfigMetadata{
+			"endpoint": {Type: "string"},
+		}},
+		ExportedConfigs: map[string]*ConfigMetadata{
+			"sub_config": {Type: "object", Properties: map[string]*ConfigMetadata{
+				"port": {Type: "integer"},
+			}},
+		},
+	}).AsJSONSchema()
+
+	err := WriteJSONSchema(dir, doc)
+	require.NoError(t, err)
+	content, err := os.ReadFile(filepath.Join(dir, fileName)) // #nosec G304
+	require.NoError(t, err)
+	require.Contains(t, string(content), `"$defs"`)
+	require.Contains(t, string(content), `"sub_config"`)
+	require.Contains(t, string(content), `"port"`)
 }

--- a/internal/schemagen/writer_test.go
+++ b/internal/schemagen/writer_test.go
@@ -13,13 +13,13 @@ import (
 
 func TestWriteJSONSchema(t *testing.T) {
 	dir := t.TempDir()
-	doc := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{
+	doc := NewJSONSchemaDoc(&ConfigMetadata{
 		Schema: schemaVersion,
 		Type:   "object",
 		Properties: map[string]*ConfigMetadata{
 			"endpoint": {Type: "string"},
 		},
-	}}
+	})
 
 	err := WriteJSONSchema(dir, doc)
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestWriteJSONSchema(t *testing.T) {
 
 func TestWriteJSONSchema_OmitsInternalResolvedFrom(t *testing.T) {
 	dir := t.TempDir()
-	doc := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{
+	doc := NewJSONSchemaDoc(&ConfigMetadata{
 		Schema:       schemaVersion,
 		Type:         "object",
 		ResolvedFrom: "go.opentelemetry.io/collector/config/confighttp.ClientConfig",
@@ -42,7 +42,7 @@ func TestWriteJSONSchema_OmitsInternalResolvedFrom(t *testing.T) {
 				ResolvedFrom: "string",
 			},
 		},
-	}}
+	})
 
 	err := WriteJSONSchema(dir, doc)
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestWriteJSONSchema_OmitsInternalResolvedFrom(t *testing.T) {
 }
 
 func TestWriteJSONSchema_InvalidDir(t *testing.T) {
-	doc := &JSONSchemaDoc{ConfigMetadata: &ConfigMetadata{Type: "object"}}
+	doc := NewJSONSchemaDoc(&ConfigMetadata{Type: "object"})
 	err := WriteJSONSchema("/nonexistent/path/that/does/not/exist", doc)
 	require.Error(t, err)
 }


### PR DESCRIPTION
**Description:**

Option A from the open question on #15315: split the writer-side JSON Schema document from the source-side `ConfigMetadata` so `metadata.yaml` parsing and `config.schema.json` output no longer share one struct, and stop the `metadata.Config.Defs = metadata.ExportedConfigs` mutation in the loader.

What changed:

- `internal/schemagen` gains `JSONSchemaDoc`, a standalone writer-side type (it does not embed `ConfigMetadata`). It mirrors the full set of emittable JSON Schema keywords plus a top-level `$defs`, so a config root projects onto it without dropping any field. `ConfigMetadata.Defs` loses its `json:"$defs"` tag and is resolver-internal now, used only for nested-`$defs` ref lookup.
- `Loader.Load` returns `*Metadata` instead of `*ConfigMetadata`. The two call sites that did `metadata.Config.Defs = metadata.ExportedConfigs` are gone.
- `Resolver.Resolve(*Metadata) (*ConfigMetadata, error)` is the new entry point. It clones the source tree before resolving so resolution never writes back into the parsed metadata, merges `exported_configs` into the defs used for ref lookup (a node's own nested `$defs` win on name collisions), and returns the resolved root. The caller projects it to the document with `NewJSONSchemaDoc` and writes it. The deprecated `ResolveSchema(*ConfigMetadata)` wrapper has been removed.
- `WriteJSONSchema` takes `*JSONSchemaDoc`.
- `cmd/mdatagen` migrates to the new shape. `generateConfigFiles` no longer mutates `md.Config.Defs`; it builds the resolver input from `config` plus `exported_configs`, resolves, then projects and writes.

**Link to tracking issue:**
Fixes #15315

**Testing:**

- `internal/schemagen`: existing tests pass, plus coverage for the resolver clone (no source mutation), `$defs` precedence, and `NewJSONSchemaDoc` carrying root-level keywords (`default`, `examples`, `deprecated`, `enum`, `const`, and the scalar/array validation keywords).
- `cmd/mdatagen`: all subpackage tests pass.

**Documentation:**
No user-facing docs. Internal package refactor; the generated `config.schema.json` output is unchanged.