### PR TITLE
[chore] [internal/schemagen]: fix mdatagenDir

### DIFF
--- a/internal/schemagen/loader_test.go
+++ b/internal/schemagen/loader_test.go
@@ -601,5 +601,5 @@ func mdatagenDir(t *testing.T) string {
 	t.Helper()
 	_, file, _, ok := runtime.Caller(0)
 	require.True(t, ok, "could not determine caller file")
-	return filepath.Join(filepath.Dir(file), "../..")
+	return filepath.Join(filepath.Dir(file), "../../cmd/mdatagen")
 }


### PR DESCRIPTION
#### Description

Return the path to cmd/mdatagen, not the repo root, otherwise the schemagen tests resolve the wrong Go module and make the go.mod/go.sum files dirty.

#### Link to tracking issue

https://github.com/open-telemetry/opentelemetry-collector/pull/15352

#### Testing

Run the tests, verify that go.mod and go.sum aren't changed

#### Documentation

N/A