### PR TITLE
[chore] Avoid using pull_request_target on tidy-dependencies workflow

### DIFF
--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -1,6 +1,6 @@
 name: "Project: Tidy"
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
     branches:
       - main


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Switches to `pull_request` on the tidy dependencies workflow, see https://github.com/open-telemetry/opentelemetry-collector/pull/15356#discussion_r3298915964