### PR TITLE
[exporter/exporterhelper] Add otelcol_exporter_sent_bytes metric

### DIFF
--- a/.chloggen/add-exporter-sent-bytes-metric.yaml
+++ b/.chloggen/add-exporter-sent-bytes-metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporter/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `otelcol_exporter_sent_bytes` counter to track bytes successfully sent per exporter and signal type.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The counter includes `exporter` and `data_type` (traces/metrics/logs/profiles) attributes,
+  mirroring the granularity of the existing `exporter_sent_*` item-count metrics.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/documentation.md
+++ b/exporter/exporterhelper/documentation.md
@@ -110,6 +110,14 @@ Number of spans in failed attempts to send to destination. At detailed telemetry
 | ---- | ----------- | ---------- | --------- | --------- |
 | {span} | Sum | Int | true | Alpha |
 
+### otelcol_exporter_sent_bytes
+
+Number of bytes successfully sent to destination.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| By | Sum | Int | true | Alpha |
+
 ### otelcol_exporter_sent_log_records
 
 Number of log record successfully sent to destination.

--- a/exporter/exporterhelper/generated_package_test.go
+++ b/exporter/exporterhelper/generated_package_test.go
@@ -3,9 +3,8 @@
 package exporterhelper
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/exporter/exporterhelper/internal/metadata/generated_telemetry.go
+++ b/exporter/exporterhelper/internal/metadata/generated_telemetry.go
@@ -41,6 +41,7 @@ type TelemetryBuilder struct {
 	ExporterSendFailedMetricPoints      metric.Int64Counter
 	ExporterSendFailedProfileSamples    metric.Int64Counter
 	ExporterSendFailedSpans             metric.Int64Counter
+	ExporterSentBytes                   metric.Int64Counter
 	ExporterSentLogRecords              metric.Int64Counter
 	ExporterSentMetricPoints            metric.Int64Counter
 	ExporterSentProfileSamples          metric.Int64Counter
@@ -194,6 +195,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_exporter_send_failed_spans",
 		metric.WithDescription("Number of spans in failed attempts to send to destination. At detailed telemetry level, includes attributes: error.type (semantic convention), error.permanent. [Alpha]"),
 		metric.WithUnit("{span}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ExporterSentBytes, err = builder.meter.Int64Counter(
+		"otelcol_exporter_sent_bytes",
+		metric.WithDescription("Number of bytes successfully sent to destination. [Alpha]"),
+		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterSentLogRecords, err = builder.meter.Int64Counter(

--- a/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
-
-	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 func AssertEqualExporterEnqueueFailedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
@@ -210,6 +209,22 @@ func AssertEqualExporterSendFailedSpans(t *testing.T, tt *componenttest.Telemetr
 		},
 	}
 	got, err := tt.GetMetric("otelcol_exporter_send_failed_spans")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualExporterSentBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_exporter_sent_bytes",
+		Description: "Number of bytes successfully sent to destination. [Alpha]",
+		Unit:        "By",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_exporter_sent_bytes")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/exporterhelper/internal/metadatatest/generated_telemetrytest_test.go
@@ -39,6 +39,7 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ExporterSendFailedMetricPoints.Add(context.Background(), 1)
 	tb.ExporterSendFailedProfileSamples.Add(context.Background(), 1)
 	tb.ExporterSendFailedSpans.Add(context.Background(), 1)
+	tb.ExporterSentBytes.Add(context.Background(), 1)
 	tb.ExporterSentLogRecords.Add(context.Background(), 1)
 	tb.ExporterSentMetricPoints.Add(context.Background(), 1)
 	tb.ExporterSentProfileSamples.Add(context.Background(), 1)
@@ -80,6 +81,9 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterSendFailedSpans(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualExporterSentBytes(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterSentLogRecords(t, testTel,

--- a/exporter/exporterhelper/internal/obs_report_sender.go
+++ b/exporter/exporterhelper/internal/obs_report_sender.go
@@ -57,6 +57,7 @@ type obsReportSender[K request.Request] struct {
 	inFlightMetricAttr metric.MeasurementOption
 	itemsSentInst      metric.Int64Counter
 	itemsFailedInst    metric.Int64Counter
+	bytesSentInst      metric.Int64Counter
 	inFlightInst       metric.Int64UpDownCounter
 	next               sender.Sender[K]
 }
@@ -80,6 +81,7 @@ func newObsReportSender[K request.Request](set exporter.Settings, signal pipelin
 	}
 
 	or.inFlightInst = telemetryBuilder.ExporterInFlightRequests
+	or.bytesSentInst = telemetryBuilder.ExporterSentBytes
 
 	switch signal {
 	case pipeline.SignalTraces:
@@ -103,13 +105,14 @@ func newObsReportSender[K request.Request](set exporter.Settings, signal pipelin
 }
 
 func (ors *obsReportSender[K]) Send(ctx context.Context, req K) error {
-	// Have to read the number of items before sending the request since the request can
-	// be modified by the downstream components like the batcher.
+	// Have to read items and bytes before sending since the request can be
+	// modified by downstream components like the batcher.
 	c := ors.startOp(ctx)
 	items := req.ItemsCount()
+	bytes := req.BytesSize()
 	// Forward the data to the next consumer (this pusher is the next).
 	err := ors.next.Send(c, req)
-	ors.endOp(c, items, err)
+	ors.endOp(c, items, bytes, err)
 	return err
 }
 
@@ -127,8 +130,8 @@ func (ors *obsReportSender[K]) startOp(ctx context.Context) context.Context {
 	return ctx
 }
 
-// EndOp completes the export operation that was started with StartOp.
-func (ors *obsReportSender[K]) endOp(ctx context.Context, numRecords int, err error) {
+// endOp completes the export operation that was started with startOp.
+func (ors *obsReportSender[K]) endOp(ctx context.Context, numRecords int, numBytes int, err error) {
 	if ors.inFlightInst != nil {
 		ors.inFlightInst.Add(ctx, -1, ors.inFlightMetricAttr)
 	}
@@ -137,6 +140,10 @@ func (ors *obsReportSender[K]) endOp(ctx context.Context, numRecords int, err er
 
 	if ors.itemsSentInst != nil {
 		ors.itemsSentInst.Add(ctx, numSent, ors.metricAttr)
+	}
+
+	if err == nil && ors.bytesSentInst != nil {
+		ors.bytesSentInst.Add(ctx, int64(numBytes), ors.inFlightMetricAttr)
 	}
 
 	if ors.itemsFailedInst != nil && numFailedToSend > 0 {

--- a/exporter/exporterhelper/internal/obs_report_sender_test.go
+++ b/exporter/exporterhelper/internal/obs_report_sender_test.go
@@ -219,23 +219,25 @@ func TestExportTraceDataOp(t *testing.T) {
 	require.NoError(t, err)
 
 	params := []testParams{
-		{items: 22, err: nil},
-		{items: 14, err: errFake},
+		{items: 22, bytes: 220, err: nil},
+		{items: 14, bytes: 140, err: errFake},
 	}
 	for i := range params {
 		exporterErr = params[i].err
-		require.ErrorIs(t, obsrep.Send(parentCtx, &requesttest.FakeRequest{Items: params[i].items}), params[i].err)
+		require.ErrorIs(t, obsrep.Send(parentCtx, &requesttest.FakeRequest{Items: params[i].items, Bytes: params[i].bytes}), params[i].err)
 	}
 
 	spans := tt.SpanRecorder.Ended()
 	require.Len(t, spans, len(params))
 
 	var sentSpans, failedToSendSpans int
+	var sentBytes int
 	for i, span := range spans {
 		assert.Equal(t, "exporter/"+exporterID.String()+"/traces", span.Name())
 		switch {
 		case params[i].err == nil:
 			sentSpans += params[i].items
+			sentBytes += params[i].bytes
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: ItemsSent, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: ItemsFailed, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
@@ -256,6 +258,16 @@ func TestExportTraceDataOp(t *testing.T) {
 				Attributes: attribute.NewSet(
 					attribute.String("exporter", exporterID.String())),
 				Value: int64(sentSpans),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+	metadatatest.AssertEqualExporterSentBytes(t, tt,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", exporterID.String()),
+					attribute.String(DataTypeKey, "traces")),
+				Value: int64(sentBytes),
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
@@ -294,23 +306,25 @@ func TestExportMetricsOp(t *testing.T) {
 	require.NoError(t, err)
 
 	params := []testParams{
-		{items: 17, err: nil},
-		{items: 23, err: errFake},
+		{items: 17, bytes: 170, err: nil},
+		{items: 23, bytes: 230, err: errFake},
 	}
 	for i := range params {
 		exporterErr = params[i].err
-		require.ErrorIs(t, obsrep.Send(parentCtx, &requesttest.FakeRequest{Items: params[i].items}), params[i].err)
+		require.ErrorIs(t, obsrep.Send(parentCtx, &requesttest.FakeRequest{Items: params[i].items, Bytes: params[i].bytes}), params[i].err)
 	}
 
 	spans := tt.SpanRecorder.Ended()
 	require.Len(t, spans, len(params))
 
 	var sentMetricPoints, failedToSendMetricPoints int
+	var sentBytes int
 	for i, span := range spans {
 		assert.Equal(t, "exporter/"+exporterID.String()+"/metrics", span.Name())
 		switch {
 		case params[i].err == nil:
 			sentMetricPoints += params[i].items
+			sentBytes += params[i].bytes
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: ItemsSent, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: ItemsFailed, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
@@ -331,6 +345,16 @@ func TestExportMetricsOp(t *testing.T) {
 				Attributes: attribute.NewSet(
 					attribute.String("exporter", exporterID.String())),
 				Value: int64(sentMetricPoints),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+	metadatatest.AssertEqualExporterSentBytes(t, tt,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", exporterID.String()),
+					attribute.String(DataTypeKey, "metrics")),
+				Value: int64(sentBytes),
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
@@ -369,23 +393,25 @@ func TestExportLogsOp(t *testing.T) {
 	require.NoError(t, err)
 
 	params := []testParams{
-		{items: 17, err: nil},
-		{items: 23, err: errFake},
+		{items: 17, bytes: 170, err: nil},
+		{items: 23, bytes: 230, err: errFake},
 	}
 	for i := range params {
 		exporterErr = params[i].err
-		require.ErrorIs(t, obsrep.Send(parentCtx, &requesttest.FakeRequest{Items: params[i].items}), params[i].err)
+		require.ErrorIs(t, obsrep.Send(parentCtx, &requesttest.FakeRequest{Items: params[i].items, Bytes: params[i].bytes}), params[i].err)
 	}
 
 	spans := tt.SpanRecorder.Ended()
 	require.Len(t, spans, len(params))
 
 	var sentLogRecords, failedToSendLogRecords int
+	var sentBytes int
 	for i, span := range spans {
 		assert.Equal(t, "exporter/"+exporterID.String()+"/logs", span.Name())
 		switch {
 		case params[i].err == nil:
 			sentLogRecords += params[i].items
+			sentBytes += params[i].bytes
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: ItemsSent, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: ItemsFailed, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
@@ -406,6 +432,16 @@ func TestExportLogsOp(t *testing.T) {
 				Attributes: attribute.NewSet(
 					attribute.String("exporter", exporterID.String())),
 				Value: int64(sentLogRecords),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+	metadatatest.AssertEqualExporterSentBytes(t, tt,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", exporterID.String()),
+					attribute.String(DataTypeKey, "logs")),
+				Value: int64(sentBytes),
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
@@ -566,23 +602,25 @@ func TestExportProfilesOp(t *testing.T) {
 	require.NoError(t, err)
 
 	params := []testParams{
-		{items: 17, err: nil},
-		{items: 23, err: errFake},
+		{items: 17, bytes: 170, err: nil},
+		{items: 23, bytes: 230, err: errFake},
 	}
 	for i := range params {
 		exporterErr = params[i].err
-		require.ErrorIs(t, obsrep.Send(parentCtx, &requesttest.FakeRequest{Items: params[i].items}), params[i].err)
+		require.ErrorIs(t, obsrep.Send(parentCtx, &requesttest.FakeRequest{Items: params[i].items, Bytes: params[i].bytes}), params[i].err)
 	}
 
 	spans := tt.SpanRecorder.Ended()
 	require.Len(t, spans, len(params))
 
 	var sentProfileRecords, failedToSendProfileRecords int
+	var sentBytes int
 	for i, span := range spans {
 		assert.Equal(t, "exporter/"+exporterID.String()+"/profiles", span.Name())
 		switch {
 		case params[i].err == nil:
 			sentProfileRecords += params[i].items
+			sentBytes += params[i].bytes
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: ItemsSent, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: ItemsFailed, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
@@ -606,6 +644,16 @@ func TestExportProfilesOp(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
+	metadatatest.AssertEqualExporterSentBytes(t, tt,
+		[]metricdata.DataPoint[int64]{
+			{
+				Attributes: attribute.NewSet(
+					attribute.String("exporter", exporterID.String()),
+					attribute.String(DataTypeKey, "profiles")),
+				Value: int64(sentBytes),
+			},
+		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
 	var expectedDataPoints []metricdata.DataPoint[int64]
 	if failedToSendProfileRecords > 0 {
 		wantAttrs := attribute.NewSet(
@@ -626,5 +674,6 @@ func TestExportProfilesOp(t *testing.T) {
 
 type testParams struct {
 	items int
+	bytes int
 	err   error
 }

--- a/exporter/exporterhelper/metadata.yaml
+++ b/exporter/exporterhelper/metadata.yaml
@@ -170,6 +170,15 @@ telemetry:
         value_type: int
         monotonic: true
 
+    exporter_sent_bytes:
+      enabled: true
+      stability: alpha
+      description: Number of bytes successfully sent to destination.
+      unit: By
+      sum:
+        value_type: int
+        monotonic: true
+
     exporter_sent_log_records:
       enabled: true
       stability: alpha


### PR DESCRIPTION
## Description

This PR adds a new `otelcol_exporter_sent_bytes` counter metric to the `exporterhelper` package to track the number of bytes successfully sent to the destination per exporter.

## Motivation

The existing internal telemetry for exporters tracks item counts (`otelcol_exporter_sent_spans`, `otelcol_exporter_sent_metric_points`, `otelcol_exporter_sent_log_records`) but does not track bytes transferred. This makes it difficult to:
- Monitor data volume / egress throughput per exporter
- Detect serialization anomalies (e.g. unexpectedly large or small payloads)
- Capacity plan based on bytes rather than item counts

## Implementation

### Metric definition (`metadata.yaml`)
Added `exporter_sent_bytes` as an alpha-stability monotonic counter with unit `By`.

### Instrumentation (`obs_report_sender.go`)
- Added `bytesSentInst metric.Int64Counter` field to `obsReportSender`
- `Send()` captures `bytes := req.BytesSize()` before forwarding (same reason as items — request can be mutated by downstream components)
- Bytes are recorded **only on success** (`err == nil`), consistent with the all-or-nothing send semantics of the exporter pipeline

### Attributes
The metric carries `exporter` and `data_type` attributes (e.g. `traces`, `metrics`, `logs`, `profiles`), using the existing `inFlightMetricAttr` attribute set — mirroring the granularity of the in-flight requests metric.

### Generated files
The following files were regenerated via `mdatagen`:
- `internal/metadata/generated_telemetry.go`
- `internal/metadatatest/generated_telemetrytest.go`
- `internal/metadatatest/generated_telemetrytest_test.go`
- `documentation.md`
- `generated_package_test.go`

## Testing

Extended the existing signal-level tests (`TestExportTraceDataOp`, `TestExportMetricsOp`, `TestExportLogsOp`, `TestExportProfilesOp`) to:
- Pass `Bytes` values through `FakeRequest`
- Assert the `otelcol_exporter_sent_bytes` counter with the correct `exporter` + `data_type` attribute set
- Verify bytes are only counted on successful sends (not on error)

All tests pass: `go test ./exporter/exporterhelper/...`

## Changelog

Added `.chloggen/add-exporter-sent-bytes-metric.yaml`.