### PR TITLE
[chore] [cmd/mdatagen] replace deprecated strings.Title

### DIFF
--- a/cmd/mdatagen/internal/helpers/lint.go
+++ b/cmd/mdatagen/internal/helpers/lint.go
@@ -16,10 +16,16 @@ func FormatIdentifier(s string, exported bool) (string, error) {
 	if s == "" {
 		return "", errors.New("string cannot be empty")
 	}
-	// Convert various characters to . for strings.Title to operate on.
+	// Convert various characters to . to use as word separator for capitalization.
 	replace := strings.NewReplacer("_", ".", "-", ".", "<", ".", ">", ".", "/", ".", ":", ".")
 	str := replace.Replace(s)
-	str = strings.Title(str) //nolint:staticcheck // SA1019
+	parts := strings.Split(str, ".")
+	for i, part := range parts {
+		if len(part) > 0 {
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+	}
+	str = strings.Join(parts, ".")
 	str = strings.ReplaceAll(str, ".", "")
 
 	var word string

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -542,7 +542,8 @@ func (mvt *ValueType) UnmarshalText(text []byte) error {
 
 // String returns capitalized name of the ValueType.
 func (mvt ValueType) String() string {
-	return strings.Title(strings.ToLower(mvt.ValueType.String())) //nolint:staticcheck // SA1019
+	s := strings.ToLower(mvt.ValueType.String())
+	return strings.ToUpper(s[:1]) + s[1:]
 }
 
 // Primitive returns name of primitive type for the ValueType.


### PR DESCRIPTION
`strings.Title` has been deprecated since Go 1.18 (SA1019). Two spots in `cmd/mdatagen` were suppressing the warning with `//nolint:staticcheck` comments.

The direct replacement (`golang.org/x/text/cases.Title`) can't be dropped in here bc `cases.Title(language.English)` doesnt treat `.` as a word boundary, so `"max.cpu"` gives `"Max.cpu"` instead of the expected `"Max.Cpu"`. Verified with a quick test:

```
max.cpu:  strings.Title="Max.Cpu"  cases.Title="Max.cpu"  DIFF
cpu.state: strings.Title="Cpu.State" cases.Title="Cpu.state" DIFF
```

Fix is to split on `.`, capitalize each part's first byte, join back - same behavior, no new deps (the `strings` pkg is already imported in both files).

**helpers/lint.go** - `FormatIdentifier` uses `.` as a word separator to title-case identifier parts before stripping dots.

**metadata.go** - `ValueType.String()` just needs the first letter upcased on a simple lowercase word like `"string"` or `"int"`.

All existing tests pass.