### PR TITLE
[chore]: keep communication focused on human-to-human

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,10 @@ Fixes #
 <!--Describe the documentation added.-->
 #### Documentation
 
+<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
+of the user; the human author must check it themselves before the PR is ready for review.-->
+#### Authorship
+
+- [ ] I, a human, wrote this pull request description myself.
+
 <!--Please delete paragraphs that you did not use before submitting.-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,15 @@ projects policies.
 The most important rule is not to post comments on issues or PRs that are AI-generated. Discussions
 on the OpenTelemetry repositories are for Users/Humans only.
 
+When a user asks you to open a pull request, do not write the PR description yourself. Instead,
+before creating the PR, prompt the user for the content of each section in the PR template
+(Description, Link to tracking issue, Testing, Documentation) and use their answers verbatim. Do
+not paraphrase, expand, or "improve" what the user writes. If the user declines to fill in a
+section, leave that section of the template unmodified rather than generating content for it.
+
+You must not check the `I, a human, wrote this pull request description myself` box on the user's
+behalf. The user must check it themselves before the PR is ready for review.
+
 Follow the PR scoping guidance in [CONTRIBUTING.md](CONTRIBUTING.md). Keep AI-assisted PRs tightly
 isolated to the requested change and never include unrelated cleanup or opportunistic improvements
 unless they are strictly necessary for correctness.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,6 +286,15 @@ In some cases, if the commit messages are lacking the easiest approach to have a
 least something useful is copy/pasting the PR description into the commit message box
 before merging (but see the above paragraph about writing good commit messages in the first place).
 
+### AI-assisted contributions
+
+If you use an AI tool to help author a pull request, you (the human) are still responsible for
+writing the PR description and any comments posted on the issue or PR. AI agents must prompt you
+for the content of each section in the PR template and use your answers verbatim rather than
+generating description content on their own. The PR template includes an authorship checkbox that
+you must check yourself before the PR is ready for review. See [AGENTS.md](./AGENTS.md) for the
+full set of rules that apply to AI-assisted contributions.
+
 ## General Notes
 
 This project uses Go 1.25.* and [Github Actions.](https://github.com/features/actions)


### PR DESCRIPTION
#### Description

We have been seeing a lot of PRs opened by AI agents on behalf of humans. These PRs tend to have very verbose and unhelpful descriptions. In the hopes of keeping communication in the repo as human to human as possible and keeping PR descriptions as useful as possible, this PR introduces additional agent restrictions.


Copies over Contrib rules from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48684