### PR TITLE
[cmd/mdatagen] Add stability field to resource attributes

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for defining stability levels for resource attributes
+
+# One or more tracking issues or pull requests related to the change
+issues: [15312]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -132,6 +132,7 @@ func TestLoadMetadata(t *testing.T) {
 						},
 						FullName:         "optional.resource.attr",
 						RequirementLevel: AttributeRequirementLevelRecommended,
+						Stability:        component.StabilityLevelDevelopment,
 					},
 					"slice.resource.attr": {
 						Description: "Resource attribute with a slice value.",
@@ -141,6 +142,7 @@ func TestLoadMetadata(t *testing.T) {
 						},
 						FullName:         "slice.resource.attr",
 						RequirementLevel: AttributeRequirementLevelRecommended,
+						Stability:        component.StabilityLevelDevelopment,
 					},
 					"map.resource.attr": {
 						Description: "Resource attribute with a map value.",
@@ -150,6 +152,7 @@ func TestLoadMetadata(t *testing.T) {
 						},
 						FullName:         "map.resource.attr",
 						RequirementLevel: AttributeRequirementLevelRecommended,
+						Stability:        component.StabilityLevelDevelopment,
 					},
 					"string.resource.attr_disable_warning": {
 						Description: "Resource attribute with any string value.",

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -641,6 +641,8 @@ type Attribute struct {
 	RequirementLevel AttributeRequirementLevel `mapstructure:"requirement_level"`
 	// The semantic convention reference of the attribute.
 	SemanticConvention *SemanticConvention `mapstructure:"semantic_convention"`
+	// Stability is the stability level of the resource attribute.
+	Stability component.StabilityLevel `mapstructure:"stability"`
 }
 
 // IsConditional returns true if the attribute is conditionally required.

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -76,6 +76,14 @@ func TestValidate(t *testing.T) {
 			wantErr: "empty type for resource attribute: string.resource.attr",
 		},
 		{
+			name:    "testdata/rattr_stability_valid.yaml",
+			wantErr: "",
+		},
+		{
+			name:    "testdata/invalid_rattr_stability.yaml",
+			wantErr: `unsupported stability level: "test42"`,
+		},
+		{
 			name:    "testdata/no_metric_description.yaml",
 			wantErr: "metric \"default.metric\": missing metric description",
 		},

--- a/cmd/mdatagen/internal/sampleconnector/documentation.md
+++ b/cmd/mdatagen/internal/sampleconnector/documentation.md
@@ -124,16 +124,16 @@ metrics:
 
 ## Resource Attributes
 
-| Name | Description | Values | Enabled | Semantic Convention |
-| ---- | ----------- | ------ | ------- | ------------------- |
-| map.resource.attr | Resource attribute with a map value. | Any Map | true | - |
-| optional.resource.attr | Explicitly disabled ResourceAttribute. | Any Str | false | - |
-| slice.resource.attr | Resource attribute with a slice value. | Any Slice | true | - |
-| string.enum.resource.attr | Resource attribute with a known set of string values. | Str: ``one``, ``two`` | true | - |
-| string.resource.attr | Resource attribute with any string value. | Any Str | true | - |
-| string.resource.attr_disable_warning | Resource attribute with any string value. | Any Str | true | - |
-| string.resource.attr_remove_warning | Resource attribute with any string value. | Any Str | false | - |
-| string.resource.attr_to_be_removed | Resource attribute with any string value. | Any Str | true | - |
+| Name | Description | Values | Enabled | Semantic Convention | Stability |
+| ---- | ----------- | ------ | ------- | ------------------- | --------- |
+| map.resource.attr | Resource attribute with a map value. | Any Map | true | - | - |
+| optional.resource.attr | Explicitly disabled ResourceAttribute. | Any Str | false | - | - |
+| slice.resource.attr | Resource attribute with a slice value. | Any Slice | true | - | - |
+| string.enum.resource.attr | Resource attribute with a known set of string values. | Str: ``one``, ``two`` | true | - | - |
+| string.resource.attr | Resource attribute with any string value. | Any Str | true | - | - |
+| string.resource.attr_disable_warning | Resource attribute with any string value. | Any Str | true | - | - |
+| string.resource.attr_remove_warning | Resource attribute with any string value. | Any Str | false | - | - |
+| string.resource.attr_to_be_removed | Resource attribute with any string value. | Any Str | true | - | - |
 
 ## Entities
 

--- a/cmd/mdatagen/internal/sampleentityreceiver/documentation.md
+++ b/cmd/mdatagen/internal/sampleentityreceiver/documentation.md
@@ -44,13 +44,13 @@ Number of desired replicas
 
 ## Resource Attributes
 
-| Name | Description | Values | Enabled | Semantic Convention |
-| ---- | ----------- | ------ | ------- | ------------------- |
-| k8s.namespace.name | The name of the Kubernetes Namespace | Any Str | true | - |
-| k8s.pod.name | The name of the Kubernetes Pod | Any Str | true | - |
-| k8s.pod.uid | The UID of the Kubernetes Pod | Any Str | true | - |
-| k8s.replicaset.name | The name of the Kubernetes ReplicaSet | Any Str | true | - |
-| k8s.replicaset.uid | The UID of the Kubernetes ReplicaSet | Any Str | true | - |
+| Name | Description | Values | Enabled | Semantic Convention | Stability |
+| ---- | ----------- | ------ | ------- | ------------------- | --------- |
+| k8s.namespace.name | The name of the Kubernetes Namespace | Any Str | true | - | - |
+| k8s.pod.name | The name of the Kubernetes Pod | Any Str | true | - | - |
+| k8s.pod.uid | The UID of the Kubernetes Pod | Any Str | true | - | - |
+| k8s.replicaset.name | The name of the Kubernetes ReplicaSet | Any Str | true | - | - |
+| k8s.replicaset.uid | The UID of the Kubernetes ReplicaSet | Any Str | true | - | - |
 
 ## Entities
 

--- a/cmd/mdatagen/internal/sampleprocessor/documentation.md
+++ b/cmd/mdatagen/internal/sampleprocessor/documentation.md
@@ -4,13 +4,13 @@
 
 ## Resource Attributes
 
-| Name | Description | Values | Enabled | Semantic Convention |
-| ---- | ----------- | ------ | ------- | ------------------- |
-| map.resource.attr | Resource attribute with a map value. | Any Map | true | - |
-| optional.resource.attr | Explicitly disabled ResourceAttribute. | Any Str | false | - |
-| slice.resource.attr | Resource attribute with a slice value. | Any Slice | true | - |
-| string.enum.resource.attr | Resource attribute with a known set of string values. | Str: ``one``, ``two`` | true | - |
-| string.resource.attr | Resource attribute with any string value. | Any Str | true | - |
-| string.resource.attr_disable_warning | Resource attribute with any string value. | Any Str | true | - |
-| string.resource.attr_remove_warning | Resource attribute with any string value. | Any Str | false | - |
-| string.resource.attr_to_be_removed | Resource attribute with any string value. | Any Str | true | - |
+| Name | Description | Values | Enabled | Semantic Convention | Stability |
+| ---- | ----------- | ------ | ------- | ------------------- | --------- |
+| map.resource.attr | Resource attribute with a map value. | Any Map | true | - | - |
+| optional.resource.attr | Explicitly disabled ResourceAttribute. | Any Str | false | - | - |
+| slice.resource.attr | Resource attribute with a slice value. | Any Slice | true | - | - |
+| string.enum.resource.attr | Resource attribute with a known set of string values. | Str: ``one``, ``two`` | true | - | - |
+| string.resource.attr | Resource attribute with any string value. | Any Str | true | - | - |
+| string.resource.attr_disable_warning | Resource attribute with any string value. | Any Str | true | - | - |
+| string.resource.attr_remove_warning | Resource attribute with any string value. | Any Str | false | - | - |
+| string.resource.attr_to_be_removed | Resource attribute with any string value. | Any Str | true | - | - |

--- a/cmd/mdatagen/internal/samplereceiver/documentation.md
+++ b/cmd/mdatagen/internal/samplereceiver/documentation.md
@@ -244,17 +244,17 @@ The event will be renamed soon.
 
 ## Resource Attributes
 
-| Name | Description | Values | Enabled | Semantic Convention |
-| ---- | ----------- | ------ | ------- | ------------------- |
-| map.resource.attr | Resource attribute with a map value. | Any Map | true | - |
-| optional.resource.attr | Explicitly disabled ResourceAttribute. | Any Str | false | - |
-| slice.resource.attr | Resource attribute with a slice value. | Any Slice | true | - |
-| string.enum.resource.attr | Resource attribute with a known set of string values. | Str: ``one``, ``two`` | true | - |
-| string.resource.attr | Resource attribute with any string value. | Any Str | true | - |
-| string.resource.attr_disable_warning | Resource attribute with any string value. | Any Str | true | - |
-| string.resource.attr_remove_warning | Resource attribute with any string value. | Any Str | false | - |
-| string.resource.attr_to_be_removed | Resource attribute with any string value. | Any Str | true | - |
-| string.resource.disabled_attr_to_be_removed | Resource attribute with any string value. | Any Str | false | - |
+| Name | Description | Values | Enabled | Semantic Convention | Stability |
+| ---- | ----------- | ------ | ------- | ------------------- | --------- |
+| map.resource.attr | Resource attribute with a map value. | Any Map | true | - | Development |
+| optional.resource.attr | Explicitly disabled ResourceAttribute. | Any Str | false | - | Development |
+| slice.resource.attr | Resource attribute with a slice value. | Any Slice | true | - | Development |
+| string.enum.resource.attr | Resource attribute with a known set of string values. | Str: ``one``, ``two`` | true | - | - |
+| string.resource.attr | Resource attribute with any string value. | Any Str | true | - | - |
+| string.resource.attr_disable_warning | Resource attribute with any string value. | Any Str | true | - | - |
+| string.resource.attr_remove_warning | Resource attribute with any string value. | Any Str | false | - | - |
+| string.resource.attr_to_be_removed | Resource attribute with any string value. | Any Str | true | - | - |
+| string.resource.disabled_attr_to_be_removed | Resource attribute with any string value. | Any Str | false | - | - |
 
 ## Internal Telemetry
 

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -62,16 +62,19 @@ resource_attributes:
     description: Resource attribute with a map value.
     type: map
     enabled: true
+    stability: development
 
   optional.resource.attr:
     description: Explicitly disabled ResourceAttribute.
     type: string
     enabled: false
+    stability: development
 
   slice.resource.attr:
     description: Resource attribute with a slice value.
     type: slice
     enabled: true
+    stability: development
 
   string.enum.resource.attr:
     description: Resource attribute with a known set of string values.

--- a/cmd/mdatagen/internal/samplescraper/documentation.md
+++ b/cmd/mdatagen/internal/samplescraper/documentation.md
@@ -134,13 +134,13 @@ metrics:
 
 ## Resource Attributes
 
-| Name | Description | Values | Enabled | Semantic Convention |
-| ---- | ----------- | ------ | ------- | ------------------- |
-| map.resource.attr | Resource attribute with a map value. | Any Map | true | - |
-| optional.resource.attr | Explicitly disabled ResourceAttribute. | Any Str | false | - |
-| slice.resource.attr | Resource attribute with a slice value. | Any Slice | true | - |
-| string.enum.resource.attr | Resource attribute with a known set of string values. | Str: ``one``, ``two`` | true | - |
-| string.resource.attr | Resource attribute with any string value. | Any Str | true | - |
-| string.resource.attr_disable_warning | Resource attribute with any string value. | Any Str | true | - |
-| string.resource.attr_remove_warning | Resource attribute with any string value. | Any Str | false | - |
-| string.resource.attr_to_be_removed | Resource attribute with any string value. | Any Str | true | - |
+| Name | Description | Values | Enabled | Semantic Convention | Stability |
+| ---- | ----------- | ------ | ------- | ------------------- | --------- |
+| map.resource.attr | Resource attribute with a map value. | Any Map | true | - | - |
+| optional.resource.attr | Explicitly disabled ResourceAttribute. | Any Str | false | - | - |
+| slice.resource.attr | Resource attribute with a slice value. | Any Slice | true | - | - |
+| string.enum.resource.attr | Resource attribute with a known set of string values. | Str: ``one``, ``two`` | true | - | - |
+| string.resource.attr | Resource attribute with any string value. | Any Str | true | - | - |
+| string.resource.attr_disable_warning | Resource attribute with any string value. | Any Str | true | - | - |
+| string.resource.attr_remove_warning | Resource attribute with any string value. | Any Str | false | - | - |
+| string.resource.attr_to_be_removed | Resource attribute with any string value. | Any Str | true | - | - |

--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -238,11 +238,11 @@ events:
 
 ## Resource Attributes
 
-| Name | Description | Values | Enabled | Semantic Convention |
-| ---- | ----------- | ------ | ------- | ------------------- |
+| Name | Description | Values | Enabled | Semantic Convention | Stability |
+| ---- | ----------- | ------ | ------- | ------------------- | --------- |
 {{- range $attributeName, $attribute := .ResourceAttributes }}
 | {{ $attributeName }} | {{ $attribute.Description }} |
-{{- if $attribute.Enum }} {{ $attribute.Type }}: ``{{ stringsJoin $attribute.Enum "``, ``" }}``{{ else }} Any {{ $attribute.Type }}{{ end }} | {{ $attribute.Enabled }} |{{ if $attribute.SemanticConvention }} [{{ $attributeName }}]({{ $attribute.SemanticConvention.SemanticConventionRef }}) |{{ else }} - |{{ end }}
+{{- if $attribute.Enum }} {{ $attribute.Type }}: ``{{ stringsJoin $attribute.Enum "``, ``" }}``{{ else }} Any {{ $attribute.Type }}{{ end }} | {{ $attribute.Enabled }} |{{ if $attribute.SemanticConvention }} [{{ $attributeName }}]({{ $attribute.SemanticConvention.SemanticConventionRef }}) |{{ else }} - |{{ end }}{{ if $attribute.Stability }} {{ $attribute.Stability }} |{{ else }} - |{{ end }}
 {{- end }}
 
 {{- end }}

--- a/cmd/mdatagen/internal/testdata/invalid_rattr_stability.yaml
+++ b/cmd/mdatagen/internal/testdata/invalid_rattr_stability.yaml
@@ -1,0 +1,18 @@
+type: metricreceiver
+
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+  distributions: [contrib]
+  warnings:
+    - Any additional information that should be brought to the consumer's attention
+
+resource_attributes:
+  default.attribute:
+    enabled: true
+    description: Unique host identifier
+    type: string
+    stability: test42

--- a/cmd/mdatagen/internal/testdata/rattr_stability_valid.yaml
+++ b/cmd/mdatagen/internal/testdata/rattr_stability_valid.yaml
@@ -1,0 +1,14 @@
+type: file
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+
+resource_attributes:
+  string.resource.attr:
+    description: Unique host identifier
+    type: string
+    enabled: true
+    stability: beta

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -168,6 +168,8 @@ resource_attributes:
     enum: [string]
     # Required: attribute value type.
     type: <string|int|double|bool|bytes|slice|map>
+    # Optional: the stability level of the resource attribute.
+    stability: <development|alpha|beta|release_candidate|stable>
     # Optional: warnings that will be shown to user under specified conditions.
     warnings:
       # A warning that will be displayed if the resource_attribute is enabled in user config.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds support for defining stability levels for resource attributes in `cmd/mdatagen`.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15312

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added cmd/mdatagen/internal/testdata/invalid_rattr_stability.yaml as a test fixture
- Added a test case in metadata_test.go that verifies an invalid stability value produces the correct error
- Ran go test ./internal/... and all tests passed

<!--Describe the documentation added.-->
#### Documentation
- Added stability under resource attributes in metadata-schema.yaml

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->