### PR TITLE
[chore] Persist credentials on tidying job

### DIFF
--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -18,7 +18,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
-          persist-credentials: false
+          # Keep token so the `go mod tidy` step can push.
+          persist-credentials: true # zizmor: ignore[artipacked]
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: oldstable


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Reverts `persist-credentials` to `true` on this job to see if that fixes issues seen on Dependabot PRs such as #15374 

<!-- Issue number if applicable -->
#### Link to tracking issue
Partial revert of #15356

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
