### PR TITLE
[cmd/mdatagen] Remove reaggregation feature gate

### DIFF
--- a/.chloggen/remove-mdatagen-reaggregation-gate.yaml
+++ b/.chloggen/remove-mdatagen-reaggregation-gate.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the `reaggregation_enabled` metadata setting and always generate per-metric reaggregation config.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15305]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/remove-mdatagen-reaggregation-gate.yaml
+++ b/.chloggen/remove-mdatagen-reaggregation-gate.yaml
@@ -15,7 +15,7 @@ issues: [15305]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: Legacy metadata files that still contain `reaggregation_enabled` are accepted, but the value is ignored.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/cmd/mdatagen/README.md
+++ b/cmd/mdatagen/README.md
@@ -142,9 +142,8 @@ This lets users:
 
 ### Metric Reaggregation Configuration
 
-By default, `mdatagen` lets users reduce metric cardinality by dropping selected metric
-attributes and aggregating the resulting datapoints. Set `reaggregation_enabled: false`
-to generate metric config with only the `enabled` field.
+`mdatagen` lets users reduce metric cardinality by dropping selected metric attributes
+and aggregating the resulting datapoints.
 
 ```yaml
 attributes:

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -53,6 +53,7 @@ func LoadMetadata(filePath string) (Metadata, error) {
 	if err != nil {
 		return Metadata{}, err
 	}
+	conf.Delete("reaggregation_enabled")
 
 	md := Metadata{
 		ShortFolderName: shortFolderName(filePath),

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -55,9 +55,8 @@ func LoadMetadata(filePath string) (Metadata, error) {
 	}
 
 	md := Metadata{
-		ShortFolderName:      shortFolderName(filePath),
-		ReaggregationEnabled: true,
-		Tests:                Tests{Host: "newMdatagenNopHost()"},
+		ShortFolderName: shortFolderName(filePath),
+		Tests:           Tests{Host: "newMdatagenNopHost()"},
 	}
 	err = conf.Unmarshal(&md)
 	if err != nil {

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -640,6 +640,24 @@ func TestLoadMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "testdata/reaggregation_disabled.yaml",
+			want: Metadata{
+				Type:                       "test",
+				GeneratedPackageName:       "metadata",
+				ScopeName:                  "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
+				PackageName:                "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
+				ShortFolderName:            "testdata",
+				LegacyReaggregationEnabled: boolPtr(false),
+				Tests:                      Tests{Host: "newMdatagenNopHost()"},
+				Status: &Status{
+					Class: "receiver",
+					Stability: map[component.StabilityLevel][]string{
+						component.StabilityLevelBeta: {"logs"},
+					},
+				},
+			},
+		},
+		{
 			name:    "testdata/invalid_type_rattr.yaml",
 			want:    Metadata{},
 			wantErr: "decoding failed due to the following error(s):\n\n'resource_attributes[string.resource.attr].type' invalid type: \"invalidtype\"",

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -642,13 +642,12 @@ func TestLoadMetadata(t *testing.T) {
 		{
 			name: "testdata/reaggregation_disabled.yaml",
 			want: Metadata{
-				Type:                       "test",
-				GeneratedPackageName:       "metadata",
-				ScopeName:                  "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
-				PackageName:                "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
-				ShortFolderName:            "testdata",
-				LegacyReaggregationEnabled: boolPtr(false),
-				Tests:                      Tests{Host: "newMdatagenNopHost()"},
+				Type:                 "test",
+				GeneratedPackageName: "metadata",
+				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
+				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
+				ShortFolderName:      "testdata",
+				Tests:                Tests{Host: "newMdatagenNopHost()"},
 				Status: &Status{
 					Class: "receiver",
 					Stability: map[component.StabilityLevel][]string{
@@ -797,7 +796,6 @@ func TestLoadMetadata(t *testing.T) {
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				ShortFolderName:      "testdata",
 				Tests:                Tests{Host: "newMdatagenNopHost()"},
-				ReaggregationEnabled: true,
 				Status: &Status{
 					Class: "receiver",
 					Stability: map[component.StabilityLevel][]string{

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -52,7 +52,6 @@ func TestLoadMetadata(t *testing.T) {
 				Description:          "This receiver is used for testing purposes to check the output of mdatagen.",
 				SemConvVersion:       "1.40.0",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplereceiver",
-				ReaggregationEnabled: true,
 				OverrideValueEnabled: true,
 				Status: &Status{
 					DisableCodeCov: true,
@@ -601,7 +600,6 @@ func TestLoadMetadata(t *testing.T) {
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				ShortFolderName:      "testdata",
-				ReaggregationEnabled: true,
 				Tests:                Tests{Host: "newMdatagenNopHost()"},
 			},
 		},
@@ -613,7 +611,6 @@ func TestLoadMetadata(t *testing.T) {
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				ShortFolderName:      "testdata",
-				ReaggregationEnabled: true,
 				Tests:                Tests{Host: "newMdatagenNopHost()"},
 				Status: &Status{
 					Class: "receiver",
@@ -633,25 +630,6 @@ func TestLoadMetadata(t *testing.T) {
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				ShortFolderName:      "testdata",
-				ReaggregationEnabled: true,
-				Tests:                Tests{Host: "newMdatagenNopHost()"},
-				Status: &Status{
-					Class: "receiver",
-					Stability: map[component.StabilityLevel][]string{
-						component.StabilityLevelBeta: {"logs"},
-					},
-				},
-			},
-		},
-		{
-			name: "testdata/reaggregation_disabled.yaml",
-			want: Metadata{
-				Type:                 "test",
-				GeneratedPackageName: "metadata",
-				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
-				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
-				ShortFolderName:      "testdata",
-				ReaggregationEnabled: false,
 				Tests:                Tests{Host: "newMdatagenNopHost()"},
 				Status: &Status{
 					Class: "receiver",
@@ -744,7 +722,6 @@ func TestLoadMetadata(t *testing.T) {
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				ShortFolderName:      "testdata",
-				ReaggregationEnabled: true,
 				Tests:                Tests{Host: "newMdatagenNopHost()"},
 				Status: &Status{
 					Class: "receiver",
@@ -763,7 +740,6 @@ func TestLoadMetadata(t *testing.T) {
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				ShortFolderName:      "testdata",
-				ReaggregationEnabled: true,
 				Tests:                Tests{Host: "newMdatagenNopHost()"},
 				Status: &Status{
 					Class: "receiver",
@@ -783,7 +759,6 @@ func TestLoadMetadata(t *testing.T) {
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				ShortFolderName:      "testdata",
-				ReaggregationEnabled: true,
 				Tests:                Tests{Host: "newMdatagenNopHost()"},
 				Status: &Status{
 					Class: "receiver",
@@ -822,7 +797,6 @@ func TestLoadMetadata(t *testing.T) {
 				ScopeName:            "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				PackageName:          "go.opentelemetry.io/collector/cmd/mdatagen/internal/testdata",
 				ShortFolderName:      "testdata",
-				ReaggregationEnabled: true,
 				Tests:                Tests{Host: "newMdatagenNopHost()"},
 				Status: &Status{
 					Class: "receiver",

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -38,8 +38,6 @@ type Metadata struct {
 	Parent string `mapstructure:"parent"`
 	// Status information for the component.
 	Status *Status `mapstructure:"status"`
-	// Deprecated: reaggregation_enabled is accepted for compatibility and ignored.
-	LegacyReaggregationEnabled *bool `mapstructure:"reaggregation_enabled"`
 	// Override value featuregate for resource attributes.
 	OverrideValueEnabled bool `mapstructure:"override_value_enabled"`
 	// The name of the package that will be generated.

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -38,6 +38,8 @@ type Metadata struct {
 	Parent string `mapstructure:"parent"`
 	// Status information for the component.
 	Status *Status `mapstructure:"status"`
+	// Deprecated: reaggregation_enabled is accepted for compatibility and ignored.
+	LegacyReaggregationEnabled *bool `mapstructure:"reaggregation_enabled"`
 	// Override value featuregate for resource attributes.
 	OverrideValueEnabled bool `mapstructure:"override_value_enabled"`
 	// The name of the package that will be generated.

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -38,8 +38,6 @@ type Metadata struct {
 	Parent string `mapstructure:"parent"`
 	// Status information for the component.
 	Status *Status `mapstructure:"status"`
-	// ReaggregationEnabled enables spatial re-aggregation configuration generation. Defaults to true.
-	ReaggregationEnabled bool `mapstructure:"reaggregation_enabled"`
 	// Override value featuregate for resource attributes.
 	OverrideValueEnabled bool `mapstructure:"override_value_enabled"`
 	// The name of the package that will be generated.

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config.go
@@ -3,18 +3,88 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// K8sPodCPUTimeMetricConfig provides config for the k8s.pod.cpu_time metric.
+type K8sPodCPUTimeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *K8sPodCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodPhaseMetricAttributeKey specifies the key of an attribute for the k8s.pod.phase metric.
+type K8sPodPhaseMetricAttributeKey string
+
+const (
+	K8sPodPhaseMetricAttributeKeyPhase K8sPodPhaseMetricAttributeKey = "phase"
+)
+
+// K8sPodPhaseMetricConfig provides config for the k8s.pod.phase metric.
+type K8sPodPhaseMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                          `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []K8sPodPhaseMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *K8sPodPhaseMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *K8sPodPhaseMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case K8sPodPhaseMetricAttributeKeyPhase:
+		default:
+			return fmt.Errorf("metric k8s.pod.phase doesn't have an attribute %v, valid attributes: [phase]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// K8sReplicasetDesiredMetricConfig provides config for the k8s.replicaset.desired metric.
+type K8sReplicasetDesiredMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sReplicasetDesiredMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -30,20 +100,22 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for sampleentity metrics.
 type MetricsConfig struct {
-	K8sPodCPUTime        MetricConfig `mapstructure:"k8s.pod.cpu_time"`
-	K8sPodPhase          MetricConfig `mapstructure:"k8s.pod.phase"`
-	K8sReplicasetDesired MetricConfig `mapstructure:"k8s.replicaset.desired"`
+	K8sPodCPUTime        K8sPodCPUTimeMetricConfig        `mapstructure:"k8s.pod.cpu_time"`
+	K8sPodPhase          K8sPodPhaseMetricConfig          `mapstructure:"k8s.pod.phase"`
+	K8sReplicasetDesired K8sReplicasetDesiredMetricConfig `mapstructure:"k8s.replicaset.desired"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		K8sPodCPUTime: MetricConfig{
+		K8sPodCPUTime: K8sPodCPUTimeMetricConfig{
 			Enabled: true,
 		},
-		K8sPodPhase: MetricConfig{
-			Enabled: true,
+		K8sPodPhase: K8sPodPhaseMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []K8sPodPhaseMetricAttributeKey{K8sPodPhaseMetricAttributeKeyPhase},
 		},
-		K8sReplicasetDesired: MetricConfig{
+		K8sReplicasetDesired: K8sReplicasetDesiredMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config_test.go
@@ -28,13 +28,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					K8sPodCPUTime: MetricConfig{
+					K8sPodCPUTime: K8sPodCPUTimeMetricConfig{
 						Enabled: true,
 					},
-					K8sPodPhase: MetricConfig{
-						Enabled: true,
+					K8sPodPhase: K8sPodPhaseMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []K8sPodPhaseMetricAttributeKey{K8sPodPhaseMetricAttributeKeyPhase},
 					},
-					K8sReplicasetDesired: MetricConfig{
+					K8sReplicasetDesired: K8sReplicasetDesiredMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -51,13 +53,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					K8sPodCPUTime: MetricConfig{
+					K8sPodCPUTime: K8sPodCPUTimeMetricConfig{
 						Enabled: false,
 					},
-					K8sPodPhase: MetricConfig{
-						Enabled: false,
+					K8sPodPhase: K8sPodPhaseMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []K8sPodPhaseMetricAttributeKey{K8sPodPhaseMetricAttributeKeyPhase},
 					},
-					K8sReplicasetDesired: MetricConfig{
+					K8sReplicasetDesired: K8sReplicasetDesiredMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -74,7 +78,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, K8sNamespaceNameResourceAttributeConfig{}, K8sPodNameResourceAttributeConfig{}, K8sPodUIDResourceAttributeConfig{}, K8sReplicasetNameResourceAttributeConfig{}, K8sReplicasetUIDResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(K8sPodCPUTimeMetricConfig{}, K8sPodPhaseMetricConfig{}, K8sReplicasetDesiredMetricConfig{}, K8sNamespaceNameResourceAttributeConfig{}, K8sPodNameResourceAttributeConfig{}, K8sPodUIDResourceAttributeConfig{}, K8sReplicasetNameResourceAttributeConfig{}, K8sReplicasetUIDResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config_test.go
@@ -84,6 +84,18 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	}
 }
 
+func TestK8sPodPhaseMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().K8sPodPhase
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []K8sPodPhaseMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric k8s.pod.phase doesn't have an attribute invalid, valid attributes: [phase]")
+
+	cfg = DefaultMetricsConfig().K8sPodPhase
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func loadMetricsBuilderConfig(t *testing.T, name string) MetricsBuilderConfig {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
@@ -12,6 +13,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributePhase specifies the value phase attribute.
@@ -77,9 +85,9 @@ type metricInfo struct {
 }
 
 type metricK8sPodCPUTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   K8sPodCPUTimeMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.cpu_time metric with initial data.
@@ -118,7 +126,7 @@ func (m *metricK8sPodCPUTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodCPUTime(cfg MetricConfig) metricK8sPodCPUTime {
+func newMetricK8sPodCPUTime(cfg K8sPodCPUTimeMetricConfig) metricK8sPodCPUTime {
 	m := metricK8sPodCPUTime{config: cfg}
 
 	if cfg.Enabled {
@@ -129,9 +137,10 @@ func newMetricK8sPodCPUTime(cfg MetricConfig) metricK8sPodCPUTime {
 }
 
 type metricK8sPodPhase struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric          // data buffer for generated metric.
+	config        K8sPodPhaseMetricConfig // metric config provided by user.
+	capacity      int                     // max observed number of data points added to the metric.
+	aggDataPoints []int64                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills k8s.pod.phase metric with initial data.
@@ -141,17 +150,48 @@ func (m *metricK8sPodPhase) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricK8sPodPhase) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, phaseAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, K8sPodPhaseMetricAttributeKeyPhase) {
+		dp.Attributes().PutStr("phase", phaseAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("phase", phaseAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -164,13 +204,18 @@ func (m *metricK8sPodPhase) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodPhase) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodPhase(cfg MetricConfig) metricK8sPodPhase {
+func newMetricK8sPodPhase(cfg K8sPodPhaseMetricConfig) metricK8sPodPhase {
 	m := metricK8sPodPhase{config: cfg}
 
 	if cfg.Enabled {
@@ -181,9 +226,9 @@ func newMetricK8sPodPhase(cfg MetricConfig) metricK8sPodPhase {
 }
 
 type metricK8sReplicasetDesired struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   K8sReplicasetDesiredMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills k8s.replicaset.desired metric with initial data.
@@ -220,7 +265,7 @@ func (m *metricK8sReplicasetDesired) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sReplicasetDesired(cfg MetricConfig) metricK8sReplicasetDesired {
+func newMetricK8sReplicasetDesired(cfg K8sReplicasetDesiredMetricConfig) metricK8sReplicasetDesired {
 	m := metricK8sReplicasetDesired{config: cfg}
 
 	if cfg.Enabled {

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_metrics_test.go
@@ -20,6 +20,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -36,6 +37,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -61,9 +67,13 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["k8s.pod.phase"] = mb.metricK8sPodPhase.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -75,6 +85,10 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			ebK8sPod.RecordK8sPodPhaseDataPoint(ts, 1, AttributePhasePending)
+			if tt.name == "reaggregate_set" {
+				ebK8sPod.RecordK8sPodPhaseDataPoint(ts, 3, AttributePhaseRunning)
+			}
+
 			defaultMetricsCount++
 			allMetricsCount++
 			ebK8sReplicaset.RecordK8sReplicasetDesiredDataPoint(ts, 1)
@@ -89,6 +103,9 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetK8sReplicasetUID("k8s.replicaset.uid-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricK8sPodPhase.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -130,20 +147,45 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "k8s.pod.phase":
-					assert.False(t, validatedMetrics["k8s.pod.phase"], "Found a duplicate in the metrics slice: k8s.pod.phase")
-					validatedMetrics["k8s.pod.phase"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Current phase of the pod", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					phaseAttrVal, ok := dp.Attributes().Get("phase")
-					assert.True(t, ok)
-					assert.Equal(t, "Pending", phaseAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["k8s.pod.phase"], "Found a duplicate in the metrics slice: k8s.pod.phase")
+						validatedMetrics["k8s.pod.phase"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Current phase of the pod", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						phaseAttrVal, ok := dp.Attributes().Get("phase")
+						assert.True(t, ok)
+						assert.Equal(t, "Pending", phaseAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["k8s.pod.phase"], "Found a duplicate in the metrics slice: k8s.pod.phase")
+						validatedMetrics["k8s.pod.phase"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Current phase of the pod", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["k8s.pod.phase"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("phase")
+						assert.False(t, ok)
+					}
 				case "k8s.replicaset.desired":
 					assert.False(t, validatedMetrics["k8s.replicaset.desired"], "Found a duplicate in the metrics slice: k8s.replicaset.desired")
 					validatedMetrics["k8s.replicaset.desired"] = true

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_metrics_test.go
@@ -88,7 +88,6 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				ebK8sPod.RecordK8sPodPhaseDataPoint(ts, 3, AttributePhaseRunning)
 			}
-
 			defaultMetricsCount++
 			allMetricsCount++
 			ebK8sReplicaset.RecordK8sReplicasetDesiredDataPoint(ts, 1)

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/testdata/config.yaml
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/testdata/config.yaml
@@ -5,6 +5,27 @@ all_set:
       enabled: true
     k8s.pod.phase:
       enabled: true
+      attributes: ["phase"]
+    k8s.replicaset.desired:
+      enabled: true
+  resource_attributes:
+    k8s.namespace.name:
+      enabled: true
+    k8s.pod.name:
+      enabled: true
+    k8s.pod.uid:
+      enabled: true
+    k8s.replicaset.name:
+      enabled: true
+    k8s.replicaset.uid:
+      enabled: true
+reaggregate_set:
+  metrics:
+    k8s.pod.cpu_time:
+      enabled: true
+    k8s.pod.phase:
+      enabled: true
+      attributes: []
     k8s.replicaset.desired:
       enabled: true
   resource_attributes:
@@ -24,6 +45,7 @@ none_set:
       enabled: false
     k8s.pod.phase:
       enabled: false
+      attributes: ["phase"]
     k8s.replicaset.desired:
       enabled: false
   resource_attributes:

--- a/cmd/mdatagen/internal/sampleentityreceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/sampleentityreceiver/metadata.yaml
@@ -3,7 +3,6 @@
 type: sampleentity
 display_name: Sample Entity Receiver
 description: This receiver demonstrates entity-based metrics builder API.
-reaggregation_enabled: false
 override_value_enabled: true
 scope_name: go.opentelemetry.io/collector/internal/receiver/sampleentityreceiver
 sem_conv_version: 1.40.0

--- a/cmd/mdatagen/internal/samplefactoryreceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplefactoryreceiver/metadata.yaml
@@ -3,7 +3,6 @@
 type: sample
 display_name: Sample Factory Receiver
 description: This receiver is used for testing purposes to check the output of mdatagen.
-reaggregation_enabled: false
 scope_name: go.opentelemetry.io/collector/internal/receiver/samplefactoryreceiver
 github_project: open-telemetry/opentelemetry-collector
 

--- a/cmd/mdatagen/internal/sampleprocessor/internal/metadata/testdata/config.yaml
+++ b/cmd/mdatagen/internal/sampleprocessor/internal/metadata/testdata/config.yaml
@@ -17,24 +17,6 @@ all_set:
       enabled: true
     string.resource.attr_to_be_removed:
       enabled: true
-reaggregate_set:
-  resource_attributes:
-    map.resource.attr:
-      enabled: true
-    optional.resource.attr:
-      enabled: true
-    slice.resource.attr:
-      enabled: true
-    string.enum.resource.attr:
-      enabled: true
-    string.resource.attr:
-      enabled: true
-    string.resource.attr_disable_warning:
-      enabled: true
-    string.resource.attr_remove_warning:
-      enabled: true
-    string.resource.attr_to_be_removed:
-      enabled: true
 none_set:
   resource_attributes:
     map.resource.attr:

--- a/cmd/mdatagen/internal/templates/config.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config.go.tmpl
@@ -2,10 +2,9 @@
 
 package {{ .Package }}
 
-{{ $reag := .ReaggregationEnabled }}
 {{- $hasReagMetrics := false }}
 {{- $hasReagMetricsWithRequired := false }}
-{{- range $name, $metric := .Metrics }}{{- if and $reag (hasAggregatableAttributes $metric.Attributes) }}{{- $hasReagMetrics = true }}{{- range $element := $metric.Attributes }}{{- if (attributeInfo $element).IsRequired }}{{- $hasReagMetricsWithRequired = true }}{{- end }}{{- end }}{{- end }}{{- end }}
+{{- range $name, $metric := .Metrics }}{{- if hasAggregatableAttributes $metric.Attributes }}{{- $hasReagMetrics = true }}{{- range $element := $metric.Attributes }}{{- if (attributeInfo $element).IsRequired }}{{- $hasReagMetricsWithRequired = true }}{{- end }}{{- end }}{{- end }}{{- end }}
 {{- $hasEnumResourceAttr := false }}
 {{- range $_, $attr := .ResourceAttributes }}{{- if $attr.Enum }}{{- $hasEnumResourceAttr = true }}{{- end }}{{- end }}
 
@@ -26,18 +25,6 @@ import (
 	{{- end }}
 )
 {{ if .Metrics -}}
-
-{{- if not $reag }}
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-}
-
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
-	{{- template "metricUnmarshal" "ms" }}
-}
-{{- else }}
 
 {{- range $name, $metric := .Metrics }}
 {{- if hasAggregatableAttributes $metric.Attributes }}
@@ -94,20 +81,19 @@ func (ms *{{ $name.Render }}MetricConfig) Validate() error {
 }
 {{- end }}
 {{- end }}
-{{- end }}
 
 // MetricsConfig provides config for {{ .Type }} metrics.
 type MetricsConfig struct {
 	{{- range $name, $metric := .Metrics }}
-	{{ $name.Render }} {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig `mapstructure:"{{ $name }}"`
+	{{ $name.Render }} {{ $name.Render }}MetricConfig `mapstructure:"{{ $name }}"`
 	{{- end }}
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		{{- range $name, $metric := .Metrics }}
-		{{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
-		{{ $name.Render }}: {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig{
+		{{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
+		{{ $name.Render }}: {{ $name.Render }}MetricConfig{
 			Enabled: {{ $metric.Enabled }},
 			{{- if $metricReag }}
 			AggregationStrategy: AggregationStrategy{{ if eq $metric.Data.Type "Sum" }}Sum{{ else }}Avg{{ end }},

--- a/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
+++ b/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
@@ -1,11 +1,10 @@
-{{- $reag := .ReaggregationEnabled }}
 {{- if .Metrics }}
   metrics_config:
     description: MetricsConfig provides config for {{ .Type }} metrics.
     type: object
     properties:
       {{- range $name, $metric := .Metrics }}
-      {{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
+      {{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
       {{ $name }}:
         description: "{{ $name.Render }}MetricConfig provides config for the {{ $name }} metric."
         type: object

--- a/cmd/mdatagen/internal/templates/config_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_test.go.tmpl
@@ -32,11 +32,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 		{
 			name: "all_set",
 			want: MetricsBuilderConfig{
-					Metrics: MetricsConfig{
-						{{- range $name, $metric := .Metrics }}
-						{{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
-						{{ $name.Render }}: {{ $name.Render }}MetricConfig{
-							Enabled: true,
+				Metrics: MetricsConfig{
+					{{- range $name, $metric := .Metrics }}
+					{{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
+					{{ $name.Render }}: {{ $name.Render }}MetricConfig{
+						Enabled: true,
 						{{- if $metricReag }}
 						AggregationStrategy: AggregationStrategy{{ if eq $metric.Data.Type "Sum" }}Sum{{ else }}Avg{{ end }},
 						EnabledAttributes:   []{{ $name.Render }}MetricAttributeKey{ {{- range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}MetricAttributeKey{{ $element.Render }}{{ end -}} },
@@ -56,11 +56,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 		{
 			name: "none_set",
 			want: MetricsBuilderConfig{
-					Metrics: MetricsConfig{
-						{{- range $name, $metric := .Metrics }}
-						{{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
-						{{ $name.Render }}: {{ $name.Render }}MetricConfig{
-							Enabled: false,
+				Metrics: MetricsConfig{
+					{{- range $name, $metric := .Metrics }}
+					{{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
+					{{ $name.Render }}: {{ $name.Render }}MetricConfig{
+						Enabled: false,
 						{{- if $metricReag }}
 						AggregationStrategy: AggregationStrategy{{ if eq $metric.Data.Type "Sum" }}Sum{{ else }}Avg{{ end }},
 						EnabledAttributes:   []{{ $name.Render }}MetricAttributeKey{ {{- range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}MetricAttributeKey{{ $element.Render }}{{ end -}} },

--- a/cmd/mdatagen/internal/templates/config_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_test.go.tmpl
@@ -95,7 +95,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 }
 
 {{- range $name, $metric := .Metrics }}
-{{ if and $reag (hasAggregatableAttributes $metric.Attributes) -}}
+{{ if hasAggregatableAttributes $metric.Attributes -}}
 func Test{{ $name.Render }}MetricsConfig_Validate(t *testing.T) {
   cfg := DefaultMetricsConfig().{{ $name.Render }}
   require.NoError(t, cfg.Validate())

--- a/cmd/mdatagen/internal/templates/config_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_test.go.tmpl
@@ -19,8 +19,6 @@ import (
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 
-{{ $reag := .ReaggregationEnabled }}
-
 {{ if .Metrics }}
 func TestMetricsBuilderConfig(t *testing.T) {
 	tests := []struct {
@@ -34,11 +32,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 		{
 			name: "all_set",
 			want: MetricsBuilderConfig{
-				Metrics: MetricsConfig{
-					{{- range $name, $metric := .Metrics }}
-					{{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
-					{{ $name.Render }}: {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig{
-						Enabled: true,
+					Metrics: MetricsConfig{
+						{{- range $name, $metric := .Metrics }}
+						{{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
+						{{ $name.Render }}: {{ $name.Render }}MetricConfig{
+							Enabled: true,
 						{{- if $metricReag }}
 						AggregationStrategy: AggregationStrategy{{ if eq $metric.Data.Type "Sum" }}Sum{{ else }}Avg{{ end }},
 						EnabledAttributes:   []{{ $name.Render }}MetricAttributeKey{ {{- range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}MetricAttributeKey{{ $element.Render }}{{ end -}} },
@@ -58,11 +56,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 		{
 			name: "none_set",
 			want: MetricsBuilderConfig{
-				Metrics: MetricsConfig{
-					{{- range $name, $metric := .Metrics }}
-					{{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
-					{{ $name.Render }}: {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig{
-						Enabled: false,
+					Metrics: MetricsConfig{
+						{{- range $name, $metric := .Metrics }}
+						{{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
+						{{ $name.Render }}: {{ $name.Render }}MetricConfig{
+							Enabled: false,
 						{{- if $metricReag }}
 						AggregationStrategy: AggregationStrategy{{ if eq $metric.Data.Type "Sum" }}Sum{{ else }}Avg{{ end }},
 						EnabledAttributes:   []{{ $name.Render }}MetricAttributeKey{ {{- range $index, $element := $metric.Attributes -}}{{ if $index }}, {{ end }}{{ $name.Render }}MetricAttributeKey{{ $element.Render }}{{ end -}} },
@@ -84,9 +82,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
 			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(
-				{{- if $reag }}
 				{{- range $name, $metric := .Metrics }}{{ $name.Render }}MetricConfig{}, {{ end }}
-				{{- else }}MetricConfig{},{{ end }}
 				{{- if $.OverrideValueEnabled }}
 				{{- range $name, $_ := .ResourceAttributes }}{{ $name.Render }}ResourceAttributeConfig{}, {{ end }}
 				{{- else }}

--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -2,9 +2,8 @@
 
 package {{ .Package }}
 
-{{ $reag := .ReaggregationEnabled }}
 {{- $hasReagMetrics := false }}
-{{- range $name, $metric := .Metrics }}{{- if and $reag (hasAggregatableAttributes $metric.Attributes) }}{{- $hasReagMetrics = true }}{{- end }}{{- end }}
+{{- range $name, $metric := .Metrics }}{{- if hasAggregatableAttributes $metric.Attributes }}{{- $hasReagMetrics = true }}{{- end }}{{- end }}
 {{- $hasMigrations := false }}
 {{- range $name, $metric := .Metrics }}{{- if $metric.Migration }}{{- $hasMigrations = true }}{{- end }}{{- end }}
 
@@ -35,14 +34,12 @@ import (
 	{{- end }}
 )
 
-{{- if $reag }}
 const (
 	AggregationStrategySum = "sum"
 	AggregationStrategyAvg = "avg"
 	AggregationStrategyMin = "min"
 	AggregationStrategyMax = "max"
 )
-{{- end }}
 
 {{- if needsStrToIntConversion }}
 func mustParseInt64(s string) int64 {
@@ -131,10 +128,10 @@ func With{{ .Render }}MetricAttribute({{ .RenderUnexported }}AttributeValue {{ (
 {{ end }}
 
 {{ range $name, $metric := .Metrics }}
-{{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) -}}
+{{- $metricReag := hasAggregatableAttributes $metric.Attributes -}}
 type metric{{ $name.Render }} struct {
 	data                     pmetric.Metric // data buffer for generated metric.
-	config                   {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig // metric config provided by user.
+	config                   {{ $name.Render }}MetricConfig // metric config provided by user.
 	capacity                 int // max observed number of data points added to the metric.
 	{{- if $metricReag }}
 	aggDataPoints            []{{ $metric.Data.MetricValueType.BasicType }} // slice containing number of aggregated datapoints at each index
@@ -303,7 +300,7 @@ func (m *metric{{ $name.Render }}) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetric{{ $name.Render }}(cfg {{ if $reag }}{{ $name.Render }}{{ end }}MetricConfig) metric{{ $name.Render }} {
+func newMetric{{ $name.Render }}(cfg {{ $name.Render }}MetricConfig) metric{{ $name.Render }} {
 	m := metric{{ $name.Render }}{config: cfg}
 
 	if cfg.Enabled {

--- a/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
@@ -2,10 +2,9 @@
 
 package {{ .Package }}
 
-{{ $reag := .ReaggregationEnabled }}
 {{- $hasReagMetrics := false }}
 {{- $hasVersionedMetrics := false }}
-{{- range $name, $metric := .Metrics }}{{- if and $reag (hasAggregatableAttributes $metric.Attributes) }}{{- $hasReagMetrics = true }}{{- end }}
+{{- range $name, $metric := .Metrics }}{{- if hasAggregatableAttributes $metric.Attributes }}{{- $hasReagMetrics = true }}{{- end }}
 {{- if $metric.Migration }}{{ $hasVersionedMetrics = true }}{{- end }}
 {{- end }}
 
@@ -32,7 +31,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
-	{{- if $reag }}
+	{{- if $hasReagMetrics }}
 	testDataSetReag
 	{{- end }}
 )
@@ -52,7 +51,7 @@ func TestMetricsBuilder(t *testing.T) {
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
 		},
-		{{- if $reag }}
+		{{- if $hasReagMetrics }}
 		{
 			name: "reaggregate_set",
 			metricsSet: testDataSetReag,
@@ -170,7 +169,7 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 			{{- end }}
 
-			{{- if $reag }}
+			{{- if $hasReagMetrics }}
 			if tt.metricsSet != testDataSetReag {
 				assert.Equal(t, expectedWarnings, observedLogs.Len())
 			}
@@ -225,7 +224,7 @@ func TestMetricsBuilder(t *testing.T) {
 			{{- end -}}
 			{{- end -}}
 			)
-			{{- if and $reag (hasAggregatableAttributes $metric.Attributes) }}
+			{{- if hasAggregatableAttributes $metric.Attributes }}
 			if tt.name == "reaggregate_set" {
 				{{ if $metric.Entity }}eb{{ publicVar $metric.Entity }}{{ else }}mb{{ end }}.Record{{ $name.Render }}DataPoint(ts, {{ if $metric.Data.HasMetricInputType }}"3"{{ else }}3{{ end }}
 				{{- range $metric.Attributes -}}
@@ -267,7 +266,7 @@ func TestMetricsBuilder(t *testing.T) {
 			res := pcommon.NewResource()
 			{{- end }}
 			metrics := mb.Emit(WithResource(res))
-			{{- if $reag }}
+			{{- if $hasReagMetrics }}
 			if tt.name == "reaggregate_set" {
 				{{- range $name, $metric := .Metrics }}
 				{{- if hasAggregatableAttributes $metric.Attributes }}
@@ -305,7 +304,7 @@ func TestMetricsBuilder(t *testing.T) {
 				{{- range $name, $metric := .Metrics }}
         {{- if and (not $metric.Versioned) (not $metric.Migration) }}
         case "{{ $name.EmittedName }}":
-					{{- if and $reag (hasAggregatableAttributes $metric.Attributes) }}
+					{{- if hasAggregatableAttributes $metric.Attributes }}
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["{{ $name }}"], "Found a duplicate in the metrics slice: {{ $name }}")
 						validatedMetrics["{{ $name }}"] = true
@@ -601,4 +600,3 @@ func TestVersionedMetrics(t *testing.T) {
     {{- end }}
 }
 {{- end }}
-

--- a/cmd/mdatagen/internal/templates/testdata/config.yaml.tmpl
+++ b/cmd/mdatagen/internal/templates/testdata/config.yaml.tmpl
@@ -1,12 +1,12 @@
-{{- $reag := .ReaggregationEnabled -}}
+{{- $hasReagMetrics := false }}
+{{- range $name, $metric := .Metrics }}{{- if hasAggregatableAttributes $metric.Attributes }}{{- $hasReagMetrics = true }}{{- end }}{{- end -}}
 
 default:
 all_set:
-{{- if $reag }}
   {{- if .Metrics }}
   metrics:
     {{- range $name, $metric := .Metrics }}
-    {{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
+    {{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
     {{ $name }}:
       enabled: true
       {{- if $metricReag }}
@@ -28,12 +28,12 @@ all_set:
       enabled: true
     {{- end }}
   {{- end }}
+{{- if $hasReagMetrics }}
 reaggregate_set:
-{{- end }}
   {{- if .Metrics }}
   metrics:
     {{- range $name, $metric := .Metrics }}
-    {{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
+    {{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
     {{ $name }}:
       enabled: true
       {{- if $metricReag }}
@@ -55,11 +55,12 @@ reaggregate_set:
       enabled: true
     {{- end }}
   {{- end }}
+{{- end }}
 none_set:
   {{- if .Metrics }}
   metrics:
     {{- range $name, $metric := .Metrics }}
-    {{- $metricReag := and $reag (hasAggregatableAttributes $metric.Attributes) }}
+    {{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
     {{ $name }}:
       enabled: false
       {{- if $metricReag }}

--- a/cmd/mdatagen/internal/testdata/reaggregation_disabled.yaml
+++ b/cmd/mdatagen/internal/testdata/reaggregation_disabled.yaml
@@ -1,7 +1,0 @@
-type: test
-reaggregation_enabled: false
-
-status:
-  class: receiver
-  stability:
-    beta: [logs]

--- a/cmd/mdatagen/internal/testdata/reaggregation_disabled.yaml
+++ b/cmd/mdatagen/internal/testdata/reaggregation_disabled.yaml
@@ -1,0 +1,7 @@
+type: test
+reaggregation_enabled: false
+
+status:
+  class: receiver
+  stability:
+    beta: [logs]

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -19,13 +19,6 @@ scope_name: string
 # Optional: The name of the package that mdatagen generates. If not set, the name "metadata" will be used.
 generated_package_name: string
 
-# Optional: Enables per-metric reaggregation config generation for metrics with attributes.
-# Enabled by default. Set to false to generate metric config with only the `enabled`
-# field.
-# When enabled, generated metrics config includes `aggregation_strategy` and `attributes`
-# fields that let users reduce metric cardinality by choosing which dimensions are kept.
-reaggregation_enabled: bool
-
 # Optional: Enables per-resource-attribute override_value config generation.
 # When enabled, generated resource attribute config includes typed `override_value`
 # fields that let users override resource attribute values in the collector config.


### PR DESCRIPTION
Removes the mdatagen `reaggregation_enabled` opt-out and the legacy template branch that generated shared metric config