### PR TITLE
[chore][govuln] pin Go version in govuln check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: oldstable
+          go-version: 1.25.11 # TODO: revert to oldstable when actions/setup-go reliably resolves oldstable to 1.25.11
           cache: false
       - name: Cache Go
         id: go-cache


### PR DESCRIPTION
#### Description
Pin Go version to 1.25.11 in govuln check to fix CI failures. Right now actions/setup-go resolves oldstable to 1.25.10 which has known vulns.

Counterpart in contrib: http://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48854

#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
