### PR TITLE
[cmd/builder] Make `--skip-get-modules` not regenerate go.mod

### DIFF
--- a/.chloggen/skip-get-module-no-go-mod-gen.yaml
+++ b/.chloggen/skip-get-module-no-go-mod-gen.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `--skip-get-modules` flag will no longer regenerate your `go.mod` file.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15390]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This is mostly a bug fix, as it led to adverse behaviour that was unintended in the described flow in the README.
+  Now when you run `--skip-get-modules`, your `go.mod` file will truly be untouched by `ocb` as the info log claims.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -99,6 +99,9 @@ func Generate(cfg *Config) error {
 		componentsTemplate,
 		goModTemplate,
 	} {
+		if tmpl == goModTemplate && cfg.SkipGetModules {
+			continue
+		}
 		if err := processAndWrite(cfg, tmpl, tmpl.Name(), cfg); err != nil {
 			return fmt.Errorf("failed to generate source file %q: %w", tmpl.Name(), err)
 		}

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -271,6 +271,21 @@ func TestSkipGenerate(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF, "skip generate should leave output directory empty")
 }
 
+func TestSkipGetModules(t *testing.T) {
+	cfg := newInitializedConfig(t)
+	cfg.Distribution.OutputPath = t.TempDir()
+	cfg.SkipGetModules = true
+	err := Generate(cfg)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(cfg.Distribution.OutputPath, "go.mod"))
+	require.ErrorIs(t, err, os.ErrNotExist, "go.mod should not be generated when skip-get-modules is enabled")
+
+	_, err = os.Stat(filepath.Join(cfg.Distribution.OutputPath, "main.go"))
+	require.NoError(t, err, "main.go should be generated even when skip-get-modules is enabled")
+}
+
+
 func TestGenerateAndCompile(t *testing.T) {
 	replaces := generateReplaces()
 	testCases := []struct {

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -285,7 +285,6 @@ func TestSkipGetModules(t *testing.T) {
 	require.NoError(t, err, "main.go should be generated even when skip-get-modules is enabled")
 }
 
-
 func TestGenerateAndCompile(t *testing.T) {
 	replaces := generateReplaces()
 	testCases := []struct {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR makes it so `--skip-get-modules` does not regenerate the `go.mod` template. This should make it accomplish its stated goals of "not updating go.mod" that the info log states.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15390 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
I used a compiled builder with these changes and ensured that my `go.mod` didn't get clobbered when I ran it with the `--skip-get-modules` flag.

<!--Describe the documentation added.-->
#### Documentation
Documentation remains the same.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

#### AI Usage Disclosure
I leveraged Google Antigravity for the code changes.

<!--Please delete paragraphs that you did not use before submitting.-->
