### PR TITLE
[exporterhelper] guard sizer inheritance when batch is disabled

### DIFF
--- a/.chloggen/fix-queuebatch-unmarshal-nil-when-batch-disabled.yaml
+++ b/.chloggen/fix-queuebatch-unmarshal-nil-when-batch-disabled.yaml
@@ -1,0 +1,15 @@
+change_type: bug_fix
+
+component: exporterhelper
+
+note: Fix nil-pointer panic in `sending_queue::batch` Unmarshal when `sending_queue::sizer` is set and `sending_queue::batch::enabled` is false.
+
+issues: [14687]
+
+subtext: |
+  When `sending_queue::sizer` was set and `sending_queue::batch::enabled: false`
+  cleared the batch Optional to None, the sizer-inheritance branch in
+  `queuebatch.Config.Unmarshal` dereferenced a nil Optional and crashed the
+  collector at startup. The branch now also requires `Batch.HasValue()`.
+
+change_logs: [user]

--- a/.chloggen/fix-queuebatch-unmarshal-nil-when-batch-disabled.yaml
+++ b/.chloggen/fix-queuebatch-unmarshal-nil-when-batch-disabled.yaml
@@ -1,6 +1,6 @@
 change_type: bug_fix
 
-component: exporterhelper
+component: pkg/exporterhelper
 
 note: Fix nil-pointer panic in `sending_queue::batch` Unmarshal when `sending_queue::sizer` is set and `sending_queue::batch::enabled` is false.
 

--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -53,10 +53,11 @@ func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
 
 	// If all of the following hold:
 	// 1. the sizer is set,
-	// 2. the batch sizer is not set and
-	// 3. the batch section is nonempty,
+	// 2. the batch sizer is not set,
+	// 3. the batch section is nonempty, and
+	// 4. the batch Optional has a value,
 	// then use the same value as the queue sizer.
-	if conf.IsSet("sizer") && !conf.IsSet("batch::sizer") && conf.IsSet("batch") && conf.Get("batch") != nil {
+	if conf.IsSet("sizer") && !conf.IsSet("batch::sizer") && conf.IsSet("batch") && conf.Get("batch") != nil && cfg.Batch.HasValue() {
 		cfg.Batch.Get().Sizer = cfg.Sizer
 	}
 	return nil

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -200,6 +200,16 @@ func TestUnmarshal(t *testing.T) {
 			// Batch remains unset, sizer override does not apply.
 			expectedCfg: newBaseCfg,
 		},
+		{
+			path: "batch_disabled_explicit_sizer.yaml",
+			// Batch is explicitly disabled. Sizer inheritance must not
+			// panic and Batch must remain absent.
+			expectedCfg: func() configoptional.Optional[Config] {
+				cfg := newBaseCfg()
+				cfg.Get().Batch = configoptional.None[BatchConfig]()
+				return cfg
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/exporterhelper/internal/queuebatch/testdata/batch_disabled_explicit_sizer.yaml
+++ b/exporter/exporterhelper/internal/queuebatch/testdata/batch_disabled_explicit_sizer.yaml
@@ -1,0 +1,5 @@
+enabled: true
+sizer: requests
+# batch is explicitly disabled
+batch:
+  enabled: false


### PR DESCRIPTION
When sending_queue::sizer is set and sending_queue::batch::enabled is false, configoptional.AddEnabledField clears the batch Optional to None, but the sizer-inheritance branch in queuebatch.Config.Unmarshal still calls cfg.Batch.Get() and dereferences the nil pointer, panicking on collector startup.

Adds a small fix, a test.

See also #14695 
Part of #14687
