### PR TITLE
[chore] docs: clarify processor ordering relative to batching

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -28,10 +28,10 @@ order in each section below is the best practice. Refer to the individual
 processor documentation for more information.
 
 1. [memory_limiter](memorylimiterprocessor/README.md)
-2. Any sampling or initial filtering processors
+2. Any sampling or filtering processors that drop data
 3. Any processor relying on sending source from `Context` (e.g. `k8sattributes`)
-3. [batch](batchprocessor/README.md), although prefer using the exporter's batching capabilities
-4. Any other processors
+4. Any processors that transform or enrich telemetry data (e.g. attributes, transform)
+5. [batch](batchprocessor/README.md), although prefer using the exporter's batching capabilities
 
 ## Data Ownership
 
@@ -106,6 +106,8 @@ data cloning described in Exclusive Ownership section.
 
 The order processors are specified in a pipeline is important as this is the
 order in which each processor is applied.
+
+In general, processors that drop, transform, or enrich telemetry should run before batching. This avoids batching telemetry that may later be discarded and ensures batching happens after the data has reached its final shape for export. Processors that rely on request context, such as `k8sattributes`, should also run before batching so they can access the context they need.
 
 ## Creating Custom Processors
 

--- a/processor/README.md
+++ b/processor/README.md
@@ -107,7 +107,7 @@ data cloning described in Exclusive Ownership section.
 The order processors are specified in a pipeline is important as this is the
 order in which each processor is applied.
 
-In general, processors that drop, transform, or enrich telemetry should run before batching. This avoids batching telemetry that may later be discarded and ensures batching happens after the data has reached its final shape for export. Processors that rely on request context, such as `k8sattributes`, should also run before batching so they can access the context they need.
+Processors that drop, transform, or enrich telemetry should run before batching. This avoids batching telemetry that may later be discarded. Processors that rely on request context, such as `k8sattributes`, should also run before batching so they can access the context they need.
 
 ## Creating Custom Processors
 


### PR DESCRIPTION
## Description

Clarifies the recommended processor ordering in `processor/README.md`.

This change updates the guidance to explicitly place filtering, transformation, and enrichment processors before batching, and adds a short explanation of the rationale. The goal is to avoid batching telemetry that may later be discarded and to ensure telemetry reaches its final form before batching for export.

Related to #15075

## Testing

Documentation-only change.

## Documentation

Updated `processor/README.md`.