### PR TITLE
[chore] Fix flaky test TestDefaultBatcher_Split_TimeoutDisabled

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
@@ -82,11 +82,9 @@ func TestPartitionBatcher_NoSplit_MinThresholdZero_TimeoutDisabled(t *testing.T)
 			ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 35, Bytes: 35}, done)
 			ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 2, Bytes: 2}, done)
 			assert.Eventually(t, func() bool {
-				return sink.RequestsCount() == 5 && (sink.ItemsCount() == 75 || sink.BytesCount() == 75)
+				return sink.RequestsCount() == 5 && (sink.ItemsCount() == 75 || sink.BytesCount() == 75) &&
+					done.errors.Load() == 1 && done.success.Load() == 5
 			}, 1*time.Second, 10*time.Millisecond)
-			// Check that done callback is called for the right number of times.
-			assert.EqualValues(t, 1, done.errors.Load())
-			assert.EqualValues(t, 5, done.success.Load())
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The race condition that I can see is the sink.Export increments the requestCount and before it could return and let the done.OnDone to do the job the assert.Eventually might have read the counter and moved to assert the done checks. 

It is safe to add the done checks to the eventually to ensure that the checks are asserted.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15395 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
