### PR TITLE
[cmd/builder] add @braydonk and @jmacd as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 # Start components list
 
 client/                                                @open-telemetry/collector-approvers
-cmd/builder/                                           @open-telemetry/collector-approvers @dmathieu
+cmd/builder/                                           @open-telemetry/collector-approvers @dmathieu @braydonk @jmacd
 cmd/mdatagen/                                          @open-telemetry/collector-approvers @dmitryax
 cmd/mdatagen/internal/sampleconnector/                 @open-telemetry/collector-approvers
 cmd/mdatagen/internal/sampleentityreceiver/            @open-telemetry/collector-approvers @dmitryax

--- a/cmd/builder/metadata.yaml
+++ b/cmd/builder/metadata.yaml
@@ -7,4 +7,4 @@ status:
   stability:
     alpha: [metrics]
   codeowners:
-    active: [dmathieu]
+    active: [dmathieu, braydonk, jmacd]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds myself and @jmacd as codeowners on `cmd/builder` (`ocb`). Josh has done a fair bit of development on the tool. I have made some minimal changes, and am a heavy user of the tool as I leverage it in my [distrogen
project](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/tree/master/cmd/distrogen) and support heavy usage of it internally.

<!-- Issue number if applicable -->
#### Link to tracking issue
Did not create an issue.

#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
