### PR TITLE
service: flush logger before tearing down pipelines on reload

### DIFF
--- a/.chloggen/fix-sighup-reload-logger-shutdown-order.yaml
+++ b/.chloggen/fix-sighup-reload-logger-shutdown-order.yaml
@@ -1,0 +1,10 @@
+change_type: bug_fix
+component: pkg/service
+note: "Fix SIGHUP reload exiting with status 1 when service.telemetry.logs.processors uses an in-process OTLP pipeline. The logger is now flushed before receiver pipelines are torn down, preventing connection-refused errors during reload."
+issues: [15400]
+subtext: |
+  Without this fix, collectors configured with an in-process OTLP self-loop
+  (logger -> otlp/selftelemetry receiver, a common observability pattern)
+  exited with status 1 on every SIGHUP because the logger's OTLP batch
+  exporter tried to flush to a receiver that had already been shut down.
+change_logs: [user]

--- a/service/service.go
+++ b/service/service.go
@@ -266,16 +266,34 @@ func (srv *Service) Start(ctx context.Context) error {
 }
 
 // Shutdown the service. Shutdown will do the following steps in order:
-// 1. Notify extensions that the pipeline is shutting down.
-// 2. Shutdown all pipelines.
-// 3. Shutdown all extensions.
-// 4. Shutdown telemetry.
+// 1. Flush the logger so that any buffered log records are exported before
+//    receivers are torn down. This must happen first: when
+//    service.telemetry.logs.processors routes internal logs through an
+//    in-process OTLP pipeline (the "self-loop" pattern), the logger's OTLP
+//    exporter must flush while the in-process receiver is still alive.
+// 2. Notify extensions that the pipeline is shutting down.
+// 3. Shutdown all pipelines.
+// 4. Shutdown all extensions.
+// 5. Shutdown remaining telemetry providers (meter, tracer).
 func (srv *Service) Shutdown(ctx context.Context) error {
 	// Accumulate errors and proceed with shutting down remaining components.
 	var errs error
 
 	// Begin shutdown sequence.
 	srv.telemetrySettings.Logger.Info("Starting shutdown...")
+
+	// Flush the logger's OTLP exporter (if any) BEFORE tearing down pipelines.
+	// When service.telemetry.logs.processors is configured with an in-process
+	// OTLP self-loop (logger → otlp/selftelemetry receiver), calling
+	// loggerShutdownFunc.Shutdown after ShutdownAll would attempt to POST to a
+	// receiver that is already gone, producing "connection refused" errors that
+	// propagate back to reloadConfiguration and cause the process to exit 1 on
+	// every SIGHUP.  Moving the flush here keeps the reload clean.
+	// The base zap core (stdout/stderr) continues to operate after this call,
+	// so console/file logging is unaffected for the remainder of shutdown.
+	if err := srv.loggerShutdownFunc.Shutdown(ctx); err != nil {
+		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown logger: %w", err))
+	}
 
 	if err := srv.host.ServiceExtensions.NotifyPipelineNotReady(); err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("failed to notify that pipeline is not ready: %w", err))
@@ -291,16 +309,12 @@ func (srv *Service) Shutdown(ctx context.Context) error {
 
 	srv.telemetrySettings.Logger.Info("Shutdown complete.")
 
-	// Shut down telemetry providers in the reverse order of creation,
-	// since the tracer and meter providers may use the logger.
+	// Shut down remaining telemetry providers in the reverse order of creation.
 	if err := srv.tracerProvider.Shutdown(ctx); err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown tracer provider: %w", err))
 	}
 	if err := srv.meterProvider.Shutdown(ctx); err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown meter provider: %w", err))
-	}
-	if err := srv.loggerShutdownFunc.Shutdown(ctx); err != nil {
-		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown logger: %w", err))
 	}
 
 	return errs

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,12 +28,14 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/internal/testutil"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/pipeline/xpipeline"
+	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/service/extensions"
 	"go.opentelemetry.io/collector/service/internal/builders"
 	"go.opentelemetry.io/collector/service/internal/proctelemetry"
@@ -359,10 +362,87 @@ func TestServiceTelemetryShutdownError(t *testing.T) {
 	// Shutdown the service
 	err = srv.Shutdown(context.Background())
 	assert.EqualError(t, err, ""+
+		"failed to shutdown logger: an exception occurred; "+
 		"failed to shutdown tracer provider: an exception occurred; "+
-		"failed to shutdown meter provider: an exception occurred; "+
-		"failed to shutdown logger: an exception occurred",
+		"failed to shutdown meter provider: an exception occurred",
 	)
+}
+
+// TestShutdownFlushesLoggerBeforeReceiverShutdown verifies that the logger's
+// flush/shutdown function is called before any pipeline receiver is shut down.
+//
+// Motivation: when service.telemetry.logs.processors routes internal logs
+// through an in-process OTLP self-loop (logger → otlp receiver), the logger's
+// OTLP batch exporter must flush BEFORE the receiver is stopped.  If the order
+// is reversed the flush dials a dead receiver, gets "connection refused", and
+// the error propagates to reloadConfiguration causing the process to exit 1 on
+// every SIGHUP reload (https://github.com/open-telemetry/opentelemetry-collector/issues/15400).
+func TestShutdownFlushesLoggerBeforeReceiverShutdown(t *testing.T) {
+	var callOrder atomic.Int64 // increments on each Shutdown call; lower == earlier
+
+	var loggerShutdownOrder int64
+	var receiverShutdownOrder int64
+
+	// The custom logger shutdown func records its position in the call order.
+	set := newNopSettings()
+	set.TelemetryFactory = telemetry.NewFactory(
+		func() component.Config { return nil },
+		telemetry.WithCreateLogger(
+			func(_ context.Context, _ telemetry.LoggerSettings, _ component.Config) (*zap.Logger, component.ShutdownFunc, error) {
+				return zap.NewNop(), func(context.Context) error {
+					loggerShutdownOrder = callOrder.Add(1)
+					return nil
+				}, nil
+			},
+		),
+	)
+
+	// Build a custom receiver whose Shutdown records its position in call order.
+	recvType := component.MustNewType("ordertracker")
+	recvCfg := &struct{}{}
+	recvInstance := &struct {
+		component.StartFunc
+		component.ShutdownFunc
+	}{
+		ShutdownFunc: func(context.Context) error {
+			receiverShutdownOrder = callOrder.Add(1)
+			return nil
+		},
+	}
+	fact := receiver.NewFactory(
+		recvType,
+		func() component.Config { return recvCfg },
+		receiver.WithLogs(
+			func(_ context.Context, _ receiver.Settings, _ component.Config, _ consumer.Logs) (receiver.Logs, error) {
+				return recvInstance, nil
+			},
+			component.StabilityLevelDevelopment,
+		),
+	)
+	set.ReceiversConfigs = map[component.ID]component.Config{
+		component.NewID(recvType): recvCfg,
+	}
+	set.ReceiversFactories = map[component.Type]receiver.Factory{
+		recvType: fact,
+	}
+
+	cfg := newNopConfigPipelineConfigs(pipelines.Config{
+		pipeline.NewID(pipeline.SignalLogs): {
+			Receivers: []component.ID{component.NewID(recvType)},
+			Exporters: []component.ID{component.NewID(nopType)},
+		},
+	})
+
+	srv, err := New(context.Background(), set, cfg)
+	require.NoError(t, err)
+	require.NoError(t, srv.Start(context.Background()))
+
+	require.NoError(t, srv.Shutdown(context.Background()))
+
+	// Logger must be flushed before the receiver is torn down.
+	assert.Less(t, loggerShutdownOrder, receiverShutdownOrder,
+		"logger shutdown (order %d) must happen before receiver shutdown (order %d)",
+		loggerShutdownOrder, receiverShutdownOrder)
 }
 
 func TestExtensionNotificationFailure(t *testing.T) {


### PR DESCRIPTION
#### Description

When `service.telemetry.logs.processors` routes the collector's internal logs through an in-process OTLP self-loop (a common observability pattern), `Service.Shutdown` previously tore down all pipeline receivers **before** flushing the logger's OTLP batch exporter. The flush then attempted to POST to a receiver that was already dead, producing `connect: connection refused`, which propagated through `reloadConfiguration` and caused the process to exit with status 1 on every SIGHUP — turning a graceful in-place reload into an unnecessary container restart (incrementing Kubernetes `RESTART_COUNT` and producing a brief unavailability window).

The fix moves `loggerShutdownFunc.Shutdown` to the very beginning of `Service.Shutdown`, before any pipeline component is stopped. The base zap core (stdout/stderr) continues to function after this call, so console/file logging is preserved for the remainder of the shutdown sequence. Non-self-loop logger configs (the common case, where `loggerShutdownFunc` is a no-op or has no network dependency) are unaffected.

#### Link to tracking issue
Fixes #15400

#### Testing

New regression test `TestShutdownFlushesLoggerBeforeReceiverShutdown` in `service/service_test.go` exercises the ordering invariant using an `atomic.Int64` call counter — it asserts that the logger shutdown position is strictly less than the receiver shutdown position after `Service.Shutdown` returns. The existing `TestServiceTelemetryShutdownError` is updated to reflect the new error sequence (logger error now appears before tracer/meter, matching the new ordering).

Test run on the affected package:

```
=== RUN   TestShutdownFlushesLoggerBeforeReceiverShutdown
--- PASS: TestShutdownFlushesLoggerBeforeReceiverShutdown (0.00s)
=== RUN   TestServiceTelemetryShutdownError
--- PASS: TestServiceTelemetryShutdownError (0.00s)
PASS
ok      go.opentelemetry.io/collector/service   0.014s
```

Full `./service/...` suite passes locally (two pre-existing failures in `service/telemetry/otelconftelemetry` are port-conflict flakes on `localhost:8888` and reproduce identically on `upstream/main` without this change).

#### Documentation

Added a `.chloggen/fix-sighup-reload-logger-shutdown-order.yaml` entry (`change_type: bug_fix`, `component: pkg/service`). The fix also updates the doc comment on `Service.Shutdown` to make the new ordering and its rationale explicit.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.
