### PR TITLE
otelcol: drain async error channel during reload and shutdown

### DIFF
--- a/.chloggen/fix-async-error-shutdown-deadlock.yaml
+++ b/.chloggen/fix-async-error-shutdown-deadlock.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/otelcol
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Drain the asynchronous error channel during configuration reload and shutdown so a component reporting a fatal error while it stops does not block on the send and deadlock the collector.
+
+# One or more tracking issues or pull requests related to the change
+issues: [9824]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -267,6 +267,12 @@ func (col *Collector) reloadConfiguration(ctx context.Context) error {
 	col.service.Logger().Warn("Config updated, restart service")
 	col.setCollectorState(StateClosing)
 
+	// The control loop is blocked here and not reading asyncErrorChannel while the
+	// retiring service stops and the new one starts, so keep draining it. Otherwise
+	// a component reporting a fatal error during the restart would block on the send.
+	stop := col.drainAsyncErrors()
+	defer stop()
+
 	if err := col.service.Shutdown(ctx); err != nil {
 		return fmt.Errorf("failed to shutdown the retiring config: %w", err)
 	}
@@ -407,8 +413,39 @@ LOOP:
 	return col.shutdown(ctx)
 }
 
+// drainAsyncErrors starts consuming asyncErrorChannel and returns a stop function
+// that blocks until draining has finished. It is used during the configuration
+// reload and shutdown phases, when the Run control loop is not selecting on the
+// channel, so that a component reporting a fatal error while it stops does not
+// block on the send and deadlock.
+func (col *Collector) drainAsyncErrors() (stop func()) {
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		for {
+			select {
+			case err := <-col.asyncErrorChannel:
+				col.service.Logger().Error("Asynchronous error received while reconfiguring or shutting down", zap.Error(err))
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		<-stopped
+	}
+}
+
 func (col *Collector) shutdown(ctx context.Context) error {
 	col.setCollectorState(StateClosing)
+
+	// The Run control loop no longer reads asyncErrorChannel once shutdown starts,
+	// so keep draining it while components stop. Otherwise a component reporting a
+	// fatal error during shutdown would block on the send.
+	stop := col.drainAsyncErrors()
+	defer stop()
 
 	// Accumulate errors and proceed with shutting down remaining components.
 	var errs error

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -174,6 +174,106 @@ func TestCollectorReportError(t *testing.T) {
 	assert.Equal(t, StateClosed, col.GetState())
 }
 
+func TestCollectorShutdownDrainsAsyncErrorChannel(t *testing.T) {
+	// A component reporting a fatal error while the collector is shutting down must
+	// not block: the Run control loop, the only reader of the async error channel,
+	// has already stopped reading by then. See issue #9824.
+	var col *Collector
+
+	// Telemetry is shut down as part of the service shutdown, after the Run loop has
+	// exited, so reporting an async error from here exercises the shutdown path.
+	shutdown := func(context.Context) error {
+		col.asyncErrorChannel <- errors.New("fatal error while shutting down")
+		return nil
+	}
+	factories, err := nopFactories()
+	require.NoError(t, err)
+	factories.Telemetry = telemetry.NewFactory(
+		func() component.Config { return fakeTelemetryConfig{} },
+		telemetrytest.WithLogger(zap.NewNop(), shutdown),
+	)
+
+	col, err = NewCollector(CollectorSettings{
+		BuildInfo:              component.NewDefaultBuildInfo(),
+		Factories:              func() (Factories, error) { return factories, nil },
+		ConfigProviderSettings: newDefaultConfigProviderSettings(t, []string{filepath.Join("testdata", "otelcol-nop.yaml")}),
+	})
+	require.NoError(t, err)
+
+	wg := startCollector(context.Background(), t, col)
+
+	assert.Eventually(t, func() bool {
+		return StateRunning == col.GetState()
+	}, 2*time.Second, 200*time.Millisecond)
+
+	// Shutdown blocks until Run returns. If the async error reported during
+	// shutdown is not drained, the reporting goroutine blocks and Shutdown never
+	// returns, so guard it with a timeout to fail fast instead of hanging.
+	done := make(chan struct{})
+	go func() {
+		col.Shutdown()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for shutdown; async error reported during shutdown blocked")
+	}
+
+	wg.Wait()
+	assert.Equal(t, StateClosed, col.GetState())
+}
+
+func TestCollectorReloadDrainsAsyncErrorChannel(t *testing.T) {
+	// During a config reload the control loop is blocked in reloadConfiguration and
+	// not reading asyncErrorChannel. A component reporting a fatal error while the
+	// retiring service stops must not block. See issue #9824.
+	var col *Collector
+	var reportOnce sync.Once
+	reloadStarted := make(chan struct{})
+	shutdown := func(context.Context) error {
+		// On the retiring service's shutdown during the reload triggered below,
+		// signal the test and then report a fatal error on the async error channel.
+		reportOnce.Do(func() {
+			close(reloadStarted)
+			col.asyncErrorChannel <- errors.New("fatal error during reload")
+		})
+		return nil
+	}
+	factories, err := nopFactories()
+	require.NoError(t, err)
+	factories.Telemetry = telemetry.NewFactory(
+		func() component.Config { return fakeTelemetryConfig{} },
+		telemetrytest.WithLogger(zap.NewNop(), shutdown),
+	)
+
+	col, err = NewCollector(CollectorSettings{
+		BuildInfo:              component.NewDefaultBuildInfo(),
+		Factories:              func() (Factories, error) { return factories, nil },
+		ConfigProviderSettings: newDefaultConfigProviderSettings(t, []string{filepath.Join("testdata", "otelcol-nop.yaml")}),
+	})
+	require.NoError(t, err)
+
+	wg := startCollector(context.Background(), t, col)
+	assert.Eventually(t, func() bool {
+		return StateRunning == col.GetState()
+	}, 2*time.Second, 200*time.Millisecond)
+
+	// Trigger a reload. Once the retiring service begins shutting down (reloadStarted),
+	// the fatal error is being reported on the async error channel. With the fix it is
+	// drained and the reload completes (back to Running); without it the send blocks
+	// and the collector stays in StateClosing.
+	col.signalsChannel <- SIGHUP
+	<-reloadStarted
+	require.Eventually(t, func() bool {
+		return StateRunning == col.GetState()
+	}, 5*time.Second, 50*time.Millisecond, "reload did not complete; async error reported during reload blocked")
+
+	col.Shutdown()
+	wg.Wait()
+	assert.Equal(t, StateClosed, col.GetState())
+}
+
 // NewStatusWatcherExtensionFactory returns a component.ExtensionFactory to construct a status watcher extension.
 func NewStatusWatcherExtensionFactory(
 	onStatusChanged func(source *componentstatus.InstanceID, event *componentstatus.Event),


### PR DESCRIPTION
otelcol: drain async error channel during reload and shutdown

asyncErrorChannel is only read by the Run control loop's select. While a
configuration reload or shutdown is in progress the loop is not selecting
on it, so a component that reports a fatal error as it stops (for example,
a server goroutine returning after its listener is closed) sends on the
unbuffered channel with no reader and blocks forever, deadlocking the
reload or shutdown.

This adds a small drainAsyncErrors helper that consumes the channel for
the duration of the reload and shutdown phases and stops once they finish.
Normal operation is unchanged.

Fixes #9824

Signed-off-by: Rajneesh Chaudhary <rajneeshrehsaan48@gmail.com>
