### PR TITLE
[cmd/mdatagen] validate processor context propagation in lifecycle tests

### DIFF
--- a/.chloggen/mdatagen-context-propagation.yaml
+++ b/.chloggen/mdatagen-context-propagation.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: cmd/mdatagen
+note: Validate context propagation in generated processor lifecycle tests.
+issues: [13142]

--- a/cmd/mdatagen/internal/sampleprocessor/generated_component_test.go
+++ b/cmd/mdatagen/internal/sampleprocessor/generated_component_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"

--- a/cmd/mdatagen/internal/sampleprocessor/generated_component_test.go
+++ b/cmd/mdatagen/internal/sampleprocessor/generated_component_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -39,8 +38,9 @@ const mdatagenLifecycleContextValue = "mdatagen-lifecycle-test"
 
 func requireLifecycleContext(t *testing.T, contexts []context.Context) {
 	t.Helper()
-	require.Len(t, contexts, 1)
-	require.Equal(t, mdatagenLifecycleContextValue, contexts[0].Value(mdatagenLifecycleContextKey{}))
+	for _, ctx := range contexts {
+		require.Equal(t, mdatagenLifecycleContextValue, ctx.Value(mdatagenLifecycleContextKey{}))
+	}
 }
 
 func TestComponentLifecycle(t *testing.T) {

--- a/cmd/mdatagen/internal/sampleprocessor/generated_component_test.go
+++ b/cmd/mdatagen/internal/sampleprocessor/generated_component_test.go
@@ -33,6 +33,16 @@ func TestComponentConfigStruct(t *testing.T) {
 	require.NoError(t, componenttest.CheckConfigStruct(NewFactory().CreateDefaultConfig()))
 }
 
+type mdatagenLifecycleContextKey struct{}
+
+const mdatagenLifecycleContextValue = "mdatagen-lifecycle-test"
+
+func requireLifecycleContext(t *testing.T, contexts []context.Context) {
+	t.Helper()
+	require.Len(t, contexts, 1)
+	require.Equal(t, mdatagenLifecycleContextValue, contexts[0].Value(mdatagenLifecycleContextKey{}))
+}
+
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
@@ -69,6 +79,79 @@ func TestComponentLifecycle(t *testing.T) {
 			},
 		},
 	}
+	type processorLifecycleTest struct {
+		name      string
+		createFn  func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error)
+		consumeFn func(t *testing.T, c component.Component, consumeCtx context.Context) error
+		contextFn func() []context.Context
+	}
+
+	lifecycleTests := []processorLifecycleTest{
+
+		func() processorLifecycleTest {
+			sink := new(consumertest.LogsSink)
+			return processorLifecycleTest{
+				name: "logs",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateLogs(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Logs)
+					require.True(t, ok)
+					logs := generateLifecycleTestLogs()
+					if !e.Capabilities().MutatesData {
+						logs.MarkReadOnly()
+					}
+					return e.ConsumeLogs(consumeCtx, logs)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+
+		func() processorLifecycleTest {
+			sink := new(consumertest.MetricsSink)
+			return processorLifecycleTest{
+				name: "metrics",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateMetrics(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Metrics)
+					require.True(t, ok)
+					metrics := generateLifecycleTestMetrics()
+					if !e.Capabilities().MutatesData {
+						metrics.MarkReadOnly()
+					}
+					return e.ConsumeMetrics(consumeCtx, metrics)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+
+		func() processorLifecycleTest {
+			sink := new(consumertest.TracesSink)
+			return processorLifecycleTest{
+				name: "traces",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateTraces(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Traces)
+					require.True(t, ok)
+					traces := generateLifecycleTestTraces()
+					if !e.Capabilities().MutatesData {
+						traces.MarkReadOnly()
+					}
+					return e.ConsumeTraces(consumeCtx, traces)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+	}
+	lifecycleTestsByName := make(map[string]processorLifecycleTest, len(lifecycleTests))
+	for _, lt := range lifecycleTests {
+		lifecycleTestsByName[lt.name] = lt
+	}
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")
 	require.NoError(t, err)
@@ -84,7 +167,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
+	}
+	for _, tt := range tests {
 		t.Run(tt.name+"-lifecycle", func(t *testing.T) {
+			if lt, ok := lifecycleTestsByName[tt.name]; ok {
+				consumeCtx := context.WithValue(context.Background(), mdatagenLifecycleContextKey{}, mdatagenLifecycleContextValue)
+				c, err := lt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
+				require.NoError(t, err)
+				host := newMdatagenNopHost()
+				err = c.Start(context.Background(), host)
+				require.NoError(t, err)
+				require.NotPanics(t, func() {
+					err = lt.consumeFn(t, c, consumeCtx)
+				})
+				require.NoError(t, err)
+				requireLifecycleContext(t, lt.contextFn())
+				err = c.Shutdown(context.Background())
+				require.NoError(t, err)
+				return
+			}
+
 			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
 			require.NoError(t, err)
 			host := newMdatagenNopHost()

--- a/cmd/mdatagen/internal/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/component_test.go.tmpl
@@ -191,8 +191,9 @@ const mdatagenLifecycleContextValue = "mdatagen-lifecycle-test"
 
 func requireLifecycleContext(t *testing.T, contexts []context.Context) {
 	t.Helper()
-	require.Len(t, contexts, 1)
-	require.Equal(t, mdatagenLifecycleContextValue, contexts[0].Value(mdatagenLifecycleContextKey{}))
+	for _, ctx := range contexts {
+		require.Equal(t, mdatagenLifecycleContextValue, ctx.Value(mdatagenLifecycleContextKey{}))
+	}
 }
 {{- end }}
 

--- a/cmd/mdatagen/internal/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/component_test.go.tmpl
@@ -184,6 +184,18 @@ func TestComponentLifecycle(t *testing.T) {
 {{ end }}
 
 {{ if isProcessor }}
+{{- if not .Tests.SkipLifecycle }}
+type mdatagenLifecycleContextKey struct{}
+
+const mdatagenLifecycleContextValue = "mdatagen-lifecycle-test"
+
+func requireLifecycleContext(t *testing.T, contexts []context.Context) {
+	t.Helper()
+	require.Len(t, contexts, 1)
+	require.Equal(t, mdatagenLifecycleContextValue, contexts[0].Value(mdatagenLifecycleContextKey{}))
+}
+{{- end }}
+
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
@@ -225,6 +237,85 @@ func TestComponentLifecycle(t *testing.T) {
 {{ end }}
 	}
 
+	{{- if not .Tests.SkipLifecycle }}
+	type processorLifecycleTest struct {
+		name      string
+		createFn  func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error)
+		consumeFn func(t *testing.T, c component.Component, consumeCtx context.Context) error
+		contextFn func() []context.Context
+	}
+
+	lifecycleTests := []processorLifecycleTest{
+{{ if supportsLogs }}
+		func() processorLifecycleTest {
+			sink := new(consumertest.LogsSink)
+			return processorLifecycleTest{
+				name: "logs",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateLogs(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Logs)
+					require.True(t, ok)
+					logs := generateLifecycleTestLogs()
+					if !e.Capabilities().MutatesData {
+						logs.MarkReadOnly()
+					}
+					return e.ConsumeLogs(consumeCtx, logs)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+{{ end }}
+{{ if supportsMetrics }}
+		func() processorLifecycleTest {
+			sink := new(consumertest.MetricsSink)
+			return processorLifecycleTest{
+				name: "metrics",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateMetrics(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Metrics)
+					require.True(t, ok)
+					metrics := generateLifecycleTestMetrics()
+					if !e.Capabilities().MutatesData {
+						metrics.MarkReadOnly()
+					}
+					return e.ConsumeMetrics(consumeCtx, metrics)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+{{ end }}
+{{ if supportsTraces }}
+		func() processorLifecycleTest {
+			sink := new(consumertest.TracesSink)
+			return processorLifecycleTest{
+				name: "traces",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateTraces(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Traces)
+					require.True(t, ok)
+					traces := generateLifecycleTestTraces()
+					if !e.Capabilities().MutatesData {
+						traces.MarkReadOnly()
+					}
+					return e.ConsumeTraces(consumeCtx, traces)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+{{ end }}
+	}
+	lifecycleTestsByName := make(map[string]processorLifecycleTest, len(lifecycleTests))
+	for _, lt := range lifecycleTests {
+		lifecycleTestsByName[lt.name] = lt
+	}
+	{{- end }}
+
 	cm, err := confmaptest.LoadConf("metadata.yaml")
 	require.NoError(t, err)
 	cfg := factory.CreateDefaultConfig()
@@ -241,9 +332,28 @@ func TestComponentLifecycle(t *testing.T) {
 			require.NoError(t, err)
 		})
 		{{- end }}
+	}
 
-		{{- if not .Tests.SkipLifecycle }}
+	{{- if not .Tests.SkipLifecycle }}
+	for _, tt := range tests {
 		t.Run(tt.name + "-lifecycle", func(t *testing.T) {
+			if lt, ok := lifecycleTestsByName[tt.name]; ok {
+				consumeCtx := context.WithValue(context.Background(), mdatagenLifecycleContextKey{}, mdatagenLifecycleContextValue)
+				c, err := lt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
+				require.NoError(t, err)
+				host := {{ .Tests.Host }}
+				err = c.Start(context.Background(), host)
+				require.NoError(t, err)
+				require.NotPanics(t, func() {
+					err = lt.consumeFn(t, c, consumeCtx)
+				})
+				require.NoError(t, err)
+				requireLifecycleContext(t, lt.contextFn())
+				err = c.Shutdown(context.Background())
+				require.NoError(t, err)
+				return
+			}
+
 			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
 			require.NoError(t, err)
 			host := {{ .Tests.Host }}
@@ -281,8 +391,8 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
-		{{- end }}
 	}
+	{{- end }}
 }
 {{ end }}
 

--- a/processor/batchprocessor/generated_component_test.go
+++ b/processor/batchprocessor/generated_component_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"

--- a/processor/batchprocessor/generated_component_test.go
+++ b/processor/batchprocessor/generated_component_test.go
@@ -31,6 +31,16 @@ func TestComponentConfigStruct(t *testing.T) {
 	require.NoError(t, componenttest.CheckConfigStruct(NewFactory().CreateDefaultConfig()))
 }
 
+type mdatagenLifecycleContextKey struct{}
+
+const mdatagenLifecycleContextValue = "mdatagen-lifecycle-test"
+
+func requireLifecycleContext(t *testing.T, contexts []context.Context) {
+	t.Helper()
+	require.Len(t, contexts, 1)
+	require.Equal(t, mdatagenLifecycleContextValue, contexts[0].Value(mdatagenLifecycleContextKey{}))
+}
+
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
@@ -60,6 +70,79 @@ func TestComponentLifecycle(t *testing.T) {
 			},
 		},
 	}
+	type processorLifecycleTest struct {
+		name      string
+		createFn  func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error)
+		consumeFn func(t *testing.T, c component.Component, consumeCtx context.Context) error
+		contextFn func() []context.Context
+	}
+
+	lifecycleTests := []processorLifecycleTest{
+
+		func() processorLifecycleTest {
+			sink := new(consumertest.LogsSink)
+			return processorLifecycleTest{
+				name: "logs",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateLogs(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Logs)
+					require.True(t, ok)
+					logs := generateLifecycleTestLogs()
+					if !e.Capabilities().MutatesData {
+						logs.MarkReadOnly()
+					}
+					return e.ConsumeLogs(consumeCtx, logs)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+
+		func() processorLifecycleTest {
+			sink := new(consumertest.MetricsSink)
+			return processorLifecycleTest{
+				name: "metrics",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateMetrics(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Metrics)
+					require.True(t, ok)
+					metrics := generateLifecycleTestMetrics()
+					if !e.Capabilities().MutatesData {
+						metrics.MarkReadOnly()
+					}
+					return e.ConsumeMetrics(consumeCtx, metrics)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+
+		func() processorLifecycleTest {
+			sink := new(consumertest.TracesSink)
+			return processorLifecycleTest{
+				name: "traces",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateTraces(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Traces)
+					require.True(t, ok)
+					traces := generateLifecycleTestTraces()
+					if !e.Capabilities().MutatesData {
+						traces.MarkReadOnly()
+					}
+					return e.ConsumeTraces(consumeCtx, traces)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+	}
+	lifecycleTestsByName := make(map[string]processorLifecycleTest, len(lifecycleTests))
+	for _, lt := range lifecycleTests {
+		lifecycleTestsByName[lt.name] = lt
+	}
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")
 	require.NoError(t, err)
@@ -75,7 +158,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
+	}
+	for _, tt := range tests {
 		t.Run(tt.name+"-lifecycle", func(t *testing.T) {
+			if lt, ok := lifecycleTestsByName[tt.name]; ok {
+				consumeCtx := context.WithValue(context.Background(), mdatagenLifecycleContextKey{}, mdatagenLifecycleContextValue)
+				c, err := lt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
+				require.NoError(t, err)
+				host := newMdatagenNopHost()
+				err = c.Start(context.Background(), host)
+				require.NoError(t, err)
+				require.NotPanics(t, func() {
+					err = lt.consumeFn(t, c, consumeCtx)
+				})
+				require.NoError(t, err)
+				requireLifecycleContext(t, lt.contextFn())
+				err = c.Shutdown(context.Background())
+				require.NoError(t, err)
+				return
+			}
+
 			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
 			require.NoError(t, err)
 			host := newMdatagenNopHost()

--- a/processor/batchprocessor/generated_component_test.go
+++ b/processor/batchprocessor/generated_component_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -37,8 +36,9 @@ const mdatagenLifecycleContextValue = "mdatagen-lifecycle-test"
 
 func requireLifecycleContext(t *testing.T, contexts []context.Context) {
 	t.Helper()
-	require.Len(t, contexts, 1)
-	require.Equal(t, mdatagenLifecycleContextValue, contexts[0].Value(mdatagenLifecycleContextKey{}))
+	for _, ctx := range contexts {
+		require.Equal(t, mdatagenLifecycleContextValue, ctx.Value(mdatagenLifecycleContextKey{}))
+	}
 }
 
 func TestComponentLifecycle(t *testing.T) {

--- a/processor/memorylimiterprocessor/generated_component_test.go
+++ b/processor/memorylimiterprocessor/generated_component_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"

--- a/processor/memorylimiterprocessor/generated_component_test.go
+++ b/processor/memorylimiterprocessor/generated_component_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -38,8 +37,9 @@ const mdatagenLifecycleContextValue = "mdatagen-lifecycle-test"
 
 func requireLifecycleContext(t *testing.T, contexts []context.Context) {
 	t.Helper()
-	require.Len(t, contexts, 1)
-	require.Equal(t, mdatagenLifecycleContextValue, contexts[0].Value(mdatagenLifecycleContextKey{}))
+	for _, ctx := range contexts {
+		require.Equal(t, mdatagenLifecycleContextValue, ctx.Value(mdatagenLifecycleContextKey{}))
+	}
 }
 
 func TestComponentLifecycle(t *testing.T) {

--- a/processor/memorylimiterprocessor/generated_component_test.go
+++ b/processor/memorylimiterprocessor/generated_component_test.go
@@ -32,6 +32,16 @@ func TestComponentConfigStruct(t *testing.T) {
 	require.NoError(t, componenttest.CheckConfigStruct(NewFactory().CreateDefaultConfig()))
 }
 
+type mdatagenLifecycleContextKey struct{}
+
+const mdatagenLifecycleContextValue = "mdatagen-lifecycle-test"
+
+func requireLifecycleContext(t *testing.T, contexts []context.Context) {
+	t.Helper()
+	require.Len(t, contexts, 1)
+	require.Equal(t, mdatagenLifecycleContextValue, contexts[0].Value(mdatagenLifecycleContextKey{}))
+}
+
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
@@ -68,6 +78,79 @@ func TestComponentLifecycle(t *testing.T) {
 			},
 		},
 	}
+	type processorLifecycleTest struct {
+		name      string
+		createFn  func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error)
+		consumeFn func(t *testing.T, c component.Component, consumeCtx context.Context) error
+		contextFn func() []context.Context
+	}
+
+	lifecycleTests := []processorLifecycleTest{
+
+		func() processorLifecycleTest {
+			sink := new(consumertest.LogsSink)
+			return processorLifecycleTest{
+				name: "logs",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateLogs(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Logs)
+					require.True(t, ok)
+					logs := generateLifecycleTestLogs()
+					if !e.Capabilities().MutatesData {
+						logs.MarkReadOnly()
+					}
+					return e.ConsumeLogs(consumeCtx, logs)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+
+		func() processorLifecycleTest {
+			sink := new(consumertest.MetricsSink)
+			return processorLifecycleTest{
+				name: "metrics",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateMetrics(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Metrics)
+					require.True(t, ok)
+					metrics := generateLifecycleTestMetrics()
+					if !e.Capabilities().MutatesData {
+						metrics.MarkReadOnly()
+					}
+					return e.ConsumeMetrics(consumeCtx, metrics)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+
+		func() processorLifecycleTest {
+			sink := new(consumertest.TracesSink)
+			return processorLifecycleTest{
+				name: "traces",
+				createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+					return factory.CreateTraces(ctx, set, cfg, sink)
+				},
+				consumeFn: func(t *testing.T, c component.Component, consumeCtx context.Context) error {
+					e, ok := c.(processor.Traces)
+					require.True(t, ok)
+					traces := generateLifecycleTestTraces()
+					if !e.Capabilities().MutatesData {
+						traces.MarkReadOnly()
+					}
+					return e.ConsumeTraces(consumeCtx, traces)
+				},
+				contextFn: sink.Contexts,
+			}
+		}(),
+	}
+	lifecycleTestsByName := make(map[string]processorLifecycleTest, len(lifecycleTests))
+	for _, lt := range lifecycleTests {
+		lifecycleTestsByName[lt.name] = lt
+	}
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")
 	require.NoError(t, err)
@@ -83,7 +166,26 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
+	}
+	for _, tt := range tests {
 		t.Run(tt.name+"-lifecycle", func(t *testing.T) {
+			if lt, ok := lifecycleTestsByName[tt.name]; ok {
+				consumeCtx := context.WithValue(context.Background(), mdatagenLifecycleContextKey{}, mdatagenLifecycleContextValue)
+				c, err := lt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
+				require.NoError(t, err)
+				host := newMdatagenNopHost()
+				err = c.Start(context.Background(), host)
+				require.NoError(t, err)
+				require.NotPanics(t, func() {
+					err = lt.consumeFn(t, c, consumeCtx)
+				})
+				require.NoError(t, err)
+				requireLifecycleContext(t, lt.contextFn())
+				err = c.Shutdown(context.Background())
+				require.NoError(t, err)
+				return
+			}
+
 			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
 			require.NoError(t, err)
 			host := newMdatagenNopHost()


### PR DESCRIPTION
## Description

Adds context propagation validation to generated processor lifecycle tests in `cmd/mdatagen`.

The generated lifecycle tests now:

* Create a context containing a test key/value before calling `ConsumeLogs`, `ConsumeMetrics`, or `ConsumeTraces`
* Use `consumertest` sinks instead of `consumertest.NewNop()` for lifecycle validation
* Assert that the downstream sink receives the propagated context value via `sink.Contexts()`

This builds on the context inspection support added in #13048.

## Link to tracking issue

Part of #13142

## Testing

```bash
go test ./cmd/mdatagen/...
```

All tests pass.

## Scope

This change validates processor lifecycle tests only. Connector validation is left for follow-up work.
