### PR TITLE
[cmd/builder] Add source_archive support for modules with build-time-generated source

### DIFF
--- a/.chloggen/builder-source-archive.yaml
+++ b/.chloggen/builder-source-archive.yaml
@@ -10,8 +10,7 @@ component: cmd/builder
 note: Add `source_archive` as a standalone module source for components whose source must be downloaded from a release archive because generated code is not committed to version control.
 
 # One or more tracking issues or pull requests related to the change
-# TODO: replace placeholder issue number with the real tracking issue once it exists.
-issues: [99999]
+issues: [15430]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/builder-source-archive.yaml
+++ b/.chloggen/builder-source-archive.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `source_archive` as a standalone module source for components whose source must be downloaded from a release archive because generated code is not committed to version control.
+
+# One or more tracking issues or pull requests related to the change
+# TODO: replace placeholder issue number with the real tracking issue once it exists.
+issues: [99999]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  A module may declare a `source_archive` block (with a `url` and either a `sha256` digest or a
+  `sha256_url`) instead of `gomod`; the two are mutually exclusive. The builder downloads,
+  checksum-verifies, and extracts the archive (`.tar.gz`, `.tgz`, or `.zip`) into a local cache and
+  builds the component from it. No module version is declared: the artifact is the version, pinned
+  by `sha256`, so the manifest never asserts a Go module version that cannot be verified against the
+  downloaded bytes. The required `import` selects the package to build from the archive. The cache
+  root can be overridden with the `--download-cache-dir` flag or the `download_cache_dir` config field.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -174,6 +174,64 @@ replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.128.0
 ```
 
+### Source archives
+
+Some components cannot be built directly from their version control contents because
+generated code is not committed and is instead published as a release asset. For these
+components, a module may declare a `source_archive` block instead of a `gomod` entry. A
+`source_archive` is a *standalone module source*: the builder downloads the archive, verifies
+its checksum, extracts it into a local cache, and builds the component entirely from the
+extracted directory.
+
+```yaml
+receivers:
+    # import is mandatory for source_archive modules: it selects the package to build
+    # out of the archive, and there is no gomod to default it from.
+  - import: go.opentelemetry.io/obi/collector
+    source_archive:
+      # The URL of the archive to download. Required. Must use the https or file scheme.
+      url: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v0.9.0/obi-v0.9.0-source-generated.tar.gz
+      # The expected hex-encoded sha256 digest of the archive. Exactly one of
+      # sha256 or sha256_url is required.
+      sha256: "<hex digest>"
+      # Alternatively, a URL to a SHA256SUMS-style file from which to resolve the
+      # digest, matching on the archive's base file name.
+      # sha256_url: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v0.9.0/SHA256SUMS
+      # An optional subdirectory within the archive where the module's go.mod lives. Optional.
+      # subdir: collector
+```
+
+`gomod` and `source_archive` are mutually exclusive: a module is *either* a Go module
+reference *or* an artifact. There is deliberately no module version declared alongside a
+`source_archive`. The artifact **is** the version — pinned exactly by its `sha256` — so the
+manifest never makes a Go module version assertion that cannot be verified against the
+downloaded bytes. (Earlier drafts paired `gomod: foo v0.9.0` with the archive; that allowed
+the manifest to claim a version the archive did not actually contain. The standalone form
+removes that unverifiable claim.) The builder reads the real module path from the extracted
+`go.mod` and synthesizes an internal `replace` against the cache directory, so nothing
+downstream needs a version.
+
+`import` is required and must be the module path from the archive's `go.mod` or a package
+within it; otherwise the component would not actually be built from the archive and the
+builder fails with a clear error. A nested module (its own `go.mod`) along the import path is
+also rejected, since the replace would not cover the import.
+
+Supported archive formats are `.tar.gz`/`.tgz` and `.zip`. The `source_archive` and `path`
+fields are mutually exclusive on the same module. If the extracted archive contains a single
+top-level directory and no top-level `go.mod`, the builder descends into it automatically;
+`subdir` is then applied relative to that.
+
+Multiple components may be built from a single archive — for example a receiver and an
+extension published in one artifact. Declare each with its own `import` and an identical
+`source_archive` (same `sha256`); the archive is downloaded and extracted once (the cache is
+keyed by digest), and the generated `go.mod` emits a single deduplicated `require`/`replace`
+for the shared module. Declaring the same module path from two different archives is an error.
+
+Archives are cached under `os.UserCacheDir()/otelcol-builder/source_archive/<sha256>`. The
+cache root can be overridden with the `--download-cache-dir` flag or the top-level
+`download_cache_dir` configuration field. A cached archive is reused without any network
+access on subsequent builds.
+
 The builder also allows setting the scheme to use as the default URI scheme via `conf_resolver.default_uri_scheme`:
 
 ```yaml

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -4,8 +4,11 @@
 package builder // import "go.opentelemetry.io/collector/cmd/builder/internal/builder"
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,8 +26,8 @@ const (
 	DefaultStableOtelColVersion = "v1.59.0"
 )
 
-// errMissingGoMod indicates an empty gomod field
-var errMissingGoMod = errors.New("missing gomod specification for module")
+// errMissingGoMod indicates a module that specifies neither gomod nor source_archive.
+var errMissingGoMod = errors.New("module requires either a gomod specification or a source_archive")
 
 // Config holds the builder's configuration
 type Config struct {
@@ -55,7 +58,12 @@ type Config struct {
 
 	ConfResolver ConfResolver `mapstructure:"conf_resolver,omitempty"`
 
-	downloadModules retry `mapstructure:"-"`
+	// DownloadCacheDir overrides the cache root for downloaded source archives.
+	DownloadCacheDir string `mapstructure:"download_cache_dir,omitempty"`
+
+	downloadModules        retry        `mapstructure:"-"`
+	sourceArchiveCacheRoot string       `mapstructure:"-"` // test-only override
+	httpClient             *http.Client `mapstructure:"-"` // test-only override
 }
 
 type ConfResolver struct {
@@ -81,10 +89,28 @@ type Distribution struct {
 
 // Module represents a receiver, exporter, processor or extension for the distribution
 type Module struct {
-	Name   string `mapstructure:"name,omitempty"`   // if not specified, this is package part of the go mod (last part of the path)
-	Import string `mapstructure:"import,omitempty"` // if not specified, this is the path part of the go mods
-	GoMod  string `mapstructure:"gomod,omitempty"`  // a gomod-compatible spec for the module
-	Path   string `mapstructure:"path,omitempty"`   // an optional path to the local version of this module
+	Name          string         `mapstructure:"name,omitempty"`           // if not specified, this is package part of the go mod (last part of the path)
+	Import        string         `mapstructure:"import,omitempty"`         // if not specified, this is the path part of the go mods; mandatory for source_archive modules
+	GoMod         string         `mapstructure:"gomod,omitempty"`          // a gomod-compatible spec for the module; mutually exclusive with source_archive
+	Path          string         `mapstructure:"path,omitempty"`           // an optional path to the local version of this module
+	SourceArchive *SourceArchive `mapstructure:"source_archive,omitempty"` // a downloaded source archive used as the module's source; mutually exclusive with gomod
+
+	fromSourceArchive bool `mapstructure:"-"`
+}
+
+// IsFromSourceArchive reports whether this module was resolved from a source_archive.
+func (m Module) IsFromSourceArchive() bool {
+	return m.fromSourceArchive
+}
+
+// SourceArchive is a downloaded, checksum-verified archive used as a module's
+// source, for components whose committed source does not compile (e.g. generated
+// code published as a release asset rather than committed).
+type SourceArchive struct {
+	URL       string `mapstructure:"url,omitempty"`        // https or file scheme
+	SHA256    string `mapstructure:"sha256,omitempty"`     // expected hex sha256; exactly one of sha256/sha256_url
+	SHA256URL string `mapstructure:"sha256_url,omitempty"` // SHA256SUMS-style file to resolve the digest from
+	Subdir    string `mapstructure:"subdir,omitempty"`     // optional subdirectory holding the module's go.mod
 }
 
 type retry struct {
@@ -169,6 +195,15 @@ func (c *Config) SetGoPath() error {
 
 // ParseModules will parse the Modules entries and populate the missing values
 func (c *Config) ParseModules() error {
+	// Resolve any declared source archives before path handling, so that the
+	// downloaded/extracted location can be used as the module's replace target.
+	if err := c.resolveSourceArchives(); err != nil {
+		return err
+	}
+	if err := c.checkSourceArchiveConflicts(); err != nil {
+		return err
+	}
+
 	var err error
 	usedNames := make(map[string]int)
 
@@ -218,11 +253,116 @@ func (c *Config) allComponents() []Module {
 	return slices.Concat(c.Exporters, c.Receivers, c.Processors, c.Extensions, c.Connectors, []Module{c.Telemetry}, c.ConfmapProviders, c.ConfmapConverters)
 }
 
+// SourceArchiveModules returns one module per distinct source-archive module
+// path, so the go.mod template emits a single require/replace when several
+// components share one archive.
+func (c *Config) SourceArchiveModules() []Module {
+	seen := make(map[string]struct{})
+	var out []Module
+	for _, mod := range c.allComponents() {
+		if !mod.fromSourceArchive {
+			continue
+		}
+		modulePath, _, _ := strings.Cut(mod.GoMod, " ")
+		if _, ok := seen[modulePath]; ok {
+			continue
+		}
+		seen[modulePath] = struct{}{}
+		out = append(out, mod)
+	}
+	return out
+}
+
+// checkSourceArchiveConflicts rejects two archives claiming the same module path.
+func (c *Config) checkSourceArchiveConflicts() error {
+	paths := make(map[string]string) // module path -> replace target
+	for _, mod := range c.allComponents() {
+		if !mod.fromSourceArchive {
+			continue
+		}
+		modulePath, _, _ := strings.Cut(mod.GoMod, " ")
+		if existing, ok := paths[modulePath]; ok {
+			if existing != mod.Path {
+				return fmt.Errorf("source_archive module %q is provided by two different archives (%q and %q); a module path can only be replaced once", modulePath, existing, mod.Path)
+			}
+			continue
+		}
+		paths[modulePath] = mod.Path
+	}
+	return nil
+}
+
 func validateModules(name string, mods []Module) error {
 	for i, mod := range mods {
-		if mod.GoMod == "" {
-			return fmt.Errorf("%s module at index %v: %w", name, i, errMissingGoMod)
+		if err := validateModuleSource(mod); err != nil {
+			return fmt.Errorf("%s module at index %v: %w", name, i, err)
 		}
+	}
+	return nil
+}
+
+// validateModuleSource enforces exactly one of gomod/source_archive.
+func validateModuleSource(mod Module) error {
+	switch {
+	case mod.GoMod != "" && mod.SourceArchive != nil:
+		return errors.New("gomod and source_archive are mutually exclusive")
+	case mod.GoMod == "" && mod.SourceArchive == nil:
+		return errMissingGoMod
+	}
+	return validateSourceArchive(mod)
+}
+
+// validateSourceArchive checks the source_archive block of a module, if present.
+func validateSourceArchive(mod Module) error {
+	if mod.SourceArchive == nil {
+		return nil
+	}
+	sa := mod.SourceArchive
+	if mod.Path != "" {
+		return errors.New("source_archive and path cannot both be set on the same module")
+	}
+	if mod.Import == "" {
+		return errors.New("source_archive requires import to be set (the package to build from the archive)")
+	}
+	if sa.URL == "" {
+		return errors.New("source_archive requires url")
+	}
+	if err := validateArchiveURLScheme("url", sa.URL); err != nil {
+		return err
+	}
+
+	switch {
+	case sa.SHA256 != "" && sa.SHA256URL != "":
+		return errors.New("source_archive: exactly one of sha256 or sha256_url must be set, not both")
+	case sa.SHA256 == "" && sa.SHA256URL == "":
+		return errors.New("source_archive: exactly one of sha256 or sha256_url must be set")
+	}
+
+	if sa.SHA256 != "" {
+		if len(sa.SHA256) != 64 {
+			return fmt.Errorf("source_archive: sha256 must be 64 hex characters, got %d", len(sa.SHA256))
+		}
+		if _, err := hex.DecodeString(sa.SHA256); err != nil {
+			return fmt.Errorf("source_archive: sha256 is not valid hex: %w", err)
+		}
+	}
+
+	if sa.SHA256URL != "" {
+		if err := validateArchiveURLScheme("sha256_url", sa.SHA256URL); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateArchiveURLScheme(field, raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("source_archive: %s is not a valid URL: %w", field, err)
+	}
+	if u.Scheme != "https" && u.Scheme != "file" {
+		return fmt.Errorf("source_archive: %s scheme must be https or file, got %q", field, u.Scheme)
 	}
 	return nil
 }
@@ -234,12 +374,18 @@ func validateTelemetry(c *Config) error {
 	// would get a blend of this value and user-provided values. Once
 	// otelconftelemetry is its own module (that is, the `Import` field is not
 	// set), we can likely move the default to createDefaultConfig.
-	if c.Telemetry.Name == "" && c.Telemetry.Import == "" && c.Telemetry.GoMod == "" && c.Telemetry.Path == "" {
+	if c.Telemetry.Name == "" && c.Telemetry.Import == "" && c.Telemetry.GoMod == "" && c.Telemetry.Path == "" && c.Telemetry.SourceArchive == nil {
 		c.Telemetry = Module{
 			GoMod:  "go.opentelemetry.io/collector/service " + DefaultBetaOtelColVersion,
 			Import: "go.opentelemetry.io/collector/service/telemetry/otelconftelemetry",
 		}
-	} else if c.Telemetry.GoMod == "" {
+		return nil
+	}
+	// Telemetry has no component-import wiring, so source_archive is unsupported.
+	if c.Telemetry.SourceArchive != nil {
+		return errors.New("telemetry module: source_archive is not supported for the telemetry module; use gomod")
+	}
+	if c.Telemetry.GoMod == "" {
 		return fmt.Errorf("telemetry module: %w", errMissingGoMod)
 	}
 
@@ -281,7 +427,8 @@ func (c *Config) parseModules(mods []Module, usedNames map[string]int) ([]Module
 				return mods, fmt.Errorf("failed to resolve absolute path for %s: %w", mod.Path, err)
 			}
 
-			if c.Distribution.UseAbsoluteReplacePaths {
+			if c.Distribution.UseAbsoluteReplacePaths || mod.fromSourceArchive {
+				// Archive-derived paths live in a machine-local cache; keep absolute.
 				mod.Path = absPath
 			} else {
 				absOutputPath, err := filepath.Abs(c.Distribution.OutputPath)

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -629,3 +629,134 @@ func TestMarshalYAML(t *testing.T) {
 	assert.NotContains(t, m, "conf_resolver")
 	assert.NotContains(t, m, "telemetry")
 }
+
+func TestValidateSourceArchive(t *testing.T) {
+	const validHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	tests := []struct {
+		name    string
+		mod     Module
+		wantErr string
+	}{
+		{
+			name: "valid inline sha256",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz", SHA256: validHash},
+			},
+		},
+		{
+			name: "valid sha256_url",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz", SHA256URL: "https://example.com/SHA256SUMS"},
+			},
+		},
+		{
+			name: "valid file scheme",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "file:///tmp/a.tar.gz", SHA256: validHash},
+			},
+		},
+		{
+			name: "missing url",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{SHA256: validHash},
+			},
+			wantErr: "requires url",
+		},
+		{
+			name: "missing checksum",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz"},
+			},
+			wantErr: "exactly one of sha256 or sha256_url must be set",
+		},
+		{
+			name: "both checksums",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz", SHA256: validHash, SHA256URL: "https://example.com/SHA256SUMS"},
+			},
+			wantErr: "not both",
+		},
+		{
+			name: "bad url scheme",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "ftp://example.com/a.tar.gz", SHA256: validHash},
+			},
+			wantErr: "scheme must be https or file",
+		},
+		{
+			name: "bad sha256_url scheme",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz", SHA256URL: "http://example.com/SHA256SUMS"},
+			},
+			wantErr: "sha256_url scheme must be https or file",
+		},
+		{
+			name: "path and source_archive conflict",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				Path:          "./local",
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz", SHA256: validHash},
+			},
+			wantErr: "source_archive and path cannot both be set",
+		},
+		{
+			name: "gomod and source_archive mutually exclusive",
+			mod: Module{
+				GoMod:         "go.opentelemetry.io/obi v0.9.0",
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz", SHA256: validHash},
+			},
+			wantErr: "gomod and source_archive are mutually exclusive",
+		},
+		{
+			name: "source_archive requires import",
+			mod: Module{
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz", SHA256: validHash},
+			},
+			wantErr: "source_archive requires import",
+		},
+		{
+			name:    "neither gomod nor source_archive",
+			mod:     Module{Import: "go.opentelemetry.io/obi/collector"},
+			wantErr: "either a gomod specification or a source_archive",
+		},
+		{
+			name: "bad hex length",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz", SHA256: "abcd"},
+			},
+			wantErr: "must be 64 hex characters",
+		},
+		{
+			name: "not hex",
+			mod: Module{
+				Import:        "go.opentelemetry.io/obi/collector",
+				SourceArchive: &SourceArchive{URL: "https://example.com/a.tar.gz", SHA256: "zz" + validHash[2:]},
+			},
+			wantErr: "not valid hex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{Logger: zap.NewNop(), Receivers: []Module{tt.mod}}
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -201,6 +201,13 @@ func GetModules(cfg *Config) error {
 	}
 
 	for _, mod := range cfg.allComponents() {
+		if mod.fromSourceArchive {
+			// Source-archive modules carry a synthetic v0.0.0-sourcearchive version
+			// (the artifact is the version, pinned by sha256) and are wired in via a
+			// directory replace, so their require version is never resolved against a
+			// proxy. There is no upstream version to reconcile, so skip them.
+			continue
+		}
 		module, version, _ := strings.Cut(mod.GoMod, " ")
 		if module == modulePath {
 			// No need to check the version of components that are part of the

--- a/cmd/builder/internal/builder/source_archive.go
+++ b/cmd/builder/internal/builder/source_archive.go
@@ -1,0 +1,566 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package builder // import "go.opentelemetry.io/collector/cmd/builder/internal/builder"
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/mod/modfile"
+)
+
+const (
+	// completeMarker marks a cache directory as fully extracted and reusable.
+	completeMarker = ".complete"
+
+	// maxDecompressedSize and maxFileCount bound decompression bombs.
+	maxDecompressedSize = 8 << 30
+	maxFileCount        = 1 << 20
+
+	httpClientTimeout = 5 * time.Minute
+)
+
+// resolveSourceArchives downloads, verifies and extracts every module's source archive.
+func (c *Config) resolveSourceArchives() error {
+	lists := [][]Module{
+		c.Extensions,
+		c.Receivers,
+		c.Exporters,
+		c.Processors,
+		c.Connectors,
+		{c.Telemetry},
+		c.ConfmapProviders,
+		c.ConfmapConverters,
+	}
+	for _, list := range lists {
+		for i := range list {
+			if list[i].SourceArchive == nil {
+				continue
+			}
+			if err := c.resolveSourceArchive(&list[i]); err != nil {
+				return err
+			}
+		}
+	}
+	// c.Telemetry was passed by a one-element slice literal above, so copy back.
+	c.Telemetry = lists[5][0]
+	return nil
+}
+
+// sourceArchiveVersion is the synthetic require version for archive modules. It
+// is never resolved (a directory replace bypasses the proxy) but must be valid semver.
+const sourceArchiveVersion = "v0.0.0-sourcearchive"
+
+func (c *Config) resolveSourceArchive(mod *Module) error {
+	sa := mod.SourceArchive
+
+	wantHash, err := c.resolveExpectedHash(sa)
+	if err != nil {
+		return fmt.Errorf("source_archive %q: %w", sa.URL, err)
+	}
+
+	cacheRoot, err := c.sourceArchiveCache()
+	if err != nil {
+		return err
+	}
+	cacheDir := filepath.Join(cacheRoot, wantHash)
+
+	effectiveRoot, modulePath, err := c.ensureExtracted(cacheRoot, cacheDir, sa, wantHash)
+	if err != nil {
+		return fmt.Errorf("source_archive %q: %w", sa.URL, err)
+	}
+
+	// Runs on cache hits too: mod.Import can differ between runs.
+	if err := validateArchiveImport(mod.Import, modulePath, effectiveRoot); err != nil {
+		return fmt.Errorf("source_archive %q: %w", sa.URL, err)
+	}
+
+	c.Logger.Info("Resolved source archive", zap.String("module", modulePath), zap.String("import", mod.Import), zap.String("path", effectiveRoot))
+	mod.Path = effectiveRoot
+	mod.GoMod = modulePath + " " + sourceArchiveVersion
+	mod.fromSourceArchive = true
+	return nil
+}
+
+// validateArchiveImport verifies mod.Import is within the archive's module and
+// not shadowed by a nested module along the import path.
+func validateArchiveImport(importPath, modulePath, effectiveRoot string) error {
+	if importPath != modulePath && !strings.HasPrefix(importPath, modulePath+"/") {
+		return fmt.Errorf("import %q is not within module %q provided by the archive — the component would not be built from the archive", importPath, modulePath)
+	}
+
+	// A go.mod along the import path is a nested module that would own the import,
+	// which the outer module's replace would not cover.
+	rel := strings.TrimPrefix(importPath, modulePath)
+	rel = strings.TrimPrefix(rel, "/")
+	if rel == "" {
+		return nil
+	}
+	segments := strings.Split(rel, "/")
+	dir := effectiveRoot
+	for _, seg := range segments {
+		dir = filepath.Join(dir, seg)
+		if fileExists(filepath.Join(dir, "go.mod")) {
+			nested := modulePath + "/" + strings.TrimPrefix(strings.TrimPrefix(dir, effectiveRoot), string(filepath.Separator))
+			nested = filepath.ToSlash(nested)
+			return fmt.Errorf("import %q is shadowed by nested module %q in the archive — its replace would not cover the import", importPath, nested)
+		}
+	}
+	return nil
+}
+
+// sourceArchiveCache returns the root directory used to cache source archives.
+func (c *Config) sourceArchiveCache() (string, error) {
+	if c.sourceArchiveCacheRoot != "" {
+		return c.sourceArchiveCacheRoot, nil
+	}
+	if c.DownloadCacheDir != "" {
+		return c.DownloadCacheDir, nil
+	}
+	userCache, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine user cache dir: %w", err)
+	}
+	return filepath.Join(userCache, "otelcol-builder", "source_archive"), nil
+}
+
+func (c *Config) resolveExpectedHash(sa *SourceArchive) (string, error) {
+	if sa.SHA256 != "" {
+		return strings.ToLower(sa.SHA256), nil
+	}
+
+	body, err := c.fetchBytes(sa.SHA256URL)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch sha256_url: %w", err)
+	}
+
+	base := path.Base(mustURLPath(sa.URL))
+	for line := range strings.SplitSeq(string(body), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// sha256sum format: "<hex>  <filename>", '*' prefix for binary mode.
+		name := strings.TrimPrefix(fields[len(fields)-1], "*")
+		if path.Base(name) == base {
+			return strings.ToLower(fields[0]), nil
+		}
+	}
+	return "", fmt.Errorf("sha256_url %q does not contain an entry for %q", sa.SHA256URL, base)
+}
+
+// ensureExtracted populates cacheDir with the verified, extracted archive and
+// returns the effective module root and the module path from its go.mod. The
+// download is skipped when cacheDir already has a completion marker.
+func (c *Config) ensureExtracted(cacheRoot, cacheDir string, sa *SourceArchive, wantHash string) (string, string, error) {
+	if marker := filepath.Join(cacheDir, completeMarker); fileExists(marker) {
+		c.Logger.Info("Using cached source archive", zap.String("path", cacheDir))
+		return c.effectiveRoot(cacheDir, sa)
+	}
+
+	if err := os.MkdirAll(cacheRoot, 0o750); err != nil {
+		return "", "", fmt.Errorf("failed to create cache root: %w", err)
+	}
+
+	archivePath, err := c.downloadArchive(cacheRoot, sa, wantHash)
+	if err != nil {
+		return "", "", err
+	}
+	defer os.Remove(archivePath)
+
+	tmpDir, err := os.MkdirTemp(cacheRoot, "extract-")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp extraction dir: %w", err)
+	}
+	// On any error, clean up the partial extraction.
+	committed := false
+	defer func() {
+		if !committed {
+			os.RemoveAll(tmpDir)
+		}
+	}()
+
+	if err := extractArchive(archivePath, sa.URL, tmpDir); err != nil {
+		return "", "", err
+	}
+
+	if _, _, err := c.effectiveRoot(tmpDir, sa); err != nil {
+		return "", "", err
+	}
+
+	if err := os.WriteFile(filepath.Join(tmpDir, completeMarker), nil, 0o600); err != nil {
+		return "", "", fmt.Errorf("failed to write completion marker: %w", err)
+	}
+	if err := os.Rename(tmpDir, cacheDir); err != nil {
+		// Lost-race case: another process already populated the cache dir.
+		if fileExists(filepath.Join(cacheDir, completeMarker)) {
+			os.RemoveAll(tmpDir)
+			committed = true
+			return c.effectiveRoot(cacheDir, sa)
+		}
+		return "", "", fmt.Errorf("failed to move extracted archive into cache: %w", err)
+	}
+	committed = true
+
+	return c.effectiveRoot(cacheDir, sa)
+}
+
+// effectiveRoot resolves the module root within an extracted tree (auto-stripping
+// a lone top-level directory and applying subdir) and returns it with the module
+// path read from the resolved go.mod.
+func (c *Config) effectiveRoot(root string, sa *SourceArchive) (string, string, error) {
+	effective := root
+
+	// Auto-strip a lone top-level directory when there is no top-level go.mod.
+	if !fileExists(filepath.Join(effective, "go.mod")) {
+		entries, err := os.ReadDir(effective)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to read extracted root: %w", err)
+		}
+		var dirs []string
+		extraFiles := false
+		for _, e := range entries {
+			switch {
+			case e.IsDir():
+				dirs = append(dirs, e.Name())
+			case e.Name() == completeMarker:
+				// ignore the completion marker written by ensureExtracted
+			default:
+				extraFiles = true
+			}
+		}
+		if len(dirs) == 1 && !extraFiles {
+			effective = filepath.Join(effective, dirs[0])
+		}
+	}
+
+	if sa.Subdir != "" {
+		cleaned := filepath.Clean(sa.Subdir)
+		if filepath.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			return "", "", fmt.Errorf("subdir %q escapes the archive tree", sa.Subdir)
+		}
+		candidate := filepath.Join(effective, cleaned)
+		rel, err := filepath.Rel(effective, candidate)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return "", "", fmt.Errorf("subdir %q escapes the archive tree", sa.Subdir)
+		}
+		effective = candidate
+	}
+
+	goModPath := filepath.Join(effective, "go.mod")
+	data, err := os.ReadFile(filepath.Clean(goModPath))
+	if err != nil {
+		return "", "", fmt.Errorf("expected go.mod at %q: %w", goModPath, err)
+	}
+	parsed, err := modfile.Parse(goModPath, data, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse go.mod at %q: %w", goModPath, err)
+	}
+	if parsed.Module == nil {
+		return "", "", fmt.Errorf("go.mod at %q has no module path", goModPath)
+	}
+
+	return effective, parsed.Module.Mod.Path, nil
+}
+
+// downloadArchive downloads and sha256-verifies the archive, retrying on failure.
+func (c *Config) downloadArchive(cacheRoot string, sa *SourceArchive, wantHash string) (string, error) {
+	var failReason string
+	for i := 1; i <= c.downloadModules.numRetries; i++ {
+		archivePath, err := c.downloadArchiveOnce(cacheRoot, sa, wantHash)
+		if err == nil {
+			return archivePath, nil
+		}
+		failReason = err.Error()
+		c.Logger.Info("Failed source archive download", zap.String("retry", fmt.Sprintf("%d/%d", i, c.downloadModules.numRetries)), zap.String("error", failReason))
+		if i < c.downloadModules.numRetries {
+			time.Sleep(c.downloadModules.wait)
+		}
+	}
+	return "", fmt.Errorf("failed to download source archive: %s", failReason)
+}
+
+func (c *Config) downloadArchiveOnce(cacheRoot string, sa *SourceArchive, wantHash string) (string, error) {
+	c.Logger.Info("Downloading source archive", zap.String("url", sa.URL))
+
+	rc, err := c.openURL(sa.URL)
+	if err != nil {
+		return "", err
+	}
+	defer rc.Close()
+
+	tmp, err := os.CreateTemp(cacheRoot, "download-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp download file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	hasher := sha256.New()
+	if _, err = io.Copy(tmp, io.TeeReader(rc, hasher)); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return "", fmt.Errorf("failed to read source archive: %w", err)
+	}
+	if err = tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return "", fmt.Errorf("failed to close download file: %w", err)
+	}
+
+	gotHash := hex.EncodeToString(hasher.Sum(nil))
+	if gotHash != wantHash {
+		os.Remove(tmpName)
+		return "", fmt.Errorf("sha256 mismatch: got %s, want %s", gotHash, wantHash)
+	}
+	return tmpName, nil
+}
+
+// fileURLPath converts a file:// URL to an OS path, handling Windows drive paths
+// (file:///C:/dir -> C:\dir).
+func fileURLPath(u *url.URL) string {
+	p := u.Path
+	if len(p) >= 3 && p[0] == '/' && p[2] == ':' {
+		p = p[1:]
+	}
+	return filepath.FromSlash(p)
+}
+
+// openURL opens an https or file URL for reading.
+func (c *Config) openURL(raw string) (io.ReadCloser, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL %q: %w", raw, err)
+	}
+	switch {
+	case u.Scheme == "file":
+		f, err := os.Open(filepath.Clean(fileURLPath(u)))
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	case u.Scheme == "https", u.Scheme == "http" && c.httpClient != nil:
+		// http is honored only with an injected client (test-only).
+		client := c.httpClient
+		if client == nil {
+			client = &http.Client{Timeout: httpClientTimeout}
+		}
+		//nolint:noctx // download uses a client-level timeout
+		resp, err := client.Get(raw)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("unexpected status %s for %q", resp.Status, raw)
+		}
+		return resp.Body, nil
+	default:
+		return nil, fmt.Errorf("unsupported URL scheme %q", u.Scheme)
+	}
+}
+
+// fetchBytes reads the full contents of an https or file URL.
+func (c *Config) fetchBytes(raw string) ([]byte, error) {
+	rc, err := c.openURL(raw)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(io.LimitReader(rc, 1<<20))
+}
+
+// extractArchive extracts a .tar.gz/.tgz or .zip archive into dst.
+func extractArchive(archivePath, sourceURL, dst string) error {
+	switch {
+	case hasSuffixFold(sourceURL, ".tar.gz"), hasSuffixFold(sourceURL, ".tgz"):
+		return extractTarGz(archivePath, dst)
+	case hasSuffixFold(sourceURL, ".zip"):
+		return extractZip(archivePath, dst)
+	default:
+		return fmt.Errorf("unsupported archive type for %q (expected .tar.gz, .tgz or .zip)", sourceURL)
+	}
+}
+
+func extractTarGz(archivePath, dst string) error {
+	f, err := os.Open(filepath.Clean(archivePath))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("failed to open gzip stream: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var total int64
+	var count int
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar entry: %w", err)
+		}
+
+		count++
+		if count > maxFileCount {
+			return fmt.Errorf("archive exceeds maximum file count of %d", maxFileCount)
+		}
+
+		target, err := sanitizeEntryPath(dst, hdr.Name)
+		if err != nil {
+			return err
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o750); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			written, err := writeRegularFile(target, tr, hdr.FileInfo().Mode(), total)
+			if err != nil {
+				return err
+			}
+			total = written
+		default:
+			// Skip symlinks, devices, etc.
+			continue
+		}
+	}
+	return nil
+}
+
+func extractZip(archivePath, dst string) error {
+	zr, err := zip.OpenReader(filepath.Clean(archivePath))
+	if err != nil {
+		return fmt.Errorf("failed to open zip: %w", err)
+	}
+	defer zr.Close()
+
+	var total int64
+	var count int
+	for _, file := range zr.File {
+		count++
+		if count > maxFileCount {
+			return fmt.Errorf("archive exceeds maximum file count of %d", maxFileCount)
+		}
+
+		target, err := sanitizeEntryPath(dst, file.Name)
+		if err != nil {
+			return err
+		}
+
+		if file.FileInfo().IsDir() {
+			if mkErr := os.MkdirAll(target, 0o750); mkErr != nil {
+				return mkErr
+			}
+			continue
+		}
+		if !file.Mode().IsRegular() {
+			// Skip symlinks, devices, etc.
+			continue
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			return err
+		}
+		written, err := writeRegularFile(target, rc, file.Mode(), total)
+		rc.Close()
+		if err != nil {
+			return err
+		}
+		total = written
+	}
+	return nil
+}
+
+// sanitizeEntryPath validates an archive entry name and returns the absolute
+// destination path, rejecting absolute paths and parent-directory traversal.
+func sanitizeEntryPath(dst, name string) (string, error) {
+	slashed := filepath.ToSlash(name)
+	if name == "" || slashed == "/" {
+		return "", fmt.Errorf("archive entry %q has an empty name", name)
+	}
+	if filepath.IsAbs(name) || strings.HasPrefix(slashed, "/") {
+		return "", fmt.Errorf("archive entry %q has an absolute path", name)
+	}
+	// Clean unrooted so traversal segments survive for detection below.
+	clean := filepath.Clean(filepath.FromSlash(name))
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive entry %q escapes the destination directory", name)
+	}
+	target := filepath.Join(dst, clean)
+	rel, err := filepath.Rel(dst, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive entry %q escapes the destination directory", name)
+	}
+	return target, nil
+}
+
+// writeRegularFile writes the contents of r to target, enforcing the total
+// decompressed-size cap, and preserving only the exec bit of the mode.
+func writeRegularFile(target string, r io.Reader, mode os.FileMode, total int64) (int64, error) {
+	if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+		return total, err
+	}
+
+	perm := os.FileMode(0o644)
+	if mode&0o100 != 0 {
+		perm = 0o755
+	}
+
+	out, err := os.OpenFile(filepath.Clean(target), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return total, err
+	}
+	defer out.Close()
+
+	remaining := max(maxDecompressedSize-total, 0)
+	// Allow one extra byte so we can detect overflow.
+	n, err := io.Copy(out, io.LimitReader(r, remaining+1))
+	total += n
+	if err != nil {
+		return total, err
+	}
+	if total > maxDecompressedSize {
+		return total, fmt.Errorf("archive exceeds maximum decompressed size of %d bytes", maxDecompressedSize)
+	}
+	return total, nil
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+func hasSuffixFold(s, suffix string) bool {
+	return len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix)
+}
+
+func mustURLPath(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	return u.Path
+}

--- a/cmd/builder/internal/builder/source_archive_test.go
+++ b/cmd/builder/internal/builder/source_archive_test.go
@@ -1,0 +1,552 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// tarEntry describes a single file or directory to add to a test archive.
+type tarEntry struct {
+	name string
+	body string // empty => directory
+	mode int64
+}
+
+func buildTarGz(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for _, e := range entries {
+		hdr := &tar.Header{Name: e.name, Mode: e.mode}
+		if e.body == "" && e.name[len(e.name)-1] == '/' {
+			hdr.Typeflag = tar.TypeDir
+		} else {
+			hdr.Typeflag = tar.TypeReg
+			hdr.Size = int64(len(e.body))
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		if hdr.Typeflag == tar.TypeReg {
+			_, err := tw.Write([]byte(e.body))
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+func buildZip(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, e := range entries {
+		if e.body == "" && e.name[len(e.name)-1] == '/' {
+			_, err := zw.Create(e.name)
+			require.NoError(t, err)
+			continue
+		}
+		w, err := zw.Create(e.name)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(e.body))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func goModFor(module string) string {
+	return fmt.Sprintf("module %s\n\ngo 1.25.0\n", module)
+}
+
+func writeArchiveFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, data, 0o600))
+	return p
+}
+
+func fileURL(p string) string {
+	// On Windows an absolute path is e.g. C:\dir\file; a valid file URL needs
+	// forward slashes and a leading slash before the drive letter
+	// (file:///C:/dir/file). On Unix the path already starts with "/".
+	p = filepath.ToSlash(p)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return (&url.URL{Scheme: "file", Path: p}).String()
+}
+
+func newArchiveConfig(t *testing.T) *Config {
+	cfg, err := NewDefaultConfig()
+	require.NoError(t, err)
+	cfg.Logger = zap.NewNop()
+	cfg.downloadModules.numRetries = 1
+	cfg.downloadModules.wait = 0
+	cfg.sourceArchiveCacheRoot = t.TempDir()
+	cfg.ConfmapProviders = nil
+	return cfg
+}
+
+func TestExtractArchive(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+
+	tests := []struct {
+		name       string
+		fileName   string
+		entries    []tarEntry
+		subdir     string
+		importPath string // defaults to module when empty
+		zip        bool
+		wantErr    string
+		wantRelDir string // relative to extraction root, "" means root
+	}{
+		{
+			name:     "tar.gz auto strip single dir",
+			fileName: "example-v1.tar.gz",
+			entries: []tarEntry{
+				{name: "example-v1/", mode: 0o755},
+				{name: "example-v1/go.mod", body: goModFor(module), mode: 0o644},
+				{name: "example-v1/main.go", body: "package main\n", mode: 0o644},
+			},
+			wantRelDir: "example-v1",
+		},
+		{
+			name:     "tar.gz with subdir",
+			fileName: "example-v1.tar.gz",
+			entries: []tarEntry{
+				{name: "go.mod", body: goModFor("go.opentelemetry.io/example/root"), mode: 0o644},
+				{name: "collector/", mode: 0o755},
+				{name: "collector/go.mod", body: goModFor(module), mode: 0o644},
+			},
+			subdir:     "collector",
+			wantRelDir: "collector",
+		},
+		{
+			name:     "zip auto strip single dir",
+			fileName: "example-v1.zip",
+			zip:      true,
+			entries: []tarEntry{
+				{name: "example-v1/"},
+				{name: "example-v1/go.mod", body: goModFor(module)},
+			},
+			wantRelDir: "example-v1",
+		},
+		{
+			name:     "path traversal rejected",
+			fileName: "evil.tar.gz",
+			entries: []tarEntry{
+				{name: "../evil.txt", body: "x", mode: 0o644},
+			},
+			wantErr: "escapes the destination directory",
+		},
+		{
+			name:     "import outside module rejected",
+			fileName: "example-v1.tar.gz",
+			entries: []tarEntry{
+				{name: "go.mod", body: goModFor(module), mode: 0o644},
+			},
+			importPath: "go.opentelemetry.io/other/collector",
+			wantErr:    "is not within module",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			var data []byte
+			if tt.zip {
+				data = buildZip(t, tt.entries)
+			} else {
+				data = buildTarGz(t, tt.entries)
+			}
+			archivePath := writeArchiveFile(t, srcDir, tt.fileName, data)
+
+			importPath := tt.importPath
+			if importPath == "" {
+				importPath = module
+			}
+
+			cfg := newArchiveConfig(t)
+			mod := &Module{
+				Import: importPath,
+				SourceArchive: &SourceArchive{
+					URL:    fileURL(archivePath),
+					SHA256: sha256Hex(data),
+					Subdir: tt.subdir,
+				},
+			}
+
+			err := cfg.resolveSourceArchive(mod)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, mod.fromSourceArchive)
+			assert.True(t, filepath.IsAbs(mod.Path))
+			assert.FileExists(t, filepath.Join(mod.Path, "go.mod"))
+			// The module reference is synthesized from the archive's go.mod path.
+			assert.Equal(t, module+" "+sourceArchiveVersion, mod.GoMod)
+		})
+	}
+}
+
+func TestResolveSourceArchiveSHA256Mismatch(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+	srcDir := t.TempDir()
+	data := buildTarGz(t, []tarEntry{{name: "go.mod", body: goModFor(module), mode: 0o644}})
+	archivePath := writeArchiveFile(t, srcDir, "example.tar.gz", data)
+
+	cfg := newArchiveConfig(t)
+	mod := &Module{
+		Import: module,
+		SourceArchive: &SourceArchive{
+			URL:    fileURL(archivePath),
+			SHA256: sha256Hex([]byte("not the archive")),
+		},
+	}
+
+	err := cfg.resolveSourceArchive(mod)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sha256 mismatch")
+}
+
+func TestResolveSourceArchiveHTTPAndCache(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+	data := buildTarGz(t, []tarEntry{
+		{name: "example-v1/", mode: 0o755},
+		{name: "example-v1/go.mod", body: goModFor(module), mode: 0o644},
+	})
+
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	// The httptest server serves plain http; openURL only honors the http scheme
+	// when a client is injected (scheme validation happens in Validate, not here).
+	cfg := newArchiveConfig(t)
+	cfg.httpClient = srv.Client()
+	mod := &Module{
+		Import: module,
+		SourceArchive: &SourceArchive{
+			URL:    srv.URL + "/example-v1.tar.gz",
+			SHA256: sha256Hex(data),
+		},
+	}
+
+	require.NoError(t, cfg.resolveSourceArchive(mod))
+	assert.Equal(t, int32(1), requests.Load())
+	firstPath := mod.Path
+
+	// Second resolution should hit the cache and not the server.
+	mod2 := &Module{
+		Import: module,
+		SourceArchive: &SourceArchive{
+			URL:    srv.URL + "/example-v1.tar.gz",
+			SHA256: sha256Hex(data),
+		},
+	}
+	require.NoError(t, cfg.resolveSourceArchive(mod2))
+	assert.Equal(t, int32(1), requests.Load(), "second resolve must not hit the server")
+	assert.Equal(t, firstPath, mod2.Path)
+}
+
+func TestResolveSourceArchiveSHA256URL(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+	data := buildTarGz(t, []tarEntry{
+		{name: "example-v1/", mode: 0o755},
+		{name: "example-v1/go.mod", body: goModFor(module), mode: 0o644},
+	})
+	srcDir := t.TempDir()
+	archivePath := writeArchiveFile(t, srcDir, "example-v1.tar.gz", data)
+
+	sumsBody := fmt.Sprintf("%s  some-other-file.tar.gz\n%s  example-v1.tar.gz\n", sha256Hex([]byte("x")), sha256Hex(data))
+	sumsPath := writeArchiveFile(t, srcDir, "SHA256SUMS", []byte(sumsBody))
+
+	cfg := newArchiveConfig(t)
+	mod := &Module{
+		Import: module,
+		SourceArchive: &SourceArchive{
+			URL:       fileURL(archivePath),
+			SHA256URL: fileURL(sumsPath),
+		},
+	}
+
+	require.NoError(t, cfg.resolveSourceArchive(mod))
+	assert.FileExists(t, filepath.Join(mod.Path, "go.mod"))
+}
+
+func TestResolveSourceArchiveSHA256URLMissingEntry(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+	data := buildTarGz(t, []tarEntry{{name: "go.mod", body: goModFor(module), mode: 0o644}})
+	srcDir := t.TempDir()
+	archivePath := writeArchiveFile(t, srcDir, "example-v1.tar.gz", data)
+	sumsPath := writeArchiveFile(t, srcDir, "SHA256SUMS", []byte(sha256Hex([]byte("x"))+"  unrelated.tar.gz\n"))
+
+	cfg := newArchiveConfig(t)
+	mod := &Module{
+		Import: module,
+		SourceArchive: &SourceArchive{
+			URL:       fileURL(archivePath),
+			SHA256URL: fileURL(sumsPath),
+		},
+	}
+
+	err := cfg.resolveSourceArchive(mod)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not contain an entry")
+}
+
+// TestGenerateWithSourceArchive exercises the full ParseModules + Generate path
+// for a module backed by a file:// source archive, without compiling.
+func TestGenerateWithSourceArchive(t *testing.T) {
+	const module = "go.opentelemetry.io/example/extension"
+	data := buildTarGz(t, []tarEntry{
+		{name: "extension-v1/", mode: 0o755},
+		{name: "extension-v1/go.mod", body: goModFor(module), mode: 0o644},
+	})
+	srcDir := t.TempDir()
+	archivePath := writeArchiveFile(t, srcDir, "extension-v1.tar.gz", data)
+
+	cfg, err := NewDefaultConfig()
+	require.NoError(t, err)
+	cfg.Logger = zap.NewNop()
+	cfg.sourceArchiveCacheRoot = t.TempDir()
+	cfg.Distribution.OutputPath = t.TempDir()
+	cfg.SkipGenerate = false
+	cfg.SkipGetModules = true
+	cfg.SkipCompilation = true
+	cfg.Extensions = []Module{
+		{
+			Import: module,
+			SourceArchive: &SourceArchive{
+				URL:    fileURL(archivePath),
+				SHA256: sha256Hex(data),
+			},
+		},
+	}
+
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.ParseModules())
+
+	// The resolved path must be absolute and point inside the cache.
+	resolved := cfg.Extensions[0].Path
+	assert.True(t, filepath.IsAbs(resolved))
+	assert.FileExists(t, filepath.Join(resolved, "go.mod"))
+
+	require.NoError(t, Generate(cfg))
+	assert.FileExists(t, filepath.Join(cfg.Distribution.OutputPath, "go.mod"))
+}
+
+// TestResolveSourceArchiveImportSubpackage verifies a subpackage import within
+// the archive module is accepted and the synthetic module reference is the
+// archive's module path, not the import.
+func TestResolveSourceArchiveImportSubpackage(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+	data := buildTarGz(t, []tarEntry{
+		{name: "go.mod", body: goModFor(module), mode: 0o644},
+		{name: "collector/", mode: 0o755},
+		{name: "collector/component.go", body: "package collector\n", mode: 0o644},
+	})
+	srcDir := t.TempDir()
+	archivePath := writeArchiveFile(t, srcDir, "example-v1.tar.gz", data)
+
+	cfg := newArchiveConfig(t)
+	mod := &Module{
+		Import: module + "/collector",
+		SourceArchive: &SourceArchive{
+			URL:    fileURL(archivePath),
+			SHA256: sha256Hex(data),
+		},
+	}
+	require.NoError(t, cfg.resolveSourceArchive(mod))
+	assert.Equal(t, module+" "+sourceArchiveVersion, mod.GoMod)
+}
+
+// TestResolveSourceArchiveNestedModuleShadowing verifies that a nested go.mod
+// along the import's path is rejected, since its replace would not cover the
+// import.
+func TestResolveSourceArchiveNestedModuleShadowing(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+	data := buildTarGz(t, []tarEntry{
+		{name: "go.mod", body: goModFor(module), mode: 0o644},
+		{name: "collector/", mode: 0o755},
+		// A nested module owns collector/ and below.
+		{name: "collector/go.mod", body: goModFor(module + "/collector"), mode: 0o644},
+		{name: "collector/sub/", mode: 0o755},
+		{name: "collector/sub/x.go", body: "package sub\n", mode: 0o644},
+	})
+	srcDir := t.TempDir()
+	archivePath := writeArchiveFile(t, srcDir, "example-v1.tar.gz", data)
+
+	cfg := newArchiveConfig(t)
+	mod := &Module{
+		Import: module + "/collector/sub",
+		SourceArchive: &SourceArchive{
+			URL:    fileURL(archivePath),
+			SHA256: sha256Hex(data),
+		},
+	}
+	err := cfg.resolveSourceArchive(mod)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shadowed by nested module")
+}
+
+// TestSourceArchiveSharedByMultipleComponents verifies that two components built
+// from one archive (same module path, same target) produce a single deduped
+// require + replace and that Generate succeeds.
+func TestSourceArchiveSharedByMultipleComponents(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+	data := buildTarGz(t, []tarEntry{
+		{name: "go.mod", body: goModFor(module), mode: 0o644},
+		{name: "receiver/", mode: 0o755},
+		{name: "receiver/r.go", body: "package receiver\n", mode: 0o644},
+		{name: "extension/", mode: 0o755},
+		{name: "extension/e.go", body: "package extension\n", mode: 0o644},
+	})
+	srcDir := t.TempDir()
+	archivePath := writeArchiveFile(t, srcDir, "example-v1.tar.gz", data)
+	sa := func() *SourceArchive {
+		return &SourceArchive{URL: fileURL(archivePath), SHA256: sha256Hex(data)}
+	}
+
+	cfg, err := NewDefaultConfig()
+	require.NoError(t, err)
+	cfg.Logger = zap.NewNop()
+	cfg.ConfmapProviders = nil
+	cfg.sourceArchiveCacheRoot = t.TempDir()
+	cfg.Distribution.OutputPath = t.TempDir()
+	cfg.SkipGetModules = true
+	cfg.SkipCompilation = true
+	cfg.Receivers = []Module{{Import: module + "/receiver", SourceArchive: sa()}}
+	cfg.Extensions = []Module{{Import: module + "/extension", SourceArchive: sa()}}
+
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.ParseModules())
+
+	// Exactly one deduped archive module is exposed to the template.
+	require.Len(t, cfg.SourceArchiveModules(), 1)
+	assert.Equal(t, module+" "+sourceArchiveVersion, cfg.SourceArchiveModules()[0].GoMod)
+
+	require.NoError(t, Generate(cfg))
+
+	goMod, err := os.ReadFile(filepath.Join(cfg.Distribution.OutputPath, "go.mod"))
+	require.NoError(t, err)
+	replaceLine := "replace " + module + " " + sourceArchiveVersion + " => "
+	assert.Equal(t, 1, strings.Count(string(goMod), replaceLine), "expected exactly one replace for the shared archive module")
+	// The module reference "<path> <version>" appears exactly twice: once in the
+	// require block and once as the left-hand side of the single replace.
+	moduleRef := module + " " + sourceArchiveVersion
+	assert.Equal(t, 2, strings.Count(string(goMod), moduleRef), "expected one require and one replace, deduped")
+}
+
+// TestSourceArchiveConflictingDigests verifies that two components claiming the
+// same module path from different archives (different digests/targets) is a hard
+// error.
+func TestSourceArchiveConflictingDigests(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+	dataA := buildTarGz(t, []tarEntry{
+		{name: "go.mod", body: goModFor(module), mode: 0o644},
+		{name: "a.go", body: "package example // A\n", mode: 0o644},
+	})
+	dataB := buildTarGz(t, []tarEntry{
+		{name: "go.mod", body: goModFor(module), mode: 0o644},
+		{name: "b.go", body: "package example // B\n", mode: 0o644},
+	})
+	srcDir := t.TempDir()
+	pathA := writeArchiveFile(t, srcDir, "a.tar.gz", dataA)
+	pathB := writeArchiveFile(t, srcDir, "b.tar.gz", dataB)
+
+	cfg, err := NewDefaultConfig()
+	require.NoError(t, err)
+	cfg.Logger = zap.NewNop()
+	cfg.ConfmapProviders = nil
+	cfg.sourceArchiveCacheRoot = t.TempDir()
+	cfg.SkipGetModules = true
+	cfg.SkipCompilation = true
+	cfg.Receivers = []Module{{Import: module, SourceArchive: &SourceArchive{URL: fileURL(pathA), SHA256: sha256Hex(dataA)}}}
+	cfg.Extensions = []Module{{Import: module, SourceArchive: &SourceArchive{URL: fileURL(pathB), SHA256: sha256Hex(dataB)}}}
+
+	require.NoError(t, cfg.Validate())
+	err = cfg.ParseModules()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provided by two different archives")
+}
+
+// TestResolveSourceArchiveCacheHitRevalidatesImport verifies that a second
+// resolution served from the cache still runs import-prefix validation, which
+// depends on mod.Import (it can change between runs even when the archive bytes
+// are identical).
+func TestResolveSourceArchiveCacheHitRevalidatesImport(t *testing.T) {
+	const module = "go.opentelemetry.io/example"
+	data := buildTarGz(t, []tarEntry{
+		{name: "go.mod", body: goModFor(module), mode: 0o644},
+	})
+	srcDir := t.TempDir()
+	archivePath := writeArchiveFile(t, srcDir, "example-v1.tar.gz", data)
+
+	cfg := newArchiveConfig(t)
+	good := &Module{Import: module, SourceArchive: &SourceArchive{URL: fileURL(archivePath), SHA256: sha256Hex(data)}}
+	require.NoError(t, cfg.resolveSourceArchive(good))
+
+	// Same archive (cache hit), but a bad import outside the module path.
+	bad := &Module{Import: "go.opentelemetry.io/other", SourceArchive: &SourceArchive{URL: fileURL(archivePath), SHA256: sha256Hex(data)}}
+	err := cfg.resolveSourceArchive(bad)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not within module")
+}
+
+func TestSanitizeEntryPath(t *testing.T) {
+	dst := t.TempDir()
+	for _, tt := range []struct {
+		name    string
+		entry   string
+		wantErr bool
+	}{
+		{"regular", "foo/bar.go", false},
+		{"nested", "a/b/c.go", false},
+		{"absolute", "/etc/passwd", true},
+		{"traversal", "../escape", true},
+		{"traversal nested", "foo/../../escape", true},
+		{"empty", "", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sanitizeEntryPath(dst, tt.entry)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -6,25 +6,28 @@ go 1.25
 
 require (
 	{{- range .ConfmapConverters}}
-	{{if .GoMod}}{{.GoMod}}{{end}}
+	{{if and .GoMod (not .IsFromSourceArchive)}}{{.GoMod}}{{end}}
 	{{- end}}
 	{{- range .ConfmapProviders}}
-	{{if .GoMod}}{{.GoMod}}{{end}}
+	{{if and .GoMod (not .IsFromSourceArchive)}}{{.GoMod}}{{end}}
 	{{- end}}
 	{{- range .Connectors}}
-	{{if .GoMod}}{{.GoMod}}{{end}}
+	{{if and .GoMod (not .IsFromSourceArchive)}}{{.GoMod}}{{end}}
 	{{- end}}
 	{{- range .Extensions}}
-	{{if .GoMod}}{{.GoMod}}{{end}}
+	{{if and .GoMod (not .IsFromSourceArchive)}}{{.GoMod}}{{end}}
 	{{- end}}
 	{{- range .Receivers}}
-	{{if .GoMod}}{{.GoMod}}{{end}}
+	{{if and .GoMod (not .IsFromSourceArchive)}}{{.GoMod}}{{end}}
 	{{- end}}
 	{{- range .Exporters}}
-	{{if .GoMod}}{{.GoMod}}{{end}}
+	{{if and .GoMod (not .IsFromSourceArchive)}}{{.GoMod}}{{end}}
 	{{- end}}
 	{{- range .Processors}}
-	{{if .GoMod}}{{.GoMod}}{{end}}
+	{{if and .GoMod (not .IsFromSourceArchive)}}{{.GoMod}}{{end}}
+	{{- end}}
+	{{- range .SourceArchiveModules}}
+	{{.GoMod}}
 	{{- end}}
 	{{if .Telemetry.GoMod}}{{.Telemetry.GoMod}}{{end}}
 	go.opentelemetry.io/collector/otelcol {{.OtelColVersion}}
@@ -36,25 +39,28 @@ require (
 )
 
 {{- range .ConfmapConverters}}
-{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{if and (ne .Path "") (not .IsFromSourceArchive)}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
 {{- range .ConfmapProviders}}
-{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{if and (ne .Path "") (not .IsFromSourceArchive)}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
 {{- range .Connectors}}
-{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{if and (ne .Path "") (not .IsFromSourceArchive)}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
 {{- range .Extensions}}
-{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{if and (ne .Path "") (not .IsFromSourceArchive)}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
 {{- range .Receivers}}
-{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{if and (ne .Path "") (not .IsFromSourceArchive)}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
 {{- range .Exporters}}
-{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{if and (ne .Path "") (not .IsFromSourceArchive)}}replace {{.GoMod}} => {{.Path}}{{end}}
 {{- end}}
 {{- range .Processors}}
-{{if ne .Path ""}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{if and (ne .Path "") (not .IsFromSourceArchive)}}replace {{.GoMod}} => {{.Path}}{{end}}
+{{- end}}
+{{- range .SourceArchiveModules}}
+replace {{.GoMod}} => {{.Path}}
 {{- end}}
 {{if ne .Telemetry.Path ""}}replace {{.Telemetry.GoMod}} => {{.Telemetry.Path}}{{end}}
 {{- range .Replaces}}

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -29,6 +29,7 @@ const (
 	gcflagsFlag                = "gcflags"
 	distributionOutputPathFlag = "output-path"
 	verboseFlag                = "verbose"
+	downloadCacheDirFlag       = "download-cache-dir"
 )
 
 // Command is the main entrypoint for this application
@@ -85,6 +86,7 @@ func initFlags(flags *flag.FlagSet) error {
 	flags.String(ldflagsFlag, "", `ldflags to include in the "go build" command`)
 	flags.String(gcflagsFlag, "", `gcflags to include in the "go build" command`)
 	flags.String(distributionOutputPathFlag, "", "Where to write the resulting files")
+	flags.String(downloadCacheDirFlag, "", "Root directory used to cache downloaded source archives (default os.UserCacheDir()/otelcol-builder/source_archive)")
 	return flags.MarkDeprecated(distributionOutputPathFlag, "use config distribution::output_path")
 }
 
@@ -156,6 +158,11 @@ func applyFlags(flags *flag.FlagSet, cfg *builder.Config) error {
 
 	if flags.Changed(distributionOutputPathFlag) {
 		cfg.Distribution.OutputPath, err = flags.GetString(distributionOutputPathFlag)
+		errs = multierr.Append(errs, err)
+	}
+
+	if flags.Changed(downloadCacheDirFlag) {
+		cfg.DownloadCacheDir, err = flags.GetString(downloadCacheDirFlag)
 		errs = multierr.Append(errs, err)
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Some Go modules cannot be compiled from what 'go get' fetches because part of their source is generated at build time and intentionally not committed (e.g. go.opentelemetry.io/obi's bpf2go bindings). Allow a manifest module to be declared as an artifact instead of a Go module reference:

```yaml
  receivers:
    - import: go.opentelemetry.io/obi/collector 
      source_archive: 
        url: https://github.com/.../obi-v0.9.0-source-generated.tar.gz
        sha256: <hex>
        sha256_url: <hex>
```

source_archive is a standalone module source, mutually exclusive with gomod; import is required. OCB downloads the archive (https or file), verifies the sha256 (inline or from a SHA256SUMS-style url), extracts it (tar.gz/zip, hardened against traversal, symlinks and decompression bombs) into a digest-keyed cache under os.UserCacheDir()/otelcol-builder (override with --download-cache-dir), reads the module path from the archive's own go.mod, validates that import is within that module and not shadowed by a nested module, synthesizes an internal require (v0.0.0-sourcearchive, never resolved under a directory replace) and wires the existing replace machinery. Multiple components sharing one archive deduplicate to a single require/replace; the same module path with different digests is an error. No module version is declared in the manifest by design: the artifact is the version, pinned by sha256, so there is no unverifiable version claim.
<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15430

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Created a new distribution that fetches OBI from a source_archive. using the following config
```
dist:
  name: obi-otelcol
  description: Example otelcol distribution with the OBI eBPF receiver from a source archive
  module: example.com/obi-otelcol
  version: 0.1.0
  output_path: ./_build

receivers:
  # OBI publishes its compilable source (incl. generated BPF code) as a release
  # artifact, not via VCS — so it is declared as an artifact, not a gomod.
  - import: go.opentelemetry.io/obi/collector
    source_archive:
      url: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v0.9.0/obi-v0.9.0-source-generated.tar.gz
      sha256_url: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v0.9.0/SHA256SUMS
  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0

exporters:
  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.153.0
  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.153.0
```

and then build it with
```
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 ocb --config manifest.yaml
```

<!--Describe the documentation added.-->
#### Documentation
Updated README.md with how to use source_archive
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
