### PR TITLE
[chore] Skip benchmarks for non-code changes

### DIFF
--- a/.github/workflows/go-benchmarks.yml
+++ b/.github/workflows/go-benchmarks.yml
@@ -4,7 +4,25 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "Makefile"
+      - "Makefile.Common"
+      - ".github/workflows/go-benchmarks.yml"
   pull_request:
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "Makefile"
+      - "Makefile.Common"
+      - ".github/workflows/go-benchmarks.yml"
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Codspeed benchmarks are currently very flaky and unreliable. This skips them for noncode changes (e.g. RFCs or docs changes).

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
