### PR TITLE
[cmd/mdatagen] Fix: correct acronym handling in FormatIdentifier

### DIFF
--- a/.chloggen/id_formatter_fix.yaml
+++ b/.chloggen/id_formatter_fix.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: cmd/mdatagen
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix `FormatIdentifier` so that a string value that is exactly a known acronym generates the correct all-caps Go identifier
+note: Fix known acronyms at the end of generated Go identifiers to be all-caps, same as in any other position
 
 # One or more tracking issues or pull requests related to the change
 issues: [15438]

--- a/.chloggen/id_formatter_fix.yaml
+++ b/.chloggen/id_formatter_fix.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix `FormatIdentifier` so that a string value that is exactly a known acronym generates the correct all-caps Go identifier
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/.chloggen/id_formatter_fix.yaml
+++ b/.chloggen/id_formatter_fix.yaml
@@ -10,7 +10,7 @@ component: cmd/mdatagen
 note: Fix `FormatIdentifier` so that a string value that is exactly a known acronym generates the correct all-caps Go identifier
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [15438]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -2629,7 +2629,7 @@ func TestMapCustomDefaults_ArrayOfObjectsOverrides(t *testing.T) {
 		map[string]any{"url": "http://example.com"},
 	}), "", "")
 
-	require.Equal(t, []string{`[0].Url = "http://example.com"`}, exprs)
+	require.Equal(t, []string{`[0].URL = "http://example.com"`}, exprs)
 }
 
 func TestMapCustomDefaults_Panics(t *testing.T) {
@@ -2764,7 +2764,7 @@ func TestNewCfgFns_DefaultHelpers(t *testing.T) {
 		"endpoint",
 		defaultValue("localhost"),
 	))
-	require.Equal(t, []string{`[0].Url = "http://example.com"`}, mapCustomDefaults(
+	require.Equal(t, []string{`[0].URL = "http://example.com"`}, mapCustomDefaults(
 		&ConfigMetadata{
 			Type: "array",
 			Items: &ConfigMetadata{

--- a/cmd/mdatagen/internal/helpers/lint.go
+++ b/cmd/mdatagen/internal/helpers/lint.go
@@ -50,7 +50,7 @@ func FormatIdentifier(s string, exported bool) (string, error) {
 		}
 	}
 
-	if golint.Acronyms[strings.ToUpper(word)] && output != "" {
+	if golint.Acronyms[strings.ToUpper(word)] && (exported || output != "") {
 		output += strings.ToUpper(word)
 	} else {
 		output += word

--- a/cmd/mdatagen/internal/helpers/lint_test.go
+++ b/cmd/mdatagen/internal/helpers/lint_test.go
@@ -31,6 +31,14 @@ func TestFormatIdentifier(t *testing.T) {
 
 		// Exported.
 		{input: "cpu.state", want: "CPUState", exported: true},
+		// Standalone acronyms — exported must produce the all-caps form.
+		{input: "id", want: "ID", exported: true},
+		{input: "url", want: "URL", exported: true},
+		{input: "http", want: "HTTP", exported: true},
+		{input: "cpu", want: "CPU", exported: true},
+		// Standalone acronyms — unexported must stay lower-cased.
+		{input: "id", want: "id"},
+		{input: "url", want: "url"},
 
 		// Errors
 		{input: "", want: "", wantErr: "string cannot be empty"},

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
@@ -344,7 +344,7 @@ func (ms *ReaggregateMetricWithRequiredMetricConfig) Validate() error {
 type SystemCPUTimeMetricAttributeKey string
 
 const (
-	SystemCPUTimeMetricAttributeKeyCpu SystemCPUTimeMetricAttributeKey = "cpu"
+	SystemCPUTimeMetricAttributeKeyCPU SystemCPUTimeMetricAttributeKey = "cpu"
 )
 
 // SystemCPUTimeMetricConfig provides config for the system.cpu.time metric.
@@ -373,7 +373,7 @@ func (ms *SystemCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 func (ms *SystemCPUTimeMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case SystemCPUTimeMetricAttributeKeyCpu:
+		case SystemCPUTimeMetricAttributeKeyCPU:
 		default:
 			return fmt.Errorf("metric system.cpu.time doesn't have an attribute %v, valid attributes: [cpu]", val)
 		}
@@ -487,7 +487,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		SystemCPUTime: SystemCPUTimeMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCpu},
+			EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPU},
 		},
 		SystemMemoryUsage: SystemMemoryUsageMetricConfig{
 			Enabled:             true,

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config_test.go
@@ -64,7 +64,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCpu},
+						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPU},
 					},
 					SystemMemoryUsage: SystemMemoryUsageMetricConfig{
 						Enabled:             true,
@@ -125,7 +125,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCpu},
+						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPU},
 					},
 					SystemMemoryUsage: SystemMemoryUsageMetricConfig{
 						Enabled:             false,

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_metrics.go
@@ -836,7 +836,7 @@ func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SystemCPUTimeMetricAttributeKeyCpu) {
+	if slices.Contains(m.config.EnabledAttributes, SystemCPUTimeMetricAttributeKeyCPU) {
 		dp.Attributes().PutStr("cpu", cpuAttributeValue)
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix `FormatIdentifier` so that a property/attribute/metric name that is exactly a known acronym generates the correct all-caps Go identifier (e.g. `id` -> `ID`, `url` -> `URL`, `http` -> `HTTP`).

Note: any component whose metadata defines a metric, attribute, or event name that is exactly a standalone acronym (e.g. `cpu`, `id`, `url`) will have its generated exported Go identifier renamed on next regeneration — this is a source-breaking change for code that references such a generated constant directly.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Updated corresponding unit tests.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
