### PR TITLE
[pdata] Add EntityRef ID context type accessors

### DIFF
--- a/.chloggen/entityref-id-context-type.yaml
+++ b/.chloggen/entityref-id-context-type.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: pkg/xpdata
+note: Add `IdContextType` accessors to `xpdata/entity.EntityRef`.
+issues: [15441]
+change_logs: [api]

--- a/internal/cmd/pdatagen/internal/pdata/xpdata_entity_package.go
+++ b/internal/cmd/pdatagen/internal/pdata/xpdata_entity_package.go
@@ -77,5 +77,10 @@ var entityRef = &messageStruct{
 			protoType:   proto.TypeString,
 			returnSlice: stringSlice,
 		},
+		&PrimitiveField{
+			fieldName: "IdContextType",
+			protoID:   5,
+			protoType: proto.TypeString,
+		},
 	},
 }

--- a/pdata/internal/generated_proto_entityref.go
+++ b/pdata/internal/generated_proto_entityref.go
@@ -18,6 +18,7 @@ import (
 type EntityRef struct {
 	SchemaUrl       string
 	Type            string
+	IdContextType   string
 	IdKeys          []string
 	DescriptionKeys []string
 }
@@ -71,6 +72,8 @@ func CopyEntityRef(dest, src *EntityRef) *EntityRef {
 	dest.IdKeys = append(dest.IdKeys[:0], src.IdKeys...)
 
 	dest.DescriptionKeys = append(dest.DescriptionKeys[:0], src.DescriptionKeys...)
+
+	dest.IdContextType = src.IdContextType
 
 	return dest
 }
@@ -160,6 +163,10 @@ func (orig *EntityRef) MarshalJSON(dest *json.Stream) {
 		dest.WriteArrayEnd()
 	}
 
+	if orig.IdContextType != "" {
+		dest.WriteObjectField("idContextType")
+		dest.WriteString(orig.IdContextType)
+	}
 	dest.WriteObjectEnd()
 }
 
@@ -181,6 +188,8 @@ func (orig *EntityRef) UnmarshalJSON(iter *json.Iterator) {
 				orig.DescriptionKeys = append(orig.DescriptionKeys, iter.ReadString())
 			}
 
+		case "idContextType", "id_context_type":
+			orig.IdContextType = iter.ReadString()
 		default:
 			iter.HandleUnknownField(f)
 		}
@@ -207,6 +216,11 @@ func (orig *EntityRef) SizeProto() int {
 	}
 	for _, s := range orig.DescriptionKeys {
 		l = len(s)
+		n += 1 + proto.Sov(uint64(l)) + l
+	}
+
+	l = len(orig.IdContextType)
+	if l > 0 {
 		n += 1 + proto.Sov(uint64(l)) + l
 	}
 	return n
@@ -247,6 +261,14 @@ func (orig *EntityRef) MarshalProto(buf []byte) int {
 		pos = proto.EncodeVarint(buf, pos, uint64(l))
 		pos--
 		buf[pos] = 0x22
+	}
+	l = len(orig.IdContextType)
+	if l > 0 {
+		pos -= l
+		copy(buf[pos:], orig.IdContextType)
+		pos = proto.EncodeVarint(buf, pos, uint64(l))
+		pos--
+		buf[pos] = 0x2a
 	}
 	return len(buf) - pos
 }
@@ -313,6 +335,18 @@ func (orig *EntityRef) UnmarshalProto(buf []byte) error {
 			}
 			startPos := pos - length
 			orig.DescriptionKeys = append(orig.DescriptionKeys, string(buf[startPos:pos]))
+
+		case 5:
+			if wireType != proto.WireTypeLen {
+				return fmt.Errorf("proto: wrong wireType = %d for field IdContextType", wireType)
+			}
+			var length int
+			length, pos, err = proto.ConsumeLen(buf, pos)
+			if err != nil {
+				return err
+			}
+			startPos := pos - length
+			orig.IdContextType = string(buf[startPos:pos])
 		default:
 			pos, err = proto.ConsumeUnknown(buf, pos, wireType)
 			if err != nil {
@@ -329,6 +363,7 @@ func GenTestEntityRef() *EntityRef {
 	orig.Type = "test_type"
 	orig.IdKeys = []string{"", "test_idkeys"}
 	orig.DescriptionKeys = []string{"", "test_descriptionkeys"}
+	orig.IdContextType = "test_idcontexttype"
 	return orig
 }
 

--- a/pdata/internal/generated_proto_entityref_test.go
+++ b/pdata/internal/generated_proto_entityref_test.go
@@ -198,6 +198,8 @@ func genTestFailingUnmarshalProtoValuesEntityRef() map[string][]byte {
 		"IdKeys/missing_value":            {0x1a},
 		"DescriptionKeys/wrong_wire_type": {0x24},
 		"DescriptionKeys/missing_value":   {0x22},
+		"IdContextType/wrong_wire_type":   {0x2c},
+		"IdContextType/missing_value":     {0x2a},
 	}
 }
 
@@ -208,5 +210,6 @@ func genTestEncodingValuesEntityRef() map[string]*EntityRef {
 		"Type/test":            {Type: "test_type"},
 		"IdKeys/test":          {IdKeys: []string{"", "test_idkeys"}},
 		"DescriptionKeys/test": {DescriptionKeys: []string{"", "test_descriptionkeys"}},
+		"IdContextType/test":   {IdContextType: "test_idcontexttype"},
 	}
 }

--- a/pdata/xpdata/entity/entity.go
+++ b/pdata/xpdata/entity/entity.go
@@ -37,6 +37,14 @@ func (e Entity) SetSchemaURL(schemaURL string) {
 	e.ref.SetSchemaUrl(schemaURL)
 }
 
+func (e Entity) IDContextType() string {
+	return e.ref.IdContextType()
+}
+
+func (e Entity) SetIDContextType(idContextType string) {
+	e.ref.SetIdContextType(idContextType)
+}
+
 // IdentifyingAttributes returns an EntityAttributeMap for managing the entity's identifying attributes.
 func (e Entity) IdentifyingAttributes() EntityAttributeMap {
 	return EntityAttributeMap{
@@ -56,6 +64,8 @@ func (e Entity) DescriptiveAttributes() EntityAttributeMap {
 // CopyToResource moves the entity to the provided resource by overriding existing entities and attributes.
 func (e Entity) CopyToResource(res pcommon.Resource) {
 	ent := ResourceEntities(res).PutEmpty(e.Type())
+	ent.SetSchemaURL(e.SchemaURL())
+	ent.SetIDContextType(e.IDContextType())
 	for k, v := range e.IdentifyingAttributes().All() {
 		v.CopyTo(ent.IdentifyingAttributes().PutEmpty(k))
 	}

--- a/pdata/xpdata/entity/entity_test.go
+++ b/pdata/xpdata/entity/entity_test.go
@@ -19,6 +19,8 @@ func TestNewEntity(t *testing.T) {
 
 func TestEntity_CopyToResource(t *testing.T) {
 	e := NewEntity("service")
+	e.SetSchemaURL("https://opentelemetry.io/schemas/1.0.0")
+	e.SetIDContextType("host")
 	e.IdentifyingAttributes().PutStr("service.name", "my-service")
 	e.DescriptiveAttributes().PutStr("service.version", "1.0.0")
 
@@ -28,6 +30,8 @@ func TestEntity_CopyToResource(t *testing.T) {
 	entities := ResourceEntities(res)
 	copied, ok := entities.Get("service")
 	assert.True(t, ok)
+	assert.Equal(t, "https://opentelemetry.io/schemas/1.0.0", copied.SchemaURL())
+	assert.Equal(t, "host", copied.IDContextType())
 
 	idVal, ok := copied.IdentifyingAttributes().Get("service.name")
 	assert.True(t, ok)
@@ -56,6 +60,19 @@ func TestEntity_SchemaURL(t *testing.T) {
 
 	e.SetSchemaURL("https://opentelemetry.io/schemas/1.1.0")
 	assert.Equal(t, "https://opentelemetry.io/schemas/1.1.0", e.SchemaURL())
+}
+
+func TestEntity_IDContextType(t *testing.T) {
+	em := NewEntityMap()
+	e := em.PutEmpty("service")
+
+	assert.Empty(t, e.IDContextType())
+
+	e.SetIDContextType("host")
+	assert.Equal(t, "host", e.IDContextType())
+
+	e.SetIDContextType("k8s.cluster")
+	assert.Equal(t, "k8s.cluster", e.IDContextType())
 }
 
 func TestEntity_IdentifyingAttributes(t *testing.T) {

--- a/pdata/xpdata/entity/generated_entityref.go
+++ b/pdata/xpdata/entity/generated_entityref.go
@@ -75,6 +75,17 @@ func (ms EntityRef) DescriptionKeys() pcommon.StringSlice {
 	return pcommon.StringSlice(internal.NewStringSliceWrapper(&ms.getOrig().DescriptionKeys, ms.getState()))
 }
 
+// IdContextType returns the idcontexttype associated with this EntityRef.
+func (ms EntityRef) IdContextType() string {
+	return ms.getOrig().IdContextType
+}
+
+// SetIdContextType replaces the idcontexttype associated with this EntityRef.
+func (ms EntityRef) SetIdContextType(v string) {
+	ms.getState().AssertMutable()
+	ms.getOrig().IdContextType = v
+}
+
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms EntityRef) CopyTo(dest EntityRef) {
 	dest.getState().AssertMutable()

--- a/pdata/xpdata/entity/generated_entityref_test.go
+++ b/pdata/xpdata/entity/generated_entityref_test.go
@@ -76,6 +76,16 @@ func TestEntityRef_DescriptionKeys(t *testing.T) {
 	assert.Equal(t, pcommon.StringSlice(internal.GenTestStringSliceWrapper()), ms.DescriptionKeys())
 }
 
+func TestEntityRef_IdContextType(t *testing.T) {
+	ms := NewEntityRef()
+	assert.Empty(t, ms.IdContextType())
+	ms.SetIdContextType("test_idcontexttype")
+	assert.Equal(t, "test_idcontexttype", ms.IdContextType())
+	sharedState := internal.NewState()
+	sharedState.MarkReadOnly()
+	assert.Panics(t, func() { newEntityRef(internal.NewEntityRef(), sharedState).SetIdContextType("test_idcontexttype") })
+}
+
 func generateTestEntityRef() EntityRef {
 	return newEntityRef(internal.GenTestEntityRef(), internal.NewState())
 }


### PR DESCRIPTION
Adds `IdContextType` accessors to the experimental `xpdata/entity.EntityRef` API and wires field 5 through the internal JSON/proto representation.

Regenerated with `make genpdata`.
