### PR TITLE
[config/configretry] Validate BackOffConfig fields even when Enabled is false

### DIFF
--- a/.chloggen/fix-15437-configretry-validate-when-disabled.yaml
+++ b/.chloggen/fix-15437-configretry-validate-when-disabled.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: config/configretry
+note: Always validate BackOffConfig fields regardless of the Enabled flag.
+issues: [15437]
+subtext:
+change_logs: [user]

--- a/.chloggen/fix-15437-configretry-validate-when-disabled.yaml
+++ b/.chloggen/fix-15437-configretry-validate-when-disabled.yaml
@@ -1,5 +1,5 @@
 change_type: bug_fix
-component: config/configretry
+component: pkg/config/configretry
 note: Always validate BackOffConfig fields regardless of the Enabled flag.
 issues: [15437]
 subtext:

--- a/config/configretry/backoff.go
+++ b/config/configretry/backoff.go
@@ -45,9 +45,6 @@ type BackOffConfig struct {
 }
 
 func (bs *BackOffConfig) Validate() error {
-	if !bs.Enabled {
-		return nil
-	}
 	if bs.InitialInterval < 0 {
 		return errors.New("'initial_interval' must be non-negative")
 	}

--- a/config/configretry/backoff_test.go
+++ b/config/configretry/backoff_test.go
@@ -90,5 +90,17 @@ func TestDisabledWithInvalidValues(t *testing.T) {
 		MaxInterval:         -1,
 		MaxElapsedTime:      -1,
 	}
+	assert.Error(t, cfg.Validate())
+}
+
+func TestDisabledWithValidValues(t *testing.T) {
+	cfg := BackOffConfig{
+		Enabled:             false,
+		InitialInterval:     5 * time.Second,
+		RandomizationFactor: 0.5,
+		Multiplier:          1.5,
+		MaxInterval:         30 * time.Second,
+		MaxElapsedTime:      5 * time.Minute,
+	}
 	assert.NoError(t, cfg.Validate())
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When `Enabled` is set to `false`, the `Validate()` method in `BackOffConfig` returned early without checking any field values. This meant invalid configurations (e.g. negative `InitialInterval`) would silently pass validation. Removed the early return so all fields are validated regardless of the `Enabled` flag.


<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15437

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated `TestDisabledWithInvalidValues` to assert that errors are returned for invalid field values even when `Enabled=false`. Added `TestDisabledWithValidValues` to confirm a well-formed config with `Enabled=false` still passes. Run: `go test ./config/configretry/...`


<!--Describe the documentation added.-->
#### Documentation
No documentation changes needed.


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.