### PR TITLE
[cmd/mdatagen] Enforce tab indentation in Go template files

### DIFF
--- a/.chloggen/mdatagen-enforce-tab-indentation-in-go-templates.yaml
+++ b/.chloggen/mdatagen-enforce-tab-indentation-in-go-templates.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enforce tab indentation in Go template files to pass `gofmt` checks in generated code
+
+# One or more tracking issues or pull requests related to the change
+issues: [14698]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
+++ b/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
@@ -1,122 +1,122 @@
 {{- if .Metrics }}
   metrics_config:
-    description: MetricsConfig provides config for {{ .Type }} metrics.
-    type: object
-    properties:
-      {{- range $name, $metric := .Metrics }}
-      {{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
-      {{ $name }}:
-        description: "{{ $name.Render }}MetricConfig provides config for the {{ $name }} metric."
-        type: object
-        properties:
-          enabled:
-            type: bool
-            default: {{ $metric.Enabled }}
-          {{- if $metricReag }}
-          aggregation_strategy:
-            type: string
-            enum:
-              - "sum"
-              - "avg"
-              - "min"
-              - "max"
-            {{- if eq $metric.Data.Type "Sum" }}
-            default: "sum"
-            {{- else }}
-            default: "avg"
-            {{- end }}
-          attributes:
-            type: slice
-            values:
-              type: string
-              enum:
-              {{- range $metric.Attributes }}
-                - "{{ (attributeInfo .).Name }}"
-              {{- end }}
-            default:
-            {{- range $metric.Attributes }}
-            {{- if (attributeInfo .).IsNotOptIn }}
-              - "{{ (attributeInfo .).Name }}"
-            {{- end }}
-            {{- end }}
-          {{- end }}
-      {{- end }}
+	description: MetricsConfig provides config for {{ .Type }} metrics.
+	type: object
+	properties:
+	  {{- range $name, $metric := .Metrics }}
+	  {{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
+	  {{ $name }}:
+		description: "{{ $name.Render }}MetricConfig provides config for the {{ $name }} metric."
+		type: object
+		properties:
+		  enabled:
+			type: bool
+			default: {{ $metric.Enabled }}
+		  {{- if $metricReag }}
+		  aggregation_strategy:
+			type: string
+			enum:
+			  - "sum"
+			  - "avg"
+			  - "min"
+			  - "max"
+			{{- if eq $metric.Data.Type "Sum" }}
+			default: "sum"
+			{{- else }}
+			default: "avg"
+			{{- end }}
+		  attributes:
+			type: slice
+			values:
+			  type: string
+			  enum:
+			  {{- range $metric.Attributes }}
+				- "{{ (attributeInfo .).Name }}"
+			  {{- end }}
+			default:
+			{{- range $metric.Attributes }}
+			{{- if (attributeInfo .).IsNotOptIn }}
+			  - "{{ (attributeInfo .).Name }}"
+			{{- end }}
+			{{- end }}
+		  {{- end }}
+	  {{- end }}
 {{- end }}
 {{- if .Events }}
   events_config:
-    description: EventsConfig provides config for {{ .Type }} events.
-    type: object
-    properties:
-      {{- range $name, $event := .Events }}
-      {{ $name }}:
-        description: EventConfig provides common config for a  {{ $name }} event.
-        type: object
-        properties:
-          enabled:
-            type: bool
-            default: {{ $event.Enabled }}
-      {{- end }}
+	description: EventsConfig provides config for {{ .Type }} events.
+	type: object
+	properties:
+	  {{- range $name, $event := .Events }}
+	  {{ $name }}:
+		description: EventConfig provides common config for a  {{ $name }} event.
+		type: object
+		properties:
+		  enabled:
+			type: bool
+			default: {{ $event.Enabled }}
+	  {{- end }}
 {{- end }}
 {{- if .ResourceAttributes }}
   resource_attributes_config:
-    description: ResourceAttributesConfig provides config for {{ .Type }} resource attributes.
-    type: object
-    properties:
-    {{- range $name, $attr := .ResourceAttributes }}
-      {{ $name  }}:
-        description: ResourceAttributeConfig provides common config for a {{ $name }} resource attribute.
-        type: object
-        properties:
-          enabled:
-            type: bool
-            default: {{ $attr.Enabled }}
-        {{- if $.Metrics }}
-          metrics_include:
-            description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
-            type: slice
-            values:
-              $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
-          metrics_exclude:
-            description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
-            type: slice
-            values:
-              $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
-        {{- end }}
-        {{- if $.Events }}
-          events_include:
-            description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
-            type: slice
-            values:
-              $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
-          events_exclude:
-            description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
-            type: slice
-            values:
-              $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
-        {{- end }}
-    {{- end }}
+	description: ResourceAttributesConfig provides config for {{ .Type }} resource attributes.
+	type: object
+	properties:
+	{{- range $name, $attr := .ResourceAttributes }}
+	  {{ $name  }}:
+		description: ResourceAttributeConfig provides common config for a {{ $name }} resource attribute.
+		type: object
+		properties:
+		  enabled:
+			type: bool
+			default: {{ $attr.Enabled }}
+		{{- if $.Metrics }}
+		  metrics_include:
+			description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
+			type: slice
+			values:
+			  $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
+		  metrics_exclude:
+			description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
+			type: slice
+			values:
+			  $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
+		{{- end }}
+		{{- if $.Events }}
+		  events_include:
+			description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
+			type: slice
+			values:
+			  $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
+		  events_exclude:
+			description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
+			type: slice
+			values:
+			  $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
+		{{- end }}
+	{{- end }}
 {{- end }}
 {{- if .Metrics }}
   metrics_builder_config:
-    description: MetricsBuilderConfig is a configuration for {{ .Type }} metrics builder.
-    type: object
-    properties:
-      metrics:
-        $ref: metrics_config
-    {{- if .ResourceAttributes }}
-      resource_attributes:
-        $ref: resource_attributes_config
-    {{- end }}
+	description: MetricsBuilderConfig is a configuration for {{ .Type }} metrics builder.
+	type: object
+	properties:
+	  metrics:
+		$ref: metrics_config
+	{{- if .ResourceAttributes }}
+	  resource_attributes:
+		$ref: resource_attributes_config
+	{{- end }}
 {{- end }}
 {{- if .Events }}
   logs_builder_config:
-    description: LogsBuilderConfig is a configuration for {{ .Type }} logs builder.
-    type: object
-    properties:
-      events:
-        $ref: events_config
-    {{- if .ResourceAttributes }}
-      resource_attributes:
-        $ref: resource_attributes_config
-    {{- end }}
+	description: LogsBuilderConfig is a configuration for {{ .Type }} logs builder.
+	type: object
+	properties:
+	  events:
+		$ref: events_config
+	{{- if .ResourceAttributes }}
+	  resource_attributes:
+		$ref: resource_attributes_config
+	{{- end }}
 {{- end }}

--- a/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
+++ b/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
@@ -1,122 +1,122 @@
 {{- if .Metrics }}
   metrics_config:
-	description: MetricsConfig provides config for {{ .Type }} metrics.
-	type: object
-	properties:
-	  {{- range $name, $metric := .Metrics }}
-	  {{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
-	  {{ $name }}:
-		description: "{{ $name.Render }}MetricConfig provides config for the {{ $name }} metric."
-		type: object
-		properties:
-		  enabled:
-			type: bool
-			default: {{ $metric.Enabled }}
-		  {{- if $metricReag }}
-		  aggregation_strategy:
-			type: string
-			enum:
-			  - "sum"
-			  - "avg"
-			  - "min"
-			  - "max"
-			{{- if eq $metric.Data.Type "Sum" }}
-			default: "sum"
-			{{- else }}
-			default: "avg"
-			{{- end }}
-		  attributes:
-			type: slice
-			values:
-			  type: string
-			  enum:
-			  {{- range $metric.Attributes }}
-				- "{{ (attributeInfo .).Name }}"
-			  {{- end }}
-			default:
-			{{- range $metric.Attributes }}
-			{{- if (attributeInfo .).IsNotOptIn }}
-			  - "{{ (attributeInfo .).Name }}"
-			{{- end }}
-			{{- end }}
-		  {{- end }}
-	  {{- end }}
+  description: MetricsConfig provides config for {{ .Type }} metrics.
+  type: object
+  properties:
+    {{- range $name, $metric := .Metrics }}
+    {{- $metricReag := hasAggregatableAttributes $metric.Attributes }}
+    {{ $name }}:
+    description: "{{ $name.Render }}MetricConfig provides config for the {{ $name }} metric."
+    type: object
+    properties:
+      enabled:
+      type: bool
+      default: {{ $metric.Enabled }}
+      {{- if $metricReag }}
+      aggregation_strategy:
+      type: string
+      enum:
+        - "sum"
+        - "avg"
+        - "min"
+        - "max"
+      {{- if eq $metric.Data.Type "Sum" }}
+      default: "sum"
+      {{- else }}
+      default: "avg"
+      {{- end }}
+      attributes:
+      type: slice
+      values:
+        type: string
+        enum:
+        {{- range $metric.Attributes }}
+        - "{{ (attributeInfo .).Name }}"
+        {{- end }}
+      default:
+      {{- range $metric.Attributes }}
+      {{- if (attributeInfo .).IsNotOptIn }}
+        - "{{ (attributeInfo .).Name }}"
+      {{- end }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
 {{- end }}
 {{- if .Events }}
   events_config:
-	description: EventsConfig provides config for {{ .Type }} events.
-	type: object
-	properties:
-	  {{- range $name, $event := .Events }}
-	  {{ $name }}:
-		description: EventConfig provides common config for a  {{ $name }} event.
-		type: object
-		properties:
-		  enabled:
-			type: bool
-			default: {{ $event.Enabled }}
-	  {{- end }}
+  description: EventsConfig provides config for {{ .Type }} events.
+  type: object
+  properties:
+    {{- range $name, $event := .Events }}
+    {{ $name }}:
+    description: EventConfig provides common config for a  {{ $name }} event.
+    type: object
+    properties:
+      enabled:
+      type: bool
+      default: {{ $event.Enabled }}
+    {{- end }}
 {{- end }}
 {{- if .ResourceAttributes }}
   resource_attributes_config:
-	description: ResourceAttributesConfig provides config for {{ .Type }} resource attributes.
-	type: object
-	properties:
-	{{- range $name, $attr := .ResourceAttributes }}
-	  {{ $name  }}:
-		description: ResourceAttributeConfig provides common config for a {{ $name }} resource attribute.
-		type: object
-		properties:
-		  enabled:
-			type: bool
-			default: {{ $attr.Enabled }}
-		{{- if $.Metrics }}
-		  metrics_include:
-			description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
-			type: slice
-			values:
-			  $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
-		  metrics_exclude:
-			description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
-			type: slice
-			values:
-			  $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
-		{{- end }}
-		{{- if $.Events }}
-		  events_include:
-			description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
-			type: slice
-			values:
-			  $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
-		  events_exclude:
-			description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
-			type: slice
-			values:
-			  $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
-		{{- end }}
-	{{- end }}
+  description: ResourceAttributesConfig provides config for {{ .Type }} resource attributes.
+  type: object
+  properties:
+  {{- range $name, $attr := .ResourceAttributes }}
+    {{ $name  }}:
+    description: ResourceAttributeConfig provides common config for a {{ $name }} resource attribute.
+    type: object
+    properties:
+      enabled:
+      type: bool
+      default: {{ $attr.Enabled }}
+    {{- if $.Metrics }}
+      metrics_include:
+      description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
+      type: slice
+      values:
+        $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
+      metrics_exclude:
+      description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
+      type: slice
+      values:
+        $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
+    {{- end }}
+    {{- if $.Events }}
+      events_include:
+      description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
+      type: slice
+      values:
+        $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
+      events_exclude:
+      description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
+      type: slice
+      values:
+        $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- if .Metrics }}
   metrics_builder_config:
-	description: MetricsBuilderConfig is a configuration for {{ .Type }} metrics builder.
-	type: object
-	properties:
-	  metrics:
-		$ref: metrics_config
-	{{- if .ResourceAttributes }}
-	  resource_attributes:
-		$ref: resource_attributes_config
-	{{- end }}
+    description: MetricsBuilderConfig is a configuration for {{ .Type }} metrics builder.
+    type: object
+    properties:
+      metrics:
+        $ref: metrics_config
+    {{- if .ResourceAttributes }}
+      resource_attributes:
+        $ref: resource_attributes_config
+    {{- end }}
 {{- end }}
 {{- if .Events }}
   logs_builder_config:
-	description: LogsBuilderConfig is a configuration for {{ .Type }} logs builder.
-	type: object
-	properties:
-	  events:
-		$ref: events_config
-	{{- if .ResourceAttributes }}
-	  resource_attributes:
-		$ref: resource_attributes_config
-	{{- end }}
+    description: LogsBuilderConfig is a configuration for {{ .Type }} logs builder.
+    type: object
+    properties:
+      events:
+        $ref: events_config
+    {{- if .ResourceAttributes }}
+      resource_attributes:
+        $ref: resource_attributes_config
+    {{- end }}
 {{- end }}

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -11,290 +11,290 @@ import (
 	"{{ . }}"
 {{- end }}
 {{- if $hasConfig }}
-    "go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component"
 {{- end }}
 )
 {{- end }}
 
 {{ define "struct" }}
-    {{- range $propName, $prop := .Properties | embeddedProps }}
-        {{- if $prop.Description }}
-    // {{ $prop.Description }}
-        {{- end }}
-        {{- if $prop.GoStruct.Anonymous }}
-            {{ $prop.Ref | publicType }} `mapstructure:",squash"`
-        {{- else }}
-            {{ $prop.GoStruct.FieldName | publicVar }} {{ $prop.Ref | publicType }} `mapstructure:",squash"`
-        {{- end }}
+	{{- range $propName, $prop := .Properties | embeddedProps }}
+		{{- if $prop.Description }}
+	// {{ $prop.Description }}
+		{{- end }}
+		{{- if $prop.GoStruct.Anonymous }}
+			{{ $prop.Ref | publicType }} `mapstructure:",squash"`
+		{{- else }}
+			{{ $prop.GoStruct.FieldName | publicVar }} {{ $prop.Ref | publicType }} `mapstructure:",squash"`
+		{{- end }}
 
-    {{- end }}
-    {{- range $propName, $prop := .Properties | namedProps }}
-        {{- if $prop.Description }}
-            // {{ $prop.Description }}
-        {{- end }}
-        {{- $omitempty := and (not (isRequired . $propName)) (not (hasDefaultValue $prop)) }}
-        {{ $prop.GoStruct.FieldName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}{{ if $omitempty }},omitempty{{ end }}"`
-    {{- end }}
-    // prevent unkeyed literal initialization
-    _ struct{}
+	{{- end }}
+	{{- range $propName, $prop := .Properties | namedProps }}
+		{{- if $prop.Description }}
+			// {{ $prop.Description }}
+		{{- end }}
+		{{- $omitempty := and (not (isRequired . $propName)) (not (hasDefaultValue $prop)) }}
+		{{ $prop.GoStruct.FieldName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}{{ if $omitempty }},omitempty{{ end }}"`
+	{{- end }}
+	// prevent unkeyed literal initialization
+	_ struct{}
 {{ end }}
 
 {{- $defs := extractDefs .Metadata.ConfigsMetadata }}
 {{ range $defName, $def := $defs }}
-    {{- if $def.Description }}
-        // {{ $defName | publicVar }} {{ $def.Description | uncapitalize }}
-    {{- end }}
-    {{- $typeName := $defName | publicVar }}
-    {{- if isExternalRef $def.Ref }}
-        type {{ $typeName }} = {{ $def.Ref | publicType }}
-    {{- else if isPrimitiveSchema $def }}
-        type {{ $typeName }} {{ primitiveGoType $def }}
-    {{- else }}
-        type {{ $typeName }} struct {
-        {{- template "struct" $def }}
-        }
-    {{- end }}
+	{{- if $def.Description }}
+		// {{ $defName | publicVar }} {{ $def.Description | uncapitalize }}
+	{{- end }}
+	{{- $typeName := $defName | publicVar }}
+	{{- if isExternalRef $def.Ref }}
+		type {{ $typeName }} = {{ $def.Ref | publicType }}
+	{{- else if isPrimitiveSchema $def }}
+		type {{ $typeName }} {{ primitiveGoType $def }}
+	{{- else }}
+		type {{ $typeName }} struct {
+		{{- template "struct" $def }}
+		}
+	{{- end }}
 
 {{ $defValidators := extractValidators $def }}
 {{- if and $defValidators (not (isExternalRef $def.Ref)) (not (isPrimitiveSchema $def)) }}
-    // Validate validates the {{$typeName}} fields according to schema annotations.
-    func (c *{{ $typeName }}) Validate() error {
-        var err error
-        {{ range $validator := $defValidators -}}
-            {{- template "validation" $validator }}
-        {{- end }}
+	// Validate validates the {{$typeName}} fields according to schema annotations.
+	func (c *{{ $typeName }}) Validate() error {
+		var err error
+		{{ range $validator := $defValidators -}}
+			{{- template "validation" $validator }}
+		{{- end }}
 
-        return err
-    }
+		return err
+	}
 {{- end }}
 
-    {{- if and (hasDefaultValue $def) (not (isPrimitiveSchema $def)) }}
-    // NewDefault{{ $typeName }} returns a new {{ $typeName }} with default values consistent with the annotations in the schema.
-    func NewDefault{{ $typeName }}() {{ $typeName }} {
-        {{- if isExternalRef $def.Ref }}
-        return {{ externalDefaultCall $def.Ref }}
-        {{- else }}
-        {{- template "structLiteralVars" $def }}
-        return {{ $typeName }}{
-            {{- template "structLiteralFields" $def }}
-        }
-        {{- end }}
-    }
-    {{- end }}
+	{{- if and (hasDefaultValue $def) (not (isPrimitiveSchema $def)) }}
+	// NewDefault{{ $typeName }} returns a new {{ $typeName }} with default values consistent with the annotations in the schema.
+	func NewDefault{{ $typeName }}() {{ $typeName }} {
+		{{- if isExternalRef $def.Ref }}
+		return {{ externalDefaultCall $def.Ref }}
+		{{- else }}
+		{{- template "structLiteralVars" $def }}
+		return {{ $typeName }}{
+			{{- template "structLiteralFields" $def }}
+		}
+		{{- end }}
+	}
+	{{- end }}
 
 {{ end }}
 
 {{- if $hasConfig }}
-    {{- if .Metadata.Config.Description }}
-        // {{ .Metadata.Config.Description }}
-    {{- else }}
-        // Config defines the configuration for {{ .Metadata.DisplayName }} component.
-    {{- end }}
-    type Config struct {
-        {{- template "struct" .Metadata.Config }}
-    }
+	{{- if .Metadata.Config.Description }}
+		// {{ .Metadata.Config.Description }}
+	{{- else }}
+		// Config defines the configuration for {{ .Metadata.DisplayName }} component.
+	{{- end }}
+	type Config struct {
+		{{- template "struct" .Metadata.Config }}
+	}
 {{- end}}
 
 {{ define "customValidator" -}}
-    {{ $name := .FieldName | publicVar -}}
-    {{ $value := "c" }}
-    {{- if ne .FieldName "." }}
-        {{ $value = printf "c.%s" $name -}}
-    {{ end }}
-    if inner_err := {{ .CustomValidator }}({{ $value }}); inner_err != nil {
-        err = errors.Join(err, inner_err)
-    }
+	{{ $name := .FieldName | publicVar -}}
+	{{ $value := "c" }}
+	{{- if ne .FieldName "." }}
+		{{ $value = printf "c.%s" $name -}}
+	{{ end }}
+	if inner_err := {{ .CustomValidator }}({{ $value }}); inner_err != nil {
+		err = errors.Join(err, inner_err)
+	}
 {{- end }}
 
 {{ define "requiredValidator" -}}
-    {{ $name := .FieldName | publicVar -}}
-    {{- if .IsPointer }}
-        {{- if or (eq .FieldType "slice") (eq .FieldType "map") }}
-        if c.{{ $name }} == nil || len(*c.{{ $name }}) == 0 {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-        {{- else }}
-        if c.{{ $name }} == nil {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-        {{- end }}
-    {{- else if eq .FieldType "string" }}
-        if c.{{ $name }} == "" {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-    {{- else if eq .FieldType "slice" }}
-        if len(c.{{ $name }}) == 0 {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-    {{- else if eq .FieldType "map" }}
-        if c.{{ $name }} == nil || len(c.{{ $name }}) == 0 {
-            err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
-        }
-    {{- end -}}
+	{{ $name := .FieldName | publicVar -}}
+	{{- if .IsPointer }}
+		{{- if or (eq .FieldType "slice") (eq .FieldType "map") }}
+		if c.{{ $name }} == nil || len(*c.{{ $name }}) == 0 {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+		{{- else }}
+		if c.{{ $name }} == nil {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+		{{- end }}
+	{{- else if eq .FieldType "string" }}
+		if c.{{ $name }} == "" {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+	{{- else if eq .FieldType "slice" }}
+		if len(c.{{ $name }}) == 0 {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+	{{- else if eq .FieldType "map" }}
+		if c.{{ $name }} == nil || len(c.{{ $name }}) == 0 {
+			err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
+		}
+	{{- end -}}
 {{- end }}
 
 {{- define "fieldValue" -}}
-    {{- $name := .FieldName | publicVar -}}
-    {{- if .IsPointer }}*c.{{ $name -}}
-    {{- else if .IsOptional }}*c.{{ $name }}.Get()
-    {{- else }}c.{{ $name -}}
-    {{- end -}}
+	{{- $name := .FieldName | publicVar -}}
+	{{- if .IsPointer }}*c.{{ $name -}}
+	{{- else if .IsOptional }}*c.{{ $name }}.Get()
+	{{- else }}c.{{ $name -}}
+	{{- end -}}
 {{- end -}}
 
 {{ define "maxLengthValidator" -}}
-    {{ $maxLength := .Rules.MaxLength -}}
-    if len({{ template "fieldValue" . }}) > {{ $maxLength }} {
-        err = errors.Join(err, errors.New("{{ .FieldName }} exceeds maximum length of {{ $maxLength }}"))
-    }
+	{{ $maxLength := .Rules.MaxLength -}}
+	if len({{ template "fieldValue" . }}) > {{ $maxLength }} {
+		err = errors.Join(err, errors.New("{{ .FieldName }} exceeds maximum length of {{ $maxLength }}"))
+	}
 {{- end }}
 
 {{ define "minLengthValidator" -}}
-    {{ $minLength := .Rules.MinLength -}}
-    if len({{ template "fieldValue" . }}) < {{ $minLength }} {
-        err = errors.Join(err, errors.New("{{ .FieldName }} must have minimum length of {{ $minLength }}"))
-    }
+	{{ $minLength := .Rules.MinLength -}}
+	if len({{ template "fieldValue" . }}) < {{ $minLength }} {
+		err = errors.Join(err, errors.New("{{ .FieldName }} must have minimum length of {{ $minLength }}"))
+	}
 {{- end }}
 
 {{ define "patternValidator" -}}
-    {{ $pattern := .Rules.Pattern -}}
-    if matched, _ := regexp.MatchString(`{{ $pattern }}`, {{ template "fieldValue" . }}); !matched {
-        err = errors.Join(err, errors.New("{{ .FieldName }} must match pattern `{{ $pattern }}`"))
-    }
+	{{ $pattern := .Rules.Pattern -}}
+	if matched, _ := regexp.MatchString(`{{ $pattern }}`, {{ template "fieldValue" . }}); !matched {
+		err = errors.Join(err, errors.New("{{ .FieldName }} must match pattern `{{ $pattern }}`"))
+	}
 {{- end }}
 
 {{ define "minimumValidator" -}}
-    {{ $minimum := .Rules.Minimum -}}
-    if {{ template "fieldValue" . }} < {{ $minimum }} {
-        err = errors.Join(err, errors.New("{{ .FieldName }} value must be greater than or equal to {{ $minimum }}"))
-    }
+	{{ $minimum := .Rules.Minimum -}}
+	if {{ template "fieldValue" . }} < {{ $minimum }} {
+		err = errors.Join(err, errors.New("{{ .FieldName }} value must be greater than or equal to {{ $minimum }}"))
+	}
 {{- end }}
 
 {{ define "maximumValidator" -}}
-    {{ $maximum := .Rules.Maximum -}}
-    if {{ template "fieldValue" . }} > {{ $maximum }} {
-        err = errors.Join(err, errors.New("{{ .FieldName }} value must be less than or equal to {{ $maximum }}"))
-    }
+	{{ $maximum := .Rules.Maximum -}}
+	if {{ template "fieldValue" . }} > {{ $maximum }} {
+		err = errors.Join(err, errors.New("{{ .FieldName }} value must be less than or equal to {{ $maximum }}"))
+	}
 {{- end }}
 
 {{ define "exclusiveMinimumValidator" -}}
-    {{ $exclMin := .Rules.ExclusiveMinimum -}}
-    if {{ template "fieldValue" . }} <= {{ $exclMin }} {
-        err = errors.Join(err, errors.New("{{ .FieldName }} value must be greater than {{ $exclMin }}"))
-    }
+	{{ $exclMin := .Rules.ExclusiveMinimum -}}
+	if {{ template "fieldValue" . }} <= {{ $exclMin }} {
+		err = errors.Join(err, errors.New("{{ .FieldName }} value must be greater than {{ $exclMin }}"))
+	}
 {{- end }}
 
 {{ define "exclusiveMaximumValidator" -}}
-    {{ $exclMax := .Rules.ExclusiveMaximum -}}
-    if {{ template "fieldValue" . }} >= {{ $exclMax }} {
-        err = errors.Join(err, errors.New("{{ .FieldName }} value must be less than {{ $exclMax }}"))
-    }
+	{{ $exclMax := .Rules.ExclusiveMaximum -}}
+	if {{ template "fieldValue" . }} >= {{ $exclMax }} {
+		err = errors.Join(err, errors.New("{{ .FieldName }} value must be less than {{ $exclMax }}"))
+	}
 {{- end }}
 
 {{ define "enumValidator" -}}
-    if !slices.Contains({{ formatEnumSlice .Rules.Enum .FieldType }}, {{ template "fieldValue" . }}) {
-        err = errors.Join(err, errors.New("{{ .FieldName }} must be one of {{ formatEnumValues .Rules.Enum }}"))
-    }
+	if !slices.Contains({{ formatEnumSlice .Rules.Enum .FieldType }}, {{ template "fieldValue" . }}) {
+		err = errors.Join(err, errors.New("{{ .FieldName }} must be one of {{ formatEnumValues .Rules.Enum }}"))
+	}
 {{- end }}
 
 {{ define "valueValidators" }}
-    {{ if .Rules.MaxLength }}{{ template "maxLengthValidator" . }}{{ end }}
-    {{ if .Rules.MinLength }}{{ template "minLengthValidator" . }}{{ end }}
-    {{ if .Rules.Pattern }}{{ template "patternValidator" . }}{{ end }}
-    {{ if .Rules.Minimum }}{{ template "minimumValidator" . }}{{ end }}
-    {{ if .Rules.Maximum }}{{ template "maximumValidator" . }}{{ end }}
-    {{ if .Rules.ExclusiveMinimum }}{{ template "exclusiveMinimumValidator" . }}{{ end }}
-    {{ if .Rules.ExclusiveMaximum }}{{ template "exclusiveMaximumValidator" . }}{{ end }}
-    {{ if .Rules.Enum }}{{ template "enumValidator" . }}{{ end }}
+	{{ if .Rules.MaxLength }}{{ template "maxLengthValidator" . }}{{ end }}
+	{{ if .Rules.MinLength }}{{ template "minLengthValidator" . }}{{ end }}
+	{{ if .Rules.Pattern }}{{ template "patternValidator" . }}{{ end }}
+	{{ if .Rules.Minimum }}{{ template "minimumValidator" . }}{{ end }}
+	{{ if .Rules.Maximum }}{{ template "maximumValidator" . }}{{ end }}
+	{{ if .Rules.ExclusiveMinimum }}{{ template "exclusiveMinimumValidator" . }}{{ end }}
+	{{ if .Rules.ExclusiveMaximum }}{{ template "exclusiveMaximumValidator" . }}{{ end }}
+	{{ if .Rules.Enum }}{{ template "enumValidator" . }}{{ end }}
 {{ end -}}
 
 {{ define "validation" }}
 
-    {{ if .Rules.Required -}}
-        {{ template "requiredValidator" . }}
-    {{- end -}}
-    {{- if .Rules.HasValueRule }}
-        {{- $name := .FieldName | publicVar -}}
-        {{- if .IsPointer }}if c.{{ $name }} != nil { {{ end -}}
-        {{- if .IsOptional }}if c.{{ $name }}.HasValue() { {{ end -}}
-            {{ template "valueValidators" . }}
-        {{- if or .IsPointer .IsOptional }}}{{ end -}}
-    {{- end -}}
-    {{- if .CustomValidator }}
-        {{ template "customValidator" . }}
-    {{- end -}}
+	{{ if .Rules.Required -}}
+		{{ template "requiredValidator" . }}
+	{{- end -}}
+	{{- if .Rules.HasValueRule }}
+		{{- $name := .FieldName | publicVar -}}
+		{{- if .IsPointer }}if c.{{ $name }} != nil { {{ end -}}
+		{{- if .IsOptional }}if c.{{ $name }}.HasValue() { {{ end -}}
+			{{ template "valueValidators" . }}
+		{{- if or .IsPointer .IsOptional }}}{{ end -}}
+	{{- end -}}
+	{{- if .CustomValidator }}
+		{{ template "customValidator" . }}
+	{{- end -}}
 {{ end }}
 
 {{- if $validators }}
-    // Validate validates the Config fields.
-    func (c *Config) Validate() error {
-        var err error
-        {{ range $validator := $validators -}}
-            {{- template "validation" $validator }}
-        {{- end }}
+	// Validate validates the Config fields.
+	func (c *Config) Validate() error {
+		var err error
+		{{ range $validator := $validators -}}
+			{{- template "validation" $validator }}
+		{{- end }}
 
-        return err
-    }
+		return err
+	}
 {{- end }}
 
 {{- define "structLiteralVars" }}
-    {{- range $propName, $prop := .Properties | embeddedProps }}
-        {{- $exprs := mapCustomDefaults $prop $prop.Default }}
-        {{- if $exprs }}
-            {{- $varName := camelVar $prop.Ref }}
-            {{- $name := $prop.GoStruct.FieldName | publicVar }}
-            {{- $defaultValue := formatBaseValue $prop $name $prop.Default }}
-            {{ $varName }} := {{ $defaultValue }}
-            {{- range $expr := $exprs }}
-                {{ $varName }}{{ $expr }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-    {{- range $propName, $prop := .Properties | namedProps }}
-        {{- $exprs := mapCustomDefaults $prop $prop.Default }}
-        {{- if $exprs }}
-            {{- $varName := camelVar $propName }}
-            {{- $defaultValue := formatBaseValue $prop $propName $prop.Default }}
-            {{ $varName }} := {{ $defaultValue }}
-            {{- range $expr := $exprs }}
-                {{ $varName }}{{ $expr }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
+	{{- range $propName, $prop := .Properties | embeddedProps }}
+		{{- $exprs := mapCustomDefaults $prop $prop.Default }}
+		{{- if $exprs }}
+			{{- $varName := camelVar $prop.Ref }}
+			{{- $name := $prop.GoStruct.FieldName | publicVar }}
+			{{- $defaultValue := formatBaseValue $prop $name $prop.Default }}
+			{{ $varName }} := {{ $defaultValue }}
+			{{- range $expr := $exprs }}
+				{{ $varName }}{{ $expr }}
+			{{- end }}
+		{{- end }}
+	{{- end }}
+	{{- range $propName, $prop := .Properties | namedProps }}
+		{{- $exprs := mapCustomDefaults $prop $prop.Default }}
+		{{- if $exprs }}
+			{{- $varName := camelVar $propName }}
+			{{- $defaultValue := formatBaseValue $prop $propName $prop.Default }}
+			{{ $varName }} := {{ $defaultValue }}
+			{{- range $expr := $exprs }}
+				{{ $varName }}{{ $expr }}
+			{{- end }}
+		{{- end }}
+	{{- end }}
 {{- end }}
 
 {{- define "structLiteralFields" }}
-    {{- range $propName, $prop := .Properties | embeddedProps }}
-        {{- $name := $prop.GoStruct.FieldName | publicVar }}
-        {{- $defaultValue := formatDefaultValue $prop $name $prop.Default }}
-        {{- if $defaultValue }}
-            {{- $exprs := mapCustomDefaults $prop $prop.Default }}
-            {{- if $exprs }}
-                {{- $varName := camelVar $prop.Ref }}
-                {{ $name }}: {{ wrapDefaultValue $prop $varName }},
-            {{- else }}
-                {{ $name }}: {{ $defaultValue }},
-            {{- end }}
-        {{- end }}
-    {{- end }}
-    {{- range $propName, $prop := .Properties | namedProps }}
-        {{- $defaultValue := formatDefaultValue $prop $propName $prop.Default }}
-        {{- if $defaultValue }}
-            {{- $exprs := mapCustomDefaults $prop $prop.Default }}
-            {{- if $exprs }}
-                {{- $varName := camelVar $propName }}
-                {{ $prop.GoStruct.FieldName | publicVar }}: {{ wrapDefaultValue $prop $varName }},
-            {{- else }}
-                {{ $prop.GoStruct.FieldName | publicVar }}: {{ $defaultValue }},
-            {{- end }}
-        {{- end }}
-    {{- end }}
+	{{- range $propName, $prop := .Properties | embeddedProps }}
+		{{- $name := $prop.GoStruct.FieldName | publicVar }}
+		{{- $defaultValue := formatDefaultValue $prop $name $prop.Default }}
+		{{- if $defaultValue }}
+			{{- $exprs := mapCustomDefaults $prop $prop.Default }}
+			{{- if $exprs }}
+				{{- $varName := camelVar $prop.Ref }}
+				{{ $name }}: {{ wrapDefaultValue $prop $varName }},
+			{{- else }}
+				{{ $name }}: {{ $defaultValue }},
+			{{- end }}
+		{{- end }}
+	{{- end }}
+	{{- range $propName, $prop := .Properties | namedProps }}
+		{{- $defaultValue := formatDefaultValue $prop $propName $prop.Default }}
+		{{- if $defaultValue }}
+			{{- $exprs := mapCustomDefaults $prop $prop.Default }}
+			{{- if $exprs }}
+				{{- $varName := camelVar $propName }}
+				{{ $prop.GoStruct.FieldName | publicVar }}: {{ wrapDefaultValue $prop $varName }},
+			{{- else }}
+				{{ $prop.GoStruct.FieldName | publicVar }}: {{ $defaultValue }},
+			{{- end }}
+		{{- end }}
+	{{- end }}
 {{- end }}
 
 {{ if $hasConfig }}
 func createDefaultConfig() component.Config {
-    {{- template "structLiteralVars" .Metadata.Config }}
-    return &Config{
-        {{- template "structLiteralFields" .Metadata.Config }}
-    }
+	{{- template "structLiteralVars" .Metadata.Config }}
+	return &Config{
+		{{- template "structLiteralFields" .Metadata.Config }}
+	}
 }
 {{- end }}

--- a/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
@@ -23,215 +23,215 @@ require.NotNil(t, cfg)
 
 {{ $validators := extractValidators .Metadata.Config }}
 {{- if $validators }}
-    {{- template "imports" $imports_addded }}
-    {{- $imports_addded = true }}
+	{{- template "imports" $imports_addded }}
+	{{- $imports_addded = true }}
 
-    func TestConfigValidate_DefaultValid(t *testing.T) {
-    cfg := createDefaultConfig().(*Config)
+	func TestConfigValidate_DefaultValid(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
 
-    require.NoError(t, cfg.Validate())
-    }
+	require.NoError(t, cfg.Validate())
+	}
 
-    {{ range $validator := $validators }}
-        {{- if $validator.Rules.Required }}
-            func TestConfigValidate_Required{{ $validator.FieldName | publicVar }}(t *testing.T) {
-            cfg := createDefaultConfig().(*Config)
-            {{- if $validator.IsPointer }}
-                cfg.{{ $validator.FieldName | publicVar }} = nil
-            {{- else if eq $validator.FieldType "map" }}
-                clear(cfg.{{ $validator.FieldName | publicVar }})
-            {{- else if eq $validator.FieldType "slice" }}
-                cfg.{{ $validator.FieldName | publicVar }} = cfg.{{ $validator.FieldName | publicVar }}[:0]
-            {{- else if eq $validator.FieldType "string" }}
-                cfg.{{ $validator.FieldName | publicVar }} = ""
-            {{- end }}
+	{{ range $validator := $validators }}
+		{{- if $validator.Rules.Required }}
+			func TestConfigValidate_Required{{ $validator.FieldName | publicVar }}(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			{{- if $validator.IsPointer }}
+				cfg.{{ $validator.FieldName | publicVar }} = nil
+			{{- else if eq $validator.FieldType "map" }}
+				clear(cfg.{{ $validator.FieldName | publicVar }})
+			{{- else if eq $validator.FieldType "slice" }}
+				cfg.{{ $validator.FieldName | publicVar }} = cfg.{{ $validator.FieldName | publicVar }}[:0]
+			{{- else if eq $validator.FieldType "string" }}
+				cfg.{{ $validator.FieldName | publicVar }} = ""
+			{{- end }}
 
-            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} is required")
-            }
-        {{ end }}
-        {{- if $validator.Rules.Minimum }}
-            func TestConfigValidate_Minimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-            cfg := createDefaultConfig().(*Config)
-            {{- $fieldName := $validator.FieldName | publicVar }}
-            {{- $minimum := $validator.Rules.Minimum }}
-            {{- if $validator.IsPointer }}
-                cfg.{{ $fieldName }} = {{ $minimum }} - 1
-            {{- else if $validator.IsOptional }}
-                *cfg.{{ $fieldName }}.Get() = {{ $minimum }} - 1
-            {{- else }}
-                cfg.{{ $fieldName }} = {{ $minimum }} - 1
-            {{- end }}
+			require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} is required")
+			}
+		{{ end }}
+		{{- if $validator.Rules.Minimum }}
+			func TestConfigValidate_Minimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			{{- $fieldName := $validator.FieldName | publicVar }}
+			{{- $minimum := $validator.Rules.Minimum }}
+			{{- if $validator.IsPointer }}
+				cfg.{{ $fieldName }} = {{ $minimum }} - 1
+			{{- else if $validator.IsOptional }}
+				*cfg.{{ $fieldName }}.Get() = {{ $minimum }} - 1
+			{{- else }}
+				cfg.{{ $fieldName }} = {{ $minimum }} - 1
+			{{- end }}
 
-            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than or equal to {{ $minimum }}")
-            }
-        {{ end }}
-        {{- if $validator.Rules.Maximum }}
-            func TestConfigValidate_Maximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-            cfg := createDefaultConfig().(*Config)
-            {{- $fieldName := $validator.FieldName | publicVar }}
-            {{- $maximum := $validator.Rules.Maximum }}
-            {{- if $validator.IsPointer }}
-                cfg.{{ $fieldName }} = {{ $maximum }} + 1
-            {{- else if $validator.IsOptional }}
-                *cfg.{{ $fieldName }}.Get() = {{ $maximum }} + 1
-            {{- else }}
-                cfg.{{ $fieldName }} = {{ $maximum }} + 1
-            {{- end }}
+			require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than or equal to {{ $minimum }}")
+			}
+		{{ end }}
+		{{- if $validator.Rules.Maximum }}
+			func TestConfigValidate_Maximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			{{- $fieldName := $validator.FieldName | publicVar }}
+			{{- $maximum := $validator.Rules.Maximum }}
+			{{- if $validator.IsPointer }}
+				cfg.{{ $fieldName }} = {{ $maximum }} + 1
+			{{- else if $validator.IsOptional }}
+				*cfg.{{ $fieldName }}.Get() = {{ $maximum }} + 1
+			{{- else }}
+				cfg.{{ $fieldName }} = {{ $maximum }} + 1
+			{{- end }}
 
-            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than or equal to {{ $maximum }}")
-            }
-        {{ end }}
-        {{- if $validator.Rules.ExclusiveMinimum }}
-            func TestConfigValidate_ExclusiveMinimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-            cfg := createDefaultConfig().(*Config)
-            {{- $fieldName := $validator.FieldName | publicVar }}
-            {{- $exclMin := $validator.Rules.ExclusiveMinimum }}
-            {{- if $validator.IsPointer }}
-                cfg.{{ $fieldName }} = {{ $exclMin }}
-            {{- else if $validator.IsOptional }}
-                *cfg.{{ $fieldName }}.Get() = {{ $exclMin }}
-            {{- else }}
-                cfg.{{ $fieldName }} = {{ $exclMin }}
-            {{- end }}
+			require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than or equal to {{ $maximum }}")
+			}
+		{{ end }}
+		{{- if $validator.Rules.ExclusiveMinimum }}
+			func TestConfigValidate_ExclusiveMinimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			{{- $fieldName := $validator.FieldName | publicVar }}
+			{{- $exclMin := $validator.Rules.ExclusiveMinimum }}
+			{{- if $validator.IsPointer }}
+				cfg.{{ $fieldName }} = {{ $exclMin }}
+			{{- else if $validator.IsOptional }}
+				*cfg.{{ $fieldName }}.Get() = {{ $exclMin }}
+			{{- else }}
+				cfg.{{ $fieldName }} = {{ $exclMin }}
+			{{- end }}
 
-            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than {{ $exclMin }}")
-            }
-        {{ end }}
-        {{- if $validator.Rules.ExclusiveMaximum }}
-            func TestConfigValidate_ExclusiveMaximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-            cfg := createDefaultConfig().(*Config)
-            {{- $fieldName := $validator.FieldName | publicVar }}
-            {{- $exclMax := $validator.Rules.ExclusiveMaximum }}
-            {{- if $validator.IsPointer }}
-                cfg.{{ $fieldName }} = {{ $exclMax }}
-            {{- else if $validator.IsOptional }}
-                *cfg.{{ $fieldName }}.Get() = {{ $exclMax }}
-            {{- else }}
-                cfg.{{ $fieldName }} = {{ $exclMax }}
-            {{- end }}
+			require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than {{ $exclMin }}")
+			}
+		{{ end }}
+		{{- if $validator.Rules.ExclusiveMaximum }}
+			func TestConfigValidate_ExclusiveMaximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			{{- $fieldName := $validator.FieldName | publicVar }}
+			{{- $exclMax := $validator.Rules.ExclusiveMaximum }}
+			{{- if $validator.IsPointer }}
+				cfg.{{ $fieldName }} = {{ $exclMax }}
+			{{- else if $validator.IsOptional }}
+				*cfg.{{ $fieldName }}.Get() = {{ $exclMax }}
+			{{- else }}
+				cfg.{{ $fieldName }} = {{ $exclMax }}
+			{{- end }}
 
-            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than {{ $exclMax }}")
-            }
-        {{ end }}
-        {{- if $validator.Rules.Enum }}
-            func TestConfigValidate_InvalidEnum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-            cfg := createDefaultConfig().(*Config)
-            cfg.{{ $validator.FieldName | publicVar }} = {{ invalidTestValue $validator.FieldType }}
+			require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than {{ $exclMax }}")
+			}
+		{{ end }}
+		{{- if $validator.Rules.Enum }}
+			func TestConfigValidate_InvalidEnum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			cfg.{{ $validator.FieldName | publicVar }} = {{ invalidTestValue $validator.FieldType }}
 
-            require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} must be one of")
-            }
-        {{ end }}
-    {{- end }}
+			require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} must be one of")
+			}
+		{{ end }}
+	{{- end }}
 {{- end }}
 {{- end }}
 
 {{- $defs := extractDefs .Metadata.ConfigsMetadata }}
 {{ range $defName, $def := $defs }}
-    {{ $defValidators := extractValidators $def }}
-    {{- if and $defValidators (not (isPrimitiveSchema $def)) }}
-        {{- template "imports" $imports_addded }}
-        {{- $imports_addded = true }}
-        func Test{{ $defName | publicVar }}Validate_DefaultValid(t *testing.T) {
-        {{- if hasDefaultValue $def }}
-            cfg := NewDefault{{ $defName | publicVar }}()
+	{{ $defValidators := extractValidators $def }}
+	{{- if and $defValidators (not (isPrimitiveSchema $def)) }}
+		{{- template "imports" $imports_addded }}
+		{{- $imports_addded = true }}
+		func Test{{ $defName | publicVar }}Validate_DefaultValid(t *testing.T) {
+		{{- if hasDefaultValue $def }}
+			cfg := NewDefault{{ $defName | publicVar }}()
 
-            require.NoError(t, cfg.Validate())
-        {{- else }}
-            require.Fail(t, "Missing default values for {{ $defName | publicVar }} struct. Please add default values to the schema to enable this test.")
-        {{- end }}
-        }
+			require.NoError(t, cfg.Validate())
+		{{- else }}
+			require.Fail(t, "Missing default values for {{ $defName | publicVar }} struct. Please add default values to the schema to enable this test.")
+		{{- end }}
+		}
 
-        {{ range $validator := $defValidators }}
-            {{- if $validator.Rules.Required }}
-                func TestConfigValidate_Required{{ $validator.FieldName | publicVar }}(t *testing.T) {
-                cfg := NewDefault{{ $defName | publicVar }}()
-                {{- if $validator.IsPointer }}
-                    cfg.{{ $validator.FieldName | publicVar }} = nil
-                {{- else if eq $validator.FieldType "map" }}
-                    clear(cfg.{{ $validator.FieldName | publicVar }})
-                {{- else if eq $validator.FieldType "array" }}
-                    cfg.{{ $validator.FieldName | publicVar }} = cfg.{{ $validator.FieldName | publicVar }}[:0]
-                {{- else if eq $validator.FieldType "string" }}
-                    cfg.{{ $validator.FieldName | publicVar }} = ""
-                {{- end }}
+		{{ range $validator := $defValidators }}
+			{{- if $validator.Rules.Required }}
+				func TestConfigValidate_Required{{ $validator.FieldName | publicVar }}(t *testing.T) {
+				cfg := NewDefault{{ $defName | publicVar }}()
+				{{- if $validator.IsPointer }}
+					cfg.{{ $validator.FieldName | publicVar }} = nil
+				{{- else if eq $validator.FieldType "map" }}
+					clear(cfg.{{ $validator.FieldName | publicVar }})
+				{{- else if eq $validator.FieldType "slice" }}
+					cfg.{{ $validator.FieldName | publicVar }} = cfg.{{ $validator.FieldName | publicVar }}[:0]
+				{{- else if eq $validator.FieldType "string" }}
+					cfg.{{ $validator.FieldName | publicVar }} = ""
+				{{- end }}
 
-                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} is required")
-                }
-            {{ end }}
-            {{- if $validator.Rules.Minimum }}
-                func Test{{ $defName | publicVar }}Validate_Minimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-                cfg := NewDefault{{ $defName | publicVar }}()
-                {{- $fieldName := $validator.FieldName | publicVar }}
-                {{- $minimum := $validator.Rules.Minimum }}
-                {{- if $validator.IsPointer }}
-                    cfg.{{ $fieldName }} = {{ $minimum }} - 1
-                {{- else if $validator.IsOptional }}
-                    *cfg.{{ $fieldName }}.Get() = {{ $minimum }} - 1
-                {{- else }}
-                    cfg.{{ $fieldName }} = {{ $minimum }} - 1
-                {{- end }}
+				require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} is required")
+				}
+			{{ end }}
+			{{- if $validator.Rules.Minimum }}
+				func Test{{ $defName | publicVar }}Validate_Minimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+				cfg := NewDefault{{ $defName | publicVar }}()
+				{{- $fieldName := $validator.FieldName | publicVar }}
+				{{- $minimum := $validator.Rules.Minimum }}
+				{{- if $validator.IsPointer }}
+					cfg.{{ $fieldName }} = {{ $minimum }} - 1
+				{{- else if $validator.IsOptional }}
+					*cfg.{{ $fieldName }}.Get() = {{ $minimum }} - 1
+				{{- else }}
+					cfg.{{ $fieldName }} = {{ $minimum }} - 1
+				{{- end }}
 
-                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than or equal to {{ $minimum }}")
-                }
-            {{ end }}
-            {{- if $validator.Rules.Maximum }}
-                func Test{{ $defName | publicVar }}Validate_Maximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-                cfg := NewDefault{{ $defName | publicVar }}()
-                {{- $fieldName := $validator.FieldName | publicVar }}
-                {{- $maximum := $validator.Rules.Maximum }}
-                {{- if $validator.IsPointer }}
-                    cfg.{{ $fieldName }} = {{ $maximum }} + 1
-                {{- else if $validator.IsOptional }}
-                    *cfg.{{ $fieldName }}.Get() = {{ $maximum }} + 1
-                {{- else }}
-                    cfg.{{ $fieldName }} = {{ $maximum }} + 1
-                {{- end }}
+				require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than or equal to {{ $minimum }}")
+				}
+			{{ end }}
+			{{- if $validator.Rules.Maximum }}
+				func Test{{ $defName | publicVar }}Validate_Maximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+				cfg := NewDefault{{ $defName | publicVar }}()
+				{{- $fieldName := $validator.FieldName | publicVar }}
+				{{- $maximum := $validator.Rules.Maximum }}
+				{{- if $validator.IsPointer }}
+					cfg.{{ $fieldName }} = {{ $maximum }} + 1
+				{{- else if $validator.IsOptional }}
+					*cfg.{{ $fieldName }}.Get() = {{ $maximum }} + 1
+				{{- else }}
+					cfg.{{ $fieldName }} = {{ $maximum }} + 1
+				{{- end }}
 
-                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than or equal to {{ $maximum }}")
-                }
-            {{ end }}
-            {{- if $validator.Rules.ExclusiveMinimum }}
-                func Test{{ $defName | publicVar }}Validate_ExclusiveMinimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-                cfg := NewDefault{{ $defName | publicVar }}()
-                {{- $fieldName := $validator.FieldName | publicVar }}
-                {{- $exclMin := $validator.Rules.ExclusiveMinimum }}
-                {{- if $validator.IsPointer }}
-                    cfg.{{ $fieldName }} = {{ $exclMin }}
-                {{- else if $validator.IsOptional }}
-                    *cfg.{{ $fieldName }}.Get() = {{ $exclMin }}
-                {{- else }}
-                    cfg.{{ $fieldName }} = {{ $exclMin }}
-                {{- end }}
+				require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than or equal to {{ $maximum }}")
+				}
+			{{ end }}
+			{{- if $validator.Rules.ExclusiveMinimum }}
+				func Test{{ $defName | publicVar }}Validate_ExclusiveMinimum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+				cfg := NewDefault{{ $defName | publicVar }}()
+				{{- $fieldName := $validator.FieldName | publicVar }}
+				{{- $exclMin := $validator.Rules.ExclusiveMinimum }}
+				{{- if $validator.IsPointer }}
+					cfg.{{ $fieldName }} = {{ $exclMin }}
+				{{- else if $validator.IsOptional }}
+					*cfg.{{ $fieldName }}.Get() = {{ $exclMin }}
+				{{- else }}
+					cfg.{{ $fieldName }} = {{ $exclMin }}
+				{{- end }}
 
-                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than {{ $exclMin }}")
-                }
-            {{ end }}
-            {{- if $validator.Rules.ExclusiveMaximum }}
-                func Test{{ $defName | publicVar }}Validate_ExclusiveMaximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-                cfg := NewDefault{{ $defName | publicVar }}()
-                {{- $fieldName := $validator.FieldName | publicVar }}
-                {{- $exclMax := $validator.Rules.ExclusiveMaximum }}
-                {{- if $validator.IsPointer }}
-                    cfg.{{ $fieldName }} = {{ $exclMax }}
-                {{- else if $validator.IsOptional }}
-                    *cfg.{{ $fieldName }}.Get() = {{ $exclMax }}
-                {{- else }}
-                    cfg.{{ $fieldName }} = {{ $exclMax }}
-                {{- end }}
+				require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be greater than {{ $exclMin }}")
+				}
+			{{ end }}
+			{{- if $validator.Rules.ExclusiveMaximum }}
+				func Test{{ $defName | publicVar }}Validate_ExclusiveMaximum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+				cfg := NewDefault{{ $defName | publicVar }}()
+				{{- $fieldName := $validator.FieldName | publicVar }}
+				{{- $exclMax := $validator.Rules.ExclusiveMaximum }}
+				{{- if $validator.IsPointer }}
+					cfg.{{ $fieldName }} = {{ $exclMax }}
+				{{- else if $validator.IsOptional }}
+					*cfg.{{ $fieldName }}.Get() = {{ $exclMax }}
+				{{- else }}
+					cfg.{{ $fieldName }} = {{ $exclMax }}
+				{{- end }}
 
-                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than {{ $exclMax }}")
-                }
-            {{ end }}
-            {{- if $validator.Rules.Enum }}
-                func Test{{ $defName | publicVar }}Validate_InvalidEnum{{ $validator.FieldName | publicVar }}(t *testing.T) {
-                cfg := NewDefault{{ $defName | publicVar }}()
-                cfg.{{ $validator.FieldName | publicVar }} = {{ invalidTestValue $validator.FieldType }}
+				require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} value must be less than {{ $exclMax }}")
+				}
+			{{ end }}
+			{{- if $validator.Rules.Enum }}
+				func Test{{ $defName | publicVar }}Validate_InvalidEnum{{ $validator.FieldName | publicVar }}(t *testing.T) {
+				cfg := NewDefault{{ $defName | publicVar }}()
+				cfg.{{ $validator.FieldName | publicVar }} = {{ invalidTestValue $validator.FieldType }}
 
-                require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} must be one of")
-                }
-            {{ end }}
-        {{- end }}
-    {{- end }}
+				require.ErrorContains(t, cfg.Validate(), "{{ $validator.FieldName }} must be one of")
+				}
+			{{ end }}
+		{{- end }}
+	{{- end }}
 {{- end }}
 
 {{- if not $imports_addded }}

--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -154,7 +154,7 @@ The following metrics are emitted by default. Each of them can be disabled by ap
 ```yaml
 metrics:
   <metric_name>:
-    enabled: false
+	enabled: false
 ```
 
 {{- end }}
@@ -179,7 +179,7 @@ The following metrics are not emitted by default. Each of them can be enabled by
 ```yaml
 metrics:
   <metric_name>:
-    enabled: true
+	enabled: true
 ```
 
 {{- end }}
@@ -199,7 +199,7 @@ The following events are emitted by default. Each of them can be disabled by app
 ```yaml
 events:
   <event_name>:
-    enabled: false
+	enabled: false
 ```
 
 {{- range $eventName, $event := .Events }}
@@ -223,7 +223,7 @@ The following events are not emitted by default. Each of them can be enabled by 
 ```yaml
 events:
   <event_name>:
-    enabled: true
+	enabled: true
 ```
 
 {{- end }}

--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -154,7 +154,7 @@ The following metrics are emitted by default. Each of them can be disabled by ap
 ```yaml
 metrics:
   <metric_name>:
-	enabled: false
+    enabled: false
 ```
 
 {{- end }}
@@ -179,7 +179,7 @@ The following metrics are not emitted by default. Each of them can be enabled by
 ```yaml
 metrics:
   <metric_name>:
-	enabled: true
+    enabled: true
 ```
 
 {{- end }}
@@ -199,7 +199,7 @@ The following events are emitted by default. Each of them can be disabled by app
 ```yaml
 events:
   <event_name>:
-	enabled: false
+    enabled: false
 ```
 
 {{- range $eventName, $event := .Events }}
@@ -223,7 +223,7 @@ The following events are not emitted by default. Each of them can be enabled by 
 ```yaml
 events:
   <event_name>:
-	enabled: true
+    enabled: true
 ```
 
 {{- end }}

--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -46,7 +46,7 @@ func mustParseInt64(s string) int64 {
   re := regexp.MustCompile(`-?\d+`)
   match := re.FindString(s)
   if match == "" {
-      return 0
+	  return 0
   }
 	v, _ := strconv.ParseInt(match, 10, 64)
 	return v
@@ -421,30 +421,30 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings {{ .Status.Class }}.Se
   {{- if eq $name.EmittedName $metric.Migration.To.EmittedName }}
   {{- /* same emitted name: legacy & v1 collide, so disable legacy when schema differs */}}
   if {{ printf "%s" $metric.Migration.ThroughGates.EnableNew | publicVar }}FeatureGate.IsEnabled() {
-    if mb.metric{{ $name.Render }}.config.Enabled && mb.metric{{ $metric.Migration.To.Render }}.config.Enabled {
-      var disable bool
-      if mb.metric{{ $name.Render }}.data.Type() != mb.metric{{ $metric.Migration.To.Render }}.data.Type() {
-        // Disable legacy metric if legacy and latest have same name but different types
-        disable = true
-        settings.Logger.Warn("[WARNING] Legacy metric `{{ $name }}` disabled: same emitted name as `{{ $metric.Migration.To }}` with different type; only latest will be emitted")
-      }
-      if !slices.Equal(MetricsInfo.{{ $name.Render }}.Attributes, MetricsInfo.{{ $metric.Migration.To.Render }}.Attributes) {
-        // Disable legacy metric if legacy and latest have same name but different attributes
-        // The latest metric will emit both attribute sets during migration
-        disable = true
-        settings.Logger.Warn("[WARNING] Legacy metric `{{ $name }}` disabled: same emitted name as `{{ $metric.Migration.To }}` with different attributes; only latest will be emitted with combined attributes",
-          zap.Strings("legacy_attributes", MetricsInfo.{{ $name.Render }}.Attributes),
-          zap.Strings("latest_attributes", MetricsInfo.{{ $metric.Migration.To.Render }}.Attributes))
-      }
-      if disable {
-        mb.metric{{ $name.Render }}.config.Enabled = false
-      }
-    }
+	if mb.metric{{ $name.Render }}.config.Enabled && mb.metric{{ $metric.Migration.To.Render }}.config.Enabled {
+	  var disable bool
+	  if mb.metric{{ $name.Render }}.data.Type() != mb.metric{{ $metric.Migration.To.Render }}.data.Type() {
+		// Disable legacy metric if legacy and latest have same name but different types
+		disable = true
+		settings.Logger.Warn("[WARNING] Legacy metric `{{ $name }}` disabled: same emitted name as `{{ $metric.Migration.To }}` with different type; only latest will be emitted")
+	  }
+	  if !slices.Equal(MetricsInfo.{{ $name.Render }}.Attributes, MetricsInfo.{{ $metric.Migration.To.Render }}.Attributes) {
+		// Disable legacy metric if legacy and latest have same name but different attributes
+		// The latest metric will emit both attribute sets during migration
+		disable = true
+		settings.Logger.Warn("[WARNING] Legacy metric `{{ $name }}` disabled: same emitted name as `{{ $metric.Migration.To }}` with different attributes; only latest will be emitted with combined attributes",
+		  zap.Strings("legacy_attributes", MetricsInfo.{{ $name.Render }}.Attributes),
+		  zap.Strings("latest_attributes", MetricsInfo.{{ $metric.Migration.To.Render }}.Attributes))
+	  }
+	  if disable {
+		mb.metric{{ $name.Render }}.config.Enabled = false
+	  }
+	}
   } else {
-    if mb.metric{{ $metric.Migration.To.Render }}.config.Enabled {
-      mb.metric{{ $metric.Migration.To.Render }}.config.Enabled = false
-      settings.Logger.Warn("[WARNING] metric `{{ $metric.Migration.To }}` requires feature gate `{{ $metric.Migration.ThroughGates.EnableNew }}` to be enabled, metric has been disabled")
-    }
+	if !{{ printf "%s" $metric.Migration.ThroughGates.EnableNew | publicVar}}FeatureGate.IsEnabled() && mb.metric{{ $metric.Migration.To.Render }}.config.Enabled {
+	  mb.metric{{ $metric.Migration.To.Render }}.config.Enabled = false
+	  settings.Logger.Warn("[WARNING] metric `{{ $metric.Migration.To }}` requires feature gate `{{ $metric.Migration.ThroughGates.EnableNew }}` to be enabled, metric has been disabled")
+	}
   }
   {{- else }}
   {{- /* rename: no wire collision; both names emit during transition. Only gate the v1 metric. */}}
@@ -643,9 +643,9 @@ func (mb *MetricsBuilder) Record{{ $name.Render }}DataPoint(ts pcommon.Timestamp
 		{{- end -}}
 		{{- end -}}
 		{{- if $metric.HasConditionalAttributes $.Attributes -}}
-        , options...
-        {{- end -}}
-        )
+		, options...
+		{{- end -}}
+		)
 	}
 	{{- $targetMetric := index $.Metrics $metric.Migration.To }}
 	if {{ printf "%s" $metric.Migration.ThroughGates.EnableNew | publicVar }}FeatureGate.IsEnabled() {

--- a/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
@@ -455,199 +455,177 @@ func TestMetricsBuilder(t *testing.T) {
 {{- range $name, $metric := .Metrics }}{{- if $metric.Migration }}{{- $hasVersionedMetrics = true }}{{- end }}{{- end }}
 {{- if $hasVersionedMetrics }}
 func TestVersionedMetrics(t *testing.T) {
-    {{- range $name, $metric := .Metrics }}
-    {{- if $metric.Migration }}
-    {{- $targetLegacyAttrs := getLegacyAttributes $metric.Migration.To }}
-    t.Run("{{ $name }}", func(t *testing.T) {
-        tests := []struct {
-            name               string
-            disableOld         bool
-            enableNew          bool
-            expectLegacyMetric bool
-            expectNewMetric    bool
-            {{- if $targetLegacyAttrs }}
-            expectLegacyAttrs  bool
-            {{- end }}
-        }{
-            {
-                name:               "legacy_only",
-                disableOld:         false,
-                enableNew:          false,
-                expectLegacyMetric: true,
-                expectNewMetric:    false,
-            },
-            {{- if eq $name.EmittedName $metric.Migration.To.EmittedName }}
-            {
-                name:               "dual_emission",
-                disableOld:         false,
-                enableNew:          true,
-                expectLegacyMetric: false,
-                expectNewMetric:    true,
-                {{- if $targetLegacyAttrs }}
-                expectLegacyAttrs:  true,
-                {{- end }}
-            },
-            {{- else }}
-            {
-                name:               "dual_emission",
-                disableOld:         false,
-                enableNew:          true,
-                expectLegacyMetric: true,
-                expectNewMetric:    true,
-            },
-            {{- end }}
+	{{- range $name, $metric := .Metrics }}
+	{{- if $metric.Migration }}
+	{{- $targetLegacyAttrs := getLegacyAttributes $metric.Migration.To }}
+	t.Run("{{ $name }}", func(t *testing.T) {
+		tests := []struct {
+			name               string
+			disableOld         bool
+			enableNew          bool
+			expectLegacyMetric bool
+			expectNewMetric    bool
+			{{- if $targetLegacyAttrs }}
+			expectLegacyAttrs  bool
+			{{- end }}
+		}{
+			{
+				name:               "legacy_only",
+				disableOld:         false,
+				enableNew:          false,
+				expectLegacyMetric: true,
+				expectNewMetric:    false,
+			},
+			{{- if eq $name.EmittedName $metric.Migration.To.EmittedName }}
+			{
+				name:               "dual_emission",
+				disableOld:         false,
+				enableNew:          true,
+				expectLegacyMetric: false,
+				expectNewMetric:    true,
+				{{- if $targetLegacyAttrs }}
+				expectLegacyAttrs:  true,
+				{{- end }}
+			},
+			{{- else }}
+			{
+				name:               "dual_emission",
+				disableOld:         false,
+				enableNew:          true,
+				expectLegacyMetric: true,
+				expectNewMetric:    true,
+			},
+			{{- end }}
 
-            {
-                name:               "new_only",
-                disableOld:         true,
-                enableNew:          true,
-                expectLegacyMetric: false,
-                expectNewMetric:    true,
-                {{- if $targetLegacyAttrs }}
-                expectLegacyAttrs:  false,
-                {{- end }}
-            },
-        }
+			{
+				name:               "new_only",
+				disableOld:         true,
+				enableNew:          true,
+				expectLegacyMetric: false,
+				expectNewMetric:    true,
+				{{- if $targetLegacyAttrs }}
+				expectLegacyAttrs:  false,
+				{{- end }}
+			},
+		}
 
-        for _, tt := range tests {
-            t.Run(tt.name, func(t *testing.T) {
-                require.NoError(t, featuregate.GlobalRegistry().Set(
-                    "{{ $metric.Migration.ThroughGates.DisableOld }}", tt.disableOld))
-                require.NoError(t, featuregate.GlobalRegistry().Set(
-                    "{{ $metric.Migration.ThroughGates.EnableNew }}", tt.enableNew))
-                t.Cleanup(func() {
-                    featuregate.GlobalRegistry().Set("{{ $metric.Migration.ThroughGates.DisableOld }}", false)
-                    featuregate.GlobalRegistry().Set("{{ $metric.Migration.ThroughGates.EnableNew }}", false)
-                })
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				require.NoError(t, featuregate.GlobalRegistry().Set(
+					"{{ $metric.Migration.ThroughGates.DisableOld }}", tt.disableOld))
+				require.NoError(t, featuregate.GlobalRegistry().Set(
+					"{{ $metric.Migration.ThroughGates.EnableNew }}", tt.enableNew))
+				t.Cleanup(func() {
+					featuregate.GlobalRegistry().Set("{{ $metric.Migration.ThroughGates.DisableOld }}", false)
+					featuregate.GlobalRegistry().Set("{{ $metric.Migration.ThroughGates.EnableNew }}", false)
+				})
 
-                start := pcommon.Timestamp(1_000_000_000)
-                ts := pcommon.Timestamp(1_000_001_000)
-                {{- if ne $name.EmittedName $metric.Migration.To.EmittedName }}
-                observedZapCore, observedLogs := observer.New(zap.WarnLevel)
-                {{- if or isReceiver isScraper isConnector }}
-                settings := {{ $.Status.Class }}test.NewNopSettings({{ $.Status.Class }}test.NopType)
-                {{- end }}
-                settings.Logger = zap.New(observedZapCore)
-                {{- else }}
-                settings := {{ $.Status.Class }}test.NewNopSettings({{ $.Status.Class }}test.NopType)
-                {{- end }}
-                mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, "all_set"), settings, WithStartTime(start))
+				start := pcommon.Timestamp(1_000_000_000)
+				ts := pcommon.Timestamp(1_000_001_000)
+				settings := {{ $.Status.Class }}test.NewNopSettings({{ $.Status.Class }}test.NopType)
+				mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, "all_set"), settings, WithStartTime(start))
 
-                mb.Record{{ $name.Render }}DataPoint(ts, 1
-                {{- range $metric.Attributes -}}
-                {{- if not (attributeInfo .).IsConditional -}}
-                , {{- template "getAttributeValue" . -}}
-                {{- end -}}
-                {{- end -}}
-                {{- if $metric.Migration -}}
-                {{- $targetMetric := index $.Metrics $metric.Migration.To -}}
-                {{- range $i, $attr := $metric.Attributes -}}
-                {{- if not (attributeInfo $attr).IsConditional -}}
-                {{- $v1Attr := index $targetMetric.Attributes $i -}}
-                {{- if or (ne (attributeInfo $v1Attr).Name (attributeInfo $attr).Name) (ne (attributeInfo $v1Attr).Type.String (attributeInfo $attr).Type.String) -}}
-                , {{- template "getAttributeValue" $v1Attr -}}
-                {{- end -}}
-                {{- end -}}
-                {{- end -}}
-                {{- end -}}
-                )
+				mb.Record{{ $name.Render }}DataPoint(ts, 1
+				{{- range $metric.Attributes -}}
+				{{- if not (attributeInfo .).IsConditional -}}
+				, {{- template "getAttributeValue" . -}}
+				{{- end -}}
+				{{- end -}}
+				{{- if $metric.Migration -}}
+				{{- $targetMetric := index $.Metrics $metric.Migration.To -}}
+				{{- range $i, $attr := $metric.Attributes -}}
+				{{- if not (attributeInfo $attr).IsConditional -}}
+				{{- $v1Attr := index $targetMetric.Attributes $i -}}
+				{{- if or (ne (attributeInfo $v1Attr).Name (attributeInfo $attr).Name) (ne (attributeInfo $v1Attr).Type.String (attributeInfo $attr).Type.String) -}}
+				, {{- template "getAttributeValue" $v1Attr -}}
+				{{- end -}}
+				{{- end -}}
+				{{- end -}}
+				{{- end -}}
+				)
 
-                metrics := mb.Emit(WithResource(pcommon.NewResource()))
+				metrics := mb.Emit(WithResource(pcommon.NewResource()))
 
-                // Count metrics by name and type
-                var legacyFound, newFound bool
-                for ri := 0; ri < metrics.ResourceMetrics().Len(); ri++ {
-                  ms := metrics.ResourceMetrics().At(ri).ScopeMetrics().At(0).Metrics()
-                  for mi := 0; mi < ms.Len(); mi++ {
-                      m := ms.At(mi)
-                      {{- $targetMetric := metricInfo $metric.Migration.To }}
-                      {{- if eq $name.EmittedName $metric.Migration.To.EmittedName }}
-                        {{- if ne $metric.Data.Type $targetMetric.Data.Type }}
-                      // Same emitted name, different types - distinguish by type
-                      if m.Name() == "{{ $name.EmittedName }}" {
-                          if m.Type() == pmetric.MetricType{{ $metric.Data.Type }} {
-                              legacyFound = true
-                          }
-                          if m.Type() == pmetric.MetricType{{ $targetMetric.Data.Type }} {
-                              newFound = true
-                              {{- if $targetLegacyAttrs }}
-                              if tt.expectLegacyAttrs {
-                                  dp := m.{{ $targetMetric.Data.Type }}().DataPoints().At(0)
-                                  {{- range $targetLegacyAttrs }}
-                                  _, has{{ .Render }} := dp.Attributes().Get("{{ (attributeInfo .).Name }}")
-                                  assert.True(t, has{{ .Render }}, "expected legacy attr {{ . }}")
-                                  {{- end }}
-                              }
-                              {{- end }}
-                          }
-                      }
-                        {{- else }}
-                      // Same emitted name, same type - distinguish by attributes
-                      if m.Name() == "{{ $name.EmittedName }}" {
-                          dp := m.{{ $metric.Data.Type }}().DataPoints().At(0)
-                          {{- $newAttr := index $targetMetric.Attributes 0 }}
-                          _, hasNewAttr := dp.Attributes().Get("{{ (attributeInfo $newAttr).Name }}")
-                          {{- if ne $metric.Unit $targetMetric.Unit }}
-                          if hasNewAttr && m.Unit() == "{{ $targetMetric.Unit }}" {
-                          {{- else }}
-                          if hasNewAttr {
-                          {{- end }}
-                              // Has v1-specific attribute - this is the new metric
-                              newFound = true
-                              {{- if $targetLegacyAttrs }}
-                              if tt.expectLegacyAttrs {
-                                  {{- range $targetLegacyAttrs }}
-                                  _, has{{ .Render }} := dp.Attributes().Get("{{ (attributeInfo .).Name }}")
-                                  assert.True(t, has{{ .Render }}, "expected legacy attr {{ . }}")
-                                  {{- end }}
-                              }
-                              {{- end }}
-                          } else {
-                              // No v1-specific attribute - this is the legacy metric
-                              legacyFound = true
-                          }
-                      }
-                        {{- end }}
-                      {{- else }}
-                      // Different emitted names - distinguish by name
-                      if m.Name() == "{{ $name.EmittedName }}" {
-                          legacyFound = true
-                      }
-                      if m.Name() == "{{ $metric.Migration.To.EmittedName }}" {
-                          newFound = true
-                          {{- if $targetLegacyAttrs }}
-                          if tt.expectLegacyAttrs {
-                              dp := m.{{ $targetMetric.Data.Type }}().DataPoints().At(0)
-                              {{- range $targetLegacyAttrs }}
-                              _, has{{ .Render }} := dp.Attributes().Get("{{ (attributeInfo .).Name }}")
-                              assert.True(t, has{{ .Render }}, "expected legacy attr {{ . }}")
-                              {{- end }}
-                          }
-                          {{- end }}
-                      }
-                      {{- end }}
-                      }
-                  }
-                  assert.Equal(t, tt.expectLegacyMetric, legacyFound)
-                  assert.Equal(t, tt.expectNewMetric, newFound) 
-
-                  {{- if ne $name.EmittedName $metric.Migration.To.EmittedName }}
-                  // For metrics with different emitted names, no collison warning shoulds be logged
-                  // This guards against the regression where same name collision logic was
-                  // incorrectly applied to renamed metrics.
-                  if tt.enableNew {
-                      for _, log := range observedLogs.All() {
-                          if strings.Contains(log.Message, "{{ $name }}") {
-                              assert.NotContains(t, log.Message, "same emitted name",
-                                  "should not log same name collision warning for metrics with different names")
-                          }
-                      }
-                  }
-                  {{- end }}
-            })
-        }
-    })
-    {{- end }}
-    {{- end }}
+				// Count metrics by name and type
+				var legacyFound, newFound bool
+				for ri := 0; ri < metrics.ResourceMetrics().Len(); ri++ {
+				  ms := metrics.ResourceMetrics().At(ri).ScopeMetrics().At(0).Metrics()
+				  for mi := 0; mi < ms.Len(); mi++ {
+					  m := ms.At(mi)
+					  {{- $targetMetric := metricInfo $metric.Migration.To }}
+					  {{- if eq $name.EmittedName $metric.Migration.To.EmittedName }}
+						{{- if ne $metric.Data.Type $targetMetric.Data.Type }}
+					  // Same emitted name, different types - distinguish by type
+					  if m.Name() == "{{ $name.EmittedName }}" {
+						  if m.Type() == pmetric.MetricType{{ $metric.Data.Type }} {
+							  legacyFound = true
+						  }
+						  if m.Type() == pmetric.MetricType{{ $targetMetric.Data.Type }} {
+							  newFound = true
+							  {{- if $targetLegacyAttrs }}
+							  if tt.expectLegacyAttrs {
+								  dp := m.{{ $targetMetric.Data.Type }}().DataPoints().At(0)
+								  {{- range $targetLegacyAttrs }}
+								  _, has{{ .Render }} := dp.Attributes().Get("{{ (attributeInfo .).Name }}")
+								  assert.True(t, has{{ .Render }}, "expected legacy attr {{ . }}")
+								  {{- end }}
+							  }
+							  {{- end }}
+						  }
+					  }
+						{{- else }}
+					  // Same emitted name, same type - distinguish by attributes
+					  if m.Name() == "{{ $name.EmittedName }}" {
+						  dp := m.{{ $metric.Data.Type }}().DataPoints().At(0)
+						  {{- $newAttr := index $targetMetric.Attributes 0 }}
+						  _, hasNewAttr := dp.Attributes().Get("{{ (attributeInfo $newAttr).Name }}")
+						  {{- if ne $metric.Unit $targetMetric.Unit }}
+						  if hasNewAttr && m.Unit() == "{{ $targetMetric.Unit }}" {
+						  {{- else }}
+						  if hasNewAttr {
+						  {{- end }}
+							  // Has v1-specific attribute - this is the new metric
+							  newFound = true
+							  {{- if $targetLegacyAttrs }}
+							  if tt.expectLegacyAttrs {
+								  {{- range $targetLegacyAttrs }}
+								  _, has{{ .Render }} := dp.Attributes().Get("{{ (attributeInfo .).Name }}")
+								  assert.True(t, has{{ .Render }}, "expected legacy attr {{ . }}")
+								  {{- end }}
+							  }
+							  {{- end }}
+						  } else {
+							  // No v1-specific attribute - this is the legacy metric
+							  legacyFound = true
+						  }
+					  }
+						{{- end }}
+					  {{- else }}
+					  // Different emitted names - distinguish by name
+					  if m.Name() == "{{ $name.EmittedName }}" {
+						  legacyFound = true
+					  }
+					  if m.Name() == "{{ $metric.Migration.To.EmittedName }}" {
+						  newFound = true
+						  {{- if $targetLegacyAttrs }}
+						  if tt.expectLegacyAttrs {
+							  dp := m.{{ $targetMetric.Data.Type }}().DataPoints().At(0)
+							  {{- range $targetLegacyAttrs }}
+							  _, has{{ .Render }} := dp.Attributes().Get("{{ (attributeInfo .).Name }}")
+							  assert.True(t, has{{ .Render }}, "expected legacy attr {{ . }}")
+							  {{- end }}
+						  }
+						  {{- end }}
+					  }
+					  {{- end }}
+					  }
+				  }
+				  assert.Equal(t, tt.expectLegacyMetric, legacyFound)
+				  assert.Equal(t, tt.expectNewMetric, newFound) 
+			})
+		}
+	})
+	{{- end }}
+	{{- end }}
 }
 {{- end }}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Added a `check-template-tabs` Makefile target and a corresponding CI step in `build-and-test.yml` that fails if any `.go.tmpl` file under `cmd/mdatagen` or `cmd/builder` contains lines with leading spaces. Converted the two remaining offending templates (`config_from_cfggen.go.tmpl` and `config_from_cfggen_test.go.tmpl`) from space indentation to tab indentation to bring them in line with all other templates.


<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #14698

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Ran `make check-template-tabs` locally — passes with no output. All other `.go.tmpl` files were already tab-indented and continue to pass.


<!--Describe the documentation added.-->
#### Documentation
No documentation changes needed. The `check-template-tabs` target is self-documenting via the Makefile.


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.