### PR TITLE
[pdata] Support Strindex for Value

### DIFF
--- a/.chloggen/pdata-value-support-strindex.yaml
+++ b/.chloggen/pdata-value-support-strindex.yaml
@@ -22,4 +22,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [api]

--- a/.chloggen/pdata-value-support-strindex.yaml
+++ b/.chloggen/pdata-value-support-strindex.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: pdata
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Support Strindex for Value
+note: Support Strindex as AnyValue for OTel Profiles
 
 # One or more tracking issues or pull requests related to the change
 issues: [15450]

--- a/.chloggen/pdata-value-support-strindex.yaml
+++ b/.chloggen/pdata-value-support-strindex.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support Strindex for Value
+
+# One or more tracking issues or pull requests related to the change
+issues: [15450]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/pdata-value-support-strindex.yaml
+++ b/.chloggen/pdata-value-support-strindex.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: pdata
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Support Strindex as AnyValue for OTel Profiles
+note: Support Strindex as Value for OTel Profiles
 
 # One or more tracking issues or pull requests related to the change
 issues: [15450]

--- a/pdata/internal/wrapper_value.go
+++ b/pdata/internal/wrapper_value.go
@@ -75,3 +75,10 @@ func NewAnyValueKvlistValue() *AnyValue_KvlistValue {
 	}
 	return ProtoPoolAnyValue_KvlistValue.Get().(*AnyValue_KvlistValue)
 }
+
+func NewAnyValueStringValueStrindex() *AnyValue_StringValueStrindex {
+	if !metadata.PdataUseProtoPoolingFeatureGate.IsEnabled() {
+		return &AnyValue_StringValueStrindex{}
+	}
+	return ProtoPoolAnyValue_StringValueStrindex.Get().(*AnyValue_StringValueStrindex)
+}

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -297,6 +297,8 @@ func (v Value) Bytes() ByteSlice {
 
 // Strindex returns the strindex value associated with this Value.
 // If the Type() is not ValueTypeStrindex then returns zero value.
+// Note: This is currently used exclusively in the Profiling signal.
+// Status: [Alpha]
 func (v Value) Strindex() int32 {
 	return v.getOrig().GetStringValueStrindex()
 }
@@ -386,6 +388,9 @@ func (v Value) SetEmptySlice() Slice {
 	return newSlice(&ov.ArrayValue.Values, v.getState())
 }
 
+// SetStrindex ...
+// Note: This is currently used exclusively in the Profiling signal.
+// Status: [Alpha]
 func (v Value) SetStrindex(i int32) {
 	v.getState().AssertMutable()
 	// Delete everything but the AnyValue object itself.

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -388,7 +388,7 @@ func (v Value) SetEmptySlice() Slice {
 	return newSlice(&ov.ArrayValue.Values, v.getState())
 }
 
-// SetStr replaces the strindex associated with this Value,
+// SetStrindex replaces the strindex associated with this Value,
 // it also changes the type to be ValueTypeStrindex.
 // Note: This is currently used exclusively in the Profiling signal.
 // Status: [Alpha]

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -18,6 +18,8 @@ import (
 // ValueType specifies the type of Value.
 type ValueType int32
 
+type Strindex int32
+
 const (
 	ValueTypeEmpty ValueType = iota
 	ValueTypeStr
@@ -27,6 +29,7 @@ const (
 	ValueTypeMap
 	ValueTypeSlice
 	ValueTypeBytes
+	ValueTypeStrindex
 )
 
 // String returns the string representation of the ValueType.
@@ -48,6 +51,8 @@ func (avt ValueType) String() string {
 		return "Slice"
 	case ValueTypeBytes:
 		return "Bytes"
+	case ValueTypeStrindex:
+		return "Strindex"
 	}
 	return ""
 }
@@ -137,6 +142,15 @@ func NewValueBytes() Value {
 	return newValue(orig, internal.NewState())
 }
 
+// NewValueStrindex creates a new Value of strindex type.
+func NewValueStrindex(i int32) Value {
+	ov := internal.NewAnyValueStringValueStrindex()
+	ov.StringValueStrindex = i
+	orig := internal.NewAnyValue()
+	orig.Value = ov
+	return newValue(orig, internal.NewState())
+}
+
 func newValue(orig *internal.AnyValue, state *internal.State) Value {
 	return Value(internal.NewValueWrapper(orig, state))
 }
@@ -189,6 +203,8 @@ func (v Value) FromRaw(iv any) error {
 		return v.SetEmptyMap().FromRaw(tv)
 	case []any:
 		return v.SetEmptySlice().FromRaw(tv)
+	case Strindex:
+		v.SetStrindex(int32(tv))
 	default:
 		return fmt.Errorf("<Invalid value type %T>", tv)
 	}
@@ -213,6 +229,8 @@ func (v Value) Type() ValueType {
 		return ValueTypeSlice
 	case *internal.AnyValue_BytesValue:
 		return ValueTypeBytes
+	case *internal.AnyValue_StringValueStrindex:
+		return ValueTypeStrindex
 	}
 	return ValueTypeEmpty
 }
@@ -273,6 +291,12 @@ func (v Value) Bytes() ByteSlice {
 		return ByteSlice{}
 	}
 	return ByteSlice(internal.NewByteSliceWrapper(&bv.BytesValue, internal.GetValueState(internal.ValueWrapper(v))))
+}
+
+// Strindex returns the strindex value associated with this Value.
+// If the Type() is not ValueTypeStrindex then returns zero value.
+func (v Value) Strindex() int32 {
+	return v.getOrig().GetStringValueStrindex()
 }
 
 // SetStr replaces the string value associated with this Value,
@@ -360,6 +384,15 @@ func (v Value) SetEmptySlice() Slice {
 	return newSlice(&ov.ArrayValue.Values, v.getState())
 }
 
+func (v Value) SetStrindex(i int32) {
+	v.getState().AssertMutable()
+	// Delete everything but the AnyValue object itself.
+	internal.DeleteAnyValue(v.getOrig(), false)
+	ov := internal.NewAnyValueStringValueStrindex()
+	ov.StringValueStrindex = i
+	v.getOrig().Value = ov
+}
+
 // MoveTo moves the Value from current overriding the destination and
 // resetting the current instance to empty value.
 // Calling this function on zero-initialized Value will cause a panic.
@@ -410,6 +443,9 @@ func (v Value) AsString() string {
 
 	case ValueTypeSlice:
 		return marshalJSONNoHTMLEscape(v.Slice().AsRaw())
+
+	case ValueTypeStrindex:
+		return fmt.Sprintf("<strindex>%d", v.Strindex())
 
 	default:
 		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", v.Type())
@@ -488,6 +524,8 @@ func (v Value) AsRaw() any {
 		return v.Map().AsRaw()
 	case ValueTypeSlice:
 		return v.Slice().AsRaw()
+	case ValueTypeStrindex:
+		return Strindex(v.Strindex())
 	}
 	return fmt.Sprintf("<Unknown OpenTelemetry value type %q>", v.Type())
 }
@@ -514,6 +552,8 @@ func (v Value) Equal(c Value) bool {
 		return v.Map().Equal(c.Map())
 	case ValueTypeSlice:
 		return v.Slice().Equal(c.Slice())
+	case ValueTypeStrindex:
+		return v.Strindex() == c.Strindex()
 	}
 
 	return false

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -143,6 +143,8 @@ func NewValueBytes() Value {
 }
 
 // NewValueStrindex creates a new Value of strindex type.
+// Note: This is currently used exclusively in the Profiling signal.
+// Status: [Alpha]
 func NewValueStrindex(i int32) Value {
 	ov := internal.NewAnyValueStringValueStrindex()
 	ov.StringValueStrindex = i

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -388,7 +388,8 @@ func (v Value) SetEmptySlice() Slice {
 	return newSlice(&ov.ArrayValue.Values, v.getState())
 }
 
-// SetStrindex ...
+// SetStr replaces the strindex associated with this Value,
+// it also changes the type to be ValueTypeStrindex.
 // Note: This is currently used exclusively in the Profiling signal.
 // Status: [Alpha]
 func (v Value) SetStrindex(i int32) {

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -84,6 +84,7 @@ func TestValueType(t *testing.T) {
 	assert.Equal(t, "Map", ValueTypeMap.String())
 	assert.Equal(t, "Slice", ValueTypeSlice.String())
 	assert.Equal(t, "Bytes", ValueTypeBytes.String())
+	assert.Equal(t, "Strindex", ValueTypeStrindex.String())
 	assert.Empty(t, ValueType(100).String())
 }
 
@@ -228,6 +229,11 @@ func TestNilOrigSetValue(t *testing.T) {
 	av = NewValueEmpty()
 	require.NoError(t, av.SetEmptySlice().FromRaw([]any{int64(1), "val"}))
 	assert.Equal(t, []any{int64(1), "val"}, av.Slice().AsRaw())
+
+	av = NewValueEmpty()
+	index := int32(123456789)
+	av.SetStrindex(index)
+	assert.Equal(t, index, av.Strindex())
 }
 
 func TestValue_MoveTo(t *testing.T) {
@@ -372,6 +378,11 @@ func TestValueAsString(t *testing.T) {
 			}(),
 			expected: `["<",">","&"]`,
 		},
+		{
+			name:     "strindex",
+			input:    NewValueStrindex(int32(123456789)),
+			expected: `<strindex>123456789`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -429,6 +440,11 @@ func TestValueAsRaw(t *testing.T) {
 				"floatKey": 18.6,
 				"intKey":   int64(7),
 			},
+		},
+		{
+			name:     "strindex",
+			input:    NewValueStrindex(int32(123456789)),
+			expected: Strindex(123456789),
 		},
 	}
 	for _, tt := range tests {
@@ -566,6 +582,11 @@ func TestNewValueFromRaw(t *testing.T) {
 				assert.NoError(t, s.Slice().FromRaw([]any{}))
 				return s
 			})(),
+		},
+		{
+			name:     "strindex",
+			input:    Strindex(123456789),
+			expected: NewValueStrindex(int32(123456789)),
 		},
 	}
 	for _, tt := range tests {
@@ -758,6 +779,18 @@ func TestValueEqual(t *testing.T) {
 			}(),
 			expected: false,
 		},
+		{
+			name:       "same strindexes",
+			value:      NewValueStrindex(int32(123456789)),
+			comparison: NewValueStrindex(int32(123456789)),
+			expected:   true,
+		},
+		{
+			name:       "different strindexes",
+			value:      NewValueStrindex(int32(123456789)),
+			comparison: NewValueStrindex(int32(12346789)),
+			expected:   false,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.value.Equal(tt.comparison))
@@ -836,6 +869,11 @@ func BenchmarkValueEqual(b *testing.B) {
 				m.Map().PutStr("hello", "world")
 				return m
 			}(),
+		},
+		{
+			name:       "strindexes",
+			value:      NewValueStrindex(int32(123456789)),
+			comparison: NewValueStrindex(int32(123456789)),
 		},
 	} {
 		b.Run(bb.name, func(b *testing.B) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Support Strindex for Value, so user can access and modify `string_value_strindex` within OTLP profiles directly.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15450

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A.

<!--Describe the documentation added.-->
#### Documentation
N/A.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
