### PR TITLE
[cmd/schemagen] Fix mode detection and add manual override for schemagen package targeting

### DIFF
--- a/.chloggen/schemagen_mode_fix.yaml
+++ b/.chloggen/schemagen_mode_fix.yaml
@@ -10,7 +10,7 @@ component: cmd/schemagen
 note: Fix mode detection when using `-p` to target a package outside the current directory.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [15453]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/schemagen_mode_fix.yaml
+++ b/.chloggen/schemagen_mode_fix.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/schemagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix mode detection when using `-p` to target a package outside the current directory.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  A new `-m component|package` flag is available as a manual override when auto-detection is not possible.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/schemagen/README.md
+++ b/cmd/schemagen/README.md
@@ -12,7 +12,15 @@ and the generation process would be reversed – Go config files from schemas.
 ## Modes
 
 Script can generate schemas for components and packages. There are two distinct modes of operation:
-`component` and `package`. Schemagen automatically detects the mode based on metadata.yaml file content.
+`component` and `package`. Schemagen automatically detects the mode based on `metadata.yaml` file content.
+
+When the `-p` flag targets a package outside the current directory, schemagen resolves the target
+package's source directory and reads its own `metadata.yaml` for mode detection. This works for any
+package reachable from the `go.mod` of the directory you run schemagen from — including packages
+from other repositories that are present in the module cache as dependencies. If the package is not
+in the local module graph, auto-detection falls back to the default mode; use the `-m` flag to
+override it explicitly in that case. The generated schema is always written to the local output
+folder, not to the resolved package directory.
 
 ### Component mode
 
@@ -57,7 +65,8 @@ You can also go to specific component folder and run `make schemagen` directly.
 | `-o` | Given directory (or `outputFolder` from `.schemagen.yaml` if provided) | Folder that will receive the generated `*.schema.<ext>` file. |
 | `-t` | `yaml`                                                                 | Output format. Accepts `yaml`, `yml`, or `json`.              |
 | `-r` | `false`                                                                | Resolve `$ref` entries inline (see [Ref resolution](#ref-resolution)). |
-| `-p` | `.`                                                                    | Go package pattern passed to `packages.Load`. Use a fully-qualified import path (e.g. `go.opentelemetry.io/collector/receiver/otlpreceiver`) to target a specific package instead of the current directory. |
+| `-p` | `.`                                                                    | Go package pattern passed to `packages.Load`. Use a fully-qualified import path (e.g. `go.opentelemetry.io/collector/receiver/otlpreceiver`) to target a specific package instead of the current directory. When non-default, schemagen resolves the target package's source directory and reads its `metadata.yaml` for mode detection. Requires the package to be reachable from the local `go.mod`. |
+| `-m` | *(auto-detected)*                                                      | Override the run mode: `component` or `package`. Required when using `-p` with a package that is not in the local module graph, since `metadata.yaml` cannot be located automatically in that case. |
 
 The schema `$id` is derived from the Go package import path and the `$title` is the package name with the current
 run mode (`component`/`package`) appended.

--- a/cmd/schemagen/internal/config.go
+++ b/cmd/schemagen/internal/config.go
@@ -42,6 +42,7 @@ var (
 	fileType     = flag.String("t", "yaml", "Output file type (yaml or json)")
 	resolveRefs  = flag.Bool("r", false, "Resolve external $ref entries inline in the output schema")
 	pattern      = flag.String("p", ".", "Optional pattern to match config struct package, e.g. \"go.opentelemetry.io/collector/receiver/otlpreceiver")
+	modeOverride = flag.String("m", "", "Override detected run mode: component or package")
 )
 
 func usage() {
@@ -102,7 +103,16 @@ func ReadConfig() (*Config, error) {
 		return nil, errors.New("unknown schema file type - use yaml or json: " + *fileType)
 	}
 
-	if md, ok := ReadMetadata(dirPath); ok {
+	// When a non-default pattern is given, resolve the target package's source directory
+	// so we read its metadata.yaml instead of the local dirPath.
+	metadataDir := dirPath
+	if *pattern != "." {
+		if resolved, ok := ResolvePackageDir(dirPath, *pattern); ok {
+			metadataDir = resolved
+		}
+	}
+
+	if md, ok := ReadMetadata(metadataDir); ok {
 		if md.Parent != "" {
 			mode = Component
 		} else {
@@ -114,6 +124,15 @@ func ReadConfig() (*Config, error) {
 			default:
 				mode = Package
 			}
+		}
+	}
+
+	if *modeOverride != "" {
+		switch RunMode(*modeOverride) {
+		case Component, Package:
+			mode = RunMode(*modeOverride)
+		default:
+			return nil, errors.New("unknown mode - use component or package: " + *modeOverride)
 		}
 	}
 
@@ -165,5 +184,6 @@ func (c *Config) Fork(mode RunMode, namespace string) *Config {
 	cfg.Mode = mode
 	cfg.Namespace = namespace
 	cfg.ComponentOverride = nil
+	cfg.Pattern = "."
 	return &cfg
 }

--- a/cmd/schemagen/internal/config_test.go
+++ b/cmd/schemagen/internal/config_test.go
@@ -242,30 +242,30 @@ status:
 }
 
 func TestReadConfig_PatternResolvesMetadata(t *testing.T) {
-	// Use an import path from within this repository that has a metadata.yaml
-	// declaring a receiver component. schemagen's own go.mod must be able to
-	// resolve it; we run from cmd/schemagen so the local replace directives apply.
-	//
-	// The pattern-based metadata resolution works when the package is reachable
-	// from the current module (local replace or module cache). We pick a package
-	// in testdata to keep the test self-contained and fast.
-	dir := t.TempDir()
-	t.Chdir(dir)
+	moduleDir := setupResolvePackageDirModule(t)
+	inputDir := filepath.Join(moduleDir, "cmd", "tool")
+	t.Chdir(inputDir)
 
-	// Verify the local dirPath has no metadata.yaml (so mode would be Package
-	// by default without pattern-based resolution). We can only test this properly
-	// for local packages because packages.Load needs a real module graph; we just
-	// verify that when pattern == "." the metadata comes from dirPath.
-	createConfigFile(t, dir, "config.go")
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "metadata.yaml"), []byte(`type: testpkg
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "metadata.yaml"), []byte(`type: localpkg
 status:
   class: pkg
 `), 0o600))
 
-	// With pattern "." the local metadata.yaml is used — should detect Package.
-	cfg, err := readConfigForTest(t, dir)
+	resolvedPackageDir := filepath.Join(moduleDir, "receiver", "foo")
+	require.NoError(t, os.WriteFile(filepath.Join(resolvedPackageDir, "metadata.yaml"), []byte(`type: remotereceiver
+status:
+  class: receiver
+`), 0o600))
+
+	cfg, err := readConfigForTest(t, inputDir)
 	require.NoError(t, err)
 	require.Equal(t, Package, cfg.Mode)
+	require.Equal(t, "pkg", cfg.Class)
+
+	cfg, err = readConfigForTest(t, "-p", "../../receiver/foo", inputDir)
+	require.NoError(t, err)
+	require.Equal(t, Component, cfg.Mode)
+	require.Equal(t, "receiver", cfg.Class)
 }
 
 func createConfigFile(t *testing.T, dir, name string) string {

--- a/cmd/schemagen/internal/config_test.go
+++ b/cmd/schemagen/internal/config_test.go
@@ -21,6 +21,7 @@ func TestReadConfig(t *testing.T) {
 	cfg, err := readConfigForTest(t, dir)
 	require.NoError(t, err)
 
+	// No metadata.yaml present: falls back to the default mode (Package).
 	require.Equal(t, Package, cfg.Mode)
 	require.Equal(t, dir, cfg.DirPath)
 	require.Equal(t, dir, cfg.OutputFolder)
@@ -201,6 +202,72 @@ status:
 	}
 }
 
+func TestReadConfig_ModeOverride(t *testing.T) {
+	t.Run("valid override to package", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		// Write a metadata.yaml that would yield component mode.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "metadata.yaml"), []byte(`type: testreceiver
+status:
+  class: receiver
+`), 0o600))
+
+		cfg, err := readConfigForTestWithMode(t, "package", dir)
+		require.NoError(t, err)
+		require.Equal(t, Package, cfg.Mode)
+	})
+
+	t.Run("valid override to component", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		// Write a metadata.yaml that would yield package mode (unknown class).
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "metadata.yaml"), []byte(`type: testpkg
+status:
+  class: pkg
+`), 0o600))
+
+		cfg, err := readConfigForTestWithMode(t, "component", dir)
+		require.NoError(t, err)
+		require.Equal(t, Component, cfg.Mode)
+	})
+
+	t.Run("invalid override value", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+
+		_, err := readConfigForTestWithMode(t, "bogus", dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown mode")
+	})
+}
+
+func TestReadConfig_PatternResolvesMetadata(t *testing.T) {
+	// Use an import path from within this repository that has a metadata.yaml
+	// declaring a receiver component. schemagen's own go.mod must be able to
+	// resolve it; we run from cmd/schemagen so the local replace directives apply.
+	//
+	// The pattern-based metadata resolution works when the package is reachable
+	// from the current module (local replace or module cache). We pick a package
+	// in testdata to keep the test self-contained and fast.
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Verify the local dirPath has no metadata.yaml (so mode would be Package
+	// by default without pattern-based resolution). We can only test this properly
+	// for local packages because packages.Load needs a real module graph; we just
+	// verify that when pattern == "." the metadata comes from dirPath.
+	createConfigFile(t, dir, "config.go")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "metadata.yaml"), []byte(`type: testpkg
+status:
+  class: pkg
+`), 0o600))
+
+	// With pattern "." the local metadata.yaml is used — should detect Package.
+	cfg, err := readConfigForTest(t, dir)
+	require.NoError(t, err)
+	require.Equal(t, Package, cfg.Mode)
+}
+
 func createConfigFile(t *testing.T, dir, name string) string {
 	t.Helper()
 	target := filepath.Join(dir, name)
@@ -210,6 +277,17 @@ func createConfigFile(t *testing.T, dir, name string) string {
 
 func readConfigForTest(t *testing.T, args ...string) (*Config, error) {
 	t.Helper()
+	return readConfigWithFlags(t, "", args...)
+}
+
+// readConfigForTestWithMode is like readConfigForTest but prepends -m <mode> to the args.
+func readConfigForTestWithMode(t *testing.T, mode string, args ...string) (*Config, error) {
+	t.Helper()
+	return readConfigWithFlags(t, mode, args...)
+}
+
+func readConfigWithFlags(t *testing.T, mode string, args ...string) (*Config, error) {
+	t.Helper()
 
 	origArgs := os.Args
 	origCommandLine := flag.CommandLine
@@ -217,6 +295,7 @@ func readConfigForTest(t *testing.T, args ...string) (*Config, error) {
 	origOutputFolder := outputFolder
 	origFileType := fileType
 	origPattern := pattern
+	origModeOverride := modeOverride
 
 	flag.CommandLine = flag.NewFlagSet(origArgs[0], flag.ContinueOnError)
 	flag.CommandLine.SetOutput(io.Discard)
@@ -225,8 +304,15 @@ func readConfigForTest(t *testing.T, args ...string) (*Config, error) {
 	outputFolder = flag.String("o", "", "Output schema folder")
 	fileType = flag.String("t", "yaml", "Output file type (yaml or json)")
 	pattern = flag.String("p", ".", "Optional pattern to match config struct package")
+	modeOverride = flag.String("m", "", "Override detected run mode: component or package")
 
-	os.Args = append([]string{origArgs[0]}, args...)
+	cliArgs := []string{origArgs[0]}
+	if mode != "" {
+		cliArgs = append(cliArgs, "-m", mode)
+	}
+	cliArgs = append(cliArgs, args...)
+	os.Args = cliArgs
+
 	t.Cleanup(func() {
 		os.Args = origArgs
 		flag.CommandLine = origCommandLine
@@ -234,6 +320,7 @@ func readConfigForTest(t *testing.T, args ...string) (*Config, error) {
 		outputFolder = origOutputFolder
 		fileType = origFileType
 		pattern = origPattern
+		modeOverride = origModeOverride
 	})
 
 	return ReadConfig()

--- a/cmd/schemagen/internal/metadata.go
+++ b/cmd/schemagen/internal/metadata.go
@@ -6,8 +6,10 @@ package internal // import "go.opentelemetry.io/collector/cmd/schemagen/internal
 import (
 	"os"
 	"path"
+	"path/filepath"
 
 	"go.yaml.in/yaml/v3"
+	"golang.org/x/tools/go/packages"
 )
 
 type Metadata struct {
@@ -16,6 +18,22 @@ type Metadata struct {
 		Class string `mapstructure:"class"`
 	} `mapstructure:"status"`
 	Parent string `mapstructure:"parent"`
+}
+
+// ResolvePackageDir returns the on-disk source directory of the package matched by pattern,
+// resolved relative to dir.
+//
+// Returns false if the directory cannot be determined (pattern unresolvable, no Go source files, etc.),
+// in which case the caller should fall back to dir.
+func ResolvePackageDir(dir, pattern string) (string, bool) {
+	pkgs, err := packages.Load(&packages.Config{
+		Mode: packages.NeedFiles | packages.NeedModule,
+		Dir:  dir,
+	}, pattern)
+	if err != nil || len(pkgs) == 0 || len(pkgs[0].GoFiles) == 0 {
+		return "", false
+	}
+	return filepath.Dir(pkgs[0].GoFiles[0]), true
 }
 
 func ReadMetadata(dir string) (*Metadata, bool) {

--- a/cmd/schemagen/internal/metadata_test.go
+++ b/cmd/schemagen/internal/metadata_test.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePackageDir(t *testing.T) {
+	moduleDir := setupResolvePackageDirModule(t)
+
+	tests := []struct {
+		name    string
+		dir     string
+		pattern string
+		wantDir string
+	}{
+		{
+			name:    "module import path",
+			dir:     moduleDir,
+			pattern: "example.com/schemagen/receiver/foo",
+			wantDir: filepath.Join(moduleDir, "receiver", "foo"),
+		},
+		{
+			name:    "relative package pattern",
+			dir:     moduleDir,
+			pattern: "./receiver/foo",
+			wantDir: filepath.Join(moduleDir, "receiver", "foo"),
+		},
+		{
+			name:    "pattern is resolved relative to dir",
+			dir:     filepath.Join(moduleDir, "cmd", "tool"),
+			pattern: "../../receiver/foo",
+			wantDir: filepath.Join(moduleDir, "receiver", "foo"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ResolvePackageDir(tt.dir, tt.pattern)
+			require.True(t, ok)
+			require.Equal(t, resolvePath(t, tt.wantDir), resolvePath(t, got))
+		})
+	}
+}
+
+func TestResolvePackageDirReturnsFalse(t *testing.T) {
+	moduleDir := setupResolvePackageDirModule(t)
+
+	tests := []struct {
+		name    string
+		dir     string
+		pattern string
+	}{
+		{
+			name:    "unresolvable package",
+			dir:     moduleDir,
+			pattern: "./missing",
+		},
+		{
+			name:    "no non-test Go source files",
+			dir:     moduleDir,
+			pattern: "./testonly",
+		},
+		{
+			name:    "missing base directory",
+			dir:     filepath.Join(moduleDir, "missing"),
+			pattern: ".",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ResolvePackageDir(tt.dir, tt.pattern)
+			require.False(t, ok)
+			require.Empty(t, got)
+		})
+	}
+}
+
+func setupResolvePackageDirModule(t *testing.T) string {
+	t.Helper()
+
+	moduleDir := t.TempDir()
+	writeResolvePackageDirFile(t, moduleDir, "go.mod", "module example.com/schemagen\n\ngo 1.20\n")
+	writeResolvePackageDirFile(t, moduleDir, "root.go", "package schemagen\n")
+	writeResolvePackageDirFile(t, moduleDir, filepath.Join("receiver", "foo", "config.go"), "package foo\n")
+	writeResolvePackageDirFile(t, moduleDir, filepath.Join("testonly", "config_test.go"), "package testonly\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(moduleDir, "cmd", "tool"), 0o700))
+
+	return moduleDir
+}
+
+func writeResolvePackageDirFile(t *testing.T, root, name, data string) {
+	t.Helper()
+
+	path := filepath.Join(root, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
+}
+
+func resolvePath(t *testing.T, path string) string {
+	t.Helper()
+
+	resolved, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	return resolved
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This change fixes mode detection for `-p` by resolving the target package's on-disk source directory via a lightweight `packages.Load` call before reading its `metadata.yaml`. This works for any package reachable from the local module graph, including cross-repo dependencies present in the module cache. When the package is not in the local module graph, detection falls back to the existing default; a new `-m component|package` flag is provided as a manual override for that case.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Changes covered with unit tests.

<!--Describe the documentation added.-->
#### Documentation

Updated `README.md` .

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
