### PR TITLE
fixing components not knowing they have received the data

### DIFF
--- a/consumer/internal/consumer.go
+++ b/consumer/internal/consumer.go
@@ -11,6 +11,18 @@ type Capabilities struct {
 	// does not modify the data it MUST set this flag to false. If the processor creates
 	// a copy of the data before modifying then this flag can be safely set to false.
 	MutatesData bool
+
+	// HasReceivedData is set to true if the component has received the data from the upstream
+	// and has taken over the responsibility to move them forward without blocking the upstream.
+	// Components that process data asynchronously (e.g. batch processor, queue-backed exporters)
+	// MUST set this flag to true, as they accept data immediately but process it asynchronously.
+	// Synchronous components that block the upstream until processing is complete MUST NOT set
+	// this flag (or set it to false).
+	//
+	// This flag is used to validate expectations about the pipeline behavior:
+	// - Ensure a collector is running synchronously end-to-end (for error back-propagation).
+	// - Identify components which may be adding substantial latency or burying errors.
+	HasReceivedData bool
 }
 
 type BaseConsumer interface {

--- a/consumer/logs_test.go
+++ b/consumer/logs_test.go
@@ -18,7 +18,7 @@ func TestDefaultLogs(t *testing.T) {
 	cp, err := NewLogs(func(context.Context, plog.Logs) error { return nil })
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeLogs(context.Background(), plog.NewLogs()))
-	assert.Equal(t, Capabilities{MutatesData: false}, cp.Capabilities())
+	assert.Equal(t, Capabilities{MutatesData: false, HasReceivedData: false}, cp.Capabilities())
 }
 
 func TestNilFuncLogs(t *testing.T) {
@@ -33,6 +33,15 @@ func TestWithCapabilitiesLogs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeLogs(context.Background(), plog.NewLogs()))
 	assert.Equal(t, Capabilities{MutatesData: true}, cp.Capabilities())
+}
+
+func TestWithCapabilitiesHasReceivedDataLogs(t *testing.T) {
+	cp, err := NewLogs(
+		func(context.Context, plog.Logs) error { return nil },
+		WithCapabilities(Capabilities{HasReceivedData: true}))
+	assert.NoError(t, err)
+	assert.NoError(t, cp.ConsumeLogs(context.Background(), plog.NewLogs()))
+	assert.Equal(t, Capabilities{HasReceivedData: true}, cp.Capabilities())
 }
 
 func TestConsumeLogs(t *testing.T) {

--- a/consumer/logs_test.go
+++ b/consumer/logs_test.go
@@ -18,7 +18,7 @@ func TestDefaultLogs(t *testing.T) {
 	cp, err := NewLogs(func(context.Context, plog.Logs) error { return nil })
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeLogs(context.Background(), plog.NewLogs()))
-	assert.Equal(t, Capabilities{MutatesData: false}, cp.Capabilities())
+	assert.Equal(t, Capabilities{MutatesData: false, HasReceivedData: false}, cp.Capabilities())
 }
 
 func TestNilFuncLogs(t *testing.T) {
@@ -34,6 +34,15 @@ func TestWithCapabilitiesLogs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeLogs(context.Background(), plog.NewLogs()))
 	assert.Equal(t, Capabilities{MutatesData: true}, cp.Capabilities())
+}
+
+func TestWithCapabilitiesHasReceivedDataLogs(t *testing.T) {
+	cp, err := NewLogs(
+		func(context.Context, plog.Logs) error { return nil },
+		WithCapabilities(Capabilities{HasReceivedData: true}))
+	assert.NoError(t, err)
+	assert.NoError(t, cp.ConsumeLogs(context.Background(), plog.NewLogs()))
+	assert.Equal(t, Capabilities{HasReceivedData: true}, cp.Capabilities())
 }
 
 func TestConsumeLogs(t *testing.T) {

--- a/consumer/metrics_test.go
+++ b/consumer/metrics_test.go
@@ -18,7 +18,7 @@ func TestDefaultMetrics(t *testing.T) {
 	cp, err := NewMetrics(func(context.Context, pmetric.Metrics) error { return nil })
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
-	assert.Equal(t, Capabilities{MutatesData: false}, cp.Capabilities())
+	assert.Equal(t, Capabilities{MutatesData: false, HasReceivedData: false}, cp.Capabilities())
 }
 
 func TestNilFuncMetrics(t *testing.T) {
@@ -33,6 +33,15 @@ func TestWithCapabilitiesMetrics(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
 	assert.Equal(t, Capabilities{MutatesData: true}, cp.Capabilities())
+}
+
+func TestWithCapabilitiesHasReceivedDataMetrics(t *testing.T) {
+	cp, err := NewMetrics(
+		func(context.Context, pmetric.Metrics) error { return nil },
+		WithCapabilities(Capabilities{HasReceivedData: true}))
+	assert.NoError(t, err)
+	assert.NoError(t, cp.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
+	assert.Equal(t, Capabilities{HasReceivedData: true}, cp.Capabilities())
 }
 
 func TestConsumeMetrics(t *testing.T) {

--- a/consumer/metrics_test.go
+++ b/consumer/metrics_test.go
@@ -18,7 +18,7 @@ func TestDefaultMetrics(t *testing.T) {
 	cp, err := NewMetrics(func(context.Context, pmetric.Metrics) error { return nil })
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
-	assert.Equal(t, Capabilities{MutatesData: false}, cp.Capabilities())
+	assert.Equal(t, Capabilities{MutatesData: false, HasReceivedData: false}, cp.Capabilities())
 }
 
 func TestNilFuncMetrics(t *testing.T) {
@@ -34,6 +34,15 @@ func TestWithCapabilitiesMetrics(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
 	assert.Equal(t, Capabilities{MutatesData: true}, cp.Capabilities())
+}
+
+func TestWithCapabilitiesHasReceivedDataMetrics(t *testing.T) {
+	cp, err := NewMetrics(
+		func(context.Context, pmetric.Metrics) error { return nil },
+		WithCapabilities(Capabilities{HasReceivedData: true}))
+	assert.NoError(t, err)
+	assert.NoError(t, cp.ConsumeMetrics(context.Background(), pmetric.NewMetrics()))
+	assert.Equal(t, Capabilities{HasReceivedData: true}, cp.Capabilities())
 }
 
 func TestConsumeMetrics(t *testing.T) {

--- a/consumer/traces_test.go
+++ b/consumer/traces_test.go
@@ -18,7 +18,7 @@ func TestDefaultTraces(t *testing.T) {
 	cp, err := NewTraces(func(context.Context, ptrace.Traces) error { return nil })
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeTraces(context.Background(), ptrace.NewTraces()))
-	assert.Equal(t, Capabilities{MutatesData: false}, cp.Capabilities())
+	assert.Equal(t, Capabilities{MutatesData: false, HasReceivedData: false}, cp.Capabilities())
 }
 
 func TestNilFuncTraces(t *testing.T) {
@@ -33,6 +33,15 @@ func TestWithCapabilitiesTraces(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeTraces(context.Background(), ptrace.NewTraces()))
 	assert.Equal(t, Capabilities{MutatesData: true}, cp.Capabilities())
+}
+
+func TestWithCapabilitiesHasReceivedDataTraces(t *testing.T) {
+	cp, err := NewTraces(
+		func(context.Context, ptrace.Traces) error { return nil },
+		WithCapabilities(Capabilities{HasReceivedData: true}))
+	assert.NoError(t, err)
+	assert.NoError(t, cp.ConsumeTraces(context.Background(), ptrace.NewTraces()))
+	assert.Equal(t, Capabilities{HasReceivedData: true}, cp.Capabilities())
 }
 
 func TestConsumeTraces(t *testing.T) {

--- a/consumer/traces_test.go
+++ b/consumer/traces_test.go
@@ -18,7 +18,7 @@ func TestDefaultTraces(t *testing.T) {
 	cp, err := NewTraces(func(context.Context, ptrace.Traces) error { return nil })
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeTraces(context.Background(), ptrace.NewTraces()))
-	assert.Equal(t, Capabilities{MutatesData: false}, cp.Capabilities())
+	assert.Equal(t, Capabilities{MutatesData: false, HasReceivedData: false}, cp.Capabilities())
 }
 
 func TestNilFuncTraces(t *testing.T) {
@@ -34,6 +34,15 @@ func TestWithCapabilitiesTraces(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeTraces(context.Background(), ptrace.NewTraces()))
 	assert.Equal(t, Capabilities{MutatesData: true}, cp.Capabilities())
+}
+
+func TestWithCapabilitiesHasReceivedDataTraces(t *testing.T) {
+	cp, err := NewTraces(
+		func(context.Context, ptrace.Traces) error { return nil },
+		WithCapabilities(Capabilities{HasReceivedData: true}))
+	assert.NoError(t, err)
+	assert.NoError(t, cp.ConsumeTraces(context.Background(), ptrace.NewTraces()))
+	assert.Equal(t, Capabilities{HasReceivedData: true}, cp.Capabilities())
 }
 
 func TestConsumeTraces(t *testing.T) {

--- a/consumer/xconsumer/profiles_test.go
+++ b/consumer/xconsumer/profiles_test.go
@@ -19,7 +19,7 @@ func TestDefaultProfiles(t *testing.T) {
 	cp, err := NewProfiles(func(context.Context, pprofile.Profiles) error { return nil })
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeProfiles(context.Background(), pprofile.NewProfiles()))
-	assert.Equal(t, consumer.Capabilities{MutatesData: false}, cp.Capabilities())
+	assert.Equal(t, consumer.Capabilities{MutatesData: false, HasReceivedData: false}, cp.Capabilities())
 }
 
 func TestNilFuncProfiles(t *testing.T) {
@@ -34,6 +34,15 @@ func TestWithCapabilitiesProfiles(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeProfiles(context.Background(), pprofile.NewProfiles()))
 	assert.Equal(t, consumer.Capabilities{MutatesData: true}, cp.Capabilities())
+}
+
+func TestWithCapabilitiesHasReceivedDataProfiles(t *testing.T) {
+	cp, err := NewProfiles(
+		func(context.Context, pprofile.Profiles) error { return nil },
+		consumer.WithCapabilities(consumer.Capabilities{HasReceivedData: true}))
+	assert.NoError(t, err)
+	assert.NoError(t, cp.ConsumeProfiles(context.Background(), pprofile.NewProfiles()))
+	assert.Equal(t, consumer.Capabilities{HasReceivedData: true}, cp.Capabilities())
 }
 
 func TestConsumeProfiles(t *testing.T) {

--- a/consumer/xconsumer/profiles_test.go
+++ b/consumer/xconsumer/profiles_test.go
@@ -19,7 +19,7 @@ func TestDefaultProfiles(t *testing.T) {
 	cp, err := NewProfiles(func(context.Context, pprofile.Profiles) error { return nil })
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeProfiles(context.Background(), pprofile.NewProfiles()))
-	assert.Equal(t, consumer.Capabilities{MutatesData: false}, cp.Capabilities())
+	assert.Equal(t, consumer.Capabilities{MutatesData: false, HasReceivedData: false}, cp.Capabilities())
 }
 
 func TestNilFuncProfiles(t *testing.T) {
@@ -35,6 +35,15 @@ func TestWithCapabilitiesProfiles(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, cp.ConsumeProfiles(context.Background(), pprofile.NewProfiles()))
 	assert.Equal(t, consumer.Capabilities{MutatesData: true}, cp.Capabilities())
+}
+
+func TestWithCapabilitiesHasReceivedDataProfiles(t *testing.T) {
+	cp, err := NewProfiles(
+		func(context.Context, pprofile.Profiles) error { return nil },
+		consumer.WithCapabilities(consumer.Capabilities{HasReceivedData: true}))
+	assert.NoError(t, err)
+	assert.NoError(t, cp.ConsumeProfiles(context.Background(), pprofile.NewProfiles()))
+	assert.Equal(t, consumer.Capabilities{HasReceivedData: true}, cp.Capabilities())
 }
 
 func TestConsumeProfiles(t *testing.T) {

--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -91,6 +91,12 @@ func NewBaseExporter(set exporter.Settings, signal pipeline.Signal, pusher sende
 		be.ConsumerOptions = append(be.ConsumerOptions, consumer.WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	}
 
+	if be.queueCfg.HasValue() && !be.queueCfg.Get().WaitForResult {
+		// When the queue does not wait for result (async mode), the component has received
+		// the data and taken over the responsibility to move it forward without blocking upstream.
+		be.ConsumerOptions = append(be.ConsumerOptions, consumer.WithCapabilities(consumer.Capabilities{HasReceivedData: true}))
+	}
+
 	if be.queueCfg.HasValue() {
 		qSet := queuebatch.AllSettings[request.Request]{
 			Settings:  be.queueBatchSettings,

--- a/exporter/exporterhelper/internal/base_exporter_test.go
+++ b/exporter/exporterhelper/internal/base_exporter_test.go
@@ -20,11 +20,13 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/metadatatest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/requesttest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pipeline"
 )
 
@@ -33,6 +35,62 @@ func TestBaseExporter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, be.Shutdown(context.Background()))
+}
+
+// TestBaseExporterQueueHasReceivedData verifies that an exporter with an async queue
+// (WaitForResult=false) sets HasReceivedData=true in its ConsumerOptions, indicating
+// that the component has received the data and taken over responsibility for processing.
+func TestBaseExporterQueueHasReceivedData(t *testing.T) {
+	// An exporter without a queue should NOT set HasReceivedData
+	beNoQueue, err := NewBaseExporter(exportertest.NewNopSettings(exportertest.NopType), pipeline.SignalMetrics, noopExport)
+	require.NoError(t, err)
+	// ConsumerOptions should not contain HasReceivedData=true for non-queued exporter
+	caps := consumer.Capabilities{}
+	for _, opt := range beNoQueue.ConsumerOptions {
+		c := consumer.Capabilities{}
+		testConsumer, _ := consumer.NewLogs(func(context.Context, plog.Logs) error { return nil }, opt)
+		c = testConsumer.Capabilities()
+		caps.HasReceivedData = caps.HasReceivedData || c.HasReceivedData
+	}
+	assert.False(t, caps.HasReceivedData, "non-queued exporter should not set HasReceivedData")
+
+	// An exporter with queue (WaitForResult=false, async mode) SHOULD set HasReceivedData
+	qCfg := NewDefaultQueueConfig()
+	qCfg.WaitForResult = false
+	beWithQueue, err := NewBaseExporter(
+		exportertest.NewNopSettings(exportertest.NopType),
+		pipeline.SignalMetrics,
+		noopExport,
+		WithQueueBatchSettings(newFakeQueueBatch()),
+		WithQueue(configoptional.Some(qCfg)),
+	)
+	require.NoError(t, err)
+	caps = consumer.Capabilities{}
+	for _, opt := range beWithQueue.ConsumerOptions {
+		testConsumer, _ := consumer.NewLogs(func(context.Context, plog.Logs) error { return nil }, opt)
+		c := testConsumer.Capabilities()
+		caps.HasReceivedData = caps.HasReceivedData || c.HasReceivedData
+	}
+	assert.True(t, caps.HasReceivedData, "async-queued exporter (WaitForResult=false) should set HasReceivedData=true")
+
+	// An exporter with queue and WaitForResult=true (sync mode) should NOT set HasReceivedData
+	qCfgSync := NewDefaultQueueConfig()
+	qCfgSync.WaitForResult = true
+	beWithSyncQueue, err := NewBaseExporter(
+		exportertest.NewNopSettings(exportertest.NopType),
+		pipeline.SignalMetrics,
+		noopExport,
+		WithQueueBatchSettings(newFakeQueueBatch()),
+		WithQueue(configoptional.Some(qCfgSync)),
+	)
+	require.NoError(t, err)
+	caps = consumer.Capabilities{}
+	for _, opt := range beWithSyncQueue.ConsumerOptions {
+		testConsumer, _ := consumer.NewLogs(func(context.Context, plog.Logs) error { return nil }, opt)
+		c := testConsumer.Capabilities()
+		caps.HasReceivedData = caps.HasReceivedData || c.HasReceivedData
+	}
+	assert.False(t, caps.HasReceivedData, "sync-queued exporter (WaitForResult=true) should NOT set HasReceivedData")
 }
 
 func TestBaseExporterWithOptions(t *testing.T) {

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -164,7 +164,7 @@ func (bp *batchProcessor[T]) newShard(md map[string][]string) *shard[T] {
 }
 
 func (bp *batchProcessor[T]) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: true}
+	return consumer.Capabilities{MutatesData: true, HasReceivedData: true}
 }
 
 // Start is invoked during service startup.

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -83,6 +83,34 @@ func TestProcessorLifecycle(t *testing.T) {
 	}
 }
 
+// TestBatchProcessorHasReceivedData verifies that the batch processor correctly declares
+// HasReceivedData=true in its capabilities, indicating it is an asynchronous component
+// that buffers data and returns immediately without blocking the upstream.
+func TestBatchProcessorHasReceivedData(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	ctx := context.Background()
+	processorCreationSet := processortest.NewNopSettings(metadata.Type)
+
+	tProc, err := factory.CreateTraces(ctx, processorCreationSet, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.True(t, tProc.Capabilities().HasReceivedData,
+		"batch processor should declare HasReceivedData=true as it processes data asynchronously")
+	assert.True(t, tProc.Capabilities().MutatesData,
+		"batch processor should declare MutatesData=true")
+
+	mProc, err := factory.CreateMetrics(ctx, processorCreationSet, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.True(t, mProc.Capabilities().HasReceivedData,
+		"batch processor should declare HasReceivedData=true as it processes data asynchronously")
+
+	lProc, err := factory.CreateLogs(ctx, processorCreationSet, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.True(t, lProc.Capabilities().HasReceivedData,
+		"batch processor should declare HasReceivedData=true as it processes data asynchronously")
+}
+
 func TestBatchProcessorSpansDelivered(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 	cfg := createDefaultConfig().(*Config)

--- a/service/internal/capabilityconsumer/capabilities_test.go
+++ b/service/internal/capabilityconsumer/capabilities_test.go
@@ -30,6 +30,18 @@ func TestLogs(t *testing.T) {
 	assert.Equal(t, testdata.GenerateLogs(1), sink.AllLogs()[0])
 }
 
+func TestLogsHasReceivedData(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	require.Equal(t, consumer.Capabilities{MutatesData: false}, sink.Capabilities())
+
+	// Wrapping with HasReceivedData=true should return a new consumer with updated capabilities
+	wrap := NewLogs(sink, consumer.Capabilities{HasReceivedData: true})
+	assert.Equal(t, consumer.Capabilities{HasReceivedData: true}, wrap.Capabilities())
+
+	require.NoError(t, wrap.ConsumeLogs(context.Background(), testdata.GenerateLogs(1)))
+	assert.Len(t, sink.AllLogs(), 1)
+}
+
 func TestMetrics(t *testing.T) {
 	sink := &consumertest.MetricsSink{}
 	require.Equal(t, consumer.Capabilities{MutatesData: false}, sink.Capabilities())
@@ -43,6 +55,18 @@ func TestMetrics(t *testing.T) {
 	require.NoError(t, wrap.ConsumeMetrics(context.Background(), testdata.GenerateMetrics(1)))
 	assert.Len(t, sink.AllMetrics(), 1)
 	assert.Equal(t, testdata.GenerateMetrics(1), sink.AllMetrics()[0])
+}
+
+func TestMetricsHasReceivedData(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	require.Equal(t, consumer.Capabilities{MutatesData: false}, sink.Capabilities())
+
+	// Wrapping with HasReceivedData=true should return a new consumer with updated capabilities
+	wrap := NewMetrics(sink, consumer.Capabilities{HasReceivedData: true})
+	assert.Equal(t, consumer.Capabilities{HasReceivedData: true}, wrap.Capabilities())
+
+	require.NoError(t, wrap.ConsumeMetrics(context.Background(), testdata.GenerateMetrics(1)))
+	assert.Len(t, sink.AllMetrics(), 1)
 }
 
 func TestTraces(t *testing.T) {
@@ -60,6 +84,18 @@ func TestTraces(t *testing.T) {
 	assert.Equal(t, testdata.GenerateTraces(1), sink.AllTraces()[0])
 }
 
+func TestTracesHasReceivedData(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	require.Equal(t, consumer.Capabilities{MutatesData: false}, sink.Capabilities())
+
+	// Wrapping with HasReceivedData=true should return a new consumer with updated capabilities
+	wrap := NewTraces(sink, consumer.Capabilities{HasReceivedData: true})
+	assert.Equal(t, consumer.Capabilities{HasReceivedData: true}, wrap.Capabilities())
+
+	require.NoError(t, wrap.ConsumeTraces(context.Background(), testdata.GenerateTraces(1)))
+	assert.Len(t, sink.AllTraces(), 1)
+}
+
 func TestProfiles(t *testing.T) {
 	sink := &consumertest.ProfilesSink{}
 	require.Equal(t, consumer.Capabilities{MutatesData: false}, sink.Capabilities())
@@ -73,4 +109,16 @@ func TestProfiles(t *testing.T) {
 	require.NoError(t, wrap.ConsumeProfiles(context.Background(), testdata.GenerateProfiles(1)))
 	assert.Len(t, sink.AllProfiles(), 1)
 	assert.Equal(t, testdata.GenerateProfiles(1), sink.AllProfiles()[0])
+}
+
+func TestProfilesHasReceivedData(t *testing.T) {
+	sink := &consumertest.ProfilesSink{}
+	require.Equal(t, consumer.Capabilities{MutatesData: false}, sink.Capabilities())
+
+	// Wrapping with HasReceivedData=true should return a new consumer with updated capabilities
+	wrap := NewProfiles(sink, consumer.Capabilities{HasReceivedData: true})
+	assert.Equal(t, consumer.Capabilities{HasReceivedData: true}, wrap.Capabilities())
+
+	require.NoError(t, wrap.ConsumeProfiles(context.Background(), testdata.GenerateProfiles(1)))
+	assert.Len(t, sink.AllProfiles(), 1)
 }


### PR DESCRIPTION
#### Description

This PR addresses [issue #11673](https://github.com/open-telemetry/opentelemetry-collector/issues/11673), which requests that components declare whether they acknowledge data receipt synchronously or asynchronously.

Currently, there is no way to know if a component processes data synchronously (blocking the upstream until done) or asynchronously (accepting data immediately and processing it in the background). This distinction is important for:
- **Error back-propagation**: Only synchronous pipelines can reliably propagate errors from exporters back to receivers (e.g., in an OTLP receiver → OTLP exporter pipeline).
- **Latency and reliability visibility**: Asynchronous components (like the batch processor or queue-backed exporters) may add substantial latency or bury errors silently.

**Changes made:**

1. **Added `HasReceivedData bool` field to `consumer.Capabilities`** (`consumer/internal/consumer.go`): Components set this to `true` when they accept data immediately but process it asynchronously — i.e., they return from `Consume*()` before forwarding/processing data downstream.

2. **Updated `batchprocessor`** to set `HasReceivedData: true` since it buffers data via goroutine channels and returns from `Consume*()` immediately.

3. **Updated `exporterhelper`** to set `HasReceivedData: true` when a queue is configured with `WaitForResult=false` (the default async mode), as the exporter accepts data into a queue and returns before processing it.

Synchronous components (the default, `HasReceivedData: false`) block the upstream until processing completes, enabling end-to-end error propagation.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/11673

#### Testing

New tests were added following the same patterns as existing tests for `MutatesData`:

- `consumer` package: `TestWithCapabilitiesHasReceivedDataTraces`, `TestWithCapabilitiesHasReceivedDataMetrics`, `TestWithCapabilitiesHasReceivedDataLogs` — verify the new field is correctly stored and returned via `Capabilities()`.
- `consumer/xconsumer` package: `TestWithCapabilitiesHasReceivedDataProfiles` — same for profiles signal.
- `service/internal/capabilityconsumer`: `TestTracesHasReceivedData`, `TestMetricsHasReceivedData`, `TestLogsHasReceivedData`, `TestProfilesHasReceivedData` — verify that the capability consumer wrapper correctly propagates the `HasReceivedData` flag.
- `processor/batchprocessor`: `TestBatchProcessorHasReceivedData` — verifies that the batch processor correctly declares `HasReceivedData=true` for all signal types (traces, metrics, logs).
- `exporter/exporterhelper/internal`: `TestBaseExporterQueueHasReceivedData` — verifies that an exporter with an async queue (`WaitForResult=false`) sets `HasReceivedData=true`, while a sync queue (`WaitForResult=true`) and no-queue exporters do not.

All tests pass.

#### Documentation

See description.
