### PR TITLE
[cmd/mdatagen] Fix the extra blank line in the documentation template

### DIFF
--- a/.chloggen/documentation-fix-extra-line.yaml
+++ b/.chloggen/documentation-fix-extra-line.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removes the extra line in the documentation.md between extended description and table
+
+# One or more tracking issues or pull requests related to the change
+issues: [15458]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -435,7 +435,7 @@ func TestLoadMetadata(t *testing.T) {
 						Signal: Signal{
 							Enabled:               true,
 							Description:           "[DEPRECATED] Non-monotonic delta sum double metric enabled by default.",
-							ExtendedDocumentation: "The metric will be removed soon.",
+							ExtendedDocumentation: "The metric will be removed soon.\n",
 							Stability:             component.StabilityLevelDeprecated,
 							Warnings: Warnings{
 								IfEnabled: "This metric is deprecated and will be removed soon.",
@@ -483,7 +483,7 @@ func TestLoadMetadata(t *testing.T) {
 						Signal: Signal{
 							Enabled:               false,
 							Description:           "[DEPRECATED] Example event disabled by default.",
-							ExtendedDocumentation: "The event will be renamed soon.",
+							ExtendedDocumentation: "The event will be renamed soon.\n",
 							Warnings: Warnings{
 								IfConfigured: "This event is deprecated and will be renamed soon.",
 							},

--- a/cmd/mdatagen/internal/samplereceiver/metadata.yaml
+++ b/cmd/mdatagen/internal/samplereceiver/metadata.yaml
@@ -206,7 +206,8 @@ events:
   default.event.to_be_renamed:
     enabled: false
     description: "[DEPRECATED] Example event disabled by default."
-    extended_documentation: The event will be renamed soon.
+    extended_documentation: |
+            The event will be renamed soon.
     attributes: [string_attr, boolean_attr, boolean_attr2, conditional_string_attr]
     warnings:
       if_configured: This event is deprecated and will be renamed soon.
@@ -242,7 +243,8 @@ metrics:
   default.metric.to_be_removed:
     enabled: true
     description: "[DEPRECATED] Non-monotonic delta sum double metric enabled by default."
-    extended_documentation: The metric will be removed soon.
+    extended_documentation: |
+            The metric will be removed soon.
     stability: deprecated
     deprecated:
       since: "1.0.0"

--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -8,7 +8,7 @@
 
 {{- if $metric.ExtendedDocumentation }}
 
-{{ $metric.ExtendedDocumentation }}
+{{ trimRight $metric.ExtendedDocumentation "\n" }}
 
 {{- end }}
 
@@ -68,7 +68,7 @@ When the disable-old gate is enabled, emission of this metric is suppressed. Whe
 
 {{- if $event.ExtendedDocumentation }}
 
-{{ $event.ExtendedDocumentation }}
+{{ trimRight $event.ExtendedDocumentation "\n" }}
 
 {{- end }}
 
@@ -105,7 +105,7 @@ When the disable-old gate is enabled, emission of this metric is suppressed. Whe
 
 {{- if $metric.ExtendedDocumentation }}
 
-{{ $metric.ExtendedDocumentation }}
+{{ trimRight $metric.ExtendedDocumentation "\n" }}
 
 {{- end }}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fixes the extra line in the documentation.md between extended description and table

Similar to https://github.com/open-telemetry/opentelemetry-collector/pull/15307

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15458

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Local testing with one of the component.


<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
