### PR TITLE
[chore][cmd/mdatagen] Prevent overwriting authoritative definitions with ref-site nodes

### DIFF
--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -377,7 +377,9 @@ func collectDefs(md *ConfigMetadata, defs map[string]*ConfigMetadata) {
 		if !refDesc.IsInternal() {
 			return
 		}
-		defs[md.ResolvedFrom] = md
+		if _, exists := defs[md.ResolvedFrom]; !exists {
+			defs[md.ResolvedFrom] = md
+		}
 	}
 
 	for _, name := range slices.Sorted(maps.Keys(md.Defs)) {
@@ -402,7 +404,10 @@ func collectDefsForSchema(propName string, md *ConfigMetadata, defs map[string]*
 	if md.ResolvedFrom != "" {
 		refDesc := NewRef(md.ResolvedFrom)
 		if refDesc.IsInternal() {
-			defs[md.ResolvedFrom] = md
+			// Only register the ref-site node if no authoritative definition was already collected from md.Defs.
+			if _, exists := defs[md.ResolvedFrom]; !exists {
+				defs[md.ResolvedFrom] = md
+			}
 			collectDefs(md, defs)
 		}
 		return

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -2779,3 +2779,87 @@ func TestNewCfgFns_DefaultHelpers(t *testing.T) {
 	require.True(t, hasDefaultValue(&ConfigMetadata{Type: "string", Default: defaultValue("localhost")}))
 	require.False(t, hasDefaultValue(&ConfigMetadata{Type: "string"}))
 }
+
+// TestExtractDefs_DefsNotOverwrittenByRefSite verifies that when a type is registered both
+// via md.Defs (the authoritative definition) and again as a property's ResolvedFrom (the ref-site
+// node carrying a property-level GoStruct), ExtractDefs keeps the Defs entry and does not
+// overwrite it with the ref-site node.
+func TestExtractDefs_DefsNotOverwrittenByRefSite(t *testing.T) {
+	authoritativeDef := &ConfigMetadata{
+		Type: "object",
+		GoStruct: GoStructConfig{
+			CustomValidator: &CustomValidatorConfig{Name: "validateBatchConfig"},
+		},
+		Properties: map[string]*ConfigMetadata{
+			"size": {Type: "integer"},
+		},
+	}
+	// Simulates what the resolver produces for a property that $refs batch_config:
+	// the ref-site node copies the property's go_struct (validateBatchProp) over the
+	// resolved type's go_struct (validateBatchConfig).
+	refSiteNode := &ConfigMetadata{
+		Type:         "object",
+		ResolvedFrom: "batch_config",
+		GoStruct: GoStructConfig{
+			CustomValidator: &CustomValidatorConfig{Name: "validateBatchProp"},
+		},
+		Properties: map[string]*ConfigMetadata{
+			"size": {Type: "integer"},
+		},
+	}
+	md := &ConfigMetadata{
+		Defs: map[string]*ConfigMetadata{
+			"batch_config": authoritativeDef,
+		},
+		Properties: map[string]*ConfigMetadata{
+			"batch": refSiteNode,
+		},
+	}
+
+	result := ExtractDefs(md)
+	require.Contains(t, result, "batch_config")
+	require.Same(t, authoritativeDef, result["batch_config"], "Defs entry must not be overwritten by the ref-site node")
+}
+
+// TestExtractValidators_DefsValidatorNotOverwrittenByRefSite verifies that ExtractValidators on
+// a def collected via md.Defs uses the type-level custom validator (validateBatchConfig), not
+// the property-level one (validateBatchProp) that the resolver copies onto the ref-site node.
+func TestExtractValidators_DefsValidatorNotOverwrittenByRefSite(t *testing.T) {
+	authoritativeDef := &ConfigMetadata{
+		Type: "object",
+		GoStruct: GoStructConfig{
+			CustomValidator: &CustomValidatorConfig{Name: "validateBatchConfig"},
+		},
+		Properties: map[string]*ConfigMetadata{
+			"size": {Type: "integer"},
+		},
+	}
+	refSiteNode := &ConfigMetadata{
+		Type:         "object",
+		ResolvedFrom: "batch_config",
+		GoStruct: GoStructConfig{
+			CustomValidator: &CustomValidatorConfig{Name: "validateBatchProp"},
+		},
+		IsOptional: true,
+		Properties: map[string]*ConfigMetadata{
+			"size": {Type: "integer"},
+		},
+	}
+	md := &ConfigMetadata{
+		Defs: map[string]*ConfigMetadata{
+			"batch_config": authoritativeDef,
+		},
+		Properties: map[string]*ConfigMetadata{
+			"batch": refSiteNode,
+		},
+	}
+
+	defs := ExtractDefs(md)
+	require.Contains(t, defs, "batch_config")
+
+	validators := ExtractValidators(defs["batch_config"])
+	require.Len(t, validators, 1)
+	require.Equal(t, ".", validators[0].FieldName)
+	require.Equal(t, "validateBatchConfig", validators[0].CustomValidator,
+		"struct-level validator must come from the type definition, not the ref-site property")
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR fixes following problem:  when `exported_configs` defines both a parent struct and a child struct, and the parent references the child via `$ref`, `mdatagen` generated the wrong struct-level validator name for the child type.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit test.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
