### PR TITLE
fix ( exporter) 👍 File Exporter configurations should check that the destination directory 

### DIFF
--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -1,0 +1,103 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileexporter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// Marshaler configuration used for marshaling Protobuf to JSON.
+var tracesMarshaler = &ptrace.JSONMarshaler{}
+var metricsMarshaler = &pmetric.JSONMarshaler{}
+var logsMarshaler = &plog.JSONMarshaler{}
+
+// fileExporter is the implementation of file exporter that writes telemetry data to a file
+// in Protobuf-JSON format.
+type fileExporter struct {
+	path  string
+	file  io.WriteCloser
+	mutex sync.Mutex
+}
+
+func (e *fileExporter) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (e *fileExporter) ConsumeTraces(_ context.Context, td ptrace.Traces) error {
+	buf, err := tracesMarshaler.MarshalTraces(td)
+	if err != nil {
+		return err
+	}
+	return exportMessageAsLine(e, buf)
+}
+
+func (e *fileExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
+	buf, err := metricsMarshaler.MarshalMetrics(md)
+	if err != nil {
+		return err
+	}
+	return exportMessageAsLine(e, buf)
+}
+
+func (e *fileExporter) ConsumeLogs(_ context.Context, ld plog.Logs) error {
+	buf, err := logsMarshaler.MarshalLogs(ld)
+	if err != nil {
+		return err
+	}
+	return exportMessageAsLine(e, buf)
+}
+
+func exportMessageAsLine(e *fileExporter, buf []byte) error {
+	// Ensure only one write operation happens at a time.
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	if _, err := e.file.Write(buf); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(e.file, "\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *fileExporter) Start(_ context.Context, _ component.Host) error {
+	dir := filepath.Dir(e.path)
+	testFile := filepath.Join(dir, ".otelcol_write_test")
+	f, err := os.Create(testFile)
+	if err != nil {
+		return fmt.Errorf("directory %q is not writable: %w", dir, err)
+	}
+	f.Close()
+	_ = os.Remove(testFile)
+
+	e.file, err = os.OpenFile(e.path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	return err
+}
+
+// Shutdown stops the exporter and is invoked during shutdown.
+func (e *fileExporter) Shutdown(context.Context) error {
+	return e.file.Close()
+}

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -1,0 +1,143 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package fileexporter
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/testdata"
+)
+
+func TestFileTracesExporter(t *testing.T) {
+	fe := &fileExporter{path: tempFileName(t)}
+	require.NotNil(t, fe)
+
+	td := testdata.GenerateTraces(2)
+	assert.NoError(t, fe.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, fe.ConsumeTraces(context.Background(), td))
+	assert.NoError(t, fe.Shutdown(context.Background()))
+
+	unmarshaler := &ptrace.JSONUnmarshaler{}
+	buf, err := os.ReadFile(fe.path)
+	assert.NoError(t, err)
+	got, err := unmarshaler.UnmarshalTraces(buf)
+	assert.NoError(t, err)
+	assert.EqualValues(t, td, got)
+}
+
+func TestFileTracesExporterError(t *testing.T) {
+	mf := &errorWriter{}
+	fe := &fileExporter{file: mf}
+	require.NotNil(t, fe)
+
+	td := testdata.GenerateTraces(2)
+	// Cannot call Start since we inject directly the WriterCloser.
+	assert.Error(t, fe.ConsumeTraces(context.Background(), td))
+	assert.NoError(t, fe.Shutdown(context.Background()))
+}
+
+func TestFileMetricsExporter(t *testing.T) {
+	fe := &fileExporter{path: tempFileName(t)}
+	require.NotNil(t, fe)
+
+	md := testdata.GenerateMetrics(2)
+	assert.NoError(t, fe.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, fe.ConsumeMetrics(context.Background(), md))
+	assert.NoError(t, fe.Shutdown(context.Background()))
+
+	unmarshaler := &pmetric.JSONUnmarshaler{}
+	buf, err := os.ReadFile(fe.path)
+	assert.NoError(t, err)
+	got, err := unmarshaler.UnmarshalMetrics(buf)
+	assert.NoError(t, err)
+	assert.EqualValues(t, md, got)
+}
+
+func TestFileMetricsExporterError(t *testing.T) {
+	mf := &errorWriter{}
+	fe := &fileExporter{file: mf}
+	require.NotNil(t, fe)
+
+	md := testdata.GenerateMetrics(2)
+	// Cannot call Start since we inject directly the WriterCloser.
+	assert.Error(t, fe.ConsumeMetrics(context.Background(), md))
+	assert.NoError(t, fe.Shutdown(context.Background()))
+}
+
+func TestFileLogsExporter(t *testing.T) {
+	fe := &fileExporter{path: tempFileName(t)}
+	require.NotNil(t, fe)
+
+	ld := testdata.GenerateLogs(2)
+	assert.NoError(t, fe.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, fe.ConsumeLogs(context.Background(), ld))
+	assert.NoError(t, fe.Shutdown(context.Background()))
+
+	unmarshaler := &plog.JSONUnmarshaler{}
+	buf, err := os.ReadFile(fe.path)
+	assert.NoError(t, err)
+	got, err := unmarshaler.UnmarshalLogs(buf)
+	assert.NoError(t, err)
+	assert.EqualValues(t, ld, got)
+}
+
+func TestFileLogsExporterErrors(t *testing.T) {
+	mf := &errorWriter{}
+	fe := &fileExporter{file: mf}
+	require.NotNil(t, fe)
+
+	ld := testdata.GenerateLogs(2)
+	// Cannot call Start since we inject directly the WriterCloser.
+	assert.Error(t, fe.ConsumeLogs(context.Background(), ld))
+	assert.NoError(t, fe.Shutdown(context.Background()))
+}
+
+// tempFileName provides a temporary file name for testing.
+func tempFileName(t *testing.T) string {
+	tmpfile, err := os.CreateTemp("", "*.json")
+	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
+	socket := tmpfile.Name()
+	require.NoError(t, os.Remove(socket))
+	return socket
+}
+
+// errorWriter is an io.Writer that will return an error all ways
+type errorWriter struct {
+}
+
+func (e errorWriter) Write([]byte) (n int, err error) {
+	return 0, errors.New("all ways return error")
+}
+
+func (e *errorWriter) Close() error {
+	return nil
+}
+
+func TestFileExporterStart_NonWritableDir(t *testing.T) {
+	fe := &fileExporter{path: "/non_existent_directory_12345/file.json"}
+	err := fe.Start(context.Background(), componenttest.NewNopHost())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is not writable")
+}

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.60.0
+	go.opentelemetry.io/collector/component/componenttest v0.154.0
 	go.opentelemetry.io/collector/config/configoptional v1.60.0
 	go.opentelemetry.io/collector/config/configretry v1.60.0
 	go.opentelemetry.io/collector/consumer v1.60.0
@@ -12,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper v0.154.0
 	go.opentelemetry.io/collector/internal/componentalias v0.154.0
 	go.opentelemetry.io/collector/pdata v1.60.0
+	go.opentelemetry.io/collector/pdata/testdata v0.154.0
 	go.opentelemetry.io/collector/pipeline v1.60.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
@@ -21,8 +23,11 @@ require (
 	github.com/cenkalti/backoff/v6 v6.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -34,6 +39,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/client v1.60.0 // indirect
 	go.opentelemetry.io/collector/confmap v1.60.0 // indirect
 	go.opentelemetry.io/collector/confmap/xconfmap v0.154.0 // indirect
@@ -47,6 +53,8 @@ require (
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.154.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/exporter/go.sum
+++ b/exporter/go.sum
@@ -5,6 +5,7 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -48,8 +49,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
-github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
@@ -60,6 +61,8 @@ go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
+go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=
+go.opentelemetry.io/otel/metric/x v0.66.0/go.mod h1:d1+BDj9t96do0/1LoU1ayfCv79ZgNE41qbhBvnMOBZk=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
 go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=


### PR DESCRIPTION

#### Description
File Exporter configurations should check that the destination directory is writable before execution, reducing silent telemetry drop failures.

#### Reason
Without a startup check, the collector runs fine until it tries to write telemetry data, failing silently or filling error logs when it runs out of disk space or lacks permissions.

#### Key Considerations
* Reduces probability of silent telemetry data drops.
* Identifies directory permission issues during deployment phase.
* Minimizes runtime log pollution caused by continuous disk write errors.
* Prevents execution loops from working with dead directories.

```mermaid
graph TD
    A[Start File Exporter] --> B{Check Write Permissions on Target Dir}
    B -->|Cannot Write| C[Fail to Start Exporter]
    B -->|Writable| D[Start Exporter Successfully]
```



<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes open-telemetry/opentelemetry-collector-contrib#49599 

<!--Describe what testing was performed and which tests were added.-->
#### Testing



- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
