### PR TITLE
 Fix exporter deadlock

### DIFF
--- a/.chloggen/fix-queue-cond-deadlock.yaml
+++ b/.chloggen/fix-queue-cond-deadlock.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a deadlock in the sending queue where the context-aware condition variable could block forever while holding the queue mutex.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The previous implementation backed the cond with a size-1 buffered channel and sent on it from
+  Signal/Broadcast while holding the lock. Under load the buffer could fill and the send would block
+  forever under the lock, freezing the whole queue (observed with the persistent file_storage queue and
+  the queue batcher enabled). The cond now uses per-waiter channels and wakes waiters via close(), which
+  never blocks.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/queue/cond.go
+++ b/exporter/exporterhelper/internal/queue/cond.go
@@ -13,51 +13,64 @@ import (
 // Also, it requires the caller to hold the c.L during all calls.
 type cond struct {
 	L       sync.Locker
-	ch      chan struct{}
-	waiting int64
+	waiters []chan struct{}
 }
 
 func newCond(l sync.Locker) *cond {
-	return &cond{L: l, ch: make(chan struct{}, 1)}
+	return &cond{L: l}
 }
 
 // Signal wakes one goroutine waiting on c, if there is any.
 // It requires for the caller to hold c.L during the call.
 func (c *cond) Signal() {
-	if c.waiting == 0 {
+	if len(c.waiters) == 0 {
 		return
 	}
-	c.waiting--
-	c.ch <- struct{}{}
+	// Each waiter owns its own channel, so closing it wakes exactly that waiter
+	// and, unlike a send on a shared buffered channel, close() can never block.
+	// The previous implementation sent on a size-1 buffered channel while holding
+	// c.L, which deadlocked forever once the buffer filled under load.
+	w := c.waiters[0]
+	c.waiters[0] = nil
+	c.waiters = c.waiters[1:]
+	close(w)
 }
 
 // Broadcast wakes all goroutines waiting on c.
 // It requires for the caller to hold c.L during the call.
 func (c *cond) Broadcast() {
-	for ; c.waiting > 0; c.waiting-- {
-		c.ch <- struct{}{}
+	for i, w := range c.waiters {
+		c.waiters[i] = nil
+		close(w)
 	}
+	c.waiters = nil
 }
 
 // Wait atomically unlocks c.L and suspends execution of the calling goroutine. After later resuming execution, Wait locks c.L before returning.
 func (c *cond) Wait(ctx context.Context) error {
-	c.waiting++
+	w := make(chan struct{})
+	c.waiters = append(c.waiters, w)
 	c.L.Unlock()
 	select {
 	case <-ctx.Done():
 		c.L.Lock()
-		if c.waiting == 0 {
-			// If waiting is 0, it means that there was a signal sent and nobody else waits for it.
-			// Consume it, so that we don't unblock other consumer unnecessary,
-			// or we don't block the producer because the channel buffer is full.
-			<-c.ch
-		} else {
-			// Decrease the number of waiting routines.
-			c.waiting--
-		}
+		c.removeWaiter(w)
 		return ctx.Err()
-	case <-c.ch:
+	case <-w:
 		c.L.Lock()
 		return nil
+	}
+}
+
+// removeWaiter removes w from the waiters slice if it is still present. A
+// concurrent Signal/Broadcast may have already popped and closed it, in which
+// case there is nothing to remove. It requires for the caller to hold c.L.
+func (c *cond) removeWaiter(w chan struct{}) {
+	for i, x := range c.waiters {
+		if x == w {
+			c.waiters[i] = nil
+			c.waiters = append(c.waiters[:i], c.waiters[i+1:]...)
+			return
+		}
 	}
 }

--- a/exporter/exporterhelper/internal/queue/cond_test.go
+++ b/exporter/exporterhelper/internal/queue/cond_test.go
@@ -1,0 +1,275 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCondSignalWakesExactlyOneWaiter verifies a normal Signal wakes exactly one
+// waiter, that Wait returns nil, and that it returns with the lock held.
+func TestCondSignalWakesExactlyOneWaiter(t *testing.T) {
+	mu := &sync.Mutex{}
+	c := newCond(mu)
+
+	const numWaiters = 5
+	var woken atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(numWaiters)
+	for i := 0; i < numWaiters; i++ {
+		go func() {
+			defer wg.Done()
+			mu.Lock()
+			err := c.Wait(context.Background())
+			assert.NoError(t, err)
+			woken.Add(1)
+			// Wait must return with the lock held; if not, this Unlock panics.
+			mu.Unlock()
+		}()
+	}
+
+	// Wait for all goroutines to register as waiters.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(c.waiters) == numWaiters
+	}, time.Second, time.Millisecond)
+
+	mu.Lock()
+	c.Signal()
+	mu.Unlock()
+
+	// Exactly one waiter should wake; the rest stay blocked.
+	require.Eventually(t, func() bool { return woken.Load() == 1 }, time.Second, time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+	require.EqualValues(t, 1, woken.Load())
+
+	// Wake the rest so the goroutines exit cleanly.
+	mu.Lock()
+	c.Broadcast()
+	mu.Unlock()
+	wg.Wait()
+	assert.EqualValues(t, numWaiters, woken.Load())
+}
+
+// TestCondBroadcastWakesAllWaiters verifies Broadcast wakes N>1 concurrent waiters.
+func TestCondBroadcastWakesAllWaiters(t *testing.T) {
+	mu := &sync.Mutex{}
+	c := newCond(mu)
+
+	const numWaiters = 50
+	var woken atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(numWaiters)
+	for i := 0; i < numWaiters; i++ {
+		go func() {
+			defer wg.Done()
+			mu.Lock()
+			err := c.Wait(context.Background())
+			assert.NoError(t, err)
+			mu.Unlock()
+			woken.Add(1)
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(c.waiters) == numWaiters
+	}, time.Second, time.Millisecond)
+
+	mu.Lock()
+	c.Broadcast()
+	mu.Unlock()
+
+	wg.Wait()
+	assert.EqualValues(t, numWaiters, woken.Load())
+
+	mu.Lock()
+	assert.Empty(t, c.waiters)
+	mu.Unlock()
+}
+
+// TestCondCancelledWaiterIsRemoved verifies a waiter whose context is cancelled
+// returns ctx.Err() and is removed from the waiter set (no leak).
+func TestCondCancelledWaiterIsRemoved(t *testing.T) {
+	mu := &sync.Mutex{}
+	c := newCond(mu)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var err error
+	done := make(chan struct{})
+	go func() {
+		mu.Lock()
+		err = c.Wait(ctx)
+		mu.Unlock()
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(c.waiters) == 1
+	}, time.Second, time.Millisecond)
+
+	cancel()
+	<-done
+
+	assert.ErrorIs(t, err, context.Canceled)
+	mu.Lock()
+	assert.Empty(t, c.waiters, "cancelled waiter must be removed")
+	mu.Unlock()
+}
+
+// TestCondSignalRacesCancel exercises the race where a Signal and ctx
+// cancellation fire near-simultaneously for the same waiter. The Signal must
+// never block under the lock, the waiter set must not leak, and the waiter must
+// observe either nil (woken) or context.Canceled.
+func TestCondSignalRacesCancel(t *testing.T) {
+	for iter := 0; iter < 200; iter++ {
+		mu := &sync.Mutex{}
+		c := newCond(mu)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var err error
+		done := make(chan struct{})
+		go func() {
+			mu.Lock()
+			err = c.Wait(ctx)
+			mu.Unlock()
+			close(done)
+		}()
+
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return len(c.waiters) == 1
+		}, time.Second, time.Millisecond)
+
+		// Fire Signal and cancel concurrently to hit the race window.
+		var raceWG sync.WaitGroup
+		raceWG.Add(2)
+		go func() {
+			defer raceWG.Done()
+			mu.Lock()
+			c.Signal()
+			mu.Unlock()
+		}()
+		go func() {
+			defer raceWG.Done()
+			cancel()
+		}()
+		raceWG.Wait()
+
+		<-done
+		if err != nil {
+			assert.ErrorIs(t, err, context.Canceled)
+		}
+		mu.Lock()
+		assert.Empty(t, c.waiters, "no waiter should leak after signal/cancel race")
+		mu.Unlock()
+	}
+}
+
+// TestCondNoDeadlockUnderLoad reproduces the original deadlock class: many
+// Signal/Broadcast calls (all made while holding the lock) interleaved with
+// Wait(ctx) calls that frequently cancel via context. Against the old
+// buffered-channel implementation, Signal/Broadcast would block forever under
+// the lock and this test would hang (caught by the deadline guard). With the
+// per-waiter-channel fix it completes promptly.
+func TestCondNoDeadlockUnderLoad(t *testing.T) {
+	deadline := time.Now().Add(20 * time.Second)
+	if d, ok := t.Deadline(); ok && d.Before(deadline) {
+		deadline = d.Add(-2 * time.Second)
+	}
+
+	mu := &sync.Mutex{}
+	c := newCond(mu)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Waiters: repeatedly Wait with a short, frequently-expiring context.
+	const numWaiters = 16
+	for i := 0; i < numWaiters; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+				mu.Lock()
+				_ = c.Wait(ctx)
+				mu.Unlock()
+				cancel()
+			}
+		}()
+	}
+
+	// Signalers: hammer Signal/Broadcast while holding the lock.
+	const numSignalers = 8
+	for i := 0; i < numSignalers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				mu.Lock()
+				if id%2 == 0 {
+					c.Signal()
+				} else {
+					c.Broadcast()
+				}
+				mu.Unlock()
+			}
+		}(i)
+	}
+
+	// Run for a fixed window, then signal stop. The deadline guard catches a hang.
+	runFor := time.Until(deadline)
+	if runFor > 3*time.Second {
+		runFor = 3 * time.Second
+	}
+	time.Sleep(runFor)
+	close(stop)
+
+	finished := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+		// All goroutines exited: no Signal/Broadcast/Wait deadlocked under the lock.
+	case <-time.After(time.Until(deadline)):
+		// A goroutine is stuck (the original-bug behavior).
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("deadlock: goroutines did not finish before deadline\n%s", buf[:n])
+	}
+
+	mu.Lock()
+	// Any remaining waiters are in-flight Waits that will drain; no shared
+	// channel to desync, so this is just a sanity bound.
+	assert.LessOrEqual(t, len(c.waiters), numWaiters)
+	mu.Unlock()
+}


### PR DESCRIPTION
#### Description
Fixes a bug that can deadlock exporters.

This was observed when using the persistent `file_storage` queue with the queue batcher enabled in higher latency environments, where context cancellations are more likely to happen.

#### Steps to reproduce
The deadlock occurs in  `Wait` in in [cond.go](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/internal/queue/cond.go#L43).

Setup: Two producers (A, B) waiting in `Wait` on the `select` on `c.ch` / `ctx.Done()`. `c.ch` capacity is 1, so once it's full we'll block attempting to write to it.

1. Consumer 1 calls `Signal()`→ sends {} to channel. Buffer full.
2. Consumer 2 calls `Signal()`→ tries to send {} to channel. Blocks holding the mutex.
3. A and B's contexts expire. Both pick ctx.Done(), try to re-acquire the mutex. Blocked.
4. Nobody left to drain the channel. Permanent deadlock.

#### Link to tracking issue
Fixes # https://github.com/open-telemetry/opentelemetry-collector/issues/12532. There may be other issues like this.

#### Testing
- New tests added to `cond_test.go`
- Tested in our production environment, confirming that:
    1. The deadlock is fixed
    3. Performance overhead was negligible

- [X] I, a human, wrote this pull request description myself.
