### PR TITLE
fix(configretry): validate field-level invariants regardless of Enabled

### DIFF
--- a/.chloggen/liketosweep_fix-backoff-validate-enabled-false.yaml
+++ b/.chloggen/liketosweep_fix-backoff-validate-enabled-false.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: configretry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Validate field-level invariants (e.g. negative durations, out-of-range `randomization_factor`) regardless of the `enabled` flag.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15469]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+change_logs: []

--- a/config/configretry/backoff.go
+++ b/config/configretry/backoff.go
@@ -45,9 +45,6 @@ type BackOffConfig struct {
 }
 
 func (bs *BackOffConfig) Validate() error {
-	if !bs.Enabled {
-		return nil
-	}
 	if bs.InitialInterval < 0 {
 		return errors.New("'initial_interval' must be non-negative")
 	}
@@ -62,6 +59,9 @@ func (bs *BackOffConfig) Validate() error {
 	}
 	if bs.MaxElapsedTime < 0 {
 		return errors.New("'max_elapsed_time' must be non-negative")
+	}
+	if !bs.Enabled {
+		return nil
 	}
 	if bs.MaxElapsedTime > 0 {
 		if bs.MaxElapsedTime < bs.InitialInterval {

--- a/config/configretry/backoff_test.go
+++ b/config/configretry/backoff_test.go
@@ -90,5 +90,52 @@ func TestDisabledWithInvalidValues(t *testing.T) {
 		MaxInterval:         -1,
 		MaxElapsedTime:      -1,
 	}
-	assert.NoError(t, cfg.Validate())
+	assert.Error(t, cfg.Validate())
+}
+
+func TestValidate_FieldInvariantsCheckedRegardlessOfEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     BackOffConfig
+		wantErr string
+	}{
+		{
+			name: "disabled with negative initial_interval",
+			cfg: BackOffConfig{
+				Enabled:         false,
+				InitialInterval: -5 * time.Second,
+			},
+			wantErr: "'initial_interval' must be non-negative",
+		},
+		{
+			name: "disabled with out-of-range randomization_factor",
+			cfg: BackOffConfig{
+				Enabled:             false,
+				RandomizationFactor: 5,
+			},
+			wantErr: "'randomization_factor' must be within [0, 1]",
+		},
+		{
+			name: "disabled with all otherwise-valid fields still passes",
+			cfg: BackOffConfig{
+				Enabled:             false,
+				InitialInterval:     time.Second,
+				RandomizationFactor: 0.5,
+				Multiplier:          1.5,
+				MaxInterval:         time.Minute,
+				MaxElapsedTime:      0,
+			},
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
 }


### PR DESCRIPTION
## What the Issue Was

`BackOffConfig.Validate()` returns `nil` immediately when `Enabled` is
`false`, skipping every check below it - so configs with negative durations
or out-of-range `randomization_factor` values pass silently. If `enabled` is
later flipped to `true`, the collector can crash or misbehave using
never-validated values.

## Root Cause

The `if !bs.Enabled { return nil }` guard sat at the top of `Validate()`,
before the field-level invariant checks. Those checks are properties of
individual fields and don't depend on whether retries are active.

## Solution

Moved the `Enabled` guard down so it only gates the two checks that are
genuinely conditional on retries running (`MaxElapsedTime` vs.
`InitialInterval`/`MaxInterval`). The five field-level checks (durations,
`randomization_factor` range, etc.) now always run.

## Changes

- `backoff.go`: relocated the `Enabled` early-return below the field-level checks
- `backoff_test.go`: fixed `TestDisabledWithInvalidValues` (previously asserted
  `NoError` for an all-invalid disabled config); added
  `TestValidate_FieldInvariantsCheckedRegardlessOfEnabled` covering the issue's
  repro plus a disabled-but-valid case

## Testing

```
$ go test ./config/configretry/... -v
PASS
ok      go.opentelemetry.io/collector/config/configretry
```

Checked `exporter/otlpexporter`, `exporter/otlphttpexporter`,
`exporter/exportertest`, and `exporter/example_test.go`  none construct a
disabled config with invalid fields, so unaffected.

The issue also flags this pattern may exist elsewhere; left as a possible
follow-up rather than expanding scope here.

Fixes #15469