### PR TITLE
fix(mdatagen): remove extra blank line before status table in documentation.md

### DIFF
--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -9,7 +9,6 @@
 {{- if $metric.ExtendedDocumentation }}
 
 {{ $metric.ExtendedDocumentation }}
-
 {{- end }}
 
 | Unit | Metric Type | Value Type |{{ if $metric.Data.HasAggregated }} Aggregation Temporality |{{ end }}{{ if $metric.Data.HasMonotonic }} Monotonic |{{ end }}{{ if $metric.Stability }} Stability |{{ end }}{{ if $metric.SemanticConvention }} Semantic Convention |{{ end }}
@@ -69,7 +68,6 @@ When the disable-old gate is enabled, emission of this metric is suppressed. Whe
 {{- if $event.ExtendedDocumentation }}
 
 {{ $event.ExtendedDocumentation }}
-
 {{- end }}
 
 {{- if $event.Attributes }}
@@ -106,7 +104,6 @@ When the disable-old gate is enabled, emission of this metric is suppressed. Whe
 {{- if $metric.ExtendedDocumentation }}
 
 {{ $metric.ExtendedDocumentation }}
-
 {{- end }}
 
 | Unit | Metric Type | Value Type |{{ if $metric.Data.HasMonotonic }} Monotonic |{{ end }}{{ if $metric.Stability }} Stability |{{ end }}{{ if $metric.SemanticConvention }} Semantic Convention |{{ end }}


### PR DESCRIPTION
## Description

The `documentation.md` template in `cmd/mdatagen` emits an extra blank line between the `ExtendedDocumentation` section and the status table when a component has extended documentation defined.

## Root cause

In `documentation.md.tmpl`, the `ExtendedDocumentation` blocks had a trailing blank line before the `{{- end }}` directive:

```
{{- if $metric.ExtendedDocumentation }}

{{ $metric.ExtendedDocumentation }}
                                        ← extra blank line here
{{- end }}
                                        ← another blank line (paragraph spacing before table)
| Unit | Metric Type | ...
```

The `{{- end }}` trims preceding whitespace, but the blank line *above* it still emits a newline, which combined with the blank line after `{{- end }}` produces a double-blank in the output.

## Fix

Remove the trailing blank line before each `{{- end }}` in all three `ExtendedDocumentation` blocks (metrics, events, and internal metrics). This produces consistent single-blank-line spacing in the generated documentation.

Fixes #15458
