### PR TITLE
[cmd/mdatagen] Implement special handling for component.ID fields in component configs

### DIFF
--- a/.chloggen/mdatagen_component_id.yaml
+++ b/.chloggen/mdatagen_component_id.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support `component.ID` fields in schema-based config generation by appending `ID` suffix to the Go field name.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15455]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Properties with `x-customType: go.opentelemetry.io/collector/component.ID` now generate a Go field
+  name with an `_id` suffix (e.g. `storage` → `StorageID`) to match Go naming conventions for `component.ID` fields.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -486,9 +486,13 @@ func collectValidators(md *ConfigMetadata, validators *[]Validator) {
 			rules.Pattern = &prop.Pattern
 		}
 
+		fieldName := prop.GoName
+		if fieldName == "" {
+			fieldName = propName
+		}
 		if rules.Enabled() {
 			*validators = append(*validators, Validator{
-				FieldName:  propName,
+				FieldName:  fieldName,
 				FieldType:  resolveType(prop),
 				IsPointer:  prop.IsPointer,
 				IsOptional: prop.IsOptional,

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -1680,6 +1680,23 @@ func TestExtractValidators(t *testing.T) {
 			},
 			expected: []Validator{},
 		},
+		{
+			name: "GoName overrides propName in FieldName",
+			metadata: &ConfigMetadata{
+				Type:     "object",
+				Required: []string{"storage"},
+				Properties: map[string]*ConfigMetadata{
+					"storage": {Type: "string", GoName: "storage_id"},
+				},
+			},
+			expected: []Validator{
+				{
+					FieldName: "storage_id",
+					FieldType: "string",
+					Rules:     ValidationRules{Required: true},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -972,6 +972,39 @@ func TestGenerateConfigGoStruct_InternalResolvedRefGeneratesLocalType(t *testing
 	require.Contains(t, generated, "Config: config,")
 }
 
+func TestGenerateConfigGoStruct_ComponentIDFieldUsesGoName(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "shortname")
+	require.NoError(t, os.MkdirAll(outputDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmodule\n"), 0o600))
+
+	md := Metadata{
+		Type:        "test",
+		PackageName: "testmodule/shortname",
+		Status:      &Status{Class: "receiver"},
+		Config: &cfggen.ConfigMetadata{
+			Type: "object",
+			Properties: map[string]*cfggen.ConfigMetadata{
+				"storage": {
+					Type:   "string",
+					GoType: "go.opentelemetry.io/collector/component.ID",
+					GoName: "storage_id",
+				},
+			},
+		},
+	}
+
+	err := generateConfigGoStruct(md, outputDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "generated_config.go")) // #nosec G304
+	require.NoError(t, err)
+
+	generated := string(content)
+	require.Contains(t, generated, `StorageID component.ID`)
+	require.Contains(t, generated, "`mapstructure:\"storage\"`")
+}
+
 func TestGenerateConfigFiles_GoStructError(t *testing.T) {
 	// generateConfigGoStruct fails because tmpdir has no go.mod in any ancestor
 	md := Metadata{

--- a/cmd/mdatagen/internal/samplescraper/README.md
+++ b/cmd/mdatagen/internal/samplescraper/README.md
@@ -22,6 +22,7 @@ This scraper is used for testing purposes to check the output of mdatagen.
 | Setting | Type | Default | Required | Description |
 | ------- | ---- | ------- | -------- | ----------- |
 | `collection_interval` | duration | 1m | no | Sets how frequently the scraper should be called and used as the context timeout to ensure that scrapers don't exceed the interval. |
+| `component` | string |  | no | Identifies the scraper, used for telemetry and logging. |
 | `initial_delay` | duration | 1s | no | Sets the initial start delay for the scraper, any non positive value is assumed to be immediately. |
 | `job_name` | string | test_job | **yes** | Name of the scrape job, used to identify the source in telemetry. |
 | `metrics` | object (see [metrics](#metrics)) |  | no | MetricsConfig provides config for sample metrics. |

--- a/cmd/mdatagen/internal/samplescraper/config.schema.json
+++ b/cmd/mdatagen/internal/samplescraper/config.schema.json
@@ -589,6 +589,10 @@
     }
   ],
   "properties": {
+    "component": {
+      "description": "Identifies the scraper, used for telemetry and logging.",
+      "type": "string"
+    },
     "job_name": {
       "description": "Name of the scrape job, used to identify the source in telemetry.",
       "type": "string",

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -74,6 +74,8 @@ type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 	// MetricsBuilderConfig is a configuration for sample metrics builder.
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	// Identifies the scraper, used for telemetry and logging.
+	ComponentID component.ID `mapstructure:"component"`
 	// Name of the scrape job, used to identify the source in telemetry.
 	JobName string `mapstructure:"job_name"`
 	// List of targets to scrape metrics from.

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -39,6 +39,10 @@ config:
       embed: true
       go_struct:
         anonymous: true
+    component:
+      type: string
+      description: Identifies the scraper, used for telemetry and logging.
+      x-customType: go.opentelemetry.io/collector/component.ID
     job_name:
       description: Name of the scrape job, used to identify the source in telemetry.
       type: string

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -33,7 +33,7 @@ import (
         {{- if $prop.Description }}
     // {{ $prop.Description }}
         {{- end }}
-    	{{ $propName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}"`
+    	{{ or $prop.GoName $propName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}"`
     {{- end }}
     // prevent unkeyed literal initialization
     _ struct{}
@@ -275,9 +275,9 @@ import (
             {{- $exprs := mapCustomDefaults $prop $prop.Default }}
             {{- if $exprs }}
                 {{- $varName := camelVar $propName }}
-        {{ $propName | publicVar }}: {{ wrapDefaultValue $prop $varName }},
+        {{ or $prop.GoName $propName | publicVar }}: {{ wrapDefaultValue $prop $varName }},
             {{- else }}
-        {{ $propName | publicVar }}: {{ $defaultValue }},
+        {{ or $prop.GoName $propName | publicVar }}: {{ $defaultValue }},
             {{- end }}
         {{- end }}
     {{- end }}

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -60,6 +60,7 @@ type ConfigMetadata struct {
 	EmbeddedName                string `mapstructure:"-" json:"-" yaml:"-"`
 	AdditionalPropertiesAllowed *bool  `mapstructure:"-" json:"-" yaml:"-"`
 	InternalOnly                bool   `mapstructure:"-" json:"-" yaml:"-"`
+	GoName                      string `mapstructure:"-" json:"-" yaml:"-"`
 }
 
 type Metadata struct {

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -15,6 +15,7 @@ const (
 	schemaVersion = "https://json-schema.org/draft/2020-12/schema"
 	// goDurationPattern matches Go duration strings (e.g., "30s", "1h30m", "500ms")
 	goDurationPattern = `^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$`
+	componentIDType   = "go.opentelemetry.io/collector/component.ID"
 )
 
 type Resolver struct {
@@ -188,6 +189,7 @@ func (r *Resolver) resolveSchema(root, current, target *ConfigMetadata, origin *
 	handleEmbeddedStructs(target)
 	enhanceTimeTypes(target)
 	cleanupInternalDefs(target)
+	decoratePropNames(target)
 
 	return nil
 }
@@ -253,6 +255,15 @@ func (r *Resolver) loadExternalRef(ref *Ref) (*ConfigMetadata, error) {
 	}
 
 	return nil, fmt.Errorf("type %q not found in loaded schema for reference %s", ref.DefName(), ref)
+}
+
+func decoratePropNames(md *ConfigMetadata) {
+	for name, prop := range md.Properties {
+		prop.GoName = name
+		if prop.GoType == componentIDType {
+			prop.GoName = name + "_id"
+		}
+	}
 }
 
 func handleEmbeddedStructs(md *ConfigMetadata) {

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -1643,6 +1643,32 @@ func TestResolver_ResolveSchema_RefWithoutCustomExtensions(t *testing.T) {
 	require.Equal(t, "BaseConfig", base.GoType)
 }
 
+func TestResolver_ResolveSchema_DecoratesPropNames(t *testing.T) {
+	resolver := &Resolver{
+		pkgID:  "go.opentelemetry.io/collector/test/component",
+		class:  "receiver",
+		name:   "test",
+		loader: NewLoader(""),
+	}
+
+	src := &ConfigMetadata{
+		Type: "object",
+		Properties: map[string]*ConfigMetadata{
+			"endpoint": {Type: "string"},
+			"storage": {
+				Type:   "string",
+				GoType: "go.opentelemetry.io/collector/component.ID",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveSchema(src)
+	require.NoError(t, err)
+
+	require.Equal(t, "endpoint", result.Properties["endpoint"].GoName)
+	require.Equal(t, "storage_id", result.Properties["storage"].GoName)
+}
+
 func TestResolver_ResolveSchema_PreservesIntAndFloatPointers(t *testing.T) {
 	// Regression test: *int and *float64 pointer fields must be copied by the resolver.
 	// Previously, only *ConfigMetadata pointers were handled; all other pointer types


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Properties with `x-customType: go.opentelemetry.io/collector/component.ID` now generate a Go field name with an `_id` suffix (e.g. `storage` → `StorageID`) to match Go naming conventions for `component.ID` fields.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15455

<!--Describe what testing was performed and which tests were added.-->
#### Testing

1. Unit tests coverage
2. Sample component usage

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
