### PR TITLE
[chore] Add workflow to check for a linked issue on non-member PRs

### DIFF
--- a/.github/workflows/check-pr-issue-link.yml
+++ b/.github/workflows/check-pr-issue-link.yml
@@ -1,0 +1,43 @@
+name: 'Check PR links to an issue'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+      - synchronize
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  check-pr-issue-link:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{ github.repository_owner == 'open-telemetry'
+        && github.event.pull_request.user.type != 'Bot'
+        && github.event.pull_request.author_association != 'MEMBER'
+        && !contains(github.event.pull_request.title, '[chore]') }}
+    steps:
+      - name: Check for linked issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          ADDITIONS: ${{ github.event.pull_request.additions }}
+          DELETIONS: ${{ github.event.pull_request.deletions }}
+        run: |
+          # Skip trivial PRs, e.g. typo fixes.
+          if (( ${ADDITIONS:-0} + ${DELETIONS:-0} <= 20 )); then
+            echo "PR changes $(( ADDITIONS + DELETIONS )) line(s), trivial, skipping check."
+            exit 0
+          fi
+          COUNT=$(gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences --jq '.closingIssuesReferences | length')
+          if (( COUNT > 0 )); then
+            echo "Found a linked issue."
+            exit 0
+          fi
+          echo '::error::Pull requests from non-members must have a linked issue. Link one from the description, for example "Fixes #1234".'
+          exit 1


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds CI check for PRs from non-members to have a linked issue. This is a pre-requisite for us to explore implementing other workflows for flagging duplicate work or work on issues that are not ready to be worked on.

This tries to start small by excluding PRs marked as `[chore]`  and smalls PRs. We can make it more strict over time.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
