### PR TITLE
[cmd/mdatagen] Implement go_struct.skip functionality for config generation

### DIFF
--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -104,7 +104,25 @@ func NewCfgFns(rootPackage, componentPackage string) map[string]any {
 			}
 			return call
 		},
+		"hasGoStruct": HasGoStructToGenerate,
 	}
+}
+
+// HasGoStructToGenerate reports whether the resolved config schema will produce at least one Go struct.
+// It returns false when the top-level config is marked skip AND every extracted def is also marked skip (or there are no defs).
+func HasGoStructToGenerate(md *ConfigMetadata) bool {
+	if md == nil {
+		return false
+	}
+	if md.Type == "object" && !md.GoStruct.Skip {
+		return true
+	}
+	for _, def := range ExtractDefs(md) {
+		if !def.GoStruct.Skip {
+			return true
+		}
+	}
+	return false
 }
 
 // ExternalDefaultCall returns the Go expression that delegates to the upstream package's
@@ -268,8 +286,30 @@ func ExtractImports(md *ConfigMetadata, rootPackage, componentPackage string) ([
 	return slices.Collect(maps.Keys(imports)), nil
 }
 
+// collectImportsForSubNode is like collectImports but respects GoStruct.Skip:
+// sub-nodes marked skip emit no Go code, so they need no imports.
+func collectImportsForSubNode(md *ConfigMetadata, imports map[string]bool, rootPackage, componentPackage string) error {
+	if md == nil || md.GoStruct.Skip {
+		return nil
+	}
+	return collectImports(md, imports, rootPackage, componentPackage)
+}
+
 func collectImports(md *ConfigMetadata, imports map[string]bool, rootPackage, componentPackage string) error {
 	if md == nil {
+		return nil
+	}
+
+	// When a schema node is skipped, no Go struct is emitted for it.
+	// Skip its own type/validator/property imports, but still collect imports
+	// for all un-skipped definitions reachable from this node (both $defs
+	// entries and inline objects extracted from properties).
+	if md.GoStruct.Skip {
+		for _, def := range ExtractDefs(md) {
+			if err := collectImports(def, imports, rootPackage, componentPackage); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -317,35 +357,35 @@ func collectImports(md *ConfigMetadata, imports map[string]bool, rootPackage, co
 	}
 
 	for _, prop := range md.Properties {
-		if err := collectImports(prop, imports, rootPackage, componentPackage); err != nil {
+		if err := collectImportsForSubNode(prop, imports, rootPackage, componentPackage); err != nil {
 			return err
 		}
 	}
 
 	if md.Items != nil {
-		if err := collectImports(md.Items, imports, rootPackage, componentPackage); err != nil {
+		if err := collectImportsForSubNode(md.Items, imports, rootPackage, componentPackage); err != nil {
 			return err
 		}
 	}
 
 	for _, schema := range md.AllOf {
-		if err := collectImports(schema, imports, rootPackage, componentPackage); err != nil {
+		if err := collectImportsForSubNode(schema, imports, rootPackage, componentPackage); err != nil {
 			return err
 		}
 	}
 
 	for _, def := range md.Defs {
-		if err := collectImports(def, imports, rootPackage, componentPackage); err != nil {
+		if err := collectImportsForSubNode(def, imports, rootPackage, componentPackage); err != nil {
 			return err
 		}
 	}
 
-	if err := collectImports(md.AdditionalProperties, imports, rootPackage, componentPackage); err != nil {
+	if err := collectImportsForSubNode(md.AdditionalProperties, imports, rootPackage, componentPackage); err != nil {
 		return err
 	}
 
 	if md.ContentSchema != nil {
-		if err := collectImports(md.ContentSchema, imports, rootPackage, componentPackage); err != nil {
+		if err := collectImportsForSubNode(md.ContentSchema, imports, rootPackage, componentPackage); err != nil {
 			return err
 		}
 	}
@@ -422,14 +462,19 @@ func collectDefs(md *ConfigMetadata, defs map[string]*ConfigMetadata) {
 		if !refDesc.IsInternal() {
 			return
 		}
-		if _, exists := defs[md.ResolvedFrom]; !exists {
-			defs[md.ResolvedFrom] = md
+		if !md.GoStruct.Skip {
+			if _, exists := defs[md.ResolvedFrom]; !exists {
+				defs[md.ResolvedFrom] = md
+			}
 		}
 	}
 
 	for _, name := range slices.Sorted(maps.Keys(md.Defs)) {
-		defs[name] = md.Defs[name]
-		collectDefs(md.Defs[name], defs)
+		def := md.Defs[name]
+		if def != nil && !def.GoStruct.Skip {
+			defs[name] = def
+		}
+		collectDefs(def, defs)
 	}
 
 	for _, propName := range slices.Sorted(maps.Keys(md.Properties)) {
@@ -450,8 +495,10 @@ func collectDefsForSchema(propName string, md *ConfigMetadata, defs map[string]*
 		refDesc := NewRef(md.ResolvedFrom)
 		if refDesc.IsInternal() {
 			// Only register the ref-site node if no authoritative definition was already collected from md.Defs.
-			if _, exists := defs[md.ResolvedFrom]; !exists {
-				defs[md.ResolvedFrom] = md
+			if !md.GoStruct.Skip {
+				if _, exists := defs[md.ResolvedFrom]; !exists {
+					defs[md.ResolvedFrom] = md
+				}
 			}
 			collectDefs(md, defs)
 		}
@@ -461,7 +508,9 @@ func collectDefsForSchema(propName string, md *ConfigMetadata, defs map[string]*
 	switch md.Type {
 	case "object":
 		if len(md.Properties) > 0 {
-			defs[propName] = md
+			if !md.GoStruct.Skip {
+				defs[propName] = md
+			}
 			collectDefs(md, defs)
 		} else if md.AdditionalProperties != nil {
 			// map[string]V — the value type V inherits the same propName
@@ -522,6 +571,9 @@ type Validator struct {
 func collectValidators(md *ConfigMetadata, validators *[]Validator) {
 	for _, propName := range slices.Sorted(maps.Keys(md.Properties)) {
 		prop := md.Properties[propName]
+		if prop != nil && prop.GoStruct.Skip {
+			continue
+		}
 		rules := ValidationRules{
 			MaxLength:        prop.MaxLength,
 			MinLength:        prop.MinLength,

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -2967,3 +2967,150 @@ func TestExtractValidators_DefsValidatorNotOverwrittenByRefSite(t *testing.T) {
 	require.Equal(t, "validateBatchConfig", validators[0].CustomValidator,
 		"struct-level validator must come from the type definition, not the ref-site property")
 }
+
+// ---- go_struct.skip tests ----
+
+func TestExtractDefs_SkipDef(t *testing.T) {
+	md := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"VisibleType": {Type: "string"},
+			"SkippedType": {
+				Type:     "string",
+				GoStruct: GoStructConfig{Skip: true},
+			},
+		},
+	}
+
+	result := ExtractDefs(md)
+	require.Contains(t, result, "VisibleType")
+	require.NotContains(t, result, "SkippedType", "skipped def must be excluded from ExtractDefs")
+}
+
+func TestExtractDefs_SkipInlineObjectProperty(t *testing.T) {
+	md := &ConfigMetadata{
+		Type: "object",
+		Properties: map[string]*ConfigMetadata{
+			"visible_cfg": {
+				Type:       "object",
+				Properties: map[string]*ConfigMetadata{"field": {Type: "string"}},
+			},
+			"skipped_cfg": {
+				Type:       "object",
+				GoStruct:   GoStructConfig{Skip: true},
+				Properties: map[string]*ConfigMetadata{"field": {Type: "string"}},
+			},
+		},
+	}
+
+	result := ExtractDefs(md)
+	require.Contains(t, result, "visible_cfg")
+	require.NotContains(t, result, "skipped_cfg", "inline object with skip must be excluded from ExtractDefs")
+}
+
+func TestExtractImports_SkippedDefContributesNoImports(t *testing.T) {
+	md := &ConfigMetadata{
+		Type: "object",
+		Defs: map[string]*ConfigMetadata{
+			"SkippedType": {
+				Type:     "string",
+				GoType:   "time.Time",
+				GoStruct: GoStructConfig{Skip: true},
+			},
+		},
+	}
+	result, err := ExtractImports(md, "", "")
+	require.NoError(t, err)
+	require.NotContains(t, result, "time", "skipped def must not contribute imports")
+}
+
+func TestExtractValidators_SkippedPropertyOmitted(t *testing.T) {
+	md := &ConfigMetadata{
+		Type:     "object",
+		Required: []string{"visible_field", "skipped_field"},
+		Properties: map[string]*ConfigMetadata{
+			"visible_field": {Type: "string"},
+			"skipped_field": {Type: "string", GoStruct: GoStructConfig{Skip: true}},
+		},
+	}
+	validators := ExtractValidators(md)
+	names := make([]string, 0, len(validators))
+	for _, v := range validators {
+		names = append(names, v.FieldName)
+	}
+	require.Contains(t, names, "visible_field")
+	require.NotContains(t, names, "skipped_field", "skipped property must not produce a validator")
+}
+
+func TestHasGoStructToGenerate(t *testing.T) {
+	tests := []struct {
+		name     string
+		md       *ConfigMetadata
+		expected bool
+	}{
+		{
+			name:     "nil input",
+			md:       nil,
+			expected: false,
+		},
+		{
+			name: "top-level object not skipped",
+			md: &ConfigMetadata{
+				Type:       "object",
+				Properties: map[string]*ConfigMetadata{"field": {Type: "string"}},
+			},
+			expected: true,
+		},
+		{
+			name: "top-level object skipped — no defs",
+			md: &ConfigMetadata{
+				Type:       "object",
+				GoStruct:   GoStructConfig{Skip: true},
+				Properties: map[string]*ConfigMetadata{"field": {Type: "string"}},
+			},
+			expected: false,
+		},
+		{
+			name: "top-level skipped but un-skipped def present",
+			md: &ConfigMetadata{
+				Type:       "object",
+				GoStruct:   GoStructConfig{Skip: true},
+				Properties: map[string]*ConfigMetadata{"field": {Type: "string"}},
+				Defs: map[string]*ConfigMetadata{
+					"helper": {Type: "string"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "all defs skipped",
+			md: &ConfigMetadata{
+				Type:     "object",
+				GoStruct: GoStructConfig{Skip: true},
+				Defs: map[string]*ConfigMetadata{
+					"a": {Type: "string", GoStruct: GoStructConfig{Skip: true}},
+					"b": {Type: "string", GoStruct: GoStructConfig{Skip: true}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "one of two defs not skipped",
+			md: &ConfigMetadata{
+				Type:     "object",
+				GoStruct: GoStructConfig{Skip: true},
+				Defs: map[string]*ConfigMetadata{
+					"a": {Type: "string", GoStruct: GoStructConfig{Skip: true}},
+					"b": {Type: "string"},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, HasGoStructToGenerate(tt.md))
+		})
+	}
+}

--- a/cmd/mdatagen/internal/command.go
+++ b/cmd/mdatagen/internal/command.go
@@ -734,11 +734,24 @@ func generateConfigGoStruct(md Metadata, outputDir string) error {
 
 	packageName := filepath.Base(outputDir)
 
+	generatedFiles := []string{"generated_config.go", "generated_config_test.go"}
+
+	// When every config type is marked go_struct.skip, remove any previously
+	// generated Go files and skip re-generation (JSON schema is kept).
+	if !cfggen.HasGoStructToGenerate(md.Config) {
+		for _, f := range generatedFiles {
+			if removeErr := os.Remove(filepath.Join(outputDir, f)); removeErr != nil && !errors.Is(removeErr, fs.ErrNotExist) {
+				return fmt.Errorf("failed to remove stale %s: %w", f, removeErr)
+			}
+		}
+		return nil
+	}
+
 	fns := cfggen.WithCfgFns(getTemplateFuncMap(md, rootPkg), rootPkg, md.PackageName)
 
 	files := []struct{ tmpl, dst string }{
-		{tmpl: "config_from_cfggen.go.tmpl", dst: "generated_config.go"},
-		{tmpl: "config_from_cfggen_test.go.tmpl", dst: "generated_config_test.go"},
+		{tmpl: "config_from_cfggen.go.tmpl", dst: generatedFiles[0]},
+		{tmpl: "config_from_cfggen_test.go.tmpl", dst: generatedFiles[1]},
 	}
 
 	var allErrs error

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -1757,3 +1757,116 @@ func TestGenerateConfigSchema_LocalizesSameRootRefs(t *testing.T) {
 	require.Contains(t, string(actual), "$ref: /filter.config")
 	require.NotContains(t, string(actual), "$ref: go.opentelemetry.io/collector/filter.config")
 }
+
+// TestGenerateConfigFiles_SkipTopLevelConfig verifies that setting go_struct.skip
+// on the top-level config suppresses Go file generation while the JSON schema is
+// still produced.
+func TestGenerateConfigFiles_SkipTopLevelConfig(t *testing.T) {
+	root := t.TempDir()
+	tmpdir := filepath.Join(root, "shortname")
+	require.NoError(t, os.MkdirAll(tmpdir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmodule\n"), 0o600))
+
+	md := Metadata{
+		Type:        "test",
+		PackageName: "shortname",
+		Status:      &Status{Class: "receiver"},
+		Config: &cfggen.ConfigMetadata{
+			Type:     "object",
+			GoStruct: cfggen.GoStructConfig{Skip: true},
+			Properties: map[string]*cfggen.ConfigMetadata{
+				"endpoint": {Type: "string"},
+			},
+		},
+	}
+
+	err := generateConfigFiles(md, tmpdir, "testmodule")
+	require.NoError(t, err)
+
+	// JSON schema must still be produced.
+	require.FileExists(t, filepath.Join(tmpdir, "config.schema.json"))
+
+	// No Go files should be emitted.
+	require.NoFileExists(t, filepath.Join(tmpdir, "generated_config.go"))
+	require.NoFileExists(t, filepath.Join(tmpdir, "generated_config_test.go"))
+}
+
+// TestGenerateConfigFiles_SkipTopLevelConfig_StaleFilesRemoved verifies that
+// previously generated Go files are deleted when go_struct.skip is set.
+func TestGenerateConfigFiles_SkipTopLevelConfig_StaleFilesRemoved(t *testing.T) {
+	root := t.TempDir()
+	tmpdir := filepath.Join(root, "shortname")
+	require.NoError(t, os.MkdirAll(tmpdir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmodule\n"), 0o600))
+
+	// Simulate a stale generated file from a prior run.
+	staleGo := filepath.Join(tmpdir, "generated_config.go")
+	staleTest := filepath.Join(tmpdir, "generated_config_test.go")
+	require.NoError(t, os.WriteFile(staleGo, []byte("// stale\n"), 0o600))
+	require.NoError(t, os.WriteFile(staleTest, []byte("// stale\n"), 0o600))
+
+	md := Metadata{
+		Type:        "test",
+		PackageName: "shortname",
+		Status:      &Status{Class: "receiver"},
+		Config: &cfggen.ConfigMetadata{
+			Type:     "object",
+			GoStruct: cfggen.GoStructConfig{Skip: true},
+			Properties: map[string]*cfggen.ConfigMetadata{
+				"endpoint": {Type: "string"},
+			},
+		},
+	}
+
+	err := generateConfigFiles(md, tmpdir, "testmodule")
+	require.NoError(t, err)
+
+	require.NoFileExists(t, staleGo)
+	require.NoFileExists(t, staleTest)
+}
+
+// TestGenerateConfigFiles_SkipSomeDefs verifies that a skipped def type is absent
+// from the generated Go code while still appearing in the JSON schema.
+func TestGenerateConfigFiles_SkipSomeDefs(t *testing.T) {
+	root := t.TempDir()
+	tmpdir := filepath.Join(root, "shortname")
+	require.NoError(t, os.MkdirAll(tmpdir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmodule\n"), 0o600))
+
+	md := Metadata{
+		Type:        "test",
+		PackageName: "shortname",
+		Status:      &Status{Class: "receiver"},
+		Config: &cfggen.ConfigMetadata{
+			Type: "object",
+			Properties: map[string]*cfggen.ConfigMetadata{
+				"endpoint": {Type: "string"},
+			},
+			Defs: map[string]*cfggen.ConfigMetadata{
+				"visible_helper": {
+					Type:       "object",
+					Properties: map[string]*cfggen.ConfigMetadata{"name": {Type: "string"}},
+				},
+				"skipped_helper": {
+					Type:       "object",
+					GoStruct:   cfggen.GoStructConfig{Skip: true},
+					Properties: map[string]*cfggen.ConfigMetadata{"name": {Type: "string"}},
+				},
+			},
+		},
+	}
+
+	err := generateConfigFiles(md, tmpdir, "testmodule")
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(tmpdir, "config.schema.json"))
+	schema, err := os.ReadFile(filepath.Join(tmpdir, "config.schema.json")) // #nosec G304
+	require.NoError(t, err)
+	require.Contains(t, string(schema), `"skipped_helper"`, "skipped def must remain in JSON schema")
+
+	generatedGo, err := os.ReadFile(filepath.Join(tmpdir, "generated_config.go")) // #nosec G304
+	require.NoError(t, err)
+	require.Contains(t, string(generatedGo), "type Config struct")
+	require.Contains(t, string(generatedGo), "VisibleHelper")
+	require.NotContains(t, string(generatedGo), "SkippedHelper", "skipped def must be absent from generated Go")
+}

--- a/cmd/mdatagen/internal/samplescraper/config.schema.json
+++ b/cmd/mdatagen/internal/samplescraper/config.schema.json
@@ -648,6 +648,15 @@
     "targets"
   ],
   "$defs": {
+    "custom_config": {
+      "type": "object",
+      "properties": {
+        "custom_field": {
+          "type": "string",
+          "default": "value"
+        }
+      }
+    },
     "sample_pkg": {
       "type": "object",
       "properties": {

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -24,6 +24,14 @@ status:
 exported_configs:
   sample_pkg:
     $ref: ../samplepkg.sample_config
+  custom_config:
+    type: object
+    properties:
+      custom_field:
+        type: string
+        default: "value"
+    go_struct:
+      skip: true
 
 config:
   type: object
@@ -82,7 +90,7 @@ config:
             exclusiveMaximum: 30
         required: [labels]
       default:
-        - {} # one item with default values
+        - { } # one item with default values
   required: [job_name, targets]
 
 resource_attributes:

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -2,7 +2,7 @@
 
 package {{ .Package }}
 
-{{- $hasConfig := eq .Metadata.Config.Type "object" }}
+{{- $hasConfig := and (eq .Metadata.Config.Type "object") (not .Metadata.Config.GoStruct.Skip) }}
 {{- $validators := extractValidators .Metadata.Config }}
 {{ $imports := extractImports .Metadata.Config }}
 {{- if or $hasConfig $imports }}
@@ -217,7 +217,7 @@ import (
     {{- end -}}
 {{ end }}
 
-{{- if $validators }}
+{{- if and $hasConfig $validators }}
     // Validate validates the Config fields.
     func (c *Config) Validate() error {
         var err error

--- a/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
@@ -11,7 +11,7 @@ import (
 )
 {{- end }}
 {{- end }}
-{{- if eq .Metadata.Config.Type "object" }}
+{{- if and (eq .Metadata.Config.Type "object") (not .Metadata.Config.GoStruct.Skip) }}
 {{- template "imports" $imports_addded }}
 {{- $imports_addded = true }}
 

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -139,6 +139,20 @@ config:
       x-pointer: bool
       # Optional: Whether this field is optional in Go code (will use pointer or optional type).
       x-optional: bool
+      # Optional: Go struct generation settings for this schema node.
+      go_struct:
+        # Optional: When true, no Go struct is generated for this type. The JSON schema
+        # and README config docs are still produced. Use this when you provide the
+        # Go struct for this config type by hand instead of having mdatagen generate it.
+        # If every type in a config section is skipped, no Go files are emitted at all.
+        skip: bool
+        # Optional: When true, the struct is embedded anonymously (no field name).
+        anonymous: bool
+        # Optional: When true, default-value setters are not generated for this type.
+        ignore_default: bool
+        # Optional: Name of a custom validator function to call for this type.
+        custom_validator:
+          name: string
   # Optional: List of required property names. Properties in this list must be present in the config.
   required: [string]
   # Optional: Map of reusable schema definitions that can be referenced via $ref.

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -71,6 +71,7 @@ type GoStructConfig struct {
 	CustomValidator *CustomValidatorConfig `mapstructure:"custom_validator" json:"-" yaml:"custom_validator,omitempty"`
 	Anonymous       bool                   `mapstructure:"anonymous" json:"-" yaml:"anonymous,omitempty"`
 	IgnoreDefault   bool                   `mapstructure:"ignore_default" json:"-" yaml:"ignore_default,omitempty"`
+	Skip            bool                   `mapstructure:"skip" json:"-" yaml:"skip,omitempty"`
 }
 
 type CustomValidatorConfig struct {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Allow fully or partially skip go config code generation step in mdatagen. 

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
