### PR TITLE
confighttp: reject malformed compressed requests

### DIFF
--- a/.chloggen/fix-confighttp-compression-edge-cases.yaml
+++ b/.chloggen/fix-confighttp-compression-edge-cases.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: pkg/confighttp
+
+note: "Fix HTTP server decompression handling for identity encoding and malformed compressed request bodies."
+
+issues: [13228]
+
+change_logs: [user]

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -249,6 +249,9 @@ func httpContentDecompressor(h http.Handler, maxRequestBodySize int64, eh func(w
 	for _, dec := range enableDecoders {
 		enabled[dec] = availableDecoders[dec]
 
+		if dec == "" {
+			enabled["identity"] = availableDecoders[""]
+		}
 		if dec == "deflate" {
 			enabled["deflate"] = availableDecoders["zlib"]
 		}
@@ -276,17 +279,33 @@ func (d *decompressor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if newBody != nil {
-		newBody = &panicRecoverReadCloser{inner: newBody}
-		defer newBody.Close()
+		body, err := d.readDecompressedBody(w, newBody)
+		if err != nil {
+			d.errHandler(w, r, err.Error(), http.StatusBadRequest)
+			return
+		}
 		// "Content-Encoding" header is removed to avoid decompressing twice
 		// in case the next handler(s) have implemented a similar mechanism.
 		r.Header.Del("Content-Encoding")
-		// "Content-Length" is set to -1 as the size of the decompressed body is unknown.
 		r.Header.Del("Content-Length")
-		r.ContentLength = -1
-		r.Body = http.MaxBytesReader(w, newBody, d.maxRequestBodySize)
+		r.ContentLength = int64(len(body))
+		r.Body = io.NopCloser(bytes.NewReader(body))
 	}
 	d.base.ServeHTTP(w, r)
+}
+
+func (d *decompressor) readDecompressedBody(w http.ResponseWriter, body io.ReadCloser) ([]byte, error) {
+	body = &panicRecoverReadCloser{inner: body}
+	limitedBody := http.MaxBytesReader(w, body, d.maxRequestBodySize)
+	decompressed, readErr := io.ReadAll(limitedBody)
+	closeErr := body.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return decompressed, nil
 }
 
 func (d *decompressor) newBodyReader(r *http.Request) (io.ReadCloser, error) {

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -319,14 +319,14 @@ func TestHTTPContentDecompressionHandler(t *testing.T) {
 			encoding: "zstd",
 			reqBody:  bytes.NewBuffer(testBody),
 			respCode: http.StatusBadRequest,
-			respBody: "invalid input: magic number mismatch",
+			respBody: "invalid input: magic number mismatch\n",
 		},
 		{
 			name:     "InvalidSnappyFramed",
 			encoding: "x-snappy-framed",
 			reqBody:  bytes.NewBuffer(testBody),
 			respCode: http.StatusBadRequest,
-			respBody: "snappy: corrupt input",
+			respBody: "snappy: corrupt input\n",
 		},
 		{
 			name:     "InvalidSnappy",
@@ -631,14 +631,12 @@ func TestCompressionAlgorithmsEdgeCases(t *testing.T) {
 			wantBodyEcho:          true,
 		},
 		{
-			// BUG: "identity" means no encoding per RFC 7231 §3.1.2.2, but
-			// the decompressor rejects it because "identity" is not registered
-			// in availableDecoders. This should be treated the same as "".
 			name:                  "Mixed_Identity_ShouldAccept",
 			compressionAlgorithms: []string{"", "gzip", "zstd"},
 			contentEncoding:       "identity",
 			body:                  testBody,
-			wantStatus:            http.StatusBadRequest, // BUG: should be http.StatusOK
+			wantStatus:            http.StatusOK,
+			wantBodyEcho:          true,
 		},
 		{
 			name:                  "Mixed_Snappy_Rejected",
@@ -656,16 +654,12 @@ func TestCompressionAlgorithmsEdgeCases(t *testing.T) {
 			wantStatus:            http.StatusBadRequest, // gzip reader should error, not panic
 		},
 		// Edge case: zstd header but garbage body.
-		// BUG: The zstd decoder lazily initializes, so NewReader succeeds
-		// but the error surfaces during io.ReadAll in the handler, returning
-		// 500 instead of 400. This can cause panics in handlers that don't
-		// expect decompression errors. See issue #13228 comment.
 		{
 			name:                  "Mixed_Zstd_GarbageBody",
 			compressionAlgorithms: []string{"", "gzip", "zstd"},
 			contentEncoding:       "zstd",
 			body:                  []byte("this is not zstd data at all"),
-			wantStatus:            http.StatusInternalServerError, // BUG: should be http.StatusBadRequest
+			wantStatus:            http.StatusBadRequest,
 		},
 		// Edge case: gzip header but truncated data
 		{
@@ -721,8 +715,8 @@ func TestCompressionAlgorithmsEdgeCases(t *testing.T) {
 }
 
 // TestDecompressionPanicRecovery verifies that a decoder that panics during
-// Read does not crash the server. The panic should be recovered and surfaced
-// as a normal error to the handler.
+// Read does not crash the server. The panic should be recovered and rejected
+// before the downstream handler is called.
 func TestDecompressionPanicRecovery(t *testing.T) {
 	testBody := []byte("some data")
 
@@ -733,12 +727,9 @@ func TestDecompressionPanicRecovery(t *testing.T) {
 		},
 	}
 
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+	handlerCalled := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -763,7 +754,9 @@ func TestDecompressionPanicRecovery(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Contains(t, string(body), "decompression panic")
+	assert.False(t, handlerCalled)
 }
 
 func TestHTTPContentCompressionRequestWithNilBody(t *testing.T) {
@@ -901,12 +894,10 @@ func TestDecompressorAvoidDecompressionBomb(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			downstreamCalled := false
 			h := httpContentDecompressor(
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					n, err := io.Copy(io.Discard, r.Body)
-					assert.Equal(t, int64(1024), n, "Must have only read the limited value of bytes")
-					assert.EqualError(t, err, "http: request body too large")
-					w.WriteHeader(http.StatusBadRequest)
+				http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+					downstreamCalled = true
 				}),
 				1024,
 				defaultErrorHandler,
@@ -925,7 +916,8 @@ func TestDecompressorAvoidDecompressionBomb(t *testing.T) {
 			h.ServeHTTP(resp, req)
 
 			assert.Equal(t, http.StatusBadRequest, resp.Code, "Must match the expected code")
-			assert.Empty(t, resp.Body.String(), "Must match the returned string")
+			assert.Contains(t, resp.Body.String(), "http: request body too large")
+			assert.False(t, downstreamCalled, "downstream handler must not run when request is rejected")
 		})
 	}
 }
@@ -1038,35 +1030,18 @@ func TestSnappyBlockClosesOriginalBody(t *testing.T) {
 }
 
 func TestPooledZstdReadCloserReadAfterClose(t *testing.T) {
-	h := httpContentDecompressor(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			buf := make([]byte, 1024)
-			_, err := r.Body.Read(buf)
-			assert.NoError(t, err)
-			err = r.Body.Close()
-			assert.NoError(t, err)
-			_, err = r.Body.Read(buf)
-			assert.ErrorIs(t, err, zstd.ErrDecoderClosed)
-			w.WriteHeader(http.StatusBadRequest)
-		}),
-		defaultMaxRequestBodySize,
-		defaultErrorHandler,
-		defaultCompressionAlgorithms(),
-		availableDecoders,
-	)
-
 	payload := compressZstd(t, make([]byte, 2*1024)) // 2KB uncompressed payload
 	assert.NotEmpty(t, payload.Bytes(), "Must have data available")
 
-	req := httptest.NewRequest(http.MethodPost, "/", payload)
-	req.Header.Set("Content-Encoding", "zstd")
+	zstdBody, err := availableDecoders["zstd"](io.NopCloser(payload))
+	require.NoError(t, err)
 
-	resp := httptest.NewRecorder()
-
-	h.ServeHTTP(resp, req)
-
-	assert.Equal(t, http.StatusBadRequest, resp.Code, "Must match the expected code")
-	assert.Empty(t, resp.Body.String(), "Must match the returned string")
+	buf := make([]byte, 1024)
+	_, err = zstdBody.Read(buf)
+	assert.NoError(t, err)
+	require.NoError(t, zstdBody.Close())
+	_, err = zstdBody.Read(buf)
+	assert.ErrorIs(t, err, zstd.ErrDecoderClosed)
 }
 
 type closeTrackingReadCloser struct {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

  Fixes `confighttp` server decompression edge cases reported in https://github.com/open-telemetry/opentelemetry-collector/issues/13228#issuecomment-3495221849.

  This treats `Content-Encoding: identity` the same as no encoding when `compression_algorithms` includes `""`, and rejects malformed compressed request bodies with `400 Bad
  Request` before invoking downstream handlers.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13228

<!--Describe what testing was performed and which tests were added.-->
#### Testing
`test ./...`

<!--Describe the documentation added.-->
#### Documentation
Added a changelog entry.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
