### PR TITLE
[service] Start receivers after every other component type

### DIFF
--- a/.chloggen/start-receivers-last.yaml
+++ b/.chloggen/start-receivers-last.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure receivers always start after all other components
+
+# One or more tracking issues or pull requests related to the change
+issues: [15495]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  There was previously a race condition where multiple receivers using a shared internal implementation,
+  such as the OTLP receiver, could start sending telemetry into a pipeline before all its components had fully started.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -407,7 +407,7 @@ func (g *Graph) StartAll(ctx context.Context, host *Host) error {
 	}
 
 	nodes, err := topo.SortStabilized(g.componentGraph, func(nodes []graph.Node) {
-		slices.SortFunc(nodes, func(node1 graph.Node, node2 graph.Node) int {
+		slices.SortFunc(nodes, func(node1, node2 graph.Node) int {
 			// Always start receivers after non-receivers, to avoid cases where a shared receiver
 			// is started from one pipeline and starts sending to another, not yet started pipeline.
 			_, isReceiver1 := node1.(*receiverNode)

--- a/service/internal/graph/graph.go
+++ b/service/internal/graph/graph.go
@@ -13,6 +13,7 @@
 package graph // import "go.opentelemetry.io/collector/service/internal/graph"
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -405,7 +406,21 @@ func (g *Graph) StartAll(ctx context.Context, host *Host) error {
 		return errors.New("host cannot be nil")
 	}
 
-	nodes, err := topo.Sort(g.componentGraph)
+	nodes, err := topo.SortStabilized(g.componentGraph, func(nodes []graph.Node) {
+		slices.SortFunc(nodes, func(node1 graph.Node, node2 graph.Node) int {
+			// Always start receivers after non-receivers, to avoid cases where a shared receiver
+			// is started from one pipeline and starts sending to another, not yet started pipeline.
+			_, isReceiver1 := node1.(*receiverNode)
+			_, isReceiver2 := node2.(*receiverNode)
+			if isReceiver1 && !isReceiver2 {
+				return -1
+			}
+			if isReceiver2 && !isReceiver1 {
+				return 1
+			}
+			return cmp.Compare(node1.ID(), node2.ID())
+		})
+	})
 	if err != nil {
 		return err
 	}

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -2636,34 +2636,34 @@ func (ter *testEagerReceiver) Shutdown(ctx context.Context) error {
 
 var _ receiver.Traces = (*testEagerReceiver)(nil)
 
-// This processor returns an error if it receives traces before it has been started
-type testStartableProcessor struct {
+// This exporter returns an error if it receives traces before it has been started
+type testStartableExporter struct {
 	started bool
 }
 
-func (tsp *testStartableProcessor) Capabilities() consumer.Capabilities {
+func (tse *testStartableExporter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{}
 }
-func (tsp *testStartableProcessor) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
-	if !tsp.started {
+func (tse *testStartableExporter) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	if !tse.started {
 		return errors.New("not started")
 	}
 	return nil
 }
-func (tsp *testStartableProcessor) Start(ctx context.Context, host component.Host) error {
-	tsp.started = true
+func (tse *testStartableExporter) Start(ctx context.Context, host component.Host) error {
+	tse.started = true
 	return nil
 }
-func (tsp *testStartableProcessor) Shutdown(ctx context.Context) error {
+func (tse *testStartableExporter) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-var _ processor.Traces = (*testStartableProcessor)(nil)
+var _ exporter.Traces = (*testStartableExporter)(nil)
 
 func TestSharedReceiverStartOrder(t *testing.T) {
-	// Test that a shared receiver will not start before a processor it sends to
+	// Test that a shared receiver will not start before an exporter it sends to
 
-	// Define component factories:
+	// Define component factories
 
 	sharedType := component.MustNewType("shared")
 	var sharedReceiver *testEagerReceiver
@@ -2677,21 +2677,19 @@ func TestSharedReceiverStartOrder(t *testing.T) {
 	)
 
 	startableType := component.MustNewType("startable")
-	startableProcessorFactory := processor.NewFactory(
+	startableExporterFactory := exporter.NewFactory(
 		startableType,
 		func() component.Config { return nil },
-		processor.WithTraces(func(ctx context.Context, s processor.Settings, c component.Config, t consumer.Traces) (processor.Traces, error) {
-			return &testStartableProcessor{}, nil
+		exporter.WithTraces(func(ctx context.Context, s exporter.Settings, c component.Config) (exporter.Traces, error) {
+			return &testStartableExporter{}, nil
 		}, component.StabilityLevelStable),
 	)
-	nopFactory := exportertest.NewNopFactory()
-	nopType := nopFactory.Type()
 
 	// To check that the outcome isn't affected by how the topological sort decides to arbitrarily order nodes from separate pipelines,
 	// we try 10 different names for one instance of the shared receiver, resulting in 10 different node IDs and 10 different initial node orders.
 	for i := range 10 {
 		sharedReceiver = &testEagerReceiver{} // Reset shared instance
-		otherReceiverId := component.NewIDWithName(sharedType, fmt.Sprintf("%d", i))
+		otherReceiverName := fmt.Sprintf("%d", i)
 
 		// Build the pipeline
 		set := Settings{
@@ -2699,33 +2697,28 @@ func TestSharedReceiverStartOrder(t *testing.T) {
 			BuildInfo: component.NewDefaultBuildInfo(),
 			ReceiverBuilder: builders.NewReceiver(
 				map[component.ID]component.Config{
-					component.NewID(sharedType): sharedReceiverFactory.CreateDefaultConfig(),
-					otherReceiverId:             sharedReceiverFactory.CreateDefaultConfig(),
+					component.NewID(sharedType):                            sharedReceiverFactory.CreateDefaultConfig(),
+					component.NewIDWithName(sharedType, otherReceiverName): sharedReceiverFactory.CreateDefaultConfig(),
 				},
 				map[component.Type]receiver.Factory{sharedType: sharedReceiverFactory},
 			),
-			ProcessorBuilder: builders.NewProcessor(
-				map[component.ID]component.Config{component.NewID(startableType): startableProcessorFactory.CreateDefaultConfig()},
-				map[component.Type]processor.Factory{startableType: startableProcessorFactory},
-			),
+			ProcessorBuilder: builders.NewProcessor(nil, nil),
 			ExporterBuilder: builders.NewExporter(
-				map[component.ID]component.Config{component.NewID(nopType): nopFactory.CreateDefaultConfig()},
-				map[component.Type]exporter.Factory{nopType: nopFactory},
+				map[component.ID]component.Config{
+					component.NewID(startableType):              startableExporterFactory.CreateDefaultConfig(),
+					component.NewIDWithName(startableType, "2"): startableExporterFactory.CreateDefaultConfig(),
+				},
+				map[component.Type]exporter.Factory{startableType: startableExporterFactory},
 			),
-			ConnectorBuilder: builders.NewConnector(
-				map[component.ID]component.Config{},
-				map[component.Type]connector.Factory{},
-			),
+			ConnectorBuilder: builders.NewConnector(nil, nil),
 			PipelineConfigs: pipelines.Config{
 				pipeline.NewID(pipeline.SignalTraces): {
-					Receivers:  []component.ID{component.NewID(sharedType)},
-					Processors: []component.ID{component.NewID(startableType)},
-					Exporters:  []component.ID{component.NewID(nopType)},
+					Receivers: []component.ID{component.NewID(sharedType)},
+					Exporters: []component.ID{component.NewID(startableType)},
 				},
 				pipeline.NewIDWithName(pipeline.SignalTraces, "2"): {
-					Receivers:  []component.ID{otherReceiverId},
-					Processors: []component.ID{component.NewID(startableType)},
-					Exporters:  []component.ID{component.NewID(nopType)},
+					Receivers: []component.ID{component.NewIDWithName(sharedType, otherReceiverName)},
+					Exporters: []component.ID{component.NewIDWithName(startableType, "2")},
 				},
 			},
 		}

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -2622,7 +2623,7 @@ type testEagerReceiver struct {
 	next []consumer.Traces
 }
 
-func (ter *testEagerReceiver) Start(ctx context.Context, host component.Host) error {
+func (ter *testEagerReceiver) Start(ctx context.Context, _ component.Host) error {
 	td := ptrace.NewTraces()
 	var err error
 	for _, consumer := range ter.next {
@@ -2630,7 +2631,8 @@ func (ter *testEagerReceiver) Start(ctx context.Context, host component.Host) er
 	}
 	return err
 }
-func (ter *testEagerReceiver) Shutdown(ctx context.Context) error {
+
+func (ter *testEagerReceiver) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -2644,17 +2646,20 @@ type testStartableExporter struct {
 func (tse *testStartableExporter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{}
 }
-func (tse *testStartableExporter) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+
+func (tse *testStartableExporter) ConsumeTraces(context.Context, ptrace.Traces) error {
 	if !tse.started {
 		return errors.New("not started")
 	}
 	return nil
 }
-func (tse *testStartableExporter) Start(ctx context.Context, host component.Host) error {
+
+func (tse *testStartableExporter) Start(context.Context, component.Host) error {
 	tse.started = true
 	return nil
 }
-func (tse *testStartableExporter) Shutdown(ctx context.Context) error {
+
+func (tse *testStartableExporter) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -2680,7 +2685,7 @@ func TestSharedReceiverStartOrder(t *testing.T) {
 	startableExporterFactory := exporter.NewFactory(
 		startableType,
 		func() component.Config { return nil },
-		exporter.WithTraces(func(ctx context.Context, s exporter.Settings, c component.Config) (exporter.Traces, error) {
+		exporter.WithTraces(func(context.Context, exporter.Settings, component.Config) (exporter.Traces, error) {
 			return &testStartableExporter{}, nil
 		}, component.StabilityLevelStable),
 	)
@@ -2689,7 +2694,7 @@ func TestSharedReceiverStartOrder(t *testing.T) {
 	// we try 10 different names for one instance of the shared receiver, resulting in 10 different node IDs and 10 different initial node orders.
 	for i := range 10 {
 		sharedReceiver = &testEagerReceiver{} // Reset shared instance
-		otherReceiverName := fmt.Sprintf("%d", i)
+		otherReceiverName := strconv.Itoa(i)
 
 		// Build the pipeline
 		set := Settings{

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -2627,7 +2627,7 @@ func (ter *testEagerReceiver) Start(ctx context.Context, _ component.Host) error
 	td := ptrace.NewTraces()
 	var err error
 	for _, consumer := range ter.next {
-		err = errors.Join(consumer.ConsumeTraces(ctx, td))
+		err = errors.Join(err, consumer.ConsumeTraces(ctx, td))
 	}
 	return err
 }

--- a/service/internal/graph/graph_test.go
+++ b/service/internal/graph/graph_test.go
@@ -5,6 +5,7 @@ package graph
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/testdata"
 	"go.opentelemetry.io/collector/pdata/xpdata/pref"
 	"go.opentelemetry.io/collector/pipeline"
@@ -2612,5 +2614,128 @@ func testGraphBuildErrors(t *testing.T) {
 			_, err := Build(context.Background(), set)
 			assert.EqualError(t, err, tt.expected)
 		})
+	}
+}
+
+// This receiver sends a dummy payload to all its consumers as soon as it starts
+type testEagerReceiver struct {
+	next []consumer.Traces
+}
+
+func (ter *testEagerReceiver) Start(ctx context.Context, host component.Host) error {
+	td := ptrace.NewTraces()
+	var err error
+	for _, consumer := range ter.next {
+		err = errors.Join(consumer.ConsumeTraces(ctx, td))
+	}
+	return err
+}
+func (ter *testEagerReceiver) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+var _ receiver.Traces = (*testEagerReceiver)(nil)
+
+// This processor returns an error if it receives traces before it has been started
+type testStartableProcessor struct {
+	started bool
+}
+
+func (tsp *testStartableProcessor) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{}
+}
+func (tsp *testStartableProcessor) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	if !tsp.started {
+		return errors.New("not started")
+	}
+	return nil
+}
+func (tsp *testStartableProcessor) Start(ctx context.Context, host component.Host) error {
+	tsp.started = true
+	return nil
+}
+func (tsp *testStartableProcessor) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+var _ processor.Traces = (*testStartableProcessor)(nil)
+
+func TestSharedReceiverStartOrder(t *testing.T) {
+	// Test that a shared receiver will not start before a processor it sends to
+
+	// Define component factories:
+
+	sharedType := component.MustNewType("shared")
+	var sharedReceiver *testEagerReceiver
+	sharedReceiverFactory := receiver.NewFactory(
+		sharedType,
+		func() component.Config { return nil },
+		receiver.WithTraces(func(_ context.Context, _ receiver.Settings, _ component.Config, next consumer.Traces) (receiver.Traces, error) {
+			sharedReceiver.next = append(sharedReceiver.next, next)
+			return sharedReceiver, nil
+		}, component.StabilityLevelStable),
+	)
+
+	startableType := component.MustNewType("startable")
+	startableProcessorFactory := processor.NewFactory(
+		startableType,
+		func() component.Config { return nil },
+		processor.WithTraces(func(ctx context.Context, s processor.Settings, c component.Config, t consumer.Traces) (processor.Traces, error) {
+			return &testStartableProcessor{}, nil
+		}, component.StabilityLevelStable),
+	)
+	nopFactory := exportertest.NewNopFactory()
+	nopType := nopFactory.Type()
+
+	// To check that the outcome isn't affected by how the topological sort decides to arbitrarily order nodes from separate pipelines,
+	// we try 10 different names for one instance of the shared receiver, resulting in 10 different node IDs and 10 different initial node orders.
+	for i := range 10 {
+		sharedReceiver = &testEagerReceiver{} // Reset shared instance
+		otherReceiverId := component.NewIDWithName(sharedType, fmt.Sprintf("%d", i))
+
+		// Build the pipeline
+		set := Settings{
+			Telemetry: componenttest.NewNopTelemetrySettings(),
+			BuildInfo: component.NewDefaultBuildInfo(),
+			ReceiverBuilder: builders.NewReceiver(
+				map[component.ID]component.Config{
+					component.NewID(sharedType): sharedReceiverFactory.CreateDefaultConfig(),
+					otherReceiverId:             sharedReceiverFactory.CreateDefaultConfig(),
+				},
+				map[component.Type]receiver.Factory{sharedType: sharedReceiverFactory},
+			),
+			ProcessorBuilder: builders.NewProcessor(
+				map[component.ID]component.Config{component.NewID(startableType): startableProcessorFactory.CreateDefaultConfig()},
+				map[component.Type]processor.Factory{startableType: startableProcessorFactory},
+			),
+			ExporterBuilder: builders.NewExporter(
+				map[component.ID]component.Config{component.NewID(nopType): nopFactory.CreateDefaultConfig()},
+				map[component.Type]exporter.Factory{nopType: nopFactory},
+			),
+			ConnectorBuilder: builders.NewConnector(
+				map[component.ID]component.Config{},
+				map[component.Type]connector.Factory{},
+			),
+			PipelineConfigs: pipelines.Config{
+				pipeline.NewID(pipeline.SignalTraces): {
+					Receivers:  []component.ID{component.NewID(sharedType)},
+					Processors: []component.ID{component.NewID(startableType)},
+					Exporters:  []component.ID{component.NewID(nopType)},
+				},
+				pipeline.NewIDWithName(pipeline.SignalTraces, "2"): {
+					Receivers:  []component.ID{otherReceiverId},
+					Processors: []component.ID{component.NewID(startableType)},
+					Exporters:  []component.ID{component.NewID(nopType)},
+				},
+			},
+		}
+
+		pg, err := Build(context.Background(), set)
+		require.NoError(t, err)
+
+		// Check that no "not started" errors bubble up from the processors during startup
+		require.NoError(t, pg.StartAll(context.Background(), &Host{
+			Reporter: status.NewReporter(func(*componentstatus.InstanceID, *componentstatus.Event) {}, func(error) {}),
+		}))
 	}
 }


### PR DESCRIPTION
#### Description

This PR constrains the start order of components so that receivers only start after every other type of component has started across all pipelines. Note that this is still reverse topological order, but with some of the free parameters fixed.

This avoids startup issues with pipelines like this:
```
receiver/1 → exporter/1
receiver/2 → exporter/2
```
in which `receiver/1` and `receiver/2` are two instances of a `sharedcomponent`.

Since `receiver/1` and `exporter/2` are in disconnected parts of the component graph, their order in the startup schedule is undefined, so the service might (depending on the hash of the component instance identities) decide to start `receiver/1` before `exporter/2`. But since starting `receiver/1` also starts `receiver/2`, which the service has no knowledge of, there is a chance for `receiver/2` to emit data to an unstarted `exporter/2`, which violates the standard component lifecycle.

#### Link to tracking issue
Fixes #15485

#### Testing
I added a unit test in `graph_test.go` which checks that a shared receiver which eagerly sends data on startup does not send data to an unstarted exporter. This test fails with the previous code in `graph.go`.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
