### PR TITLE
[cmd/mdatagen] Add support for generating named slice types in mdatagen schema-based config

### DIFF
--- a/.chloggen/mdatagen_slice_type_generation.yaml
+++ b/.chloggen/mdatagen_slice_type_generation.yaml
@@ -1,0 +1,14 @@
+change_type: enhancement
+
+component: cmd/mdatagen
+
+note: Support generating named slice types (`type Foo []Item`) for exported array config schemas.
+
+issues: []
+
+subtext: |
+  An exported config definition with `type: array` and an `items` entry (including `$ref` to
+  another exported def) now generates a named Go slice type, e.g. `type MapList []Pair`.
+  This mirrors the `configopaque.MapList` pattern.
+
+change_logs: [api]

--- a/.chloggen/mdatagen_slice_type_generation.yaml
+++ b/.chloggen/mdatagen_slice_type_generation.yaml
@@ -4,7 +4,7 @@ component: cmd/mdatagen
 
 note: Support generating named slice types (`type Foo []Item`) for exported array config schemas.
 
-issues: []
+issues: [15497]
 
 subtext: |
   An exported config definition with `type: array` and an `items` entry (including `$ref` to

--- a/.chloggen/mdatagen_slice_type_generation.yaml
+++ b/.chloggen/mdatagen_slice_type_generation.yaml
@@ -8,7 +8,6 @@ issues: []
 
 subtext: |
   An exported config definition with `type: array` and an `items` entry (including `$ref` to
-  another exported def) now generates a named Go slice type, e.g. `type MapList []Pair`.
-  This mirrors the `configopaque.MapList` pattern.
+  another exported def) now generates a named Go slice type.
 
 change_logs: [api]

--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -59,6 +59,7 @@ func NewCfgFns(rootPackage, componentPackage string) map[string]any {
 			}
 			return goType
 		},
+		"isArraySchema": IsArraySchema,
 		"publicType": func(ref string) string {
 			typeName, err := FormatTypeName(ref, rootPackage, componentPackage)
 			if err != nil {
@@ -150,6 +151,11 @@ func IsPrimitiveSchema(md *ConfigMetadata) bool {
 	}
 	_, ok := primitiveSchemaGoTypes[md.Type]
 	return ok
+}
+
+// IsArraySchema reports whether the schema represents a named array (slice) type.
+func IsArraySchema(md *ConfigMetadata) bool {
+	return md != nil && md.Type == "array"
 }
 
 func PrimitiveGoType(md *ConfigMetadata, rootPackage, componentPackage string) (string, error) {

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -120,6 +120,46 @@ func TestPrimitiveGoType(t *testing.T) {
 	}
 }
 
+func TestIsArraySchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *ConfigMetadata
+		expected bool
+	}{
+		{
+			name:     "array type",
+			metadata: &ConfigMetadata{Type: "array"},
+			expected: true,
+		},
+		{
+			name:     "array with items",
+			metadata: &ConfigMetadata{Type: "array", Items: &ConfigMetadata{Type: "string"}},
+			expected: true,
+		},
+		{
+			name:     "object type",
+			metadata: &ConfigMetadata{Type: "object"},
+			expected: false,
+		},
+		{
+			name:     "primitive type",
+			metadata: &ConfigMetadata{Type: "integer"},
+			expected: false,
+		},
+		{
+			name:     "nil schema",
+			metadata: nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsArraySchema(tt.metadata))
+		})
+	}
+}
+
 func TestMapGoType_FormattedStrings(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/mdatagen/internal/samplepkg/config.schema.json
+++ b/cmd/mdatagen/internal/samplepkg/config.schema.json
@@ -3,6 +3,38 @@
   "$id": "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplepkg",
   "title": "pkg/samplepkg",
   "$defs": {
+    "map_list": {
+      "description": "MapList is a list of name/value pairs.",
+      "type": "array",
+      "items": {
+        "description": "Pair is an element of a MapList, consisting of a name and a value.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the pair.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The value of the pair.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "pair": {
+      "description": "Pair is an element of a MapList, consisting of a name and a value.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the pair.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value of the pair.",
+          "type": "string"
+        }
+      }
+    },
     "port_number": {
       "description": "A port number to connect to.",
       "type": "integer",

--- a/cmd/mdatagen/internal/samplepkg/generated_config.go
+++ b/cmd/mdatagen/internal/samplepkg/generated_config.go
@@ -6,6 +6,19 @@ import (
 	"errors"
 )
 
+// MapList mapList is a list of name/value pairs.
+type MapList []Pair
+
+// Pair pair is an element of a MapList, consisting of a name and a value.
+type Pair struct {
+	// The name of the pair.
+	Name string `mapstructure:"name"`
+	// The value of the pair.
+	Value string `mapstructure:"value"`
+	// prevent unkeyed literal initialization
+	_ struct{}
+}
+
 // PortNumber a port number to connect to.
 type PortNumber int32
 

--- a/cmd/mdatagen/internal/samplepkg/generated_package_test.go
+++ b/cmd/mdatagen/internal/samplepkg/generated_package_test.go
@@ -3,9 +3,8 @@
 package samplepkg
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/mdatagen/internal/samplepkg/generated_package_test.go
+++ b/cmd/mdatagen/internal/samplepkg/generated_package_test.go
@@ -3,8 +3,9 @@
 package samplepkg
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/mdatagen/internal/samplepkg/metadata.yaml
+++ b/cmd/mdatagen/internal/samplepkg/metadata.yaml
@@ -28,3 +28,18 @@ exported_configs:
         maximum: 10000
     required:
       - host_name
+  pair:
+    type: object
+    description: Pair is an element of a MapList, consisting of a name and a value.
+    properties:
+      name:
+        type: string
+        description: The name of the pair.
+      value:
+        type: string
+        description: The value of the pair.
+  map_list:
+    type: array
+    description: MapList is a list of name/value pairs.
+    items:
+      $ref: pair

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -49,6 +49,8 @@ import (
         type {{ $typeName }} = {{ $def.ResolvedFrom | publicType }}
     {{- else if isPrimitiveSchema $def }}
         type {{ $typeName }} {{ primitiveGoType $def }}
+    {{- else if isArraySchema $def }}
+        type {{ $typeName }} {{ mapGoType $def $defName }}
     {{- else }}
         type {{ $typeName }} struct {
         {{- template "struct" $def }}
@@ -56,7 +58,7 @@ import (
     {{- end }}
 
 {{ $defValidators := extractValidators $def }}
-{{- if and $defValidators (not (isExternalRef $def.ResolvedFrom)) (not (isPrimitiveSchema $def)) }}
+{{- if and $defValidators (not (isExternalRef $def.ResolvedFrom)) (not (isPrimitiveSchema $def)) (not (isArraySchema $def)) }}
     // Validate validates the {{$typeName}} fields according to schema annotations.
     func (c *{{ $typeName }}) Validate() error {
         var err error
@@ -68,7 +70,7 @@ import (
     }
 {{- end }}
 
-    {{- if and (hasDefaultValue $def) (not (isPrimitiveSchema $def)) }}
+    {{- if and (hasDefaultValue $def) (not (isPrimitiveSchema $def)) (not (isArraySchema $def)) }}
     // NewDefault{{ $typeName }} returns a new {{ $typeName }} with default values consistent with the annotations in the schema.
     func NewDefault{{ $typeName }}() {{ $typeName }} {
         {{- if isExternalRef $def.ResolvedFrom }}

--- a/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
@@ -120,7 +120,7 @@ require.NotNil(t, cfg)
 {{- $defs := extractDefs .Metadata.Config }}
 {{ range $defName, $def := $defs }}
     {{ $defValidators := extractValidators $def }}
-    {{- if and $defValidators (not (isPrimitiveSchema $def)) }}
+    {{- if and $defValidators (not (isPrimitiveSchema $def)) (not (isArraySchema $def)) }}
         {{- template "imports" $imports_addded }}
         {{- $imports_addded = true }}
         func Test{{ $defName | publicVar }}Validate_DefaultValid(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Extends the schema-based config generation introduced in #15488 with a fourth def-rendering branch for `type: array` exported configs. Given a schema like:

```yaml
exported_configs:
    map_list:
      type: array
      items:
        $ref: pair
    pair:
      type: object
      properties:
        name: { type: string }
        value: { type: string }
```
mdatagen now generates:

```go
  type MapList []Pair
```

<!--Describe what testing was performed and which tests were added.-->
#### Testing

1. Added unit tests
2. Extended samplepkg with new functionality

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
