### PR TITLE
[confighttp] Preserve IPv6 zone when parsing client address

### DIFF
--- a/.chloggen/fix-14545-confighttp-ipv6-zone.yaml
+++ b/.chloggen/fix-14545-confighttp-ipv6-zone.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: pkg/confighttp
+note: Preserve the IPv6 zone identifier when parsing the client address, so link-local IPv6 clients no longer get a nil client.Info.Addr.
+issues: [14545]
+subtext:
+change_logs: [user]

--- a/config/confighttp/clientinfohandler.go
+++ b/config/confighttp/clientinfohandler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/collector/client"
 )
@@ -56,10 +57,19 @@ func parseIP(source string) *net.IPAddr {
 	if err == nil {
 		source = ipstr
 	}
+	// net.ParseIP does not accept an IPv6 zone identifier (e.g. "fe80::1%eth0"),
+	// so split off the zone before parsing and carry it on the result. Without
+	// this, link-local IPv6 clients end up with a nil Addr in client.Info.
+	var zone string
+	if i := strings.IndexByte(source, '%'); i >= 0 {
+		zone = source[i+1:]
+		source = source[:i]
+	}
 	ip := net.ParseIP(source)
 	if ip != nil {
 		return &net.IPAddr{
-			IP: ip,
+			IP:   ip,
+			Zone: zone,
 		}
 	}
 	return nil

--- a/config/confighttp/clientinfohandler_test.go
+++ b/config/confighttp/clientinfohandler_test.go
@@ -34,6 +34,29 @@ func TestParseIP(t *testing.T) {
 			},
 		},
 		{
+			name:  "ipv6 addr:port",
+			input: "[fe80::1]:33455",
+			expected: &net.IPAddr{
+				IP: net.ParseIP("fe80::1"),
+			},
+		},
+		{
+			name:  "ipv6 zoned addr:port",
+			input: "[fe80::1%eth0]:33455",
+			expected: &net.IPAddr{
+				IP:   net.ParseIP("fe80::1"),
+				Zone: "eth0",
+			},
+		},
+		{
+			name:  "ipv6 zoned addr",
+			input: "fe80::1%eth0",
+			expected: &net.IPAddr{
+				IP:   net.ParseIP("fe80::1"),
+				Zone: "eth0",
+			},
+		},
+		{
 			name:     "protocol://addr:port",
 			input:    "http://1.2.3.4:33455",
 			expected: nil,


### PR DESCRIPTION
#### Description

parseIP in config/confighttp/clientinfohandler.go calls net.ParseIP, which doesn't accept an IPv6 zone like fe80::1%eth0. So for link-local IPv6 clients the parse returns nil and client.Info.Addr ends up empty.

The fix peels the %zone off before parsing and sets it on net.IPAddr.Zone. I kept net.ParseIP instead of switching to netip.ParseAddr, since netip stores IPv4 as 4 bytes and that would break the existing net.IPv4(...) cases in the test. Existing inputs behave the same as before, just with the zone handled now.

#### Link to tracking issue

Fixes #14545

(@axw also mentioned grabbing the connection's net.Addr via ConnContext instead of parsing RemoteAddr at all. That's a bigger change and overlaps the unix-socket work in #14248, so I kept this to the minimal zone fix.)

#### Testing

Added three TestParseIP cases: plain IPv6 with port, zoned IPv6 with port, and a bare zoned IPv6. Without the source change the zoned ones come back nil; with it they pass. go test ./... and go vet ./... in config/confighttp are clean (Go 1.26).

#### Documentation

Added a .chloggen bug_fix entry.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
