### PR TITLE
[pdata/pprofile] fix wrong error sentinel in SetString

### DIFF
--- a/.chloggen/pprofile-fix-1.yaml
+++ b/.chloggen/pprofile-fix-1.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pdata/pprofile
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix wrong error sentinel in SetString
+
+# One or more tracking issues or pull requests related to the change
+issues: [15511]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/pprofile-fix-1.yaml
+++ b/.chloggen/pprofile-fix-1.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: pdata/pprofile
+component: pkg/pprofile
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: fix wrong error sentinel in SetString

--- a/pdata/pprofile/string_table.go
+++ b/pdata/pprofile/string_table.go
@@ -25,7 +25,7 @@ func SetString(table pcommon.StringSlice, val string) (int32, error) {
 	}
 
 	if table.Len() >= math.MaxInt32 {
-		return 0, errTooManyMappingTableEntries
+		return 0, errTooManyStringTableEntries
 	}
 
 	table.Append(val)


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

SetString returned errTooManyMappingTableEntries when the StringTable reached capacity, a copy-paste error from a sibling function. This caused callers checking for a full StringTable via errors.Is to not match the returned error.

Fix this by returning errTooManyStringTableEntries instead.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
