### PR TITLE
[pdata/pprofile] add bounds checks to FromAttributeIndices

### DIFF
--- a/.chloggen/pprofiles-fixes-2.yaml
+++ b/.chloggen/pprofiles-fixes-2.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
 component: pkg/pprofile

--- a/.chloggen/pprofiles-fixes-2.yaml
+++ b/.chloggen/pprofiles-fixes-2.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/pprofile
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add bounds checks to FromAttributeIndices
+
+# One or more tracking issues or pull requests related to the change
+issues: [15517]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pdata/pprofile/attributes.go
+++ b/pdata/pprofile/attributes.go
@@ -5,6 +5,7 @@ package pprofile // import "go.opentelemetry.io/collector/pdata/pprofile"
 
 import (
 	"errors"
+	"fmt"
 	"math"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -18,17 +19,25 @@ type attributable interface {
 // record.
 // The record can be any struct that implements an `AttributeIndices` method.
 // Updates made to the return map will not be applied back to the record.
-func FromAttributeIndices(table KeyValueAndUnitSlice, record attributable, dic ProfilesDictionary) pcommon.Map {
+func FromAttributeIndices(table KeyValueAndUnitSlice, record attributable, dic ProfilesDictionary) (pcommon.Map, error) {
 	m := pcommon.NewMap()
 	m.EnsureCapacity(record.AttributeIndices().Len())
 
 	for i := 0; i < record.AttributeIndices().Len(); i++ {
-		kv := table.At(int(record.AttributeIndices().At(i)))
-		key := dic.StringTable().At(int(kv.KeyStrindex()))
+		idx := record.AttributeIndices().At(i)
+		if idx < 0 || int(idx) >= table.Len() {
+			return m, fmt.Errorf("attribute index %d out of bounds [0, %d)", idx, table.Len())
+		}
+		kv := table.At(int(idx))
+		keyIdx := kv.KeyStrindex()
+		if keyIdx < 0 || int(keyIdx) >= dic.StringTable().Len() {
+			return m, fmt.Errorf("key string index %d out of bounds [0, %d)", keyIdx, dic.StringTable().Len())
+		}
+		key := dic.StringTable().At(int(keyIdx))
 		kv.Value().CopyTo(m.PutEmpty(key))
 	}
 
-	return m
+	return m, nil
 }
 
 var errTooManyAttributeTableEntries = errors.New("too many entries in AttributeTable")

--- a/pdata/pprofile/attributes_test.go
+++ b/pdata/pprofile/attributes_test.go
@@ -56,13 +56,13 @@ func TestFromAttributeIndices(t *testing.T) {
 	oob := NewLocation()
 	oob.AttributeIndices().Append(int32(table.Len()))
 	_, err = FromAttributeIndices(table, oob, dic)
-	assert.ErrorContains(t, err, "out of bounds")
+	require.ErrorContains(t, err, "out of bounds")
 
 	// Negative attribute index
 	neg := NewLocation()
 	neg.AttributeIndices().Append(-1)
 	_, err = FromAttributeIndices(table, neg, dic)
-	assert.ErrorContains(t, err, "out of bounds")
+	require.ErrorContains(t, err, "out of bounds")
 
 	// Out-of-bounds key string index
 	badKey := NewKeyValueAndUnitSlice()

--- a/pdata/pprofile/attributes_test.go
+++ b/pdata/pprofile/attributes_test.go
@@ -28,14 +28,16 @@ func TestFromAttributeIndices(t *testing.T) {
 	att2.SetKeyStrindex(2)
 	att2.Value().SetStr("monde")
 
-	attrs := FromAttributeIndices(table, NewProfile(), dic)
+	attrs, err := FromAttributeIndices(table, NewProfile(), dic)
+	require.NoError(t, err)
 	assert.Equal(t, attrs, pcommon.NewMap())
 
 	// A Location with a single attribute
 	loc := NewLocation()
 	loc.AttributeIndices().Append(0)
 
-	attrs = FromAttributeIndices(table, loc, dic)
+	attrs, err = FromAttributeIndices(table, loc, dic)
+	require.NoError(t, err)
 
 	m := map[string]any{"hello": "world"}
 	assert.Equal(t, attrs.AsRaw(), m)
@@ -44,10 +46,33 @@ func TestFromAttributeIndices(t *testing.T) {
 	mapp := NewLocation()
 	mapp.AttributeIndices().Append(0, 1)
 
-	attrs = FromAttributeIndices(table, mapp, dic)
+	attrs, err = FromAttributeIndices(table, mapp, dic)
+	require.NoError(t, err)
 
 	m = map[string]any{"hello": "world", "bonjour": "monde"}
 	assert.Equal(t, attrs.AsRaw(), m)
+
+	// Out-of-bounds attribute index
+	oob := NewLocation()
+	oob.AttributeIndices().Append(int32(table.Len()))
+	_, err = FromAttributeIndices(table, oob, dic)
+	assert.ErrorContains(t, err, "out of bounds")
+
+	// Negative attribute index
+	neg := NewLocation()
+	neg.AttributeIndices().Append(-1)
+	_, err = FromAttributeIndices(table, neg, dic)
+	assert.ErrorContains(t, err, "out of bounds")
+
+	// Out-of-bounds key string index
+	badKey := NewKeyValueAndUnitSlice()
+	bk := badKey.AppendEmpty()
+	bk.SetKeyStrindex(int32(dic.StringTable().Len()))
+	bk.Value().SetStr("x")
+	badKeyRec := NewLocation()
+	badKeyRec.AttributeIndices().Append(0)
+	_, err = FromAttributeIndices(badKey, badKeyRec, dic)
+	assert.ErrorContains(t, err, "out of bounds")
 }
 
 func BenchmarkFromAttributeIndices(b *testing.B) {
@@ -68,7 +93,7 @@ func BenchmarkFromAttributeIndices(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		_ = FromAttributeIndices(table, obj, dic)
+		_, _ = FromAttributeIndices(table, obj, dic)
 	}
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

FromAttributeIndices passed AttributeIndices values directly to table.At() and StringTable.At() without validating them first. An out-of-range or negative index causes a panic, crashing the collector process.

Fix this by checking each index against the respective table length before access and returning a descriptive error instead.

> [!NOTE]
> As this is a breaking change, the respective change for OTel collector contrib is https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49373/.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
