### PR TITLE
[config/configgrpc] Return per-RPC credentials error when building gRPC client

### DIFF
--- a/.chloggen/configgrpc-perrpc-cred-error.yaml
+++ b/.chloggen/configgrpc-perrpc-cred-error.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/config/configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Surface the error from a client authenticator's `PerRPCCredentials` when building a gRPC client, instead of silently dropping it.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15520]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -436,7 +436,7 @@ func (cc *ClientConfig) getGrpcDialOptions(
 
 		perRPCCredentials, perr := grpcAuthenticator.PerRPCCredentials()
 		if perr != nil {
-			return nil, err
+			return nil, perr
 		}
 		opts = append(opts, grpc.WithPerRPCCredentials(perRPCCredentials))
 	}

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -591,6 +591,16 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			},
 		},
 		{
+			err: "failed to get per-RPC credentials",
+			settings: ClientConfig{
+				Endpoint: "localhost:1234",
+				Auth:     configoptional.Some(configauth.Config{AuthenticatorID: testAuthID}),
+			},
+			extensions: map[component.ID]component.Component{
+				testAuthID: extensionauthtest.NewErr(errors.New("failed to get per-RPC credentials")),
+			},
+		},
+		{
 			err: "unsupported compression type \"zlib\"",
 			settings: ClientConfig{
 				Endpoint: "localhost:1234",


### PR DESCRIPTION
#### Description

When building a gRPC client, `getGrpcDialOptions` calls the configured client
authenticator's `PerRPCCredentials()`. If that returns an error, the method was
returning `err` instead of `perr`. But `err` is the outer, already-nil-or-unrelated
error from `ToClientConn`, so the authenticator's failure was silently swallowed
and the caller saw a generic dial error instead of the real reason the credentials
could not be obtained. This returns `perr` so the actual error surfaces.

#### Link to tracking issue
Fixes #

#### Testing

Extended `TestGRPCClientSettingsError` with a case whose authenticator returns a
`PerRPCCredentials` error; the client config now produces that error ("failed to
get per-RPC credentials") rather than falling through. `go test ./config/configgrpc/...` passes.

#### Documentation

None. This is a behavior-preserving error-propagation fix. Added
`.chloggen/configgrpc-perrpc-cred-error.yaml` (`change_type: bug_fix`,
`component: pkg/config/configgrpc`).

#### Authorship

- [x] I, a human, wrote this pull request description myself.
