### PR TITLE
[chore]: enable noctx linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     - govet
     - misspell
     - modernize
+    - noctx
     - nolintlint
     - perfsprint
     - revive

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -4,6 +4,7 @@
 package builder // import "go.opentelemetry.io/collector/cmd/builder/internal/builder"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -155,7 +156,7 @@ func (c *Config) Validate() error {
 func (c *Config) SetGoPath() error {
 	if !c.SkipCompilation || !c.SkipGetModules {
 		//nolint:gosec // #nosec G204
-		if _, err := exec.Command(c.Distribution.Go, "env").CombinedOutput(); err != nil {
+		if _, err := exec.CommandContext(context.Background(), c.Distribution.Go, "env").CombinedOutput(); err != nil {
 			path, err := exec.LookPath("go")
 			if err != nil {
 				return ErrGoNotFound

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -5,6 +5,7 @@ package builder // import "go.opentelemetry.io/collector/cmd/builder/internal/bu
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -38,7 +39,7 @@ func runGoCommand(cfg *Config, args ...string) ([]byte, error) {
 	}
 
 	//nolint:gosec // #nosec G204 -- cfg.Distribution.Go is trusted to be a safe path and the caller is assumed to have carried out necessary input validation
-	cmd := exec.Command(cfg.Distribution.Go, args...)
+	cmd := exec.CommandContext(context.Background(), cfg.Distribution.Go, args...)
 	cmd.Dir = cfg.Distribution.OutputPath
 
 	cmd.Env = os.Environ()

--- a/cmd/builder/internal/command_init.go
+++ b/cmd/builder/internal/command_init.go
@@ -5,6 +5,7 @@ package internal // import "go.opentelemetry.io/collector/cmd/builder/internal"
 
 import (
 	"bytes"
+	"context"
 	"embed"
 	"errors"
 	"fmt"
@@ -105,7 +106,7 @@ func run(path string) error {
 		return fmt.Errorf("failed creating build folder: %w", err)
 	}
 
-	err = runTidy(path)
+	err = runTidy(context.Background(), path)
 	if err != nil {
 		return fmt.Errorf("failed running go mod tidy: %w", err)
 	}
@@ -157,8 +158,8 @@ func executeTemplate(tmplFile string, m metadata) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func runTidy(path string) error {
-	cmd := exec.Command("go", "mod", "tidy")
+func runTidy(ctx context.Context, path string) error {
+	cmd := exec.CommandContext(ctx, "go", "mod", "tidy")
 	cmd.Dir = path
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/mdatagen/internal/helpers/packages.go
+++ b/cmd/mdatagen/internal/helpers/packages.go
@@ -4,6 +4,7 @@
 package helpers // import "go.opentelemetry.io/collector/cmd/mdatagen/internal/helpers"
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,7 +21,7 @@ func RootPackage(componentDir string) (string, error) {
 		return "", err
 	}
 
-	cmd := exec.Command("go", "list", "-m")
+	cmd := exec.CommandContext(context.Background(), "go", "list", "-m")
 	cmd.Dir = rootModDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -112,7 +112,7 @@ func shortFolderName(filePath string) string {
 }
 
 func packageName(filePath string) (string, error) {
-	cmd := exec.Command("go", "list", "-f", "{{.ImportPath}}")
+	cmd := exec.CommandContext(context.Background(), "go", "list", "-f", "{{.ImportPath}}")
 	cmd.Dir = filePath
 	output, err := cmd.Output()
 	if err != nil {

--- a/config/confighttp/client_middleware_test.go
+++ b/config/confighttp/client_middleware_test.go
@@ -123,7 +123,7 @@ func TestClientMiddlewares(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a request to the test server
-			req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, http.NoBody)
 			require.NoError(t, err)
 
 			// Send the request

--- a/config/confighttp/client_test.go
+++ b/config/confighttp/client_test.go
@@ -516,7 +516,7 @@ func TestHTTPClientHeaders(t *testing.T) {
 				Headers:         tt.headers,
 			}
 			client, _ := setting.ToClient(context.Background(), nil, componenttest.NewNopTelemetrySettings())
-			req, err := http.NewRequest(http.MethodGet, setting.Endpoint, http.NoBody)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, setting.Endpoint, http.NoBody)
 			require.NoError(t, err)
 			_, err = client.Do(req)
 			assert.NoError(t, err)
@@ -552,7 +552,7 @@ func TestHTTPClientHostHeader(t *testing.T) {
 			Headers:         tt.headers,
 		}
 		client, _ := setting.ToClient(context.Background(), nil, componenttest.NewNopTelemetrySettings())
-		req, err := http.NewRequest(http.MethodGet, setting.Endpoint, http.NoBody)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, setting.Endpoint, http.NoBody)
 		require.NoError(t, err)
 		_, err = client.Do(req)
 		assert.NoError(t, err)

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -160,7 +160,7 @@ func TestHTTPClientCompression(t *testing.T) {
 
 			reqBody := bytes.NewBuffer(testBody)
 
-			req, err := http.NewRequest(http.MethodGet, srv.URL, reqBody)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, reqBody)
 			require.NoError(t, err, "failed to create request to test handler")
 			clientSettings := ClientConfig{
 				Endpoint:          srv.URL,
@@ -213,7 +213,7 @@ func TestHTTPCustomDecompression(t *testing.T) {
 
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, bytes.NewBuffer([]byte("123decompressed body")))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, bytes.NewBuffer([]byte("123decompressed body")))
 	require.NoError(t, err, "failed to create request to test handler")
 	req.Header.Set("Content-Encoding", "custom-encoding")
 
@@ -359,7 +359,7 @@ func TestHTTPContentDecompressionHandler(t *testing.T) {
 			}), defaultMaxRequestBodySize, defaultErrorHandler, defaultCompressionAlgorithms(), noDecoders))
 			t.Cleanup(srv.Close)
 
-			req, err := http.NewRequest(http.MethodGet, srv.URL, tt.reqBody)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, tt.reqBody)
 			require.NoError(t, err, "failed to create request to test handler")
 			req.Header.Set("Content-Encoding", tt.encoding)
 
@@ -494,7 +494,7 @@ func TestEmptyCompressionAlgorithmsAllowsUncompressed(t *testing.T) {
 			}
 
 			// Create request
-			req, err := http.NewRequest(http.MethodPost, testSrv.URL, bytes.NewReader(requestBody))
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, testSrv.URL, bytes.NewReader(requestBody))
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 
@@ -698,7 +698,7 @@ func TestCompressionAlgorithmsEdgeCases(t *testing.T) {
 			)
 			t.Cleanup(srv.Close)
 
-			req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewReader(tt.body))
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, bytes.NewReader(tt.body))
 			require.NoError(t, err)
 
 			if tt.contentEncoding != "" {
@@ -753,7 +753,7 @@ func TestDecompressionPanicRecovery(t *testing.T) {
 	)
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewReader(testBody))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, bytes.NewReader(testBody))
 	require.NoError(t, err)
 	req.Header.Set("Content-Encoding", "panic-codec")
 
@@ -776,7 +776,7 @@ func TestHTTPContentCompressionRequestWithNilBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, http.NoBody)
 	require.NoError(t, err, "failed to create request to test handler")
 
 	client := srv.Client()
@@ -797,7 +797,7 @@ func TestHTTPContentCompressionCopyError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, iotest.ErrReader(errors.New("read failed")))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, iotest.ErrReader(errors.New("read failed")))
 	require.NoError(t, err)
 
 	client := srv.Client()
@@ -822,7 +822,7 @@ func TestHTTPContentCompressionRequestBodyCloseError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, &closeFailBody{Buffer: bytes.NewBuffer([]byte("blank"))})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, &closeFailBody{Buffer: bytes.NewBuffer([]byte("blank"))})
 	require.NoError(t, err)
 
 	client := srv.Client()
@@ -842,7 +842,7 @@ func TestOverrideCompressionList(t *testing.T) {
 	}), defaultMaxRequestBodySize, defaultErrorHandler, configuredDecoders, nil))
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, compressSnappyFramed(t, []byte("123decompressed body")))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, compressSnappyFramed(t, []byte("123decompressed body")))
 	require.NoError(t, err, "failed to create request to test handler")
 	req.Header.Set("Content-Encoding", "snappy")
 

--- a/config/confighttp/server_test.go
+++ b/config/confighttp/server_test.go
@@ -265,7 +265,9 @@ func TestHTTPServerTLS(t *testing.T) {
 				client.Transport.(*http.Transport).ForceAttemptHTTP2 = false
 			}
 
-			resp, errResp := client.Get(cc.Endpoint)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, cc.Endpoint, http.NoBody)
+			require.NoError(t, err)
+			resp, errResp := client.Do(req)
 			if tt.hasError {
 				require.Error(t, errResp)
 			} else {
@@ -295,13 +297,16 @@ func TestHTTPServerTransport(t *testing.T) {
 
 			client := http.Client{
 				Transport: &http.Transport{
-					DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-						return net.Dial("unix", addr)
+					DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+						d := net.Dialer{}
+						return d.DialContext(ctx, "unix", addr)
 					},
 				},
 				Timeout: 5 * time.Second, // Set a client-level timeout
 			}
-			resp, err := client.Get("http://whatever/foo")
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://whatever/foo", http.NoBody)
+			require.NoError(t, err)
+			resp, err := client.Do(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -477,7 +482,7 @@ func TestHTTPCorsExposedHeaders(t *testing.T) {
 	url := "http://" + ln.Addr().String()
 
 	// ExposedHeaders are returned on actual requests, not preflight.
-	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
 	require.NoError(t, err)
 	req.Header.Set("Origin", "http://allowed.com")
 
@@ -532,7 +537,7 @@ func TestHTTPServerHeaders(t *testing.T) {
 }
 
 func verifyCorsResp(t *testing.T, url, origin string, set configoptional.Optional[CORSConfig], extraHeader bool, wantStatus int, wantAllowed bool) {
-	req, err := http.NewRequest(http.MethodOptions, url, http.NoBody)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodOptions, url, http.NoBody)
 	require.NoError(t, err, "Error creating trace OPTIONS request: %v", err)
 	req.Header.Set("Origin", origin)
 	if extraHeader {
@@ -567,8 +572,8 @@ func verifyCorsResp(t *testing.T, url, origin string, set configoptional.Optiona
 }
 
 func verifyHeadersResp(t *testing.T, url string, expected configopaque.MapList) {
-	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
-	require.NoError(t, err, "Error creating request")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	require.NoError(t, err)
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err, "Error sending request to http server")
@@ -729,7 +734,7 @@ func TestServerWithErrorHandler(t *testing.T) {
 	// tt
 	response := &httptest.ResponseRecorder{}
 
-	req, err := http.NewRequest(http.MethodGet, srv.Addr, http.NoBody)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.Addr, http.NoBody)
 	require.NoError(t, err, "Error creating request: %v", err)
 	req.Header.Set("Content-Encoding", "something-invalid")
 
@@ -757,7 +762,7 @@ func TestServerWithDecoder(t *testing.T) {
 	// tt
 	response := &httptest.ResponseRecorder{}
 
-	req, err := http.NewRequest(http.MethodGet, srv.Addr, bytes.NewBuffer([]byte("something")))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.Addr, bytes.NewBuffer([]byte("something")))
 	require.NoError(t, err, "Error creating request: %v", err)
 	req.Header.Set("Content-Encoding", "something-else")
 
@@ -794,7 +799,7 @@ func TestServerWithDecompression(t *testing.T) {
 	testSrv := httptest.NewServer(srv.Handler)
 	defer testSrv.Close()
 
-	req, err := http.NewRequest(http.MethodGet, testSrv.URL, compressZstd(t, body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, testSrv.URL, compressZstd(t, body))
 	require.NoError(t, err, "Error creating request: %v", err)
 
 	req.Header.Set("Content-Encoding", "zstd")
@@ -974,7 +979,9 @@ func BenchmarkHTTPRequest(b *testing.B) {
 				}
 
 				for pb.Next() {
-					resp, errResp := c.Get(cc.Endpoint)
+					req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, cc.Endpoint, http.NoBody)
+					require.NoError(b, err)
+					resp, errResp := c.Do(req)
 					require.NoError(b, errResp)
 					body, errRead := io.ReadAll(resp.Body)
 					_ = resp.Body.Close()
@@ -1039,7 +1046,9 @@ func TestHTTPServerKeepAlives(t *testing.T) {
 			// we'll verify the configuration was set by testing the server behavior.
 			// The main verification is that ToServer() succeeds without error when DisableKeepAlives is set.
 
-			resp, err := http.Get("http://" + ln.Addr().String())
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+ln.Addr().String(), http.NoBody)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 			_ = resp.Body.Close()
@@ -1108,7 +1117,7 @@ func TestHTTPServerTelemetry_Tracing(t *testing.T) {
 				<-done
 			}()
 
-			req, err := http.NewRequest(tc.httpMethod, fmt.Sprintf("http://%s/b/bucket123/o/object456/segment", lis.Addr()), http.NoBody)
+			req, err := http.NewRequestWithContext(t.Context(), tc.httpMethod, fmt.Sprintf("http://%s/b/bucket123/o/object456/segment", lis.Addr()), http.NoBody)
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)

--- a/config/confighttp/xconfighttp/options_test.go
+++ b/config/confighttp/xconfighttp/options_test.go
@@ -52,7 +52,7 @@ func TestServerWithOtelHTTPOptions(t *testing.T) {
 
 	for _, path := range []string{"/path", "/foobar"} {
 		response := &httptest.ResponseRecorder{}
-		req, err := http.NewRequest(http.MethodGet, srv.Addr+path, http.NoBody)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.Addr+path, http.NoBody)
 		require.NoError(t, err)
 		srv.Handler.ServeHTTP(response, req)
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)

--- a/config/configtls/tpm_test.go
+++ b/config/configtls/tpm_test.go
@@ -156,7 +156,8 @@ VGhpcyBpcyBub3QgYSBjZXJ0aWZpY2F0ZS4=
 
 func TestTPM_open(t *testing.T) {
 	socketPath := filepath.Join(t.TempDir(), "app.sock")
-	listener, err := net.Listen("unix", socketPath)
+	lc := &net.ListenConfig{}
+	listener, err := lc.Listen(t.Context(), "unix", socketPath)
 	require.NoError(t, err)
 	defer listener.Close()
 

--- a/confmap/provider/internal/configurablehttpprovider/provider.go
+++ b/confmap/provider/internal/configurablehttpprovider/provider.go
@@ -77,13 +77,18 @@ func (fmp *provider) createClient() (*http.Client, error) {
 	}
 }
 
-func (fmp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
+func (fmp *provider) Retrieve(ctx context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
 	if !strings.HasPrefix(uri, string(fmp.scheme)+":") {
 		return nil, fmt.Errorf("%q uri is not supported by %q provider", uri, string(fmp.scheme))
 	}
 
 	if _, err := url.ParseRequestURI(uri); err != nil {
 		return nil, fmt.Errorf("invalid uri %q: %w", uri, err)
+	}
+	// create a HTTP GET request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a HTTP GET request for uri %q: %w", uri, err)
 	}
 
 	client, err := fmp.createClient()
@@ -92,7 +97,7 @@ func (fmp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFu
 	}
 
 	// send a HTTP GET request
-	resp, err := client.Get(uri)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to download the file via HTTP GET for uri %q: %w ", uri, err)
 	}

--- a/confmap/provider/internal/configurablehttpprovider/provider_test.go
+++ b/confmap/provider/internal/configurablehttpprovider/provider_test.go
@@ -252,6 +252,35 @@ func TestRetrieveFromShutdownServer(t *testing.T) {
 	require.NoError(t, fp.Shutdown(context.Background()))
 }
 
+func TestRetrieveCanceledContext(t *testing.T) {
+	fp := New(HTTPScheme, confmaptest.NewNopProviderSettings())
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("key: value"))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := fp.Retrieve(ctx, ts.URL, nil)
+	require.ErrorContains(t, err, context.Canceled.Error())
+	require.NoError(t, fp.Shutdown(context.Background()))
+}
+
+func TestRetrieveNilContext(t *testing.T) {
+	fp := New(HTTPScheme, confmaptest.NewNopProviderSettings())
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("key: value"))
+	}))
+	defer ts.Close()
+
+	_, err := fp.Retrieve(nil, ts.URL, nil) //nolint:staticcheck // Testing nil context handling
+	require.ErrorContains(t, err, "unable to create a HTTP GET request")
+	require.NoError(t, fp.Shutdown(context.Background()))
+}
+
 func TestNonExistent(t *testing.T) {
 	fp := New(HTTPScheme, confmaptest.NewNopProviderSettings())
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/docs/rfcs/optional-config-type.md
+++ b/docs/rfcs/optional-config-type.md
@@ -142,7 +142,8 @@ func NewDefaultServerConfig() ServerConfig {
 }
 
 func (sc *ServerConfig) ToListener(ctx context.Context) (net.Listener, error) {
-  listener, err := net.Listen("tcp", sc.Endpoint)
+  lc := &net.ListenConfig{}
+  listener, err := lc.Listen(ctx, "tcp", sc.Endpoint)
   if err != nil {
     return nil, err
   }

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -300,8 +300,9 @@ func otlpProfilesReceiverOnGRPCServer(ln net.Listener, useTLS bool) (*mockProfil
 }
 
 func TestSendTraces(t *testing.T) {
+	lc := &net.ListenConfig{}
 	// Start an OTLP-compatible receiver.
-	ln, err := net.Listen("tcp", "localhost:")
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 	rcv, _ := otlpTracesReceiverOnGRPCServer(ln, false)
 	// Also closes the connection.
@@ -425,8 +426,9 @@ func TestSendTracesWhenEndpointHasHTTPScheme(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			lc := &net.ListenConfig{}
 			// Start an OTLP-compatible receiver.
-			ln, err := net.Listen("tcp", "localhost:")
+			ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 			require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 			rcv, err := otlpTracesReceiverOnGRPCServer(ln, test.useTLS)
 			require.NoError(t, err, "Failed to start mock OTLP receiver")
@@ -472,8 +474,9 @@ func TestSendTracesWhenEndpointHasHTTPScheme(t *testing.T) {
 }
 
 func TestSendMetrics(t *testing.T) {
+	lc := &net.ListenConfig{}
 	// Start an OTLP-compatible receiver.
-	ln, err := net.Listen("tcp", "localhost:")
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 	rcv := otlpMetricsReceiverOnGRPCServer(ln)
 	// Also closes the connection.
@@ -580,8 +583,9 @@ func TestSendMetrics(t *testing.T) {
 }
 
 func TestSendTraceDataServerDownAndUp(t *testing.T) {
+	lc := &net.ListenConfig{}
 	// Find the addr, but don't start the server.
-	ln, err := net.Listen("tcp", "localhost:")
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 
 	// Start an OTLP exporter and point to the receiver.
@@ -632,7 +636,7 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 
 	// First call to startServerAndMakeRequest closed the connection. There is a race condition here that the
 	// port may be reused, if this gets flaky rethink what to do.
-	ln, err = net.Listen("tcp", ln.Addr().String())
+	ln, err = lc.Listen(t.Context(), "tcp", ln.Addr().String())
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 	startServerAndMakeRequest(t, exp, td, ln)
 
@@ -643,8 +647,9 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 }
 
 func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
+	lc := &net.ListenConfig{}
 	// Find the addr, but don't start the server.
-	ln, err := net.Listen("tcp", "localhost:")
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 
 	// Start an OTLP exporter and point to the receiver.
@@ -692,7 +697,8 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 }
 
 func TestSendTracesOnResourceExhaustion(t *testing.T) {
-	ln, err := net.Listen("tcp", "localhost:")
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err)
 	rcv, _ := otlpTracesReceiverOnGRPCServer(ln, false)
 	rcv.setExportError(status.Error(codes.ResourceExhausted, "resource exhausted"))
@@ -769,8 +775,9 @@ func startServerAndMakeRequest(t *testing.T, exp exporter.Traces, td ptrace.Trac
 }
 
 func TestSendLogData(t *testing.T) {
+	lc := &net.ListenConfig{}
 	// Start an OTLP-compatible receiver.
-	ln, err := net.Listen("tcp", "localhost:")
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 	rcv := otlpLogsReceiverOnGRPCServer(ln)
 	// Also closes the connection.
@@ -873,8 +880,9 @@ func TestSendLogData(t *testing.T) {
 }
 
 func TestSendProfiles(t *testing.T) {
+	lc := &net.ListenConfig{}
 	// Start an OTLP-compatible receiver.
-	ln, err := net.Listen("tcp", "localhost:")
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 	rcv, _ := otlpProfilesReceiverOnGRPCServer(ln, false)
 	// Also closes the connection.
@@ -1038,8 +1046,9 @@ func TestSendProfilesWhenEndpointHasHTTPScheme(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			lc := &net.ListenConfig{}
 			// Start an OTLP-compatible receiver.
-			ln, err := net.Listen("tcp", "localhost:")
+			ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 			require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 			rcv, err := otlpProfilesReceiverOnGRPCServer(ln, test.useTLS)
 			require.NoError(t, err, "Failed to start mock OTLP receiver")
@@ -1086,7 +1095,8 @@ func TestSendProfilesWhenEndpointHasHTTPScheme(t *testing.T) {
 
 func TestUserAgentHeader_OverriddenByConfig(t *testing.T) {
 	// Start an OTLP-compatible receiver.
-	ln, err := net.Listen("tcp", "localhost:")
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 	rcv := otlpMetricsReceiverOnGRPCServer(ln)
 	defer rcv.srv.GracefulStop()

--- a/extension/zpagesextension/zpagesextension_test.go
+++ b/extension/zpagesextension/zpagesextension_test.go
@@ -71,8 +71,11 @@ func TestZPagesExtensionUsage(t *testing.T) {
 	// Give a chance for the server goroutine to run.
 	runtime.Gosched()
 
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+"/debug/tracez", http.NoBody)
+	require.NoError(t, err)
+
 	client := &http.Client{}
-	resp, err := client.Get("http://" + addr + "/debug/tracez")
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -99,7 +102,8 @@ func TestZPagesExtensionBadAuthExtension(t *testing.T) {
 
 func TestZPagesExtensionPortAlreadyInUse(t *testing.T) {
 	endpoint := testutil.GetAvailableLocalAddress(t)
-	ln, err := net.Listen("tcp", endpoint)
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", endpoint)
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -194,8 +198,11 @@ func TestZPagesEnableExpvar(t *testing.T) {
 	// Give a chance for the server goroutine to run.
 	runtime.Gosched()
 
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+"/debug/expvarz", http.NoBody)
+	require.NoError(t, err)
+
 	client := &http.Client{}
-	resp, err := client.Get("http://" + addr + "/debug/expvarz")
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/internal/e2e/error_propagation_test.go
+++ b/internal/e2e/error_propagation_test.go
@@ -152,7 +152,8 @@ func TestHTTPToHTTP(t *testing.T) {
 func createGRPCExporter(t *testing.T, s *status.Status) consumer.Logs {
 	t.Helper()
 
-	ln, err := net.Listen("tcp", "localhost:")
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 
 	srv := grpc.NewServer()
@@ -331,7 +332,7 @@ func createHTTPRequest(
 ) *http.Request {
 	buf := bytes.NewBuffer(data)
 
-	req, err := http.NewRequest(http.MethodPost, "http://"+url, buf)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+url, buf)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/x-protobuf")
 

--- a/internal/e2e/exporter_failure_attributes_test.go
+++ b/internal/e2e/exporter_failure_attributes_test.go
@@ -44,7 +44,7 @@ func TestExporterFailureAttributesDetailed(t *testing.T) {
 
 		otelPort, metricsPort := startFailureAttributeCollector(t, server.URL)
 
-		require.NoError(t, sendTestMetrics(otelPort))
+		require.NoError(t, sendTestMetrics(t, otelPort))
 
 		require.Eventually(t, func() bool {
 			metric := scrapeFailureMetric(t, metricsPort, "otlp_http/test")
@@ -73,7 +73,7 @@ func TestExporterFailureAttributesDetailed(t *testing.T) {
 
 		otelPort, metricsPort := startFailureAttributeCollector(t, server.URL)
 
-		require.NoError(t, sendTestMetrics(otelPort))
+		require.NoError(t, sendTestMetrics(t, otelPort))
 		assertNoFailureMetric(t, metricsPort, "otlp_http/test")
 	})
 
@@ -89,7 +89,7 @@ func TestExporterFailureAttributesDetailed(t *testing.T) {
 
 		otelPort, metricsPort := startFailureAttributeCollector(t, server.URL)
 
-		require.NoError(t, sendTestMetrics(otelPort))
+		require.NoError(t, sendTestMetrics(t, otelPort))
 
 		require.Eventually(t, func() bool {
 			metric := scrapeFailureMetric(t, metricsPort, "otlp_http/test")
@@ -145,7 +145,11 @@ func startFailureAttributeCollector(t *testing.T, exporterEndpoint string) (stri
 	}()
 
 	require.Eventually(t, func() bool {
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/metrics", metricsPort))
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("http://localhost:%s/metrics", metricsPort), http.NoBody)
+		if err != nil {
+			return false
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return false
 		}
@@ -158,7 +162,11 @@ func startFailureAttributeCollector(t *testing.T, exporterEndpoint string) (stri
 
 func scrapeFailureMetric(t *testing.T, metricsPort, exporterName string) *dto.Metric {
 	t.Helper()
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/metrics", metricsPort))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("http://localhost:%s/metrics", metricsPort), http.NoBody)
+	if err != nil {
+		return nil
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil
 	}

--- a/internal/e2e/internal_telemetry_test.go
+++ b/internal/e2e/internal_telemetry_test.go
@@ -169,7 +169,7 @@ service:
 			waitMetricsReady(t, metricsPort)
 
 			// Send some data through the pipeline to trigger internal telemetry
-			err = sendTestTraces(otlphttpPort)
+			err = sendTestTraces(t, otlphttpPort)
 			require.NoError(t, err)
 
 			// Capture service.instance.id from the Prometheus endpoint

--- a/internal/e2e/metric_stability_test.go
+++ b/internal/e2e/metric_stability_test.go
@@ -231,12 +231,12 @@ func testMetricStability(t *testing.T, configFile string, expectedMetrics map[st
 }
 
 func sendTestData(t *testing.T, otelPort string) {
-	require.NoError(t, sendTestMetrics(otelPort))
-	require.NoError(t, sendTestTraces(otelPort))
-	require.NoError(t, sendTestLogs(otelPort))
+	require.NoError(t, sendTestMetrics(t, otelPort))
+	require.NoError(t, sendTestTraces(t, otelPort))
+	require.NoError(t, sendTestLogs(t, otelPort))
 }
 
-func sendTestMetrics(otelPort string) error {
+func sendTestMetrics(t *testing.T, otelPort string) error {
 	metrics := pmetric.NewMetrics()
 	rm := metrics.ResourceMetrics().AppendEmpty()
 	sm := rm.ScopeMetrics().AppendEmpty()
@@ -256,7 +256,7 @@ func sendTestMetrics(otelPort string) error {
 		return fmt.Errorf("failed to marshal metrics: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/metrics", otelPort), bytes.NewReader(metricsBytes))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/metrics", otelPort), bytes.NewReader(metricsBytes))
 	if err != nil {
 		return fmt.Errorf("failed to create metrics request: %w", err)
 	}
@@ -271,7 +271,7 @@ func sendTestMetrics(otelPort string) error {
 	return nil
 }
 
-func sendTestTraces(otelPort string) error {
+func sendTestTraces(t *testing.T, otelPort string) error {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	ss := rs.ScopeSpans().AppendEmpty()
@@ -291,7 +291,7 @@ func sendTestTraces(otelPort string) error {
 		return fmt.Errorf("failed to marshal traces: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/traces", otelPort), bytes.NewReader(tracesBytes))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/traces", otelPort), bytes.NewReader(tracesBytes))
 	if err != nil {
 		return fmt.Errorf("failed to create traces request: %w", err)
 	}
@@ -306,7 +306,7 @@ func sendTestTraces(otelPort string) error {
 	return nil
 }
 
-func sendTestLogs(otelPort string) error {
+func sendTestLogs(t *testing.T, otelPort string) error {
 	logs := plog.NewLogs()
 	rl := logs.ResourceLogs().AppendEmpty()
 	sl := rl.ScopeLogs().AppendEmpty()
@@ -324,7 +324,7 @@ func sendTestLogs(otelPort string) error {
 		return fmt.Errorf("failed to marshal logs: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/logs", otelPort), bytes.NewReader(logsBytes))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/logs", otelPort), bytes.NewReader(logsBytes))
 	if err != nil {
 		return fmt.Errorf("failed to create logs request: %w", err)
 	}
@@ -341,7 +341,8 @@ func sendTestLogs(otelPort string) error {
 
 func getFreePort(t *testing.T) string {
 	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	lc := &net.ListenConfig{}
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("could not get free port: %v", err)
 	}
@@ -356,7 +357,9 @@ func waitMetricsReady(t *testing.T, metricsPort string) {
 }
 
 func readMetrics(t require.TestingT, metricsPort string) map[string]*dto.MetricFamily {
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/metrics", metricsPort))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("http://localhost:%s/metrics", metricsPort), http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/internal/schemagen/loader.go
+++ b/internal/schemagen/loader.go
@@ -4,6 +4,7 @@
 package schemagen // import "go.opentelemetry.io/collector/internal/schemagen"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -134,7 +135,12 @@ func (sl *schemaLoader) tryLoad(ref Ref, version string) (*ConfigMetadata, error
 		return nil, fmt.Errorf("failed to construct URL for %s: %w", ref.CacheKey(), err)
 	}
 
-	resp, err := sl.httpClient.Get(url)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a HTTP GET request for url %q: %w", url, err)
+	}
+
+	resp, err := sl.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch schema from %s: %w", url, err)
 	}
@@ -192,7 +198,7 @@ func (sl *schemaLoader) refVersion(ref *Ref) (string, error) {
 			return version, nil
 		}
 		// attempt to "go get" the module to resolve version if not found locally
-		cmd := exec.Command("go", "get", modulePath) // #nosec G204
+		cmd := exec.CommandContext(context.Background(), "go", "get", modulePath) // #nosec G204
 		cmd.Dir = sl.cd
 
 		if err := cmd.Run(); err != nil {
@@ -229,7 +235,7 @@ func (sl *schemaLoader) repoRoot(componentDir string) (string, error) {
 		return sl.rootDir, nil
 	}
 
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd := exec.CommandContext(context.Background(), "git", "rev-parse", "--show-toplevel")
 	cmd.Dir = componentDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/schemagen/loader_test.go
+++ b/internal/schemagen/loader_test.go
@@ -467,6 +467,19 @@ func TestLoader_TryLoad_URLError(t *testing.T) {
 	_ = ref
 }
 
+func TestLoader_TryLoad_RequestCreationError(t *testing.T) {
+	loader := NewLoader("").(*schemaLoader)
+	ref := *NewRef("go.opentelemetry.io/collector/test/path.config")
+
+	originalURL := namespaceToURL["go.opentelemetry.io/collector"]
+	namespaceToURL["go.opentelemetry.io/collector"] = "http://bad host"
+	defer func() { namespaceToURL["go.opentelemetry.io/collector"] = originalURL }()
+
+	_, err := loader.tryLoad(ref, "v1.0.0")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to create a HTTP GET request")
+}
+
 func TestLoader_TryLoad_HTTPError(t *testing.T) {
 	// Use a server that closes connections immediately to simulate a network error
 	// The simplest approach: use an invalid URL

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -73,7 +73,8 @@ func findAvailableAddress(tb testing.TB, network string) string {
 	}
 	require.NotEmpty(tb, host, "network must be either of tcp, tcp4 or tcp6")
 
-	ln, err := net.Listen("tcp", host+":0")
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(tb.Context(), "tcp", host+":0")
 	require.NoError(tb, err, "Failed to get a free local port")
 	// There is a possible race if something else takes this same port before
 	// the test uses it, however, that is unlikely in practice.
@@ -88,9 +89,9 @@ func getExclusionsList(tb testing.TB, network string) []portpair {
 	var cmdTCP *exec.Cmd
 	switch network {
 	case "tcp", "tcp4":
-		cmdTCP = exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=tcp")
+		cmdTCP = exec.CommandContext(tb.Context(), "netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=tcp")
 	case "tcp6":
-		cmdTCP = exec.Command("netsh", "interface", "ipv6", "show", "excludedportrange", "protocol=tcp")
+		cmdTCP = exec.CommandContext(tb.Context(), "netsh", "interface", "ipv6", "show", "excludedportrange", "protocol=tcp")
 	}
 	require.NotZero(tb, cmdTCP, "network must be either of tcp, tcp4 or tcp6")
 
@@ -98,7 +99,7 @@ func getExclusionsList(tb testing.TB, network string) []portpair {
 	require.NoError(tb, errTCP)
 	exclusions := createExclusionsList(tb, string(outputTCP))
 
-	cmdUDP := exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=udp")
+	cmdUDP := exec.CommandContext(tb.Context(), "netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=udp")
 	outputUDP, errUDP := cmdUDP.CombinedOutput()
 	require.NoError(tb, errUDP)
 	exclusions = append(exclusions, createExclusionsList(tb, string(outputUDP))...)

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -14,8 +14,10 @@ import (
 func TestGetAvailableLocalAddress(t *testing.T) {
 	endpoint := GetAvailableLocalAddress(t)
 
+	lc := &net.ListenConfig{}
+
 	// Endpoint should be free.
-	ln0, err := net.Listen("tcp", endpoint)
+	ln0, err := lc.Listen(t.Context(), "tcp", endpoint)
 	require.NoError(t, err)
 	require.NotNil(t, ln0)
 	t.Cleanup(func() {
@@ -24,7 +26,7 @@ func TestGetAvailableLocalAddress(t *testing.T) {
 
 	// Ensure that the endpoint wasn't something like ":0" by checking that a
 	// second listener will fail.
-	ln1, err := net.Listen("tcp", endpoint)
+	ln1, err := lc.Listen(t.Context(), "tcp", endpoint)
 	require.Error(t, err)
 	require.Nil(t, ln1)
 }
@@ -32,8 +34,9 @@ func TestGetAvailableLocalAddress(t *testing.T) {
 func TestGetAvailableLocalIpv6Address(t *testing.T) {
 	endpoint := GetAvailableLocalIPv6Address(t)
 
+	lc := &net.ListenConfig{}
 	// Endpoint should be free.
-	ln0, err := net.Listen("tcp", endpoint)
+	ln0, err := lc.Listen(t.Context(), "tcp", endpoint)
 	require.NoError(t, err)
 	require.NotNil(t, ln0)
 	t.Cleanup(func() {
@@ -42,7 +45,7 @@ func TestGetAvailableLocalIpv6Address(t *testing.T) {
 
 	// Ensure that the endpoint wasn't something like ":0" by checking that a
 	// second listener will fail.
-	ln1, err := net.Listen("tcp", endpoint)
+	ln1, err := lc.Listen(t.Context(), "tcp", endpoint)
 	require.Error(t, err)
 	require.Nil(t, ln1)
 }

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -5,6 +5,9 @@ package testutil
 
 import (
 	"net"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,4 +78,45 @@ Start Port    End Port
 
 	emptyExclusions := createExclusionsList(t, emptyExclusionsText)
 	require.Empty(t, emptyExclusions)
+}
+
+func TestGetExclusionsListWithMockedNetsh(t *testing.T) {
+	mockDir := t.TempDir()
+	mockNetsh := filepath.Join(mockDir, "netsh")
+
+	mockOutput := `
+
+Start Port    End Port
+----------    --------
+     49697       49796
+     49797       49896
+
+* - Administered port exclusions.
+`
+
+	if runtime.GOOS == "windows" {
+		mockNetsh += ".bat"
+		batch := "@echo off\r\n" +
+			"echo.\r\n" +
+			"echo Start Port    End Port\r\n" +
+			"echo ----------    --------\r\n" +
+			"echo      49697       49796\r\n" +
+			"echo      49797       49896\r\n" +
+			"echo.\r\n" +
+			"echo * - Administered port exclusions.\r\n"
+		require.NoError(t, os.WriteFile(mockNetsh, []byte(batch), 0o700)) // #nosec G306 -- test helper executable
+	} else {
+		require.NoError(t, os.WriteFile(mockNetsh, []byte("#!/bin/sh\nprintf '%s' \""+mockOutput+"\"\n"), 0o700)) // #nosec G306 -- test helper executable
+	}
+	t.Setenv("PATH", mockDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	t.Run("tcp", func(t *testing.T) {
+		exclusions := getExclusionsList(t, "tcp")
+		require.Len(t, exclusions, 4)
+	})
+
+	t.Run("tcp6", func(t *testing.T) {
+		exclusions := getExclusionsList(t, "tcp6")
+		require.Len(t, exclusions, 4)
+	})
 }

--- a/otelcol/collector_windows_service_test.go
+++ b/otelcol/collector_windows_service_test.go
@@ -6,6 +6,7 @@
 package otelcol
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"os"
@@ -145,7 +146,7 @@ func TestCollectorAsService(t *testing.T) {
 				// Read the events from the otelcorecol source and check that they were emitted after the service
 				// command started. This is a simple validation that the messages are being logged on the
 				// Windows event log.
-				cmd := exec.Command("wevtutil.exe", "qe", "Application", "/c:1", "/rd:true", "/f:RenderedXml", "/q:*[System[Provider[@Name='otelcorecol']]]")
+				cmd := exec.CommandContext(context.Background(), "wevtutil.exe", "qe", "Application", "/c:1", "/rd:true", "/f:RenderedXml", "/q:*[System[Provider[@Name='otelcorecol']]]")
 				out, err := cmd.CombinedOutput()
 				require.NoError(t, err)
 

--- a/receiver/otlpreceiver/fuzz_test.go
+++ b/receiver/otlpreceiver/fuzz_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 func FuzzReceiverHandlers(f *testing.F) {
-	f.Fuzz(func(_ *testing.T, data []byte, pb bool, handler int) {
-		req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(data))
+	f.Fuzz(func(t *testing.T, data []byte, pb bool, handler int) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "", bytes.NewReader(data))
 		if err != nil {
 			return
 		}

--- a/receiver/otlpreceiver/internal/logs/otlp_test.go
+++ b/receiver/otlpreceiver/internal/logs/otlp_test.go
@@ -85,7 +85,8 @@ func makeLogsServiceClient(t *testing.T, lc consumer.Logs) plogotlp.GRPCClient {
 }
 
 func otlpReceiverOnGRPCServer(t *testing.T, lc consumer.Logs) net.Addr {
-	ln, err := net.Listen("tcp", "localhost:")
+	lx := &net.ListenConfig{}
+	ln, err := lx.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 
 	t.Cleanup(func() {

--- a/receiver/otlpreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp_test.go
@@ -86,7 +86,8 @@ func makeMetricsServiceClient(t *testing.T, mc consumer.Metrics) pmetricotlp.GRP
 }
 
 func otlpReceiverOnGRPCServer(t *testing.T, mc consumer.Metrics) net.Addr {
-	ln, err := net.Listen("tcp", "localhost:")
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 
 	t.Cleanup(func() {

--- a/receiver/otlpreceiver/internal/profiles/otlp_test.go
+++ b/receiver/otlpreceiver/internal/profiles/otlp_test.go
@@ -83,7 +83,8 @@ func makeProfileServiceClient(t *testing.T, tc xconsumer.Profiles) pprofileotlp.
 }
 
 func otlpReceiverOnGRPCServer(t *testing.T, tc xconsumer.Profiles) net.Addr {
-	ln, err := net.Listen("tcp", "localhost:")
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 
 	t.Cleanup(func() {

--- a/receiver/otlpreceiver/internal/trace/otlp_test.go
+++ b/receiver/otlpreceiver/internal/trace/otlp_test.go
@@ -83,7 +83,8 @@ func makeTraceServiceClient(t *testing.T, tc consumer.Traces) ptraceotlp.GRPCCli
 }
 
 func otlpReceiverOnGRPCServer(t *testing.T, tc consumer.Traces) net.Addr {
-	ln, err := net.Listen("tcp", "localhost:")
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
 
 	t.Cleanup(func() {

--- a/receiver/otlpreceiver/otlp_benchmark_test.go
+++ b/receiver/otlpreceiver/otlp_benchmark_test.go
@@ -78,7 +78,7 @@ func BenchmarkHTTPProtoLogsSequential(b *testing.B) {
 	marshaler := &plog.ProtoMarshaler{}
 	bodyBytes, err := marshaler.MarshalLogs(testdata.GenerateLogs(itemsPerRequest))
 	require.NoError(b, err)
-	req, err := http.NewRequest(http.MethodPost, "http://"+endpoint+defaultLogsURLPath, bytes.NewReader(bodyBytes))
+	req, err := http.NewRequestWithContext(b.Context(), http.MethodPost, "http://"+endpoint+defaultLogsURLPath, bytes.NewReader(bodyBytes))
 	require.NoError(b, err)
 	req.Header.Set("Content-Type", protobufContentType)
 

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -308,7 +308,7 @@ func TestHandleInvalidRequests(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.method+" "+tt.uri+" "+tt.name, func(t *testing.T) {
 			url := "http://" + addr + tt.uri
-			req, err := http.NewRequest(tt.method, url, bytes.NewReader([]byte(`1234`)))
+			req, err := http.NewRequestWithContext(t.Context(), tt.method, url, bytes.NewReader([]byte(`1234`)))
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", tt.contentType)
 
@@ -482,7 +482,7 @@ func TestOTLPReceiverInvalidContentEncoding(t *testing.T) {
 			body, err := test.reqBodyFunc()
 			require.NoError(t, err)
 
-			req, err := http.NewRequest(http.MethodPost, url, body)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, body)
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", test.content)
 			req.Header.Set("Content-Encoding", test.encoding)
@@ -514,7 +514,7 @@ func TestOTLPReceiverNoContentType(t *testing.T) {
 	t.Run("NoContentType", func(t *testing.T) {
 		body := bytes.NewBuffer([]byte(`{"key": "value"}`))
 
-		req, err := http.NewRequest(http.MethodPost, url, body)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, body)
 		require.NoError(t, err, "Error creating trace POST request: %v", err)
 
 		// Set invalid encoding to trigger an error
@@ -531,7 +531,8 @@ func TestOTLPReceiverNoContentType(t *testing.T) {
 
 func TestGRPCNewPortAlreadyUsed(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
-	ln, err := net.Listen("tcp", addr)
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", addr)
 	require.NoError(t, err, "failed to listen on %q: %v", addr, err)
 	t.Cleanup(func() {
 		assert.NoError(t, ln.Close())
@@ -545,7 +546,8 @@ func TestGRPCNewPortAlreadyUsed(t *testing.T) {
 
 func TestHTTPNewPortAlreadyUsed(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
-	ln, err := net.Listen("tcp", addr)
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", addr)
 	require.NoError(t, err, "failed to listen on %q: %v", addr, err)
 	t.Cleanup(func() {
 		assert.NoError(t, ln.Close())
@@ -809,7 +811,7 @@ func TestOTLPReceiverHTTPTracesIngestTest(t *testing.T) {
 		pbMarshaler := ptrace.ProtoMarshaler{}
 		pbBytes, err := pbMarshaler.MarshalTraces(td)
 		require.NoError(t, err)
-		req, err := http.NewRequest(http.MethodPost, "http://"+addr+defaultTracesURLPath, bytes.NewReader(pbBytes))
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+addr+defaultTracesURLPath, bytes.NewReader(pbBytes))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", pbContentType)
 		resp, err := http.DefaultClient.Do(req)
@@ -1117,7 +1119,7 @@ func createHTTPRequest(
 		t.Fatalf("Unsupported compression type %v", encoding)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, buf)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, buf)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Content-Encoding", encoding)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -253,14 +253,14 @@ func testZPages(t *testing.T, zpagesAddr string) {
 		require.NoError(t, srv.Start(context.Background()))
 
 		assert.Eventually(t, func() bool {
-			return zpagesHealthy(zpagesAddr)
+			return zpagesHealthy(t.Context(), zpagesAddr)
 		}, 10*time.Second, 100*time.Millisecond, "zpages endpoint is not healthy")
 
 		require.NoError(t, srv.Shutdown(context.Background()))
 	}
 }
 
-func zpagesHealthy(zpagesAddr string) bool {
+func zpagesHealthy(ctx context.Context, zpagesAddr string) bool {
 	paths := []string{
 		"/debug/tracez",
 		"/debug/pipelinez",
@@ -269,7 +269,11 @@ func zpagesHealthy(zpagesAddr string) bool {
 	}
 
 	for _, path := range paths {
-		resp, err := http.Get("http://" + zpagesAddr + path)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+zpagesAddr+path, http.NoBody)
+		if err != nil {
+			return false
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return false
 		}

--- a/service/telemetry/otelconftelemetry/metrics_test.go
+++ b/service/telemetry/otelconftelemetry/metrics_test.go
@@ -173,7 +173,7 @@ func getMetricsFromPrometheus(t *testing.T, endpoint string) map[string]*io_prom
 		Timeout: 10 * time.Second,
 	}
 
-	req, err := http.NewRequest(http.MethodGet, endpoint, http.NoBody)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, endpoint, http.NoBody)
 	require.NoError(t, err)
 
 	var rr *http.Response


### PR DESCRIPTION
#### Description
This focuses on improving context propagation and test reliability, as well as enforcing better linting practices. The main changes involve consistently using context.Context with all exec.Command and HTTP request invocations, updating tests to use context-aware request creation, and adding a new linter to prevent missing contexts.

**Linting and code quality:**

Added the [noctx](https://golangci-lint.run/docs/linters/configuration/#noctx) linter to .golangci.yml to enforce that all subprocess and network operations use a context, helping prevent resource leaks and improving code quality.

**Test and network improvements:**

Updated custom DialContext usage in HTTP client transport to ensure the context is properly propagated when dialing network connections.

These changes improve the robustness, maintainability, and testability of the codebase by enforcing best practices around context usage and process management.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
