### PR TITLE
[chore] Add clarification about org membership check

### DIFF
--- a/.github/workflows/check-pr-issue-link.yml
+++ b/.github/workflows/check-pr-issue-link.yml
@@ -39,5 +39,5 @@ jobs:
             echo "Found a linked issue."
             exit 0
           fi
-          echo '::error::Pull requests from non-members must have a linked issue. Link one from the description, for example "Fixes #1234".'
+          echo '::error::Pull requests from non-members must have a linked issue. Link one in the description, for example "Fixes #1234". If you are an OpenTelemetry org member, make your membership public to skip this check: https://docs.github.com/en/account-and-profile/how-tos/organization-membership/publicizing-or-hiding-organization-membership'
           exit 1


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

On the check-pr-issue-link workflow, we check `author_association == MEMBER`, but this is only true when their membership is public. This adds a message with a link to Github docs so people can make their membership public.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
