### PR TITLE
[featuregate] Fix panic on empty feature gate identifier

### DIFF
--- a/.chloggen/fix-featuregate-empty-element.yaml
+++ b/.chloggen/fix-featuregate-empty-element.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix panic when a `--feature-gates` value contains an empty comma-separated element (e.g. `--feature-gates=alpha,`)
+
+# One or more tracking issues or pull requests related to the change
+issues: [15536]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: An empty identifier now produces a returned error instead of an index-out-of-range panic during flag parsing.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -5,6 +5,7 @@ package featuregate // import "go.opentelemetry.io/collector/featuregate"
 
 import (
 	"flag"
+	"fmt"
 	"strings"
 
 	"go.uber.org/multierr"
@@ -57,6 +58,10 @@ func (f *flagValue) Set(s string) error {
 	ids := strings.Split(s, ",")
 	for i := range ids {
 		id := ids[i]
+		if id == "" {
+			errs = multierr.Append(errs, fmt.Errorf("empty feature gate identifier at index %d", i))
+			continue
+		}
 		val := true
 		switch id[0] {
 		case '-':

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -26,6 +26,27 @@ func TestNewFlag(t *testing.T) {
 			expectedStr: "-alpha,beta,-deprecated,stable",
 		},
 		{
+			name:           "trailing empty item",
+			input:          "alpha,",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
+			expectedStr:    "alpha,beta,-deprecated,stable",
+		},
+		{
+			name:           "leading empty item",
+			input:          ",alpha",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
+			expectedStr:    "alpha,beta,-deprecated,stable",
+		},
+		{
+			name:           "only comma",
+			input:          ",",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
+			expectedStr:    "-alpha,beta,-deprecated,stable",
+		},
+		{
 			name:        "simple enable alpha",
 			input:       "alpha",
 			expected:    map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},


### PR DESCRIPTION
#### Description
`--feature-gates` splits its value on `,`. An empty comma-separated element (`--feature-gates=alpha,`, `,alpha`, or `,`) yielded an empty id and `switch id[0]` panicked with index-out-of-range during flag parsing, crashing the collector at startup. This returns a descriptive error for the empty element instead. #5663 guarded only the fully-empty value; this covers the per-element case.

#### Link to tracking issue
Fixes #15536

#### Testing
Added trailing / leading / only-comma cases to `TestNewFlag`; `go test -race ./featuregate/...` passes.

#### Documentation
None -- bug fix, no behavior change beyond replacing a panic with an error.

#### Authorship

- [x] I, a human, wrote this pull request description myself