### PR TITLE
[confmap] Fix drive-letter shortcut matching non-letter ASCII characters

### DIFF
--- a/.chloggen/fix-confmap-drive-letter-regex.yaml
+++ b/.chloggen/fix-confmap-drive-letter-regex.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Restrict the drive-letter detection to real letters so non-letter URIs are no longer misread as file paths
+
+# One or more tracking issues or pull requests related to the change
+issues: [15525]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The drive-letter shortcut used the `[A-z]` character class, which also matches
+  the ASCII characters between `Z` and `a` (`[`, `\`, `]`, `^`, `_`, and `` ` ``).
+  A config URI beginning with one of those followed by `:` was silently treated
+  as a file path instead of failing scheme validation. It now uses `[A-Za-z]`.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -18,7 +18,7 @@ import (
 
 // follows drive-letter specification:
 // https://datatracker.ietf.org/doc/html/draft-kerwin-file-scheme-07.html#section-2.2
-var driverLetterRegexp = regexp.MustCompile("^[A-z]:")
+var driverLetterRegexp = regexp.MustCompile("^[A-Za-z]:")
 
 // Resolver resolves a configuration as a Conf.
 type Resolver struct {
@@ -135,7 +135,7 @@ func NewResolver(set ResolverSettings) (*Resolver, error) {
 	for i, uri := range set.URIs {
 		// For backwards compatibility:
 		// - empty url scheme means "file".
-		// - "^[A-z]:" also means "file"
+		// - "^[A-Za-z]:" also means "file"
 		if driverLetterRegexp.MatchString(uri) || !strings.Contains(uri, ":") {
 			uris[i] = location{scheme: "file", opaqueValue: uri}
 			continue

--- a/confmap/resolver_test.go
+++ b/confmap/resolver_test.go
@@ -130,6 +130,26 @@ func TestNewResolverDuplicateScheme(t *testing.T) {
 	assert.EqualError(t, err, `duplicate 'confmap.Provider' scheme "mock"`)
 }
 
+func TestNewResolverDriveLetterShortcut(t *testing.T) {
+	// The drive-letter shortcut treats "^<ALPHA>:" URIs as file paths for
+	// backwards compatibility. It must only fire for real letters (A-Z/a-z),
+	// not for the ASCII characters between 'Z' and 'a' ([ \ ] ^ _ `).
+	t.Run("non-letter prefix is not a drive letter", func(t *testing.T) {
+		for _, uri := range []string{"_:foo", "]:foo"} {
+			_, err := NewResolver(ResolverSettings{URIs: []string{uri}, ProviderFactories: []ProviderFactory{newMockProvider(&mockProvider{scheme: "mock"})}})
+			assert.EqualError(t, err, `invalid uri: "`+uri+`"`)
+		}
+	})
+	t.Run("letter prefix resolves to the file provider", func(t *testing.T) {
+		for _, uri := range []string{"c:/config.yaml", "Z:/config.yaml"} {
+			r, err := NewResolver(ResolverSettings{URIs: []string{uri}, ProviderFactories: []ProviderFactory{newFileProvider(t)}})
+			require.NoError(t, err)
+			require.Len(t, r.uris, 1)
+			assert.Equal(t, "file", r.uris[0].scheme)
+		}
+	})
+}
+
 func TestResolverErrors(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
I found that the drive-letter shortcut used `[A-z]`, which includes six non-letter ASCII characters between `Z` and `a`. As a result, values such as `_:foo` could be treated as Windows file paths instead of rejected as invalid URIs.

I changed the expression to `[A-Za-z]` so the shortcut accepts only letter-prefixed drive paths. I also added coverage showing that non-letter prefixes are rejected while lowercase and uppercase drive letters still select the file provider.

### Authorship
- [ ] I, a human, wrote this pull request description myself.