### PR TITLE
[processor/memorylimiter] Fix data race on host when shared across pipelines

### DIFF
--- a/.chloggen/fix-memorylimiter-host-race.yaml
+++ b/.chloggen/fix-memorylimiter-host-race.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: processor/memory_limiter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a data race on the shared memory limiter host when the processor is used in more than one pipeline
+
+# One or more tracking issues or pull requests related to the change
+issues: [15197]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  A single memory limiter instance is shared across every pipeline that uses the
+  same configuration, so its Start hook runs once per pipeline. The monitor
+  goroutine started by the first Start reads the host on each check while later
+  Start calls wrote it, racing the read. The host is now stored atomically.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/memorylimiter/memorylimiter.go
+++ b/internal/memorylimiter/memorylimiter.go
@@ -96,7 +96,11 @@ type MemoryLimiter struct {
 	waitGroup      sync.WaitGroup
 	closed         chan struct{}
 
-	host component.Host
+	// host is set on every Start and read by the monitor goroutine (via
+	// componentstatus.ReportStatus) without holding refCounterLock, so it is
+	// stored atomically to avoid a data race when a shared instance is started
+	// by more than one pipeline while the goroutine is already running.
+	host atomic.Pointer[component.Host]
 }
 
 // NewMemoryLimiter returns a new memory limiter component
@@ -129,7 +133,7 @@ func NewMemoryLimiter(cfg *Config, logger *zap.Logger) (*MemoryLimiter, error) {
 }
 
 func (ml *MemoryLimiter) Start(_ context.Context, host component.Host) error {
-	ml.host = host
+	ml.host.Store(&host)
 	ml.refCounterLock.Lock()
 	defer ml.refCounterLock.Unlock()
 
@@ -253,6 +257,15 @@ func (ml *MemoryLimiter) nextBackoffInterval(current, configMin, configMax time.
 	return min(max(current, minInterval)*2, maxInterval)
 }
 
+// reportStatus reports a status event to the host set by the most recent
+// Start. The host is loaded atomically because Start may run concurrently
+// with the monitor goroutine that calls this method.
+func (ml *MemoryLimiter) reportStatus(event *componentstatus.Event) {
+	if host := ml.host.Load(); host != nil {
+		componentstatus.ReportStatus(*host, event)
+	}
+}
+
 // CheckMemLimits inspects current memory usage against threshold and toggles mustRefuse when threshold is exceeded
 func (ml *MemoryLimiter) CheckMemLimits() {
 	ms := ml.readMemStats()
@@ -269,7 +282,7 @@ func (ml *MemoryLimiter) CheckMemLimits() {
 			// Was previously refusing but enough memory is available now, no need to limit.
 			ml.logger.Info("Memory usage back within limits. Resuming normal operation.", memstatToZapField(ms))
 		}
-		componentstatus.ReportStatus(ml.host, componentstatus.NewEvent(componentstatus.StatusOK))
+		ml.reportStatus(componentstatus.NewEvent(componentstatus.StatusOK))
 		ml.mustRefuse.Store(aboveSoftLimit)
 		return
 	}
@@ -297,13 +310,13 @@ func (ml *MemoryLimiter) CheckMemLimits() {
 	}
 
 	if !ml.mustRefuse.Load() && aboveSoftLimit {
-		componentstatus.ReportStatus(ml.host, componentstatus.NewRecoverableErrorEvent(ErrDataRefused))
+		ml.reportStatus(componentstatus.NewRecoverableErrorEvent(ErrDataRefused))
 		ml.logger.Warn("Memory usage is above soft limit. Refusing data.", memstatToZapField(ms))
 	}
 
 	if !aboveSoftLimit {
 		// GC brought memory back within limits in this same tick — report OK immediately.
-		componentstatus.ReportStatus(ml.host, componentstatus.NewEvent(componentstatus.StatusOK))
+		ml.reportStatus(componentstatus.NewEvent(componentstatus.StatusOK))
 	}
 
 	ml.mustRefuse.Store(aboveSoftLimit)

--- a/internal/memorylimiter/memorylimiter_test.go
+++ b/internal/memorylimiter/memorylimiter_test.go
@@ -31,6 +31,12 @@ func (m *mockHost) Report(e *componentstatus.Event) {
 	m.events = append(m.events, e)
 }
 
+// setHost injects a host directly for tests that call CheckMemLimits without
+// going through Start.
+func setHost(ml *MemoryLimiter, host component.Host) {
+	ml.host.Store(&host)
+}
+
 // TestMemoryPressureResponse manipulates results from querying memory and
 // check expected side effects.
 func TestMemoryPressureResponse(t *testing.T) {
@@ -47,7 +53,7 @@ func TestMemoryPressureResponse(t *testing.T) {
 	}
 
 	host := &mockHost{}
-	ml.host = host
+	setHost(ml, host)
 
 	// Below memAllocLimit.
 	currentMemAlloc = 800
@@ -203,7 +209,7 @@ func TestCheckMemLimitsHealthEvents(t *testing.T) {
 			}, zap.NewNop())
 			require.NoError(t, err)
 			host := &mockHost{}
-			ml.host = host
+			setHost(ml, host)
 			ml.runGCFn = func() {}
 			var currentMemMiB uint64
 			ml.readMemStatsFn = func(ms *runtime.MemStats) { ms.Alloc = currentMemMiB * mibBytes }
@@ -904,7 +910,7 @@ func TestGCRecovery(t *testing.T) {
 			require.NoError(t, err)
 
 			host := &mockHost{}
-			ml.host = host
+			setHost(ml, host)
 
 			// Ensure the GC-interval guard passes on the first check.
 			ml.lastGCDone = ml.lastGCDone.Add(-time.Minute)
@@ -937,6 +943,35 @@ func TestStart(t *testing.T) {
 	ml, err := NewMemoryLimiter(cfg, zap.NewNop())
 	require.NoError(t, err)
 	require.NoError(t, ml.Start(context.Background(), host))
-	assert.Equal(t, host, ml.host)
+	assert.Equal(t, host, *ml.host.Load())
 	require.NoError(t, ml.Shutdown(context.Background()))
+}
+
+// TestStartConcurrentReuse exercises the case where a single MemoryLimiter is
+// shared across multiple pipelines: the factory caches one instance per config
+// and registers its Start hook for every pipeline, so Start is invoked more
+// than once on the same instance. The first Start launches the monitor
+// goroutine, which reads the host on every tick via componentstatus.ReportStatus;
+// subsequent Start calls must not write the host in a way that races that read.
+// Runs under `go test -race`.
+func TestStartConcurrentReuse(t *testing.T) {
+	cfg := &Config{
+		CheckInterval:  time.Millisecond,
+		MemoryLimitMiB: 1024,
+	}
+	ml, err := NewMemoryLimiter(cfg, zap.NewNop())
+	require.NoError(t, err)
+	// Keep reported memory below the soft limit so every tick reaches a
+	// status report call, continuously reading the host.
+	ml.readMemStatsFn = func(ms *runtime.MemStats) { ms.Alloc = 0 }
+
+	const starts = 8
+	for range starts {
+		require.NoError(t, ml.Start(context.Background(), componenttest.NewNopHost()))
+		// Let the monitor goroutine tick and read host between Start calls.
+		time.Sleep(2 * time.Millisecond)
+	}
+	for range starts {
+		require.NoError(t, ml.Shutdown(context.Background()))
+	}
 }


### PR DESCRIPTION
#### Description

The `memory_limiter` processor caches a single `MemoryLimiter` instance per
configuration and registers its `Start` hook for every pipeline that references
it, so `Start` runs once per pipeline on the same instance. The monitor goroutine
launched by the first `Start` reads `ml.host` on every check interval (through
`componentstatus.ReportStatus`) without holding `refCounterLock`, while each later
`Start` assigned `ml.host` without synchronization. When the processor is used in
more than one pipeline (a common setup) that concurrent read and write is a data
race, and `go test -race` reports it.

This stores the host in an `atomic.Pointer[component.Host]`, mirroring the
existing `mustRefuse *atomic.Bool` on the same struct, and routes the status
reports through a small `reportStatus` helper that loads atomically. The read
path was introduced by #15197 ("Add status reporting"); before that the goroutine
never touched the host, so this is a regression relative to the pre-status-report
behavior.

#### Link to tracking issue
Fixes #

#### Testing

Added `TestStartConcurrentReuse`, which constructs one shared instance with a 1ms
check interval and memory pinned below the soft limit so every tick reaches a
status report, then calls `Start` eight times with a short sleep between calls to
let the monitor goroutine read the host, followed by `Shutdown`. Under
`go test -race` it fails on the pre-fix source (write in `Start` vs read in
`CheckMemLimits`) and passes after the fix. `go test -race ./internal/memorylimiter`
is green, as are both consumers
(`processor/memorylimiterprocessor`, `extension/memorylimiterextension`).

#### Documentation

None. Behavior is unchanged; the fix only removes a race. Added
`.chloggen/fix-memorylimiter-host-race.yaml` (`change_type: bug_fix`,
`component: processor/memory_limiter`).

#### Authorship

- [x] I, a human, wrote this pull request description myself.
