### PR TITLE
[exporter/debug] Fix scope index in normal verbosity output

### DIFF
--- a/.chloggen/fix-debugexporter-normal-scope-index.yaml
+++ b/.chloggen/fix-debugexporter-normal-scope-index.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporter/debug
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the scope index printed by the `normal` verbosity marshaler; each scope was labelled with its parent resource's index instead of its own position
+
+# One or more tracking issues or pull requests related to the change
+issues: [15541]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Affected all four signals (logs, traces, metrics, profiles) — e.g. the second scope under a resource printed `#0` instead of `#1`.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/debugexporter/internal/normal/logs.go
+++ b/exporter/debugexporter/internal/normal/logs.go
@@ -31,7 +31,7 @@ func (normalLogsMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 		for j := 0; j < resourceLog.ScopeLogs().Len(); j++ {
 			scopeLog := resourceLog.ScopeLogs().At(j)
 
-			buffer.WriteString(fmt.Sprintf("ScopeLog #%d%s%s\n", i, writeScopeDetails(scopeLog.Scope().Name(), scopeLog.Scope().Version(), scopeLog.SchemaUrl()), writeAttributesString(scopeLog.Scope().Attributes())))
+			buffer.WriteString(fmt.Sprintf("ScopeLog #%d%s%s\n", j, writeScopeDetails(scopeLog.Scope().Name(), scopeLog.Scope().Version(), scopeLog.SchemaUrl()), writeAttributesString(scopeLog.Scope().Attributes())))
 
 			for k := 0; k < scopeLog.LogRecords().Len(); k++ {
 				logRecord := scopeLog.LogRecords().At(k)

--- a/exporter/debugexporter/internal/normal/logs_test.go
+++ b/exporter/debugexporter/internal/normal/logs_test.go
@@ -72,6 +72,30 @@ Single line log message key1=value1 key2=value2
 `,
 		},
 		{
+			name: "two scopes under one resource",
+			input: func() plog.Logs {
+				logs := plog.NewLogs()
+				resourceLogs := logs.ResourceLogs().AppendEmpty()
+				scopeLogs0 := resourceLogs.ScopeLogs().AppendEmpty()
+				scopeLogs0.Scope().SetName("scope-zero")
+				logRecord0 := scopeLogs0.LogRecords().AppendEmpty()
+				logRecord0.Body().SetStr("first message")
+				logRecord0.Attributes().PutStr("key", "value")
+				scopeLogs1 := resourceLogs.ScopeLogs().AppendEmpty()
+				scopeLogs1.Scope().SetName("scope-one")
+				logRecord1 := scopeLogs1.LogRecords().AppendEmpty()
+				logRecord1.Body().SetStr("second message")
+				logRecord1.Attributes().PutStr("key", "value")
+				return logs
+			}(),
+			expected: `ResourceLog #0
+ScopeLog #0 scope-zero
+first message key=value
+ScopeLog #1 scope-one
+second message key=value
+`,
+		},
+		{
 			name: "multiline log",
 			input: func() plog.Logs {
 				logs := plog.NewLogs()

--- a/exporter/debugexporter/internal/normal/metrics.go
+++ b/exporter/debugexporter/internal/normal/metrics.go
@@ -33,7 +33,7 @@ func (normalMetricsMarshaler) MarshalMetrics(md pmetric.Metrics) ([]byte, error)
 		for j := 0; j < resourceMetrics.ScopeMetrics().Len(); j++ {
 			scopeMetrics := resourceMetrics.ScopeMetrics().At(j)
 
-			buffer.WriteString(fmt.Sprintf("ScopeMetrics #%d%s%s\n", i, writeScopeDetails(scopeMetrics.Scope().Name(), scopeMetrics.Scope().Version(), scopeMetrics.SchemaUrl()), writeAttributesString(scopeMetrics.Scope().Attributes())))
+			buffer.WriteString(fmt.Sprintf("ScopeMetrics #%d%s%s\n", j, writeScopeDetails(scopeMetrics.Scope().Name(), scopeMetrics.Scope().Version(), scopeMetrics.SchemaUrl()), writeAttributesString(scopeMetrics.Scope().Attributes())))
 
 			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
 				metric := scopeMetrics.Metrics().At(k)

--- a/exporter/debugexporter/internal/normal/metrics_test.go
+++ b/exporter/debugexporter/internal/normal/metrics_test.go
@@ -26,6 +26,20 @@ func TestMarshalMetrics(t *testing.T) {
 			expected: "",
 		},
 		{
+			name: "two scopes under one resource",
+			input: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+				resourceMetrics.ScopeMetrics().AppendEmpty().Scope().SetName("scope-zero")
+				resourceMetrics.ScopeMetrics().AppendEmpty().Scope().SetName("scope-one")
+				return metrics
+			}(),
+			expected: `ResourceMetrics #0
+ScopeMetrics #0 scope-zero
+ScopeMetrics #1 scope-one
+`,
+		},
+		{
 			name: "sum data point",
 			input: func() pmetric.Metrics {
 				metrics := pmetric.NewMetrics()

--- a/exporter/debugexporter/internal/normal/profiles.go
+++ b/exporter/debugexporter/internal/normal/profiles.go
@@ -34,7 +34,7 @@ func (normalProfilesMarshaler) MarshalProfiles(pd pprofile.Profiles) ([]byte, er
 		for j := 0; j < resourceProfiles.ScopeProfiles().Len(); j++ {
 			scopeProfiles := resourceProfiles.ScopeProfiles().At(j)
 
-			buffer.WriteString(fmt.Sprintf("ScopeProfiles #%d%s%s\n", i, writeScopeDetails(scopeProfiles.Scope().Name(), scopeProfiles.Scope().Version(), scopeProfiles.SchemaUrl()), writeAttributesString(scopeProfiles.Scope().Attributes())))
+			buffer.WriteString(fmt.Sprintf("ScopeProfiles #%d%s%s\n", j, writeScopeDetails(scopeProfiles.Scope().Name(), scopeProfiles.Scope().Version(), scopeProfiles.SchemaUrl()), writeAttributesString(scopeProfiles.Scope().Attributes())))
 
 			for k := 0; k < scopeProfiles.Profiles().Len(); k++ {
 				profile := scopeProfiles.Profiles().At(k)

--- a/exporter/debugexporter/internal/normal/profiles_test.go
+++ b/exporter/debugexporter/internal/normal/profiles_test.go
@@ -24,6 +24,20 @@ func TestMarshalProfiles(t *testing.T) {
 			expected: "",
 		},
 		{
+			name: "two scopes under one resource",
+			input: func() pprofile.Profiles {
+				profiles := pprofile.NewProfiles()
+				resourceProfiles := profiles.ResourceProfiles().AppendEmpty()
+				resourceProfiles.ScopeProfiles().AppendEmpty().Scope().SetName("scope-zero")
+				resourceProfiles.ScopeProfiles().AppendEmpty().Scope().SetName("scope-one")
+				return profiles
+			}(),
+			expected: `ResourceProfiles #0
+ScopeProfiles #0 scope-zero
+ScopeProfiles #1 scope-one
+`,
+		},
+		{
 			name: "one profile",
 			input: func() pprofile.Profiles {
 				profiles := pprofile.NewProfiles()

--- a/exporter/debugexporter/internal/normal/traces.go
+++ b/exporter/debugexporter/internal/normal/traces.go
@@ -31,7 +31,7 @@ func (normalTracesMarshaler) MarshalTraces(md ptrace.Traces) ([]byte, error) {
 		for j := 0; j < resourceTraces.ScopeSpans().Len(); j++ {
 			scopeTraces := resourceTraces.ScopeSpans().At(j)
 
-			buffer.WriteString(fmt.Sprintf("ScopeTraces #%d%s%s\n", i, writeScopeDetails(scopeTraces.Scope().Name(), scopeTraces.Scope().Version(), scopeTraces.SchemaUrl()), writeAttributesString(scopeTraces.Scope().Attributes())))
+			buffer.WriteString(fmt.Sprintf("ScopeTraces #%d%s%s\n", j, writeScopeDetails(scopeTraces.Scope().Name(), scopeTraces.Scope().Version(), scopeTraces.SchemaUrl()), writeAttributesString(scopeTraces.Scope().Attributes())))
 
 			for k := 0; k < scopeTraces.Spans().Len(); k++ {
 				span := scopeTraces.Spans().At(k)

--- a/exporter/debugexporter/internal/normal/traces_test.go
+++ b/exporter/debugexporter/internal/normal/traces_test.go
@@ -24,6 +24,20 @@ func TestMarshalTraces(t *testing.T) {
 			expected: "",
 		},
 		{
+			name: "two scopes under one resource",
+			input: func() ptrace.Traces {
+				traces := ptrace.NewTraces()
+				resourceSpans := traces.ResourceSpans().AppendEmpty()
+				resourceSpans.ScopeSpans().AppendEmpty().Scope().SetName("scope-zero")
+				resourceSpans.ScopeSpans().AppendEmpty().Scope().SetName("scope-one")
+				return traces
+			}(),
+			expected: `ResourceTraces #0
+ScopeTraces #0 scope-zero
+ScopeTraces #1 scope-one
+`,
+		},
+		{
 			name: "one span with resource and scope attributes",
 			input: func() ptrace.Traces {
 				traces := ptrace.NewTraces()


### PR DESCRIPTION
#### Description
At `verbosity: normal`, the debug exporter labelled each scope header with the enclosing resource's loop index instead of the scope's own index, so the second scope under a resource printed `#0` instead of `#1`. This uses the scope loop index `j` instead of the resource index `i`. All four signals were affected (logs, traces, metrics, profiles). Diagnostic-output only; no data loss.

#### Link to tracking issue
Fixes #15541

#### Testing
Added a two-scopes-under-one-resource case to each of the four `normal` marshaler tests, asserting the second scope renders `#1`. Verified red before / green after the fix; `go test -race ./exporter/debugexporter/...` passes.

#### Documentation
None -- bug fix, output-format correction only.

#### Authorship

- [x] I, a human, wrote this pull request description myself