### PR TITLE
[exporterhelper] Replace fixed sleeps with Never/Eventually in queuebatch tests

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/queue_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch_test.go
@@ -289,7 +289,9 @@ func TestQueueBatch_Merge(t *testing.T) {
 
 			// the third and fifth requests should be sent by reaching the timeout
 			// the fourth request should be ignored because of the merge error.
-			time.Sleep(50 * time.Millisecond)
+			assert.Never(t, func() bool {
+				return sink.RequestsCount() != 1
+			}, 50*time.Millisecond, 10*time.Millisecond)
 
 			// should be ignored because of the merge error.
 			require.NoError(t, qb.Send(context.Background(), &requesttest.FakeRequest{
@@ -588,14 +590,14 @@ func TestQueueBatchTimerFlush(t *testing.T) {
 	}()
 
 	// Confirm that it is not flushed in 50ms
-	time.Sleep(60 * time.Millisecond)
-	assert.LessOrEqual(t, 1, sink.RequestsCount())
-	assert.Equal(t, 8, sink.ItemsCount())
+	assert.Never(t, func() bool {
+		return sink.ItemsCount() != 8
+	}, 60*time.Millisecond, 10*time.Millisecond)
 
-	// Confirm that it is flushed after 100ms (using 60+50=110 here to be safe)
-	time.Sleep(50 * time.Millisecond)
-	assert.LessOrEqual(t, 2, sink.RequestsCount())
-	assert.Equal(t, 12, sink.ItemsCount())
+	// Confirm that it is flushed after 100ms
+	assert.Eventually(t, func() bool {
+		return sink.RequestsCount() >= 2 && sink.ItemsCount() == 12
+	}, 1*time.Second, 10*time.Millisecond)
 	require.NoError(t, qb.Shutdown(context.Background()))
 }
 


### PR DESCRIPTION
The two timer-flush tests in `queue_batch_test.go` used fixed `time.Sleep` windows around the 100ms `FlushTimeout`:

- `TestQueueBatch_Merge` slept 50ms then checked the batch had **not** flushed yet.
- `TestQueueBatchTimerFlush` slept 60ms (not-yet-flushed) then 50ms (now-flushed).

The pre-flush checks are absence assertions, so a single snapshot after a fixed sleep races the flush timer — which is presumably why `TestQueueBatchTimerFlush` is already `t.Skip`-ped on Windows. This uses `assert.Never` to verify the "not flushed yet" invariant holds throughout the window, and `assert.Eventually` for the post-flush state so it passes as soon as the flush actually completes rather than after a fixed wait.

For the timer-flush test the pre-flush assertion now checks the meaningful invariant `ItemsCount() == 8` directly (the previous `assert.LessOrEqual(1, RequestsCount())` was true before the third request was even sent). The `assert.Never` primitive is already used this way in `exporter/otlpexporter/otlp_test.go`.

Test-only; no change to batching behaviour.

Verified locally: `go test ./exporter/exporterhelper/internal/queuebatch/... -run 'TestQueueBatch_Merge|TestQueueBatchTimerFlush' -count=10` — passes, no flakes; `gofmt`/`go vet` clean.