### PR TITLE
[exporter/otlp] Poll for retry backoff instead of a fixed 2s sleep

### DIFF
--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -657,6 +657,8 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 		},
 	}
 	set := exportertest.NewNopSettings(factory.Type())
+	logger, observed := observer.New(zap.DebugLevel)
+	set.Logger = zap.New(logger)
 	exp, err := factory.CreateTraces(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
@@ -678,7 +680,10 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 		done <- true
 	}()
 
-	time.Sleep(2 * time.Second)
+	// Start the server only once the request has failed to dial and entered retry backoff.
+	require.Eventually(t, func() bool {
+		return observed.FilterMessage("Exporting failed. Will retry the request after interval.").Len() > 0
+	}, 10*time.Second, 5*time.Millisecond)
 	rcv, _ := otlpTracesReceiverOnGRPCServer(ln, false)
 	defer rcv.srv.GracefulStop()
 	// Wait until one of the conditions below triggers.


### PR DESCRIPTION
TestSendTraceDataServerStartWhileRequest starts the OTLP exporter pointed at an address with no listener, fires `ConsumeTraces` in a goroutine, and slept a fixed 2s so the in-flight call could fail its first dial and enter retry backoff before the gRPC receiver is started.

The exporterhelper retry sender logs `"Exporting failed. Will retry the request after interval."` at exactly the moment the first attempt fails with a retryable error and the client enters backoff — precisely the state the sleep was approximating. This gates the server start on that log via an observed logger, the same pattern already used several times in this test file.

Beyond removing the fixed wait, it makes the scenario deterministic: the receiver is now guaranteed to start while the request is mid-retry, instead of hoping 2s was long enough. (Retry `InitialInterval` is ~2.5–7.5s and the request deadline is 10s, so the succeeding retry still lands comfortably within the deadline.)

Test-only. `go test -run TestSendTraceDataServerStartWhileRequest -count=5` passes; `gofmt`/`go vet` clean.

Assisted-by: Claude Code (Anthropic, Opus 4.8)