### PR TITLE
[service] Fix startup panic when a resource detector emits a slice-valued attribute

### DIFF
--- a/.chloggen/15571.yaml
+++ b/.chloggen/15571.yaml
@@ -1,0 +1,15 @@
+change_type: bug_fix
+
+component: pkg/service
+
+note: Fix collector startup panic when a resource detector emits a slice-valued attribute (e.g. the `process` detector's `process.command_args`)
+
+issues: [15571]
+
+subtext: |
+  `createResource` passed the OTel SDK attribute value straight into `pcommon.Value.FromRaw`, which
+  only accepts `[]any` for slices, so any string, int, float, or bool slice resource attribute produced
+  an `<Invalid value type>` error and aborted `service.New`. Slice-typed attributes are now converted
+  element-wise.
+
+change_logs: [user]

--- a/service/telemetry/otelconftelemetry/resource.go
+++ b/service/telemetry/otelconftelemetry/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	otelconf "go.opentelemetry.io/contrib/otelconf/v0.3.0"
 	xotelconf "go.opentelemetry.io/contrib/otelconf/x"
+	"go.opentelemetry.io/otel/attribute"
 	otelsdkresource "go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
@@ -107,12 +108,50 @@ func createResource(
 
 	for sdkIterator.Next() {
 		kv := sdkIterator.Attribute()
-		if err := pcommonAttributes.PutEmpty(string(kv.Key)).FromRaw(kv.Value.AsInterface()); err != nil {
-			return pcommon.Resource{}, err
-		}
+		putSDKAttribute(pcommonAttributes, string(kv.Key), kv.Value)
 	}
 
 	return pcommonResource, nil
+}
+
+// putSDKAttribute copies an OTel SDK attribute value into a pcommon.Map, handling every
+// attribute type explicitly (mirroring internal/telemetry.ToZapFields). Slice-typed values
+// (as emitted by resource detectors such as the process detector's process.command_args) are
+// built element-wise because pcommon.Value.FromRaw only accepts []any, not the typed scalar
+// slices returned by attribute.Value.AsInterface().
+func putSDKAttribute(attrs pcommon.Map, key string, value attribute.Value) {
+	switch value.Type() {
+	case attribute.BOOL:
+		attrs.PutBool(key, value.AsBool())
+	case attribute.INT64:
+		attrs.PutInt(key, value.AsInt64())
+	case attribute.FLOAT64:
+		attrs.PutDouble(key, value.AsFloat64())
+	case attribute.STRING:
+		attrs.PutStr(key, value.AsString())
+	case attribute.BOOLSLICE:
+		slice := attrs.PutEmptySlice(key)
+		for _, v := range value.AsBoolSlice() {
+			slice.AppendEmpty().SetBool(v)
+		}
+	case attribute.INT64SLICE:
+		slice := attrs.PutEmptySlice(key)
+		for _, v := range value.AsInt64Slice() {
+			slice.AppendEmpty().SetInt(v)
+		}
+	case attribute.FLOAT64SLICE:
+		slice := attrs.PutEmptySlice(key)
+		for _, v := range value.AsFloat64Slice() {
+			slice.AppendEmpty().SetDouble(v)
+		}
+	case attribute.STRINGSLICE:
+		slice := attrs.PutEmptySlice(key)
+		for _, v := range value.AsStringSlice() {
+			slice.AppendEmpty().SetStr(v)
+		}
+	default:
+		attrs.PutEmpty(key)
+	}
 }
 
 func newDetectionResourceSDK(ctx context.Context, detection *xotelconf.ExperimentalResourceDetection) (xotelconf.SDK, error) {

--- a/service/telemetry/otelconftelemetry/resource_test.go
+++ b/service/telemetry/otelconftelemetry/resource_test.go
@@ -4,12 +4,14 @@
 package otelconftelemetry // import "go.opentelemetry.io/collector/service/telemetry"
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
 	xotelconf "go.opentelemetry.io/contrib/otelconf/x"
+	"go.opentelemetry.io/otel/attribute"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
@@ -18,6 +20,31 @@ import (
 	"go.opentelemetry.io/collector/service/telemetry"
 	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry/internal/migration"
 )
+
+func TestPutSDKAttribute(t *testing.T) {
+	attrs := pcommon.NewMap()
+	putSDKAttribute(attrs, "bool", attribute.BoolValue(true))
+	putSDKAttribute(attrs, "int", attribute.Int64Value(7))
+	putSDKAttribute(attrs, "float", attribute.Float64Value(1.5))
+	putSDKAttribute(attrs, "str", attribute.StringValue("s"))
+	putSDKAttribute(attrs, "bool.slice", attribute.BoolSliceValue([]bool{true, false}))
+	putSDKAttribute(attrs, "int.slice", attribute.Int64SliceValue([]int64{1, 2}))
+	putSDKAttribute(attrs, "float.slice", attribute.Float64SliceValue([]float64{1.5, 2.5}))
+	putSDKAttribute(attrs, "str.slice", attribute.StringSliceValue([]string{"a", "b"}))
+	putSDKAttribute(attrs, "invalid", attribute.Value{})
+
+	assert.Equal(t, map[string]any{
+		"bool":        true,
+		"int":         int64(7),
+		"float":       1.5,
+		"str":         "s",
+		"bool.slice":  []any{true, false},
+		"int.slice":   []any{int64(1), int64(2)},
+		"float.slice": []any{1.5, 2.5},
+		"str.slice":   []any{"a", "b"},
+		"invalid":     nil,
+	}, attrs.AsRaw())
+}
 
 func TestCreateResource(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
@@ -124,6 +151,25 @@ func TestCreateResource(t *testing.T) {
 		assert.Contains(t, raw, "host.name")
 		assert.Contains(t, raw, "os.type")
 		assert.Contains(t, raw, "os.description")
+	})
+	t.Run("with process detector (slice-valued attribute)", func(t *testing.T) {
+		cfg := createDefaultConfig().(*Config)
+		cfg.Resource.DetectionDevelopment = &xotelconf.ExperimentalResourceDetection{
+			Detectors: []xotelconf.ExperimentalResourceDetector{
+				{Process: xotelconf.ExperimentalProcessResourceDetector{}},
+			},
+		}
+		set := telemetry.Settings{BuildInfo: component.BuildInfo{Command: "otelcol", Version: "latest"}}
+		res, err := createResource(t.Context(), set, cfg)
+		require.NoError(t, err)
+
+		raw := res.Attributes().AsRaw()
+		require.Contains(t, raw, "process.command_args")
+		expected := make([]any, len(os.Args))
+		for i, arg := range os.Args {
+			expected[i] = arg
+		}
+		assert.Equal(t, expected, raw["process.command_args"])
 	})
 	t.Run("with service detector explicit attributes still win", func(t *testing.T) {
 		cfg := createDefaultConfig().(*Config)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Enabling the `process` resource detector (or any detector emitting a slice-valued resource attribute) aborts collector startup with `<Invalid value type []string>`. `createResource` fed the OTel SDK attribute value directly into `pcommon.Value.FromRaw`, which only accepts `[]any` for slices — typed scalar slices (`[]string`/`[]int64`/`[]float64`/`[]bool`) hit the `default` error branch and abort `service.New`.

This converts slice-typed SDK attributes element-wise into a `pcommon` slice, mirroring the existing `ToZapFields` SDK-attribute converter (`internal/telemetry/attribute.go`, which type-switches on `attribute.Value.Type()`). Scalar and other types keep the existing `FromRaw` path. The `pcommon.FromRaw`/`AsRaw` `[]any`-symmetric contract (PR #6579) is intentional, so the fix is caller-side rather than in pdata.


<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15571

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a `TestCreateResource` subtest exercising the `process` detector; it asserts the collector resource is built and `process.command_args` is a proper element-wise slice equal to `os.Args` (not a stringified `"[...]"`). Red before the fix (`<Invalid value type []string>`), green after. Full `service/telemetry/otelconftelemetry` module passes with `-race`.


<!--Describe the documentation added.-->
#### Documentation

No changes.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
