### PR TITLE
config/configtls: gate TPM key loading behind `!requirefips`

### DIFF
--- a/.chloggen/fips-tpm-gate.yaml
+++ b/.chloggen/fips-tpm-gate.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/config/configtls
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Gate TPM key loading behind the `!requirefips` build tag. When building with `requirefips` (FIPS 140-3 mode), configuring a TPM key now returns an explicit error instead of pulling ChaCha20-Poly1305 (a non-FIPS algorithm) into the binary via `go-tpm-keyfiles`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [13925]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a library API change.
+# Default: '[user]'
+change_logs: [user]

--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -203,3 +203,5 @@ exporters:
 ```
 
 The `client-tss2.key` private key with TSS2 format will be loaded from the TPM device `/dev/tpmrm0`.
+
+> **Note:** TPM key loading is not supported when building with the `requirefips` build tag (FIPS 140-3 mode). The underlying `go-tpm-keyfiles` library uses ChaCha20-Poly1305 for key wrapping, which is not a FIPS-approved algorithm. Setting `tpm.enabled: true` in FIPS mode will return an error at runtime.

--- a/config/configtls/go.mod
+++ b/config/configtls/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/config/configopaque v1.62.0
 	go.opentelemetry.io/collector/confmap v1.62.0
-	go.opentelemetry.io/collector/internal/testutil v0.156.0
 )
 
 require (
@@ -39,4 +38,3 @@ replace go.opentelemetry.io/collector/featuregate => ../../featuregate
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil

--- a/config/configtls/tpm_fips.go
+++ b/config/configtls/tpm_fips.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build requirefips
+
+package configtls // import "go.opentelemetry.io/collector/config/configtls"
+
+import (
+	"crypto/tls"
+	"errors"
+
+	"github.com/google/go-tpm/tpm2/transport"
+)
+
+// TPMConfig defines trusted platform module configuration for storing TLS keys.
+type TPMConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+	// The path to the TPM device or Unix domain socket.
+	// For instance /dev/tpm0 or /dev/tpmrm0.
+	Path      string `mapstructure:"path"`
+	OwnerAuth string `mapstructure:"owner_auth"`
+	Auth      string `mapstructure:"auth"`
+	// prevent unkeyed literal initialization
+	_ struct{}
+}
+
+// tpmCertificate is not supported in FIPS mode because the TPM key-file format
+// relies on ChaCha20-Poly1305 for key wrapping, which is not a FIPS-approved algorithm.
+func (c TPMConfig) tpmCertificate(_ []byte, _ []byte, _ func() (transport.TPMCloser, error)) (tls.Certificate, error) {
+	return tls.Certificate{}, errors.New("TPM key loading is not supported in FIPS mode")
+}

--- a/config/configtls/tpm_fips_test.go
+++ b/config/configtls/tpm_fips_test.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build requirefips
+
+package configtls // import "go.opentelemetry.io/collector/config/configtls"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTPM_notSupportedInFIPSMode(t *testing.T) {
+	tlsCfg := Config{
+		CertPem: "anything",
+		KeyPem:  "anything",
+		TPMConfig: TPMConfig{
+			Enabled: true,
+			Path:    "/dev/tpm0",
+		},
+	}
+	_, err := tlsCfg.loadCertificate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TPM key loading is not supported in FIPS mode")
+}

--- a/config/configtls/tpm_nofips.go
+++ b/config/configtls/tpm_nofips.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !requirefips
+
 package configtls // import "go.opentelemetry.io/collector/config/configtls"
 
 import (

--- a/config/configtls/tpm_nofips_linux_test.go
+++ b/config/configtls/tpm_nofips_linux_test.go
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Don't run this test on Windows, as it requires a TPM simulator which depends on openssl headers.
-//go:build !windows && !darwin
+// The TPM simulator used here depends on OpenSSL headers not available on Windows or macOS.
+//go:build linux && !requirefips
 
 package configtls // import "go.opentelemetry.io/collector/config/configtls"
 
@@ -18,7 +18,6 @@ import (
 	"math/big"
 	"net"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -28,12 +27,9 @@ import (
 	"github.com/google/go-tpm/tpm2/transport/simulator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"go.opentelemetry.io/collector/internal/testutil"
 )
 
 func TestTPM_loadCertificate(t *testing.T) {
-	testutil.SkipIfFIPSOnly(t, "use of CFB is not allowed in FIPS 140-only mode")
 	tpm, err := simulator.OpenSimulator()
 	require.NoError(t, err)
 	defer tpm.Close()
@@ -101,7 +97,6 @@ func TestTPM_loadCertificate_error(t *testing.T) {
 }
 
 func TestTPM_tpmCertificate_errors(t *testing.T) {
-	testutil.SkipIfFIPSOnly(t, "use of CFB is not allowed in FIPS 140-only mode")
 	tpm, err := simulator.OpenSimulator()
 	require.NoError(t, err)
 	defer tpm.Close()
@@ -150,43 +145,6 @@ VGhpcyBpcyBub3QgYSBjZXJ0aWZpY2F0ZS4=
 			tpmCfg := &TPMConfig{}
 			_, err = tpmCfg.tpmCertificate([]byte(test.key), []byte(test.cert), test.openTPM)
 			assert.EqualError(t, err, test.err)
-		})
-	}
-}
-
-func TestTPM_open(t *testing.T) {
-	socketPath := filepath.Join(t.TempDir(), "app.sock")
-	listener, err := net.Listen("unix", socketPath)
-	require.NoError(t, err)
-	defer listener.Close()
-
-	tests := []struct {
-		path string
-		err  string
-	}{
-		{
-			path: "",
-			err:  "TPM path is not set",
-		},
-		{
-			path: "/foo",
-			err:  "failed to open TPM (/foo): stat /foo: no such file or directory",
-		},
-		{
-			path: socketPath,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.path, func(t *testing.T) {
-			tpm, openErr := openTPM(test.path)()
-			if test.err != "" {
-				require.Nil(t, tpm)
-				assert.Equal(t, test.err, openErr.Error())
-			} else {
-				require.NoError(t, openErr)
-				require.NotNil(t, tpm)
-				tpm.Close()
-			}
 		})
 	}
 }

--- a/config/configtls/tpm_open_linux_test.go
+++ b/config/configtls/tpm_open_linux_test.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package configtls // import "go.opentelemetry.io/collector/config/configtls"
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTPM_open(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "app.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	tests := []struct {
+		path string
+		err  string
+	}{
+		{
+			path: "",
+			err:  "TPM path is not set",
+		},
+		{
+			path: "/foo",
+			err:  "failed to open TPM (/foo): stat /foo: no such file or directory",
+		},
+		{
+			path: socketPath,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			tpm, openErr := openTPM(test.path)()
+			if test.err != "" {
+				require.Nil(t, tpm)
+				assert.Equal(t, test.err, openErr.Error())
+			} else {
+				require.NoError(t, openErr)
+				require.NotNil(t, tpm)
+				tpm.Close()
+			}
+		})
+	}
+}


### PR DESCRIPTION
`go-tpm-keyfiles` uses ChaCha20-Poly1305 to wrap TPM importable keys. That algorithm isn't FIPS-approved, so any binary built with `requirefips` that linked `config/configtls` pulled non-FIPS crypto in unconditionally — even when TPM keys were never used.

Fix follows the same pattern as `curves_fips.go` / `curves_nofips.go`: split `tpm.go` into a full implementation (`tpm_nofips.go`) and a stub (`tpm_fips.go`) that returns an explicit error. The stub doesn't import `go-tpm-keyfiles` at all, so the ChaCha20 dependency is absent from FIPS builds at the module level.

Tests split accordingly: simulator tests stay in `tpm_nofips_linux_test.go`, a new `tpm_fips_test.go` checks the stub error, and `TestTPM_open` (path-handling, no crypto dependency) lives in `tpm_open_linux_test.go` so it runs in both modes.