### PR TITLE
[chore] Add tests for batch sizer defaulting behavior

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -144,9 +144,10 @@ func TestUnmarshal(t *testing.T) {
 		})
 	}
 	tests := []struct {
-		path        string
-		expectedErr string
-		expectedCfg func() configoptional.Optional[Config]
+		path        		string
+		expectedErr 		string
+		expectedValidateErr string
+		expectedCfg         func() configoptional.Optional[Config]
 	}{
 		{
 			path: "batch_set_empty_explicit_sizer.yaml",
@@ -210,6 +211,69 @@ func TestUnmarshal(t *testing.T) {
 				return cfg
 			},
 		},
+		{
+			path: "batch_set_nonempty_queue_items_no_batch_sizer.yaml",
+			expectedCfg: func() configoptional.Optional[Config] {
+				cfg := newBaseCfg()
+				cfg.Get().Sizer = request.SizerTypeItems
+				cfg.Get().QueueSize = 2000
+				cfg.Get().Batch = configoptional.Some(BatchConfig{
+					FlushTimeout: 200 * time.Millisecond,
+					// Batch sizer inherited from the queue sizer (items).
+					Sizer:   request.SizerTypeItems,
+					MinSize: 100,
+				})
+				return cfg
+			},
+		},
+		{
+			path: "batch_set_nonempty_queue_requests_no_batch_sizer.yaml",
+			// The queue sizer (requests) is inherited by the batch, but "requests"
+			// is not a valid batch sizer, so Validate rejects the resulting config.
+			expectedValidateErr: "`batch` supports only `items` or `bytes` sizer, found \"requests\"",
+			expectedCfg: func() configoptional.Optional[Config] {
+				cfg := newBaseCfg()
+				cfg.Get().Sizer = request.SizerTypeRequests
+				cfg.Get().QueueSize = 2000
+				cfg.Get().Batch = configoptional.Some(BatchConfig{
+					FlushTimeout: 200 * time.Millisecond,
+					// Batch sizer inherited from the queue sizer (requests).
+					Sizer:   request.SizerTypeRequests,
+					MinSize: 100,
+				})
+				return cfg
+			},
+		},
+		{
+			path: "batch_set_nonempty_explicit_batch_sizer_items.yaml",
+			expectedCfg: func() configoptional.Optional[Config] {
+				cfg := newBaseCfg()
+				cfg.Get().Sizer = request.SizerTypeBytes
+				cfg.Get().QueueSize = 2000
+				cfg.Get().Batch = configoptional.Some(BatchConfig{
+					FlushTimeout: 200 * time.Millisecond,
+					// Explicit batch sizer (items) is not overridden by the queue sizer (bytes).
+					Sizer:   request.SizerTypeItems,
+					MinSize: 100,
+				})
+				return cfg
+			},
+		},
+		{
+			path: "batch_set_nonempty_explicit_batch_sizer_bytes.yaml",
+			expectedCfg: func() configoptional.Optional[Config] {
+				cfg := newBaseCfg()
+				cfg.Get().Sizer = request.SizerTypeItems
+				cfg.Get().QueueSize = 2000
+				cfg.Get().Batch = configoptional.Some(BatchConfig{
+					FlushTimeout: 200 * time.Millisecond,
+					// Explicit batch sizer (bytes) is not overridden by the queue sizer (items).
+					Sizer:   request.SizerTypeBytes,
+					MinSize: 100,
+				})
+				return cfg
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -225,6 +289,10 @@ func TestUnmarshal(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedCfg(), cfg)
+			if tt.expectedValidateErr != "" {
+				assert.ErrorContains(t, confmap.Validate(cfg), tt.expectedValidateErr)
+				return
+			}
 			assert.NoError(t, confmap.Validate(cfg))
 		})
 	}

--- a/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_nonempty_explicit_batch_sizer_bytes.yaml
+++ b/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_nonempty_explicit_batch_sizer_bytes.yaml
@@ -1,0 +1,7 @@
+enabled: true
+sizer: items
+queue_size: 2000
+batch:
+  # explicit batch sizer (bytes) must NOT be overridden by the queue sizer (items)
+  sizer: bytes
+  min_size: 100

--- a/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_nonempty_explicit_batch_sizer_items.yaml
+++ b/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_nonempty_explicit_batch_sizer_items.yaml
@@ -1,0 +1,7 @@
+enabled: true
+sizer: bytes
+queue_size: 2000
+batch:
+  # explicit batch sizer (items) must NOT be overridden by the queue sizer (bytes)
+  sizer: items
+  min_size: 100

--- a/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_nonempty_queue_items_no_batch_sizer.yaml
+++ b/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_nonempty_queue_items_no_batch_sizer.yaml
@@ -1,0 +1,6 @@
+enabled: true
+sizer: items
+queue_size: 2000
+batch:
+  # batch sizer is inherited from the queue sizer (items)
+  min_size: 100

--- a/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_nonempty_queue_requests_no_batch_sizer.yaml
+++ b/exporter/exporterhelper/internal/queuebatch/testdata/batch_set_nonempty_queue_requests_no_batch_sizer.yaml
@@ -1,0 +1,6 @@
+enabled: true
+sizer: requests
+queue_size: 2000
+batch:
+  # batch inherits the queue sizer (requests), which is invalid for batches and fails validation
+  min_size: 100


### PR DESCRIPTION
Document, via table-driven tests, how `sending_queue::batch::sizer` defaults from the queue-level `sizer` in `Config.Unmarshal`:

- a non-empty batch without an explicit sizer inherits the queue sizer when it is `items` or `bytes`;
- inheriting `requests` is surfaced as a validation error, since it is not a valid batch sizer;
- an explicit `batch::sizer` is never overridden by the queue sizer.

Supersede https://github.com/open-telemetry/opentelemetry-collector/pull/14695