### PR TITLE
exporterhelper: remove unused component.Config from NewLogs, NewMetrics, and NewTraces

### DIFF
--- a/.chloggen/exporterhelper-remove-component-config.yaml
+++ b/.chloggen/exporterhelper-remove-component-config.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `component.Config` parameter from `NewLogs`, `NewMetrics` and `NewTraces`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15094]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The config is an opaque object only used by the component itself and is no longer needed by the helper.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/exporterhelper-remove-component-config.yaml
+++ b/.chloggen/exporterhelper-remove-component-config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `NewLogs`, `NewMetrics` and `NewTraces` in favor of `NewLogsWithConfig`, `NewMetricsWithConfig` and `NewTracesWithConfig`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15094]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `component.Config` parameter is an opaque object only used by the component itself and is no longer needed by the helper.
+  In a future release `NewLogs`, `NewMetrics` and `NewTraces` will change to drop the `cfg` parameter.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/debugexporter/factory.go
+++ b/exporter/debugexporter/factory.go
@@ -56,7 +56,7 @@ func createTraces(ctx context.Context, set exporter.Settings, config component.C
 	cfg := config.(*Config)
 	exporterLogger := createLogger(cfg, set.Logger)
 	debug := newDebugExporter(exporterLogger, cfg.Verbosity)
-	return exporterhelper.NewTraces(ctx, set, config,
+	return exporterhelper.NewTraces(ctx, set,
 		debug.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithQueue(cfg.QueueConfig),
@@ -69,7 +69,7 @@ func createMetrics(ctx context.Context, set exporter.Settings, config component.
 	cfg := config.(*Config)
 	exporterLogger := createLogger(cfg, set.Logger)
 	debug := newDebugExporter(exporterLogger, cfg.Verbosity)
-	return exporterhelper.NewMetrics(ctx, set, config,
+	return exporterhelper.NewMetrics(ctx, set,
 		debug.pushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithQueue(cfg.QueueConfig),
@@ -82,7 +82,7 @@ func createLogs(ctx context.Context, set exporter.Settings, config component.Con
 	cfg := config.(*Config)
 	exporterLogger := createLogger(cfg, set.Logger)
 	debug := newDebugExporter(exporterLogger, cfg.Verbosity)
-	return exporterhelper.NewLogs(ctx, set, config,
+	return exporterhelper.NewLogs(ctx, set,
 		debug.pushLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithQueue(cfg.QueueConfig),

--- a/exporter/debugexporter/factory.go
+++ b/exporter/debugexporter/factory.go
@@ -56,7 +56,7 @@ func createTraces(ctx context.Context, set exporter.Settings, config component.C
 	cfg := config.(*Config)
 	exporterLogger := createLogger(cfg, set.Logger)
 	debug := newDebugExporter(exporterLogger, cfg.Verbosity)
-	return exporterhelper.NewTraces(ctx, set, config,
+	return exporterhelper.NewTracesWithConfig(ctx, set, config,
 		debug.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithQueue(cfg.QueueConfig),
@@ -69,7 +69,7 @@ func createMetrics(ctx context.Context, set exporter.Settings, config component.
 	cfg := config.(*Config)
 	exporterLogger := createLogger(cfg, set.Logger)
 	debug := newDebugExporter(exporterLogger, cfg.Verbosity)
-	return exporterhelper.NewMetrics(ctx, set, config,
+	return exporterhelper.NewMetricsWithConfig(ctx, set, config,
 		debug.pushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithQueue(cfg.QueueConfig),
@@ -82,7 +82,7 @@ func createLogs(ctx context.Context, set exporter.Settings, config component.Con
 	cfg := config.(*Config)
 	exporterLogger := createLogger(cfg, set.Logger)
 	debug := newDebugExporter(exporterLogger, cfg.Verbosity)
-	return exporterhelper.NewLogs(ctx, set, config,
+	return exporterhelper.NewLogsWithConfig(ctx, set, config,
 		debug.pushLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithQueue(cfg.QueueConfig),

--- a/exporter/example_test.go
+++ b/exporter/example_test.go
@@ -75,7 +75,6 @@ func createExampleExporter(ctx context.Context, params exporter.Settings, baseCf
 	return exporterhelper.NewMetrics(
 		ctx,
 		params,
-		cfg,
 		xptr.consumeMetrics,
 		exporterhelper.WithQueue(cfg.QueueSettings),
 		exporterhelper.WithRetry(cfg.BackOffConfig),

--- a/exporter/example_test.go
+++ b/exporter/example_test.go
@@ -72,7 +72,7 @@ func createExampleExporter(ctx context.Context, params exporter.Settings, baseCf
 	xptr := newExampleExporter(ctx, cfg, params)
 
 	// Wrap the exporter with the helper utilities.
-	return exporterhelper.NewMetrics(
+	return exporterhelper.NewMetricsWithConfig(
 		ctx,
 		params,
 		cfg,

--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -8,8 +8,6 @@ import (
 )
 
 var (
-	// errNilConfig is returned when an empty name is given.
-	errNilConfig = errors.New("nil config")
 	// errNilLogger is returned when a logger is nil
 	errNilLogger = errors.New("nil logger")
 	// errNilPushTraces is returned when a nil PushTraces is given.

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -6,7 +6,6 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
@@ -17,13 +16,9 @@ import (
 func NewLogs(
 	ctx context.Context,
 	set exporter.Settings,
-	cfg component.Config,
 	pusher consumer.ConsumeLogsFunc,
 	options ...Option,
 ) (exporter.Logs, error) {
-	if cfg == nil {
-		return nil, errNilConfig
-	}
 	if pusher == nil {
 		return nil, errNilPushLogs
 	}

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -14,7 +14,22 @@ import (
 )
 
 // NewLogs creates an exporter.Logs that records observability logs and wraps every request with a Span.
+//
+// Deprecated: [v0.159.0] Use NewLogsWithConfig instead. In a future release NewLogs will change to drop the cfg parameter.
+//
+//go:fix inline
 func NewLogs(
+	ctx context.Context,
+	set exporter.Settings,
+	cfg component.Config,
+	pusher consumer.ConsumeLogsFunc,
+	options ...Option,
+) (exporter.Logs, error) {
+	return NewLogsWithConfig(ctx, set, cfg, pusher, options...)
+}
+
+// NewLogsWithConfig creates an exporter.Logs that records observability logs and wraps every request with a Span.
+func NewLogsWithConfig(
 	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config,

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -44,32 +44,23 @@ const (
 	fakeLogsParentSpanName = "fake_logs_parent_span_name"
 )
 
-var (
-	fakeLogsName   = component.MustNewIDWithName("fake_logs_exporter", "with_name")
-	fakeLogsConfig = struct{}{}
-)
-
-func TestLogs_InvalidName(t *testing.T) {
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newPushLogsData(nil))
-	require.Nil(t, le)
-	require.Equal(t, errNilConfig, err)
-}
+var fakeLogsName = component.MustNewIDWithName("fake_logs_exporter", "with_name")
 
 func TestLogs_NilLogger(t *testing.T) {
-	le, err := NewLogs(context.Background(), exporter.Settings{}, &fakeLogsConfig, newPushLogsData(nil))
+	le, err := NewLogs(context.Background(), exporter.Settings{}, newPushLogsData(nil))
 	require.Nil(t, le)
 	require.Equal(t, errNilLogger, err)
 }
 
 func TestLogs_NilPushLogsData(t *testing.T) {
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, nil)
+	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil)
 	require.Nil(t, le)
 	require.Equal(t, errNilPushLogs, err)
 }
 
 func TestLogs_Default(t *testing.T) {
 	ld := plog.NewLogs()
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil))
+	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushLogsData(nil))
 	assert.NotNil(t, le)
 	require.NoError(t, err)
 
@@ -81,7 +72,7 @@ func TestLogs_Default(t *testing.T) {
 
 func TestLogs_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithCapabilities(capabilities))
+	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushLogsData(nil), WithCapabilities(capabilities))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
@@ -91,7 +82,7 @@ func TestLogs_WithCapabilities(t *testing.T) {
 func TestLogs_Default_ReturnError(t *testing.T) {
 	ld := plog.NewLogs()
 	want := errors.New("my_error")
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(want))
+	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushLogsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 	require.Equal(t, want, le.ConsumeLogs(context.Background(), ld))
@@ -140,7 +131,7 @@ func TestLogs_WithPersistentQueue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ls := consumertest.LogsSink{}
-			te, err := NewLogs(context.Background(), set, &fakeLogsConfig, ls.ConsumeLogs, WithQueue(qCfg))
+			te, err := NewLogs(context.Background(), set, ls.ConsumeLogs, WithQueue(qCfg))
 			require.NoError(t, err)
 			require.NoError(t, te.Start(context.Background(), host))
 			t.Cleanup(func() { require.NoError(t, te.Shutdown(context.Background())) })
@@ -166,7 +157,7 @@ func TestLogs_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	le, err := NewLogs(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsConfig, newPushLogsData(nil))
+	le, err := NewLogs(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newPushLogsData(nil))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
@@ -177,7 +168,7 @@ func TestLogs_pLogModifiedDownStream_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	le, err := NewLogs(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsConfig, newPushLogsDataModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
+	le, err := NewLogs(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newPushLogsDataModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	assert.NotNil(t, le)
 	require.NoError(t, err)
 	ld := testdata.GenerateLogs(2)
@@ -213,7 +204,7 @@ func TestLogs_WithRecordMetrics_ReturnError(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	le, err := NewLogs(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsConfig, newPushLogsData(want))
+	le, err := NewLogs(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newPushLogsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
@@ -240,7 +231,7 @@ func TestLogs_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
-	le, err := NewLogs(context.Background(), set, &fakeLogsConfig, newPushLogsData(nil))
+	le, err := NewLogs(context.Background(), set, newPushLogsData(nil))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 	checkWrapSpanForLogs(t, sr, set.TracerProvider.Tracer("test"), le, nil)
@@ -267,7 +258,7 @@ func TestLogs_WithSpan_ReturnError(t *testing.T) {
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
 	want := errors.New("my_error")
-	le, err := NewLogs(context.Background(), set, &fakeLogsConfig, newPushLogsData(want))
+	le, err := NewLogs(context.Background(), set, newPushLogsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 	checkWrapSpanForLogs(t, sr, set.TracerProvider.Tracer("test"), le, want)
@@ -291,7 +282,7 @@ func TestLogs_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithShutdown(shutdown))
+	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushLogsData(nil), WithShutdown(shutdown))
 	assert.NotNil(t, le)
 	assert.NoError(t, err)
 
@@ -303,7 +294,7 @@ func TestLogs_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithShutdown(shutdownErr))
+	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushLogsData(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, le)
 	require.NoError(t, err)
 

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -50,26 +50,26 @@ var (
 )
 
 func TestLogs_InvalidName(t *testing.T) {
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newPushLogsData(nil))
+	le, err := NewLogsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newPushLogsData(nil))
 	require.Nil(t, le)
 	require.Equal(t, errNilConfig, err)
 }
 
 func TestLogs_NilLogger(t *testing.T) {
-	le, err := NewLogs(context.Background(), exporter.Settings{}, &fakeLogsConfig, newPushLogsData(nil))
+	le, err := NewLogsWithConfig(context.Background(), exporter.Settings{}, &fakeLogsConfig, newPushLogsData(nil))
 	require.Nil(t, le)
 	require.Equal(t, errNilLogger, err)
 }
 
 func TestLogs_NilPushLogsData(t *testing.T) {
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, nil)
+	le, err := NewLogsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, nil)
 	require.Nil(t, le)
 	require.Equal(t, errNilPushLogs, err)
 }
 
 func TestLogs_Default(t *testing.T) {
 	ld := plog.NewLogs()
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil))
+	le, err := NewLogsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil))
 	assert.NotNil(t, le)
 	require.NoError(t, err)
 
@@ -81,7 +81,7 @@ func TestLogs_Default(t *testing.T) {
 
 func TestLogs_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithCapabilities(capabilities))
+	le, err := NewLogsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithCapabilities(capabilities))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
@@ -91,7 +91,7 @@ func TestLogs_WithCapabilities(t *testing.T) {
 func TestLogs_Default_ReturnError(t *testing.T) {
 	ld := plog.NewLogs()
 	want := errors.New("my_error")
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(want))
+	le, err := NewLogsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 	require.Equal(t, want, le.ConsumeLogs(context.Background(), ld))
@@ -140,7 +140,7 @@ func TestLogs_WithPersistentQueue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ls := consumertest.LogsSink{}
-			te, err := NewLogs(context.Background(), set, &fakeLogsConfig, ls.ConsumeLogs, WithQueue(qCfg))
+			te, err := NewLogsWithConfig(context.Background(), set, &fakeLogsConfig, ls.ConsumeLogs, WithQueue(qCfg))
 			require.NoError(t, err)
 			require.NoError(t, te.Start(context.Background(), host))
 			t.Cleanup(func() { require.NoError(t, te.Shutdown(context.Background())) })
@@ -166,7 +166,7 @@ func TestLogs_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	le, err := NewLogs(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsConfig, newPushLogsData(nil))
+	le, err := NewLogsWithConfig(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsConfig, newPushLogsData(nil))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
@@ -177,7 +177,7 @@ func TestLogs_pLogModifiedDownStream_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	le, err := NewLogs(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsConfig, newPushLogsDataModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
+	le, err := NewLogsWithConfig(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsConfig, newPushLogsDataModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	assert.NotNil(t, le)
 	require.NoError(t, err)
 	ld := testdata.GenerateLogs(2)
@@ -214,7 +214,7 @@ func TestLogs_WithRecordMetrics_ReturnError(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	le, err := NewLogs(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsConfig, newPushLogsData(want))
+	le, err := NewLogsWithConfig(context.Background(), exporter.Settings{ID: fakeLogsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsConfig, newPushLogsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 
@@ -241,7 +241,7 @@ func TestLogs_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
-	le, err := NewLogs(context.Background(), set, &fakeLogsConfig, newPushLogsData(nil))
+	le, err := NewLogsWithConfig(context.Background(), set, &fakeLogsConfig, newPushLogsData(nil))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 	checkWrapSpanForLogs(t, sr, set.TracerProvider.Tracer("test"), le, nil)
@@ -268,7 +268,7 @@ func TestLogs_WithSpan_ReturnError(t *testing.T) {
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
 	want := errors.New("my_error")
-	le, err := NewLogs(context.Background(), set, &fakeLogsConfig, newPushLogsData(want))
+	le, err := NewLogsWithConfig(context.Background(), set, &fakeLogsConfig, newPushLogsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, le)
 	checkWrapSpanForLogs(t, sr, set.TracerProvider.Tracer("test"), le, want)
@@ -292,7 +292,7 @@ func TestLogs_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithShutdown(shutdown))
+	le, err := NewLogsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithShutdown(shutdown))
 	assert.NotNil(t, le)
 	assert.NoError(t, err)
 
@@ -304,7 +304,7 @@ func TestLogs_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	le, err := NewLogs(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithShutdown(shutdownErr))
+	le, err := NewLogsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeLogsConfig, newPushLogsData(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, le)
 	require.NoError(t, err)
 

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -6,7 +6,6 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
@@ -17,13 +16,9 @@ import (
 func NewMetrics(
 	ctx context.Context,
 	set exporter.Settings,
-	cfg component.Config,
 	pusher consumer.ConsumeMetricsFunc,
 	options ...Option,
 ) (exporter.Metrics, error) {
-	if cfg == nil {
-		return nil, errNilConfig
-	}
 	if pusher == nil {
 		return nil, errNilPushMetrics
 	}

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -14,7 +14,22 @@ import (
 )
 
 // NewMetrics creates an exporter.Metrics that records observability metrics and wraps every request with a Span.
+//
+// Deprecated: [v0.159.0] Use NewMetricsWithConfig instead. In a future release NewMetrics will change to drop the cfg parameter.
+//
+//go:fix inline
 func NewMetrics(
+	ctx context.Context,
+	set exporter.Settings,
+	cfg component.Config,
+	pusher consumer.ConsumeMetricsFunc,
+	options ...Option,
+) (exporter.Metrics, error) {
+	return NewMetricsWithConfig(ctx, set, cfg, pusher, options...)
+}
+
+// NewMetricsWithConfig creates an exporter.Metrics that records observability metrics and wraps every request with a Span.
+func NewMetricsWithConfig(
 	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config,

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -44,32 +44,23 @@ const (
 	fakeMetricsParentSpanName = "fake_metrics_parent_span_name"
 )
 
-var (
-	fakeMetricsName   = component.MustNewIDWithName("fake_metrics_exporter", "with_name")
-	fakeMetricsConfig = struct{}{}
-)
-
-func TestMetrics_NilConfig(t *testing.T) {
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newPushMetricsData(nil))
-	require.Nil(t, me)
-	require.Equal(t, errNilConfig, err)
-}
+var fakeMetricsName = component.MustNewIDWithName("fake_metrics_exporter", "with_name")
 
 func TestMetrics_NilLogger(t *testing.T) {
-	me, err := NewMetrics(context.Background(), exporter.Settings{}, &fakeMetricsConfig, newPushMetricsData(nil))
+	me, err := NewMetrics(context.Background(), exporter.Settings{}, newPushMetricsData(nil))
 	require.Nil(t, me)
 	require.Equal(t, errNilLogger, err)
 }
 
 func TestMetrics_NilPushMetricsData(t *testing.T) {
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, nil)
+	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil)
 	require.Nil(t, me)
 	require.Equal(t, errNilPushMetrics, err)
 }
 
 func TestMetrics_Default(t *testing.T) {
 	md := pmetric.NewMetrics()
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil))
+	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushMetricsData(nil))
 	require.NoError(t, err)
 	assert.NotNil(t, me)
 
@@ -81,7 +72,7 @@ func TestMetrics_Default(t *testing.T) {
 
 func TestMetrics_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil), WithCapabilities(capabilities))
+	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushMetricsData(nil), WithCapabilities(capabilities))
 	require.NoError(t, err)
 	assert.NotNil(t, me)
 
@@ -91,7 +82,7 @@ func TestMetrics_WithCapabilities(t *testing.T) {
 func TestMetrics_Default_ReturnError(t *testing.T) {
 	md := pmetric.NewMetrics()
 	want := errors.New("my_error")
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(want))
+	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushMetricsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	require.Equal(t, want, me.ConsumeMetrics(context.Background(), md))
@@ -140,7 +131,7 @@ func TestMetrics_WithPersistentQueue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ms := consumertest.MetricsSink{}
-			te, err := NewMetrics(context.Background(), set, &fakeMetricsConfig, ms.ConsumeMetrics, WithQueue(configoptional.Some(qCfg)))
+			te, err := NewMetrics(context.Background(), set, ms.ConsumeMetrics, WithQueue(configoptional.Some(qCfg)))
 			require.NoError(t, err)
 			require.NoError(t, te.Start(context.Background(), host))
 			t.Cleanup(func() { require.NoError(t, te.Shutdown(context.Background())) })
@@ -166,7 +157,7 @@ func TestMetrics_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsData(nil))
+	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newPushMetricsData(nil))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 
@@ -181,7 +172,7 @@ func TestMetrics_WithAttrs(t *testing.T) {
 		attribute.Bool("test", true),
 		attribute.String("example", "value"),
 	}
-	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsData(nil), WithAttrs(attrs...))
+	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newPushMetricsData(nil), WithAttrs(attrs...))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 
@@ -192,7 +183,7 @@ func TestMetrics_pMetricModifiedDownStream_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsDataModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
+	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newPushMetricsDataModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	md := testdata.GenerateMetrics(2)
@@ -228,7 +219,7 @@ func TestMetrics_WithRecordMetrics_ReturnError(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsData(want))
+	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newPushMetricsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 
@@ -256,7 +247,7 @@ func TestMetrics_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
-	me, err := NewMetrics(context.Background(), set, &fakeMetricsConfig, newPushMetricsData(nil))
+	me, err := NewMetrics(context.Background(), set, newPushMetricsData(nil))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetrics(t, sr, set.TracerProvider.Tracer("test"), me, nil)
@@ -283,7 +274,7 @@ func TestMetrics_WithSpan_ReturnError(t *testing.T) {
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
 	want := errors.New("my_error")
-	me, err := NewMetrics(context.Background(), set, &fakeMetricsConfig, newPushMetricsData(want))
+	me, err := NewMetrics(context.Background(), set, newPushMetricsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetrics(t, sr, set.TracerProvider.Tracer("test"), me, want)
@@ -307,7 +298,7 @@ func TestMetrics_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil), WithShutdown(shutdown))
+	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushMetricsData(nil), WithShutdown(shutdown))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -320,7 +311,7 @@ func TestMetrics_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil), WithShutdown(shutdownErr))
+	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newPushMetricsData(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -50,26 +50,26 @@ var (
 )
 
 func TestMetrics_NilConfig(t *testing.T) {
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newPushMetricsData(nil))
+	me, err := NewMetricsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newPushMetricsData(nil))
 	require.Nil(t, me)
 	require.Equal(t, errNilConfig, err)
 }
 
 func TestMetrics_NilLogger(t *testing.T) {
-	me, err := NewMetrics(context.Background(), exporter.Settings{}, &fakeMetricsConfig, newPushMetricsData(nil))
+	me, err := NewMetricsWithConfig(context.Background(), exporter.Settings{}, &fakeMetricsConfig, newPushMetricsData(nil))
 	require.Nil(t, me)
 	require.Equal(t, errNilLogger, err)
 }
 
 func TestMetrics_NilPushMetricsData(t *testing.T) {
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, nil)
+	me, err := NewMetricsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, nil)
 	require.Nil(t, me)
 	require.Equal(t, errNilPushMetrics, err)
 }
 
 func TestMetrics_Default(t *testing.T) {
 	md := pmetric.NewMetrics()
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil))
+	me, err := NewMetricsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil))
 	require.NoError(t, err)
 	assert.NotNil(t, me)
 
@@ -81,7 +81,7 @@ func TestMetrics_Default(t *testing.T) {
 
 func TestMetrics_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil), WithCapabilities(capabilities))
+	me, err := NewMetricsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil), WithCapabilities(capabilities))
 	require.NoError(t, err)
 	assert.NotNil(t, me)
 
@@ -91,7 +91,7 @@ func TestMetrics_WithCapabilities(t *testing.T) {
 func TestMetrics_Default_ReturnError(t *testing.T) {
 	md := pmetric.NewMetrics()
 	want := errors.New("my_error")
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(want))
+	me, err := NewMetricsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	require.Equal(t, want, me.ConsumeMetrics(context.Background(), md))
@@ -140,7 +140,7 @@ func TestMetrics_WithPersistentQueue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ms := consumertest.MetricsSink{}
-			te, err := NewMetrics(context.Background(), set, &fakeMetricsConfig, ms.ConsumeMetrics, WithQueue(configoptional.Some(qCfg)))
+			te, err := NewMetricsWithConfig(context.Background(), set, &fakeMetricsConfig, ms.ConsumeMetrics, WithQueue(configoptional.Some(qCfg)))
 			require.NoError(t, err)
 			require.NoError(t, te.Start(context.Background(), host))
 			t.Cleanup(func() { require.NoError(t, te.Shutdown(context.Background())) })
@@ -166,7 +166,7 @@ func TestMetrics_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsData(nil))
+	me, err := NewMetricsWithConfig(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsData(nil))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 
@@ -181,7 +181,7 @@ func TestMetrics_WithAttrs(t *testing.T) {
 		attribute.Bool("test", true),
 		attribute.String("example", "value"),
 	}
-	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsData(nil), WithAttrs(attrs...))
+	me, err := NewMetricsWithConfig(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsData(nil), WithAttrs(attrs...))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 
@@ -192,7 +192,7 @@ func TestMetrics_pMetricModifiedDownStream_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsDataModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
+	me, err := NewMetricsWithConfig(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsDataModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	md := testdata.GenerateMetrics(2)
@@ -229,7 +229,7 @@ func TestMetrics_WithRecordMetrics_ReturnError(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	me, err := NewMetrics(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsData(want))
+	me, err := NewMetricsWithConfig(context.Background(), exporter.Settings{ID: fakeMetricsName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsConfig, newPushMetricsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 
@@ -257,7 +257,7 @@ func TestMetrics_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
-	me, err := NewMetrics(context.Background(), set, &fakeMetricsConfig, newPushMetricsData(nil))
+	me, err := NewMetricsWithConfig(context.Background(), set, &fakeMetricsConfig, newPushMetricsData(nil))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetrics(t, sr, set.TracerProvider.Tracer("test"), me, nil)
@@ -284,7 +284,7 @@ func TestMetrics_WithSpan_ReturnError(t *testing.T) {
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
 	want := errors.New("my_error")
-	me, err := NewMetrics(context.Background(), set, &fakeMetricsConfig, newPushMetricsData(want))
+	me, err := NewMetricsWithConfig(context.Background(), set, &fakeMetricsConfig, newPushMetricsData(want))
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetrics(t, sr, set.TracerProvider.Tracer("test"), me, want)
@@ -308,7 +308,7 @@ func TestMetrics_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil), WithShutdown(shutdown))
+	me, err := NewMetricsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil), WithShutdown(shutdown))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -321,7 +321,7 @@ func TestMetrics_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	me, err := NewMetrics(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil), WithShutdown(shutdownErr))
+	me, err := NewMetricsWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeMetricsConfig, newPushMetricsData(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -6,7 +6,6 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
@@ -17,13 +16,9 @@ import (
 func NewTraces(
 	ctx context.Context,
 	set exporter.Settings,
-	cfg component.Config,
 	pusher consumer.ConsumeTracesFunc,
 	options ...Option,
 ) (exporter.Traces, error) {
-	if cfg == nil {
-		return nil, errNilConfig
-	}
 	if pusher == nil {
 		return nil, errNilPushTraces
 	}

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -14,7 +14,22 @@ import (
 )
 
 // NewTraces creates an exporter.Traces that records observability metrics and wraps every request with a Span.
+//
+// Deprecated: [v0.159.0] Use NewTracesWithConfig instead. In a future release NewTraces will change to drop the cfg parameter.
+//
+//go:fix inline
 func NewTraces(
+	ctx context.Context,
+	set exporter.Settings,
+	cfg component.Config,
+	pusher consumer.ConsumeTracesFunc,
+	options ...Option,
+) (exporter.Traces, error) {
+	return NewTracesWithConfig(ctx, set, cfg, pusher, options...)
+}
+
+// NewTracesWithConfig creates an exporter.Traces that records observability metrics and wraps every request with a Span.
+func NewTracesWithConfig(
 	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config,

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -44,32 +44,23 @@ const (
 	fakeTraceParentSpanName = "fake_trace_parent_span_name"
 )
 
-var (
-	fakeTracesName   = component.MustNewIDWithName("fake_traces_exporter", "with_name")
-	fakeTracesConfig = struct{}{}
-)
-
-func TestTraces_InvalidName(t *testing.T) {
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newTraceDataPusher(nil))
-	require.Nil(t, te)
-	require.Equal(t, errNilConfig, err)
-}
+var fakeTracesName = component.MustNewIDWithName("fake_traces_exporter", "with_name")
 
 func TestTraces_NilLogger(t *testing.T) {
-	te, err := NewTraces(context.Background(), exporter.Settings{}, &fakeTracesConfig, newTraceDataPusher(nil))
+	te, err := NewTraces(context.Background(), exporter.Settings{}, newTraceDataPusher(nil))
 	require.Nil(t, te)
 	require.Equal(t, errNilLogger, err)
 }
 
 func TestTraces_NilPushTraceData(t *testing.T) {
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, nil)
+	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil)
 	require.Nil(t, te)
 	require.Equal(t, errNilPushTraces, err)
 }
 
 func TestTraces_Default(t *testing.T) {
 	td := ptrace.NewTraces()
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil))
+	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newTraceDataPusher(nil))
 	assert.NotNil(t, te)
 	require.NoError(t, err)
 
@@ -81,7 +72,7 @@ func TestTraces_Default(t *testing.T) {
 
 func TestTraces_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithCapabilities(capabilities))
+	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newTraceDataPusher(nil), WithCapabilities(capabilities))
 	assert.NotNil(t, te)
 	require.NoError(t, err)
 
@@ -91,7 +82,7 @@ func TestTraces_WithCapabilities(t *testing.T) {
 func TestTraces_Default_ReturnError(t *testing.T) {
 	td := ptrace.NewTraces()
 	want := errors.New("my_error")
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(want))
+	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newTraceDataPusher(want))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -142,7 +133,7 @@ func TestTraces_WithPersistentQueue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := consumertest.TracesSink{}
-			te, err := NewTraces(context.Background(), set, &fakeTracesConfig, ts.ConsumeTraces, WithQueue(configoptional.Some(qCfg)))
+			te, err := NewTraces(context.Background(), set, ts.ConsumeTraces, WithQueue(configoptional.Some(qCfg)))
 			require.NoError(t, err)
 			require.NoError(t, te.Start(context.Background(), host))
 			t.Cleanup(func() { require.NoError(t, te.Shutdown(context.Background())) })
@@ -168,7 +159,7 @@ func TestTraces_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTraces(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesConfig, newTraceDataPusher(nil))
+	te, err := NewTraces(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newTraceDataPusher(nil))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -179,7 +170,7 @@ func TestTraces_pLogModifiedDownStream_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTraces(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesConfig, newTraceDataPusherModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
+	te, err := NewTraces(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newTraceDataPusherModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	assert.NotNil(t, te)
 	require.NoError(t, err)
 	td := testdata.GenerateTraces(2)
@@ -215,7 +206,7 @@ func TestTraces_WithRecordMetrics_ReturnError(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTraces(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesConfig, newTraceDataPusher(want))
+	te, err := NewTraces(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, newTraceDataPusher(want))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -243,7 +234,7 @@ func TestTraces_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
-	te, err := NewTraces(context.Background(), set, &fakeTracesConfig, newTraceDataPusher(nil))
+	te, err := NewTraces(context.Background(), set, newTraceDataPusher(nil))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -272,7 +263,7 @@ func TestTraces_WithSpan_ReturnError(t *testing.T) {
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
 	want := errors.New("my_error")
-	te, err := NewTraces(context.Background(), set, &fakeTracesConfig, newTraceDataPusher(want))
+	te, err := NewTraces(context.Background(), set, newTraceDataPusher(want))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -298,7 +289,7 @@ func TestTraces_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithShutdown(shutdown))
+	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newTraceDataPusher(nil), WithShutdown(shutdown))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
@@ -311,7 +302,7 @@ func TestTraces_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithShutdown(shutdownErr))
+	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), newTraceDataPusher(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -50,26 +50,26 @@ var (
 )
 
 func TestTraces_InvalidName(t *testing.T) {
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newTraceDataPusher(nil))
+	te, err := NewTracesWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), nil, newTraceDataPusher(nil))
 	require.Nil(t, te)
 	require.Equal(t, errNilConfig, err)
 }
 
 func TestTraces_NilLogger(t *testing.T) {
-	te, err := NewTraces(context.Background(), exporter.Settings{}, &fakeTracesConfig, newTraceDataPusher(nil))
+	te, err := NewTracesWithConfig(context.Background(), exporter.Settings{}, &fakeTracesConfig, newTraceDataPusher(nil))
 	require.Nil(t, te)
 	require.Equal(t, errNilLogger, err)
 }
 
 func TestTraces_NilPushTraceData(t *testing.T) {
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, nil)
+	te, err := NewTracesWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, nil)
 	require.Nil(t, te)
 	require.Equal(t, errNilPushTraces, err)
 }
 
 func TestTraces_Default(t *testing.T) {
 	td := ptrace.NewTraces()
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil))
+	te, err := NewTracesWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil))
 	assert.NotNil(t, te)
 	require.NoError(t, err)
 
@@ -81,7 +81,7 @@ func TestTraces_Default(t *testing.T) {
 
 func TestTraces_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithCapabilities(capabilities))
+	te, err := NewTracesWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithCapabilities(capabilities))
 	assert.NotNil(t, te)
 	require.NoError(t, err)
 
@@ -91,7 +91,7 @@ func TestTraces_WithCapabilities(t *testing.T) {
 func TestTraces_Default_ReturnError(t *testing.T) {
 	td := ptrace.NewTraces()
 	want := errors.New("my_error")
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(want))
+	te, err := NewTracesWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(want))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -142,7 +142,7 @@ func TestTraces_WithPersistentQueue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := consumertest.TracesSink{}
-			te, err := NewTraces(context.Background(), set, &fakeTracesConfig, ts.ConsumeTraces, WithQueue(configoptional.Some(qCfg)))
+			te, err := NewTracesWithConfig(context.Background(), set, &fakeTracesConfig, ts.ConsumeTraces, WithQueue(configoptional.Some(qCfg)))
 			require.NoError(t, err)
 			require.NoError(t, te.Start(context.Background(), host))
 			t.Cleanup(func() { require.NoError(t, te.Shutdown(context.Background())) })
@@ -168,7 +168,7 @@ func TestTraces_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTraces(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesConfig, newTraceDataPusher(nil))
+	te, err := NewTracesWithConfig(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesConfig, newTraceDataPusher(nil))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -179,7 +179,7 @@ func TestTraces_pLogModifiedDownStream_WithRecordMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTraces(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesConfig, newTraceDataPusherModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
+	te, err := NewTracesWithConfig(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesConfig, newTraceDataPusherModifiedDownstream(nil), WithCapabilities(consumer.Capabilities{MutatesData: true}))
 	assert.NotNil(t, te)
 	require.NoError(t, err)
 	td := testdata.GenerateTraces(2)
@@ -216,7 +216,7 @@ func TestTraces_WithRecordMetrics_ReturnError(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTraces(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesConfig, newTraceDataPusher(want))
+	te, err := NewTracesWithConfig(context.Background(), exporter.Settings{ID: fakeTracesName, TelemetrySettings: tt.NewTelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesConfig, newTraceDataPusher(want))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -244,7 +244,7 @@ func TestTraces_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
-	te, err := NewTraces(context.Background(), set, &fakeTracesConfig, newTraceDataPusher(nil))
+	te, err := NewTracesWithConfig(context.Background(), set, &fakeTracesConfig, newTraceDataPusher(nil))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -273,7 +273,7 @@ func TestTraces_WithSpan_ReturnError(t *testing.T) {
 	defer otel.SetTracerProvider(nooptrace.NewTracerProvider())
 
 	want := errors.New("my_error")
-	te, err := NewTraces(context.Background(), set, &fakeTracesConfig, newTraceDataPusher(want))
+	te, err := NewTracesWithConfig(context.Background(), set, &fakeTracesConfig, newTraceDataPusher(want))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -299,7 +299,7 @@ func TestTraces_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithShutdown(shutdown))
+	te, err := NewTracesWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithShutdown(shutdown))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
@@ -312,7 +312,7 @@ func TestTraces_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	te, err := NewTraces(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithShutdown(shutdownErr))
+	te, err := NewTracesWithConfig(context.Background(), exportertest.NewNopSettings(exportertest.NopType), &fakeTracesConfig, newTraceDataPusher(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 

--- a/exporter/exportertest/contract_checker_test.go
+++ b/exporter/exportertest/contract_checker_test.go
@@ -45,7 +45,7 @@ func (mef *mockFactory) createMockTraces(
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Traces, error) {
-	return exporterhelper.NewTraces(ctx, set, cfg,
+	return exporterhelper.NewTraces(ctx, set,
 		mef.mr.ConsumeTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithRetry(retryConfig),
@@ -57,7 +57,7 @@ func (mef *mockFactory) createMockMetrics(
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Metrics, error) {
-	return exporterhelper.NewMetrics(ctx, set, cfg,
+	return exporterhelper.NewMetrics(ctx, set,
 		mef.mr.ConsumeMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithRetry(retryConfig),
@@ -69,7 +69,7 @@ func (mef *mockFactory) createMockLogs(
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Logs, error) {
-	return exporterhelper.NewLogs(ctx, set, cfg,
+	return exporterhelper.NewLogs(ctx, set,
 		mef.mr.ConsumeLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithRetry(retryConfig),

--- a/exporter/exportertest/contract_checker_test.go
+++ b/exporter/exportertest/contract_checker_test.go
@@ -45,7 +45,7 @@ func (mef *mockFactory) createMockTraces(
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Traces, error) {
-	return exporterhelper.NewTraces(ctx, set, cfg,
+	return exporterhelper.NewTracesWithConfig(ctx, set, cfg,
 		mef.mr.ConsumeTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithRetry(retryConfig),
@@ -57,7 +57,7 @@ func (mef *mockFactory) createMockMetrics(
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Metrics, error) {
-	return exporterhelper.NewMetrics(ctx, set, cfg,
+	return exporterhelper.NewMetricsWithConfig(ctx, set, cfg,
 		mef.mr.ConsumeMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithRetry(retryConfig),
@@ -69,7 +69,7 @@ func (mef *mockFactory) createMockLogs(
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Logs, error) {
-	return exporterhelper.NewLogs(ctx, set, cfg,
+	return exporterhelper.NewLogsWithConfig(ctx, set, cfg,
 		mef.mr.ConsumeLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithRetry(retryConfig),

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -77,7 +77,7 @@ func createTraces(
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
 
-	return exporterhelper.NewTraces(ctx, set, cfg,
+	return exporterhelper.NewTraces(ctx, set,
 		oce.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
@@ -96,7 +96,7 @@ func createMetrics(
 ) (exporter.Metrics, error) {
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
-	return exporterhelper.NewMetrics(ctx, set, cfg,
+	return exporterhelper.NewMetrics(ctx, set,
 		oce.pushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
@@ -115,7 +115,7 @@ func createLogs(
 ) (exporter.Logs, error) {
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
-	return exporterhelper.NewLogs(ctx, set, cfg,
+	return exporterhelper.NewLogs(ctx, set,
 		oce.pushLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -77,7 +77,7 @@ func createTraces(
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
 
-	return exporterhelper.NewTraces(ctx, set, cfg,
+	return exporterhelper.NewTracesWithConfig(ctx, set, cfg,
 		oce.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
@@ -96,7 +96,7 @@ func createMetrics(
 ) (exporter.Metrics, error) {
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
-	return exporterhelper.NewMetrics(ctx, set, cfg,
+	return exporterhelper.NewMetricsWithConfig(ctx, set, cfg,
 		oce.pushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),
@@ -115,7 +115,7 @@ func createLogs(
 ) (exporter.Logs, error) {
 	oce := newExporter(cfg, set)
 	oCfg := cfg.(*Config)
-	return exporterhelper.NewLogs(ctx, set, cfg,
+	return exporterhelper.NewLogsWithConfig(ctx, set, cfg,
 		oce.pushLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutConfig),

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -109,7 +109,7 @@ func createTraces(
 	}
 	oce.tracesURL = endpointURL.String()
 
-	return exporterhelper.NewTraces(ctx, set, cfg,
+	return exporterhelper.NewTraces(ctx, set,
 		oce.pushTraces,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
@@ -138,7 +138,7 @@ func createMetrics(
 	}
 	oce.metricsURL = endpointURL.String()
 
-	return exporterhelper.NewMetrics(ctx, set, cfg,
+	return exporterhelper.NewMetrics(ctx, set,
 		oce.pushMetrics,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
@@ -167,7 +167,7 @@ func createLogs(
 	}
 	oce.logsURL = endpointURL.String()
 
-	return exporterhelper.NewLogs(ctx, set, cfg,
+	return exporterhelper.NewLogs(ctx, set,
 		oce.pushLogs,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -109,7 +109,7 @@ func createTraces(
 	}
 	oce.tracesURL = endpointURL.String()
 
-	return exporterhelper.NewTraces(ctx, set, cfg,
+	return exporterhelper.NewTracesWithConfig(ctx, set, cfg,
 		oce.pushTraces,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
@@ -138,7 +138,7 @@ func createMetrics(
 	}
 	oce.metricsURL = endpointURL.String()
 
-	return exporterhelper.NewMetrics(ctx, set, cfg,
+	return exporterhelper.NewMetricsWithConfig(ctx, set, cfg,
 		oce.pushMetrics,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
@@ -167,7 +167,7 @@ func createLogs(
 	}
 	oce.logsURL = endpointURL.String()
 
-	return exporterhelper.NewLogs(ctx, set, cfg,
+	return exporterhelper.NewLogsWithConfig(ctx, set, cfg,
 		oce.pushLogs,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),

--- a/processor/queuebatchprocessor/processor.go
+++ b/processor/queuebatchprocessor/processor.go
@@ -43,15 +43,15 @@ func queueOptions(cfg *Config, next consumer.Capabilities) []exporterhelper.Opti
 }
 
 func newTracesProcessor(ctx context.Context, set processor.Settings, cfg *Config, next consumer.Traces) (processor.Traces, error) {
-	return exporterhelper.NewTraces(ctx, exporterSettings(set), cfg, next.ConsumeTraces, queueOptions(cfg, next.Capabilities())...)
+	return exporterhelper.NewTracesWithConfig(ctx, exporterSettings(set), cfg, next.ConsumeTraces, queueOptions(cfg, next.Capabilities())...)
 }
 
 func newMetricsProcessor(ctx context.Context, set processor.Settings, cfg *Config, next consumer.Metrics) (processor.Metrics, error) {
-	return exporterhelper.NewMetrics(ctx, exporterSettings(set), cfg, next.ConsumeMetrics, queueOptions(cfg, next.Capabilities())...)
+	return exporterhelper.NewMetricsWithConfig(ctx, exporterSettings(set), cfg, next.ConsumeMetrics, queueOptions(cfg, next.Capabilities())...)
 }
 
 func newLogsProcessor(ctx context.Context, set processor.Settings, cfg *Config, next consumer.Logs) (processor.Logs, error) {
-	return exporterhelper.NewLogs(ctx, exporterSettings(set), cfg, next.ConsumeLogs, queueOptions(cfg, next.Capabilities())...)
+	return exporterhelper.NewLogsWithConfig(ctx, exporterSettings(set), cfg, next.ConsumeLogs, queueOptions(cfg, next.Capabilities())...)
 }
 
 func newProfilesProcessor(ctx context.Context, set processor.Settings, cfg *Config, next xconsumer.Profiles) (xprocessor.Profiles, error) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR removes the unused `component.Config` parameter from the exporterhelper `NewLogs`, `NewMetrics`, and `NewTraces` constructors.
The helper constructors no longer using the configuration object and so passing it through is unnecessary. This change simplifies the public API by removing an unused parameter and updates all tree call sites and tests accordingly.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15094 

- [x] I, a human, wrote this pull request description myself.
