### PR TITLE
[exporter/exporterhelper] Fix retry request identity and cached size

### DIFF
--- a/.chloggen/fix-retry-request-identity.yaml
+++ b/.chloggen/fix-retry-request-identity.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix retry request identity and cached size handling in OnError
+
+# One or more tracking issues or pull requests related to the change
+issues: [14987]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: OnError now updates the existing request in place and resets cachedSize instead of allocating a new request.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/queuebatch/logs.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs.go
@@ -81,8 +81,9 @@ func (logsReferenceCounter) Unref(req request.Request) {
 func (req *logsRequest) OnError(err error) request.Request {
 	var logError consumererror.Logs
 	if errors.As(err, &logError) {
-		// TODO: Add logic to unref the new request created here.
-		return newLogsRequest(logError.Data())
+		req.ld = logError.Data()
+		req.cachedSize = -1
+		return req
 	}
 	return req
 }

--- a/exporter/exporterhelper/internal/queuebatch/logs_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_test.go
@@ -15,13 +15,16 @@ import (
 	"go.opentelemetry.io/collector/pdata/testdata"
 )
 
-func TestLogsRequest(t *testing.T) {
+func TestLogsRequestOnError(t *testing.T) {
 	lr := newLogsRequest(testdata.GenerateLogs(1))
+	req := lr.(*logsRequest)
+	req.cachedSize = 123
 
-	logErr := consumererror.NewLogs(errors.New("some error"), plog.NewLogs())
-	assert.Equal(
-		t,
-		newLogsRequest(plog.NewLogs()),
-		lr.(request.ErrorHandler).OnError(logErr),
-	)
+	remaining := plog.NewLogs()
+	logErr := consumererror.NewLogs(errors.New("some error"), remaining)
+	handled := lr.(request.ErrorHandler).OnError(logErr)
+
+	assert.Same(t, req, handled)
+	assert.Equal(t, remaining, req.ld)
+	assert.Equal(t, -1, req.cachedSize)
 }

--- a/exporter/exporterhelper/internal/queuebatch/metrics.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics.go
@@ -78,8 +78,9 @@ func (metricsReferenceCounter) Unref(req request.Request) {
 func (req *metricsRequest) OnError(err error) request.Request {
 	var metricsError consumererror.Metrics
 	if errors.As(err, &metricsError) {
-		// TODO: Add logic to unref the new request created here.
-		return newMetricsRequest(metricsError.Data())
+		req.md = metricsError.Data()
+		req.cachedSize = -1
+		return req
 	}
 	return req
 }

--- a/exporter/exporterhelper/internal/queuebatch/metrics_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_test.go
@@ -15,13 +15,16 @@ import (
 	"go.opentelemetry.io/collector/pdata/testdata"
 )
 
-func TestMetricsRequest(t *testing.T) {
+func TestMetricsRequestOnError(t *testing.T) {
 	mr := newMetricsRequest(testdata.GenerateMetrics(1))
+	req := mr.(*metricsRequest)
+	req.cachedSize = 123
 
-	metricsErr := consumererror.NewMetrics(errors.New("some error"), pmetric.NewMetrics())
-	assert.Equal(
-		t,
-		newMetricsRequest(pmetric.NewMetrics()),
-		mr.(request.ErrorHandler).OnError(metricsErr),
-	)
+	remaining := pmetric.NewMetrics()
+	metricsErr := consumererror.NewMetrics(errors.New("some error"), remaining)
+	handled := mr.(request.ErrorHandler).OnError(metricsErr)
+
+	assert.Same(t, req, handled)
+	assert.Equal(t, remaining, req.md)
+	assert.Equal(t, -1, req.cachedSize)
 }

--- a/exporter/exporterhelper/internal/queuebatch/traces.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces.go
@@ -81,8 +81,9 @@ func (tracesReferenceCounter) Unref(req request.Request) {
 func (req *tracesRequest) OnError(err error) request.Request {
 	var traceError consumererror.Traces
 	if errors.As(err, &traceError) {
-		// TODO: Add logic to unref the new request created here.
-		return newTracesRequest(traceError.Data())
+		req.td = traceError.Data()
+		req.cachedSize = -1
+		return req
 	}
 	return req
 }

--- a/exporter/exporterhelper/internal/queuebatch/traces_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_test.go
@@ -15,9 +15,16 @@ import (
 	"go.opentelemetry.io/collector/pdata/testdata"
 )
 
-func TestTracesRequest(t *testing.T) {
-	mr := newTracesRequest(testdata.GenerateTraces(1))
+func TestTracesRequestOnError(t *testing.T) {
+	tr := newTracesRequest(testdata.GenerateTraces(1))
+	req := tr.(*tracesRequest)
+	req.cachedSize = 123
 
-	traceErr := consumererror.NewTraces(errors.New("some error"), ptrace.NewTraces())
-	assert.Equal(t, newTracesRequest(ptrace.NewTraces()), mr.(request.ErrorHandler).OnError(traceErr))
+	remaining := ptrace.NewTraces()
+	traceErr := consumererror.NewTraces(errors.New("some error"), remaining)
+	handled := tr.(request.ErrorHandler).OnError(traceErr)
+
+	assert.Same(t, req, handled)
+	assert.Equal(t, remaining, req.td)
+	assert.Equal(t, -1, req.cachedSize)
 }

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -90,8 +90,9 @@ func (profilesReferenceCounter) Unref(req request.Request) {
 func (req *profilesRequest) OnError(err error) Request {
 	var profileError xconsumererror.Profiles
 	if errors.As(err, &profileError) {
-		// TODO: Add logic to unref the new request created here.
-		return newProfilesRequest(profileError.Data())
+		req.pd = profileError.Data()
+		req.cachedSize = -1
+		return req
 	}
 	return req
 }

--- a/exporter/exporterhelper/xexporterhelper/profiles_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_test.go
@@ -46,15 +46,18 @@ const (
 
 var fakeProfilesExporterConfig = struct{}{}
 
-func TestProfilesRequest(t *testing.T) {
-	lr := newProfilesRequest(testdata.GenerateProfiles(1))
+func TestProfilesRequestOnError(t *testing.T) {
+	pr := newProfilesRequest(testdata.GenerateProfiles(1))
+	req := pr.(*profilesRequest)
+	req.cachedSize = 123
 
-	profileErr := xconsumererror.NewProfiles(errors.New("some error"), pprofile.NewProfiles())
-	assert.Equal(
-		t,
-		newProfilesRequest(pprofile.NewProfiles()),
-		lr.(RequestErrorHandler).OnError(profileErr),
-	)
+	remaining := pprofile.NewProfiles()
+	profileErr := xconsumererror.NewProfiles(errors.New("some error"), remaining)
+	handled := pr.(RequestErrorHandler).OnError(profileErr)
+
+	assert.Same(t, req, handled)
+	assert.Equal(t, remaining, req.pd)
+	assert.Equal(t, -1, req.cachedSize)
 }
 
 func TestProfilesExporter_InvalidName(t *testing.T) {


### PR DESCRIPTION
Fixes #14987

On partial export failure, `OnError` created a new request instead of updating the existing one. That broke request identity relative to the queue and left `cachedSize` stale for retries.

This updates traces/metrics/logs/profiles requests in place and resets `cachedSize` to `-1` so size is  basicaly recomputed on the next use.


#### Tests

Updated unit tests:
- `TestTracesRequestOnError`
- `TestMetricsRequestOnError`
- `TestLogsRequestOnError`
- `TestProfilesRequestOnError`

They assert the same request object is returned, data is replaced with the remaining payload, and `cachedSize` is reset to `-1`.

(there was a `// TODO: Add logic to unref the new request created here.` in the codebase related to the same.)
i'v added the changelog entry in `.chloggen/fix-retry-request-identity.yaml`.

#### Writing Authorship 
- [x] I ,myself have written this pull request description myself, a human being.