### PR TITLE
[processor/batch] Honor Shutdown context during final flush

### DIFF
--- a/.chloggen/batchprocessor-shutdown-context-final-flush.yaml
+++ b/.chloggen/batchprocessor-shutdown-context-final-flush.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: processor/batch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Honor Shutdown context cancellation during the batch processor final flush
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Pending batches flushed on shutdown now use the Shutdown context so a cancelled or timed-out shutdown can unblock a stuck downstream export.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -48,8 +49,11 @@ type batchProcessor[T any] struct {
 	// with the appropriate signal.
 	batchFunc func() batch[T]
 
-	shutdownC  chan struct{}
-	goroutines sync.WaitGroup
+	shutdownC   chan struct{}
+	goroutines  sync.WaitGroup
+
+	// Shutdown context used for the final flush
+	shutdownCtx atomic.Value
 
 	telemetry *batchProcessorTelemetry
 
@@ -173,7 +177,8 @@ func (bp *batchProcessor[T]) Start(ctx context.Context, _ component.Host) error 
 }
 
 // Shutdown is invoked during service shutdown.
-func (bp *batchProcessor[T]) Shutdown(context.Context) error {
+func (bp *batchProcessor[T]) Shutdown(ctx context.Context) error {
+	bp.shutdownCtx.Store(ctx)
 	close(bp.shutdownC)
 
 	// Wait until all goroutines are done.
@@ -208,8 +213,6 @@ func (b *shard[T]) startLoop() {
 			}
 			// This is the close of the channel
 			if b.batch.itemCount() > 0 {
-				// TODO: Set a timeout on sendTraces or
-				// make it cancellable using the context that Shutdown gets as a parameter
 				b.sendItems(triggerTimeout)
 			}
 			return
@@ -267,12 +270,20 @@ func (b *shard[T]) sendItems(trigger trigger) {
 		bytes = b.batch.sizeBytes(req)
 	}
 
-	err := b.batch.export(b.exportCtx, req)
+	err := b.batch.export(b.exportContext(), req)
 	if err != nil {
 		b.processor.logger.Warn("Sender failed", zap.Error(err))
 		return
 	}
 	bpt.record(trigger, int64(sent), int64(bytes))
+}
+
+// exportContext prefers the Shutdown context (with shard metadata) when shutting down.
+func (b *shard[T]) exportContext() context.Context {
+	if v := b.processor.shutdownCtx.Load(); v != nil {
+		return client.NewContext(v.(context.Context), client.FromContext(b.exportCtx))
+	}
+	return b.exportCtx
 }
 
 // singleShardBatcher is used when metadataKeys is empty, to avoid the

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -1221,3 +1221,148 @@ func TestBatchSplitOnly(t *testing.T) {
 		require.Equal(t, maxBatch, ld.LogRecordCount())
 	}
 }
+
+type blockingLogsConsumer struct {
+	started  chan struct{}
+	gotCtx   context.Context
+	gotErr   error
+	mu       sync.Mutex
+	received int
+}
+
+func (c *blockingLogsConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (c *blockingLogsConsumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	c.mu.Lock()
+	c.gotCtx = ctx
+	c.received += ld.LogRecordCount()
+	c.mu.Unlock()
+
+	select {
+	case <-c.started:
+	default:
+		close(c.started)
+	}
+	<-ctx.Done()
+	err := ctx.Err()
+	c.mu.Lock()
+	c.gotErr = err
+	c.mu.Unlock()
+	return err
+}
+
+func TestBatchProcessorShutdownCancelsFinalFlush(t *testing.T) {
+	cfg := &Config{
+		Timeout:       100 * time.Second,
+		SendBatchSize: 1000,
+	}
+	require.NoError(t, cfg.Validate())
+
+	next := &blockingLogsConsumer{started: make(chan struct{})}
+	logs, err := NewFactory().CreateLogs(context.Background(), processortest.NewNopSettings(metadata.Type), cfg, next)
+	require.NoError(t, err)
+	require.NoError(t, logs.Start(context.Background(), componenttest.NewNopHost()))
+
+	require.NoError(t, logs.ConsumeLogs(context.Background(), testdata.GenerateLogs(5)))
+
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- logs.Shutdown(shutdownCtx)
+	}()
+
+	select {
+	case <-next.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for final flush export to start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-shutdownDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown did not return after cancelling shutdown context")
+	}
+
+	next.mu.Lock()
+	defer next.mu.Unlock()
+	require.ErrorIs(t, next.gotErr, context.Canceled)
+	require.Equal(t, 5, next.received)
+}
+
+func TestBatchProcessorShutdownFinalFlushHonorsDeadline(t *testing.T) {
+	cfg := &Config{
+		Timeout:       100 * time.Second,
+		SendBatchSize: 1000,
+	}
+	require.NoError(t, cfg.Validate())
+
+	next := &blockingLogsConsumer{started: make(chan struct{})}
+	logs, err := NewFactory().CreateLogs(context.Background(), processortest.NewNopSettings(metadata.Type), cfg, next)
+	require.NoError(t, err)
+	require.NoError(t, logs.Start(context.Background(), componenttest.NewNopHost()))
+
+	require.NoError(t, logs.ConsumeLogs(context.Background(), testdata.GenerateLogs(3)))
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// Shutdown blocks in the final flush until the deadline expires.
+	require.NoError(t, logs.Shutdown(shutdownCtx))
+
+	next.mu.Lock()
+	defer next.mu.Unlock()
+	require.ErrorIs(t, next.gotErr, context.DeadlineExceeded)
+	require.Equal(t, 3, next.received)
+}
+
+func TestBatchProcessorShutdownFinalFlushPreservesMetadata(t *testing.T) {
+	cfg := &Config{
+		Timeout:       100 * time.Second,
+		SendBatchSize: 1000,
+		MetadataKeys:  []string{"token1"},
+	}
+	require.NoError(t, cfg.Validate())
+
+	next := &blockingLogsConsumer{started: make(chan struct{})}
+	logs, err := NewFactory().CreateLogs(context.Background(), processortest.NewNopSettings(metadata.Type), cfg, next)
+	require.NoError(t, err)
+	require.NoError(t, logs.Start(context.Background(), componenttest.NewNopHost()))
+
+	callCtx := client.NewContext(context.Background(), client.Info{
+		Metadata: client.NewMetadata(map[string][]string{
+			"token1": {"shutdown-meta"},
+		}),
+	})
+	require.NoError(t, logs.ConsumeLogs(callCtx, testdata.GenerateLogs(2)))
+
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- logs.Shutdown(shutdownCtx)
+	}()
+
+	select {
+	case <-next.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for final flush export to start")
+	}
+
+	next.mu.Lock()
+	gotCtx := next.gotCtx
+	next.mu.Unlock()
+	require.Equal(t, []string{"shutdown-meta"}, client.FromContext(gotCtx).Metadata.Get("token1"))
+
+	cancel()
+
+	select {
+	case err := <-shutdownDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown did not return after cancelling shutdown context")
+	}
+}


### PR DESCRIPTION
On shutdown, the batch processor flushed pending data with a background-derived export context, so a cancelled or timed-out `Shutdown(ctx)` could not unblock a stuck downstream export.

Store the Shutdown context before signaling workers, and use it (with shard client metadata preserved) for exports after shutdown starts. Removes the long-standing TODO in `batch_processor.go`.

this PR has no corresponding dedicated issue; resolves an in-code TODO. (Happy to open one if preferred)

- `TestBatchProcessorShutdownCancelsFinalFlush`
- `TestBatchProcessorShutdownFinalFlushHonorsDeadline`
- `TestBatchProcessorShutdownFinalFlushPreservesMetadata`
- Full `go test ./processor/batchprocessor`

fixes: `// TODO: Set a timeout on sendTraces or // make it cancellable using the context that Shutdown gets as a parameter`

(i went with the second option
I did not invent a fixed timeout inside the batch processor (e.g. always “FLUSSH for 5s”).
What I did:
- Save Shutdown(ctx)
- Use that ctx for the final flush export
- So if the caller cancels or sets a deadline/timeout on that context, the flush can unblock
)

#### documentation added:
Changelog entry: `.chloggen/batchprocessor-shutdown-context-final-flush.yaml`

#### Providing authorships
I have written this PR description myself, a human being.