### PR TITLE
fix(configtls): use correct variable in invalid curve type error message

### DIFF
--- a/cmd/schemagen/README.md
+++ b/cmd/schemagen/README.md
@@ -4,7 +4,7 @@
 JSON Schema that mirrors the exported structs.
 
 Script is only for temporary use. The aim is to facilitate the process of introducing schemas for
-Open Telemetry Collector components. Ultimately, the configuration schemas would be maintained manually,
+OpenTelemetry Collector components. Ultimately, the configuration schemas would be maintained manually,
 and the generation process would be reversed – Go config files from schemas.
 
 > **Status:** In Development.

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -283,7 +283,7 @@ func (c Config) loadTLSConfig() (*tls.Config, error) {
 	for _, curve := range c.CurvePreferences {
 		curveID, ok := tlsCurveTypes[curve]
 		if !ok {
-			return nil, fmt.Errorf("invalid curve type: %s. Expected values are %s", curveID, allowedCurves)
+			return nil, fmt.Errorf("invalid curve type: %s. Expected values are %s", curve, allowedCurves)
 		}
 		curvePreferences = append(curvePreferences, curveID)
 	}


### PR DESCRIPTION
## Summary
- Fix error message that formats the wrong variable when an invalid TLS curve type is specified

## Bug
The error message formats `curveID` (the zero value of `tls.CurveID`, i.e., `0`) instead of `curve` (the user-provided string). Users see `%!s(uint16=0)` instead of the actual invalid input.

## Fix
Change `curveID` to `curve` in the error format string.
