### PR TITLE
[exporter/exporterhelper] Make partition idle cycles and max active partitions configurable

### DIFF
--- a/.chloggen/exporterhelper-configurable-partition-limits.yaml
+++ b/.chloggen/exporterhelper-configurable-partition-limits.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make partition idle cycles and max active partitions configurable
+
+# One or more tracking issues or pull requests related to the change
+issues: [15606]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Adds `sending_queue::batch::partition::idle_cycles` (default 10) and `max_active_partitions` (default 10000) so multi-tenant batchers can tune idle partition eviction and LRU size.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -66,6 +66,10 @@ Available `batch::partition` options:
   separate batches. When empty, a single batcher instance is used. When set, one batcher will be used
   per distinct combination of values for the listed metadata keys. Empty value and unset metadata are
   treated as distinct cases. Entries are case-insensitive. Duplicated entries will trigger a validation error. Default is empty.
+- `idle_cycles` (default = 10): number of `flush_timeout` periods an empty partition may remain idle
+  before it is removed. Useful to reclaim memory when many distinct metadata key combinations are seen over time.
+- `max_active_partitions` (default = 10000): maximum number of concurrent partition batchers. When the
+  limit is reached, the least recently used partition is flushed and removed.
 
 ### Timeout
 

--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -108,6 +108,11 @@ type BatchConfig struct {
 	Partition PartitionConfig `mapstructure:"partition"`
 }
 
+const (
+	defaultPartitionIdleCycles = 10
+	defaultMaxActivePartitions = 10000
+)
+
 // PartitionConfig defines a configuration for partitioning requests based on metadata keys.
 type PartitionConfig struct {
 	// MetadataKeys is a list of client.Metadata keys that will be used to partition
@@ -119,6 +124,29 @@ type PartitionConfig struct {
 	//
 	// Entries are case-insensitive. Duplicated entries will trigger a validation error.
 	MetadataKeys []string `mapstructure:"metadata_keys"`
+
+	// IdleCycles is the number of FlushTimeout periods an empty partition may remain
+	// idle before it is removed. Zero means the default (10).
+	IdleCycles int `mapstructure:"idle_cycles"`
+
+	// MaxActivePartitions is the maximum number of concurrent partition batchers.
+	// When the limit is reached, the least recently used partition is flushed and removed.
+	// Zero means the default (10000).
+	MaxActivePartitions int `mapstructure:"max_active_partitions"`
+}
+
+func (cfg PartitionConfig) idleCycles() int {
+	if cfg.IdleCycles <= 0 {
+		return defaultPartitionIdleCycles
+	}
+	return cfg.IdleCycles
+}
+
+func (cfg PartitionConfig) maxActivePartitions() int {
+	if cfg.MaxActivePartitions <= 0 {
+		return defaultMaxActivePartitions
+	}
+	return cfg.MaxActivePartitions
 }
 
 func (cfg *BatchConfig) Validate() error {
@@ -153,6 +181,14 @@ func (cfg *BatchConfig) Validate() error {
 func (cfg *PartitionConfig) Validate() error {
 	if cfg == nil {
 		return nil
+	}
+
+	if cfg.IdleCycles < 0 {
+		return fmt.Errorf("`idle_cycles` must be non-negative, found %d", cfg.IdleCycles)
+	}
+
+	if cfg.MaxActivePartitions < 0 {
+		return fmt.Errorf("`max_active_partitions` must be non-negative, found %d", cfg.MaxActivePartitions)
 	}
 
 	// Validate metadata_keys for duplicates (case-insensitive)

--- a/exporter/exporterhelper/internal/queuebatch/config.schema.yaml
+++ b/exporter/exporterhelper/internal/queuebatch/config.schema.yaml
@@ -27,6 +27,12 @@ $defs:
     description: PartitionConfig defines a configuration for partitioning requests based on metadata keys.
     type: object
     properties:
+      idle_cycles:
+        description: IdleCycles is the number of FlushTimeout periods an empty partition may remain idle before it is removed. Zero means the default (10).
+        type: integer
+      max_active_partitions:
+        description: MaxActivePartitions is the maximum number of concurrent partition batchers. When the limit is reached, the least recently used partition is flushed and removed. Zero means the default (10000).
+        type: integer
       metadata_keys:
         description: MetadataKeys is a list of client.Metadata keys that will be used to partition the data into batches. If this setting is empty, a single batcher instance will be used. When this setting is not empty, one batcher will be used per distinct combination of values for the listed metadata keys. Empty value and unset metadata are treated as distinct cases. Entries are case-insensitive. Duplicated entries will trigger a validation error.
         type: array

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -91,6 +91,30 @@ func TestBatchConfig_Validate_MetadataKeys(t *testing.T) {
 	})
 }
 
+func TestPartitionConfig_Validate_Limits(t *testing.T) {
+	cfg := newTestBatchConfig()
+	cfg.Partition.IdleCycles = -1
+	require.EqualError(t, confmap.Validate(cfg), "partition: `idle_cycles` must be non-negative, found -1")
+
+	cfg = newTestBatchConfig()
+	cfg.Partition.MaxActivePartitions = -1
+	require.EqualError(t, confmap.Validate(cfg), "partition: `max_active_partitions` must be non-negative, found -1")
+
+	cfg = newTestBatchConfig()
+	cfg.Partition.IdleCycles = 0
+	cfg.Partition.MaxActivePartitions = 0
+	require.NoError(t, confmap.Validate(cfg))
+	assert.Equal(t, defaultPartitionIdleCycles, cfg.Partition.idleCycles())
+	assert.Equal(t, defaultMaxActivePartitions, cfg.Partition.maxActivePartitions())
+
+	cfg = newTestBatchConfig()
+	cfg.Partition.IdleCycles = 3
+	cfg.Partition.MaxActivePartitions = 5
+	require.NoError(t, confmap.Validate(cfg))
+	assert.Equal(t, 3, cfg.Partition.idleCycles())
+	assert.Equal(t, 5, cfg.Partition.maxActivePartitions())
+}
+
 func TestBatchConfig_Validate(t *testing.T) {
 	cfg := newTestBatchConfig()
 	require.NoError(t, confmap.Validate(cfg))

--- a/exporter/exporterhelper/internal/queuebatch/multi_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/multi_batcher.go
@@ -47,8 +47,7 @@ func newMultiBatcher(
 	}
 
 	// Create LRU cache with eviction callback
-	// TODO: make maxActivePartitionsCount configurable
-	cache, err := lru.NewLRU[string, *partitionBatcher](10000, func(_ string, pb *partitionBatcher) {
+	cache, err := lru.NewLRU[string, *partitionBatcher](bCfg.Partition.maxActivePartitions(), func(_ string, pb *partitionBatcher) {
 		// Flush the partition when evicted
 		mb.wp.execute(pb.shutdownInternal)
 	})

--- a/exporter/exporterhelper/internal/queuebatch/multi_batcher_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/multi_batcher_test.go
@@ -123,11 +123,14 @@ func TestMultiBatcher_Timeout(t *testing.T) {
 }
 
 func TestMultiBatcher_PartitionRemovedAfterIdleTimeout(t *testing.T) {
-	// Use a short FlushTimeout so the idle threshold (partitionIdleCycles*FlushTimeout) is reached quickly.
+	// Use a short FlushTimeout so the idle threshold (idle_cycles*FlushTimeout) is reached quickly.
 	cfg := BatchConfig{
 		FlushTimeout: 10 * time.Millisecond,
 		Sizer:        request.SizerTypeItems,
 		MinSize:      100, // High min size to prevent immediate flush
+		Partition: PartitionConfig{
+			IdleCycles: 2,
+		},
 	}
 	sink := requesttest.NewSink()
 
@@ -161,9 +164,48 @@ func TestMultiBatcher_PartitionRemovedAfterIdleTimeout(t *testing.T) {
 		return sink.RequestsCount() == 1
 	}, 500*time.Millisecond, 10*time.Millisecond)
 
-	// Wait for idle timeout (partitionIdleCycles * FlushTimeout = 10 * 10ms = 100ms)
+	// Wait for idle timeout (idle_cycles * FlushTimeout = 2 * 10ms = 20ms)
 	// After this, the partition should be removed from the LRU cache.
 	assert.Eventually(t, func() bool {
 		return ba.getActivePartitionsCount() == 0
 	}, 500*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestMultiBatcher_MaxActivePartitionsEvictsLRU(t *testing.T) {
+	cfg := BatchConfig{
+		FlushTimeout: 100 * time.Millisecond,
+		Sizer:        request.SizerTypeItems,
+		MinSize:      100,
+		Partition: PartitionConfig{
+			MaxActivePartitions: 2,
+		},
+	}
+	sink := requesttest.NewSink()
+
+	type partitionKey struct{}
+
+	ba, err := newMultiBatcher(cfg,
+		request.NewItemsSizer(),
+		newWorkerPool(4),
+		NewPartitioner(func(ctx context.Context, _ request.Request) string {
+			return ctx.Value(partitionKey{}).(string)
+		}),
+		nil,
+		sink.Export,
+		zap.NewNop(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, ba.Shutdown(context.Background()))
+	})
+
+	done := newFakeDone()
+	ba.Consume(context.WithValue(context.Background(), partitionKey{}, "p1"), &requesttest.FakeRequest{Items: 1}, done)
+	ba.Consume(context.WithValue(context.Background(), partitionKey{}, "p2"), &requesttest.FakeRequest{Items: 1}, done)
+	assert.Equal(t, int64(2), ba.getActivePartitionsCount())
+
+	// Adding a third partition should evict the least recently used one.
+	ba.Consume(context.WithValue(context.Background(), partitionKey{}, "p3"), &requesttest.FakeRequest{Items: 1}, done)
+	assert.Equal(t, int64(2), ba.getActivePartitionsCount())
 }

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
@@ -17,10 +17,6 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
 )
 
-// partitionIdleCycles*FlushTimeout is the duration after which an empty partition is removed.
-// TODO make this configurable.
-const partitionIdleCycles = 10
-
 var _ Batcher[request.Request] = (*partitionBatcher)(nil)
 
 type batch struct {
@@ -262,7 +258,7 @@ func (qb *partitionBatcher) flushCurrentBatchOrRemovePartition() {
 		// No data to flush - check if idle for too long AND no one holding a reference
 		idleDuration := time.Since(qb.lastDataTime)
 
-		if idleDuration >= (partitionIdleCycles*qb.cfg.FlushTimeout) && qb.onEmpty != nil {
+		if idleDuration >= (time.Duration(qb.cfg.Partition.idleCycles())*qb.cfg.FlushTimeout) && qb.onEmpty != nil {
 			qb.currentBatchMu.Unlock()
 			qb.onEmpty()
 			return

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
@@ -560,11 +560,14 @@ func TestPartitionBatcher_ContextMerging(t *testing.T) {
 }
 
 func TestPartitionBatcher_OnEmptyCallbackTriggered(t *testing.T) {
-	// Use a very short FlushTimeout so the idle threshold (partitionIdleCycles*FlushTimeout) is reached quickly.
+	// Use a short FlushTimeout so the idle threshold (idle_cycles*FlushTimeout) is reached quickly.
 	cfg := BatchConfig{
 		FlushTimeout: 10 * time.Millisecond,
 		Sizer:        request.SizerTypeItems,
 		MinSize:      100, // High min size to ensure data doesn't flush immediately
+		Partition: PartitionConfig{
+			IdleCycles: 2,
+		},
 	}
 
 	sink := requesttest.NewSink()
@@ -588,7 +591,7 @@ func TestPartitionBatcher_OnEmptyCallbackTriggered(t *testing.T) {
 		return sink.RequestsCount() == 1
 	}, 500*time.Millisecond, 10*time.Millisecond)
 
-	// Now wait for idle timeout (partitionIdleCycles * FlushTimeout = 10 * 10ms = 100ms)
+	// Now wait for idle timeout (idle_cycles * FlushTimeout = 2 * 10ms = 20ms)
 	// The onEmpty callback should be called after the partition is idle for this duration.
 	assert.Eventually(t, func() bool {
 		return onEmptyCalled.Load() >= 1


### PR DESCRIPTION
#### Description

When `sending_queue::batch::partition` is used, idle-partition eviction and the partition LRU size were hardcoded (`10 * flush_timeout` and `10000`). Both had TODOs asking to make them configurable. I've added this:

```golang
const (
	defaultPartitionIdleCycles = 10
	defaultMaxActivePartitions = 10000
)
```

#### Link to tracking issue
Fixes #15606 

#### Testing:
I've edited/added the following tests:
- `TestPartitionConfig_Validate_Limits`
- `TestPartitionBatcher_OnEmptyCallbackTriggered` (uses configurable `idle_cycles`)
- `TestMultiBatcher_PartitionRemovedAfterIdleTimeout`
- `TestMultiBatcher_MaxActivePartitionsEvictsLRU`
- Full `go test ./exporter/exporterhelper/internal/queuebatch`

#### Documentation
I've updated `exporter/exporterhelper/README.md` . and also ,Updated `config.schema.yaml`.
Changelog: `.chloggen/exporterhelper-configurable-partition-limits.yaml`

#### Authorship

- [x] I, a human, wrote this pull request description myself.