### PR TITLE
Refresh percentage memory limits after cgroup changes

### DIFF
--- a/internal/memorylimiter/memorylimiter.go
+++ b/internal/memorylimiter/memorylimiter.go
@@ -43,6 +43,13 @@ var (
 type MemoryLimiter struct {
 	usageChecker memUsageChecker
 
+	// Percentage-based limits are refreshed on each memory check so that
+	// in-place container resizes are reflected without changing fixed limits.
+	percentageBased       bool
+	memoryLimitPercentage uint64
+	memorySpikePercentage uint64
+	getMemoryFn           func() (uint64, error)
+
 	memCheckWait time.Duration
 
 	// mustRefuse is used to indicate when data should be refused.
@@ -113,6 +120,10 @@ func NewMemoryLimiter(cfg *Config, logger *zap.Logger) (*MemoryLimiter, error) {
 
 	return &MemoryLimiter{
 		usageChecker:                 *usageChecker,
+		percentageBased:              cfg.MemoryLimitMiB == 0,
+		memoryLimitPercentage:        uint64(cfg.MemoryLimitPercentage),
+		memorySpikePercentage:        uint64(cfg.MemorySpikePercentage),
+		getMemoryFn:                  GetMemoryFn,
 		memCheckWait:                 cfg.CheckInterval,
 		ticker:                       time.NewTicker(cfg.CheckInterval),
 		minGCIntervalWhenSoftLimited: cfg.MinGCIntervalWhenSoftLimited,
@@ -255,6 +266,7 @@ func (ml *MemoryLimiter) nextBackoffInterval(current, configMin, configMax time.
 
 // CheckMemLimits inspects current memory usage against threshold and toggles mustRefuse when threshold is exceeded
 func (ml *MemoryLimiter) CheckMemLimits() {
+	ml.refreshPercentageMemoryLimit()
 	ms := ml.readMemStats()
 
 	ml.logger.Debug("Currently used memory.", memstatToZapField(ms))
@@ -307,6 +319,20 @@ func (ml *MemoryLimiter) CheckMemLimits() {
 	}
 
 	ml.mustRefuse.Store(aboveSoftLimit)
+}
+
+func (ml *MemoryLimiter) refreshPercentageMemoryLimit() {
+	if !ml.percentageBased {
+		return
+	}
+
+	totalMemory, err := ml.getMemoryFn()
+	if err != nil {
+		ml.logger.Warn("Unable to refresh percentage memory limiter; retaining previous limits.", zap.Error(err))
+		return
+	}
+
+	ml.usageChecker = *newPercentageMemUsageChecker(totalMemory, ml.memoryLimitPercentage, ml.memorySpikePercentage)
 }
 
 type memUsageChecker struct {

--- a/internal/memorylimiter/memorylimiter_test.go
+++ b/internal/memorylimiter/memorylimiter_test.go
@@ -5,6 +5,7 @@ package memorylimiter
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"testing"
 	"time"
@@ -105,6 +106,43 @@ func TestGetDecision(t *testing.T) {
 			memSpikeLimit: 10 * mibBytes,
 		}, d)
 	})
+}
+
+func TestRefreshPercentageMemoryLimit(t *testing.T) {
+	var totalMemory uint64 = 100 * mibBytes
+	getMemory := func() (uint64, error) {
+		return totalMemory, nil
+	}
+	originalGetMemory := GetMemoryFn
+	GetMemoryFn = getMemory
+	t.Cleanup(func() { GetMemoryFn = originalGetMemory })
+
+	ml, err := NewMemoryLimiter(&Config{
+		CheckInterval:         time.Minute,
+		MemoryLimitPercentage: 80,
+		MemorySpikePercentage: 20,
+	}, zap.NewNop())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(80*mibBytes), ml.usageChecker.memAllocLimit)
+	assert.Equal(t, uint64(20*mibBytes), ml.usageChecker.memSpikeLimit)
+
+	totalMemory = 200 * mibBytes
+	ml.refreshPercentageMemoryLimit()
+	assert.Equal(t, uint64(160*mibBytes), ml.usageChecker.memAllocLimit)
+	assert.Equal(t, uint64(40*mibBytes), ml.usageChecker.memSpikeLimit)
+}
+
+func TestRefreshPercentageMemoryLimitRetainsPreviousLimitOnError(t *testing.T) {
+	ml, err := NewMemoryLimiter(&Config{
+		CheckInterval:         time.Minute,
+		MemoryLimitPercentage: 80,
+		MemorySpikePercentage: 20,
+	}, zap.NewNop())
+	require.NoError(t, err)
+	previous := ml.usageChecker
+	ml.getMemoryFn = func() (uint64, error) { return 0, errors.New("cgroup unavailable") }
+	ml.refreshPercentageMemoryLimit()
+	assert.Equal(t, previous, ml.usageChecker)
 }
 
 func TestRefuseDecision(t *testing.T) {


### PR DESCRIPTION
## Problem

Percentage-based `memorylimiterprocessor` thresholds are resolved once at startup. When Kubernetes changes a container memory limit in place, the processor continues enforcing the stale thresholds.

## Solution

Refresh cgroup-backed percentage thresholds on each existing memory-check interval. If a refresh fails, retain the previous thresholds and log a warning. Fixed MiB limits are unchanged.

Addresses open-telemetry/opentelemetry-collector#15580.

## Validation

- `go test .` in `internal/memorylimiter`
- `go test .` in `processor/memorylimiterprocessor`
- `git diff --check`

Signed-off-by: ADITYA CHAUHAN <hooiv@users.noreply.github.com>