### PR TITLE
[configgrpc] Remove the `BalancerName` function

### DIFF
--- a/.chloggen/configgrpc-deprecate-balancername.yaml
+++ b/.chloggen/configgrpc-deprecate-balancername.yaml
@@ -4,7 +4,7 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: configgrpc
+component: pkg/configgrpc
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Remove the `BalancerName` function

--- a/.chloggen/configgrpc-deprecate-balancername.yaml
+++ b/.chloggen/configgrpc-deprecate-balancername.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the `BalancerName` function
+
+# One or more tracking issues or pull requests related to the change
+issues: [9477]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use the `DefaultBalancerName` constant instead.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/configgrpc-deprecate-balancername.yaml
+++ b/.chloggen/configgrpc-deprecate-balancername.yaml
@@ -4,7 +4,7 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: pkg/configgrpc
+component: pkg/config/configgrpc
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Remove the `BalancerName` function

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -67,13 +67,6 @@ func NewDefaultKeepaliveClientConfig() KeepaliveClientConfig {
 	}
 }
 
-// BalancerName returns a string with default load balancer value
-//
-// Deprecated[v0.151.0]: Use the DefaultBalancerName constant instead.
-func BalancerName() string {
-	return DefaultBalancerName
-}
-
 var _ xconfmap.Validator = (*ClientConfig)(nil)
 
 // ClientConfig defines common settings for a gRPC client configuration.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The function has been deprecated for several versions now and is ready for removal.

<!-- Issue number if applicable -->
#### Link to tracking issue

Prereq for #9477

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
