### PR TITLE
[confmap] Stabilize `WithForceUnmarshaler`

### DIFF
--- a/.chloggen/confmap-new-option.yaml
+++ b/.chloggen/confmap-new-option.yaml
@@ -10,7 +10,7 @@ component: pkg/confmap
 note: Add `WithForceUnmarshaler` option.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [15614]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/confmap-new-option.yaml
+++ b/.chloggen/confmap-new-option.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `WithForceUnmarshaler` option.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This option allows forcing the top-level Unmarshal method even if the Conf is
+  already a parameter from an Unmarshal method. See the Godoc for more details.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/xconfmap-deprecate-option.yaml
+++ b/.chloggen/xconfmap-deprecate-option.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/confmap/xconfmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `WithForceUnmarshaler` option.
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use `confmap.WithForceUnmarshaler` instead.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/xconfmap-deprecate-option.yaml
+++ b/.chloggen/xconfmap-deprecate-option.yaml
@@ -10,7 +10,7 @@ component: pkg/xconfmap
 note: Deprecate `WithForceUnmarshaler` option.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [15614]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/xconfmap-deprecate-option.yaml
+++ b/.chloggen/xconfmap-deprecate-option.yaml
@@ -4,7 +4,7 @@
 change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: pkg/confmap/xconfmap
+component: pkg/xconfmap
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Deprecate `WithForceUnmarshaler` option.

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.62.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.156.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.156.0 // indirect

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -117,8 +117,6 @@ replace go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmid
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil
 
 replace go.opentelemetry.io/collector/internal/componentalias => ../../internal/componentalias

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -61,7 +61,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/confmap v1.62.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.62.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -115,8 +115,6 @@ replace go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmid
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil
 
 replace go.opentelemetry.io/collector/internal/componentalias => ../../internal/componentalias

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -109,8 +109,6 @@ replace go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmid
 
 replace go.opentelemetry.io/collector/confmap => ../../../confmap
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/internal/testutil => ../../../internal/testutil
 
 replace go.opentelemetry.io/collector/internal/componentalias => ../../../internal/componentalias

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -49,7 +49,6 @@ require (
 	go.opentelemetry.io/collector/config/configoptional v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.62.0 // indirect
 	go.opentelemetry.io/collector/confmap v1.62.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.62.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.156.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.62.0 // indirect

--- a/config/configoptional/go.mod
+++ b/config/configoptional/go.mod
@@ -5,7 +5,6 @@ go 1.25.0
 require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/confmap v1.62.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -30,7 +29,5 @@ require (
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
 replace go.opentelemetry.io/collector/featuregate => ../../featuregate
-
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
 
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil

--- a/config/configoptional/optional.go
+++ b/config/configoptional/optional.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/confmap"
-	"go.opentelemetry.io/collector/confmap/xconfmap"
 )
 
 type flavor int
@@ -191,7 +190,7 @@ func (o *Optional[T]) Unmarshal(conf *confmap.Conf) error {
 		}
 	}
 
-	if err := conf.Unmarshal(&o.value, xconfmap.WithForceUnmarshaler()); err != nil {
+	if err := conf.Unmarshal(&o.value, confmap.WithForceUnmarshaler()); err != nil {
 		return err
 	}
 

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -39,6 +39,16 @@ func WithIgnoreUnused() UnmarshalOption {
 	return internal.WithIgnoreUnused()
 }
 
+// WithForceUnmarshaler sets an option to run a top-level Unmarshal method,
+// even if the Conf being unmarshaled is already a parameter from an Unmarshal method.
+// To avoid infinite recursion, this should only be used when unmarshaling into
+// a different type from the current Unmarshaler.
+// For instance, this should be used in wrapper types such as configoptional.Optional
+// to ensure the inner type's Unmarshal method is called.
+func WithForceUnmarshaler() UnmarshalOption {
+	return internal.WithForceUnmarshaler()
+}
+
 type MarshalOption = internal.MarshalOption
 
 // Unmarshaler interface may be implemented by types to customize their behavior when being unmarshaled from a Conf.

--- a/confmap/xconfmap/config.go
+++ b/confmap/xconfmap/config.go
@@ -27,6 +27,8 @@ func Validate(cfg any) error {
 // a different type from the current Unmarshaler.
 // For instance, this should be used in wrapper types such as configoptional.Optional
 // to ensure the inner type's Unmarshal method is called.
+//
+// Deprecated [v0.157.0]: Use [confmap.WithForceUnmarshaler] instead.
 func WithForceUnmarshaler() confmap.UnmarshalOption {
 	return internal.WithForceUnmarshaler()
 }

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -47,7 +47,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/client v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.62.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.156.0 // indirect

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -131,8 +131,6 @@ replace go.opentelemetry.io/collector/pdata/xpdata => ../../pdata/xpdata
 
 replace go.opentelemetry.io/collector/config/configoptional => ../../config/configoptional
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/exporter/exporterhelper => ../exporterhelper
 
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil

--- a/exporter/exporterhelper/go.mod
+++ b/exporter/exporterhelper/go.mod
@@ -121,8 +121,6 @@ replace go.opentelemetry.io/collector/confmap => ../../confmap
 
 replace go.opentelemetry.io/collector/config/configoptional => ../../config/configoptional
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil
 
 replace go.opentelemetry.io/collector/internal/componentalias => ../../internal/componentalias

--- a/exporter/exporterhelper/go.mod
+++ b/exporter/exporterhelper/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.156.0 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.156.0 // indirect
 	go.opentelemetry.io/collector/extension v1.62.0 // indirect

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -124,8 +124,6 @@ replace go.opentelemetry.io/collector/config/configoptional => ../../../config/c
 
 replace go.opentelemetry.io/collector/confmap => ../../../confmap
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/exporter/exporterhelper => ../
 
 replace go.opentelemetry.io/collector/internal/testutil => ../../../internal/testutil

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -51,7 +51,6 @@ require (
 	go.opentelemetry.io/collector/client v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.62.0 // indirect
 	go.opentelemetry.io/collector/confmap v1.62.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/extension v1.62.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.156.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.62.0 // indirect

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -45,7 +45,6 @@ require (
 	go.opentelemetry.io/collector/client v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configoptional v1.62.0 // indirect
 	go.opentelemetry.io/collector/confmap v1.62.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.156.0 // indirect
 	go.opentelemetry.io/collector/extension v1.62.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.156.0 // indirect

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -115,8 +115,6 @@ replace go.opentelemetry.io/collector/config/configoptional => ../../config/conf
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/exporter/exporterhelper => ../exporterhelper
 
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/client v1.62.0 // indirect
 	go.opentelemetry.io/collector/confmap v1.62.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.156.0 // indirect
 	go.opentelemetry.io/collector/extension v1.62.0 // indirect

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -106,8 +106,6 @@ replace go.opentelemetry.io/collector/confmap => ../confmap
 
 replace go.opentelemetry.io/collector/config/configoptional => ../config/configoptional
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/exporter/exporterhelper => ./exporterhelper
 
 replace go.opentelemetry.io/collector/internal/testutil => ../internal/testutil

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -109,8 +109,6 @@ replace go.opentelemetry.io/collector/pdata/xpdata => ../../pdata/xpdata
 
 replace go.opentelemetry.io/collector/config/configoptional => ../../config/configoptional
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/exporter/exporterhelper => ../exporterhelper
 
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -111,8 +111,6 @@ replace go.opentelemetry.io/collector/config/configtls => ../../config/configtls
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/exporter => ../
 
 replace go.opentelemetry.io/collector/extension => ../../extension

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -64,7 +64,6 @@ require (
 	go.opentelemetry.io/collector/client v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.62.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.156.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -66,7 +66,6 @@ require (
 	go.opentelemetry.io/collector/config/configauth v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.62.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.156.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -115,8 +115,6 @@ replace go.opentelemetry.io/collector/config/configtls => ../../config/configtls
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/exporter => ../
 
 replace go.opentelemetry.io/collector/extension => ../../extension

--- a/exporter/xexporter/go.mod
+++ b/exporter/xexporter/go.mod
@@ -80,8 +80,6 @@ replace go.opentelemetry.io/collector/config/configoptional => ../../config/conf
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/exporter/exporterhelper => ../exporterhelper
 
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -55,7 +55,6 @@ require (
 	go.opentelemetry.io/collector/config/configmiddleware v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.62.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.62.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.156.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.62.0 // indirect

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -128,8 +128,6 @@ replace go.opentelemetry.io/collector/config/configmiddleware => ../../config/co
 
 replace go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest => ../extensionmiddleware/extensionmiddlewaretest
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/internal/testutil => ../../internal/testutil
 
 replace go.opentelemetry.io/collector/internal/componentalias => ../../internal/componentalias

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -70,7 +70,6 @@ require (
 	go.opentelemetry.io/collector/config/configcompression v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v1.62.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.62.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.156.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.62.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.156.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.62.0 // indirect

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -114,8 +114,6 @@ replace go.opentelemetry.io/collector/config/configtls => ../../config/configtls
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-replace go.opentelemetry.io/collector/confmap/xconfmap => ../../confmap/xconfmap
-
 replace go.opentelemetry.io/collector/extension => ../../extension
 
 replace go.opentelemetry.io/collector/extension/extensionauth => ../../extension/extensionauth


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This option has been around for months now and is being used by stable modules. It should be safe to stabilize since we will be using it for the foreseeable future.

This also removes an `xconfmap` dependency from modules that use configoptional.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
