### PR TITLE
[debugexporter] Fix profile attribute formatting

### DIFF
--- a/.chloggen/20260723_fix-sample-formatting.yaml
+++ b/.chloggen/20260723_fix-sample-formatting.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporter/debug
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix profile sample attribute formatting for non-string values
+
+# One or more tracking issues or pull requests related to the change
+issues: [15647]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/20260723_fix-sample-formatting.yaml
+++ b/.chloggen/20260723_fix-sample-formatting.yaml
@@ -15,7 +15,10 @@ issues: [15647]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  Previously, non-string values produced malformed output such as `%!s(int64=42)`.
+  Profile sample attributes now use the debug exporter's typed attribute format, such as `Int(42)`.
+  This will also change strings from `hello-world` to `Str(hello-world)`.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/exporter/debugexporter/internal/otlptext/databuffer.go
+++ b/exporter/debugexporter/internal/otlptext/databuffer.go
@@ -361,7 +361,7 @@ func (b *dataBuffer) logProfileSamples(ss pprofile.SampleSlice, dic pprofile.Pro
 				if keyIdx < dic.StringTable().Len() {
 					key = dic.StringTable().At(keyIdx)
 				}
-				b.logEntry("             -> %s: %s", key, attr.Value().AsRaw())
+				b.logEntry("             -> %s: %v", key, attr.Value().AsRaw())
 			}
 		}
 	}

--- a/exporter/debugexporter/internal/otlptext/databuffer.go
+++ b/exporter/debugexporter/internal/otlptext/databuffer.go
@@ -361,7 +361,7 @@ func (b *dataBuffer) logProfileSamples(ss pprofile.SampleSlice, dic pprofile.Pro
 				if keyIdx < dic.StringTable().Len() {
 					key = dic.StringTable().At(keyIdx)
 				}
-				b.logEntry("             -> %s: %v", key, attr.Value().AsRaw())
+				b.logEntry("             -> %s: %s", key, valueToString(attr.Value()))
 			}
 		}
 	}

--- a/exporter/debugexporter/internal/otlptext/profiles_test.go
+++ b/exporter/debugexporter/internal/otlptext/profiles_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/testdata"
 )
@@ -46,6 +47,55 @@ func TestProfilesText(t *testing.T) {
 			require.NoError(t, err)
 			expected := strings.ReplaceAll(string(out), "\r", "")
 			assert.Equal(t, expected, string(got))
+		})
+	}
+}
+
+func TestProfilesTextSampleAttributeValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		setValue func(pcommon.Value)
+		expected string
+	}{
+		{name: "empty", setValue: func(_ pcommon.Value) {}, expected: "<nil>"},
+		{name: "string", setValue: func(v pcommon.Value) { v.SetStr("value") }, expected: "value"},
+		{name: "integer", setValue: func(v pcommon.Value) { v.SetInt(42) }, expected: "42"},
+		{name: "double", setValue: func(v pcommon.Value) { v.SetDouble(3.14) }, expected: "3.14"},
+		{name: "boolean", setValue: func(v pcommon.Value) { v.SetBool(true) }, expected: "true"},
+		{
+			name:     "bytes",
+			setValue: func(v pcommon.Value) { v.SetEmptyBytes().FromRaw([]byte{1, 2, 3}) },
+			expected: "[1 2 3]",
+		},
+		{
+			name:     "map",
+			setValue: func(v pcommon.Value) { _ = v.SetEmptyMap().FromRaw(map[string]any{"nested": "value"}) },
+			expected: "map[nested:value]",
+		},
+		{
+			name:     "slice",
+			setValue: func(v pcommon.Value) { _ = v.SetEmptySlice().FromRaw([]any{"value", true}) },
+			expected: "[value true]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profiles := pprofile.NewProfiles()
+			dic := profiles.Dictionary()
+			dic.StringTable().Append("")
+			dic.StringTable().Append("key")
+			attribute := dic.AttributeTable().AppendEmpty()
+			attribute.SetKeyStrindex(1)
+			tt.setValue(attribute.Value())
+
+			sample := profiles.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty().Samples().AppendEmpty()
+			sample.Values().Append(100)
+			sample.AttributeIndices().Append(0)
+
+			output, err := NewTextProfilesMarshaler().MarshalProfiles(profiles)
+			require.NoError(t, err)
+			assert.Contains(t, string(output), "-> key: "+tt.expected)
 		})
 	}
 }

--- a/exporter/debugexporter/internal/otlptext/profiles_test.go
+++ b/exporter/debugexporter/internal/otlptext/profiles_test.go
@@ -57,25 +57,25 @@ func TestProfilesTextSampleAttributeValues(t *testing.T) {
 		setValue func(pcommon.Value)
 		expected string
 	}{
-		{name: "empty", setValue: func(_ pcommon.Value) {}, expected: "<nil>"},
-		{name: "string", setValue: func(v pcommon.Value) { v.SetStr("value") }, expected: "value"},
-		{name: "integer", setValue: func(v pcommon.Value) { v.SetInt(42) }, expected: "42"},
-		{name: "double", setValue: func(v pcommon.Value) { v.SetDouble(3.14) }, expected: "3.14"},
-		{name: "boolean", setValue: func(v pcommon.Value) { v.SetBool(true) }, expected: "true"},
+		{name: "empty", setValue: func(_ pcommon.Value) {}, expected: "Empty()"},
+		{name: "string", setValue: func(v pcommon.Value) { v.SetStr("value") }, expected: "Str(value)"},
+		{name: "integer", setValue: func(v pcommon.Value) { v.SetInt(42) }, expected: "Int(42)"},
+		{name: "double", setValue: func(v pcommon.Value) { v.SetDouble(3.14) }, expected: "Double(3.14)"},
+		{name: "boolean", setValue: func(v pcommon.Value) { v.SetBool(true) }, expected: "Bool(true)"},
 		{
 			name:     "bytes",
 			setValue: func(v pcommon.Value) { v.SetEmptyBytes().FromRaw([]byte{1, 2, 3}) },
-			expected: "[1 2 3]",
+			expected: "Bytes(AQID)",
 		},
 		{
 			name:     "map",
 			setValue: func(v pcommon.Value) { _ = v.SetEmptyMap().FromRaw(map[string]any{"nested": "value"}) },
-			expected: "map[nested:value]",
+			expected: `Map({"nested":"value"})`,
 		},
 		{
 			name:     "slice",
 			setValue: func(v pcommon.Value) { _ = v.SetEmptySlice().FromRaw([]any{"value", true}) },
-			expected: "[value true]",
+			expected: `Slice(["value",true])`,
 		},
 	}
 

--- a/exporter/debugexporter/internal/otlptext/testdata/profiles/two_profiles.out
+++ b/exporter/debugexporter/internal/otlptext/testdata/profiles/two_profiles.out
@@ -67,7 +67,7 @@ Profile #0
     Sample #0
         Values: [4]
         Attributes:
-             -> key: value-1
+             -> key: Str(value-1)
 Profile #1
     Profile ID     : 0202030405060708090a0b0c0d0e0f10
     Start time     : 2020-02-11 20:26:12.000000321 +0000 UTC
@@ -76,4 +76,4 @@ Profile #1
     Sample #0
         Values: [9]
         Attributes:
-             -> key: value-2
+             -> key: Str(value-2)


### PR DESCRIPTION
The debug exporter formats profile sample attributes using `%s` with values returned by `AsRaw()`.

Integer and other non-string values therefore produce malformed output such as `%!s(int64=42)`. This changes the format verb to `%v`, preserving the raw attribute value while supporting all profile attribute types.

Fixes #15647