### PR TITLE
[exporterhelper] Always record send_failed metrics, even with zero value

### DIFF
--- a/.chloggen/fix-send-failed-metric-always-recorded.yaml
+++ b/.chloggen/fix-send-failed-metric-always-recorded.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Record the `otelcol_exporter_send_failed_*` metrics on every send so they are always present, restoring the behavior before v0.146.0.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15568]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Since v0.146.0 the failed items counters were only recorded when a send failed,
+  so exporters without failures no longer reported the metric at all and
+  dashboards or alerts based on it stopped working. Successful sends now record
+  a zero value again. Failed sends keep the `error.type` and `error.permanent`
+  attributes introduced in v0.146.0.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/obs_report_sender.go
+++ b/exporter/exporterhelper/internal/obs_report_sender.go
@@ -139,9 +139,14 @@ func (ors *obsReportSender[K]) endOp(ctx context.Context, numRecords int, err er
 		ors.itemsSentInst.Add(ctx, numSent, ors.metricAttr)
 	}
 
-	if ors.itemsFailedInst != nil && numFailedToSend > 0 {
-		withFailedAttrs := metric.WithAttributeSet(extractFailureAttributes(err))
-		ors.itemsFailedInst.Add(ctx, numFailedToSend, ors.metricAttr, withFailedAttrs)
+	if ors.itemsFailedInst != nil {
+		// Record the counter even when the value is zero, so the metric is always
+		// present and does not disappear for exporters that have no failures.
+		opts := []metric.AddOption{ors.metricAttr}
+		if err != nil {
+			opts = append(opts, metric.WithAttributeSet(extractFailureAttributes(err)))
+		}
+		ors.itemsFailedInst.Add(ctx, numFailedToSend, opts...)
 	}
 
 	span := trace.SpanFromContext(ctx)

--- a/exporter/exporterhelper/internal/obs_report_sender_test.go
+++ b/exporter/exporterhelper/internal/obs_report_sender_test.go
@@ -259,19 +259,25 @@ func TestExportTraceDataOp(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
-	var expectedDataPoints []metricdata.DataPoint[int64]
+	// Successful sends record a zero value with the base attributes, so the
+	// metric is always present.
+	expectedDataPoints := []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(
+				attribute.String("exporter", exporterID.String())),
+			Value: 0,
+		},
+	}
 	if failedToSendSpans > 0 {
 		wantAttrs := attribute.NewSet(
 			attribute.String("exporter", exporterID.String()),
 			attribute.String(string(semconv.ErrorTypeKey), "_OTHER"),
 			attribute.Bool(ErrorPermanentKey, false),
 		)
-		expectedDataPoints = []metricdata.DataPoint[int64]{
-			{
-				Attributes: wantAttrs,
-				Value:      int64(failedToSendSpans),
-			},
-		}
+		expectedDataPoints = append(expectedDataPoints, metricdata.DataPoint[int64]{
+			Attributes: wantAttrs,
+			Value:      int64(failedToSendSpans),
+		})
 	}
 	metadatatest.AssertEqualExporterSendFailedSpans(t, tt, expectedDataPoints,
 		metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
@@ -334,19 +340,25 @@ func TestExportMetricsOp(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
-	var expectedDataPoints []metricdata.DataPoint[int64]
+	// Successful sends record a zero value with the base attributes, so the
+	// metric is always present.
+	expectedDataPoints := []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(
+				attribute.String("exporter", exporterID.String())),
+			Value: 0,
+		},
+	}
 	if failedToSendMetricPoints > 0 {
 		wantAttrs := attribute.NewSet(
 			attribute.String("exporter", exporterID.String()),
 			attribute.String(string(semconv.ErrorTypeKey), "_OTHER"),
 			attribute.Bool(ErrorPermanentKey, false),
 		)
-		expectedDataPoints = []metricdata.DataPoint[int64]{
-			{
-				Attributes: wantAttrs,
-				Value:      int64(failedToSendMetricPoints),
-			},
-		}
+		expectedDataPoints = append(expectedDataPoints, metricdata.DataPoint[int64]{
+			Attributes: wantAttrs,
+			Value:      int64(failedToSendMetricPoints),
+		})
 	}
 	metadatatest.AssertEqualExporterSendFailedMetricPoints(t, tt, expectedDataPoints,
 		metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
@@ -409,19 +421,25 @@ func TestExportLogsOp(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
-	var expectedDataPoints []metricdata.DataPoint[int64]
+	// Successful sends record a zero value with the base attributes, so the
+	// metric is always present.
+	expectedDataPoints := []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(
+				attribute.String("exporter", exporterID.String())),
+			Value: 0,
+		},
+	}
 	if failedToSendLogRecords > 0 {
 		wantAttrs := attribute.NewSet(
 			attribute.String("exporter", exporterID.String()),
 			attribute.String(string(semconv.ErrorTypeKey), "_OTHER"),
 			attribute.Bool(ErrorPermanentKey, false),
 		)
-		expectedDataPoints = []metricdata.DataPoint[int64]{
-			{
-				Attributes: wantAttrs,
-				Value:      int64(failedToSendLogRecords),
-			},
-		}
+		expectedDataPoints = append(expectedDataPoints, metricdata.DataPoint[int64]{
+			Attributes: wantAttrs,
+			Value:      int64(failedToSendLogRecords),
+		})
 	}
 	metadatatest.AssertEqualExporterSendFailedLogRecords(t, tt, expectedDataPoints,
 		metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
@@ -606,19 +624,25 @@ func TestExportProfilesOp(t *testing.T) {
 			},
 		}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 
-	var expectedDataPoints []metricdata.DataPoint[int64]
+	// Successful sends record a zero value with the base attributes, so the
+	// metric is always present.
+	expectedDataPoints := []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(
+				attribute.String("exporter", exporterID.String())),
+			Value: 0,
+		},
+	}
 	if failedToSendProfileRecords > 0 {
 		wantAttrs := attribute.NewSet(
 			attribute.String("exporter", exporterID.String()),
 			attribute.String(string(semconv.ErrorTypeKey), "_OTHER"),
 			attribute.Bool(ErrorPermanentKey, false),
 		)
-		expectedDataPoints = []metricdata.DataPoint[int64]{
-			{
-				Attributes: wantAttrs,
-				Value:      int64(failedToSendProfileRecords),
-			},
-		}
+		expectedDataPoints = append(expectedDataPoints, metricdata.DataPoint[int64]{
+			Attributes: wantAttrs,
+			Value:      int64(failedToSendProfileRecords),
+		})
 	}
 	metadatatest.AssertEqualExporterSendFailedProfileSamples(t, tt, expectedDataPoints,
 		metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -351,6 +351,16 @@ func checkRecordedMetricsForLogs(t *testing.T, tt *componenttest.Telemetry, id c
 					Value: int64(numBatches * ld.LogRecordCount()),
 				},
 			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+		// The failed metric must be present with a zero value even when all
+		// sends succeed. See https://github.com/open-telemetry/opentelemetry-collector/issues/15568.
+		metadatatest.AssertEqualExporterSendFailedLogRecords(t, tt,
+			[]metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("exporter", id.String())),
+					Value: 0,
+				},
+			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 	}
 }
 

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -370,6 +370,16 @@ func checkRecordedMetricsForMetrics(t *testing.T, tt *componenttest.Telemetry, i
 					Value: numPoints,
 				},
 			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+		// The failed metric must be present with a zero value even when all
+		// sends succeed. See https://github.com/open-telemetry/opentelemetry-collector/issues/15568.
+		metadatatest.AssertEqualExporterSendFailedMetricPoints(t, tt,
+			[]metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(append(extraAttributes,
+						attribute.String(internal.ExporterKey, id.String()))...),
+					Value: 0,
+				},
+			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 	}
 }
 

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -360,6 +360,16 @@ func checkRecordedMetricsForTraces(t *testing.T, tt *componenttest.Telemetry, id
 					Value: int64(numBatches * td.SpanCount()),
 				},
 			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+		// The failed metric must be present with a zero value even when all
+		// sends succeed. See https://github.com/open-telemetry/opentelemetry-collector/issues/15568.
+		metadatatest.AssertEqualExporterSendFailedSpans(t, tt,
+			[]metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String(internal.ExporterKey, id.String())),
+					Value: 0,
+				},
+			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 	}
 }
 


### PR DESCRIPTION
#### Description

Since #14247, `otelcol_exporter_send_failed_*` metrics (`otelcol_exporter_send_failed_spans`, `otelcol_exporter_send_failed_metric_points`, `otelcol_exporter_send_failed_log_records`, `otelcol_exporter_send_failed_profile_samples`) were only recorded when `numFailedToSend > 0`. As a result, exporters without failing sends stopped reporting these metrics entirely, breaking dashboards, monitors, and alerts expecting continuous metric emission.

This PR restores unconditional recording of `otelcol_exporter_send_failed_*` metrics with a value of `0` when sends succeed, while maintaining the `error.type` and `error.permanent` attributes when `numFailedToSend > 0`.

#### Link to tracking issue

Fixes #15568

#### Testing

Updated unit tests in `exporter/exporterhelper/internal/obs_report_sender_test.go` (`TestExportTraceDataOp`, `TestExportMetricsOp`, `TestExportLogsOp`, `TestExportProfilesOp`) as well as `exporterhelper` tests (`logs_test.go`, `metrics_test.go`, `traces_test.go`) to verify that zero-value `send_failed` metrics are emitted on successful sends.

#### Documentation

N/A

#### Authorship

- [X] I, a human, wrote this pull request description myself.