### PR TITLE
[mdatagen] Fix panic in TestValue() and TestValueTwo() for single-element or empty enum attributes

### DIFF
--- a/.chloggen/fix-mdatagen-enum-panic.yaml
+++ b/.chloggen/fix-mdatagen-enum-panic.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: cmd/mdatagen
+
+note: Fix panic when handling single-element or empty enum attributes in cmd/mdatagen
+
+issues: [15644]
+
+change_logs: [user]

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -178,6 +178,9 @@ func (md *Metadata) validateResourceAttributes() error {
 		if attr.EnabledPtr == nil {
 			errs = errors.Join(errs, fmt.Errorf("enabled field is required for resource attribute: %v", name))
 		}
+		if attr.Enum != nil && len(attr.Enum) == 0 {
+			errs = errors.Join(errs, fmt.Errorf("empty enum for resource attribute: %v", name))
+		}
 	}
 	return errs
 }
@@ -315,6 +318,9 @@ func (md *Metadata) validateAttributes(usedAttrs map[AttributeName]bool) error {
 		}
 		if attr.EnabledPtr != nil {
 			errs = errors.Join(errs, fmt.Errorf("enabled field is not allowed for regular attribute: %v", attrName))
+		}
+		if attr.Enum != nil && len(attr.Enum) == 0 {
+			errs = errors.Join(errs, fmt.Errorf("empty enum for attribute: %v", attrName))
 		}
 		if !usedAttrs[attrName] {
 			unusedAttrs = append(unusedAttrs, attrName)
@@ -699,7 +705,7 @@ func (a Attribute) Name() AttributeName {
 }
 
 func (a Attribute) TestValue() string {
-	if a.Enum != nil {
+	if len(a.Enum) > 0 {
 		return fmt.Sprintf(`%q`, a.Enum[0])
 	}
 	switch a.Type.ValueType {
@@ -724,8 +730,11 @@ func (a Attribute) TestValue() string {
 }
 
 func (a Attribute) TestValueTwo() string {
-	if a.Enum != nil {
+	if len(a.Enum) > 1 {
 		return fmt.Sprintf(`%q`, a.Enum[1])
+	}
+	if len(a.Enum) == 1 {
+		return fmt.Sprintf(`%q`, a.Enum[0])
 	}
 	switch a.Type.ValueType {
 	case pcommon.ValueTypeEmpty:

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -178,8 +178,8 @@ func (md *Metadata) validateResourceAttributes() error {
 		if attr.EnabledPtr == nil {
 			errs = errors.Join(errs, fmt.Errorf("enabled field is required for resource attribute: %v", name))
 		}
-		if attr.Enum != nil && len(attr.Enum) == 0 {
-			errs = errors.Join(errs, fmt.Errorf("empty enum for resource attribute: %v", name))
+		if attr.Enum != nil && len(attr.Enum) < 2 {
+			errs = errors.Join(errs, fmt.Errorf("enum for resource attribute %v must have at least two values", name))
 		}
 	}
 	return errs
@@ -319,8 +319,8 @@ func (md *Metadata) validateAttributes(usedAttrs map[AttributeName]bool) error {
 		if attr.EnabledPtr != nil {
 			errs = errors.Join(errs, fmt.Errorf("enabled field is not allowed for regular attribute: %v", attrName))
 		}
-		if attr.Enum != nil && len(attr.Enum) == 0 {
-			errs = errors.Join(errs, fmt.Errorf("empty enum for attribute: %v", attrName))
+		if attr.Enum != nil && len(attr.Enum) < 2 {
+			errs = errors.Join(errs, fmt.Errorf("enum for attribute %v must have at least two values", attrName))
 		}
 		if !usedAttrs[attrName] {
 			unusedAttrs = append(unusedAttrs, attrName)
@@ -732,9 +732,6 @@ func (a Attribute) TestValue() string {
 func (a Attribute) TestValueTwo() string {
 	if len(a.Enum) > 1 {
 		return fmt.Sprintf(`%q`, a.Enum[1])
-	}
-	if len(a.Enum) == 1 {
-		return fmt.Sprintf(`%q`, a.Enum[0])
 	}
 	switch a.Type.ValueType {
 	case pcommon.ValueTypeEmpty:

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/cmd/mdatagen/internal/cfggen"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/internal/schemagen"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -129,6 +130,14 @@ func TestValidate(t *testing.T) {
 		{
 			name:    "testdata/no_type_attr.yaml",
 			wantErr: "empty type for attribute: used_attr",
+		},
+		{
+			name:    "testdata/empty_enum_attr.yaml",
+			wantErr: "empty enum for attribute: string_attr",
+		},
+		{
+			name:    "testdata/empty_enum_rattr.yaml",
+			wantErr: "empty enum for resource attribute: string.resource.attr",
 		},
 		{
 			name:    "testdata/entity_undefined_id_attribute.yaml",
@@ -320,6 +329,62 @@ func TestCodeCovID(t *testing.T) {
 		t.Run(tt.md.Type, func(t *testing.T) {
 			got := tt.md.GetCodeCovComponentID()
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAttributeTestValueAndTestValueTwo(t *testing.T) {
+	tests := []struct {
+		name         string
+		attr         Attribute
+		wantTestVal  string
+		wantTestVal2 string
+	}{
+		{
+			name: "multi element enum",
+			attr: Attribute{
+				FullName: AttributeName("mode"),
+				Type:     ValueType{ValueType: pcommon.ValueTypeStr},
+				Enum:     []string{"first", "second", "third"},
+			},
+			wantTestVal:  `"first"`,
+			wantTestVal2: `"second"`,
+		},
+		{
+			name: "single element enum",
+			attr: Attribute{
+				FullName: AttributeName("mode"),
+				Type:     ValueType{ValueType: pcommon.ValueTypeStr},
+				Enum:     []string{"default"},
+			},
+			wantTestVal:  `"default"`,
+			wantTestVal2: `"default"`,
+		},
+		{
+			name: "empty enum slice",
+			attr: Attribute{
+				FullName: AttributeName("mode"),
+				Type:     ValueType{ValueType: pcommon.ValueTypeStr},
+				Enum:     []string{},
+			},
+			wantTestVal:  `"mode-val"`,
+			wantTestVal2: `"mode-val-2"`,
+		},
+		{
+			name: "non-enum string attribute",
+			attr: Attribute{
+				FullName: AttributeName("mode"),
+				Type:     ValueType{ValueType: pcommon.ValueTypeStr},
+			},
+			wantTestVal:  `"mode-val"`,
+			wantTestVal2: `"mode-val-2"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantTestVal, tt.attr.TestValue())
+			assert.Equal(t, tt.wantTestVal2, tt.attr.TestValueTwo())
 		})
 	}
 }

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -133,11 +133,19 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name:    "testdata/empty_enum_attr.yaml",
-			wantErr: "empty enum for attribute: string_attr",
+			wantErr: "enum for attribute string_attr must have at least two values",
+		},
+		{
+			name:    "testdata/single_enum_attr.yaml",
+			wantErr: "enum for attribute string_attr must have at least two values",
 		},
 		{
 			name:    "testdata/empty_enum_rattr.yaml",
-			wantErr: "empty enum for resource attribute: string.resource.attr",
+			wantErr: "enum for resource attribute string.resource.attr must have at least two values",
+		},
+		{
+			name:    "testdata/single_enum_rattr.yaml",
+			wantErr: "enum for resource attribute string.resource.attr must have at least two values",
 		},
 		{
 			name:    "testdata/entity_undefined_id_attribute.yaml",
@@ -358,7 +366,7 @@ func TestAttributeTestValueAndTestValueTwo(t *testing.T) {
 				Enum:     []string{"default"},
 			},
 			wantTestVal:  `"default"`,
-			wantTestVal2: `"default"`,
+			wantTestVal2: `"mode-val-2"`,
 		},
 		{
 			name: "empty enum slice",

--- a/cmd/mdatagen/internal/templates/helper.tmpl
+++ b/cmd/mdatagen/internal/templates/helper.tmpl
@@ -25,11 +25,11 @@
 {{- end -}}
 
 {{- define "getAttributeValue" -}}
-{{ if (attributeInfo .).Enum }}Attribute{{ .Render }}{{ (index (attributeInfo .).Enum 0) | publicVar }}{{ else }}{{ (attributeInfo .).TestValue }}{{ end }}
+{{ if gt (len (attributeInfo .).Enum) 0 }}Attribute{{ .Render }}{{ (index (attributeInfo .).Enum 0) | publicVar }}{{ else }}{{ (attributeInfo .).TestValue }}{{ end }}
 {{- end -}}
 
 {{- define "getAttributeValueTwo" -}}
-{{ if (attributeInfo .).Enum }}Attribute{{ .Render }}{{ if gt (len (attributeInfo .).Enum) 1}}{{ (index (attributeInfo .).Enum 1) | publicVar}}{{ else }}{{ (index (attributeInfo .).Enum 0) | publicVar}}{{ end }}{{ else }}{{ (attributeInfo .).TestValueTwo }}{{ end }}
+{{ if gt (len (attributeInfo .).Enum) 0 }}Attribute{{ .Render }}{{ if gt (len (attributeInfo .).Enum) 1}}{{ (index (attributeInfo .).Enum 1) | publicVar}}{{ else }}{{ (index (attributeInfo .).Enum 0) | publicVar}}{{ end }}{{ else }}{{ (attributeInfo .).TestValueTwo }}{{ end }}
 {{- end -}}
 
 {{- define "assertResourceAttributeValue" -}}

--- a/cmd/mdatagen/internal/testdata/empty_enum_attr.yaml
+++ b/cmd/mdatagen/internal/testdata/empty_enum_attr.yaml
@@ -1,0 +1,24 @@
+type: file
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+
+attributes:
+  string_attr:
+    description: string attribute description
+    type: string
+    enum: []
+
+metrics:
+  default.metric:
+    enabled: true
+    description: Monotonic cumulative sum int metric enabled by default.
+    stability: development
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [string_attr]

--- a/cmd/mdatagen/internal/testdata/empty_enum_rattr.yaml
+++ b/cmd/mdatagen/internal/testdata/empty_enum_rattr.yaml
@@ -1,0 +1,13 @@
+type: file
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+
+resource_attributes:
+  string.resource.attr:
+    description: string resource attribute
+    type: string
+    enabled: true
+    enum: []

--- a/cmd/mdatagen/internal/testdata/single_enum_attr.yaml
+++ b/cmd/mdatagen/internal/testdata/single_enum_attr.yaml
@@ -1,0 +1,24 @@
+type: file
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+
+attributes:
+  string_attr:
+    description: string attribute description
+    type: string
+    enum: ["default"]
+
+metrics:
+  default.metric:
+    enabled: true
+    description: Monotonic cumulative sum int metric enabled by default.
+    stability: development
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [string_attr]

--- a/cmd/mdatagen/internal/testdata/single_enum_rattr.yaml
+++ b/cmd/mdatagen/internal/testdata/single_enum_rattr.yaml
@@ -1,0 +1,13 @@
+type: file
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+
+resource_attributes:
+  string.resource.attr:
+    description: string resource attribute
+    type: string
+    enabled: true
+    enum: ["default"]


### PR DESCRIPTION
#### Description

Fix index-out-of-range panic in `cmd/mdatagen` when handling single-element enum attributes or empty enum slices. Also add validation in `validateAttributes()` and `validateResourceAttributes()` to reject empty enum attributes.

#### Link to tracking issue

Fixes #15644

#### Testing

Added unit tests in `cmd/mdatagen/internal/metadata_test.go` covering single-element, multi-element, empty enum, and non-enum attributes, as well as metadata validation tests. Verified all tests pass in `cmd/mdatagen`.

#### Documentation

None

#### Authorship

- [x] I, a human, wrote this pull request description myself.
