### PR TITLE
[bug][cmd/mdatagen] mdatagen fix versioned metric collision logic

### DIFF
--- a/.chloggen/mdatagen-fix-versioned-metric-different-names.yaml
+++ b/.chloggen/mdatagen-fix-versioned-metric-different-names.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix incorrect collision warning for versioned metrics with different emitted names
+
+# One or more tracking issues or pull requests related to the change
+issues: [15648]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Same name collision detection (type/attribute checks) was being used for versioned metrics
+  with different names. This caused the legacy metric to be disabled which was incorrect and also
+  a warning msg was being incorrectly logged that stated the metrics had the same name when in
+  fact they had different names.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/internal/samplemigrationscraper/config.schema.json
+++ b/cmd/mdatagen/internal/samplemigrationscraper/config.schema.json
@@ -106,7 +106,7 @@
               },
               "description": "SystemCPUUtilizationV1MetricConfig provides config for the system.cpu.utilization@v1 metric."
             },
-            "system.memory.linux.available": {
+            "system.memory.linux.available@v1": {
               "type": "object",
               "properties": {
                 "enabled": {
@@ -114,7 +114,7 @@
                   "default": false
                 }
               },
-              "description": "SystemMemoryLinuxAvailableMetricConfig provides config for the system.memory.linux.available metric."
+              "description": "SystemMemoryLinuxAvailableV1MetricConfig provides config for the system.memory.linux.available@v1 metric."
             }
           },
           "description": "MetricsConfig provides config for samplemigration metrics."

--- a/cmd/mdatagen/internal/samplemigrationscraper/documentation.md
+++ b/cmd/mdatagen/internal/samplemigrationscraper/documentation.md
@@ -55,7 +55,7 @@ Legacy Linux available memory estimate.
 
 #### Migration
 
-- Target Metric: `system.memory.linux.available`
+- Target Metric: `system.memory.linux.available@v1`
 - Disable Old Gate: `scraper.samplemigration.DontEmitV0SystemConventions`
 - Enable New Gate: `scraper.samplemigration.EmitV1SystemConventions`
 
@@ -86,13 +86,15 @@ Emitted Name: `system.cpu.utilization`
 | cpu.logical_number | The logical CPU number [0, n-1]. | Any Int | Recommended | - |
 | cpu.mode | The CPU mode for this data point. | Str: ``system``, ``user``, ``iowait`` | Recommended | - |
 
-### system.memory.linux.available
+### system.memory.linux.available@v1
 
 An estimate of how much memory is available without swapping. (Linux only)
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | By | Sum | Int | Cumulative | false | Beta |
+
+Emitted Name: `system.memory.linux.available`
 
 ## Feature Gates
 

--- a/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_config.go
@@ -146,13 +146,13 @@ func (ms *SystemCPUUtilizationV1MetricConfig) Validate() error {
 	return nil
 }
 
-// SystemMemoryLinuxAvailableMetricConfig provides config for the system.memory.linux.available metric.
-type SystemMemoryLinuxAvailableMetricConfig struct {
+// SystemMemoryLinuxAvailableV1MetricConfig provides config for the system.memory.linux.available@v1 metric.
+type SystemMemoryLinuxAvailableV1MetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *SystemMemoryLinuxAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *SystemMemoryLinuxAvailableV1MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -168,11 +168,11 @@ func (ms *SystemMemoryLinuxAvailableMetricConfig) Unmarshal(parser *confmap.Conf
 
 // MetricsConfig provides config for samplemigration metrics.
 type MetricsConfig struct {
-	LinuxMemoryAvailable       LinuxMemoryAvailableMetricConfig       `mapstructure:"linux.memory.available"`
-	SystemCPUFoo               SystemCPUFooMetricConfig               `mapstructure:"system.cpu.foo"`
-	SystemCPUUtilization       SystemCPUUtilizationMetricConfig       `mapstructure:"system.cpu.utilization"`
-	SystemCPUUtilizationV1     SystemCPUUtilizationV1MetricConfig     `mapstructure:"system.cpu.utilization@v1"`
-	SystemMemoryLinuxAvailable SystemMemoryLinuxAvailableMetricConfig `mapstructure:"system.memory.linux.available"`
+	LinuxMemoryAvailable         LinuxMemoryAvailableMetricConfig         `mapstructure:"linux.memory.available"`
+	SystemCPUFoo                 SystemCPUFooMetricConfig                 `mapstructure:"system.cpu.foo"`
+	SystemCPUUtilization         SystemCPUUtilizationMetricConfig         `mapstructure:"system.cpu.utilization"`
+	SystemCPUUtilizationV1       SystemCPUUtilizationV1MetricConfig       `mapstructure:"system.cpu.utilization@v1"`
+	SystemMemoryLinuxAvailableV1 SystemMemoryLinuxAvailableV1MetricConfig `mapstructure:"system.memory.linux.available@v1"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -193,7 +193,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []SystemCPUUtilizationV1MetricAttributeKey{SystemCPUUtilizationV1MetricAttributeKeyCPULogicalNumber, SystemCPUUtilizationV1MetricAttributeKeyCPUMode},
 		},
-		SystemMemoryLinuxAvailable: SystemMemoryLinuxAvailableMetricConfig{
+		SystemMemoryLinuxAvailableV1: SystemMemoryLinuxAvailableV1MetricConfig{
 			Enabled: false,
 		},
 	}

--- a/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_config_test.go
@@ -43,7 +43,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SystemCPUUtilizationV1MetricAttributeKey{SystemCPUUtilizationV1MetricAttributeKeyCPULogicalNumber, SystemCPUUtilizationV1MetricAttributeKeyCPUMode},
 					},
-					SystemMemoryLinuxAvailable: SystemMemoryLinuxAvailableMetricConfig{
+					SystemMemoryLinuxAvailableV1: SystemMemoryLinuxAvailableV1MetricConfig{
 						Enabled: true,
 					},
 				},
@@ -69,7 +69,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SystemCPUUtilizationV1MetricAttributeKey{SystemCPUUtilizationV1MetricAttributeKeyCPULogicalNumber, SystemCPUUtilizationV1MetricAttributeKeyCPUMode},
 					},
-					SystemMemoryLinuxAvailable: SystemMemoryLinuxAvailableMetricConfig{
+					SystemMemoryLinuxAvailableV1: SystemMemoryLinuxAvailableV1MetricConfig{
 						Enabled: false,
 					},
 				},
@@ -79,7 +79,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(LinuxMemoryAvailableMetricConfig{}, SystemCPUFooMetricConfig{}, SystemCPUUtilizationMetricConfig{}, SystemCPUUtilizationV1MetricConfig{}, SystemMemoryLinuxAvailableMetricConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(LinuxMemoryAvailableMetricConfig{}, SystemCPUFooMetricConfig{}, SystemCPUUtilizationMetricConfig{}, SystemCPUUtilizationV1MetricConfig{}, SystemMemoryLinuxAvailableV1MetricConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_metrics.go
@@ -128,17 +128,17 @@ var MetricsInfo = metricsInfo{
 		Name:       "system.cpu.utilization",
 		Attributes: []string{"cpu.logical_number", "cpu.mode"},
 	},
-	SystemMemoryLinuxAvailable: metricInfo{
+	SystemMemoryLinuxAvailableV1: metricInfo{
 		Name: "system.memory.linux.available",
 	},
 }
 
 type metricsInfo struct {
-	LinuxMemoryAvailable       metricInfo
-	SystemCPUFoo               metricInfo
-	SystemCPUUtilization       metricInfo
-	SystemCPUUtilizationV1     metricInfo
-	SystemMemoryLinuxAvailable metricInfo
+	LinuxMemoryAvailable         metricInfo
+	SystemCPUFoo                 metricInfo
+	SystemCPUUtilization         metricInfo
+	SystemCPUUtilizationV1       metricInfo
+	SystemMemoryLinuxAvailableV1 metricInfo
 }
 
 type metricInfo struct {
@@ -438,14 +438,14 @@ func newMetricSystemCPUUtilizationV1(cfg SystemCPUUtilizationV1MetricConfig) met
 	return m
 }
 
-type metricSystemMemoryLinuxAvailable struct {
-	data     pmetric.Metric                         // data buffer for generated metric.
-	config   SystemMemoryLinuxAvailableMetricConfig // metric config provided by user.
-	capacity int                                    // max observed number of data points added to the metric.
+type metricSystemMemoryLinuxAvailableV1 struct {
+	data     pmetric.Metric                           // data buffer for generated metric.
+	config   SystemMemoryLinuxAvailableV1MetricConfig // metric config provided by user.
+	capacity int                                      // max observed number of data points added to the metric.
 }
 
-// init fills system.memory.linux.available metric with initial data.
-func (m *metricSystemMemoryLinuxAvailable) init() {
+// init fills system.memory.linux.available@v1 metric with initial data.
+func (m *metricSystemMemoryLinuxAvailableV1) init() {
 	m.data.SetName("system.memory.linux.available")
 	m.data.SetDescription("An estimate of how much memory is available without swapping. (Linux only)")
 	m.data.SetUnit("By")
@@ -454,7 +454,7 @@ func (m *metricSystemMemoryLinuxAvailable) init() {
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 }
 
-func (m *metricSystemMemoryLinuxAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricSystemMemoryLinuxAvailableV1) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.config.Enabled {
 		return
 	}
@@ -465,14 +465,14 @@ func (m *metricSystemMemoryLinuxAvailable) recordDataPoint(start pcommon.Timesta
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricSystemMemoryLinuxAvailable) updateCapacity() {
+func (m *metricSystemMemoryLinuxAvailableV1) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricSystemMemoryLinuxAvailable) emit(metrics pmetric.MetricSlice) {
+func (m *metricSystemMemoryLinuxAvailableV1) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -480,8 +480,8 @@ func (m *metricSystemMemoryLinuxAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricSystemMemoryLinuxAvailable(cfg SystemMemoryLinuxAvailableMetricConfig) metricSystemMemoryLinuxAvailable {
-	m := metricSystemMemoryLinuxAvailable{config: cfg}
+func newMetricSystemMemoryLinuxAvailableV1(cfg SystemMemoryLinuxAvailableV1MetricConfig) metricSystemMemoryLinuxAvailableV1 {
+	m := metricSystemMemoryLinuxAvailableV1{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -493,16 +493,16 @@ func newMetricSystemMemoryLinuxAvailable(cfg SystemMemoryLinuxAvailableMetricCon
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                           MetricsBuilderConfig // config of the metrics builder.
-	startTime                        pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                  int                  // maximum observed number of metrics per resource.
-	metricsBuffer                    pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                        component.BuildInfo  // contains version information.
-	metricLinuxMemoryAvailable       metricLinuxMemoryAvailable
-	metricSystemCPUFoo               metricSystemCPUFoo
-	metricSystemCPUUtilization       metricSystemCPUUtilization
-	metricSystemCPUUtilizationV1     metricSystemCPUUtilizationV1
-	metricSystemMemoryLinuxAvailable metricSystemMemoryLinuxAvailable
+	config                             MetricsBuilderConfig // config of the metrics builder.
+	startTime                          pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                    int                  // maximum observed number of metrics per resource.
+	metricsBuffer                      pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                          component.BuildInfo  // contains version information.
+	metricLinuxMemoryAvailable         metricLinuxMemoryAvailable
+	metricSystemCPUFoo                 metricSystemCPUFoo
+	metricSystemCPUUtilization         metricSystemCPUUtilization
+	metricSystemCPUUtilizationV1       metricSystemCPUUtilizationV1
+	metricSystemMemoryLinuxAvailableV1 metricSystemMemoryLinuxAvailableV1
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -524,41 +524,19 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings scraper.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                           mbc,
-		startTime:                        pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                    pmetric.NewMetrics(),
-		buildInfo:                        settings.BuildInfo,
-		metricLinuxMemoryAvailable:       newMetricLinuxMemoryAvailable(mbc.Metrics.LinuxMemoryAvailable),
-		metricSystemCPUFoo:               newMetricSystemCPUFoo(mbc.Metrics.SystemCPUFoo),
-		metricSystemCPUUtilization:       newMetricSystemCPUUtilization(mbc.Metrics.SystemCPUUtilization),
-		metricSystemCPUUtilizationV1:     newMetricSystemCPUUtilizationV1(mbc.Metrics.SystemCPUUtilizationV1),
-		metricSystemMemoryLinuxAvailable: newMetricSystemMemoryLinuxAvailable(mbc.Metrics.SystemMemoryLinuxAvailable),
+		config:                             mbc,
+		startTime:                          pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                      pmetric.NewMetrics(),
+		buildInfo:                          settings.BuildInfo,
+		metricLinuxMemoryAvailable:         newMetricLinuxMemoryAvailable(mbc.Metrics.LinuxMemoryAvailable),
+		metricSystemCPUFoo:                 newMetricSystemCPUFoo(mbc.Metrics.SystemCPUFoo),
+		metricSystemCPUUtilization:         newMetricSystemCPUUtilization(mbc.Metrics.SystemCPUUtilization),
+		metricSystemCPUUtilizationV1:       newMetricSystemCPUUtilizationV1(mbc.Metrics.SystemCPUUtilizationV1),
+		metricSystemMemoryLinuxAvailableV1: newMetricSystemMemoryLinuxAvailableV1(mbc.Metrics.SystemMemoryLinuxAvailableV1),
 	}
-	if ScraperSamplemigrationEmitV1SystemConventionsFeatureGate.IsEnabled() {
-		if mb.metricLinuxMemoryAvailable.config.Enabled && mb.metricSystemMemoryLinuxAvailable.config.Enabled {
-			var disable bool
-			if mb.metricLinuxMemoryAvailable.data.Type() != mb.metricSystemMemoryLinuxAvailable.data.Type() {
-				// Disable legacy metric if legacy and latest have same name but different types
-				disable = true
-				settings.Logger.Warn("[WARNING] Legacy metric `linux.memory.available` disabled: same emitted name as `system.memory.linux.available` with different type; only latest will be emitted")
-			}
-			if !slices.Equal(MetricsInfo.LinuxMemoryAvailable.Attributes, MetricsInfo.SystemMemoryLinuxAvailable.Attributes) {
-				// Disable legacy metric if legacy and latest have same name but different attributes
-				// The latest metric will emit both attribute sets during migration
-				disable = true
-				settings.Logger.Warn("[WARNING] Legacy metric `linux.memory.available` disabled: same emitted name as `system.memory.linux.available` with different attributes; only latest will be emitted with combined attributes",
-					zap.Strings("legacy_attributes", MetricsInfo.LinuxMemoryAvailable.Attributes),
-					zap.Strings("latest_attributes", MetricsInfo.SystemMemoryLinuxAvailable.Attributes))
-			}
-			if disable {
-				mb.metricLinuxMemoryAvailable.config.Enabled = false
-			}
-		}
-	} else {
-		if !ScraperSamplemigrationEmitV1SystemConventionsFeatureGate.IsEnabled() && mb.metricSystemMemoryLinuxAvailable.config.Enabled {
-			mb.metricSystemMemoryLinuxAvailable.config.Enabled = false
-			settings.Logger.Warn("[WARNING] metric `system.memory.linux.available` requires feature gate `scraper.samplemigration.EmitV1SystemConventions` to be enabled, metric has been disabled")
-		}
+	if !ScraperSamplemigrationEmitV1SystemConventionsFeatureGate.IsEnabled() && mb.metricSystemMemoryLinuxAvailableV1.config.Enabled {
+		mb.metricSystemMemoryLinuxAvailableV1.config.Enabled = false
+		settings.Logger.Warn("[WARNING] metric `system.memory.linux.available@v1` requires feature gate `scraper.samplemigration.EmitV1SystemConventions` to be enabled, metric has been disabled")
 	}
 	if ScraperSamplemigrationEmitV1SystemConventionsFeatureGate.IsEnabled() {
 		if mb.metricSystemCPUUtilization.config.Enabled && mb.metricSystemCPUUtilizationV1.config.Enabled {
@@ -581,7 +559,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings scraper.Settings, opti
 			}
 		}
 	} else {
-		if !ScraperSamplemigrationEmitV1SystemConventionsFeatureGate.IsEnabled() && mb.metricSystemCPUUtilizationV1.config.Enabled {
+		if mb.metricSystemCPUUtilizationV1.config.Enabled {
 			mb.metricSystemCPUUtilizationV1.config.Enabled = false
 			settings.Logger.Warn("[WARNING] metric `system.cpu.utilization@v1` requires feature gate `scraper.samplemigration.EmitV1SystemConventions` to be enabled, metric has been disabled")
 		}
@@ -654,7 +632,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSystemCPUFoo.emit(ils.Metrics())
 	mb.metricSystemCPUUtilization.emit(ils.Metrics())
 	mb.metricSystemCPUUtilizationV1.emit(ils.Metrics())
-	mb.metricSystemMemoryLinuxAvailable.emit(ils.Metrics())
+	mb.metricSystemMemoryLinuxAvailableV1.emit(ils.Metrics())
 
 	for _, op := range options {
 		op.apply(rm)
@@ -683,7 +661,7 @@ func (mb *MetricsBuilder) RecordLinuxMemoryAvailableDataPoint(ts pcommon.Timesta
 		mb.metricLinuxMemoryAvailable.recordDataPoint(mb.startTime, ts, val)
 	}
 	if ScraperSamplemigrationEmitV1SystemConventionsFeatureGate.IsEnabled() {
-		mb.metricSystemMemoryLinuxAvailable.recordDataPoint(mb.startTime, ts, val)
+		mb.metricSystemMemoryLinuxAvailableV1.recordDataPoint(mb.startTime, ts, val)
 	}
 }
 
@@ -701,11 +679,6 @@ func (mb *MetricsBuilder) RecordSystemCPUUtilizationDataPoint(ts pcommon.Timesta
 	if ScraperSamplemigrationEmitV1SystemConventionsFeatureGate.IsEnabled() {
 		mb.metricSystemCPUUtilizationV1.recordDataPoint(mb.startTime, ts, val, cpuLogicalNumberAttributeValue, cpuModeAttributeValue.String(), cpuAttributeValue, stateAttributeValue.String(), true)
 	}
-}
-
-// RecordSystemMemoryLinuxAvailableDataPoint adds a data point to system.memory.linux.available metric.
-func (mb *MetricsBuilder) RecordSystemMemoryLinuxAvailableDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricSystemMemoryLinuxAvailable.recordDataPoint(mb.startTime, ts, val)
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,

--- a/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_metrics_test.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,9 +102,6 @@ func TestMetricsBuilder(t *testing.T) {
 				mb.RecordSystemCPUUtilizationDataPoint(ts, 1, "cpu-val", AttributeStateIdle, 18, AttributeCPUModeSystem)
 			}
 
-			allMetricsCount++
-			mb.RecordSystemMemoryLinuxAvailableDataPoint(ts, 1)
-
 			res := pcommon.NewResource()
 			metrics := mb.Emit(WithResource(res))
 			if tt.name == "reaggregate_set" {
@@ -148,20 +146,6 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-				case "system.memory.linux.available":
-					assert.False(t, validatedMetrics["system.memory.linux.available"], "Found a duplicate in the metrics slice: system.memory.linux.available")
-					validatedMetrics["system.memory.linux.available"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "An estimate of how much memory is available without swapping. (Linux only)", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
 				}
 			}
 		})
@@ -213,7 +197,9 @@ func TestVersionedMetrics(t *testing.T) {
 
 				start := pcommon.Timestamp(1_000_000_000)
 				ts := pcommon.Timestamp(1_000_001_000)
+				observedZapCore, observedLogs := observer.New(zap.WarnLevel)
 				settings := scrapertest.NewNopSettings(scrapertest.NopType)
+				settings.Logger = zap.New(observedZapCore)
 				mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, "all_set"), settings, WithStartTime(start))
 
 				mb.RecordLinuxMemoryAvailableDataPoint(ts, 1)
@@ -237,6 +223,17 @@ func TestVersionedMetrics(t *testing.T) {
 				}
 				assert.Equal(t, tt.expectLegacyMetric, legacyFound)
 				assert.Equal(t, tt.expectNewMetric, newFound)
+				// For metrics with different emitted names, no collison warning shoulds be logged
+				// This guards against the regression where same name collision logic was
+				// incorrectly applied to renamed metrics.
+				if tt.enableNew {
+					for _, log := range observedLogs.All() {
+						if strings.Contains(log.Message, "linux.memory.available") {
+							assert.NotContains(t, log.Message, "same emitted name",
+								"should not log same name collision warning for metrics with different names")
+						}
+					}
+				}
 			})
 		}
 	})

--- a/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/testdata/config.yaml
+++ b/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/testdata/config.yaml
@@ -11,7 +11,7 @@ all_set:
     system.cpu.utilization@v1:
       enabled: true
       attributes: ["cpu.logical_number","cpu.mode"]
-    system.memory.linux.available:
+    system.memory.linux.available@v1:
       enabled: true
 reaggregate_set:
   metrics:
@@ -25,7 +25,7 @@ reaggregate_set:
     system.cpu.utilization@v1:
       enabled: true
       attributes: []
-    system.memory.linux.available:
+    system.memory.linux.available@v1:
       enabled: true
 none_set:
   metrics:
@@ -39,5 +39,5 @@ none_set:
     system.cpu.utilization@v1:
       enabled: false
       attributes: ["cpu.logical_number","cpu.mode"]
-    system.memory.linux.available:
+    system.memory.linux.available@v1:
       enabled: false

--- a/cmd/mdatagen/internal/samplemigrationscraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplemigrationscraper/metadata.yaml
@@ -70,7 +70,7 @@ metrics:
       aggregation_temporality: cumulative
       monotonic: false
     migration:
-      to: system.memory.linux.available
+      to: system.memory.linux.available@v1
       through_gates:
         disable_old: scraper.samplemigration.DontEmitV0SystemConventions
         enable_new: scraper.samplemigration.EmitV1SystemConventions
@@ -111,7 +111,7 @@ metrics:
       monotonic: true
     attributes: [cpu.logical_number, cpu.mode]
 
-  system.memory.linux.available:
+  system.memory.linux.available@v1:
     enabled: false
     description: An estimate of how much memory is available without swapping. (Linux only)
     stability: beta

--- a/cmd/mdatagen/internal/samplemigrationscraper/metrics_test.go
+++ b/cmd/mdatagen/internal/samplemigrationscraper/metrics_test.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package samplemigrationscraper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"go.opentelemetry.io/collector/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/scraper/scrapertest"
+)
+
+func TestDifferentNameVersionedMetricNoCollision(t *testing.T) {
+	require.NoError(t, featuregate.GlobalRegistry().Set("scraper.samplemigration.EmitV1SystemConventions", true))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set("scraper.samplemigration.EmitV1SystemConventions", false))
+	})
+
+	cfg := metadata.NewDefaultMetricsBuilderConfig()
+	cm := confmap.NewFromStringMap(map[string]any{
+		"metrics": map[string]any{
+			"linux.memory.available": map[string]any{
+				"enabled": true,
+			},
+			"system.memory.linux.available@v1": map[string]any{
+				"enabled": true,
+			},
+		},
+	})
+	require.NoError(t, cm.Unmarshal(&cfg))
+
+	observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := scrapertest.NewNopSettings(metadata.Type)
+	settings.Logger = zap.New(observedZapCore)
+
+	ts := pcommon.Timestamp(1_000_001_000)
+	mb := metadata.NewMetricsBuilder(cfg, settings)
+
+	mb.RecordLinuxMemoryAvailableDataPoint(ts, 1)
+
+	m := mb.Emit()
+	require.Equal(t, 1, m.ResourceMetrics().Len())
+	ms := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+
+	var foundLegacy, foundV1 bool
+	for i := 0; i < ms.Len(); i++ {
+		switch ms.At(i).Name() {
+		case "linux.memory.available":
+			foundLegacy = true
+		case "system.memory.linux.available":
+			foundV1 = true
+		}
+	}
+	assert.True(t, foundLegacy, "legacy metric should still be emitted for a rename")
+	assert.True(t, foundV1, "v1 metric should be emitted for a rename")
+
+	for _, log := range observedLogs.All() {
+		assert.NotContains(t, log.Message, "same emitted name",
+			"should not log same-name collision warning for metrics with different names")
+	}
+}

--- a/cmd/mdatagen/internal/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics.go.tmpl
@@ -407,6 +407,8 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings {{ .Status.Class }}.Se
 
   {{- range $name, $metric := .Metrics }}
   {{- if $metric.Migration }}
+  {{- if eq $name.EmittedName $metric.Migration.To.EmittedName }}
+  {{- /* same emitted name: legacy & v1 collide, so disable legacy when schema differs */}}
   if {{ printf "%s" $metric.Migration.ThroughGates.EnableNew | publicVar }}FeatureGate.IsEnabled() {
     if mb.metric{{ $name.Render }}.config.Enabled && mb.metric{{ $metric.Migration.To.Render }}.config.Enabled {
       var disable bool
@@ -428,11 +430,18 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings {{ .Status.Class }}.Se
       }
     }
   } else {
-    if !{{ printf "%s" $metric.Migration.ThroughGates.EnableNew | publicVar}}FeatureGate.IsEnabled() && mb.metric{{ $metric.Migration.To.Render }}.config.Enabled {
+    if mb.metric{{ $metric.Migration.To.Render }}.config.Enabled {
       mb.metric{{ $metric.Migration.To.Render }}.config.Enabled = false
       settings.Logger.Warn("[WARNING] metric `{{ $metric.Migration.To }}` requires feature gate `{{ $metric.Migration.ThroughGates.EnableNew }}` to be enabled, metric has been disabled")
     }
   }
+  {{- else }}
+  {{- /* rename: no wire collision; both names emit during transition. Only gate the v1 metric. */}}
+  if !{{ printf "%s" $metric.Migration.ThroughGates.EnableNew | publicVar }}FeatureGate.IsEnabled() && mb.metric{{ $metric.Migration.To.Render }}.config.Enabled {
+    mb.metric{{ $metric.Migration.To.Render }}.config.Enabled = false
+    settings.Logger.Warn("[WARNING] metric `{{ $metric.Migration.To }}` requires feature gate `{{ $metric.Migration.ThroughGates.EnableNew }}` to be enabled, metric has been disabled")
+  }
+  {{- end }}
   {{- end }}
   {{- end }}
 

--- a/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/metrics_test.go.tmpl
@@ -9,6 +9,9 @@ package {{ .Package }}
 {{- end }}
 
 import (
+  {{- if $hasVersionedMetrics }}
+  "strings"
+  {{- end }}
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -519,7 +522,15 @@ func TestVersionedMetrics(t *testing.T) {
 
                 start := pcommon.Timestamp(1_000_000_000)
                 ts := pcommon.Timestamp(1_000_001_000)
+                {{- if ne $name.EmittedName $metric.Migration.To.EmittedName }}
+                observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+                {{- if or isReceiver isScraper isConnector }}
                 settings := {{ $.Status.Class }}test.NewNopSettings({{ $.Status.Class }}test.NopType)
+                {{- end }}
+                settings.Logger = zap.New(observedZapCore)
+                {{- else }}
+                settings := {{ $.Status.Class }}test.NewNopSettings({{ $.Status.Class }}test.NopType)
+                {{- end }}
                 mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, "all_set"), settings, WithStartTime(start))
 
                 mb.Record{{ $name.Render }}DataPoint(ts, 1
@@ -619,6 +630,20 @@ func TestVersionedMetrics(t *testing.T) {
                   }
                   assert.Equal(t, tt.expectLegacyMetric, legacyFound)
                   assert.Equal(t, tt.expectNewMetric, newFound) 
+
+                  {{- if ne $name.EmittedName $metric.Migration.To.EmittedName }}
+                  // For metrics with different emitted names, no collison warning shoulds be logged
+                  // This guards against the regression where same name collision logic was
+                  // incorrectly applied to renamed metrics.
+                  if tt.enableNew {
+                      for _, log := range observedLogs.All() {
+                          if strings.Contains(log.Message, "{{ $name }}") {
+                              assert.NotContains(t, log.Message, "same emitted name",
+                                  "should not log same name collision warning for metrics with different names")
+                          }
+                      }
+                  }
+                  {{- end }}
             })
         }
     })


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix incorrect collision warning logged for versioned metrics with different names. Previously, the same-name collision detection (type/attribute check) ran unconditionally for all migrations, causing warnings and incorrectly disabling legacy metrics when legacy and v1 had different names. Test coverage was also added here for this issue.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15648 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

metrics_test.go.tmpl was updated with a test that is generated for versioned metrics where legacy and v1 have different names. This tests that no warning log msg is recorded.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
