### PR TITLE
[chore][cmd/mdatagen] Align types for mdatagen configs

### DIFF
--- a/cmd/mdatagen/README.md
+++ b/cmd/mdatagen/README.md
@@ -81,8 +81,7 @@ config:
       description: The endpoint to listen on
       default: "localhost:4317"
     timeout:
-      type: string
-      format: duration
+      type: duration
       description: Request timeout duration
       default: "30s"
     tls:
@@ -90,41 +89,82 @@ config:
   required: [endpoint]
 ```
 
-The `config` section is based on [JSON Schema standard](https://json-schema.org/) (draft 2020-12) and supports:
+The `config` section uses Go-centric types directly in the `type` field, and also supports:
 
-- **Standard JSON Schema types**: string, number, integer, boolean, object, array, null
 - **Validation constraints**: minLength, maxLength, pattern, minimum, maximum, enum, etc.
 - **References**: Internal (`$ref: definition_name`), external (`$ref: package.path.type`), or relative (`$ref: ./internal/config.type`)
 - **Reusable definitions**: Define common schemas in `$defs` and reference them with `$ref`
 - **Schema composition**: Use `allOf` for complex configurations
-- **Extended type aliases**: first-class aliases that expand to the correct JSON Schema shape and Go type automatically (see table below)
 
-#### Extended type aliases
+#### Supported types
 
-Instead of combining `type`+`format` or `type`+`x-customType` by hand, you can use an alias directly as the `type` value:
+##### Primitive types
 
-| Alias | Go type | JSON Schema representation        |
-|---|---|-----------------------------------|
-| `rune` | `rune` | `integer`                         |
-| `byte` | `byte` | `integer`                         |
-| `uint` | `uint` | `integer`                         |
-| `int8` | `int8` | `integer`                         |
-| `uint8` | `uint8` | `integer`                         |
-| `int16` | `int16` | `integer`                         |
-| `uint16` | `uint16` | `integer`                         |
-| `int32` | `int32` | `integer`                         |
-| `uint32` | `uint32` | `integer`                         |
-| `int64` | `int64` | `integer`                         |
-| `uint64` | `uint64` | `integer`                         |
-| `float32` | `float32` | `number`                          |
-| `float64` | `float64` | `number`                          |
-| `duration` | `time.Duration` | `string` with Go duration pattern |
-| `time` | `time.Time` | `string` with `format: date-time` |
-| `opaque_string` | `configopaque.String` | `string`                          |
-| `opaque_map` | `configopaque.MapList` | `object` of name/value pairs      |
-| `id` | `component.ID` | `string`                          |
+Use Go type names directly in the `type` field:
 
-Example:
+| Type | Go type | JSON Schema type |
+|------|---------|-----------------|
+| `string` | `string` | `string` |
+| `bool` | `bool` | `boolean` |
+| `int` | `int` | `integer` |
+| `int8` | `int8` | `integer` |
+| `int16` | `int16` | `integer` |
+| `int32` | `int32` | `integer` |
+| `int64` | `int64` | `integer` |
+| `uint` | `uint` | `integer` |
+| `uint8` | `uint8` | `integer` |
+| `uint16` | `uint16` | `integer` |
+| `uint32` | `uint32` | `integer` |
+| `uint64` | `uint64` | `integer` |
+| `byte` | `byte` | `integer` |
+| `rune` | `rune` | `integer` |
+| `float32` | `float32` | `number` |
+| `float64` | `float64` | `number` |
+| `any` | `any` | *(no type constraint)* |
+
+##### Container types
+
+| Type | Go type | JSON Schema type | Notes |
+|------|---------|-----------------|-------|
+| `object` | struct | `object` | Requires `properties:` |
+| `slice` | `[]T` | `array` | Requires `values:` for the element type |
+| `map` | `map[string]T` | `object` | Requires `values:` for the value type |
+
+Example using container types:
+
+```yaml
+config:
+  type: object
+  properties:
+    endpoints:
+      type: slice
+      values:
+        type: string
+      description: List of endpoints to connect to.
+    headers:
+      type: map
+      values:
+        type: string
+      description: Extra HTTP headers to attach to each request.
+    tls:
+      $ref: go.opentelemetry.io/collector/config/configtls.server_config
+```
+
+##### Alias types
+
+Shorthand types that expand to a primitive or container type with additional annotations:
+
+| Alias | Go type | JSON Schema representation | Notes |
+|-------|---------|---------------------------|-------|
+| `float` | `float32` | `number` | Shorthand for `float32` |
+| `double` | `float64` | `number` | Shorthand for `float64` |
+| `duration` | `time.Duration` | `string` with Go duration pattern | e.g. `"30s"`, `"1h30m"` |
+| `time` | `time.Time` | `string` with `format: date-time` | RFC 3339 format |
+| `opaque_string` | `configopaque.String` | `string` | Masked in logs |
+| `component_id` | `component.ID` | `string` | Collector component ID |
+| `opaque_map` | `configopaque.MapList` | `object` of name/value pairs | Values masked in logs |
+
+Example using alias types:
 
 ```yaml
 config:
@@ -139,8 +179,6 @@ config:
     api_token:
       type: opaque_string
 ```
-
-Aliases are additive: existing uses of standard JSON Schema types, `format`, and `x-customType` remain supported without migration.
 
 ### Metrics Builder Configuration
 
@@ -172,7 +210,7 @@ metrics:
     description: Number of received requests.
     unit: "{request}"
     sum:
-      value_type: int
+      values: int
       monotonic: true
       aggregation_temporality: cumulative
     attributes: [status_code]

--- a/cmd/mdatagen/internal/cfggen/docgen.go
+++ b/cmd/mdatagen/internal/cfggen/docgen.go
@@ -111,24 +111,18 @@ func CfgDocType(cfg *ConfigMetadata) string {
 			return "string (one of: " + strings.Join(vals, ", ") + ")"
 		}
 		return "string"
-	case "integer":
-		return "int"
-	case "number":
-		return "float"
-	case "boolean":
-		return "bool"
-	case "array":
-		if cfg.Items != nil {
-			return "[]" + CfgDocType(cfg.Items)
+	case "slice":
+		if cfg.Values != nil {
+			return "[]" + CfgDocType(cfg.Values)
 		}
 		return "[]any"
-	case "object":
-		if cfg.AdditionalProperties != nil {
-			return "map[string]" + CfgDocType(cfg.AdditionalProperties)
+	case "map":
+		if cfg.Values != nil {
+			return "map[string]" + CfgDocType(cfg.Values)
 		}
-		return "object"
+		return "map[string]any"
 	default:
-		return "any"
+		return cfg.Type
 	}
 }
 

--- a/cmd/mdatagen/internal/cfggen/docgen.go
+++ b/cmd/mdatagen/internal/cfggen/docgen.go
@@ -96,7 +96,7 @@ func CfgDocType(cfg *ConfigMetadata) string {
 		return "object"
 	}
 	switch cfg.Type {
-	case "string":
+	case StringType:
 		if cfg.GoType == "time.Duration" || cfg.Format == "duration" {
 			return "duration"
 		}
@@ -111,18 +111,18 @@ func CfgDocType(cfg *ConfigMetadata) string {
 			return "string (one of: " + strings.Join(vals, ", ") + ")"
 		}
 		return "string"
-	case "slice":
+	case SliceType:
 		if cfg.Values != nil {
 			return "[]" + CfgDocType(cfg.Values)
 		}
 		return "[]any"
-	case "map":
+	case MapType:
 		if cfg.Values != nil {
 			return "map[string]" + CfgDocType(cfg.Values)
 		}
 		return "map[string]any"
 	default:
-		return cfg.Type
+		return string(cfg.Type)
 	}
 }
 

--- a/cmd/mdatagen/internal/cfggen/docgen_test.go
+++ b/cmd/mdatagen/internal/cfggen/docgen_test.go
@@ -107,10 +107,10 @@ func TestCfgIsObject(t *testing.T) {
 	}{
 		{"nil", nil, false},
 		{"primitive string", &ConfigMetadata{Type: "string"}, false},
-		{"array of strings", &ConfigMetadata{Type: "array", Items: &ConfigMetadata{Type: "string"}}, false},
+		{"slice of strings", &ConfigMetadata{Type: "slice", Values: &ConfigMetadata{Type: "string"}}, false},
 		{"inline object", &ConfigMetadata{Type: "object", Properties: map[string]*ConfigMetadata{"x": {Type: "string"}}}, true},
 		{"ref-resolved object", &ConfigMetadata{Type: "object", Ref: "confighttp.ServerConfig", Properties: map[string]*ConfigMetadata{"port": {Type: "integer"}}}, true},
-		{"map without properties", &ConfigMetadata{Type: "object", AdditionalProperties: &ConfigMetadata{Type: "string"}}, false},
+		{"map without properties", &ConfigMetadata{Type: "map", Values: &ConfigMetadata{Type: "string"}}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -140,15 +140,15 @@ func TestCfgDocType(t *testing.T) {
 		{"datetime via GoType", &ConfigMetadata{Type: "string", GoType: "time.Time"}, "datetime"},
 		{"datetime via Format", &ConfigMetadata{Type: "string", Format: "date-time"}, "datetime"},
 		{"enum string", &ConfigMetadata{Type: "string", Enum: []any{"a", "b"}}, "string (one of: a, b)"},
-		{"integer", &ConfigMetadata{Type: "integer"}, "int"},
-		{"number", &ConfigMetadata{Type: "number"}, "float"},
-		{"boolean", &ConfigMetadata{Type: "boolean"}, "bool"},
-		{"array of string", &ConfigMetadata{Type: "array", Items: &ConfigMetadata{Type: "string"}}, "[]string"},
-		{"array of any", &ConfigMetadata{Type: "array"}, "[]any"},
-		{"map of string", &ConfigMetadata{Type: "object", AdditionalProperties: &ConfigMetadata{Type: "string"}}, "map[string]string"},
+		{"int", &ConfigMetadata{Type: "int"}, "int"},
+		{"float64", &ConfigMetadata{Type: "float64"}, "float64"},
+		{"bool", &ConfigMetadata{Type: "bool"}, "bool"},
+		{"array of string", &ConfigMetadata{Type: "slice", Values: &ConfigMetadata{Type: "string"}}, "[]string"},
+		{"array of any", &ConfigMetadata{Type: "slice"}, "[]any"},
+		{"map of string", &ConfigMetadata{Type: "map", Values: &ConfigMetadata{Type: "string"}}, "map[string]string"},
 		{"inline object", &ConfigMetadata{Type: "object", Properties: map[string]*ConfigMetadata{"x": {Type: "string"}}}, "object"},
 		{"plain object no props", &ConfigMetadata{Type: "object"}, "object"},
-		{"unknown type", &ConfigMetadata{Type: "unknown"}, "any"},
+		{"unknown type", &ConfigMetadata{Type: "unknown"}, "unknown"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -131,18 +131,24 @@ func WithCfgFns(fns map[string]any, rootPackage, componentPackage string) map[st
 	return fns
 }
 
-var goBasicTypes = []string{
-	"rune", "byte",
-	"uint", "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64",
-	"float32", "float64",
-	"time.Time", "time.Duration",
-}
-
 var primitiveSchemaGoTypes = map[string]string{
 	"string":  "string",
-	"integer": "int",
-	"number":  "float64",
-	"boolean": "bool",
+	"bool":    "bool",
+	"byte":    "byte",
+	"rune":    "rune",
+	"uint":    "uint",
+	"int":     "int",
+	"int8":    "int8",
+	"uint8":   "uint8",
+	"int16":   "int16",
+	"uint16":  "uint16",
+	"int32":   "int32",
+	"uint32":  "uint32",
+	"int64":   "int64",
+	"uint64":  "uint64",
+	"float32": "float32",
+	"float64": "float64",
+	"any":     "any",
 }
 
 func IsPrimitiveSchema(md *ConfigMetadata) bool {
@@ -162,9 +168,6 @@ func PrimitiveGoType(md *ConfigMetadata, rootPackage, componentPackage string) (
 		return "", fmt.Errorf("unsupported primitive type: %q", md.Type)
 	}
 	if md.GoType != "" {
-		if slices.Contains(goBasicTypes, md.GoType) {
-			return md.GoType, nil
-		}
 		typeName, err := FormatTypeName(md.GoType, rootPackage, componentPackage)
 		if err != nil {
 			return "", fmt.Errorf("failed to format custom type %q: %w", md.GoType, err)
@@ -201,9 +204,6 @@ func resolveGoType(md *ConfigMetadata, propName, rootPackage, componentPackage s
 		return typeName, nil
 	}
 	if md.GoType != "" {
-		if slices.Contains(goBasicTypes, md.GoType) {
-			return md.GoType, nil
-		}
 		typeName, err := FormatTypeName(md.GoType, rootPackage, componentPackage)
 		if err != nil {
 			return "", fmt.Errorf("failed to format custom type %q: %w", md.GoType, err)
@@ -217,29 +217,25 @@ func resolveGoType(md *ConfigMetadata, propName, rootPackage, componentPackage s
 			return md.GoType, nil
 		}
 		return "string", nil
-	case "integer":
-		return "int", nil
-	case "number":
-		return "float64", nil
-	case "boolean":
-		return "bool", nil
-	case "array":
-		if md.Items == nil {
+	case "slice":
+		if md.Values == nil {
 			return "[]any", nil
 		}
-		itemType, err := MapGoType(md.Items, propName+"_item", rootPackage, componentPackage)
+		itemType, err := MapGoType(md.Values, propName+"_item", rootPackage, componentPackage)
 		if err != nil {
-			return "", fmt.Errorf("failed to map array item type: %w", err)
+			return "", fmt.Errorf("failed to resolve slice value type: %w", err)
 		}
 		return "[]" + itemType, nil
-	case "object":
-		if md.AdditionalProperties != nil {
-			valueType, err := MapGoType(md.AdditionalProperties, propName, rootPackage, componentPackage)
+	case "map":
+		if md.Values != nil {
+			valueType, err := MapGoType(md.Values, propName, rootPackage, componentPackage)
 			if err != nil {
-				return "", fmt.Errorf("failed to map additionalProperties type: %w", err)
+				return "", fmt.Errorf("failed to resolve map value type: %w", err)
 			}
 			return "map[string]" + valueType, nil
 		}
+		return "map[string]any", nil
+	case "object":
 		if md.Properties != nil {
 			formatted, err := helpers.FormatIdentifier(propName, true)
 			if err != nil {
@@ -247,11 +243,11 @@ func resolveGoType(md *ConfigMetadata, propName, rootPackage, componentPackage s
 			}
 			return formatted, nil
 		}
-		return "map[string]any", nil
+		return "", fmt.Errorf("empty object properties in %q field", propName)
 	case "":
 		return "any", nil
 	default:
-		return "", fmt.Errorf("unsupported type: %q", md.Type)
+		return md.Type, nil
 	}
 }
 
@@ -355,14 +351,10 @@ func collectImports(md *ConfigMetadata, imports map[string]bool, rootPackage, co
 		}
 	}
 
-	if md.Items != nil {
-		if err := collectImports(md.Items, imports, rootPackage, componentPackage); err != nil {
+	if md.Values != nil {
+		if err := collectImports(md.Values, imports, rootPackage, componentPackage); err != nil {
 			return err
 		}
-	}
-
-	if err := collectImports(md.AdditionalProperties, imports, rootPackage, componentPackage); err != nil {
-		return err
 	}
 
 	return nil
@@ -375,7 +367,7 @@ func collectCustomDefaultImports(md *ConfigMetadata, defaultValue any, imports m
 
 	switch typedValue := defaultValue.(type) {
 	case map[string]any:
-		if md.AdditionalProperties != nil {
+		if md.Values != nil {
 			return nil
 		}
 		for key, value := range typedValue {
@@ -391,11 +383,11 @@ func collectCustomDefaultImports(md *ConfigMetadata, defaultValue any, imports m
 			}
 		}
 	case []any:
-		if md.Items == nil || md.Items.Type != "object" {
+		if md.Values == nil || md.Values.Type != "object" {
 			return nil
 		}
 		for _, item := range typedValue {
-			if err := collectCustomDefaultImports(md.Items, item, imports, rootPackage, componentPackage); err != nil {
+			if err := collectCustomDefaultImports(md.Values, item, imports, rootPackage, componentPackage); err != nil {
 				return err
 			}
 		}
@@ -482,14 +474,10 @@ func collectDefsForSchema(propName string, md *ConfigMetadata, defs map[string]*
 		if len(md.Properties) > 0 {
 			defs[propName] = md
 			collectDefs(md, defs)
-		} else if md.AdditionalProperties != nil {
-			// map[string]V — the value type V inherits the same propName
-			collectDefsForSchema(propName, md.AdditionalProperties, defs)
 		}
-	case "array":
-		if md.Items != nil {
-			// []T — item type uses propName+"_item", matching MapGoType
-			collectDefsForSchema(propName+"_item", md.Items, defs)
+	case "slice", "map":
+		if md.Values != nil {
+			collectDefsForSchema(propName+"_item", md.Values, defs)
 		}
 	}
 }
@@ -604,8 +592,6 @@ func resolveType(md *ConfigMetadata) string {
 		return "datetime"
 	case md.Type == "string" && md.GoType == "time.Duration":
 		return "duration"
-	case md.Type == "object" && md.AdditionalProperties != nil:
-		return "map"
 	default:
 		return md.Type
 	}
@@ -627,7 +613,7 @@ func MapCustomDefaults(schema *ConfigMetadata, defaultValue any, rootPackage, co
 	switch typedValue := defaultValue.(type) {
 	case map[string]any:
 		// is nested struct
-		if schema.AdditionalProperties == nil {
+		if schema.Values == nil {
 			for key, value := range typedValue {
 				propSchema := schema.Properties[key]
 				if propSchema == nil {
@@ -637,16 +623,16 @@ func MapCustomDefaults(schema *ConfigMetadata, defaultValue any, rootPackage, co
 				exp := fmt.Sprintf(".%s = %s", varName, FormatDefaultValue(propSchema, key, value, rootPackage, componentPackage))
 				exps = append(exps, exp)
 			}
-		} else if schema.AdditionalProperties.Type == "object" { // is a map of object
+		} else if schema.Values.Type == "object" { // is a map of object
 			panic("map of structs is not supported yet")
 		}
 	case []any:
 		// is an array of objects
-		if schema.Items == nil || schema.Items.Type != "object" {
+		if schema.Values == nil || schema.Values.Type != "object" {
 			return nil
 		}
 		for i, item := range typedValue {
-			nestedExps := MapCustomDefaults(schema.Items, item, rootPackage, componentPackage)
+			nestedExps := MapCustomDefaults(schema.Values, item, rootPackage, componentPackage)
 			for _, exp := range nestedExps {
 				exps = append(exps, fmt.Sprintf("[%d]%s", i, exp))
 			}
@@ -727,7 +713,7 @@ func CamelVar(ref string) string {
 func formatSimpleValue(md *ConfigMetadata, name string, defaultValue any, rootPackage, componentPackage string) string {
 	// handle references
 	isReference := md.Ref != ""
-	isSubStruct := md.Type == "object" && md.AdditionalProperties == nil
+	isSubStruct := md.Type == "object"
 	if (isReference && !IsPrimitiveSchema(md)) || isSubStruct {
 		if hasDefaultValue(md) {
 			if isReference {
@@ -755,21 +741,21 @@ func formatSimpleValue(md *ConfigMetadata, name string, defaultValue any, rootPa
 	}
 
 	switch md.Type {
-	case "array":
-		typeExpr, err := resolveGoType(md.Items, name+"_item", "", "")
+	case "slice":
+		typeExpr, err := resolveGoType(md.Values, name+"_item", "", "")
 		if err == nil {
 			if defaultValues, ok := defaultValue.([]any); ok {
 				exps := make([]string, 0, len(defaultValues))
 				for _, defaultValue := range defaultValues {
-					exps = append(exps, FormatDefaultValue(md.Items, name+"_item", defaultValue, rootPackage, componentPackage))
+					exps = append(exps, FormatDefaultValue(md.Values, name+"_item", defaultValue, rootPackage, componentPackage))
 				}
 				return fmt.Sprintf("[]%s{%s}", typeExpr, strings.Join(exps, ", "))
 			}
 			panic("invalid default value, array expected")
 		}
 		panic(fmt.Sprintf("Could not resolve type, due to %e", err))
-	case "object":
-		typeExpr, err := resolveGoType(md.AdditionalProperties, name, "", "")
+	case "map":
+		typeExpr, err := resolveGoType(md.Values, name, "", "")
 		if err == nil {
 			if defaultValues, ok := defaultValue.(map[string]any); ok {
 				exps := make([]string, 0, len(defaultValues))
@@ -777,7 +763,7 @@ func formatSimpleValue(md *ConfigMetadata, name string, defaultValue any, rootPa
 					value := defaultValues[keyName]
 					exps = append(
 						exps,
-						fmt.Sprintf("%q: %v", keyName, FormatDefaultValue(md.AdditionalProperties, name, value, rootPackage, componentPackage)))
+						fmt.Sprintf("%q: %v", keyName, FormatDefaultValue(md.Values, name, value, rootPackage, componentPackage)))
 				}
 				return fmt.Sprintf("map[string]%s{%s}", typeExpr, strings.Join(exps, ", "))
 			}

--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -15,13 +15,6 @@ import (
 	"go.opentelemetry.io/collector/cmd/mdatagen/internal/helpers"
 )
 
-const (
-	StringType = "string"
-	SliceType  = "slice"
-	MapType    = "map"
-	ObjectType = "object"
-)
-
 // NewCfgFns returns template functions for config generation with rootPackage and componentPackage
 // baked into closures. This way the template itself never needs to pass these context values around.
 func NewCfgFns(rootPackage, componentPackage string) map[string]any {
@@ -138,24 +131,24 @@ func WithCfgFns(fns map[string]any, rootPackage, componentPackage string) map[st
 	return fns
 }
 
-var primitiveSchemaGoTypes = map[string]string{
-	"string":  "string",
-	"bool":    "bool",
-	"byte":    "byte",
-	"rune":    "rune",
-	"uint":    "uint",
-	"int":     "int",
-	"int8":    "int8",
-	"uint8":   "uint8",
-	"int16":   "int16",
-	"uint16":  "uint16",
-	"int32":   "int32",
-	"uint32":  "uint32",
-	"int64":   "int64",
-	"uint64":  "uint64",
-	"float32": "float32",
-	"float64": "float64",
-	"any":     "any",
+var primitiveSchemaGoTypes = map[SchemaType]string{
+	StringType:  "string",
+	BoolType:    "bool",
+	ByteType:    "byte",
+	RuneType:    "rune",
+	UintType:    "uint",
+	IntType:     "int",
+	Int8Type:    "int8",
+	Uint8Type:   "uint8",
+	Int16Type:   "int16",
+	Uint16Type:  "uint16",
+	Int32Type:   "int32",
+	Uint32Type:  "uint32",
+	Int64Type:   "int64",
+	Uint64Type:  "uint64",
+	Float32Type: "float32",
+	Float64Type: "float64",
+	AnyType:     "any",
 }
 
 func IsPrimitiveSchema(md *ConfigMetadata) bool {
@@ -254,7 +247,7 @@ func resolveGoType(md *ConfigMetadata, propName, rootPackage, componentPackage s
 	case "":
 		return "any", nil
 	default:
-		return md.Type, nil
+		return string(md.Type), nil
 	}
 }
 
@@ -315,7 +308,7 @@ func collectImports(md *ConfigMetadata, imports map[string]bool, rootPackage, co
 		}
 	}
 
-	if md.Type == "string" && strings.HasPrefix(md.GoType, "time.") {
+	if md.Type == StringType && strings.HasPrefix(md.GoType, "time.") {
 		imports["time"] = true
 	}
 
@@ -390,7 +383,7 @@ func collectCustomDefaultImports(md *ConfigMetadata, defaultValue any, imports m
 			}
 		}
 	case []any:
-		if md.Values == nil || md.Values.Type != "object" {
+		if md.Values == nil || md.Values.Type != ObjectType {
 			return nil
 		}
 		for _, item := range typedValue {
@@ -585,7 +578,7 @@ func collectValidators(md *ConfigMetadata, validators *[]Validator) {
 	if md.GoStruct.CustomValidator != nil {
 		*validators = append(*validators, Validator{
 			FieldName:       ".",
-			FieldType:       md.Type,
+			FieldType:       string(md.Type),
 			CustomValidator: generateValidatorName("", md.GoStruct.CustomValidator),
 		})
 	}
@@ -600,7 +593,7 @@ func resolveType(md *ConfigMetadata) string {
 	case md.GoType == "time.Duration":
 		return "duration"
 	default:
-		return md.Type
+		return string(md.Type)
 	}
 }
 
@@ -630,12 +623,12 @@ func MapCustomDefaults(schema *ConfigMetadata, defaultValue any, rootPackage, co
 				exp := fmt.Sprintf(".%s = %s", varName, FormatDefaultValue(propSchema, key, value, rootPackage, componentPackage))
 				exps = append(exps, exp)
 			}
-		} else if schema.Values.Type == "object" { // is a map of object
+		} else if schema.Values.Type == ObjectType { // is a map of object
 			panic("map of structs is not supported yet")
 		}
 	case []any:
 		// is an array of objects
-		if schema.Values == nil || schema.Values.Type != "object" {
+		if schema.Values == nil || schema.Values.Type != ObjectType {
 			return nil
 		}
 		for i, item := range typedValue {
@@ -665,7 +658,7 @@ func FormatDefaultValue(md *ConfigMetadata, name string, defaultValue any, rootP
 		return "&" + exp
 	}
 	if md.IsOptional {
-		if md.Type == "object" && md.Properties != nil {
+		if md.Type == ObjectType && md.Properties != nil {
 			return fmt.Sprintf("configoptional.Default(%s)", exp)
 		}
 		return fmt.Sprintf("configoptional.Some(%s)", exp)
@@ -687,7 +680,7 @@ func WrapDefaultValue(md *ConfigMetadata, varName string) string {
 		return "&" + exp
 	}
 	if md.IsOptional {
-		if md.Type == "object" && md.Properties != nil {
+		if md.Type == ObjectType && md.Properties != nil {
 			return fmt.Sprintf("configoptional.Default(%s)", exp)
 		}
 		return fmt.Sprintf("configoptional.Some(%s)", exp)
@@ -720,7 +713,7 @@ func CamelVar(ref string) string {
 func formatSimpleValue(md *ConfigMetadata, name string, defaultValue any, rootPackage, componentPackage string) string {
 	// handle references
 	isReference := md.Ref != ""
-	isSubStruct := md.Type == "object"
+	isSubStruct := md.Type == ObjectType
 	if (isReference && !IsPrimitiveSchema(md)) || isSubStruct {
 		if hasDefaultValue(md) {
 			if isReference {

--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -15,6 +15,13 @@ import (
 	"go.opentelemetry.io/collector/cmd/mdatagen/internal/helpers"
 )
 
+const (
+	StringType = "string"
+	SliceType  = "slice"
+	MapType    = "map"
+	ObjectType = "object"
+)
+
 // NewCfgFns returns template functions for config generation with rootPackage and componentPackage
 // baked into closures. This way the template itself never needs to pass these context values around.
 func NewCfgFns(rootPackage, componentPackage string) map[string]any {
@@ -212,12 +219,12 @@ func resolveGoType(md *ConfigMetadata, propName, rootPackage, componentPackage s
 	}
 
 	switch md.Type {
-	case "string":
+	case StringType:
 		if strings.HasPrefix(md.GoType, "time.") {
 			return md.GoType, nil
 		}
 		return "string", nil
-	case "slice":
+	case SliceType:
 		if md.Values == nil {
 			return "[]any", nil
 		}
@@ -226,7 +233,7 @@ func resolveGoType(md *ConfigMetadata, propName, rootPackage, componentPackage s
 			return "", fmt.Errorf("failed to resolve slice value type: %w", err)
 		}
 		return "[]" + itemType, nil
-	case "map":
+	case MapType:
 		if md.Values != nil {
 			valueType, err := MapGoType(md.Values, propName, rootPackage, componentPackage)
 			if err != nil {
@@ -235,7 +242,7 @@ func resolveGoType(md *ConfigMetadata, propName, rootPackage, componentPackage s
 			return "map[string]" + valueType, nil
 		}
 		return "map[string]any", nil
-	case "object":
+	case ObjectType:
 		if md.Properties != nil {
 			formatted, err := helpers.FormatIdentifier(propName, true)
 			if err != nil {
@@ -470,12 +477,12 @@ func collectDefsForSchema(propName string, md *ConfigMetadata, defs map[string]*
 	}
 
 	switch md.Type {
-	case "object":
+	case ObjectType:
 		if len(md.Properties) > 0 {
 			defs[propName] = md
 			collectDefs(md, defs)
 		}
-	case "slice", "map":
+	case SliceType, MapType:
 		if md.Values != nil {
 			collectDefsForSchema(propName+"_item", md.Values, defs)
 		}
@@ -588,9 +595,9 @@ func resolveType(md *ConfigMetadata) string {
 	switch {
 	case md.Ref != "":
 		return "ref"
-	case md.Type == "string" && md.GoType == "time.Time":
+	case md.GoType == "time.Time":
 		return "datetime"
-	case md.Type == "string" && md.GoType == "time.Duration":
+	case md.GoType == "time.Duration":
 		return "duration"
 	default:
 		return md.Type
@@ -741,7 +748,7 @@ func formatSimpleValue(md *ConfigMetadata, name string, defaultValue any, rootPa
 	}
 
 	switch md.Type {
-	case "slice":
+	case SliceType:
 		typeExpr, err := resolveGoType(md.Values, name+"_item", "", "")
 		if err == nil {
 			if defaultValues, ok := defaultValue.([]any); ok {
@@ -754,7 +761,7 @@ func formatSimpleValue(md *ConfigMetadata, name string, defaultValue any, rootPa
 			panic("invalid default value, array expected")
 		}
 		panic(fmt.Sprintf("Could not resolve type, due to %e", err))
-	case "map":
+	case MapType:
 		typeExpr, err := resolveGoType(md.Values, name, "", "")
 		if err == nil {
 			if defaultValues, ok := defaultValue.(map[string]any); ok {
@@ -770,7 +777,7 @@ func formatSimpleValue(md *ConfigMetadata, name string, defaultValue any, rootPa
 			panic("invalid default value, map expected")
 		}
 		panic(fmt.Sprintf("Could not resolve type, due to %e", err))
-	case "string":
+	case StringType:
 		switch md.GoType {
 		case "time.Duration":
 			if durationExpr, ok := renderDurationExpr(defaultValue); ok {

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -29,20 +29,20 @@ func TestMapGoType_BasicTypes(t *testing.T) {
 			expected: "string",
 		},
 		{
-			name:     "integer type",
-			metadata: &ConfigMetadata{Type: "integer"},
+			name:     "int type",
+			metadata: &ConfigMetadata{Type: "int"},
 			propName: "field",
 			expected: "int",
 		},
 		{
-			name:     "number type",
-			metadata: &ConfigMetadata{Type: "number"},
+			name:     "float64 type",
+			metadata: &ConfigMetadata{Type: "float64"},
 			propName: "field",
 			expected: "float64",
 		},
 		{
-			name:     "boolean type",
-			metadata: &ConfigMetadata{Type: "boolean"},
+			name:     "bool type",
+			metadata: &ConfigMetadata{Type: "bool"},
 			propName: "field",
 			expected: "bool",
 		},
@@ -76,18 +76,18 @@ func TestPrimitiveGoType(t *testing.T) {
 			expected: "string",
 		},
 		{
-			name:     "integer",
-			metadata: &ConfigMetadata{Type: "integer"},
+			name:     "int",
+			metadata: &ConfigMetadata{Type: "int"},
 			expected: "int",
 		},
 		{
-			name:     "number",
-			metadata: &ConfigMetadata{Type: "number"},
+			name:     "float64",
+			metadata: &ConfigMetadata{Type: "float64"},
 			expected: "float64",
 		},
 		{
-			name:     "boolean",
-			metadata: &ConfigMetadata{Type: "boolean"},
+			name:     "bool",
+			metadata: &ConfigMetadata{Type: "bool"},
 			expected: "bool",
 		},
 		{
@@ -165,34 +165,34 @@ func TestMapGoType_Arrays(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "array with string items",
+			name: "slice with string value type",
 			metadata: &ConfigMetadata{
-				Type:  "array",
-				Items: &ConfigMetadata{Type: "string"},
+				Type:   "slice",
+				Values: &ConfigMetadata{Type: "string"},
 			},
 			expected: "[]string",
 		},
 		{
-			name: "array with int items",
+			name: "slice with int value type",
 			metadata: &ConfigMetadata{
-				Type:  "array",
-				Items: &ConfigMetadata{Type: "integer"},
+				Type:   "slice",
+				Values: &ConfigMetadata{Type: "int"},
 			},
 			expected: "[]int",
 		},
 		{
-			name: "array with ref items",
+			name: "slice with ref value type",
 			metadata: &ConfigMetadata{
-				Type:  "array",
-				Items: &ConfigMetadata{Ref: "./internal/metadata.custom_type"},
+				Type:   "slice",
+				Values: &ConfigMetadata{Ref: "./internal/metadata.custom_type"},
 			},
 			expected: "[]metadata.CustomType",
 		},
 		{
-			name: "array with nested object items ",
+			name: "slice with nested object value type",
 			metadata: &ConfigMetadata{
-				Type: "array",
-				Items: &ConfigMetadata{
+				Type: "slice",
+				Values: &ConfigMetadata{
 					Type: "object",
 					Properties: map[string]*ConfigMetadata{
 						"name": {Type: "string"},
@@ -202,10 +202,10 @@ func TestMapGoType_Arrays(t *testing.T) {
 			expected: "[]FieldItem",
 		},
 		{
-			name: "array without items defaults to any",
+			name: "slice without value type defaults to any",
 			metadata: &ConfigMetadata{
-				Type:  "array",
-				Items: nil,
+				Type:   "slice",
+				Values: nil,
 			},
 			expected: "[]any",
 		},
@@ -230,36 +230,36 @@ func TestMapGoType_Objects(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "object with additionalProperties string",
+			name: "map with string value type",
 			metadata: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "string"},
+				Type:   "map",
+				Values: &ConfigMetadata{Type: "string"},
 			},
 			propName: "field",
 			expected: "map[string]string",
 		},
 		{
-			name: "object with additionalProperties int",
+			name: "map with int value type",
 			metadata: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "integer"},
+				Type:   "map",
+				Values: &ConfigMetadata{Type: "int"},
 			},
 			propName: "field",
 			expected: "map[string]int",
 		},
 		{
-			name: "object with additionalProperties ref",
+			name: "map with ref value type",
 			metadata: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Ref: "./internal/metadata.custom_type"},
+				Type:   "map",
+				Values: &ConfigMetadata{Ref: "./internal/metadata.custom_type"},
 			},
 			propName: "field",
 			expected: "map[string]metadata.CustomType",
 		},
 		{
-			name: "object without additionalProperties or properties",
+			name: "map without value type defaults to map[string]any",
 			metadata: &ConfigMetadata{
-				Type: "object",
+				Type: "map",
 			},
 			propName: "field",
 			expected: "map[string]any",
@@ -276,12 +276,12 @@ func TestMapGoType_Objects(t *testing.T) {
 			expected: "MyConfig",
 		},
 		{
-			name: "map of arrays of objects",
+			name: "map of slices of objects",
 			metadata: &ConfigMetadata{
-				Type: "object",
-				AdditionalProperties: &ConfigMetadata{
-					Type: "array",
-					Items: &ConfigMetadata{
+				Type: "map",
+				Values: &ConfigMetadata{
+					Type: "slice",
+					Values: &ConfigMetadata{
 						Type: "object",
 						Properties: map[string]*ConfigMetadata{
 							"id": {Type: "integer"},
@@ -310,10 +310,9 @@ func TestMapGoType_CustomTypes(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "custom type with basic type",
+			name: "custom type with primitive go type — uses type field not GoType",
 			metadata: &ConfigMetadata{
-				Type:   "string",
-				GoType: "rune",
+				Type: "rune",
 			},
 			expected: "rune",
 		},
@@ -406,10 +405,10 @@ func TestMapGoType_Modifiers(t *testing.T) {
 			expected: "configoptional.Optional[*string]",
 		},
 		{
-			name: "array of pointers",
+			name: "slice of pointers",
 			metadata: &ConfigMetadata{
-				Type: "array",
-				Items: &ConfigMetadata{
+				Type: "slice",
+				Values: &ConfigMetadata{
 					Type:      "string",
 					IsPointer: true,
 				},
@@ -433,13 +432,15 @@ func TestMapGoType_NilInput(t *testing.T) {
 	require.Contains(t, err.Error(), "nil ConfigMetadata")
 }
 
-func TestMapGoType_UnsupportedType(t *testing.T) {
+func TestMapGoType_UnknownTypePassThrough(t *testing.T) {
+	// Unknown types are passed through as-is so metadata.yaml authors can reference
+	// custom Go types directly in the type field without a GoType override.
 	md := &ConfigMetadata{
-		Type: "unsupported_type",
+		Type: "custom_vendor_type",
 	}
-	_, err := MapGoType(md, "field", "", "")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unsupported type")
+	result, err := MapGoType(md, "field", "", "")
+	require.NoError(t, err)
+	require.Equal(t, "custom_vendor_type", result)
 }
 
 func TestExtractImports_BasicTypes(t *testing.T) {
@@ -604,10 +605,10 @@ func TestCollectCustomDefaultImports(t *testing.T) {
 			defaultValue: map[string]any{"timeout": "30s"},
 		},
 		{
-			name: "map schema with additional properties does not inspect entries",
+			name: "map schema does not inspect entries",
 			metadata: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "string", GoType: "time.Duration"},
+				Type:   "map",
+				Values: &ConfigMetadata{Type: "string", GoType: "time.Duration"},
 			},
 			defaultValue: map[string]any{"timeout": "30s"},
 		},
@@ -631,10 +632,10 @@ func TestCollectCustomDefaultImports(t *testing.T) {
 			expected:     []string{"time"},
 		},
 		{
-			name: "array default imports object item property types",
+			name: "slice default imports object value type property types",
 			metadata: &ConfigMetadata{
-				Type: "array",
-				Items: &ConfigMetadata{
+				Type: "slice",
+				Values: &ConfigMetadata{
 					Type: "object",
 					Properties: map[string]*ConfigMetadata{
 						"timestamp": {Type: "string", GoType: "time.Time"},
@@ -645,10 +646,10 @@ func TestCollectCustomDefaultImports(t *testing.T) {
 			expected:     []string{"time"},
 		},
 		{
-			name: "array default with non-object item does not inspect entries",
+			name: "slice default with non-object value type does not inspect entries",
 			metadata: &ConfigMetadata{
-				Type:  "array",
-				Items: &ConfigMetadata{Type: "string", GoType: "time.Duration"},
+				Type:   "slice",
+				Values: &ConfigMetadata{Type: "string", GoType: "time.Duration"},
 			},
 			defaultValue: []any{"30s"},
 		},
@@ -734,10 +735,10 @@ func TestExtractImports_AllOf(t *testing.T) {
 	require.Contains(t, result, "time")
 }
 
-func TestExtractImports_ArrayItems(t *testing.T) {
+func TestExtractImports_SliceValueType(t *testing.T) {
 	md := &ConfigMetadata{
-		Type: "array",
-		Items: &ConfigMetadata{
+		Type: "slice",
+		Values: &ConfigMetadata{
 			Type:   "string",
 			GoType: "time.Time",
 		},
@@ -747,10 +748,10 @@ func TestExtractImports_ArrayItems(t *testing.T) {
 	require.Contains(t, result, "time")
 }
 
-func TestExtractImports_AdditionalProperties(t *testing.T) {
+func TestExtractImports_MapValueType(t *testing.T) {
 	md := &ConfigMetadata{
-		Type: "object",
-		AdditionalProperties: &ConfigMetadata{
+		Type: "map",
+		Values: &ConfigMetadata{
 			Type:   "string",
 			GoType: "time.Duration",
 		},
@@ -935,8 +936,8 @@ func TestExtractDefs_MapValueObject(t *testing.T) {
 		Type: "object",
 		Properties: map[string]*ConfigMetadata{
 			"labels": {
-				Type: "object",
-				AdditionalProperties: &ConfigMetadata{
+				Type: "map",
+				Values: &ConfigMetadata{
 					Type: "object",
 					Properties: map[string]*ConfigMetadata{
 						"name": {Type: "string"},
@@ -955,17 +956,17 @@ func TestExtractDefs_MapValueObject(t *testing.T) {
 
 	result := ExtractDefsFromConfig(md)
 	require.Len(t, result, 1)
-	require.Contains(t, result, "labels")
-	require.Same(t, md.Properties["labels"].AdditionalProperties, result["labels"])
+	require.Contains(t, result, "labels_item")
+	require.Same(t, md.Properties["labels"].Values, result["labels_item"])
 }
 
-func TestExtractDefs_ArrayItems(t *testing.T) {
+func TestExtractDefs_SliceValueObject(t *testing.T) {
 	md := &ConfigMetadata{
 		Type: "object",
 		Properties: map[string]*ConfigMetadata{
 			"servers": {
-				Type: "array",
-				Items: &ConfigMetadata{
+				Type: "slice",
+				Values: &ConfigMetadata{
 					Type: "object",
 					Properties: map[string]*ConfigMetadata{
 						"host": {Type: "string"},
@@ -1290,26 +1291,26 @@ func TestResolveGoType_RefFormatError(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to format reference type")
 }
 
-func TestResolveGoType_ArrayItemError(t *testing.T) {
-	// Array whose item type fails to resolve
+func TestResolveGoType_SliceValueTypeError(t *testing.T) {
+	// Slice whose value type GoType is malformed
 	md := &ConfigMetadata{
-		Type:  "array",
-		Items: &ConfigMetadata{Type: "unsupported_array_item"},
+		Type:   "slice",
+		Values: &ConfigMetadata{GoType: "github.com/pkg."},
 	}
 	_, err := MapGoType(md, "field", "", "")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to map array item type")
+	require.Contains(t, err.Error(), "failed to resolve slice value type")
 }
 
-func TestResolveGoType_AdditionalPropertiesError(t *testing.T) {
-	// Object with additionalProperties whose type fails to resolve
+func TestResolveGoType_MapValueTypeError(t *testing.T) {
+	// Map whose value type GoType is malformed
 	md := &ConfigMetadata{
-		Type:                 "object",
-		AdditionalProperties: &ConfigMetadata{Type: "unsupported_value"},
+		Type:   "map",
+		Values: &ConfigMetadata{GoType: "github.com/pkg."},
 	}
 	_, err := MapGoType(md, "field", "", "")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to map additionalProperties type")
+	require.Contains(t, err.Error(), "failed to resolve map value type")
 }
 
 func TestResolveGoType_EmbeddedObjectNameError(t *testing.T) {
@@ -1351,10 +1352,10 @@ func TestExtractImports_RefError(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to resolve import for reference")
 }
 
-func TestExtractImports_ItemsError(t *testing.T) {
+func TestExtractImports_SliceValueTypeError(t *testing.T) {
 	md := &ConfigMetadata{
-		Type:  "array",
-		Items: &ConfigMetadata{GoType: "github.com/pkg."},
+		Type:   "slice",
+		Values: &ConfigMetadata{GoType: "github.com/pkg."},
 	}
 	_, err := ExtractImportsFromConfig(md, "", "")
 	require.Error(t, err)
@@ -1385,10 +1386,10 @@ func TestExtractImports_DefsError(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to resolve import for custom type")
 }
 
-func TestExtractImports_AdditionalPropertiesError(t *testing.T) {
+func TestExtractImports_MapValueTypeError(t *testing.T) {
 	md := &ConfigMetadata{
-		Type:                 "object",
-		AdditionalProperties: &ConfigMetadata{GoType: "github.com/pkg."},
+		Type:   "map",
+		Values: &ConfigMetadata{GoType: "github.com/pkg."},
 	}
 	_, err := ExtractImportsFromConfig(md, "", "")
 	require.Error(t, err)
@@ -1446,12 +1447,12 @@ func TestExtractImports_ExternalRefNestedDefaultsError(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to resolve import for custom type")
 }
 
-func TestExtractImports_ExternalRefArrayDefaultsError(t *testing.T) {
-	// collectCustomDefaultImports over array items fails (line 306-307)
+func TestExtractImports_ExternalRefSliceDefaultsError(t *testing.T) {
+	// collectCustomDefaultImports over slice value type fails
 	md := &ConfigMetadata{
 		Ref:  "go.opentelemetry.io/collector/scraper/scraperhelper.ControllerConfig",
-		Type: "array",
-		Items: &ConfigMetadata{
+		Type: "slice",
+		Values: &ConfigMetadata{
 			Type: "object",
 			Properties: map[string]*ConfigMetadata{
 				"bad": {GoType: "github.com/pkg."},
@@ -1464,10 +1465,10 @@ func TestExtractImports_ExternalRefArrayDefaultsError(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to resolve import for custom type")
 }
 
-func TestExtractImports_ItemsPath(t *testing.T) {
+func TestExtractImports_SliceValueTypePath(t *testing.T) {
 	md := &ConfigMetadata{
-		Type: "array",
-		Items: &ConfigMetadata{
+		Type: "slice",
+		Values: &ConfigMetadata{
 			Type:       "string",
 			IsOptional: true,
 		},
@@ -1526,10 +1527,10 @@ func TestExtractImports_Pattern(t *testing.T) {
 			},
 		},
 		{
-			name: "pattern in array items",
+			name: "pattern in slice value type",
 			metadata: &ConfigMetadata{
-				Type:  "array",
-				Items: &ConfigMetadata{Type: "string", Pattern: `^[a-z]+$`},
+				Type:   "slice",
+				Values: &ConfigMetadata{Type: "string", Pattern: `^[a-z]+$`},
 			},
 		},
 	}
@@ -1751,15 +1752,13 @@ func TestExtractValidators(t *testing.T) {
 			},
 		},
 		{
-			name: "object with additionalProperties but no required children emits nothing",
+			name: "map type but no required children emits nothing",
 			metadata: &ConfigMetadata{
 				Type: "object",
 				Properties: map[string]*ConfigMetadata{
 					"labels": {
-						Type: "object",
-						AdditionalProperties: &ConfigMetadata{
-							Type: "string",
-						},
+						Type:   "map",
+						Values: &ConfigMetadata{Type: "string"},
 					},
 				},
 			},
@@ -2283,8 +2282,8 @@ func TestResolveType(t *testing.T) {
 		{
 			name: "map",
 			metadata: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "string"},
+				Type:   "map",
+				Values: &ConfigMetadata{Type: "string"},
 			},
 			expected: "map",
 		},
@@ -2449,8 +2448,8 @@ func TestRenderDurationExpr_InvalidInputs(t *testing.T) {
 
 func TestFormatDefaultValue_MapDefault(t *testing.T) {
 	md := &ConfigMetadata{
-		Type:                 "object",
-		AdditionalProperties: &ConfigMetadata{Type: "string"},
+		Type:   "map",
+		Values: &ConfigMetadata{Type: "string"},
 	}
 
 	require.Equal(t, `map[string]string{"env": "prod"}`, FormatDefaultValue(md, "labels", defaultValue(map[string]any{"env": "prod"}), "", ""))
@@ -2468,11 +2467,11 @@ func TestFormatDefaultValue_OptionalObjectDefault(t *testing.T) {
 	require.Equal(t, "configoptional.Default(NewDefaultClient())", FormatDefaultValue(md, "client", defaultValue(map[string]any{"endpoint": "localhost"}), "", ""))
 }
 
-func TestFormatDefaultValue_PointerArrayOfObjects(t *testing.T) {
+func TestFormatDefaultValue_PointerSliceOfObjects(t *testing.T) {
 	md := &ConfigMetadata{
-		Type:      "array",
+		Type:      "slice",
 		IsPointer: true,
-		Items: &ConfigMetadata{
+		Values: &ConfigMetadata{
 			Type: "object",
 			Properties: map[string]*ConfigMetadata{
 				"url": {Type: "string", Default: defaultValue("http://example.com")},
@@ -2549,34 +2548,34 @@ func TestFormatDefaultValue_Panics(t *testing.T) {
 			defaultValue: defaultValue(map[string]any{}),
 		},
 		{
-			name: "invalid array default value",
+			name: "invalid slice default value",
 			metadata: &ConfigMetadata{
-				Type:  "array",
-				Items: &ConfigMetadata{Type: "string"},
+				Type:   "slice",
+				Values: &ConfigMetadata{Type: "string"},
 			},
 			defaultValue: defaultValue("localhost"),
 		},
 		{
-			name: "invalid array item type",
+			name: "invalid slice value type GoType",
 			metadata: &ConfigMetadata{
-				Type:  "array",
-				Items: &ConfigMetadata{Type: "unknown"},
+				Type:   "slice",
+				Values: &ConfigMetadata{GoType: "github.com/pkg."},
 			},
 			defaultValue: defaultValue([]any{"localhost"}),
 		},
 		{
 			name: "invalid map default value",
 			metadata: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "string"},
+				Type:   "map",
+				Values: &ConfigMetadata{Type: "string"},
 			},
 			defaultValue: defaultValue("localhost"),
 		},
 		{
-			name: "invalid map value type",
+			name: "invalid map value type GoType",
 			metadata: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "unknown"},
+				Type:   "map",
+				Values: &ConfigMetadata{GoType: "github.com/pkg."},
 			},
 			defaultValue: defaultValue(map[string]any{"endpoint": "localhost"}),
 		},
@@ -2659,7 +2658,7 @@ func TestFormatDefaultValue_ResolvedReferenceWithDefaults(t *testing.T) {
 
 func TestFormatDefaultValue_ResolvedPrimitiveReferenceWithDefault(t *testing.T) {
 	md := &ConfigMetadata{
-		Type:    "integer",
+		Type:    "int",
 		Ref:     "port_number",
 		Default: defaultValue(8080),
 	}
@@ -2726,10 +2725,10 @@ func TestMapCustomDefaults_NestedObjectOverrides(t *testing.T) {
 	}, exprs)
 }
 
-func TestMapCustomDefaults_ArrayOfObjectsOverrides(t *testing.T) {
+func TestMapCustomDefaults_SliceOfObjectsOverrides(t *testing.T) {
 	md := &ConfigMetadata{
-		Type: "array",
-		Items: &ConfigMetadata{
+		Type: "slice",
+		Values: &ConfigMetadata{
 			Type: "object",
 			Properties: map[string]*ConfigMetadata{
 				"url": {Type: "string"},
@@ -2761,8 +2760,8 @@ func TestMapCustomDefaults_Panics(t *testing.T) {
 		{
 			name: "map of structs",
 			metadata: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "object"},
+				Type:   "map",
+				Values: &ConfigMetadata{Type: "object"},
 			},
 			defaultValue: defaultValue(map[string]any{"entry": map[string]any{}}),
 		},
@@ -2781,10 +2780,10 @@ func TestMapCustomDefaults_EmptyInput(t *testing.T) {
 	require.Empty(t, MapCustomDefaults(&ConfigMetadata{Type: "string"}, nil, "", ""))
 }
 
-func TestMapCustomDefaults_ScalarArray(t *testing.T) {
+func TestMapCustomDefaults_ScalarSlice(t *testing.T) {
 	md := &ConfigMetadata{
-		Type:  "array",
-		Items: &ConfigMetadata{Type: "string"},
+		Type:   "slice",
+		Values: &ConfigMetadata{Type: "string"},
 	}
 
 	require.Empty(t, MapCustomDefaults(md, defaultValue([]any{"value"}), "", ""))
@@ -2878,8 +2877,8 @@ func TestNewCfgFns_DefaultHelpers(t *testing.T) {
 	))
 	require.Equal(t, []string{`[0].URL = "http://example.com"`}, mapCustomDefaults(
 		&ConfigMetadata{
-			Type: "array",
-			Items: &ConfigMetadata{
+			Type: "slice",
+			Values: &ConfigMetadata{
 				Type: "object",
 				Properties: map[string]*ConfigMetadata{
 					"url": {Type: "string"},

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -928,7 +928,7 @@ func TestExtractDefs_EmbeddedObjects(t *testing.T) {
 	result := ExtractDefsFromConfig(md)
 	require.Len(t, result, 1)
 	require.Contains(t, result, "config")
-	require.Equal(t, "object", result["config"].Type)
+	require.Equal(t, SchemaType("object"), result["config"].Type)
 }
 
 func TestExtractDefs_MapValueObject(t *testing.T) {
@@ -979,7 +979,7 @@ func TestExtractDefs_SliceValueObject(t *testing.T) {
 	result := ExtractDefsFromConfig(md)
 	require.Len(t, result, 1)
 	require.Contains(t, result, "servers_item")
-	require.Equal(t, "object", result["servers_item"].Type)
+	require.Equal(t, SchemaType("object"), result["servers_item"].Type)
 }
 
 func TestExtractDefs_InternalResolvedReference(t *testing.T) {

--- a/cmd/mdatagen/internal/cfggen/shared_alias.go
+++ b/cmd/mdatagen/internal/cfggen/shared_alias.go
@@ -14,12 +14,42 @@ type (
 	Ref                   = schemagen.Ref
 	RefKind               = schemagen.RefKind
 	Resolver              = schemagen.Resolver
+	SchemaType            = schemagen.SchemaType
 )
 
 const (
 	External = schemagen.External
 	Internal = schemagen.Internal
 	Local    = schemagen.Local
+
+	StringType  = schemagen.StringType
+	BoolType    = schemagen.BoolType
+	IntType     = schemagen.IntType
+	Int8Type    = schemagen.Int8Type
+	Int16Type   = schemagen.Int16Type
+	Int32Type   = schemagen.Int32Type
+	Int64Type   = schemagen.Int64Type
+	UintType    = schemagen.UintType
+	Uint8Type   = schemagen.Uint8Type
+	Uint16Type  = schemagen.Uint16Type
+	Uint32Type  = schemagen.Uint32Type
+	Uint64Type  = schemagen.Uint64Type
+	ByteType    = schemagen.ByteType
+	RuneType    = schemagen.RuneType
+	Float32Type = schemagen.Float32Type
+	Float64Type = schemagen.Float64Type
+	AnyType     = schemagen.AnyType
+	ObjectType  = schemagen.ObjectType
+	SliceType   = schemagen.SliceType
+	MapType     = schemagen.MapType
+
+	FloatType        = schemagen.FloatType
+	DoubleType       = schemagen.DoubleType
+	DurationType     = schemagen.DurationType
+	TimeType         = schemagen.TimeType
+	OpaqueStringType = schemagen.OpaqueStringType
+	ComponentIDType  = schemagen.ComponentIDType
+	OpaqueMapType    = schemagen.OpaqueMapType
 )
 
 var (

--- a/cmd/mdatagen/internal/cfggen/type_ref.go
+++ b/cmd/mdatagen/internal/cfggen/type_ref.go
@@ -59,9 +59,19 @@ func ResolveGoTypeRef(ref, rootPackage, componentPackage string) (GoTypeRef, err
 		return resolveLocalRelative(cleanRef, componentPackage)
 	case strings.Contains(cleanRef, "/"):
 		return resolveExternal(cleanRef)
+	case strings.Contains(cleanRef, "."):
+		return resolveCore(cleanRef)
 	default:
 		return resolveInternal(cleanRef)
 	}
+}
+
+func resolveCore(ref string) (GoTypeRef, error) {
+	parts := strings.Split(ref, ".")
+	if len(parts) != 2 {
+		return GoTypeRef{}, fmt.Errorf("invalid reference format: %q", ref)
+	}
+	return GoTypeRef{ImportPath: parts[0], TypeName: parts[1]}, nil
 }
 
 func resolveInternal(ref string) (GoTypeRef, error) {

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -691,13 +691,13 @@ func TestInjectInternalMetadataDefs(t *testing.T) {
 
 		require.Contains(t, src.ExportedConfigs, "resource_attributes_config")
 		resourceAttributes := src.ExportedConfigs["resource_attributes_config"]
-		require.Equal(t, "object", resourceAttributes.Type)
+		require.Equal(t, schemagen.ObjectType, resourceAttributes.Type)
 		require.True(t, resourceAttributes.InternalOnly)
 		require.Contains(t, resourceAttributes.Properties, "service.name")
 
 		resourceAttribute := resourceAttributes.Properties["service.name"]
 		require.Contains(t, resourceAttribute.Properties, "enabled")
-		require.Equal(t, "bool", resourceAttribute.Properties["enabled"].Type)
+		require.Equal(t, schemagen.BoolType, resourceAttribute.Properties["enabled"].Type)
 		require.Equal(t, true, resourceAttribute.Properties["enabled"].Default)
 	})
 

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -697,7 +697,7 @@ func TestInjectInternalMetadataDefs(t *testing.T) {
 
 		resourceAttribute := resourceAttributes.Properties["service.name"]
 		require.Contains(t, resourceAttribute.Properties, "enabled")
-		require.Equal(t, "boolean", resourceAttribute.Properties["enabled"].Type)
+		require.Equal(t, "bool", resourceAttribute.Properties["enabled"].Type)
 		require.Equal(t, true, resourceAttribute.Properties["enabled"].Default)
 	})
 

--- a/cmd/mdatagen/internal/samplemigrationscraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplemigrationscraper/metadata.yaml
@@ -21,7 +21,7 @@ config:
         anonymous: true
     emit_legacy_metrics:
       description: Whether to emit legacy metric names alongside new ones.
-      type: boolean
+      type: bool
       default: false
 
 feature_gates:

--- a/cmd/mdatagen/internal/samplepkg/generated_config.go
+++ b/cmd/mdatagen/internal/samplepkg/generated_config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // PortNumber a port number to connect to.
-type PortNumber int32
+type PortNumber int
 
 type SampleConfig struct {
 	// The host name to connect to.

--- a/cmd/mdatagen/internal/samplepkg/metadata.yaml
+++ b/cmd/mdatagen/internal/samplepkg/metadata.yaml
@@ -8,9 +8,8 @@ status:
 
 exported_configs:
   port_number:
-    type: integer
+    type: int
     description: A port number to connect to.
-    x-customType: int32
     minimum: 1
     maximum: 65535
   sample_config:

--- a/cmd/mdatagen/internal/samplereceiver/README.md
+++ b/cmd/mdatagen/internal/samplereceiver/README.md
@@ -38,7 +38,7 @@ This is where warnings are described.
 | `component_id` | string |  | no | Component ID used to identify this receiver instance. |
 | `endpoint` | string | localhost:12345 | **yes** | The endpoint to scrape metrics from. |
 | `headers` | map[string]string |  | no | Extra HTTP headers to attach to each request. |
-| `max_results` | int | 100 | no | Maximum number of results to return per scrape. |
+| `max_results` | int64 | 100 | no | Maximum number of results to return per scrape. |
 | `metrics` | object (see [metrics](#metrics)) |  | no | MetricsConfig provides config for sample metrics. |
 | `resource_attributes` | object (see [resource_attributes](#resource_attributes)) |  | no | ResourceAttributesConfig provides config for sample resource attributes. |
 | `sample_pkg` | object (see [sample_pkg](#sample_pkg)) |  | no |  |

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -56,8 +56,8 @@ config:
     targets:
       description: List of targets to scrape metrics from.
       x-pointer: true
-      type: array
-      items:
+      type: slice
+      values:
         type: object
         properties:
           interval:
@@ -66,21 +66,21 @@ config:
             default: 10s
           labels:
             description: Static key-value labels attached to all metrics from this target.
-            type: object
-            additionalProperties:
+            type: map
+            values:
               type: string
             default:
               option1: value1
               option2: value2
           retry_count:
             description: Number of retry attempts for failed scrapes.
-            type: integer
+            type: int
             default: 3
             minimum: 0
             maximum: 10
           timeout_seconds:
             description: Timeout in seconds for each scrape request.
-            type: number
+            type: double
             default: 5.0
             exclusiveMinimum: 0
             exclusiveMaximum: 30
@@ -183,7 +183,7 @@ metrics:
     stability: development
     unit: s
     sum:
-      value_type: int
+      values: int
       monotonic: true
       aggregation_temporality: cumulative
     attributes:
@@ -201,7 +201,7 @@ metrics:
       note: "This metric will be removed"
     unit: s
     sum:
-      value_type: double
+      values: double
       monotonic: false
       aggregation_temporality: delta
     warnings:
@@ -213,7 +213,7 @@ metrics:
     description: Monotonic cumulative sum int metric with string input_type enabled by default.
     unit: s
     sum:
-      value_type: int
+      values: int
       input_type: string
       monotonic: true
       aggregation_temporality: cumulative
@@ -229,7 +229,7 @@ metrics:
       note: "This metric will be removed"
     unit: "1"
     gauge:
-      value_type: double
+      values: double
     attributes: [string_attr, boolean_attr, boolean_attr2]
     warnings:
       if_configured: This metric is deprecated and will be removed soon.
@@ -243,7 +243,7 @@ metrics:
       note: "This metric will be removed"
     unit: ""
     gauge:
-      value_type: double
+      values: double
     attributes: [string_attr, boolean_attr]
     warnings:
       if_configured: This metric is deprecated and will be removed soon.
@@ -254,7 +254,7 @@ metrics:
     unit: "1"
     stability: beta
     gauge:
-      value_type: double
+      values: double
     attributes: [string_attr, boolean_attr]
 
   system.cpu.time:
@@ -264,7 +264,7 @@ metrics:
     extended_documentation: The metric will be become optional soon.
     unit: s
     sum:
-      value_type: int
+      values: int
       monotonic: true
       aggregation_temporality: cumulative
     semantic_convention:

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -183,7 +183,7 @@ metrics:
     stability: development
     unit: s
     sum:
-      values: int
+      value_type: int
       monotonic: true
       aggregation_temporality: cumulative
     attributes:
@@ -201,7 +201,7 @@ metrics:
       note: "This metric will be removed"
     unit: s
     sum:
-      values: double
+      value_type: double
       monotonic: false
       aggregation_temporality: delta
     warnings:
@@ -213,7 +213,7 @@ metrics:
     description: Monotonic cumulative sum int metric with string input_type enabled by default.
     unit: s
     sum:
-      values: int
+      value_type: int
       input_type: string
       monotonic: true
       aggregation_temporality: cumulative
@@ -229,7 +229,7 @@ metrics:
       note: "This metric will be removed"
     unit: "1"
     gauge:
-      values: double
+      value_type: double
     attributes: [string_attr, boolean_attr, boolean_attr2]
     warnings:
       if_configured: This metric is deprecated and will be removed soon.
@@ -243,7 +243,7 @@ metrics:
       note: "This metric will be removed"
     unit: ""
     gauge:
-      values: double
+      value_type: double
     attributes: [string_attr, boolean_attr]
     warnings:
       if_configured: This metric is deprecated and will be removed soon.
@@ -254,7 +254,7 @@ metrics:
     unit: "1"
     stability: beta
     gauge:
-      values: double
+      value_type: double
     attributes: [string_attr, boolean_attr]
 
   system.cpu.time:
@@ -264,7 +264,7 @@ metrics:
     extended_documentation: The metric will be become optional soon.
     unit: s
     sum:
-      values: int
+      value_type: int
       monotonic: true
       aggregation_temporality: cumulative
     semantic_convention:

--- a/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
+++ b/cmd/mdatagen/internal/templates/config.schema.yaml.tmpl
@@ -10,7 +10,7 @@
         type: object
         properties:
           enabled:
-            type: boolean
+            type: bool
             default: {{ $metric.Enabled }}
           {{- if $metricReag }}
           aggregation_strategy:
@@ -26,8 +26,8 @@
             default: "avg"
             {{- end }}
           attributes:
-            type: array
-            items:
+            type: slice
+            values:
               type: string
               enum:
               {{- range $metric.Attributes }}
@@ -53,7 +53,7 @@
         type: object
         properties:
           enabled:
-            type: boolean
+            type: bool
             default: {{ $event.Enabled }}
       {{- end }}
 {{- end }}
@@ -68,30 +68,30 @@
         type: object
         properties:
           enabled:
-            type: boolean
+            type: bool
             default: {{ $attr.Enabled }}
         {{- if $.Metrics }}
           metrics_include:
             description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
-            type: array
-            items:
+            type: slice
+            values:
               $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
           metrics_exclude:
             description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
-            type: array
-            items:
+            type: slice
+            values:
               $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
         {{- end }}
         {{- if $.Events }}
           events_include:
             description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
-            type: array
-            items:
+            type: slice
+            values:
               $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
           events_exclude:
             description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
-            type: array
-            items:
+            type: slice
+            values:
               $ref: {{ schemaRef "go.opentelemetry.io/collector/filter.config" }}
         {{- end }}
     {{- end }}

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -108,7 +108,7 @@ import (
 {{ define "requiredValidator" -}}
     {{ $name := .FieldName | publicVar -}}
     {{- if .IsPointer }}
-        {{- if or (eq .FieldType "array") (eq .FieldType "map") }}
+        {{- if or (eq .FieldType "slice") (eq .FieldType "map") }}
         if c.{{ $name }} == nil || len(*c.{{ $name }}) == 0 {
             err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
         }
@@ -121,7 +121,7 @@ import (
         if c.{{ $name }} == "" {
             err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
         }
-    {{- else if eq .FieldType "array" }}
+    {{- else if eq .FieldType "slice" }}
         if len(c.{{ $name }}) == 0 {
             err = errors.Join(err, errors.New("{{ .FieldName }} is required"))
         }

--- a/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen_test.go.tmpl
@@ -40,7 +40,7 @@ require.NotNil(t, cfg)
                 cfg.{{ $validator.FieldName | publicVar }} = nil
             {{- else if eq $validator.FieldType "map" }}
                 clear(cfg.{{ $validator.FieldName | publicVar }})
-            {{- else if eq $validator.FieldType "array" }}
+            {{- else if eq $validator.FieldType "slice" }}
                 cfg.{{ $validator.FieldName | publicVar }} = cfg.{{ $validator.FieldName | publicVar }}[:0]
             {{- else if eq $validator.FieldType "string" }}
                 cfg.{{ $validator.FieldName | publicVar }} = ""

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -70,14 +70,18 @@ config:
   # Optional: Additional comments for developers (not included in JSON output).
   $comment: string
   # Required: The type of the configuration object. Typically "object" for component configs.
-  type: <string|number|integer|boolean|object|array|null>
+  # Primitive types: string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, byte, rune, float32, float64, any
+  # Container types: object (requires properties:), slice (requires values:), map (requires values:)
+  # Alias types: float (→float32), double (→float64), duration (→time.Duration), time (→time.Time),
+  #              opaque_string (→configopaque.String), component_id (→component.ID), opaque_map (→configopaque.MapList)
+  type: <string|bool|int|int8|int16|int32|int64|uint|uint8|uint16|uint32|uint64|byte|rune|float32|float64|any|object|slice|map|float|double|duration|time|opaque_string|component_id|opaque_map>
   # Optional: Map of configuration properties that define the component's configuration fields.
   properties:
     <property.name>:
       # Optional: Description of this configuration property.
       description: string
-      # Optional: The JSON Schema type of this property.
-      type: <string|number|integer|boolean|object|array|null>
+      # Optional: The type of this property. See the type comment above for supported values.
+      type: <string|bool|int|int8|int16|int32|int64|uint|uint8|uint16|uint32|uint64|byte|rune|float32|float64|any|object|slice|map|float|double|duration|time|opaque_string|component_id|opaque_map>
       # Optional: Reference to another schema definition. Can be:
       # - Internal reference: name of a type in $defs (e.g., "endpoint_config")
       # - External reference: full package path with type (e.g., "go.opentelemetry.io/collector/config/confighttp.client_config")
@@ -113,23 +117,21 @@ config:
       multipleOf: number
       # Optional: For object types - properties of the nested object.
       properties: {} # Recursively follows same structure
-      # Optional: For object types - whether additional properties beyond those defined are allowed.
-      # Can be true, false, or an object schema defining the type of additional properties.
-      additionalProperties: <bool|object>
+      # Optional: For slice and map types - schema for the element/value type.
+      # Required when type is "slice" (element type) or "map" (value type).
+      values:
+        # Same structure as property definition
+        type: string
+        # ... other item properties
       # Optional: For object types - minimum number of properties required.
       minProperties: int
       # Optional: For object types - maximum number of properties allowed.
       maxProperties: int
-      # Optional: For array types - schema for array items.
-      items:
-        # Same structure as property definition
-        type: string
-        # ... other item properties
-      # Optional: For array types - minimum number of items.
+      # Optional: For slice types - minimum number of items.
       minItems: int
-      # Optional: For array types - maximum number of items.
+      # Optional: For slice types - maximum number of items.
       maxItems: int
-      # Optional: For array types - whether all items must be unique.
+      # Optional: For slice types - whether all items must be unique.
       uniqueItems: bool
       # Optional: All of these schemas must be satisfied (schema composition).
       allOf:
@@ -148,7 +150,7 @@ config:
   # These definitions are not directly part of the config but can be reused multiple times.
   $defs:
     <definition.name>:
-      # Same structure as property definition
+      # Same structure as property definition. Type can be any supported type (see type comment above).
       type: object
       properties: {}
       # ... other schema properties
@@ -265,7 +267,7 @@ metrics:
     # Required: metric type with its settings.
     <sum|gauge>:
       # Required for sum and gauge metrics: type of number data point values.
-      value_type: <int|double>
+      values: <int|double>
       # Required for sum metric: whether the metric is monotonic (no negative delta values).
       monotonic: bool
       # Required for sum metric: whether reported values incorporate previous measurements
@@ -397,7 +399,7 @@ telemetry:
         # pass in options to the callbacks that are called when the metric is observed.
         async: bool
         # Required: type of number data point values.
-        value_type: <int|double>
+        values: <int|double>
         # Required for sum metric: whether the metric is monotonic (no negative delta values).
         monotonic: bool
         # Bucket boundaries are only available to set for histogram metrics.

--- a/config/configcompression/metadata.yaml
+++ b/config/configcompression/metadata.yaml
@@ -13,7 +13,7 @@ exported_configs:
       level:
         $ref: level
   level:
-    type: integer
+    type: int
   type:
     description: Type represents a compression method
     type: string

--- a/internal/schemagen/extended_types.go
+++ b/internal/schemagen/extended_types.go
@@ -3,8 +3,6 @@
 
 package schemagen // import "go.opentelemetry.io/collector/internal/schemagen"
 
-import "fmt"
-
 // goDurationPattern matches Go duration strings (e.g., "30s", "1h30m", "500ms")
 const goDurationPattern = `^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$`
 
@@ -14,22 +12,8 @@ const goDurationPattern = `^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$`
 //
 // To add a new alias, add a single entry here. No other switch or case needs editing.
 var extendedTypes = map[string]ConfigMetadata{
-	// Integer aliases
-	"rune":   {Type: "integer", GoType: "rune"},
-	"byte":   {Type: "integer", GoType: "byte"},
-	"uint":   {Type: "integer", GoType: "uint"},
-	"int8":   {Type: "integer", GoType: "int8"},
-	"uint8":  {Type: "integer", GoType: "uint8"},
-	"int16":  {Type: "integer", GoType: "int16"},
-	"uint16": {Type: "integer", GoType: "uint16"},
-	"int32":  {Type: "integer", GoType: "int32"},
-	"uint32": {Type: "integer", GoType: "uint32"},
-	"int64":  {Type: "integer", GoType: "int64"},
-	"uint64": {Type: "integer", GoType: "uint64"},
-
-	// Number aliases
-	"float32": {Type: "number", GoType: "float32"},
-	"float64": {Type: "number", GoType: "float64"},
+	"float":  {Type: "float32"},
+	"double": {Type: "float64"},
 
 	// String-backed aliases using full import-path GoType convention
 	"opaque_string": {Type: "string", GoType: "go.opentelemetry.io/collector/config/configopaque.String"},
@@ -41,27 +25,12 @@ var extendedTypes = map[string]ConfigMetadata{
 
 	// opaque_map: Go uses configopaque.MapList; JSON gets a map[string]string
 	"opaque_map": {
-		Type:   "object",
+		Type:   "map",
 		GoType: "go.opentelemetry.io/collector/config/configopaque.MapList",
-		AdditionalProperties: &ConfigMetadata{
+		Values: &ConfigMetadata{
 			Type: "string",
 		},
 	},
-}
-
-var basicTypes = map[string]bool{
-	"":        true, // empty is allowed (treated as "any" by the generator)
-	"string":  true,
-	"integer": true,
-	"number":  true,
-	"boolean": true,
-	"object":  true,
-	"array":   true,
-	"null":    true,
-}
-
-func isBasicType(typ string) bool {
-	return basicTypes[typ]
 }
 
 // expandExtendedType rewrites md.Type from an extended alias to the equivalent standard JSON Schema fields.
@@ -70,12 +39,9 @@ func isBasicType(typ string) bool {
 //
 // Returns an actionable error for unknown aliases.
 func expandExtendedType(md *ConfigMetadata) error {
-	if isBasicType(md.Type) {
-		return nil
-	}
 	ext, ok := extendedTypes[md.Type]
-	if !ok {
-		return fmt.Errorf("unknown config type %q: not a JSON Schema type and not a known extended type alias (e.g. int64, duration, opaque_string, id, opaque_map)", md.Type)
+	if !ok { // not an extended type
+		return nil
 	}
 
 	md.Type = ext.Type
@@ -92,12 +58,8 @@ func expandExtendedType(md *ConfigMetadata) error {
 		md.Pattern = ext.Pattern
 	}
 
-	if md.Items == nil {
-		md.Items = ext.Items
-	}
-
-	if md.AdditionalProperties == nil {
-		md.AdditionalProperties = ext.AdditionalProperties
+	if md.Values == nil {
+		md.Values = ext.Values
 	}
 
 	return nil

--- a/internal/schemagen/extended_types.go
+++ b/internal/schemagen/extended_types.go
@@ -6,29 +6,41 @@ package schemagen // import "go.opentelemetry.io/collector/internal/schemagen"
 // goDurationPattern matches Go duration strings (e.g., "30s", "1h30m", "500ms")
 const goDurationPattern = `^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$`
 
+// Extended type alias constants — these are the user-facing names accepted in the type: field
+// of metadata.yaml. Each one expands to a primitive SchemaType during schema resolution.
+const (
+	FloatType        SchemaType = "float"
+	DoubleType       SchemaType = "double"
+	DurationType     SchemaType = "duration"
+	TimeType         SchemaType = "time"
+	OpaqueStringType SchemaType = "opaque_string"
+	ComponentIDType  SchemaType = "component_id"
+	OpaqueMapType    SchemaType = "opaque_map"
+)
+
 // extendedTypes is the centralized registry of first-class type aliases that can be used as the "type" field
 // in a metadata.yaml config schema. Each entry maps an alias name to the standard JSON Schema fields it expands to,
 // together with any Go-specific annotations (GoType) needed for code generation.
 //
 // To add a new alias, add a single entry here. No other switch or case needs editing.
-var extendedTypes = map[string]ConfigMetadata{
-	"float":  {Type: "float32"},
-	"double": {Type: "float64"},
+var extendedTypes = map[SchemaType]ConfigMetadata{
+	FloatType:  {Type: Float32Type},
+	DoubleType: {Type: Float64Type},
 
 	// String-backed aliases using full import-path GoType convention
-	"opaque_string": {Type: "string", GoType: "go.opentelemetry.io/collector/config/configopaque.String"},
-	"component_id":  {Type: "string", GoType: "go.opentelemetry.io/collector/component.ID"},
+	OpaqueStringType: {Type: StringType, GoType: "go.opentelemetry.io/collector/config/configopaque.String"},
+	ComponentIDType:  {Type: StringType, GoType: "go.opentelemetry.io/collector/component.ID"},
 
 	// duration and time
-	"duration": {Type: "string", GoType: "time.Duration", Pattern: goDurationPattern},
-	"time":     {Type: "string", GoType: "time.Time", Format: "date-time"},
+	DurationType: {Type: StringType, GoType: "time.Duration", Pattern: goDurationPattern},
+	TimeType:     {Type: StringType, GoType: "time.Time", Format: "date-time"},
 
 	// opaque_map: Go uses configopaque.MapList; JSON gets a map[string]string
-	"opaque_map": {
-		Type:   "map",
+	OpaqueMapType: {
+		Type:   MapType,
 		GoType: "go.opentelemetry.io/collector/config/configopaque.MapList",
 		Values: &ConfigMetadata{
-			Type: "string",
+			Type: StringType,
 		},
 	},
 }
@@ -36,8 +48,6 @@ var extendedTypes = map[string]ConfigMetadata{
 // expandExtendedType rewrites md.Type from an extended alias to the equivalent standard JSON Schema fields.
 // It is a no-op when md.Type is already a standard JSON Schema type. An explicit x-customType on the node
 // is never overwritten.
-//
-// Returns an actionable error for unknown aliases.
 func expandExtendedType(md *ConfigMetadata) error {
 	ext, ok := extendedTypes[md.Type]
 	if !ok { // not an extended type

--- a/internal/schemagen/extended_types_test.go
+++ b/internal/schemagen/extended_types_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestExpandExtendedType_StandardTypes_NoOp(t *testing.T) {
-	standardTypes := []string{"", "string", "integer", "number", "boolean", "object", "array", "null"}
+	// These are the native types the generator understands directly — expandType is a no-op for them.
+	standardTypes := []string{"", "string", "bool", "int", "uint", "int8", "uint8", "int16", "uint16",
+		"int32", "uint32", "int64", "uint64", "object", "slice", "map", "any"}
 	for _, typ := range standardTypes {
 		t.Run(typ, func(t *testing.T) {
 			md := &ConfigMetadata{Type: typ}
@@ -19,62 +21,62 @@ func TestExpandExtendedType_StandardTypes_NoOp(t *testing.T) {
 			assert.Equal(t, typ, md.Type, "standard type should not be modified")
 			assert.Empty(t, md.GoType)
 			assert.Empty(t, md.Format)
-			assert.Nil(t, md.Items)
+			assert.Nil(t, md.Values)
 		})
 	}
 }
 
-func TestExpandExtendedType_UnknownAlias_Error(t *testing.T) {
+func TestExpandExtendedType_UnknownAlias_NoOp(t *testing.T) {
+	// expandType is a no-op for types not in the alias registry — unknown types are passed through
+	// so the generator can handle them (e.g. fall through to the default case in resolveGoType).
 	md := &ConfigMetadata{Type: "foobar"}
 	err := expandExtendedType(md)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "foobar")
-	assert.Contains(t, err.Error(), "unknown config type")
+	require.NoError(t, err)
+	assert.Equal(t, "foobar", md.Type, "unknown type should be unchanged")
 }
 
 func TestExpandExtendedType_IntegerAliases(t *testing.T) {
-	cases := []struct {
-		alias  string
-		goType string
-	}{
-		{"rune", "rune"},
-		{"byte", "byte"},
-		{"uint", "uint"},
-		{"int8", "int8"},
-		{"uint8", "uint8"},
-		{"int16", "int16"},
-		{"uint16", "uint16"},
-		{"int32", "int32"},
-		{"uint32", "uint32"},
-		{"int64", "int64"},
-		{"uint64", "uint64"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.alias, func(t *testing.T) {
-			md := &ConfigMetadata{Type: tc.alias}
+	// rune, byte, and the full int/uint family are now first-class types — expandType is a no-op for them.
+	cases := []string{"rune", "byte", "uint", "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64"}
+	for _, alias := range cases {
+		t.Run(alias, func(t *testing.T) {
+			md := &ConfigMetadata{Type: alias}
 			require.NoError(t, expandExtendedType(md))
-			assert.Equal(t, "integer", md.Type)
-			assert.Equal(t, tc.goType, md.GoType)
+			assert.Equal(t, alias, md.Type, "integer aliases are passed through unchanged")
+			assert.Empty(t, md.GoType)
 			assert.Empty(t, md.Format)
-			assert.Nil(t, md.Items)
+			assert.Nil(t, md.Values)
 		})
 	}
 }
 
-func TestExpandExtendedType_NumberAliases(t *testing.T) {
+func TestExpandExtendedType_FloatAliases(t *testing.T) {
+	// "float" and "double" are shorthands that expand to "float32"/"float64".
 	cases := []struct {
-		alias  string
-		goType string
+		alias    string
+		wantType string
 	}{
-		{"float32", "float32"},
-		{"float64", "float64"},
+		{"float", "float32"},
+		{"double", "float64"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.alias, func(t *testing.T) {
 			md := &ConfigMetadata{Type: tc.alias}
 			require.NoError(t, expandExtendedType(md))
-			assert.Equal(t, "number", md.Type)
-			assert.Equal(t, tc.goType, md.GoType)
+			assert.Equal(t, tc.wantType, md.Type)
+			assert.Empty(t, md.GoType)
+		})
+	}
+}
+
+func TestExpandExtendedType_NativeFloatTypes_NoOp(t *testing.T) {
+	// "float32" and "float64" are native — expandType leaves them unchanged.
+	for _, typ := range []string{"float32", "float64"} {
+		t.Run(typ, func(t *testing.T) {
+			md := &ConfigMetadata{Type: typ}
+			require.NoError(t, expandExtendedType(md))
+			assert.Equal(t, typ, md.Type)
+			assert.Empty(t, md.GoType)
 		})
 	}
 }
@@ -112,19 +114,20 @@ func TestExpandExtendedType_ID(t *testing.T) {
 func TestExpandExtendedType_OpaqueMap(t *testing.T) {
 	md := &ConfigMetadata{Type: "opaque_map"}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "object", md.Type)
+	assert.Equal(t, "map", md.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/config/configopaque.MapList", md.GoType)
-	require.NotNil(t, md.AdditionalProperties)
-	assert.Equal(t, "string", md.AdditionalProperties.Type)
+	require.NotNil(t, md.Values)
+	assert.Equal(t, "string", md.Values.Type)
 }
 
 // TestExpandExtendedType_DoesNotClobberExplicitGoType verifies that an explicit x-customType
 // on the alias node is preserved (e.g. type: int64 + x-customType: myapp.SpecialInt).
 func TestExpandExtendedType_DoesNotClobberExplicitGoType(t *testing.T) {
-	md := &ConfigMetadata{Type: "int64", GoType: "myapp/pkg.SpecialInt"}
+	// "float" expands to "float32" but must not overwrite an explicit GoType.
+	md := &ConfigMetadata{Type: "float", GoType: "myapp/pkg.SpecialFloat"}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "integer", md.Type)
-	assert.Equal(t, "myapp/pkg.SpecialInt", md.GoType, "explicit GoType must not be overwritten")
+	assert.Equal(t, "float32", md.Type)
+	assert.Equal(t, "myapp/pkg.SpecialFloat", md.GoType, "explicit GoType must not be overwritten")
 }
 
 // TestExpandExtendedType_DoesNotClobberExplicitFormat verifies that an explicit format
@@ -137,11 +140,11 @@ func TestExpandExtendedType_DoesNotClobberExplicitFormat(t *testing.T) {
 	assert.Equal(t, "custom-format", md.Format, "explicit Format must not be overwritten")
 }
 
-// TestExpandExtendedType_DoesNotClobberExplicitAdditionalProperties verifies that explicit Items is kept.
-func TestExpandExtendedType_DoesNotClobberExplicitAdditionalProperties(t *testing.T) {
-	existingItems := &ConfigMetadata{Type: "integer"}
-	md := &ConfigMetadata{Type: "opaque_map", AdditionalProperties: existingItems}
+// TestExpandExtendedType_DoesNotClobberExplicitValueType verifies that an explicit ValueType is kept.
+func TestExpandExtendedType_DoesNotClobberExplicitValueType(t *testing.T) {
+	existingValueType := &ConfigMetadata{Type: "int"}
+	md := &ConfigMetadata{Type: "opaque_map", Values: existingValueType}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "object", md.Type)
-	assert.Same(t, existingItems, md.AdditionalProperties, "explicit AdditionalProperties must not be overwritten")
+	assert.Equal(t, "map", md.Type)
+	assert.Same(t, existingValueType, md.Values, "explicit ValueType must not be overwritten")
 }

--- a/internal/schemagen/extended_types_test.go
+++ b/internal/schemagen/extended_types_test.go
@@ -12,8 +12,10 @@ import (
 
 func TestExpandExtendedType_StandardTypes_NoOp(t *testing.T) {
 	// These are the native types the generator understands directly — expandType is a no-op for them.
-	standardTypes := []string{"", "string", "bool", "int", "uint", "int8", "uint8", "int16", "uint16",
-		"int32", "uint32", "int64", "uint64", "object", "slice", "map", "any"}
+	standardTypes := []string{
+		"", "string", "bool", "int", "uint", "int8", "uint8", "int16", "uint16",
+		"int32", "uint32", "int64", "uint64", "object", "slice", "map", "any",
+	}
 	for _, typ := range standardTypes {
 		t.Run(typ, func(t *testing.T) {
 			md := &ConfigMetadata{Type: typ}

--- a/internal/schemagen/extended_types_test.go
+++ b/internal/schemagen/extended_types_test.go
@@ -18,9 +18,9 @@ func TestExpandExtendedType_StandardTypes_NoOp(t *testing.T) {
 	}
 	for _, typ := range standardTypes {
 		t.Run(typ, func(t *testing.T) {
-			md := &ConfigMetadata{Type: typ}
+			md := &ConfigMetadata{Type: SchemaType(typ)}
 			require.NoError(t, expandExtendedType(md))
-			assert.Equal(t, typ, md.Type, "standard type should not be modified")
+			assert.Equal(t, SchemaType(typ), md.Type, "standard type should not be modified")
 			assert.Empty(t, md.GoType)
 			assert.Empty(t, md.Format)
 			assert.Nil(t, md.Values)
@@ -34,7 +34,7 @@ func TestExpandExtendedType_UnknownAlias_NoOp(t *testing.T) {
 	md := &ConfigMetadata{Type: "foobar"}
 	err := expandExtendedType(md)
 	require.NoError(t, err)
-	assert.Equal(t, "foobar", md.Type, "unknown type should be unchanged")
+	assert.Equal(t, SchemaType("foobar"), md.Type, "unknown type should be unchanged")
 }
 
 func TestExpandExtendedType_IntegerAliases(t *testing.T) {
@@ -42,9 +42,9 @@ func TestExpandExtendedType_IntegerAliases(t *testing.T) {
 	cases := []string{"rune", "byte", "uint", "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64"}
 	for _, alias := range cases {
 		t.Run(alias, func(t *testing.T) {
-			md := &ConfigMetadata{Type: alias}
+			md := &ConfigMetadata{Type: SchemaType(alias)}
 			require.NoError(t, expandExtendedType(md))
-			assert.Equal(t, alias, md.Type, "integer aliases are passed through unchanged")
+			assert.Equal(t, SchemaType(alias), md.Type, "integer aliases are passed through unchanged")
 			assert.Empty(t, md.GoType)
 			assert.Empty(t, md.Format)
 			assert.Nil(t, md.Values)
@@ -55,14 +55,14 @@ func TestExpandExtendedType_IntegerAliases(t *testing.T) {
 func TestExpandExtendedType_FloatAliases(t *testing.T) {
 	// "float" and "double" are shorthands that expand to "float32"/"float64".
 	cases := []struct {
-		alias    string
-		wantType string
+		alias    SchemaType
+		wantType SchemaType
 	}{
-		{"float", "float32"},
-		{"double", "float64"},
+		{FloatType, Float32Type},
+		{DoubleType, Float64Type},
 	}
 	for _, tc := range cases {
-		t.Run(tc.alias, func(t *testing.T) {
+		t.Run(string(tc.alias), func(t *testing.T) {
 			md := &ConfigMetadata{Type: tc.alias}
 			require.NoError(t, expandExtendedType(md))
 			assert.Equal(t, tc.wantType, md.Type)
@@ -73,8 +73,8 @@ func TestExpandExtendedType_FloatAliases(t *testing.T) {
 
 func TestExpandExtendedType_NativeFloatTypes_NoOp(t *testing.T) {
 	// "float32" and "float64" are native — expandType leaves them unchanged.
-	for _, typ := range []string{"float32", "float64"} {
-		t.Run(typ, func(t *testing.T) {
+	for _, typ := range []SchemaType{Float32Type, Float64Type} {
+		t.Run(string(typ), func(t *testing.T) {
 			md := &ConfigMetadata{Type: typ}
 			require.NoError(t, expandExtendedType(md))
 			assert.Equal(t, typ, md.Type)
@@ -84,51 +84,51 @@ func TestExpandExtendedType_NativeFloatTypes_NoOp(t *testing.T) {
 }
 
 func TestExpandExtendedType_Duration(t *testing.T) {
-	md := &ConfigMetadata{Type: "duration"}
+	md := &ConfigMetadata{Type: DurationType}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "string", md.Type)
+	assert.Equal(t, StringType, md.Type)
 	assert.Equal(t, "time.Duration", md.GoType)
 }
 
 func TestExpandExtendedType_Time(t *testing.T) {
-	md := &ConfigMetadata{Type: "time"}
+	md := &ConfigMetadata{Type: TimeType}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "string", md.Type)
+	assert.Equal(t, StringType, md.Type)
 	assert.Equal(t, "time.Time", md.GoType)
 	assert.Equal(t, "date-time", md.Format)
 }
 
 func TestExpandExtendedType_OpaqueString(t *testing.T) {
-	md := &ConfigMetadata{Type: "opaque_string"}
+	md := &ConfigMetadata{Type: OpaqueStringType}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "string", md.Type)
+	assert.Equal(t, StringType, md.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/config/configopaque.String", md.GoType)
 	assert.Empty(t, md.Format)
 }
 
 func TestExpandExtendedType_ID(t *testing.T) {
-	md := &ConfigMetadata{Type: "component_id"}
+	md := &ConfigMetadata{Type: ComponentIDType}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "string", md.Type)
+	assert.Equal(t, StringType, md.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/component.ID", md.GoType)
 }
 
 func TestExpandExtendedType_OpaqueMap(t *testing.T) {
-	md := &ConfigMetadata{Type: "opaque_map"}
+	md := &ConfigMetadata{Type: OpaqueMapType}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "map", md.Type)
+	assert.Equal(t, MapType, md.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/config/configopaque.MapList", md.GoType)
 	require.NotNil(t, md.Values)
-	assert.Equal(t, "string", md.Values.Type)
+	assert.Equal(t, StringType, md.Values.Type)
 }
 
 // TestExpandExtendedType_DoesNotClobberExplicitGoType verifies that an explicit x-customType
 // on the alias node is preserved (e.g. type: int64 + x-customType: myapp.SpecialInt).
 func TestExpandExtendedType_DoesNotClobberExplicitGoType(t *testing.T) {
 	// "float" expands to "float32" but must not overwrite an explicit GoType.
-	md := &ConfigMetadata{Type: "float", GoType: "myapp/pkg.SpecialFloat"}
+	md := &ConfigMetadata{Type: FloatType, GoType: "myapp/pkg.SpecialFloat"}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "float32", md.Type)
+	assert.Equal(t, Float32Type, md.Type)
 	assert.Equal(t, "myapp/pkg.SpecialFloat", md.GoType, "explicit GoType must not be overwritten")
 }
 
@@ -136,17 +136,17 @@ func TestExpandExtendedType_DoesNotClobberExplicitGoType(t *testing.T) {
 // on a duration-like alias is not overwritten.
 func TestExpandExtendedType_DoesNotClobberExplicitFormat(t *testing.T) {
 	// opaque_string with an explicit format — should keep the custom format
-	md := &ConfigMetadata{Type: "opaque_string", Format: "custom-format"}
+	md := &ConfigMetadata{Type: OpaqueStringType, Format: "custom-format"}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "string", md.Type)
+	assert.Equal(t, StringType, md.Type)
 	assert.Equal(t, "custom-format", md.Format, "explicit Format must not be overwritten")
 }
 
 // TestExpandExtendedType_DoesNotClobberExplicitValueType verifies that an explicit ValueType is kept.
 func TestExpandExtendedType_DoesNotClobberExplicitValueType(t *testing.T) {
-	existingValueType := &ConfigMetadata{Type: "int"}
-	md := &ConfigMetadata{Type: "opaque_map", Values: existingValueType}
+	existingValueType := &ConfigMetadata{Type: IntType}
+	md := &ConfigMetadata{Type: OpaqueMapType, Values: existingValueType}
 	require.NoError(t, expandExtendedType(md))
-	assert.Equal(t, "map", md.Type)
+	assert.Equal(t, MapType, md.Type)
 	assert.Same(t, existingValueType, md.Values, "explicit ValueType must not be overwritten")
 }

--- a/internal/schemagen/loader_test.go
+++ b/internal/schemagen/loader_test.go
@@ -36,7 +36,7 @@ func TestLoader_LoadFromFile_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result.Config)
 	require.Equal(t, "A test schema", result.Config.Description)
-	require.Equal(t, "object", result.Config.Type)
+	require.Equal(t, SchemaType("object"), result.Config.Type)
 }
 
 func TestLoader_LoadFromFile_ExportedConfigsOnly(t *testing.T) {
@@ -58,7 +58,7 @@ func TestLoader_LoadFromFile_ExportedConfigsOnly(t *testing.T) {
 	require.NotNil(t, result)
 	require.NotNil(t, result.ExportedConfigs)
 	require.Contains(t, result.ExportedConfigs, "sample_config")
-	require.Equal(t, "object", result.ExportedConfigs["sample_config"].Type)
+	require.Equal(t, SchemaType("object"), result.ExportedConfigs["sample_config"].Type)
 	require.Contains(t, result.ExportedConfigs["sample_config"].Properties, "endpoint")
 }
 
@@ -112,7 +112,7 @@ func TestLoader_LoadFromHTTP_Success(t *testing.T) {
 
 	result, err := loader.loadFromHTTP(ref, filepath.Join(tempDir, ".schemas"))
 	require.NoError(t, err)
-	require.Equal(t, "string", result.Config.Type)
+	require.Equal(t, SchemaType("string"), result.Config.Type)
 }
 
 func TestLoader_LoadFromHTTP_NotFound(t *testing.T) {
@@ -204,7 +204,7 @@ func TestLoader_TryLoad_ExportedConfigsOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Contains(t, result.ExportedConfigs, "sample_config")
-	require.Equal(t, "object", result.ExportedConfigs["sample_config"].Type)
+	require.Equal(t, SchemaType("object"), result.ExportedConfigs["sample_config"].Type)
 	require.Contains(t, result.ExportedConfigs["sample_config"].Properties, "endpoint")
 }
 

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -10,10 +10,35 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 )
 
+type SchemaType string
+
+const (
+	StringType  SchemaType = "string"
+	BoolType    SchemaType = "bool"
+	IntType     SchemaType = "int"
+	Int8Type    SchemaType = "int8"
+	Int16Type   SchemaType = "int16"
+	Int32Type   SchemaType = "int32"
+	Int64Type   SchemaType = "int64"
+	UintType    SchemaType = "uint"
+	Uint8Type   SchemaType = "uint8"
+	Uint16Type  SchemaType = "uint16"
+	Uint32Type  SchemaType = "uint32"
+	Uint64Type  SchemaType = "uint64"
+	ByteType    SchemaType = "byte"
+	RuneType    SchemaType = "rune"
+	Float32Type SchemaType = "float32"
+	Float64Type SchemaType = "float64"
+	AnyType     SchemaType = "any"
+	ObjectType  SchemaType = "object"
+	SliceType   SchemaType = "slice"
+	MapType     SchemaType = "map"
+)
+
 // ConfigMetadata represents a component's configuration definition of metadata.yaml
 type ConfigMetadata struct {
 	Description      string                     `mapstructure:"description,omitempty" json:"description,omitempty" yaml:"description,omitempty"`
-	Type             string                     `mapstructure:"type,omitempty" json:"type,omitempty" yaml:"type,omitempty"`
+	Type             SchemaType                 `mapstructure:"type,omitempty" json:"type,omitempty" yaml:"type,omitempty"`
 	Ref              string                     `mapstructure:"$ref,omitempty" json:"-" yaml:"$ref,omitempty"`
 	Default          any                        `mapstructure:"default,omitempty" json:"default,omitempty" yaml:"default,omitempty"`
 	Deprecated       bool                       `mapstructure:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
@@ -78,7 +103,7 @@ func (g *GoStructConfig) Unmarshal(parser *confmap.Conf) error {
 
 func (md *ConfigsMetadata) Validate() error {
 	if md.Config != nil {
-		if md.Config.Type != "object" && md.Config.Type != "" {
+		if md.Config.Type != ObjectType && md.Config.Type != "" {
 			return fmt.Errorf("config type must be \"object\", got %q", md.Config.Type)
 		}
 		if err := md.Config.Validate(); err != nil {
@@ -283,12 +308,12 @@ func cloneAny(v any) any {
 func (md *ConfigMetadata) Validate() error {
 	var errs error
 
-	if md.Type == "" || md.Type == "object" {
+	if md.Type == "" || md.Type == ObjectType {
 		if len(md.Properties) == 0 && md.Ref == "" {
 			errs = errors.Join(errs, errors.New("config must specify at least one property"))
 		}
 	}
-	if len(md.Enum) > 0 && (md.Type == "object" || md.Type == "array" || md.Type == "slice" || md.Type == "map") {
+	if len(md.Enum) > 0 && (md.Type == ObjectType || md.Type == "array" || md.Type == SliceType || md.Type == MapType) {
 		errs = errors.Join(errs, fmt.Errorf("enum is not supported for type %q", md.Type))
 	}
 	for name, prop := range md.Properties {

--- a/internal/schemagen/model.go
+++ b/internal/schemagen/model.go
@@ -12,29 +12,28 @@ import (
 
 // ConfigMetadata represents a component's configuration definition of metadata.yaml
 type ConfigMetadata struct {
-	Description          string                     `mapstructure:"description,omitempty" json:"description,omitempty" yaml:"description,omitempty"`
-	Type                 string                     `mapstructure:"type,omitempty" json:"type,omitempty" yaml:"type,omitempty"`
-	Ref                  string                     `mapstructure:"$ref,omitempty" json:"-" yaml:"$ref,omitempty"`
-	Default              any                        `mapstructure:"default,omitempty" json:"default,omitempty" yaml:"default,omitempty"`
-	Deprecated           bool                       `mapstructure:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-	Enum                 []any                      `mapstructure:"enum,omitempty" json:"enum,omitempty" yaml:"enum,omitempty"`
-	Properties           map[string]*ConfigMetadata `mapstructure:"properties,omitempty" json:"properties,omitempty" yaml:"properties,omitempty"`
-	AdditionalProperties *ConfigMetadata            `mapstructure:"additionalProperties,omitempty" json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
-	Required             []string                   `mapstructure:"required,omitempty" json:"required,omitempty" yaml:"required,omitempty"`
-	MinProperties        *int                       `mapstructure:"minProperties,omitempty" json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
-	MaxProperties        *int                       `mapstructure:"maxProperties,omitempty" json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
-	Items                *ConfigMetadata            `mapstructure:"items,omitempty" json:"items,omitempty" yaml:"items,omitempty"`
-	MinItems             *int                       `mapstructure:"minItems,omitempty" json:"minItems,omitempty" yaml:"minItems,omitempty"`
-	MaxItems             *int                       `mapstructure:"maxItems,omitempty" json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
-	UniqueItems          bool                       `mapstructure:"uniqueItems,omitempty" json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
-	MaxLength            *int                       `mapstructure:"maxLength,omitempty" json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-	MinLength            *int                       `mapstructure:"minLength,omitempty" json:"minLength,omitempty" yaml:"minLength,omitempty"`
-	Pattern              string                     `mapstructure:"pattern,omitempty" json:"pattern,omitempty" yaml:"pattern,omitempty"`
-	Format               string                     `mapstructure:"format,omitempty" json:"format,omitempty" yaml:"format,omitempty"`
-	Maximum              *float64                   `mapstructure:"maximum,omitempty" json:"maximum,omitempty" yaml:"maximum,omitempty"`
-	ExclusiveMaximum     *float64                   `mapstructure:"exclusiveMaximum,omitempty" json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
-	Minimum              *float64                   `mapstructure:"minimum,omitempty" json:"minimum,omitempty" yaml:"minimum,omitempty"`
-	ExclusiveMinimum     *float64                   `mapstructure:"exclusiveMinimum,omitempty" json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	Description      string                     `mapstructure:"description,omitempty" json:"description,omitempty" yaml:"description,omitempty"`
+	Type             string                     `mapstructure:"type,omitempty" json:"type,omitempty" yaml:"type,omitempty"`
+	Ref              string                     `mapstructure:"$ref,omitempty" json:"-" yaml:"$ref,omitempty"`
+	Default          any                        `mapstructure:"default,omitempty" json:"default,omitempty" yaml:"default,omitempty"`
+	Deprecated       bool                       `mapstructure:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Enum             []any                      `mapstructure:"enum,omitempty" json:"enum,omitempty" yaml:"enum,omitempty"`
+	Properties       map[string]*ConfigMetadata `mapstructure:"properties,omitempty" json:"properties,omitempty" yaml:"properties,omitempty"`
+	Values           *ConfigMetadata            `mapstructure:"values,omitempty" json:"values,omitempty" yaml:"values,omitempty"`
+	Required         []string                   `mapstructure:"required,omitempty" json:"required,omitempty" yaml:"required,omitempty"`
+	MinProperties    *int                       `mapstructure:"minProperties,omitempty" json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	MaxProperties    *int                       `mapstructure:"maxProperties,omitempty" json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
+	MinItems         *int                       `mapstructure:"minItems,omitempty" json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	MaxItems         *int                       `mapstructure:"maxItems,omitempty" json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	UniqueItems      bool                       `mapstructure:"uniqueItems,omitempty" json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	MaxLength        *int                       `mapstructure:"maxLength,omitempty" json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MinLength        *int                       `mapstructure:"minLength,omitempty" json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	Pattern          string                     `mapstructure:"pattern,omitempty" json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Format           string                     `mapstructure:"format,omitempty" json:"format,omitempty" yaml:"format,omitempty"`
+	Maximum          *float64                   `mapstructure:"maximum,omitempty" json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	ExclusiveMaximum *float64                   `mapstructure:"exclusiveMaximum,omitempty" json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	Minimum          *float64                   `mapstructure:"minimum,omitempty" json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	ExclusiveMinimum *float64                   `mapstructure:"exclusiveMinimum,omitempty" json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
 	// Additional custom fields
 	GoStruct   GoStructConfig `mapstructure:"go_struct,omitempty" json:"-" yaml:"go_struct,omitempty"`
 	GoType     string         `mapstructure:"x-customType,omitempty" json:"-" yaml:"x-customType,omitempty"`
@@ -175,11 +174,8 @@ func (md *ConfigMetadata) MergeFrom(other *ConfigMetadata) {
 		}
 	}
 	// *ConfigMetadata
-	if md.AdditionalProperties == nil {
-		md.AdditionalProperties = other.AdditionalProperties.Clone()
-	}
-	if md.Items == nil {
-		md.Items = other.Items.Clone()
+	if md.Values == nil {
+		md.Values = other.Values.Clone()
 	}
 
 	// *int
@@ -287,14 +283,12 @@ func cloneAny(v any) any {
 func (md *ConfigMetadata) Validate() error {
 	var errs error
 
-	switch md.Type {
-	case "object":
-	case "":
-		if len(md.Properties) == 0 && md.AdditionalProperties == nil && md.Ref == "" {
+	if md.Type == "" || md.Type == "object" {
+		if len(md.Properties) == 0 && md.Ref == "" {
 			errs = errors.Join(errs, errors.New("config must specify at least one property"))
 		}
 	}
-	if len(md.Enum) > 0 && (md.Type == "object" || md.Type == "array") {
+	if len(md.Enum) > 0 && (md.Type == "object" || md.Type == "array" || md.Type == "slice" || md.Type == "map") {
 		errs = errors.Join(errs, fmt.Errorf("enum is not supported for type %q", md.Type))
 	}
 	for name, prop := range md.Properties {
@@ -302,13 +296,8 @@ func (md *ConfigMetadata) Validate() error {
 			errs = errors.Join(errs, fmt.Errorf("property %q is invalid: %w", name, err))
 		}
 	}
-	if md.AdditionalProperties != nil {
-		if err := md.AdditionalProperties.Validate(); err != nil {
-			errs = errors.Join(errs, err)
-		}
-	}
-	if md.Items != nil {
-		if err := md.Items.Validate(); err != nil {
+	if md.Values != nil {
+		if err := md.Values.Validate(); err != nil {
 			errs = errors.Join(errs, err)
 		}
 	}

--- a/internal/schemagen/model_test.go
+++ b/internal/schemagen/model_test.go
@@ -533,14 +533,14 @@ func TestConfigMetadata_Clone(t *testing.T) {
 	clone.Values.Type = "changed"
 
 	assert.Equal(t, "root", orig.Description)
-	assert.Equal(t, "string", orig.Properties["endpoint"].Type)
+	assert.Equal(t, SchemaType("string"), orig.Properties["endpoint"].Type)
 	assert.Equal(t, "endpoint", orig.Required[0])
 	assert.Equal(t, "x", orig.Enum[0])
 	assert.Equal(t, 1, *orig.MinProperties)
 	assert.Equal(t, true, orig.Default.(map[string]any)["flag"])
 	assert.Equal(t, "a", orig.Default.(map[string]any)["nested"].([]any)[0])
 	assert.Equal(t, "validate", orig.GoStruct.CustomValidator.Name)
-	assert.Equal(t, "string", orig.Values.Type)
+	assert.Equal(t, SchemaType("string"), orig.Values.Type)
 }
 
 func TestConfigMetadata_Clone_Nil(t *testing.T) {
@@ -567,8 +567,8 @@ func TestConfigsMetadata_Clone(t *testing.T) {
 
 	clone.Config.Type = "changed"
 	clone.ExportedConfigs["sample"].Type = "changed"
-	assert.Equal(t, "object", orig.Config.Type)
-	assert.Equal(t, "object", orig.ExportedConfigs["sample"].Type)
+	assert.Equal(t, SchemaType("object"), orig.Config.Type)
+	assert.Equal(t, SchemaType("object"), orig.ExportedConfigs["sample"].Type)
 }
 
 func TestConfigsMetadata_Clone_Nil(t *testing.T) {
@@ -580,7 +580,7 @@ func TestConfigMetadata_MergeFrom(t *testing.T) {
 	t.Run("nil other is a no-op", func(t *testing.T) {
 		md := &ConfigMetadata{Type: "string"}
 		md.MergeFrom(nil)
-		assert.Equal(t, "string", md.Type)
+		assert.Equal(t, SchemaType("string"), md.Type)
 	})
 
 	t.Run("existing fields are preserved", func(t *testing.T) {
@@ -607,13 +607,13 @@ func TestConfigMetadata_MergeFrom(t *testing.T) {
 		md.MergeFrom(other)
 
 		assert.Equal(t, "mine", md.Description)
-		assert.Equal(t, "string", md.Type)
+		assert.Equal(t, SchemaType("string"), md.Type)
 		assert.Equal(t, []any{"keep"}, md.Enum)
 		assert.Equal(t, []string{"keep"}, md.Required)
 		// shared property is kept, missing one is merged in
-		assert.Equal(t, "integer", md.Properties["shared"].Type)
+		assert.Equal(t, SchemaType("integer"), md.Properties["shared"].Type)
 		require.Contains(t, md.Properties, "extra")
-		assert.Equal(t, "boolean", md.Properties["extra"].Type)
+		assert.Equal(t, SchemaType("boolean"), md.Properties["extra"].Type)
 	})
 
 	t.Run("missing fields are filled from other", func(t *testing.T) {

--- a/internal/schemagen/model_test.go
+++ b/internal/schemagen/model_test.go
@@ -320,20 +320,21 @@ func TestConfigMetadata_Validate_EnumOnComplexType(t *testing.T) {
 			md: &ConfigMetadata{
 				Type: "object",
 				Properties: map[string]*ConfigMetadata{
-					"nested": {Type: "object", Enum: []any{"a"}},
+					// Ref satisfies the "must have properties" check; Enum triggers the type check.
+					"nested": {Type: "object", Ref: "some_type", Enum: []any{"a"}},
 				},
 			},
 			wantErr: `property "nested" is invalid: enum is not supported for type "object"`,
 		},
 		{
-			name: "enum on array",
+			name: "enum on slice",
 			md: &ConfigMetadata{
 				Type: "object",
 				Properties: map[string]*ConfigMetadata{
-					"items": {Type: "array", Enum: []any{"a"}},
+					"items": {Type: "slice", Enum: []any{"a"}},
 				},
 			},
-			wantErr: `property "items" is invalid: enum is not supported for type "array"`,
+			wantErr: `property "items" is invalid: enum is not supported for type "slice"`,
 		},
 		{
 			name: "enum on string is valid",
@@ -366,33 +367,33 @@ func TestConfigMetadata_Validate_NestedContainers(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "invalid additionalProperties",
+			name: "invalid map value type",
 			md: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "object", Enum: []any{"a"}},
+				Type:   "map",
+				Values: &ConfigMetadata{Type: "object", Enum: []any{"a"}},
 			},
 			wantErr: `enum is not supported for type "object"`,
 		},
 		{
-			name: "valid additionalProperties",
+			name: "valid map value type",
 			md: &ConfigMetadata{
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "string"},
+				Type:   "map",
+				Values: &ConfigMetadata{Type: "string"},
 			},
 		},
 		{
-			name: "invalid items",
+			name: "invalid slice value type",
 			md: &ConfigMetadata{
-				Type:  "array",
-				Items: &ConfigMetadata{Type: "array", Enum: []any{"a"}},
+				Type:   "slice",
+				Values: &ConfigMetadata{Type: "slice", Enum: []any{"a"}},
 			},
-			wantErr: `enum is not supported for type "array"`,
+			wantErr: `enum is not supported for type "slice"`,
 		},
 		{
-			name: "valid items",
+			name: "valid slice value type",
 			md: &ConfigMetadata{
-				Type:  "array",
-				Items: &ConfigMetadata{Type: "string"},
+				Type:   "slice",
+				Values: &ConfigMetadata{Type: "string"},
 			},
 		},
 	}
@@ -462,11 +463,11 @@ func TestConfigsMetadata_Validate(t *testing.T) {
 				"sample": {
 					Type: "object",
 					Properties: map[string]*ConfigMetadata{
-						"nested": {Type: "array", Enum: []any{"a"}},
+						"nested": {Type: "slice", Enum: []any{"a"}},
 					},
 				},
 			}},
-			wantErr: `enum is not supported for type "array"`,
+			wantErr: `enum is not supported for type "slice"`,
 		},
 	}
 
@@ -488,7 +489,7 @@ func TestConfigMetadata_Clone(t *testing.T) {
 	maximum := 10.5
 	orig := &ConfigMetadata{
 		Description:   "root",
-		Type:          "object",
+		Type:          "map",
 		Default:       map[string]any{"nested": []any{"a", "b"}, "flag": true},
 		Enum:          []any{"x", "y"},
 		Required:      []string{"endpoint"},
@@ -506,8 +507,7 @@ func TestConfigMetadata_Clone(t *testing.T) {
 		Properties: map[string]*ConfigMetadata{
 			"endpoint": {Type: "string", Description: "the endpoint"},
 		},
-		AdditionalProperties: &ConfigMetadata{Type: "string"},
-		Items:                &ConfigMetadata{Type: "integer"},
+		Values: &ConfigMetadata{Type: "string"},
 		GoStruct: GoStructConfig{
 			Anonymous:       true,
 			IgnoreDefault:   true,
@@ -530,8 +530,7 @@ func TestConfigMetadata_Clone(t *testing.T) {
 	clone.Default.(map[string]any)["flag"] = false
 	clone.Default.(map[string]any)["nested"].([]any)[0] = "changed"
 	clone.GoStruct.CustomValidator.Name = "other"
-	clone.AdditionalProperties.Type = "changed"
-	clone.Items.Type = "changed"
+	clone.Values.Type = "changed"
 
 	assert.Equal(t, "root", orig.Description)
 	assert.Equal(t, "string", orig.Properties["endpoint"].Type)
@@ -541,8 +540,7 @@ func TestConfigMetadata_Clone(t *testing.T) {
 	assert.Equal(t, true, orig.Default.(map[string]any)["flag"])
 	assert.Equal(t, "a", orig.Default.(map[string]any)["nested"].([]any)[0])
 	assert.Equal(t, "validate", orig.GoStruct.CustomValidator.Name)
-	assert.Equal(t, "string", orig.AdditionalProperties.Type)
-	assert.Equal(t, "integer", orig.Items.Type)
+	assert.Equal(t, "string", orig.Values.Type)
 }
 
 func TestConfigMetadata_Clone_Nil(t *testing.T) {

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -71,14 +71,8 @@ func (r *Resolver) resolveSchema(root *ConfigsMetadata, target *ConfigMetadata, 
 		}
 	}
 
-	if target.AdditionalProperties != nil {
-		if err := r.resolveSchema(root, target.AdditionalProperties, origin); err != nil {
-			return err
-		}
-	}
-
-	if target.Items != nil {
-		if err := r.resolveSchema(root, target.Items, origin); err != nil {
+	if target.Values != nil {
+		if err := r.resolveSchema(root, target.Values, origin); err != nil {
 			return err
 		}
 	}

--- a/internal/schemagen/resolver.go
+++ b/internal/schemagen/resolver.go
@@ -46,7 +46,7 @@ func (r *Resolver) ResolveSchema(src *ConfigsMetadata) (*ConfigsMetadata, error)
 
 func (r *Resolver) resolveSchema(root *ConfigsMetadata, target *ConfigMetadata, origin *Ref) error {
 	if len(target.Properties) > 0 {
-		target.Type = "object"
+		target.Type = ObjectType
 	}
 
 	if target.Ref != "" {

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -128,8 +128,8 @@ func TestResolver_ResolveSchema_ArrayItems(t *testing.T) {
 	}
 
 	src := &ConfigsMetadata{Config: &ConfigMetadata{
-		Type: "array",
-		Items: &ConfigMetadata{
+		Type: "slice",
+		Values: &ConfigMetadata{
 			Type: "object",
 			Properties: map[string]*ConfigMetadata{
 				"name": {Type: "string"},
@@ -139,10 +139,10 @@ func TestResolver_ResolveSchema_ArrayItems(t *testing.T) {
 
 	result, err := resolver.ResolveSchema(src)
 	require.NoError(t, err)
-	require.Equal(t, "array", result.Config.Type)
-	require.NotNil(t, result.Config.Items)
-	require.Equal(t, "object", result.Config.Items.Type)
-	require.NotNil(t, result.Config.Items.Properties["name"])
+	require.Equal(t, "slice", result.Config.Type)
+	require.NotNil(t, result.Config.Values)
+	require.Equal(t, "object", result.Config.Values.Type)
+	require.NotNil(t, result.Config.Values.Properties["name"])
 }
 
 func TestResolver_LoadExternalRef_Success(t *testing.T) {
@@ -656,8 +656,8 @@ func TestResolver_ResolveSchema_PointerFields(t *testing.T) {
 		Type: "object",
 		Properties: map[string]*ConfigMetadata{
 			"tags": {
-				Type:     "array",
-				Items:    &ConfigMetadata{Type: "string"},
+				Type:     "slice",
+				Values:   &ConfigMetadata{Type: "string"},
 				MinItems: &minItems,
 				MaxItems: &maxItems,
 			},
@@ -668,9 +668,9 @@ func TestResolver_ResolveSchema_PointerFields(t *testing.T) {
 	require.NoError(t, err)
 	tags := result.Config.Properties["tags"]
 	require.NotNil(t, tags)
-	require.Equal(t, "array", tags.Type)
-	require.NotNil(t, tags.Items)
-	require.Equal(t, "string", tags.Items.Type)
+	require.Equal(t, "slice", tags.Type)
+	require.NotNil(t, tags.Values)
+	require.Equal(t, "string", tags.Values.Type)
 }
 
 func TestResolver_ResolveSchema_PreservesIntAndFloatPointers(t *testing.T) {
@@ -794,13 +794,13 @@ func TestResolver_ResolveSchema_ExtendedTypes_InProperties(t *testing.T) {
 
 	count := result.Config.Properties["count"]
 	require.NotNil(t, count)
-	assert.Equal(t, "integer", count.Type)
-	assert.Equal(t, "int64", count.GoType)
+	assert.Equal(t, "int64", count.Type)
+	assert.Empty(t, count.GoType)
 
 	ratio := result.Config.Properties["ratio"]
 	require.NotNil(t, ratio)
-	assert.Equal(t, "number", ratio.Type)
-	assert.Equal(t, "float32", ratio.GoType)
+	assert.Equal(t, "float32", ratio.Type)
+	assert.Empty(t, ratio.GoType)
 
 	timeout := result.Config.Properties["timeout"]
 	require.NotNil(t, timeout)
@@ -834,8 +834,8 @@ func TestResolver_ResolveSchema_ExtendedType_InArrayItems(t *testing.T) {
 		Type: "object",
 		Properties: map[string]*ConfigMetadata{
 			"ids": {
-				Type:  "array",
-				Items: &ConfigMetadata{Type: "component_id"},
+				Type:   "slice",
+				Values: &ConfigMetadata{Type: "component_id"},
 			},
 		},
 	}}
@@ -844,10 +844,10 @@ func TestResolver_ResolveSchema_ExtendedType_InArrayItems(t *testing.T) {
 	require.NoError(t, err)
 	ids := result.Config.Properties["ids"]
 	require.NotNil(t, ids)
-	assert.Equal(t, "array", ids.Type)
-	require.NotNil(t, ids.Items)
-	assert.Equal(t, "string", ids.Items.Type)
-	assert.Equal(t, "go.opentelemetry.io/collector/component.ID", ids.Items.GoType)
+	assert.Equal(t, "slice", ids.Type)
+	require.NotNil(t, ids.Values)
+	assert.Equal(t, "string", ids.Values.Type)
+	assert.Equal(t, "go.opentelemetry.io/collector/component.ID", ids.Values.GoType)
 }
 
 func TestResolver_ResolveSchema_ExtendedType_InAdditionalProperties(t *testing.T) {
@@ -859,8 +859,8 @@ func TestResolver_ResolveSchema_ExtendedType_InAdditionalProperties(t *testing.T
 		Type: "object",
 		Properties: map[string]*ConfigMetadata{
 			"secrets": {
-				Type:                 "object",
-				AdditionalProperties: &ConfigMetadata{Type: "opaque_string"},
+				Type:   "map",
+				Values: &ConfigMetadata{Type: "opaque_string"},
 			},
 		},
 	}}
@@ -869,9 +869,9 @@ func TestResolver_ResolveSchema_ExtendedType_InAdditionalProperties(t *testing.T
 	require.NoError(t, err)
 	secrets := result.Config.Properties["secrets"]
 	require.NotNil(t, secrets)
-	require.NotNil(t, secrets.AdditionalProperties)
-	assert.Equal(t, "string", secrets.AdditionalProperties.Type)
-	assert.Equal(t, "go.opentelemetry.io/collector/config/configopaque.String", secrets.AdditionalProperties.GoType)
+	require.NotNil(t, secrets.Values)
+	assert.Equal(t, "string", secrets.Values.Type)
+	assert.Equal(t, "go.opentelemetry.io/collector/config/configopaque.String", secrets.Values.GoType)
 }
 
 func TestResolver_ResolveSchema_ExtendedType_InDefs_ViaRef(t *testing.T) {
@@ -895,8 +895,8 @@ func TestResolver_ResolveSchema_ExtendedType_InDefs_ViaRef(t *testing.T) {
 	require.NoError(t, err)
 	count := result.Config.Properties["count"]
 	require.NotNil(t, count)
-	assert.Equal(t, "integer", count.Type)
-	assert.Equal(t, "int64", count.GoType)
+	assert.Equal(t, "int64", count.Type)
+	assert.Empty(t, count.GoType)
 }
 
 func TestResolver_ResolveSchema_ExtendedType_OpaqueMap(t *testing.T) {
@@ -915,13 +915,14 @@ func TestResolver_ResolveSchema_ExtendedType_OpaqueMap(t *testing.T) {
 	require.NoError(t, err)
 	headers := result.Config.Properties["headers"]
 	require.NotNil(t, headers)
-	assert.Equal(t, "object", headers.Type)
+	assert.Equal(t, "map", headers.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/config/configopaque.MapList", headers.GoType)
-	require.NotNil(t, headers.AdditionalProperties)
-	assert.Equal(t, "string", headers.AdditionalProperties.Type)
+	require.NotNil(t, headers.Values)
+	assert.Equal(t, "string", headers.Values.Type)
 }
 
-func TestResolver_ResolveSchema_ExtendedType_UnknownAlias_Error(t *testing.T) {
+func TestResolver_ResolveSchema_ExtendedType_UnknownAlias_PassThrough(t *testing.T) {
+	// expandType is a no-op for unknown types; the generator handles them in resolveGoType.
 	resolver := &Resolver{
 		loader: NewLoader(""),
 	}
@@ -929,11 +930,11 @@ func TestResolver_ResolveSchema_ExtendedType_UnknownAlias_Error(t *testing.T) {
 	src := &ConfigsMetadata{Config: &ConfigMetadata{
 		Type: "object",
 		Properties: map[string]*ConfigMetadata{
-			"bad": {Type: "not_a_type"},
+			"custom": {Type: "not_a_known_alias"},
 		},
 	}}
 
-	_, err := resolver.ResolveSchema(src)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not_a_type")
+	result, err := resolver.ResolveSchema(src)
+	require.NoError(t, err)
+	assert.Equal(t, "not_a_known_alias", result.Config.Properties["custom"].Type)
 }

--- a/internal/schemagen/resolver_test.go
+++ b/internal/schemagen/resolver_test.go
@@ -42,7 +42,7 @@ func TestResolver_ResolveSchema_BasicMetadata(t *testing.T) {
 	result, err := resolver.ResolveSchema(src)
 	require.NoError(t, err)
 	require.Equal(t, "OTLP receiver configuration", result.Config.Description)
-	require.Equal(t, "object", result.Config.Type)
+	require.Equal(t, SchemaType("object"), result.Config.Type)
 }
 
 func TestResolver_ResolveSchema_InternalReference(t *testing.T) {
@@ -69,9 +69,9 @@ func TestResolver_ResolveSchema_InternalReference(t *testing.T) {
 
 	result, err := resolver.ResolveSchema(src)
 	require.NoError(t, err)
-	require.Equal(t, "object", result.Config.Type)
+	require.Equal(t, SchemaType("object"), result.Config.Type)
 	require.NotNil(t, result.Config.Properties["config"])
-	require.Equal(t, "string", result.Config.Properties["config"].Type)
+	require.Equal(t, SchemaType("string"), result.Config.Properties["config"].Type)
 	require.Equal(t, "Target type description", result.Config.Properties["config"].Description)
 }
 
@@ -117,9 +117,9 @@ func TestResolver_ResolveSchema_NestedStructures(t *testing.T) {
 	require.NoError(t, err)
 	nested := result.Config.Properties["nested"]
 	require.NotNil(t, nested)
-	require.Equal(t, "object", nested.Type)
-	require.Equal(t, "string", nested.Properties["field1"].Type)
-	require.Equal(t, "integer", nested.Properties["field2"].Type)
+	require.Equal(t, SchemaType("object"), nested.Type)
+	require.Equal(t, SchemaType("string"), nested.Properties["field1"].Type)
+	require.Equal(t, SchemaType("integer"), nested.Properties["field2"].Type)
 }
 
 func TestResolver_ResolveSchema_ArrayItems(t *testing.T) {
@@ -139,9 +139,9 @@ func TestResolver_ResolveSchema_ArrayItems(t *testing.T) {
 
 	result, err := resolver.ResolveSchema(src)
 	require.NoError(t, err)
-	require.Equal(t, "slice", result.Config.Type)
+	require.Equal(t, SchemaType("slice"), result.Config.Type)
 	require.NotNil(t, result.Config.Values)
-	require.Equal(t, "object", result.Config.Values.Type)
+	require.Equal(t, SchemaType("object"), result.Config.Values.Type)
 	require.NotNil(t, result.Config.Values.Properties["name"])
 }
 
@@ -168,9 +168,9 @@ func TestResolver_LoadExternalRef_Success(t *testing.T) {
 	ref := NewRef("go.opentelemetry.io/collector/scraper/scraperhelper.controller_config")
 	result, err := resolver.loadExternalRef(ref)
 	require.NoError(t, err)
-	require.Equal(t, "object", result.Type)
+	require.Equal(t, SchemaType("object"), result.Type)
 	require.NotNil(t, result.Properties["timeout"])
-	require.Equal(t, "string", result.Properties["timeout"].Type)
+	require.Equal(t, SchemaType("string"), result.Properties["timeout"].Type)
 }
 
 func TestResolver_LoadExternalRef_InvalidPath(t *testing.T) {
@@ -335,7 +335,7 @@ func TestResolver_ResolveSchema_ExternalReference_Integration(t *testing.T) {
 	require.NoError(t, err)
 	http := result.Config.Properties["http"]
 	require.NotNil(t, http)
-	require.Equal(t, "object", http.Type)
+	require.Equal(t, SchemaType("object"), http.Type)
 	require.Equal(t, "HTTP endpoint", http.Properties["endpoint"].Description)
 	require.Equal(t, "Request timeout", http.Properties["timeout"].Description)
 }
@@ -362,14 +362,14 @@ func TestResolver_ResolveSchema_DurationFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	timeout := result.Config.Properties["timeout"]
-	require.Equal(t, "string", timeout.Type)
+	require.Equal(t, SchemaType("string"), timeout.Type)
 	require.Empty(t, timeout.Format, "format should be cleared")
 	require.Equal(t, "time.Duration", timeout.GoType)
 	require.Equal(t, `^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$`, timeout.Pattern)
 	require.Equal(t, "Request timeout", timeout.Description)
 
 	interval := result.Config.Properties["interval"]
-	require.Equal(t, "string", interval.Type)
+	require.Equal(t, SchemaType("string"), interval.Type)
 	require.Empty(t, interval.Format)
 	require.Equal(t, "time.Duration", interval.GoType)
 	require.Equal(t, `^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$`, interval.Pattern)
@@ -426,11 +426,11 @@ func TestResolver_ResolveSchema_OriginConvertsLocalRefToExternal(t *testing.T) {
 	require.NoError(t, err)
 	http := result.Config.Properties["http"]
 	require.NotNil(t, http)
-	require.Equal(t, "object", http.Type)
-	require.Equal(t, "string", http.Properties["endpoint"].Type)
+	require.Equal(t, SchemaType("object"), http.Type)
+	require.Equal(t, SchemaType("string"), http.Properties["endpoint"].Type)
 	auth := http.Properties["auth"]
 	require.NotNil(t, auth)
-	require.Equal(t, "object", auth.Type)
+	require.Equal(t, SchemaType("object"), auth.Type)
 	require.Equal(t, "Auth configuration", auth.Description)
 	require.NotNil(t, auth.Properties["token"])
 }
@@ -497,10 +497,10 @@ func TestResolver_ResolveSchema_NestedOriginPropagation(t *testing.T) {
 	require.NoError(t, err)
 	auth := result.Config.Properties["http"].Properties["auth"]
 	require.NotNil(t, auth)
-	require.Equal(t, "object", auth.Type)
+	require.Equal(t, SchemaType("object"), auth.Type)
 	tls := auth.Properties["tls"]
 	require.NotNil(t, tls)
-	require.Equal(t, "object", tls.Type)
+	require.Equal(t, SchemaType("object"), tls.Type)
 	require.Equal(t, "TLS configuration", tls.Description)
 }
 
@@ -551,7 +551,7 @@ func TestResolver_ResolveSchema_RelativeRefWithOrigin(t *testing.T) {
 	require.NoError(t, err)
 	metrics := result.Config.Properties["http"].Properties["metrics"]
 	require.NotNil(t, metrics)
-	require.Equal(t, "object", metrics.Type)
+	require.Equal(t, SchemaType("object"), metrics.Type)
 	require.Equal(t, "Metrics configuration", metrics.Description)
 }
 
@@ -602,7 +602,7 @@ func TestResolver_ResolveSchema_ParentRelativeRefWithOrigin(t *testing.T) {
 	require.NoError(t, err)
 	tls := result.Config.Properties["http"].Properties["tls"]
 	require.NotNil(t, tls)
-	require.Equal(t, "object", tls.Type)
+	require.Equal(t, SchemaType("object"), tls.Type)
 	require.Equal(t, "TLS settings", tls.Description)
 }
 
@@ -668,9 +668,9 @@ func TestResolver_ResolveSchema_PointerFields(t *testing.T) {
 	require.NoError(t, err)
 	tags := result.Config.Properties["tags"]
 	require.NotNil(t, tags)
-	require.Equal(t, "slice", tags.Type)
+	require.Equal(t, SchemaType("slice"), tags.Type)
 	require.NotNil(t, tags.Values)
-	require.Equal(t, "string", tags.Values.Type)
+	require.Equal(t, SchemaType("string"), tags.Values.Type)
 }
 
 func TestResolver_ResolveSchema_PreservesIntAndFloatPointers(t *testing.T) {
@@ -794,34 +794,34 @@ func TestResolver_ResolveSchema_ExtendedTypes_InProperties(t *testing.T) {
 
 	count := result.Config.Properties["count"]
 	require.NotNil(t, count)
-	assert.Equal(t, "int64", count.Type)
+	assert.Equal(t, SchemaType("int64"), count.Type)
 	assert.Empty(t, count.GoType)
 
 	ratio := result.Config.Properties["ratio"]
 	require.NotNil(t, ratio)
-	assert.Equal(t, "float32", ratio.Type)
+	assert.Equal(t, SchemaType("float32"), ratio.Type)
 	assert.Empty(t, ratio.GoType)
 
 	timeout := result.Config.Properties["timeout"]
 	require.NotNil(t, timeout)
-	assert.Equal(t, "string", timeout.Type)
+	assert.Equal(t, SchemaType("string"), timeout.Type)
 	assert.Equal(t, "time.Duration", timeout.GoType)
 	assert.Equal(t, goDurationPattern, timeout.Pattern)
 	assert.Empty(t, timeout.Format)
 
 	ts := result.Config.Properties["ts"]
 	require.NotNil(t, ts)
-	assert.Equal(t, "string", ts.Type)
+	assert.Equal(t, SchemaType("string"), ts.Type)
 	assert.Equal(t, "time.Time", ts.GoType)
 
 	token := result.Config.Properties["token"]
 	require.NotNil(t, token)
-	assert.Equal(t, "string", token.Type)
+	assert.Equal(t, SchemaType("string"), token.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/config/configopaque.String", token.GoType)
 
 	comp := result.Config.Properties["component"]
 	require.NotNil(t, comp)
-	assert.Equal(t, "string", comp.Type)
+	assert.Equal(t, SchemaType("string"), comp.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/component.ID", comp.GoType)
 }
 
@@ -844,9 +844,9 @@ func TestResolver_ResolveSchema_ExtendedType_InArrayItems(t *testing.T) {
 	require.NoError(t, err)
 	ids := result.Config.Properties["ids"]
 	require.NotNil(t, ids)
-	assert.Equal(t, "slice", ids.Type)
+	assert.Equal(t, SchemaType("slice"), ids.Type)
 	require.NotNil(t, ids.Values)
-	assert.Equal(t, "string", ids.Values.Type)
+	assert.Equal(t, SchemaType("string"), ids.Values.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/component.ID", ids.Values.GoType)
 }
 
@@ -870,7 +870,7 @@ func TestResolver_ResolveSchema_ExtendedType_InAdditionalProperties(t *testing.T
 	secrets := result.Config.Properties["secrets"]
 	require.NotNil(t, secrets)
 	require.NotNil(t, secrets.Values)
-	assert.Equal(t, "string", secrets.Values.Type)
+	assert.Equal(t, SchemaType("string"), secrets.Values.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/config/configopaque.String", secrets.Values.GoType)
 }
 
@@ -895,7 +895,7 @@ func TestResolver_ResolveSchema_ExtendedType_InDefs_ViaRef(t *testing.T) {
 	require.NoError(t, err)
 	count := result.Config.Properties["count"]
 	require.NotNil(t, count)
-	assert.Equal(t, "int64", count.Type)
+	assert.Equal(t, SchemaType("int64"), count.Type)
 	assert.Empty(t, count.GoType)
 }
 
@@ -915,10 +915,10 @@ func TestResolver_ResolveSchema_ExtendedType_OpaqueMap(t *testing.T) {
 	require.NoError(t, err)
 	headers := result.Config.Properties["headers"]
 	require.NotNil(t, headers)
-	assert.Equal(t, "map", headers.Type)
+	assert.Equal(t, SchemaType("map"), headers.Type)
 	assert.Equal(t, "go.opentelemetry.io/collector/config/configopaque.MapList", headers.GoType)
 	require.NotNil(t, headers.Values)
-	assert.Equal(t, "string", headers.Values.Type)
+	assert.Equal(t, SchemaType("string"), headers.Values.Type)
 }
 
 func TestResolver_ResolveSchema_ExtendedType_UnknownAlias_PassThrough(t *testing.T) {
@@ -936,5 +936,5 @@ func TestResolver_ResolveSchema_ExtendedType_UnknownAlias_PassThrough(t *testing
 
 	result, err := resolver.ResolveSchema(src)
 	require.NoError(t, err)
-	assert.Equal(t, "not_a_known_alias", result.Config.Properties["custom"].Type)
+	assert.Equal(t, SchemaType("not_a_known_alias"), result.Config.Properties["custom"].Type)
 }

--- a/internal/schemagen/schema.go
+++ b/internal/schemagen/schema.go
@@ -16,6 +16,29 @@ const schemaVersion = "https://json-schema.org/draft/2020-12/schema"
 // JSONSchema models a JSON Schema Draft 2020-12 schema.
 type JSONSchema = jsonschema.Schema
 
+var typesMapping = map[string]string{
+	"object":  "object",
+	"map":     "object",
+	"slice":   "array",
+	"string":  "string",
+	"bool":    "boolean",
+	"byte":    "integer",
+	"rune":    "integer",
+	"uint":    "integer",
+	"int":     "integer",
+	"int8":    "integer",
+	"uint8":   "integer",
+	"int16":   "integer",
+	"uint16":  "integer",
+	"int32":   "integer",
+	"uint32":  "integer",
+	"int64":   "integer",
+	"uint64":  "integer",
+	"float32": "number",
+	"float64": "number",
+	"any":     "",
+}
+
 func FromMetadata(id, title string, md *ConfigsMetadata) *JSONSchema {
 	jsonSchema := &JSONSchema{
 		Schema: schemaVersion,
@@ -61,7 +84,7 @@ func convertMetadataToJSONSchema(md *ConfigMetadata, jsonSchema *JSONSchema) *JS
 	}
 
 	if md.Type != "" {
-		jsonSchema.Type = md.Type
+		jsonSchema.Type = typesMapping[md.Type]
 	}
 	jsonSchema.Description = md.Description
 	if md.Default != nil {
@@ -108,11 +131,13 @@ func convertMetadataToJSONSchema(md *ConfigMetadata, jsonSchema *JSONSchema) *JS
 		jsonSchema.ExclusiveMaximum = md.ExclusiveMaximum
 	}
 
-	if md.Items != nil {
-		jsonSchema.Items = convertMetadataToJSONSchema(md.Items, &JSONSchema{})
-	}
-	if md.AdditionalProperties != nil {
-		jsonSchema.AdditionalProperties = convertMetadataToJSONSchema(md.AdditionalProperties, &JSONSchema{})
+	if md.Values != nil {
+		if md.Type == "slice" {
+			jsonSchema.Items = convertMetadataToJSONSchema(md.Values, &JSONSchema{})
+		}
+		if md.Type == "map" {
+			jsonSchema.AdditionalProperties = convertMetadataToJSONSchema(md.Values, &JSONSchema{})
+		}
 	}
 
 	return jsonSchema

--- a/internal/schemagen/schema.go
+++ b/internal/schemagen/schema.go
@@ -16,27 +16,27 @@ const schemaVersion = "https://json-schema.org/draft/2020-12/schema"
 // JSONSchema models a JSON Schema Draft 2020-12 schema.
 type JSONSchema = jsonschema.Schema
 
-var typesMapping = map[string]string{
-	"object":  "object",
-	"map":     "object",
-	"slice":   "array",
-	"string":  "string",
-	"bool":    "boolean",
-	"byte":    "integer",
-	"rune":    "integer",
-	"uint":    "integer",
-	"int":     "integer",
-	"int8":    "integer",
-	"uint8":   "integer",
-	"int16":   "integer",
-	"uint16":  "integer",
-	"int32":   "integer",
-	"uint32":  "integer",
-	"int64":   "integer",
-	"uint64":  "integer",
-	"float32": "number",
-	"float64": "number",
-	"any":     "",
+var typesMapping = map[SchemaType]string{
+	ObjectType:  "object",
+	MapType:     "object",
+	SliceType:   "array",
+	StringType:  "string",
+	BoolType:    "boolean",
+	ByteType:    "integer",
+	RuneType:    "integer",
+	UintType:    "integer",
+	IntType:     "integer",
+	Int8Type:    "integer",
+	Uint8Type:   "integer",
+	Int16Type:   "integer",
+	Uint16Type:  "integer",
+	Int32Type:   "integer",
+	Uint32Type:  "integer",
+	Int64Type:   "integer",
+	Uint64Type:  "integer",
+	Float32Type: "number",
+	Float64Type: "number",
+	AnyType:     "",
 }
 
 func FromMetadata(id, title string, md *ConfigsMetadata) *JSONSchema {
@@ -132,10 +132,10 @@ func convertMetadataToJSONSchema(md *ConfigMetadata, jsonSchema *JSONSchema) *JS
 	}
 
 	if md.Values != nil {
-		if md.Type == "slice" {
+		if md.Type == SliceType {
 			jsonSchema.Items = convertMetadataToJSONSchema(md.Values, &JSONSchema{})
 		}
-		if md.Type == "map" {
+		if md.Type == MapType {
 			jsonSchema.AdditionalProperties = convertMetadataToJSONSchema(md.Values, &JSONSchema{})
 		}
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Replace JSON Schema vocabulary with Go-centric types in mdatagen config schema: `int/bool/slice/map` instead of `integer/boolean/array/object`, and merge `items/additionalProperties` into a single `values` field.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests and sample component aligned.

<!--Describe the documentation added.-->
#### Documentation

1. Added list of supported types to README.md file
2. Metadata.yaml schema aligned

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
