### PR TITLE
[pdata/pprofile] MergeTo: reserve index 0 of empty destination dictionary tables

### DIFF
--- a/.chloggen/fix-pprofile-mergeto-dictionary-zero-value.yaml
+++ b/.chloggen/fix-pprofile-mergeto-dictionary-zero-value.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/pprofile
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`Profiles.MergeTo` no longer overwrites index 0 of an empty destination dictionary table with real data"
+
+# One or more tracking issues or pull requests related to the change
+issues: [15661]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `MergeTo` did not reserve index 0 of the destination dictionary's tables for their zero value before
+  remapping entries into them. When the destination dictionary was empty, the first entry merged in would
+  land at index 0, the slot every unset reference (e.g. an unset Strindex) resolves to, producing a
+  dictionary that violates the `ProfilesDictionary` protocol. `MergeTo` now seeds index 0 of any table that
+  is still empty with that table's zero value before remapping.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.github/workflows/utils/cspell.json
+++ b/.github/workflows/utils/cspell.json
@@ -76,6 +76,7 @@
       "Sharma",
       "Statefulness",
       "Stencel",
+      "Strindex",
       "Strindices",
       "Tailsampling",
       "Tigran",

--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -19,8 +19,7 @@ func mapKeyValues(m pcommon.Map) []internal.KeyValue {
 // ProfilesDictionary contract, index 0 of every table MUST hold the zero
 // value for that table's element type, since unset references (e.g. an
 // unset Strindex) resolve to it. Tables that already hold entries are left
-// untouched, since inserting at index 0 would invalidate every existing
-// reference into them.
+// untouched.
 func ensureDictionarySentinels(dst ProfilesDictionary) {
 	if dst.StringTable().Len() == 0 {
 		dst.StringTable().Append("")

--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -14,6 +14,37 @@ func mapKeyValues(m pcommon.Map) []internal.KeyValue {
 	return *internal.GetMapOrig(internal.MapWrapper(m))
 }
 
+// ensureDictionarySentinels seeds index 0 of each of dst's tables with that
+// table's zero value, but only for tables that are still empty. Per the
+// ProfilesDictionary contract, index 0 of every table MUST hold the zero
+// value for that table's element type, since unset references (e.g. an
+// unset Strindex) resolve to it. Tables that already hold entries are left
+// untouched, since inserting at index 0 would invalidate every existing
+// reference into them.
+func ensureDictionarySentinels(dst ProfilesDictionary) {
+	if dst.StringTable().Len() == 0 {
+		dst.StringTable().Append("")
+	}
+	if dst.AttributeTable().Len() == 0 {
+		dst.AttributeTable().AppendEmpty()
+	}
+	if dst.FunctionTable().Len() == 0 {
+		dst.FunctionTable().AppendEmpty()
+	}
+	if dst.LinkTable().Len() == 0 {
+		dst.LinkTable().AppendEmpty()
+	}
+	if dst.LocationTable().Len() == 0 {
+		dst.LocationTable().AppendEmpty()
+	}
+	if dst.MappingTable().Len() == 0 {
+		dst.MappingTable().AppendEmpty()
+	}
+	if dst.StackTable().Len() == 0 {
+		dst.StackTable().AppendEmpty()
+	}
+}
+
 // resolveProfilesReferences walks through all profiles data after unmarshaling
 // and resolves any string_value_ref and key_ref to their actual string values.
 // This ensures the pdata API works transparently with referenced strings.

--- a/pdata/pprofile/profiles_merge.go
+++ b/pdata/pprofile/profiles_merge.go
@@ -13,6 +13,8 @@ func (ms Profiles) MergeTo(dest Profiles) error {
 		return nil
 	}
 
+	reserveDictionaryZeroValues(dest.Dictionary())
+
 	if err := ms.switchDictionary(ms.Dictionary(), dest.Dictionary()); err != nil {
 		return err
 	}
@@ -21,4 +23,35 @@ func (ms Profiles) MergeTo(dest Profiles) error {
 	ms.MarkReadOnly()
 
 	return nil
+}
+
+// reserveDictionaryZeroValues seeds index 0 of each of dst's tables with that
+// table's zero value, but only for tables that are still empty. Per the
+// ProfilesDictionary contract, index 0 of every table MUST hold the zero
+// value for that table's element type, since unset references (e.g. an
+// unset Strindex) resolve to it. Tables that already hold entries are left
+// untouched, since inserting at index 0 would invalidate every existing
+// reference into them.
+func reserveDictionaryZeroValues(dst ProfilesDictionary) {
+	if dst.StringTable().Len() == 0 {
+		dst.StringTable().Append("")
+	}
+	if dst.AttributeTable().Len() == 0 {
+		dst.AttributeTable().AppendEmpty()
+	}
+	if dst.FunctionTable().Len() == 0 {
+		dst.FunctionTable().AppendEmpty()
+	}
+	if dst.LinkTable().Len() == 0 {
+		dst.LinkTable().AppendEmpty()
+	}
+	if dst.LocationTable().Len() == 0 {
+		dst.LocationTable().AppendEmpty()
+	}
+	if dst.MappingTable().Len() == 0 {
+		dst.MappingTable().AppendEmpty()
+	}
+	if dst.StackTable().Len() == 0 {
+		dst.StackTable().AppendEmpty()
+	}
 }

--- a/pdata/pprofile/profiles_merge.go
+++ b/pdata/pprofile/profiles_merge.go
@@ -13,7 +13,7 @@ func (ms Profiles) MergeTo(dest Profiles) error {
 		return nil
 	}
 
-	reserveDictionaryZeroValues(dest.Dictionary())
+	ensureDictionarySentinels(dest.Dictionary())
 
 	if err := ms.switchDictionary(ms.Dictionary(), dest.Dictionary()); err != nil {
 		return err
@@ -23,35 +23,4 @@ func (ms Profiles) MergeTo(dest Profiles) error {
 	ms.MarkReadOnly()
 
 	return nil
-}
-
-// reserveDictionaryZeroValues seeds index 0 of each of dst's tables with that
-// table's zero value, but only for tables that are still empty. Per the
-// ProfilesDictionary contract, index 0 of every table MUST hold the zero
-// value for that table's element type, since unset references (e.g. an
-// unset Strindex) resolve to it. Tables that already hold entries are left
-// untouched, since inserting at index 0 would invalidate every existing
-// reference into them.
-func reserveDictionaryZeroValues(dst ProfilesDictionary) {
-	if dst.StringTable().Len() == 0 {
-		dst.StringTable().Append("")
-	}
-	if dst.AttributeTable().Len() == 0 {
-		dst.AttributeTable().AppendEmpty()
-	}
-	if dst.FunctionTable().Len() == 0 {
-		dst.FunctionTable().AppendEmpty()
-	}
-	if dst.LinkTable().Len() == 0 {
-		dst.LinkTable().AppendEmpty()
-	}
-	if dst.LocationTable().Len() == 0 {
-		dst.LocationTable().AppendEmpty()
-	}
-	if dst.MappingTable().Len() == 0 {
-		dst.MappingTable().AppendEmpty()
-	}
-	if dst.StackTable().Len() == 0 {
-		dst.StackTable().AppendEmpty()
-	}
 }

--- a/pdata/pprofile/profiles_merge_test.go
+++ b/pdata/pprofile/profiles_merge_test.go
@@ -608,7 +608,7 @@ func TestProfilesMergeTo_ReservesDictionaryZeroValues(t *testing.T) {
 	dest := NewProfiles()
 	require.NoError(t, src.MergeTo(dest))
 
-	assert.Equal(t, "", dest.Dictionary().StringTable().At(0))
+	assert.Empty(t, dest.Dictionary().StringTable().At(0))
 	assert.Equal(t, "inuse_space", dest.Dictionary().StringTable().At(1))
 
 	require.Equal(t, 1, dest.Dictionary().AttributeTable().Len())

--- a/pdata/pprofile/profiles_merge_test.go
+++ b/pdata/pprofile/profiles_merge_test.go
@@ -585,6 +585,59 @@ func TestProfilesMergeTo(t *testing.T) {
 	}
 }
 
+// TestProfilesMergeTo_ReservesDictionaryZeroValues verifies that MergeTo
+// reserves index 0 of every destination table for that table's zero value,
+// even when the destination dictionary starts out completely empty (not
+// pre-populated by the caller). See
+// https://github.com/open-telemetry/opentelemetry-collector/issues/15661.
+func TestProfilesMergeTo_ReservesDictionaryZeroValues(t *testing.T) {
+	src := NewProfiles()
+	dic := src.Dictionary()
+	dic.StringTable().Append("") // conformant source
+	dic.AttributeTable().AppendEmpty()
+	dic.StackTable().AppendEmpty()
+	dic.LocationTable().AppendEmpty()
+	dic.FunctionTable().AppendEmpty()
+	dic.MappingTable().AppendEmpty()
+	dic.LinkTable().AppendEmpty()
+	dic.StringTable().Append("inuse_space") // index 1
+
+	prof := src.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+	prof.SampleType().SetTypeStrindex(1)
+
+	dest := NewProfiles()
+	require.NoError(t, src.MergeTo(dest))
+
+	assert.Equal(t, "", dest.Dictionary().StringTable().At(0))
+	assert.Equal(t, "inuse_space", dest.Dictionary().StringTable().At(1))
+
+	require.Equal(t, 1, dest.Dictionary().AttributeTable().Len())
+	attr := dest.Dictionary().AttributeTable().At(0)
+	assert.Zero(t, attr.KeyStrindex())
+	assert.Zero(t, attr.UnitStrindex())
+	assert.Equal(t, pcommon.ValueTypeEmpty, attr.Value().Type())
+
+	require.Equal(t, 1, dest.Dictionary().StackTable().Len())
+	assert.Zero(t, dest.Dictionary().StackTable().At(0).LocationIndices().Len())
+
+	require.Equal(t, 1, dest.Dictionary().LocationTable().Len())
+	loc := dest.Dictionary().LocationTable().At(0)
+	assert.Zero(t, loc.MappingIndex())
+	assert.Zero(t, loc.Address())
+	assert.Zero(t, loc.Lines().Len())
+
+	require.Equal(t, 1, dest.Dictionary().FunctionTable().Len())
+	fn := dest.Dictionary().FunctionTable().At(0)
+	assert.Zero(t, fn.NameStrindex())
+	assert.Zero(t, fn.SystemNameStrindex())
+	assert.Zero(t, fn.FilenameStrindex())
+
+	require.Equal(t, 1, dest.Dictionary().MappingTable().Len())
+	assert.Zero(t, dest.Dictionary().MappingTable().At(0).FilenameStrindex())
+
+	require.Equal(t, 1, dest.Dictionary().LinkTable().Len())
+}
+
 func TestProfilesMergeToSelf(t *testing.T) {
 	profiles := NewProfiles()
 	profiles.Dictionary().StringTable().Append("", "test")


### PR DESCRIPTION
#### Description

Profiles.MergeTo remaps entries from the source dictionary into the
destination dictionary but never reserves index 0 of each destination
table for that table's zero value. profiles.proto requires that "the
element at index 0 MUST be the zero value for the dictionary's element
type" (e.g. "" for string_table), since every unset reference (e.g. an
unset Strindex) resolves to it. When the destination dictionary starts
out empty, the first entry switched over lands at index 0 instead of
the zero value, producing a non-conformant dictionary in which unset
references silently resolve to real data. This is a data-correctness
bug, not a crash: MergeTo itself does not panic or error. Concretely,
if the first string merged into an empty destination is some real
value (e.g. a semconv attribute key), any function/location that had
an unset filename/name (Strindex == 0) will report that unrelated
string as its filename/name after the merge, as described in the
issue's pprofreceiver-based repro. Destinations that are already
pre-populated with conformant zero values before calling MergeTo (the
existing convention used throughout this package's own tests) are
unaffected, since the fix only seeds tables that are still empty.

The fix adds ensureDictionarySentinels (pdata/pprofile/dictionary_helpers.go),
called at the top of MergeTo (after the self-merge no-op check, before
switchDictionary runs). It seeds index 0 of each of the destination
dictionary's 7 tables (string, attribute, function, link, location,
mapping, stack) with that table's zero value, but only for tables that
are still empty. A table that already holds entries is left untouched,
since inserting at index 0 would shift every existing index and
invalidate references already pointing into it. This matches the fix
suggested in the issue.

#### Link to tracking issue

Fixes #15661

#### Testing

Added TestProfilesMergeTo_ReservesDictionaryZeroValues, adapted from
the issue's reproduction: it merges a conformant source (whose index 0
in every table is already the zero value, plus one real string at
index 1) into a freshly empty destination, and asserts every
destination table's index-0 entry is the zero value while index 1
still holds the real value. Confirmed the test fails (wrong value,
then an index-out-of-range panic) when profiles_merge.go's fix is
reverted, and passes with it applied.

Ran `cd pdata/pprofile && go build ./... && go vet ./... && go test ./...`;
all packages pass, including the existing MergeTo test suite in
profiles_merge_test.go, which already covers destinations that are
pre-populated with zero values by the caller and confirms no
regression there.

#### Documentation

Added a `.chloggen` entry (`fix-pprofile-mergeto-dictionary-zero-value.yaml`)
describing the bug fix for release notes.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

---
AI assistance: this change was drafted with Claude Code.
