### PR TITLE
feat(confignet): add Unix domain socket lifecycle management

### DIFF
--- a/.chloggen/confignet-unix-socket-lifecycle.yaml
+++ b/.chloggen/confignet-unix-socket-lifecycle.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/config/confignet
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Automatically manage Unix domain socket lifecycle in AddrConfig.Listen()
+
+# One or more tracking issues or pull requests related to the change
+issues: [15189]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  For filesystem-based Unix domain sockets, Listen() now automatically:
+  - Removes stale socket files before binding (refuses to remove non-socket files)
+  - Sets socket permissions to 0722 so any local process can connect
+  - Cleans up socket files on Close()
+  Abstract sockets (@ prefix) are unaffected. No configuration is needed.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/confignet-unix-socket-lifecycle.yaml
+++ b/.chloggen/confignet-unix-socket-lifecycle.yaml
@@ -18,9 +18,11 @@ issues: [15189]
 subtext: |
   For filesystem-based Unix domain sockets, Listen() now automatically:
   - Removes stale socket files before binding (refuses to remove non-socket files)
-  - Sets socket permissions to 0722 so any local process can connect
+  - Sets socket permissions to 0722 by default so any local process can connect,
+    configurable via the new `socket_permissions` field on AddrConfig
   - Cleans up socket files on Close()
-  Abstract sockets (@ prefix) are unaffected. No configuration is needed.
+  Abstract sockets (@ prefix) are unaffected. No configuration is needed beyond the
+  optional `socket_permissions` override.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/.chloggen/confignet-unix-socket-lifecycle.yaml
+++ b/.chloggen/confignet-unix-socket-lifecycle.yaml
@@ -22,7 +22,9 @@ subtext: |
     configurable via the new `socket_permissions` field on AddrConfig
   - Cleans up socket files on Close()
   Abstract sockets (@ prefix) are unaffected. No configuration is needed beyond the
-  optional `socket_permissions` override.
+  optional `socket_permissions` override. The new `socket_management_disabled` field
+  fully opts out of this lifecycle management, for sockets whose file is managed
+  externally.
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/config/confignet/README.md
+++ b/config/confignet/README.md
@@ -22,6 +22,13 @@ leverage network configuration to set connection and transport information.
   starting with `@`) and all other transports. Defaults to `0722`, which
   allows any local process to connect to the socket while only the owner
   can otherwise manage it.
+- `socket_management_disabled`: Disables all automatic lifecycle management
+  of a filesystem-based Unix domain socket file: no stale-socket removal
+  before binding, no permission changes after binding (`socket_permissions`
+  is ignored), and no cleanup on close. Only applies to the `unix`,
+  `unixgram` and `unixpacket` transports. Use this if the socket file's
+  lifecycle is managed externally (e.g. systemd socket activation, an init
+  container, custom ACLs/SELinux labels). Defaults to `false`.
 
 Note that for TCP receivers only the `endpoint` configuration setting is
 required.

--- a/config/confignet/README.md
+++ b/config/confignet/README.md
@@ -16,6 +16,12 @@ leverage network configuration to set connection and transport information.
   "npipe" (Windows named pipes, Windows-only).
 - `dialer`: Dialer configuration
   - `timeout`: Dialer timeout is the maximum amount of time a dial will wait for a connect to complete. The default is no timeout.
+- `socket_permissions`: File permissions applied to a filesystem-based Unix
+  domain socket file after binding. Only applies to the `unix`, `unixgram`
+  and `unixpacket` transports; ignored for abstract sockets (endpoints
+  starting with `@`) and all other transports. Defaults to `0722`, which
+  allows any local process to connect to the socket while only the owner
+  can otherwise manage it.
 
 Note that for TCP receivers only the `endpoint` configuration setting is
 required.

--- a/config/confignet/config.schema.json
+++ b/config/confignet/config.schema.json
@@ -21,6 +21,10 @@
           "type": "string",
           "description": "Configures the address for this network connection. For TCP and UDP networks,\nthe address has the form \"host:port\". The host must be a literal IP address,\nor a host name that can be resolved to IP addresses. The port must\nbe a literal port number or a service name. If the host is a literal IPv6 address\nit must be enclosed in square brackets, as in \"[2001:db8::1]:80\" or \"[fe80::1%zone]:80\".\nThe zone specifies the scope of the literal IPv6 address as defined in RFC 4007.\n"
         },
+        "socket_management_disabled": {
+          "type": "boolean",
+          "description": "Disables all automatic lifecycle management of filesystem-based Unix domain\nsocket files: no stale-socket removal before binding, no permission changes\nafter binding (socket_permissions is ignored), and no cleanup on Close(). Only\napplies to filesystem-based Unix transports (\"unix\", \"unixgram\", \"unixpacket\");\nignored for abstract sockets and all other transports. Use this if the socket\nfile's lifecycle is managed externally (e.g. systemd socket activation, an init\ncontainer, custom ACLs/SELinux labels).\n"
+        },
         "socket_permissions": {
           "type": "integer",
           "description": "Sets the file permissions applied to a filesystem-based Unix domain socket file\nafter binding. Only applies to filesystem-based Unix transports (\"unix\", \"unixgram\",\n\"unixpacket\"); ignored for abstract sockets (endpoints starting with \"@\") and all\nother transports. If unset, defaults to 0722, which allows any local process to\nconnect to the socket while only the owner can otherwise manage it.\n",

--- a/config/confignet/config.schema.json
+++ b/config/confignet/config.schema.json
@@ -19,11 +19,16 @@
         },
         "endpoint": {
           "type": "string",
-          "description": "Configures the address for this network connection. For TCP and UDP networks, \nthe address has the form \"host:port\". The host must be a literal IP address, \nor a host name that can be resolved to IP addresses. The port must \nbe a literal port number or a service name. If the host is a literal IPv6 address \nit must be enclosed in square brackets, as in \"[2001:db8::1]:80\" or \"[fe80::1%zone]:80\". \nThe zone specifies the scope of the literal IPv6 address as defined in RFC 4007.\n"
+          "description": "Configures the address for this network connection. For TCP and UDP networks,\nthe address has the form \"host:port\". The host must be a literal IP address,\nor a host name that can be resolved to IP addresses. The port must\nbe a literal port number or a service name. If the host is a literal IPv6 address\nit must be enclosed in square brackets, as in \"[2001:db8::1]:80\" or \"[fe80::1%zone]:80\".\nThe zone specifies the scope of the literal IPv6 address as defined in RFC 4007.\n"
+        },
+        "socket_permissions": {
+          "type": "integer",
+          "description": "Sets the file permissions applied to a filesystem-based Unix domain socket file\nafter binding. Only applies to filesystem-based Unix transports (\"unix\", \"unixgram\",\n\"unixpacket\"); ignored for abstract sockets (endpoints starting with \"@\") and all\nother transports. If unset, defaults to 0722, which allows any local process to\nconnect to the socket while only the owner can otherwise manage it.\n",
+          "default": 466
         },
         "transport": {
           "type": "string",
-          "description": "Defines the type of transport protocol used. Allowed protocols are \"tcp\", \"tcp4\" (IPv4-only), \n\"tcp6\" (IPv6-only), \"udp\", \"udp4\" (IPv4-only), \"udp6\" (IPv6-only), \"ip\", \"ip4\" (IPv4-only), \n\"ip6\" (IPv6-only), \"unix\", \"unixgram\", \"unixpacket\" and \"npipe\" (Windows named pipes, Windows-only).\n"
+          "description": "Defines the type of transport protocol used. Allowed protocols are \"tcp\", \"tcp4\" (IPv4-only),\n\"tcp6\" (IPv6-only), \"udp\", \"udp4\" (IPv4-only), \"udp6\" (IPv6-only), \"ip\", \"ip4\" (IPv4-only),\n\"ip6\" (IPv6-only), \"unix\", \"unixgram\", \"unixpacket\" and \"npipe\" (Windows named pipes, Windows-only).\n"
         }
       },
       "description": "Represents a network endpoint address."

--- a/config/confignet/config.schema.yaml
+++ b/config/confignet/config.schema.yaml
@@ -9,6 +9,9 @@ $defs:
       endpoint:
         description: Endpoint configures the address for this network connection. For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
         type: string
+      socket_management_disabled:
+        description: 'SocketManagementDisabled disables all automatic lifecycle management of filesystem-based Unix domain socket files: no stale-socket removal before binding, no permission changes after binding (SocketPermissions is ignored), and no cleanup on Close(). Only applies to filesystem-based Unix transports ("unix", "unixgram", "unixpacket"); ignored for abstract sockets and all other transports. Use this if the socket file''s lifecycle is managed externally (e.g. systemd socket activation, an init container, custom ACLs/SELinux labels).'
+        type: boolean
       socket_permissions:
         description: Sets the file permissions applied to a filesystem-based Unix domain socket file after binding. Only applies to filesystem-based Unix transports ("unix", "unixgram", "unixpacket"); ignored for abstract sockets (endpoints starting with "@") and all other transports. If unset, defaults to 0722, which allows any local process to connect to the socket while only the owner can otherwise manage it.
         type: integer

--- a/config/confignet/config.schema.yaml
+++ b/config/confignet/config.schema.yaml
@@ -9,6 +9,11 @@ $defs:
       endpoint:
         description: Endpoint configures the address for this network connection. For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
         type: string
+      socket_permissions:
+        description: Sets the file permissions applied to a filesystem-based Unix domain socket file after binding. Only applies to filesystem-based Unix transports ("unix", "unixgram", "unixpacket"); ignored for abstract sockets (endpoints starting with "@") and all other transports. If unset, defaults to 0722, which allows any local process to connect to the socket while only the owner can otherwise manage it.
+        type: integer
+        x-customType: os.FileMode
+        default: 466
       transport:
         description: Transport to use. Allowed protocols are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only), "ip6" (IPv6-only), "unix", "unixgram", "unixpacket" and "npipe" (Windows named pipes, Windows-only).
         $ref: transport_type

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -5,8 +5,10 @@ package confignet // import "go.opentelemetry.io/collector/config/confignet"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 )
@@ -88,6 +90,7 @@ type AddrConfig struct {
 
 	// DialerConfig contains options for connecting to an address.
 	DialerConfig DialerConfig `mapstructure:"dialer,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -113,8 +116,36 @@ func (na *AddrConfig) Listen(ctx context.Context) (net.Listener, error) {
 	if na.Transport == TransportTypeNpipe {
 		return listenNpipe(na.Endpoint)
 	}
+
+	// Filesystem-based Unix sockets need lifecycle handling:
+	// remove any stale socket before binding and clean up on close.
+	// Abstract sockets (@ prefix) live in kernel memory and need none of this.
+	isFsSocket := na.isUnixTransport() && !isAbstractSocket(na.Endpoint)
+
+	if isFsSocket {
+		if err := removeStaleSocket(na.Endpoint); err != nil {
+			return nil, fmt.Errorf("failed to clean up stale socket %q: %w", na.Endpoint, err)
+		}
+	}
+
 	lc := net.ListenConfig{}
-	return lc.Listen(ctx, string(na.Transport), na.Endpoint)
+	ln, err := lc.Listen(ctx, string(na.Transport), na.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if isFsSocket {
+		// Allow any local process to connect to the socket (owner rwx, group/other write).
+		// The write bit on a Unix socket controls connect access.
+		if err := os.Chmod(na.Endpoint, socketFileMode); err != nil {
+			_ = ln.Close()
+			_ = os.Remove(na.Endpoint)
+			return nil, fmt.Errorf("failed to set socket permissions on %q: %w", na.Endpoint, err)
+		}
+		ln = &unixListener{Listener: ln, path: na.Endpoint}
+	}
+
+	return ln, nil
 }
 
 func (na *AddrConfig) Validate() error {
@@ -137,6 +168,61 @@ func (na *AddrConfig) Validate() error {
 	default:
 		return fmt.Errorf("invalid transport type %q", na.Transport)
 	}
+}
+
+func (na *AddrConfig) isUnixTransport() bool {
+	switch na.Transport {
+	case TransportTypeUnix, TransportTypeUnixgram, TransportTypeUnixPacket:
+		return true
+	default:
+		return false
+	}
+}
+
+// socketFileMode is the permission set on Unix domain socket files.
+// Owner rwx (7), group write (2), other write (2). The write bit on a
+// Unix socket controls connect access, so 0o722 allows any local process
+// to connect while only the owner can manage the socket.
+const socketFileMode os.FileMode = 0o722
+
+// isAbstractSocket reports whether path refers to a Linux abstract Unix socket.
+// Abstract sockets live in kernel memory and have no filesystem representation.
+func isAbstractSocket(path string) bool {
+	return strings.HasPrefix(path, "@")
+}
+
+// removeStaleSocket removes a leftover socket file at path so a new
+// listener can bind. It refuses to remove non-socket files.
+// Note: there is an inherent TOCTOU race between the Stat and Remove
+// calls; this is acceptable for a startup-time code path.
+func removeStaleSocket(path string) error {
+	fi, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if fi.Mode().Type()&os.ModeSocket == 0 {
+		return fmt.Errorf("path %q exists but is not a socket (mode: %s)", path, fi.Mode())
+	}
+
+	return os.Remove(path)
+}
+
+// unixListener wraps a net.Listener for Unix domain sockets and removes
+// the socket file on Close.
+type unixListener struct {
+	net.Listener
+	path string
+}
+
+func (u *unixListener) Close() error {
+	err := u.Listener.Close()
+	// Best-effort cleanup of the socket file.
+	_ = os.Remove(u.path)
+	return err
 }
 
 // validateNpipePath validates a Windows named pipe path.

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -106,7 +106,7 @@ func (na *AddrConfig) listenUnix(ctx context.Context) (net.Listener, error) {
 	// socket controls connect access.
 	mode := na.SocketPermissions
 	if mode == 0 {
-		mode = socketFileMode
+		mode = defaultSocketPermissions
 	}
 	if err := os.Chmod(na.Endpoint, mode); err != nil {
 		_ = ln.Close()
@@ -147,12 +147,12 @@ func (na *AddrConfig) isUnixTransport() bool {
 	}
 }
 
-// socketFileMode is the default permission set applied to Unix domain socket
-// files, used when AddrConfig.SocketPermissions is unset.
+// defaultSocketPermissions is the default permission set applied to Unix
+// domain socket files, used when AddrConfig.SocketPermissions is unset.
 // Owner rwx (7), group write (2), other write (2). The write bit on a
 // Unix socket controls connect access, so 0o722 allows any local process
 // to connect while only the owner can manage the socket.
-const socketFileMode os.FileMode = 0o722
+const defaultSocketPermissions os.FileMode = 0o722
 
 // isAbstractSocket reports whether path refers to a Linux abstract Unix socket.
 // Abstract sockets live in kernel memory and have no filesystem representation.

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -70,11 +70,20 @@ func (na *AddrConfig) Listen(ctx context.Context) (net.Listener, error) {
 	if na.Transport == TransportTypeNpipe {
 		return listenNpipe(na.Endpoint)
 	}
+	if na.isUnixTransport() {
+		return na.listenUnix(ctx)
+	}
 
-	// Filesystem-based Unix sockets need lifecycle handling:
-	// remove any stale socket before binding and clean up on close.
-	// Abstract sockets (@ prefix) live in kernel memory and need none of this.
-	isFsSocket := na.isUnixTransport() && !isAbstractSocket(na.Endpoint)
+	lc := net.ListenConfig{}
+	return lc.Listen(ctx, string(na.Transport), na.Endpoint)
+}
+
+// listenUnix binds a Unix domain socket, handling the filesystem lifecycle
+// of the socket file: removing any stale socket before binding, setting the
+// configured permissions, and cleaning up on close. Abstract sockets
+// (@ prefix) live in kernel memory and need none of this.
+func (na *AddrConfig) listenUnix(ctx context.Context) (net.Listener, error) {
+	isFsSocket := !isAbstractSocket(na.Endpoint)
 
 	if isFsSocket {
 		if err := removeStaleSocket(na.Endpoint); err != nil {
@@ -88,23 +97,23 @@ func (na *AddrConfig) Listen(ctx context.Context) (net.Listener, error) {
 		return nil, err
 	}
 
-	if isFsSocket {
-		// Apply the configured socket permissions, falling back to the default
-		// (owner rwx, group/other write) when unset. The write bit on a Unix
-		// socket controls connect access.
-		mode := na.SocketPermissions
-		if mode == 0 {
-			mode = socketFileMode
-		}
-		if err := os.Chmod(na.Endpoint, mode); err != nil {
-			_ = ln.Close()
-			_ = os.Remove(na.Endpoint)
-			return nil, fmt.Errorf("failed to set socket permissions on %q: %w", na.Endpoint, err)
-		}
-		ln = &unixListener{Listener: ln, path: na.Endpoint}
+	if !isFsSocket {
+		return ln, nil
 	}
 
-	return ln, nil
+	// Apply the configured socket permissions, falling back to the default
+	// (owner rwx, group/other write) when unset. The write bit on a Unix
+	// socket controls connect access.
+	mode := na.SocketPermissions
+	if mode == 0 {
+		mode = socketFileMode
+	}
+	if err := os.Chmod(na.Endpoint, mode); err != nil {
+		_ = ln.Close()
+		_ = os.Remove(na.Endpoint)
+		return nil, fmt.Errorf("failed to set socket permissions on %q: %w", na.Endpoint, err)
+	}
+	return &unixListener{Listener: ln, path: na.Endpoint}, nil
 }
 
 func (na *AddrConfig) Validate() error {

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -5,8 +5,10 @@ package confignet // import "go.opentelemetry.io/collector/config/confignet"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 )
 
@@ -68,8 +70,36 @@ func (na *AddrConfig) Listen(ctx context.Context) (net.Listener, error) {
 	if na.Transport == TransportTypeNpipe {
 		return listenNpipe(na.Endpoint)
 	}
+
+	// Filesystem-based Unix sockets need lifecycle handling:
+	// remove any stale socket before binding and clean up on close.
+	// Abstract sockets (@ prefix) live in kernel memory and need none of this.
+	isFsSocket := na.isUnixTransport() && !isAbstractSocket(na.Endpoint)
+
+	if isFsSocket {
+		if err := removeStaleSocket(na.Endpoint); err != nil {
+			return nil, fmt.Errorf("failed to clean up stale socket %q: %w", na.Endpoint, err)
+		}
+	}
+
 	lc := net.ListenConfig{}
-	return lc.Listen(ctx, string(na.Transport), na.Endpoint)
+	ln, err := lc.Listen(ctx, string(na.Transport), na.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if isFsSocket {
+		// Allow any local process to connect to the socket (owner rwx, group/other write).
+		// The write bit on a Unix socket controls connect access.
+		if err := os.Chmod(na.Endpoint, socketFileMode); err != nil {
+			_ = ln.Close()
+			_ = os.Remove(na.Endpoint)
+			return nil, fmt.Errorf("failed to set socket permissions on %q: %w", na.Endpoint, err)
+		}
+		ln = &unixListener{Listener: ln, path: na.Endpoint}
+	}
+
+	return ln, nil
 }
 
 func (na *AddrConfig) Validate() error {
@@ -92,6 +122,61 @@ func (na *AddrConfig) Validate() error {
 	default:
 		return fmt.Errorf("invalid transport type %q", na.Transport)
 	}
+}
+
+func (na *AddrConfig) isUnixTransport() bool {
+	switch na.Transport {
+	case TransportTypeUnix, TransportTypeUnixgram, TransportTypeUnixPacket:
+		return true
+	default:
+		return false
+	}
+}
+
+// socketFileMode is the permission set on Unix domain socket files.
+// Owner rwx (7), group write (2), other write (2). The write bit on a
+// Unix socket controls connect access, so 0o722 allows any local process
+// to connect while only the owner can manage the socket.
+const socketFileMode os.FileMode = 0o722
+
+// isAbstractSocket reports whether path refers to a Linux abstract Unix socket.
+// Abstract sockets live in kernel memory and have no filesystem representation.
+func isAbstractSocket(path string) bool {
+	return strings.HasPrefix(path, "@")
+}
+
+// removeStaleSocket removes a leftover socket file at path so a new
+// listener can bind. It refuses to remove non-socket files.
+// Note: there is an inherent TOCTOU race between the Stat and Remove
+// calls; this is acceptable for a startup-time code path.
+func removeStaleSocket(path string) error {
+	fi, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if fi.Mode().Type()&os.ModeSocket == 0 {
+		return fmt.Errorf("path %q exists but is not a socket (mode: %s)", path, fi.Mode())
+	}
+
+	return os.Remove(path)
+}
+
+// unixListener wraps a net.Listener for Unix domain sockets and removes
+// the socket file on Close.
+type unixListener struct {
+	net.Listener
+	path string
+}
+
+func (u *unixListener) Close() error {
+	err := u.Listener.Close()
+	// Best-effort cleanup of the socket file.
+	_ = os.Remove(u.path)
+	return err
 }
 
 // validateNpipePath validates a Windows named pipe path.

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -89,9 +89,14 @@ func (na *AddrConfig) Listen(ctx context.Context) (net.Listener, error) {
 	}
 
 	if isFsSocket {
-		// Allow any local process to connect to the socket (owner rwx, group/other write).
-		// The write bit on a Unix socket controls connect access.
-		if err := os.Chmod(na.Endpoint, socketFileMode); err != nil {
+		// Apply the configured socket permissions, falling back to the default
+		// (owner rwx, group/other write) when unset. The write bit on a Unix
+		// socket controls connect access.
+		mode := na.SocketPermissions
+		if mode == 0 {
+			mode = socketFileMode
+		}
+		if err := os.Chmod(na.Endpoint, mode); err != nil {
 			_ = ln.Close()
 			_ = os.Remove(na.Endpoint)
 			return nil, fmt.Errorf("failed to set socket permissions on %q: %w", na.Endpoint, err)
@@ -133,7 +138,8 @@ func (na *AddrConfig) isUnixTransport() bool {
 	}
 }
 
-// socketFileMode is the permission set on Unix domain socket files.
+// socketFileMode is the default permission set applied to Unix domain socket
+// files, used when AddrConfig.SocketPermissions is unset.
 // Owner rwx (7), group write (2), other write (2). The write bit on a
 // Unix socket controls connect access, so 0o722 allows any local process
 // to connect while only the owner can manage the socket.

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -71,11 +71,36 @@ func (na *AddrConfig) Listen(ctx context.Context) (net.Listener, error) {
 		return listenNpipe(na.Endpoint)
 	}
 	if na.isUnixTransport() {
+		if na.SocketManagementDisabled {
+			return na.listenUnixUnmanaged(ctx)
+		}
 		return na.listenUnix(ctx)
 	}
 
 	lc := net.ListenConfig{}
 	return lc.Listen(ctx, string(na.Transport), na.Endpoint)
+}
+
+// bindUnix binds a Unix domain socket at the configured endpoint.
+func (na *AddrConfig) bindUnix(ctx context.Context) (net.Listener, error) {
+	lc := net.ListenConfig{}
+	return lc.Listen(ctx, string(na.Transport), na.Endpoint)
+}
+
+// listenUnixUnmanaged binds a Unix domain socket without any automatic
+// lifecycle management. It disables Go's default behavior of removing the
+// socket file on Close (net.UnixListener.SetUnlinkOnClose), since that
+// default would otherwise silently delete a file the caller intends to
+// manage themselves, contradicting SocketManagementDisabled.
+func (na *AddrConfig) listenUnixUnmanaged(ctx context.Context) (net.Listener, error) {
+	ln, err := na.bindUnix(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if ul, ok := ln.(*net.UnixListener); ok {
+		ul.SetUnlinkOnClose(false)
+	}
+	return ln, nil
 }
 
 // listenUnix binds a Unix domain socket, handling the filesystem lifecycle
@@ -91,8 +116,7 @@ func (na *AddrConfig) listenUnix(ctx context.Context) (net.Listener, error) {
 		}
 	}
 
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(ctx, string(na.Transport), na.Endpoint)
+	ln, err := na.bindUnix(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -7,10 +7,7 @@ import (
 	"context"
 	"errors"
 	"net"
-	"os"
-	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -202,167 +199,11 @@ func Test_TransportType_UnmarshalText(t *testing.T) {
 	require.Error(t, err)
 }
 
-func Test_removeStaleSocket(t *testing.T) {
-	t.Parallel()
-	t.Run("path does not exist", func(t *testing.T) {
-		t.Parallel()
-		err := removeStaleSocket(filepath.Join(t.TempDir(), "nonexistent.sock"))
-		assert.NoError(t, err)
-	})
-
-	t.Run("path is a regular file", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "regular.txt")
-		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
-
-		err := removeStaleSocket(path)
-		assert.ErrorContains(t, err, "not a socket")
-		// File should still exist.
-		_, statErr := os.Stat(path)
-		assert.NoError(t, statErr)
-	})
-
-	t.Run("path is a stale socket", func(t *testing.T) {
-		t.Parallel()
-		// Use os.MkdirTemp with an empty base so the OS chooses a short path,
-		// avoiding the 104-character Unix socket path limit on macOS/BSD.
-		dir, err := os.MkdirTemp("", "confignet-sock-test-*")
-		require.NoError(t, err)
-		t.Cleanup(func() { os.RemoveAll(dir) })
-		path := filepath.Join(dir, "stale.sock")
-		// Create a socket file directly via syscall so it is not auto-removed
-		// when closed (Go's net.Listener.Close removes socket files on some OSes).
-		fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-		require.NoError(t, err)
-		err = syscall.Bind(fd, &syscall.SockaddrUnix{Name: path})
-		require.NoError(t, err)
-		require.NoError(t, syscall.Close(fd))
-		// Socket file should still exist after closing the fd.
-		_, err = os.Stat(path)
-		require.NoError(t, err)
-
-		err = removeStaleSocket(path)
-		assert.NoError(t, err)
-		// Socket file should be removed.
-		_, err = os.Stat(path)
-		assert.True(t, os.IsNotExist(err))
-	})
-
-}
-
 func Test_isAbstractSocket(t *testing.T) {
 	t.Parallel()
 	assert.True(t, isAbstractSocket("@abstract"))
 	assert.False(t, isAbstractSocket("/var/run/test.sock"))
 	assert.False(t, isAbstractSocket(""))
-}
-
-func Test_unixListener_Close(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "listener.sock")
-
-	ln, err := net.Listen("unix", path)
-	require.NoError(t, err)
-
-	// Socket file exists after listen.
-	_, err = os.Stat(path)
-	require.NoError(t, err)
-
-	uln := &unixListener{Listener: ln, path: path}
-	require.NoError(t, uln.Close())
-
-	// Socket file should be removed after close.
-	_, err = os.Stat(path)
-	assert.True(t, os.IsNotExist(err))
-}
-
-func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "stale.sock")
-
-	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
-	fd, sysErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-	require.NoError(t, sysErr)
-	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
-	require.NoError(t, syscall.Close(fd))
-	_, sysErr = os.Stat(path)
-	require.NoError(t, sysErr)
-
-	// Listen should succeed despite stale socket.
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, ln.Close()) })
-}
-
-func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "regular.txt")
-	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	_, err = na.Listen(context.Background())
-	assert.ErrorContains(t, err, "not a socket")
-}
-
-func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "perms.sock")
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, ln.Close()) })
-
-	fi, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
-}
-
-func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "cleanup.sock")
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-
-	_, err = os.Stat(path)
-	require.NoError(t, err)
-
-	require.NoError(t, ln.Close())
-
-	// Socket file should be removed after close.
-	_, err = os.Stat(path)
-	assert.True(t, os.IsNotExist(err))
 }
 
 func Test_AddrConfig_isUnixTransport(t *testing.T) {

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -7,7 +7,10 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -197,4 +200,195 @@ func Test_TransportType_UnmarshalText(t *testing.T) {
 	assert.Equal(t, TransportTypeNpipe, tt)
 	err = tt.UnmarshalText([]byte("invalid"))
 	require.Error(t, err)
+}
+
+func Test_removeStaleSocket(t *testing.T) {
+	t.Parallel()
+	t.Run("path does not exist", func(t *testing.T) {
+		t.Parallel()
+		err := removeStaleSocket(filepath.Join(t.TempDir(), "nonexistent.sock"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("path is a regular file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "regular.txt")
+		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+
+		err := removeStaleSocket(path)
+		assert.ErrorContains(t, err, "not a socket")
+		// File should still exist.
+		_, statErr := os.Stat(path)
+		assert.NoError(t, statErr)
+	})
+
+	t.Run("path is a stale socket", func(t *testing.T) {
+		t.Parallel()
+		// Use os.MkdirTemp with an empty base so the OS chooses a short path,
+		// avoiding the 104-character Unix socket path limit on macOS/BSD.
+		dir, err := os.MkdirTemp("", "confignet-sock-test-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		path := filepath.Join(dir, "stale.sock")
+		// Create a socket file directly via syscall so it is not auto-removed
+		// when closed (Go's net.Listener.Close removes socket files on some OSes).
+		fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+		require.NoError(t, err)
+		err = syscall.Bind(fd, &syscall.SockaddrUnix{Name: path})
+		require.NoError(t, err)
+		require.NoError(t, syscall.Close(fd))
+		// Socket file should still exist after closing the fd.
+		_, err = os.Stat(path)
+		require.NoError(t, err)
+
+		err = removeStaleSocket(path)
+		assert.NoError(t, err)
+		// Socket file should be removed.
+		_, err = os.Stat(path)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+}
+
+func Test_isAbstractSocket(t *testing.T) {
+	t.Parallel()
+	assert.True(t, isAbstractSocket("@abstract"))
+	assert.False(t, isAbstractSocket("/var/run/test.sock"))
+	assert.False(t, isAbstractSocket(""))
+}
+
+func Test_unixListener_Close(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "listener.sock")
+
+	ln, err := net.Listen("unix", path)
+	require.NoError(t, err)
+
+	// Socket file exists after listen.
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	uln := &unixListener{Listener: ln, path: path}
+	require.NoError(t, uln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "stale.sock")
+
+	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
+	fd, sysErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	require.NoError(t, sysErr)
+	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
+	require.NoError(t, syscall.Close(fd))
+	_, sysErr = os.Stat(path)
+	require.NoError(t, sysErr)
+
+	// Listen should succeed despite stale socket.
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+}
+
+func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "regular.txt")
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	_, err = na.Listen(context.Background())
+	assert.ErrorContains(t, err, "not a socket")
+}
+
+func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "perms.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
+}
+
+func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "cleanup.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	require.NoError(t, ln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func Test_AddrConfig_isUnixTransport(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		transport TransportType
+		expected  bool
+	}{
+		{TransportTypeTCP, false},
+		{TransportTypeTCP4, false},
+		{TransportTypeTCP6, false},
+		{TransportTypeUDP, false},
+		{TransportTypeUDP4, false},
+		{TransportTypeUDP6, false},
+		{TransportTypeIP, false},
+		{TransportTypeIP4, false},
+		{TransportTypeIP6, false},
+		{TransportTypeUnix, true},
+		{TransportTypeUnixgram, true},
+		{TransportTypeUnixPacket, true},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.transport), func(t *testing.T) {
+			t.Parallel()
+			na := &AddrConfig{Transport: tt.transport}
+			assert.Equal(t, tt.expected, na.isUnixTransport())
+		})
+	}
 }

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -7,10 +7,7 @@ import (
 	"context"
 	"errors"
 	"net"
-	"os"
-	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -200,167 +197,11 @@ func Test_TransportType_UnmarshalText(t *testing.T) {
 	require.Error(t, err)
 }
 
-func Test_removeStaleSocket(t *testing.T) {
-	t.Parallel()
-	t.Run("path does not exist", func(t *testing.T) {
-		t.Parallel()
-		err := removeStaleSocket(filepath.Join(t.TempDir(), "nonexistent.sock"))
-		assert.NoError(t, err)
-	})
-
-	t.Run("path is a regular file", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "regular.txt")
-		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
-
-		err := removeStaleSocket(path)
-		assert.ErrorContains(t, err, "not a socket")
-		// File should still exist.
-		_, statErr := os.Stat(path)
-		assert.NoError(t, statErr)
-	})
-
-	t.Run("path is a stale socket", func(t *testing.T) {
-		t.Parallel()
-		// Use os.MkdirTemp with an empty base so the OS chooses a short path,
-		// avoiding the 104-character Unix socket path limit on macOS/BSD.
-		dir, err := os.MkdirTemp("", "confignet-sock-test-*")
-		require.NoError(t, err)
-		t.Cleanup(func() { os.RemoveAll(dir) })
-		path := filepath.Join(dir, "stale.sock")
-		// Create a socket file directly via syscall so it is not auto-removed
-		// when closed (Go's net.Listener.Close removes socket files on some OSes).
-		fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-		require.NoError(t, err)
-		err = syscall.Bind(fd, &syscall.SockaddrUnix{Name: path})
-		require.NoError(t, err)
-		require.NoError(t, syscall.Close(fd))
-		// Socket file should still exist after closing the fd.
-		_, err = os.Stat(path)
-		require.NoError(t, err)
-
-		err = removeStaleSocket(path)
-		assert.NoError(t, err)
-		// Socket file should be removed.
-		_, err = os.Stat(path)
-		assert.True(t, os.IsNotExist(err))
-	})
-
-}
-
 func Test_isAbstractSocket(t *testing.T) {
 	t.Parallel()
 	assert.True(t, isAbstractSocket("@abstract"))
 	assert.False(t, isAbstractSocket("/var/run/test.sock"))
 	assert.False(t, isAbstractSocket(""))
-}
-
-func Test_unixListener_Close(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "listener.sock")
-
-	ln, err := net.Listen("unix", path)
-	require.NoError(t, err)
-
-	// Socket file exists after listen.
-	_, err = os.Stat(path)
-	require.NoError(t, err)
-
-	uln := &unixListener{Listener: ln, path: path}
-	require.NoError(t, uln.Close())
-
-	// Socket file should be removed after close.
-	_, err = os.Stat(path)
-	assert.True(t, os.IsNotExist(err))
-}
-
-func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "stale.sock")
-
-	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
-	fd, sysErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-	require.NoError(t, sysErr)
-	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
-	require.NoError(t, syscall.Close(fd))
-	_, sysErr = os.Stat(path)
-	require.NoError(t, sysErr)
-
-	// Listen should succeed despite stale socket.
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, ln.Close()) })
-}
-
-func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "regular.txt")
-	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	_, err = na.Listen(context.Background())
-	assert.ErrorContains(t, err, "not a socket")
-}
-
-func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "perms.sock")
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, ln.Close()) })
-
-	fi, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
-}
-
-func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
-	t.Parallel()
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "cleanup.sock")
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
-	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-
-	_, err = os.Stat(path)
-	require.NoError(t, err)
-
-	require.NoError(t, ln.Close())
-
-	// Socket file should be removed after close.
-	_, err = os.Stat(path)
-	assert.True(t, os.IsNotExist(err))
 }
 
 func Test_AddrConfig_isUnixTransport(t *testing.T) {

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -7,7 +7,10 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -195,4 +198,195 @@ func Test_TransportType_UnmarshalText(t *testing.T) {
 	assert.Equal(t, TransportTypeNpipe, tt)
 	err = tt.UnmarshalText([]byte("invalid"))
 	require.Error(t, err)
+}
+
+func Test_removeStaleSocket(t *testing.T) {
+	t.Parallel()
+	t.Run("path does not exist", func(t *testing.T) {
+		t.Parallel()
+		err := removeStaleSocket(filepath.Join(t.TempDir(), "nonexistent.sock"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("path is a regular file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "regular.txt")
+		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+
+		err := removeStaleSocket(path)
+		assert.ErrorContains(t, err, "not a socket")
+		// File should still exist.
+		_, statErr := os.Stat(path)
+		assert.NoError(t, statErr)
+	})
+
+	t.Run("path is a stale socket", func(t *testing.T) {
+		t.Parallel()
+		// Use os.MkdirTemp with an empty base so the OS chooses a short path,
+		// avoiding the 104-character Unix socket path limit on macOS/BSD.
+		dir, err := os.MkdirTemp("", "confignet-sock-test-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		path := filepath.Join(dir, "stale.sock")
+		// Create a socket file directly via syscall so it is not auto-removed
+		// when closed (Go's net.Listener.Close removes socket files on some OSes).
+		fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+		require.NoError(t, err)
+		err = syscall.Bind(fd, &syscall.SockaddrUnix{Name: path})
+		require.NoError(t, err)
+		require.NoError(t, syscall.Close(fd))
+		// Socket file should still exist after closing the fd.
+		_, err = os.Stat(path)
+		require.NoError(t, err)
+
+		err = removeStaleSocket(path)
+		assert.NoError(t, err)
+		// Socket file should be removed.
+		_, err = os.Stat(path)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+}
+
+func Test_isAbstractSocket(t *testing.T) {
+	t.Parallel()
+	assert.True(t, isAbstractSocket("@abstract"))
+	assert.False(t, isAbstractSocket("/var/run/test.sock"))
+	assert.False(t, isAbstractSocket(""))
+}
+
+func Test_unixListener_Close(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "listener.sock")
+
+	ln, err := net.Listen("unix", path)
+	require.NoError(t, err)
+
+	// Socket file exists after listen.
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	uln := &unixListener{Listener: ln, path: path}
+	require.NoError(t, uln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "stale.sock")
+
+	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
+	fd, sysErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	require.NoError(t, sysErr)
+	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
+	require.NoError(t, syscall.Close(fd))
+	_, sysErr = os.Stat(path)
+	require.NoError(t, sysErr)
+
+	// Listen should succeed despite stale socket.
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+}
+
+func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "regular.txt")
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	_, err = na.Listen(context.Background())
+	assert.ErrorContains(t, err, "not a socket")
+}
+
+func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "perms.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
+}
+
+func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
+	t.Parallel()
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "cleanup.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	require.NoError(t, ln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func Test_AddrConfig_isUnixTransport(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		transport TransportType
+		expected  bool
+	}{
+		{TransportTypeTCP, false},
+		{TransportTypeTCP4, false},
+		{TransportTypeTCP6, false},
+		{TransportTypeUDP, false},
+		{TransportTypeUDP4, false},
+		{TransportTypeUDP6, false},
+		{TransportTypeIP, false},
+		{TransportTypeIP4, false},
+		{TransportTypeIP6, false},
+		{TransportTypeUnix, true},
+		{TransportTypeUnixgram, true},
+		{TransportTypeUnixPacket, true},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.transport), func(t *testing.T) {
+			t.Parallel()
+			na := &AddrConfig{Transport: tt.transport}
+			assert.Equal(t, tt.expected, na.isUnixTransport())
+		})
+	}
 }

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -22,7 +22,7 @@ func TestNewDefaultDialerConfig(t *testing.T) {
 }
 
 func TestNewDefaultAddrConfig(t *testing.T) {
-	expectedAddrConfig := AddrConfig{}
+	expectedAddrConfig := AddrConfig{SocketPermissions: socketFileMode}
 	addrConfig := NewDefaultAddrConfig()
 	require.Equal(t, expectedAddrConfig, addrConfig)
 }

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -22,7 +22,7 @@ func TestNewDefaultDialerConfig(t *testing.T) {
 }
 
 func TestNewDefaultAddrConfig(t *testing.T) {
-	expectedAddrConfig := AddrConfig{SocketPermissions: socketFileMode}
+	expectedAddrConfig := AddrConfig{}
 	addrConfig := NewDefaultAddrConfig()
 	require.Equal(t, expectedAddrConfig, addrConfig)
 }

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -22,7 +22,7 @@ func TestNewDefaultDialerConfig(t *testing.T) {
 }
 
 func TestNewDefaultAddrConfig(t *testing.T) {
-	expectedAddrConfig := AddrConfig{}
+	expectedAddrConfig := AddrConfig{SocketPermissions: defaultSocketPermissions}
 	addrConfig := NewDefaultAddrConfig()
 	require.Equal(t, expectedAddrConfig, addrConfig)
 }

--- a/config/confignet/confignet_unix_test.go
+++ b/config/confignet/confignet_unix_test.go
@@ -151,6 +151,75 @@ func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
 	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
 }
 
+func TestAddrConfig_Listen_UnixInvalidEndpoint(t *testing.T) {
+	t.Parallel()
+	na := &AddrConfig{
+		Endpoint:  "/nonexistent/dir/deep/socket.sock",
+		Transport: TransportTypeUnix,
+	}
+	_, err := na.Listen(context.Background())
+	assert.Error(t, err)
+}
+
+func TestAddrConfig_Listen_UnixChmodFailure(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "chmod.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+
+	// Remove the socket file behind the listener's back so that the
+	// Chmod in a second Listen call fails (socket won't exist to chmod).
+	require.NoError(t, ln.Close())
+
+	// Now make the directory read-only so Listen succeeds at binding
+	// but Chmod fails due to permission denied.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o700))
+	subPath := filepath.Join(dir, "sub", "chmod.sock")
+	na2 := &AddrConfig{
+		Endpoint:  subPath,
+		Transport: TransportTypeUnix,
+	}
+	ln2, err := na2.Listen(context.Background())
+	require.NoError(t, err)
+	// Verify listener works, then close
+	require.NoError(t, ln2.Close())
+
+	// Make dir read-only to cause Chmod failure
+	require.NoError(t, os.Chmod(filepath.Join(dir, "sub"), 0o444))       //nolint:gosec // intentional for test
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "sub"), 0o700) }) //nolint:gosec // restore perms for cleanup
+
+	_, err = na2.Listen(context.Background())
+	// On some systems this fails at Listen (can't bind), on others at Chmod.
+	// Either way it should error.
+	assert.Error(t, err)
+}
+
+func Test_removeStaleSocket_StatError(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700); os.RemoveAll(dir) }) //nolint:gosec // restore perms for cleanup
+	path := filepath.Join(dir, "socket.sock")
+
+	// Create a file so the path exists.
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+	// Remove permission on the directory so Stat fails with permission denied.
+	require.NoError(t, os.Chmod(dir, 0o000))
+
+	err = removeStaleSocket(path)
+	assert.Error(t, err)
+}
+
 func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
 	t.Parallel()
 	//nolint:usetesting // short path needed for Unix socket limit

--- a/config/confignet/confignet_unix_test.go
+++ b/config/confignet/confignet_unix_test.go
@@ -1,0 +1,177 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package confignet
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_removeStaleSocket(t *testing.T) {
+	t.Parallel()
+	t.Run("path does not exist", func(t *testing.T) {
+		t.Parallel()
+		err := removeStaleSocket(filepath.Join(t.TempDir(), "nonexistent.sock"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("path is a regular file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "regular.txt")
+		require.NoError(t, os.WriteFile(path, []byte("data"), 0o600))
+
+		err := removeStaleSocket(path)
+		require.ErrorContains(t, err, "not a socket")
+		// File should still exist.
+		_, statErr := os.Stat(path)
+		assert.NoError(t, statErr)
+	})
+
+	t.Run("path is a stale socket", func(t *testing.T) {
+		t.Parallel()
+		//nolint:usetesting // short path needed for Unix socket limit
+		dir, err := os.MkdirTemp("", "confignet-sock-test-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		path := filepath.Join(dir, "stale.sock")
+		// Create a socket file directly via syscall so it is not auto-removed
+		// when closed (Go's net.Listener.Close removes socket files on some OSes).
+		fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+		require.NoError(t, err)
+		err = syscall.Bind(fd, &syscall.SockaddrUnix{Name: path})
+		require.NoError(t, err)
+		require.NoError(t, syscall.Close(fd))
+		// Socket file should still exist after closing the fd.
+		_, err = os.Stat(path)
+		require.NoError(t, err)
+
+		err = removeStaleSocket(path)
+		require.NoError(t, err)
+		// Socket file should be removed.
+		_, err = os.Stat(path)
+		assert.True(t, os.IsNotExist(err))
+	})
+}
+
+func Test_unixListener_Close(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "listener.sock")
+
+	ln, err := net.Listen("unix", path)
+	require.NoError(t, err)
+
+	// Socket file exists after listen.
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	uln := &unixListener{Listener: ln, path: path}
+	require.NoError(t, uln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "stale.sock")
+
+	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
+	fd, sysErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	require.NoError(t, sysErr)
+	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
+	require.NoError(t, syscall.Close(fd))
+	_, sysErr = os.Stat(path)
+	require.NoError(t, sysErr)
+
+	// Listen should succeed despite stale socket.
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+}
+
+func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "regular.txt")
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o600))
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	_, err = na.Listen(context.Background())
+	assert.ErrorContains(t, err, "not a socket")
+}
+
+func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "perms.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
+}
+
+func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "cleanup.sock")
+
+	na := &AddrConfig{
+		Endpoint:  path,
+		Transport: TransportTypeUnix,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	require.NoError(t, ln.Close())
+
+	// Socket file should be removed after close.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}

--- a/config/confignet/confignet_unix_test.go
+++ b/config/confignet/confignet_unix_test.go
@@ -136,7 +136,7 @@ func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
 		socketPermissions os.FileMode
 		want              os.FileMode
 	}{
-		{name: "default", want: socketFileMode},
+		{name: "default", want: defaultSocketPermissions},
 		{name: "custom", socketPermissions: 0o700, want: 0o700},
 	}
 	for _, tt := range tests {

--- a/config/confignet/confignet_unix_test.go
+++ b/config/confignet/confignet_unix_test.go
@@ -28,6 +28,17 @@ func tempSocketDir(t *testing.T) string {
 	return dir
 }
 
+// createStaleSocket creates a socket file directly via syscall, bypassing
+// net.Listen, so it is not auto-removed when closed (Go's net.Listener.Close
+// removes socket files on some OSes) and remains on disk as a "stale" socket.
+func createStaleSocket(t *testing.T, path string) {
+	t.Helper()
+	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	require.NoError(t, err)
+	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
+	require.NoError(t, syscall.Close(fd))
+}
+
 func Test_removeStaleSocket(t *testing.T) {
 	t.Parallel()
 	t.Run("path does not exist", func(t *testing.T) {
@@ -53,15 +64,9 @@ func Test_removeStaleSocket(t *testing.T) {
 		t.Parallel()
 		dir := tempSocketDir(t)
 		path := filepath.Join(dir, "stale.sock")
-		// Create a socket file directly via syscall so it is not auto-removed
-		// when closed (Go's net.Listener.Close removes socket files on some OSes).
-		fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-		require.NoError(t, err)
-		err = syscall.Bind(fd, &syscall.SockaddrUnix{Name: path})
-		require.NoError(t, err)
-		require.NoError(t, syscall.Close(fd))
+		createStaleSocket(t, path)
 		// Socket file should still exist after closing the fd.
-		_, err = os.Stat(path)
+		_, err := os.Stat(path)
 		require.NoError(t, err)
 
 		err = removeStaleSocket(path)
@@ -96,14 +101,7 @@ func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
 	t.Parallel()
 	dir := tempSocketDir(t)
 	path := filepath.Join(dir, "stale.sock")
-
-	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
-	fd, sysErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-	require.NoError(t, sysErr)
-	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}))
-	require.NoError(t, syscall.Close(fd))
-	_, sysErr = os.Stat(path)
-	require.NoError(t, sysErr)
+	createStaleSocket(t, path)
 
 	// Listen should succeed despite stale socket.
 	na := &AddrConfig{
@@ -161,6 +159,21 @@ func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
 	}
 }
 
+func TestAddrConfig_Listen_UnixSocketManagementDisabled_StaleSocketNotRemoved(t *testing.T) {
+	t.Parallel()
+	dir := tempSocketDir(t)
+	path := filepath.Join(dir, "stale.sock")
+	createStaleSocket(t, path)
+
+	na := &AddrConfig{
+		Endpoint:                 path,
+		Transport:                TransportTypeUnix,
+		SocketManagementDisabled: true,
+	}
+	_, err := na.Listen(context.Background())
+	assert.Error(t, err)
+}
+
 func TestAddrConfig_Listen_UnixInvalidEndpoint(t *testing.T) {
 	t.Parallel()
 	na := &AddrConfig{
@@ -214,22 +227,40 @@ func Test_removeStaleSocket_StatError(t *testing.T) {
 
 func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
 	t.Parallel()
-	dir := tempSocketDir(t)
-	path := filepath.Join(dir, "cleanup.sock")
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
+	tests := []struct {
+		name                     string
+		socketManagementDisabled bool
+		wantRemoved              bool
+	}{
+		{name: "managed: file removed on close", wantRemoved: true},
+		{name: "unmanaged: file kept on close", socketManagementDisabled: true},
 	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := tempSocketDir(t)
+			path := filepath.Join(dir, "cleanup.sock")
 
-	_, err = os.Stat(path)
-	require.NoError(t, err)
+			na := &AddrConfig{
+				Endpoint:                 path,
+				Transport:                TransportTypeUnix,
+				SocketManagementDisabled: tt.socketManagementDisabled,
+			}
+			ln, err := na.Listen(context.Background())
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.Remove(path) })
 
-	require.NoError(t, ln.Close())
+			_, err = os.Stat(path)
+			require.NoError(t, err)
 
-	// Socket file should be removed after close.
-	_, err = os.Stat(path)
-	assert.True(t, os.IsNotExist(err))
+			require.NoError(t, ln.Close())
+
+			_, err = os.Stat(path)
+			if tt.wantRemoved {
+				assert.True(t, os.IsNotExist(err))
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/config/confignet/confignet_unix_test.go
+++ b/config/confignet/confignet_unix_test.go
@@ -17,6 +17,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// tempSocketDir creates a temp directory short enough to stay under the
+// Unix socket path length limit and registers cleanup.
+func tempSocketDir(t *testing.T) string {
+	t.Helper()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
 func Test_removeStaleSocket(t *testing.T) {
 	t.Parallel()
 	t.Run("path does not exist", func(t *testing.T) {
@@ -40,10 +51,7 @@ func Test_removeStaleSocket(t *testing.T) {
 
 	t.Run("path is a stale socket", func(t *testing.T) {
 		t.Parallel()
-		//nolint:usetesting // short path needed for Unix socket limit
-		dir, err := os.MkdirTemp("", "confignet-sock-test-*")
-		require.NoError(t, err)
-		t.Cleanup(func() { os.RemoveAll(dir) })
+		dir := tempSocketDir(t)
 		path := filepath.Join(dir, "stale.sock")
 		// Create a socket file directly via syscall so it is not auto-removed
 		// when closed (Go's net.Listener.Close removes socket files on some OSes).
@@ -66,10 +74,7 @@ func Test_removeStaleSocket(t *testing.T) {
 
 func Test_unixListener_Close(t *testing.T) {
 	t.Parallel()
-	//nolint:usetesting // short path needed for Unix socket limit
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := tempSocketDir(t)
 	path := filepath.Join(dir, "listener.sock")
 
 	ln, err := net.Listen("unix", path)
@@ -89,10 +94,7 @@ func Test_unixListener_Close(t *testing.T) {
 
 func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
 	t.Parallel()
-	//nolint:usetesting // short path needed for Unix socket limit
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := tempSocketDir(t)
 	path := filepath.Join(dir, "stale.sock")
 
 	// Create a stale socket using syscall (macOS removes socket on net.Listener.Close).
@@ -115,10 +117,7 @@ func TestAddrConfig_Listen_UnixRemovesStaleSocket(t *testing.T) {
 
 func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
 	t.Parallel()
-	//nolint:usetesting // short path needed for Unix socket limit
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := tempSocketDir(t)
 	path := filepath.Join(dir, "regular.txt")
 	require.NoError(t, os.WriteFile(path, []byte("data"), 0o600))
 
@@ -126,51 +125,40 @@ func TestAddrConfig_Listen_UnixRefusesToRemoveNonSocket(t *testing.T) {
 		Endpoint:  path,
 		Transport: TransportTypeUnix,
 	}
-	_, err = na.Listen(context.Background())
+	_, err := na.Listen(context.Background())
 	assert.ErrorContains(t, err, "not a socket")
 }
 
 func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
 	t.Parallel()
-	//nolint:usetesting // short path needed for Unix socket limit
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "perms.sock")
-
-	na := &AddrConfig{
-		Endpoint:  path,
-		Transport: TransportTypeUnix,
+	tests := []struct {
+		name              string
+		socketPermissions os.FileMode
+		want              os.FileMode
+	}{
+		{name: "default", want: socketFileMode},
+		{name: "custom", socketPermissions: 0o700, want: 0o700},
 	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := tempSocketDir(t)
+			path := filepath.Join(dir, "perms.sock")
 
-	fi, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
-}
+			na := &AddrConfig{
+				Endpoint:          path,
+				Transport:         TransportTypeUnix,
+				SocketPermissions: tt.socketPermissions,
+			}
+			ln, err := na.Listen(context.Background())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, ln.Close()) })
 
-func TestAddrConfig_Listen_UnixSocketPermissions_Custom(t *testing.T) {
-	t.Parallel()
-	//nolint:usetesting // short path needed for Unix socket limit
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "perms.sock")
-
-	na := &AddrConfig{
-		Endpoint:          path,
-		Transport:         TransportTypeUnix,
-		SocketPermissions: 0o700,
+			fi, err := os.Stat(path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want|os.ModeSocket, fi.Mode())
+		})
 	}
-	ln, err := na.Listen(context.Background())
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, ln.Close()) })
-
-	fi, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o700)|os.ModeSocket, fi.Mode())
 }
 
 func TestAddrConfig_Listen_UnixInvalidEndpoint(t *testing.T) {
@@ -185,41 +173,25 @@ func TestAddrConfig_Listen_UnixInvalidEndpoint(t *testing.T) {
 
 func TestAddrConfig_Listen_UnixChmodFailure(t *testing.T) {
 	t.Parallel()
-	//nolint:usetesting // short path needed for Unix socket limit
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	path := filepath.Join(dir, "chmod.sock")
+	dir := tempSocketDir(t)
 
+	// Make the directory read-only so Listen succeeds at binding but Chmod
+	// fails due to permission denied.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o700))
+	subPath := filepath.Join(dir, "sub", "chmod.sock")
 	na := &AddrConfig{
-		Endpoint:  path,
+		Endpoint:  subPath,
 		Transport: TransportTypeUnix,
 	}
 	ln, err := na.Listen(context.Background())
 	require.NoError(t, err)
-
-	// Remove the socket file behind the listener's back so that the
-	// Chmod in a second Listen call fails (socket won't exist to chmod).
 	require.NoError(t, ln.Close())
-
-	// Now make the directory read-only so Listen succeeds at binding
-	// but Chmod fails due to permission denied.
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o700))
-	subPath := filepath.Join(dir, "sub", "chmod.sock")
-	na2 := &AddrConfig{
-		Endpoint:  subPath,
-		Transport: TransportTypeUnix,
-	}
-	ln2, err := na2.Listen(context.Background())
-	require.NoError(t, err)
-	// Verify listener works, then close
-	require.NoError(t, ln2.Close())
 
 	// Make dir read-only to cause Chmod failure
 	require.NoError(t, os.Chmod(filepath.Join(dir, "sub"), 0o444))       //nolint:gosec // intentional for test
 	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "sub"), 0o700) }) //nolint:gosec // restore perms for cleanup
 
-	_, err = na2.Listen(context.Background())
+	_, err = na.Listen(context.Background())
 	// On some systems this fails at Listen (can't bind), on others at Chmod.
 	// Either way it should error.
 	assert.Error(t, err)
@@ -227,10 +199,8 @@ func TestAddrConfig_Listen_UnixChmodFailure(t *testing.T) {
 
 func Test_removeStaleSocket_StatError(t *testing.T) {
 	t.Parallel()
-	//nolint:usetesting // short path needed for Unix socket limit
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700); os.RemoveAll(dir) }) //nolint:gosec // restore perms for cleanup
+	dir := tempSocketDir(t)
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) //nolint:gosec // restore perms for cleanup
 	path := filepath.Join(dir, "socket.sock")
 
 	// Create a file so the path exists.
@@ -238,16 +208,13 @@ func Test_removeStaleSocket_StatError(t *testing.T) {
 	// Remove permission on the directory so Stat fails with permission denied.
 	require.NoError(t, os.Chmod(dir, 0o000))
 
-	err = removeStaleSocket(path)
+	err := removeStaleSocket(path)
 	assert.Error(t, err)
 }
 
 func TestAddrConfig_Listen_UnixSocketCloseRemovesFile(t *testing.T) {
 	t.Parallel()
-	//nolint:usetesting // short path needed for Unix socket limit
-	dir, err := os.MkdirTemp("", "confignet-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := tempSocketDir(t)
 	path := filepath.Join(dir, "cleanup.sock")
 
 	na := &AddrConfig{

--- a/config/confignet/confignet_unix_test.go
+++ b/config/confignet/confignet_unix_test.go
@@ -151,6 +151,28 @@ func TestAddrConfig_Listen_UnixSocketPermissions(t *testing.T) {
 	assert.Equal(t, socketFileMode|os.ModeSocket, fi.Mode())
 }
 
+func TestAddrConfig_Listen_UnixSocketPermissions_Custom(t *testing.T) {
+	t.Parallel()
+	//nolint:usetesting // short path needed for Unix socket limit
+	dir, err := os.MkdirTemp("", "confignet-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "perms.sock")
+
+	na := &AddrConfig{
+		Endpoint:          path,
+		Transport:         TransportTypeUnix,
+		SocketPermissions: 0o700,
+	}
+	ln, err := na.Listen(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ln.Close()) })
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700)|os.ModeSocket, fi.Mode())
+}
+
 func TestAddrConfig_Listen_UnixInvalidEndpoint(t *testing.T) {
 	t.Parallel()
 	na := &AddrConfig{

--- a/config/confignet/generated_config.go
+++ b/config/confignet/generated_config.go
@@ -3,6 +3,7 @@
 package confignet
 
 import (
+	"os"
 	"time"
 )
 
@@ -19,6 +20,13 @@ type AddrConfig struct {
 	// The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
 	Endpoint string `mapstructure:"endpoint,omitempty"`
 
+	// SocketPermissions sets the file permissions applied to a filesystem-based Unix domain socket file
+	// after binding. Only applies to filesystem-based Unix transports ("unix", "unixgram",
+	// "unixpacket"); ignored for abstract sockets (endpoints starting with "@") and all
+	// other transports. If unset, defaults to 0722, which allows any local process to
+	// connect to the socket while only the owner can otherwise manage it.
+	SocketPermissions os.FileMode `mapstructure:"socket_permissions"`
+
 	// Transport defines the type of transport protocol used. Allowed protocols are "tcp", "tcp4" (IPv4-only),
 	// "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only),
 	// "ip6" (IPv6-only), "unix", "unixgram", "unixpacket" and "npipe" (Windows named pipes, Windows-only).
@@ -31,7 +39,8 @@ type AddrConfig struct {
 // NewDefaultAddrConfig returns a new AddrConfig with default values consistent with the annotations in the schema.
 func NewDefaultAddrConfig() AddrConfig {
 	return AddrConfig{
-		DialerConfig: NewDefaultDialerConfig(),
+		DialerConfig:      NewDefaultDialerConfig(),
+		SocketPermissions: 466,
 	}
 }
 

--- a/config/confignet/generated_config.go
+++ b/config/confignet/generated_config.go
@@ -20,6 +20,15 @@ type AddrConfig struct {
 	// The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
 	Endpoint string `mapstructure:"endpoint,omitempty"`
 
+	// SocketManagementDisabled disables all automatic lifecycle management of filesystem-based Unix domain
+	// socket files: no stale-socket removal before binding, no permission changes
+	// after binding (socket_permissions is ignored), and no cleanup on Close(). Only
+	// applies to filesystem-based Unix transports ("unix", "unixgram", "unixpacket");
+	// ignored for abstract sockets and all other transports. Use this if the socket
+	// file's lifecycle is managed externally (e.g. systemd socket activation, an init
+	// container, custom ACLs/SELinux labels).
+	SocketManagementDisabled bool `mapstructure:"socket_management_disabled,omitempty"`
+
 	// SocketPermissions sets the file permissions applied to a filesystem-based Unix domain socket file
 	// after binding. Only applies to filesystem-based Unix transports ("unix", "unixgram",
 	// "unixpacket"); ignored for abstract sockets (endpoints starting with "@") and all

--- a/config/confignet/metadata.yaml
+++ b/config/confignet/metadata.yaml
@@ -23,6 +23,16 @@ exported_configs:
           it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80".
           The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
         type: string
+      socket_management_disabled:
+        description: |
+          Disables all automatic lifecycle management of filesystem-based Unix domain
+          socket files: no stale-socket removal before binding, no permission changes
+          after binding (socket_permissions is ignored), and no cleanup on Close(). Only
+          applies to filesystem-based Unix transports ("unix", "unixgram", "unixpacket");
+          ignored for abstract sockets and all other transports. Use this if the socket
+          file's lifecycle is managed externally (e.g. systemd socket activation, an init
+          container, custom ACLs/SELinux labels).
+        type: bool
       socket_permissions:
         description: |
           Sets the file permissions applied to a filesystem-based Unix domain socket file

--- a/config/confignet/metadata.yaml
+++ b/config/confignet/metadata.yaml
@@ -16,17 +16,27 @@ exported_configs:
           field_name: DialerConfig
       endpoint:
         description: |
-          Configures the address for this network connection. For TCP and UDP networks, 
-          the address has the form "host:port". The host must be a literal IP address, 
-          or a host name that can be resolved to IP addresses. The port must 
-          be a literal port number or a service name. If the host is a literal IPv6 address 
-          it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". 
+          Configures the address for this network connection. For TCP and UDP networks,
+          the address has the form "host:port". The host must be a literal IP address,
+          or a host name that can be resolved to IP addresses. The port must
+          be a literal port number or a service name. If the host is a literal IPv6 address
+          it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80".
           The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
         type: string
+      socket_permissions:
+        description: |
+          Sets the file permissions applied to a filesystem-based Unix domain socket file
+          after binding. Only applies to filesystem-based Unix transports ("unix", "unixgram",
+          "unixpacket"); ignored for abstract sockets (endpoints starting with "@") and all
+          other transports. If unset, defaults to 0722, which allows any local process to
+          connect to the socket while only the owner can otherwise manage it.
+        type: uint32
+        x-customType: os.FileMode
+        default: 0o722
       transport:
         description: |
-          Defines the type of transport protocol used. Allowed protocols are "tcp", "tcp4" (IPv4-only), 
-          "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only), 
+          Defines the type of transport protocol used. Allowed protocols are "tcp", "tcp4" (IPv4-only),
+          "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only),
           "ip6" (IPv6-only), "unix", "unixgram", "unixpacket" and "npipe" (Windows named pipes, Windows-only).
         $ref: transport_type
   dialer_config:


### PR DESCRIPTION
#### Description

AddrConfig.Listen() now automatically manages the full lifecycle of filesystem-based Unix domain sockets:
- Removes stale socket files before binding (refuses to remove non-socket files for safety)
- Sets socket permissions to 0722 so any local process can connect
- Cleans up socket files on Close()
- Abstract sockets (@ prefix) are unaffected — they live in kernel memory and need no filesystem handling
- No configuration needed — the behavior is automatic for all Unix transport types

#### Link to tracking issue
Fixes #15189

#### Testing

- Unit tests for removeStaleSocket (nonexistent path, regular file, stale socket)
- Unit tests for isAbstractSocket helper
- Unit tests for unixListener.Close removing socket file
- Integration test: Listen succeeds despite pre-existing stale socket
- Integration test: Listen refuses to remove a non-socket file
- Integration test: socket gets 0722 permissions after Listen
- Integration test: socket file removed after Close
- All tests pass locally (go test ./... -count=1)

#### Documentation

#### Authorship

- [x] I, a human, wrote this pull request description myself.