### PR TITLE
[chore] Test all contrib exporter groups in contrib-tests

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -51,6 +51,8 @@ jobs:
           - processor
           - exporter-0
           - exporter-1
+          - exporter-2
+          - exporter-3
           - extension
           - connector
           - internal


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Contrib tests were not running against all modules since we at some point created more module sets on contrib for exproters/

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
