### PR TITLE
featuregate: reject IDs with empty dot-separated segments

### DIFF
--- a/.chloggen/featuregate-reject-empty-id-segments.yaml
+++ b/.chloggen/featuregate-reject-empty-id-segments.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pkg/featuregate
+note: Reject feature gate IDs with empty dot-separated namespace segments.
+issues: [15676]
+change_logs: [user, api]

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -19,8 +19,8 @@ var (
 	globalRegistry = NewRegistry()
 
 	// idRegexp is used to validate the ID of a Gate.
-	// IDs' characters must be alphanumeric or dots.
-	idRegexp = regexp.MustCompile(`^[0-9a-zA-Z.]*$`)
+	// IDs must contain alphanumeric segments separated by dots.
+	idRegexp = regexp.MustCompile(`^[0-9a-zA-Z]+(?:\.[0-9a-zA-Z]+)*$`)
 )
 
 // ErrAlreadyRegistered is returned when adding a Gate that is already registered.
@@ -126,7 +126,7 @@ func validateID(id string) error {
 }
 
 // Register a Gate and return it. The returned Gate can be used to check if is enabled or not.
-// id must be an ASCII alphanumeric nonempty string. Dots are allowed for namespacing.
+// id must contain nonempty ASCII alphanumeric segments separated by dots.
 func (r *Registry) Register(id string, stage Stage, opts ...RegisterOption) (*Gate, error) {
 	if err := validateID(id); err != nil {
 		return nil, fmt.Errorf("invalid ID %q: %w", id, err)

--- a/featuregate/registry_test.go
+++ b/featuregate/registry_test.go
@@ -153,6 +153,24 @@ func TestRegisterGateLifecycle(t *testing.T) {
 			shouldErr: true,
 		},
 		{
+			name:      "Invalid gate name with leading dot",
+			id:        ".invalid.gate.name",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid gate name with trailing dot",
+			id:        "invalid.gate.name.",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid gate name with consecutive dots",
+			id:        "invalid..gate.name",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
 			name:      "Invalid empty gate",
 			id:        "",
 			stage:     StageAlpha,


### PR DESCRIPTION
#### Description

validateID previously accepted malformed feature-gate IDs with leading, trailing, or consecutive dots (e.g. .foo, foo., foo..bar). These IDs are now rejected so each dot-separated segment must be non-empty.

#### Link to tracking issue

Fixes #15676

#### Testing

- C:\Program Files\Go\bin\go.exe test . in featuregate - passed

#### Documentation

Not needed.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
