### PR TITLE
[chore][internal/e2e] Wait for the collector to be running in TestInternalTelemetry_ServiceInstanceID

### DIFF
--- a/internal/e2e/internal_telemetry_test.go
+++ b/internal/e2e/internal_telemetry_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -163,9 +164,16 @@ service:
 			require.NoError(t, err)
 
 			// Start collector
+			runErr := make(chan error, 1)
 			go func() {
-				assert.NoError(t, collector.Run(t.Context()))
+				runErr <- collector.Run(context.Background())
 			}()
+			t.Cleanup(func() {
+				collector.Shutdown()
+				require.NoError(t, <-runErr, "collector stopped with an error")
+			})
+
+			waitCollectorRunning(t, collector)
 			waitMetricsReady(t, metricsPort)
 
 			// Send some data through the pipeline to trigger internal telemetry

--- a/internal/e2e/internal_telemetry_test.go
+++ b/internal/e2e/internal_telemetry_test.go
@@ -163,9 +163,11 @@ service:
 			require.NoError(t, err)
 
 			// Start collector
+			runErr := make(chan error, 1)
 			go func() {
-				assert.NoError(t, collector.Run(t.Context()))
+				runErr <- collector.Run(t.Context())
 			}()
+			waitCollectorRunning(t, collector, runErr)
 			waitMetricsReady(t, metricsPort)
 
 			// Send some data through the pipeline to trigger internal telemetry

--- a/internal/e2e/metric_stability_test.go
+++ b/internal/e2e/metric_stability_test.go
@@ -213,12 +213,11 @@ func testMetricStability(t *testing.T, configFile string, expectedMetrics map[st
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	runErr := make(chan error, 1)
 	go func() {
-		err := collector.Run(ctx)
-		if err != nil {
-			t.Logf("Collector stopped with error: %v", err)
-		}
+		runErr <- collector.Run(ctx)
 	}()
+	waitCollectorRunning(t, collector, runErr)
 	waitMetricsReady(t, metricsPort)
 
 	for range 5 {
@@ -347,6 +346,24 @@ func getFreePort(t *testing.T) string {
 	}
 	defer l.Close()
 	return strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
+}
+
+// waitCollectorRunning blocks until the collector reports StateRunning, i.e. until
+// every pipeline component has started. The telemetry endpoint is served from
+// service.New, before service.Start launches the receivers, so waiting on /metrics
+// alone can return while the OTLP receiver is not yet listening.
+func waitCollectorRunning(t *testing.T, collector *otelcol.Collector, runErr <-chan error) {
+	t.Helper()
+	timeout := time.After(30 * time.Second)
+	for collector.GetState() != otelcol.StateRunning {
+		select {
+		case err := <-runErr:
+			require.FailNow(t, "collector stopped before it finished starting", "%v", err)
+		case <-timeout:
+			require.FailNow(t, "collector did not reach the running state", "last state: %v", collector.GetState())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
 }
 
 func waitMetricsReady(t *testing.T, metricsPort string) {


### PR DESCRIPTION
#### Description

#15717 fixed this readiness bug in `TestMetricStability`: the telemetry `/metrics` endpoint comes up in `service.New` ([`service.go:194`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/service/service.go#L194)), while the OTLP receiver only binds later in `service.Start` -> `Pipelines.StartAll`. A successful scrape of `/metrics` therefore does not mean the collector can receive data, and a test that treats it that way can send into a port nothing is listening on yet.

That fix left the same pattern in `TestInternalTelemetry_ServiceInstanceID`, which still went straight from a `collector.Run` goroutine into `waitMetricsReady`.

This applies the same fix to that test, reusing the `waitCollectorRunning` helper #15717 added, and surfaces a startup failure through a channel instead of asserting from a goroutine that can outlive the test (which panics with `Log in goroutine after test has completed` and would mask the real error).

#### Link to tracking issue

Related to #15492.

#### Testing

The flake does not reproduce naturally on a developer machine — the window is 0-2 ms locally. Lowering the `waitMetricsReady` tick from `100*time.Millisecond` to `time.Nanosecond` opens the same window a slow CI runner does:

- before this change: fails 10/10 runs, both subtests, with `connect: connection refused` at `internal_telemetry_test.go:180`
- after this change: 10/10 pass, including under `-race`

Since the only mutation is the `waitCollectorRunning` line, that guard is what the test is measuring.

At the unmodified tick, `go test -race -count=3 ./...` and `make -C internal/e2e lint` are both clean.

#### Documentation

None. Test-only change.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
