### PR TITLE
[zpages] Avoid embedding ServerConfig

### DIFF
--- a/.chloggen/zpages-named-serverconfig.yaml
+++ b/.chloggen/zpages-named-serverconfig.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: extension/zpages
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make `confighttp.ServerConfig` a named field of `Config` instead of an embedded one.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15308]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/extension/zpagesextension/config.go
+++ b/extension/zpagesextension/config.go
@@ -12,7 +12,7 @@ import (
 
 // Config has the configuration for the extension enabling the zPages extension.
 type Config struct {
-	confighttp.ServerConfig `mapstructure:",squash"`
+	ServerConfig confighttp.ServerConfig `mapstructure:",squash"`
 
 	Expvar ExpvarConfig `mapstructure:"expvar"`
 	// prevent unkeyed literal initialization
@@ -32,7 +32,7 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks if the extension configuration is valid
 func (cfg *Config) Validate() error {
-	if cfg.NetAddr.Endpoint == "" {
+	if cfg.ServerConfig.NetAddr.Endpoint == "" {
 		return errors.New("\"endpoint\" is required when using the \"zpages\" extension")
 	}
 	return nil

--- a/extension/zpagesextension/config_test.go
+++ b/extension/zpagesextension/config_test.go
@@ -38,3 +38,18 @@ func TestUnmarshalConfig(t *testing.T) {
 
 	assert.Equal(t, &Config{ServerConfig: expectedServerConfig}, cfg)
 }
+
+// Fields declared next to the squashed ServerConfig must still be decoded.
+func TestUnmarshalConfigWithExpvar(t *testing.T) {
+	cm := confmap.NewFromStringMap(map[string]any{
+		"endpoint": "localhost:56888",
+		"expvar":   map[string]any{"enabled": true},
+	})
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	require.NoError(t, cm.Unmarshal(&cfg))
+
+	zCfg := cfg.(*Config)
+	assert.Equal(t, "localhost:56888", zCfg.ServerConfig.NetAddr.Endpoint)
+	assert.True(t, zCfg.Expvar.Enabled)
+}

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -33,7 +33,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 
 func TestFactoryCreate(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.ServerConfig.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := extensiontest.NewNopSettings(extensiontest.NopType)
 	set.ID = component.NewID(NewFactory().Type())

--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -86,13 +86,13 @@ func (zpe *zpagesExtension) Start(ctx context.Context, host component.Host) erro
 
 	// Start the listener here so we can have earlier failure if port is
 	// already in use.
-	ln, err := zpe.config.ToListener(ctx)
+	ln, err := zpe.config.ServerConfig.ToListener(ctx)
 	if err != nil {
 		return err
 	}
 
 	zpe.telemetry.Logger.Info("Starting zPages extension", zap.Any("config", zpe.config))
-	zpe.server, err = zpe.config.ToServer(ctx, host.GetExtensions(), zpe.telemetry, zPagesMux)
+	zpe.server, err = zpe.config.ServerConfig.ToServer(ctx, host.GetExtensions(), zpe.telemetry, zPagesMux)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Avoids embedding `ServerConfig` on zpages configuration. Part of #15308

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
