### PR TITLE
[confighttp] Unembed `configauth.Config`

### DIFF
--- a/.chloggen/confighttp-auth-named-config.yaml
+++ b/.chloggen/confighttp-auth-named-config.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make `configauth.Config` a named field of `AuthConfig` instead of an embedded one.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15308]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/config/confighttp/server.go
+++ b/config/confighttp/server.go
@@ -126,7 +126,7 @@ func NewDefaultServerConfig() ServerConfig {
 
 type AuthConfig struct {
 	// Auth for this receiver.
-	configauth.Config `mapstructure:",squash"`
+	Config configauth.Config `mapstructure:",squash"`
 
 	// RequestParameters is a list of parameters that should be extracted from the request and added to the context.
 	// When a parameter is found in both the query string and the header, the value from the query string will be used.
@@ -236,7 +236,7 @@ func (sc *ServerConfig) ToServer(ctx context.Context, extensions map[component.I
 		}
 
 		auth := sc.Auth.Get()
-		server, err := auth.GetServerAuthenticator(ctx, extensions)
+		server, err := auth.Config.GetServerAuthenticator(ctx, extensions)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Stops embedding `configauth.Config`

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
