### PR TITLE
[chore][cmd/mdatagen] Keep omitempty attribute on fields with zero-value defaults

### DIFF
--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -105,10 +105,15 @@ func NewCfgFns(rootPackage, componentPackage string) map[string]any {
 				return !prop.Embed
 			})
 		},
-		"isRequired": func(md *ConfigMetadata, propName string) bool {
-			return slices.Contains(md.Required, propName)
+		"isRequired": isRequired,
+		"shouldOmitEmpty": func(md *ConfigMetadata, propName string, prop *ConfigMetadata) bool {
+			return !isRequired(md, propName) && !hasNonZeroDefault(prop)
 		},
 	}
+}
+
+func isRequired(md *ConfigMetadata, propName string) bool {
+	return slices.Contains(md.Required, propName)
 }
 
 // ExternalDefaultCall returns the Go expression that delegates to the upstream package's
@@ -697,6 +702,22 @@ func hasDefaultValue(md *ConfigMetadata) bool {
 	}
 	for _, prop := range md.Properties {
 		if hasDefaultValue(prop) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNonZeroDefault(md *ConfigMetadata) bool {
+	if !md.GoStruct.IgnoreDefault && md.Default != nil {
+		m, isMap := md.Default.(map[string]any)
+		// empty map {} is the zero value
+		if !isMap || len(m) > 0 {
+			return true
+		}
+	}
+	for _, prop := range md.Properties {
+		if hasNonZeroDefault(prop) {
 			return true
 		}
 	}

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -1273,6 +1273,8 @@ func TestWithCfgFns(t *testing.T) {
 	require.Contains(t, result, "hasDefaultValue")
 	require.Contains(t, result, "publicType")
 	require.Contains(t, result, "camelVar")
+	require.Contains(t, result, "isRequired")
+	require.Contains(t, result, "shouldOmitEmpty")
 }
 
 func TestResolveGoType_CustomTypeFormatError(t *testing.T) {
@@ -2703,6 +2705,55 @@ func TestHasDefaultValue(t *testing.T) {
 		Type: "object",
 		Ref:  "go.opentelemetry.io/collector/config/confighttp.ClientConfig",
 	}))
+}
+
+func TestHasNonZeroDefault(t *testing.T) {
+	require.False(t, hasNonZeroDefault(&ConfigMetadata{Type: "object"}))
+	require.True(t, hasNonZeroDefault(&ConfigMetadata{Type: "string", Default: defaultValue("value")}))
+	// A default of the Go zero value should not count as a non-zero default.
+	require.False(t, hasNonZeroDefault(&ConfigMetadata{Type: "object", Default: defaultValue(map[string]any{})}))
+	require.True(t, hasNonZeroDefault(&ConfigMetadata{Type: "object", Default: defaultValue(map[string]any{"enabled": true})}))
+	// GoStruct.IgnoreDefault means the default is not surfaced, but nested properties are still checked.
+	require.False(t, hasNonZeroDefault(&ConfigMetadata{
+		Type:     "string",
+		Default:  defaultValue("value"),
+		GoStruct: GoStructConfig{IgnoreDefault: true},
+	}))
+	require.True(t, hasNonZeroDefault(&ConfigMetadata{
+		Type: "object",
+		Properties: map[string]*ConfigMetadata{
+			"timeout": {Type: "string", GoType: "time.Duration", Default: defaultValue("30s")},
+		},
+	}))
+	require.False(t, hasNonZeroDefault(&ConfigMetadata{
+		Type: "object",
+		Properties: map[string]*ConfigMetadata{
+			"base": {Type: "object", Default: defaultValue(map[string]any{})},
+		},
+	}))
+}
+
+func TestIsRequired(t *testing.T) {
+	md := &ConfigMetadata{Required: []string{"endpoint", "timeout"}}
+
+	require.True(t, isRequired(md, "endpoint"))
+	require.True(t, isRequired(md, "timeout"))
+	require.False(t, isRequired(md, "optional_field"))
+	require.False(t, isRequired(&ConfigMetadata{}, "endpoint"))
+}
+
+func TestNewCfgFns_ShouldOmitEmpty(t *testing.T) {
+	fns := NewCfgFns("", "")
+	shouldOmitEmpty := fns["shouldOmitEmpty"].(func(*ConfigMetadata, string, *ConfigMetadata) bool)
+
+	md := &ConfigMetadata{Required: []string{"endpoint"}}
+
+	// Required fields never get omitempty, even with a non-zero default.
+	require.False(t, shouldOmitEmpty(md, "endpoint", &ConfigMetadata{Type: "string", Default: defaultValue("localhost")}))
+	// Optional fields with a non-zero default don't need omitempty either.
+	require.False(t, shouldOmitEmpty(md, "timeout", &ConfigMetadata{Type: "string", Default: defaultValue("30s")}))
+	// Optional fields without a non-zero default get omitempty.
+	require.True(t, shouldOmitEmpty(md, "timeout", &ConfigMetadata{Type: "string"}))
 }
 
 func TestMapCustomDefaults_NestedObjectOverrides(t *testing.T) {

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -32,8 +32,7 @@ import (
         {{- if $prop.Description }}
             // {{ $prop.Description }}
         {{- end }}
-        {{- $omitempty := and (not (isRequired . $propName)) (not (hasDefaultValue $prop)) }}
-        {{ $prop.GoStruct.FieldName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}{{ if $omitempty }},omitempty{{ end }}"`
+        {{ $prop.GoStruct.FieldName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}{{ if shouldOmitEmpty . $propName $prop }},omitempty{{ end }}"`
     {{- end }}
     // prevent unkeyed literal initialization
     _ struct{}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Update `mdatagen` config generation so `mapstructure` tags add `omitempty` only for optional fields without a non-zero default. They introduce shared helpers for required-field checks and non-zero default detection, including empty-map defaults and ignored defaults.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tests were added for the new helpers and template function wiring.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
