### PR TITLE
[scraperhelper] Use {record} unit for log and profile record metrics

### DIFF
--- a/.chloggen/scraperhelper-log-record-unit.yaml
+++ b/.chloggen/scraperhelper-log-record-unit.yaml
@@ -4,7 +4,7 @@ component: pkg/scraperhelper
 
 note: Use `{record}` instead of `{datapoint}` as the unit of the log record and profile record scraper metrics
 
-issues: []
+issues: [15730]
 
 subtext: |
   Affects `otelcol_scraper_scraped_log_records`, `otelcol_scraper_errored_log_records`,

--- a/.chloggen/scraperhelper-log-record-unit.yaml
+++ b/.chloggen/scraperhelper-log-record-unit.yaml
@@ -1,0 +1,13 @@
+change_type: bug_fix
+
+component: pkg/scraperhelper
+
+note: Use `{record}` instead of `{datapoint}` as the unit of the log record and profile record scraper metrics
+
+issues: []
+
+subtext: |
+  Affects `otelcol_scraper_scraped_log_records`, `otelcol_scraper_errored_log_records`,
+  `otelcol_scraper_scraped_profile_records` and `otelcol_scraper_errored_profile_records`.
+
+change_logs: [user]

--- a/scraper/scraperhelper/documentation.md
+++ b/scraper/scraperhelper/documentation.md
@@ -12,7 +12,7 @@ Number of log records that were unable to be scraped.
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
-| {datapoint} | Sum | Int | true | Alpha |
+| {record} | Sum | Int | true | Alpha |
 
 ### otelcol_scraper_errored_metric_points
 
@@ -28,7 +28,7 @@ Number of log records successfully scraped.
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
-| {datapoint} | Sum | Int | true | Alpha |
+| {record} | Sum | Int | true | Alpha |
 
 ### otelcol_scraper_scraped_metric_points
 

--- a/scraper/scraperhelper/internal/metadata/generated_telemetry.go
+++ b/scraper/scraperhelper/internal/metadata/generated_telemetry.go
@@ -64,7 +64,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.ScraperErroredLogRecords, err = builder.meter.Int64Counter(
 		"otelcol_scraper_errored_log_records",
 		metric.WithDescription("Number of log records that were unable to be scraped. [Alpha]"),
-		metric.WithUnit("{datapoint}"),
+		metric.WithUnit("{record}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ScraperErroredMetricPoints, err = builder.meter.Int64Counter(
@@ -76,7 +76,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.ScraperScrapedLogRecords, err = builder.meter.Int64Counter(
 		"otelcol_scraper_scraped_log_records",
 		metric.WithDescription("Number of log records successfully scraped. [Alpha]"),
-		metric.WithUnit("{datapoint}"),
+		metric.WithUnit("{record}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ScraperScrapedMetricPoints, err = builder.meter.Int64Counter(

--- a/scraper/scraperhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/scraper/scraperhelper/internal/metadatatest/generated_telemetrytest.go
@@ -16,7 +16,7 @@ func AssertEqualScraperErroredLogRecords(t *testing.T, tt *componenttest.Telemet
 	want := metricdata.Metrics{
 		Name:        "otelcol_scraper_errored_log_records",
 		Description: "Number of log records that were unable to be scraped. [Alpha]",
-		Unit:        "{datapoint}",
+		Unit:        "{record}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
 			IsMonotonic: true,
@@ -48,7 +48,7 @@ func AssertEqualScraperScrapedLogRecords(t *testing.T, tt *componenttest.Telemet
 	want := metricdata.Metrics{
 		Name:        "otelcol_scraper_scraped_log_records",
 		Description: "Number of log records successfully scraped. [Alpha]",
-		Unit:        "{datapoint}",
+		Unit:        "{record}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
 			IsMonotonic: true,

--- a/scraper/scraperhelper/metadata.yaml
+++ b/scraper/scraperhelper/metadata.yaml
@@ -17,7 +17,7 @@ telemetry:
       enabled: true
       stability: alpha
       description: Number of log records that were unable to be scraped.
-      unit: "{datapoint}"
+      unit: "{record}"
       sum:
         value_type: int
         monotonic: true
@@ -35,7 +35,7 @@ telemetry:
       enabled: true
       stability: alpha
       description: Number of log records successfully scraped.
-      unit: "{datapoint}"
+      unit: "{record}"
       sum:
         value_type: int
         monotonic: true

--- a/scraper/scraperhelper/xscraperhelper/documentation.md
+++ b/scraper/scraperhelper/xscraperhelper/documentation.md
@@ -12,7 +12,7 @@ Number of profile records that were unable to be scraped.
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
-| {datapoint} | Sum | Int | true | Alpha |
+| {record} | Sum | Int | true | Alpha |
 
 ### otelcol_scraper_scraped_profile_records
 
@@ -20,4 +20,4 @@ Number of profile records successfully scraped.
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
-| {datapoint} | Sum | Int | true | Alpha |
+| {record} | Sum | Int | true | Alpha |

--- a/scraper/scraperhelper/xscraperhelper/internal/metadata/generated_telemetry.go
+++ b/scraper/scraperhelper/xscraperhelper/internal/metadata/generated_telemetry.go
@@ -62,13 +62,13 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.ScraperErroredProfileRecords, err = builder.meter.Int64Counter(
 		"otelcol_scraper_errored_profile_records",
 		metric.WithDescription("Number of profile records that were unable to be scraped. [Alpha]"),
-		metric.WithUnit("{datapoint}"),
+		metric.WithUnit("{record}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ScraperScrapedProfileRecords, err = builder.meter.Int64Counter(
 		"otelcol_scraper_scraped_profile_records",
 		metric.WithDescription("Number of profile records successfully scraped. [Alpha]"),
-		metric.WithUnit("{datapoint}"),
+		metric.WithUnit("{record}"),
 	)
 	errs = errors.Join(errs, err)
 	return &builder, errs

--- a/scraper/scraperhelper/xscraperhelper/internal/metadatatest/generated_telemetrytest.go
+++ b/scraper/scraperhelper/xscraperhelper/internal/metadatatest/generated_telemetrytest.go
@@ -16,7 +16,7 @@ func AssertEqualScraperErroredProfileRecords(t *testing.T, tt *componenttest.Tel
 	want := metricdata.Metrics{
 		Name:        "otelcol_scraper_errored_profile_records",
 		Description: "Number of profile records that were unable to be scraped. [Alpha]",
-		Unit:        "{datapoint}",
+		Unit:        "{record}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
 			IsMonotonic: true,
@@ -32,7 +32,7 @@ func AssertEqualScraperScrapedProfileRecords(t *testing.T, tt *componenttest.Tel
 	want := metricdata.Metrics{
 		Name:        "otelcol_scraper_scraped_profile_records",
 		Description: "Number of profile records successfully scraped. [Alpha]",
-		Unit:        "{datapoint}",
+		Unit:        "{record}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
 			IsMonotonic: true,

--- a/scraper/scraperhelper/xscraperhelper/metadata.yaml
+++ b/scraper/scraperhelper/xscraperhelper/metadata.yaml
@@ -16,7 +16,7 @@ telemetry:
       enabled: true
       stability: alpha
       description: Number of profile records that were unable to be scraped.
-      unit: "{datapoint}"
+      unit: "{record}"
       sum:
         value_type: int
         monotonic: true
@@ -25,7 +25,7 @@ telemetry:
       enabled: true
       stability: alpha
       description: Number of profile records successfully scraped.
-      unit: "{datapoint}"
+      unit: "{record}"
       sum:
         value_type: int
         monotonic: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Correct units for scraper metrics.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
