### PR TITLE
[chore] Fix flaky Prometheus port collision in otelconftelemetry tests

### DIFF
--- a/service/telemetry/otelconftelemetry/metrics_test.go
+++ b/service/telemetry/otelconftelemetry/metrics_test.go
@@ -205,6 +205,9 @@ func TestCreateMeterProvider_020MigrationWarning(t *testing.T) {
 
 	cfg := createDefaultConfig().(*Config)
 	cfg.Metrics.MigratedFromV02 = true
+	cfg.Metrics.Readers = []config.MetricReader{{
+		Pull: &config.PullMetricReader{Exporter: config.PullMetricExporter{Prometheus: promtest.GetAvailableLocalAddressPrometheus(t)}},
+	}}
 
 	resource, err := createResource(t.Context(), telemetry.Settings{}, cfg)
 	require.NoError(t, err)
@@ -229,6 +232,9 @@ func TestCreateMeterProvider_NoMigrationWarning(t *testing.T) {
 	core, observedLogs := observer.New(zapcore.DebugLevel)
 
 	cfg := createDefaultConfig().(*Config)
+	cfg.Metrics.Readers = []config.MetricReader{{
+		Pull: &config.PullMetricReader{Exporter: config.PullMetricExporter{Prometheus: promtest.GetAvailableLocalAddressPrometheus(t)}},
+	}}
 
 	resource, err := createResource(t.Context(), telemetry.Settings{}, cfg)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Uses new port for internal telemetry on each test to avoid flakiness because of port collision.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
