### PR TITLE
[chore][cmd/mdatagen] Handle subpackage metadata.yaml in config generator

### DIFF
--- a/cmd/mdatagen/internal/command.go
+++ b/cmd/mdatagen/internal/command.go
@@ -715,7 +715,10 @@ func generateConfigFiles(md Metadata, mdDir, importRootPath string) error {
 
 func generateJSONSchema(dir string, md Metadata) error {
 	id := md.PackageName
-	title := fmt.Sprintf("%s/%s", md.Status.Class, md.Type)
+	title := md.Type
+	if md.Status != nil {
+		title = fmt.Sprintf("%s/%s", md.Status.Class, md.Type)
+	}
 	return cfggen.WriteJSONSchema(dir, id, title, md.ConfigsMetadata)
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR fixes issue with running config generator on subpackage (`metadata.yaml` with `parent` defined but without `status`), but properly building schema title.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
