### PR TITLE
fix(mdatagen): handle single-element and empty enum attributes in test value generation

### DIFF
--- a/.chloggen/mdatagen-enum-panic.yaml
+++ b/.chloggen/mdatagen-enum-panic.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: cmd/mdatagen
+note: Fix panic in Attribute.TestValue() and TestValueTwo() when handling single-element or empty enum attributes.
+issues: [15644]

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -706,7 +706,7 @@ func (a Attribute) Name() AttributeName {
 }
 
 func (a Attribute) TestValue() string {
-	if a.Enum != nil {
+	if len(a.Enum) > 0 {
 		return fmt.Sprintf(`%q`, a.Enum[0])
 	}
 	switch a.Type.ValueType {
@@ -731,8 +731,11 @@ func (a Attribute) TestValue() string {
 }
 
 func (a Attribute) TestValueTwo() string {
-	if a.Enum != nil {
+	if len(a.Enum) > 1 {
 		return fmt.Sprintf(`%q`, a.Enum[1])
+	}
+	if len(a.Enum) == 1 {
+		return fmt.Sprintf(`%q`, a.Enum[0])
 	}
 	switch a.Type.ValueType {
 	case pcommon.ValueTypeEmpty:

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/cmd/mdatagen/internal/cfggen"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/internal/schemagen"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -1133,4 +1134,26 @@ func TestValidateConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAttributeTestValueEnum(t *testing.T) {
+	strAttr := Attribute{FullName: "mode", Type: ValueType{ValueType: pcommon.ValueTypeStr}}
+	emptyEnum := Attribute{FullName: "mode", Enum: []string{}, Type: ValueType{ValueType: pcommon.ValueTypeStr}}
+	singleEnum := Attribute{FullName: "mode", Enum: []string{"default"}, Type: ValueType{ValueType: pcommon.ValueTypeStr}}
+	doubleEnum := Attribute{FullName: "mode", Enum: []string{"default", "custom"}, Type: ValueType{ValueType: pcommon.ValueTypeStr}}
+
+	// TestValue returns the first enum value, or the type-based value when the
+	// enum is empty.
+	assert.Equal(t, `"mode-val"`, strAttr.TestValue())
+	assert.Equal(t, `"mode-val"`, emptyEnum.TestValue(), "empty enum should fall back to the type-based value")
+	assert.Equal(t, `"default"`, singleEnum.TestValue())
+	assert.Equal(t, `"default"`, doubleEnum.TestValue())
+
+	// TestValueTwo returns the second enum value when available, the only
+	// value for a single-element enum, or the type-based value when the enum
+	// is empty.
+	assert.Equal(t, `"mode-val-2"`, strAttr.TestValueTwo())
+	assert.Equal(t, `"mode-val-2"`, emptyEnum.TestValueTwo(), "empty enum should fall back to the type-based value")
+	assert.Equal(t, `"default"`, singleEnum.TestValueTwo(), "single-element enum uses its only value as the second value")
+	assert.Equal(t, `"custom"`, doubleEnum.TestValueTwo())
 }


### PR DESCRIPTION
#### Description

fix(mdatagen): handle single-element and empty enum attributes in test value generation

`cmd/mdatagen` panicked with an index-out-of-range error when generating
code for an attribute configured with a single-element enum
 or an empty enum slice in `metadata.yaml`:

- `Attribute.TestValue()` indexed `a.Enum[0]` without a length check
- `Attribute.TestValueTwo()` indexed `a.Enum[1]` whenever the enum was
  non-nil

Both now fall back safely:
- `TestValue()` returns `Enum[0]` when the enum has ≥1 element, otherwise
  the type-based test value
- `TestValueTwo()` returns `Enum[1]` when available, the only value for a
  single-element enum (matching the existing `getAttributeValueTwo` template
  behavior), otherwise the type-based test value

#### Link to tracking issue

Fixes #15644

#### Testing

Added `TestAttributeTestValueEnum` covering empty, single-element, and
two-element enums plus a non-enum string attribute; ran `go test ./cmd/mdatagen/`
and `go vet`.

#### Documentation

Changelog entry added in `.chloggen/mdatagen-enum-panic.yaml`.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
