### PR TITLE
fix(batch): preserve metric metadata when splitting a metric

### DIFF
--- a/.chloggen/batchprocessor-split-metric-metadata.yaml
+++ b/.chloggen/batchprocessor-split-metric-metadata.yaml
@@ -4,7 +4,7 @@ component: processor/batch
 
 note: Preserve metric metadata when a metric is split across a `send_batch_max_size` boundary
 
-issues: []
+issues: [15744]
 
 subtext: |
   `splitMetric` rebuilt the destination metric from its name, description and unit only, dropping

--- a/.chloggen/batchprocessor-split-metric-metadata.yaml
+++ b/.chloggen/batchprocessor-split-metric-metadata.yaml
@@ -1,0 +1,15 @@
+change_type: bug_fix
+
+component: processor/batch
+
+note: Preserve metric metadata when a metric is split across a `send_batch_max_size` boundary
+
+issues: []
+
+subtext: |
+  `splitMetric` rebuilt the destination metric from its name, description and unit only, dropping
+  `Metric.Metadata()`. A metric whose data point count exceeded the space left in the batch lost its
+  metadata on every chunk except the trailing remainder, which is moved rather than rebuilt. This
+  silently discarded the `prometheus.type` metadata set by the Prometheus receiver.
+
+change_logs: [user]

--- a/processor/batchprocessor/splitmetrics.go
+++ b/processor/batchprocessor/splitmetrics.go
@@ -120,6 +120,7 @@ func splitMetric(ms, dest pmetric.Metric, size int) (int, bool) {
 	dest.SetName(ms.Name())
 	dest.SetDescription(ms.Description())
 	dest.SetUnit(ms.Unit())
+	ms.Metadata().CopyTo(dest.Metadata())
 
 	switch ms.Type() {
 	case pmetric.MetricTypeGauge:

--- a/processor/batchprocessor/splitmetrics_test.go
+++ b/processor/batchprocessor/splitmetrics_test.go
@@ -329,3 +329,21 @@ func TestSplitMetricsPreserveSchemaURLOnPartialSplit(t *testing.T) {
 	assert.Equal(t, resourceSchemaURL, split.ResourceMetrics().At(0).SchemaUrl())
 	assert.Equal(t, scopeSchemaURL, split.ResourceMetrics().At(0).ScopeMetrics().At(0).SchemaUrl())
 }
+
+func TestSplitMetricsPreserveMetadataOnPartialSplit(t *testing.T) {
+	md := testdata.GenerateMetrics(1)
+	metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	metric.Metadata().PutStr("prometheus.type", "gauge")
+
+	// splitSize is below the metric's data point count, so the metric is split
+	// into a new one instead of being moved as a whole.
+	splitSize := 1
+	assert.Greater(t, metricDPC(metric), splitSize)
+
+	split := splitMetrics(splitSize, md)
+
+	splitMetric := split.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	assert.Equal(t, map[string]any{"prometheus.type": "gauge"}, splitMetric.Metadata().AsRaw())
+	// The data points left behind in the source keep their metadata too.
+	assert.Equal(t, map[string]any{"prometheus.type": "gauge"}, metric.Metadata().AsRaw())
+}


### PR DESCRIPTION
**Description**

splitMetric sets name, description and unit on the destination metric but never copies Metric.Metadata(). A metric with more datapoints than the space left in the batch is rebuilt this way and loses its metadata; metrics that fit are moved via MoveTo and are unaffected.
Net effect: **prometheus.type** from the Prometheus receiver is silently dropped on high-cardinality metrics. 

**Testing**
Added test which validates metric metadata is preserved when a metric is split. 


**Authorship**
- [x] I, a human, wrote this pull request description myself.