### PR TITLE
[confmap] Remove dead isStringyStructure and add regression test

### DIFF
--- a/.chloggen/remove-dead-isstringystructure.yaml
+++ b/.chloggen/remove-dead-isstringystructure.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove dead `isStringyStructure` helper (unused since #14413/#14617/#15339) and its orphaned test from `confmap/internal`, and add a regression test for the decoding scenario it used to guard.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12793]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This is an internal, unexported code path with no user-facing behavior change.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/confmap/internal/confmap_test.go
+++ b/confmap/internal/confmap_test.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -1104,58 +1103,35 @@ func TestSubExpandedValue(t *testing.T) {
 	assert.Nil(t, cm.Get("key::subkey::subsubkey"))
 }
 
-func TestStringyTypes(t *testing.T) {
-	tests := []struct {
-		valueOfType any
-		isStringy   bool
-	}{
-		{
-			valueOfType: "string",
-			isStringy:   true,
-		},
-		{
-			valueOfType: 1,
-			isStringy:   false,
-		},
-		{
-			valueOfType: map[string]any{},
-			isStringy:   false,
-		},
-		{
-			valueOfType: []any{},
-			isStringy:   false,
-		},
-		{
-			valueOfType: map[string]string{},
-			isStringy:   true,
-		},
-		{
-			valueOfType: []string{},
-			isStringy:   true,
-		},
-		{
-			valueOfType: map[string][]string{},
-			isStringy:   true,
-		},
-		{
-			valueOfType: map[string]map[string]string{},
-			isStringy:   true,
-		},
-		{
-			valueOfType: []map[string]any{},
-			isStringy:   false,
-		},
-		{
-			valueOfType: []map[string]string{},
-			isStringy:   true,
-		},
+// TestExpandedValueInStructSlice reproduces
+// https://github.com/open-telemetry/opentelemetry-collector/issues/12793,
+// where a numerically-valued environment variable expanded into a string field
+// nested inside a slice of structs failed to decode.
+func TestExpandedValueInStructSlice(t *testing.T) {
+	type Header struct {
+		Key          string `mapstructure:"key"`
+		DefaultValue string `mapstructure:"default_value"`
+	}
+	type Config struct {
+		Headers []Header `mapstructure:"headers"`
 	}
 
-	for _, tt := range tests {
-		// Create a reflect.Type from the value
-		to := reflect.TypeOf(tt.valueOfType)
-		assert.Equal(t, tt.isStringy, isStringyStructure(to))
-	}
+	cm := NewFromStringMap(map[string]any{
+		"headers": []any{
+			map[string]any{
+				"key": "X-SF-TOKEN",
+				"default_value": ExpandedValue{
+					Value:    12345,
+					Original: "12345",
+				},
+			},
+		},
+	})
+
+	cfg := Config{}
+	require.NoError(t, cm.Unmarshal(&cfg))
+	require.Len(t, cfg.Headers, 1)
+	assert.Equal(t, "12345", cfg.Headers[0].DefaultValue)
 }
 
 func TestConfDelete(t *testing.T) {

--- a/confmap/internal/decoder.go
+++ b/confmap/internal/decoder.go
@@ -406,19 +406,3 @@ func castTo(exp ExpandedValue, useOriginal bool) any {
 	// Otherwise, use the parsed value (previous behavior).
 	return exp.Value
 }
-
-// Check if a reflect.Type is of the form T, where:
-// X is any type or interface
-// T = string | map[X]T | []T | [n]T
-func isStringyStructure(t reflect.Type) bool {
-	if t.Kind() == reflect.String {
-		return true
-	}
-	if t.Kind() == reflect.Map {
-		return isStringyStructure(t.Elem())
-	}
-	if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
-		return isStringyStructure(t.Elem())
-	}
-	return false
-}


### PR DESCRIPTION
#### Description

The bug reported in the tracking issue (a slice of structs with a plain
`string` field failing to decode when an env var expands to a value that
parses as a number, e.g. `SPLUNK_ACCESS_TOKEN=12345`) was already fixed on
`main` by prior work (#14413, #14617, #15339), which changed `useExpandValue()`
to check each target field's own type directly instead of relying on an
upfront structural walk via `isStringyStructure()`.

That stabilization work removed the code path that called
`isStringyStructure()`, but left the function itself behind in
`confmap/internal/decoder.go` with no remaining callers outside of its own
dedicated unit test. This PR removes that dead code and its orphaned test,
and adds a regression test that reproduces the exact scenario from the
tracking issue to guard against future regressions.

This is a dead-code cleanup and test-coverage addition, not a behavioral bug
fix — the underlying bug was already resolved before this change.

#### Link to tracking issue
Fixes #

#### Testing

Ran, from `confmap/`: `go build ./...`, `go vet ./...`, and `go test ./...`
(all packages, including `confmap/internal`) — all passed. Separately ran
`go test ./...` in `confmap/internal/e2e` (its own `go.mod`) — passed.

Before making any edits, confirmed via a throwaway reproduction test that the
original issue's scenario (slice of struct, plain string field, numeric-valued
expanded env var) already decodes correctly on `main`, proving the underlying
bug is fixed and this change is purely cleanup plus regression coverage. Also
confirmed via `grep` across the whole repository that `isStringyStructure` has
no remaining callers after removal.

Added `TestExpandedValueInStructSlice` in `confmap/internal/confmap_test.go`,
which reproduces the tracking issue's exact scenario and fails without the
fix already present on `main` (i.e. it would have caught the original bug had
it existed before #14413/#14617/#15339).

#### Documentation

No documentation changes — this is an internal, unexported code path with no
user-facing behavior change.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->

---
AI assistance: this change was drafted with Claude Code.

Fixes #12793