### PR TITLE
[chore][cmd/mdatagen] fix confmap import in resource test generation template

### DIFF
--- a/cmd/mdatagen/internal/templates/resource_test.go.tmpl
+++ b/cmd/mdatagen/internal/templates/resource_test.go.tmpl
@@ -9,7 +9,7 @@ import (
 	{{- if .OverrideValueEnabled }}
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/confmap/xconfmap"
+	"go.opentelemetry.io/collector/confmap"
 	{{- end }}
 )
 


### PR DESCRIPTION
### Description

#### The Bug
The template to generate `resource_test.go` files is currently hardcoded to import from `go.opentelemetry.io/confmap/xconfmap`, but recently, all references in this file were changed from `xconfmap` to `confmap` (see: https://github.com/open-telemetry/opentelemetry-collector/pull/15618).

On contrib, this is causing an issue while developing components with `override_value_enabled: true`. Their generated tests currently use the correct `confmap` import (Otelbot [automatically updated them](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49809/changes#diff-b04954c2f1ae32692ebea806ba15c308d03de440158ea1a54abe247ff8ea09fbL10-R10)), but running `make mdatagen` reverts it back to to the old `xconfmap`, causing compilation errors.

#### Steps for Reproduction
1. On contrib, Run `make mdatagen` against `receiver/sqlserverreceiver`, `oracledbreceiver`, `mysqlreceiver` or `postgresqlreceiver`
2. Run `make tidy && make gci`

Result: In `generated_resource_test.go`, the import `go.opentelemetry.io/collector/confmap` reverts to `go.opentelemetry.io/collector/xconfmap`, causing an `import not used` error.

Alternatively, you can run `mdatagen` against its own `samplescraper` and observe the import change.

#### The Fix
This PR updates the import in the template.

### Link to tracking issue
Tangentially related to https://github.com/open-telemetry/opentelemetry-collector/pull/15613

### Testing
1. Installed this version of mdatagen using `go install`
2. Against `sqlserverreceiver` and other components, ran `make mdatagen MDATAGEN=<local_binary>` and `make tidy && make gci`
3. Observed import no longer reverts

### Authorship

- [x] I, a human, wrote this pull request description myself.
