### PR TITLE
config/confighttp: preserve zone when parsing client IPv6 address

### DIFF
--- a/.chloggen/fix-14545-ipv6-zone-parseip.yaml
+++ b/.chloggen/fix-14545-ipv6-zone-parseip.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: pkg/confighttp
+
+note: Fix `parseIP` to correctly populate `client.Info.Addr` for link-local IPv6 addresses that include a zone identifier (e.g. `fe80::1%eth0`), which `net.ParseIP` cannot parse.
+
+issues: [14545]
+
+subtext:
+
+change_logs: []

--- a/config/confighttp/client_test.go
+++ b/config/confighttp/client_test.go
@@ -613,7 +613,7 @@ func TestContextWithClient(t *testing.T) {
 			},
 			expected: client.Info{
 				Addr: &net.IPAddr{
-					IP: net.IPv4(1, 2, 3, 4),
+					IP: net.IPv4(1, 2, 3, 4).To4(),
 				},
 			},
 		},

--- a/config/confighttp/clientinfohandler.go
+++ b/config/confighttp/clientinfohandler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"net/netip"
 
 	"go.opentelemetry.io/collector/client"
 )
@@ -51,16 +52,14 @@ func contextWithClient(req *http.Request, includeMetadata bool) context.Context 
 
 // parseIP parses the given string for an IP address. The input string might contain the port,
 // but must not contain a protocol or path. Suitable for getting the IP part of a client connection.
+// It supports IPv6 addresses with a zone identifier (e.g. "fe80::1%eth0"), which net.ParseIP does
+// not.
 func parseIP(source string) *net.IPAddr {
-	ipstr, _, err := net.SplitHostPort(source)
-	if err == nil {
-		source = ipstr
+	if addrPort, err := netip.ParseAddrPort(source); err == nil {
+		return &net.IPAddr{IP: addrPort.Addr().AsSlice(), Zone: addrPort.Addr().Zone()}
 	}
-	ip := net.ParseIP(source)
-	if ip != nil {
-		return &net.IPAddr{
-			IP: ip,
-		}
+	if addr, err := netip.ParseAddr(source); err == nil {
+		return &net.IPAddr{IP: addr.AsSlice(), Zone: addr.Zone()}
 	}
 	return nil
 }

--- a/config/confighttp/clientinfohandler_test.go
+++ b/config/confighttp/clientinfohandler_test.go
@@ -23,14 +23,14 @@ func TestParseIP(t *testing.T) {
 			name:  "addr",
 			input: "1.2.3.4",
 			expected: &net.IPAddr{
-				IP: net.IPv4(1, 2, 3, 4),
+				IP: net.IPv4(1, 2, 3, 4).To4(),
 			},
 		},
 		{
 			name:  "addr:port",
 			input: "1.2.3.4:33455",
 			expected: &net.IPAddr{
-				IP: net.IPv4(1, 2, 3, 4),
+				IP: net.IPv4(1, 2, 3, 4).To4(),
 			},
 		},
 		{
@@ -42,6 +42,29 @@ func TestParseIP(t *testing.T) {
 			name:     "addr/path",
 			input:    "1.2.3.4/orders",
 			expected: nil,
+		},
+		{
+			name:  "ipv6 addr with zone",
+			input: "fe80::1%eth0",
+			expected: &net.IPAddr{
+				IP:   net.ParseIP("fe80::1"),
+				Zone: "eth0",
+			},
+		},
+		{
+			name:  "ipv6 addr with zone and port",
+			input: "[fe80::1%eth0]:33455",
+			expected: &net.IPAddr{
+				IP:   net.ParseIP("fe80::1"),
+				Zone: "eth0",
+			},
+		},
+		{
+			name:  "ipv6 addr without zone",
+			input: "::1",
+			expected: &net.IPAddr{
+				IP: net.ParseIP("::1"),
+			},
 		},
 	}
 	for _, tt := range testCases {


### PR DESCRIPTION
#### Description

`parseIP` in `config/confighttp/clientinfohandler.go` used `net.ParseIP`, which does not
understand the zone identifier on a link-local IPv6 address (e.g. `fe80::1%eth0`). For clients
connecting from such an address, parsing silently failed and `client.Info.Addr` was left `nil`
for the rest of the pipeline.

This replaces `net.SplitHostPort` + `net.ParseIP` with `netip.ParseAddrPort` (tried first,
handles `host:port`, including bracketed IPv6 with a zone) falling back to `netip.ParseAddr`
(handles a bare host with no port). Both paths build the returned `*net.IPAddr` from
`addr.AsSlice()` and `addr.Zone()`, so the zone is now preserved.

Note this changes the byte representation of parsed IPv4 addresses: `netip.Addr.AsSlice()` for
IPv4 returns a 4-byte slice, whereas the previous `net.ParseIP`-based code returned a 16-byte
IPv4-in-IPv6 mapped slice. Existing tests for plain IPv4 inputs were updated accordingly
(`net.IPv4(1,2,3,4).To4()`). `client.Info.Addr` is exposed as the `net.Addr` interface, and no
other code in the repository was found asserting it to `*net.IPAddr` and depending on the
16-byte form.

#### Link to tracking issue
Fixes #14545

#### Testing

- `go build ./...` and `go test ./...` in `config/confighttp` pass.
- Added `TestParseIP` cases for a bare zoned IPv6 address (`fe80::1%eth0`), a zoned IPv6 address
  with a port (`[fe80::1%eth0]:33455`), and an unzoned IPv6 address (`::1`). Verified these fail
  with a nil `*net.IPAddr` against the pre-change code and pass after this change.
- `golangci-lint run ./...` in `config/confighttp` reports two pre-existing gosec findings
  unrelated to this change (verified present identically on unmodified main); no new lint
  findings.
- `make chlog-validate` passes.

#### Documentation

Added a `.chloggen` bug_fix entry describing the fix.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

---
AI assistance: this change was drafted with Claude Code.