### PR TITLE
Add capability to waitForResult per request in sending_queue

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -22,6 +22,7 @@ The following configuration options can be modified:
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`
   - `wait_for_result` (default = false): determines if incoming requests are blocked until the request is processed or not.
+  - `wait_for_result_metadata_key` (default = ""): optional `client.Metadata` key used to wait for the result on a per-request basis when `wait_for_result` is false. A request waits only if the metadata value parses as true (for example `true` or `1`). When `wait_for_result` is true, all requests wait and this key is ignored. The receiver must enable `include_metadata` so request headers are available. Not supported with a persistent queue (`storage`).
   - `block_on_overflow` (default = false): If true, blocks the request until the queue has space otherwise rejects the data immediately; ignored if `enabled` is `false`
   - `sizer` (default = requests): How the queue and batching is measured. Available options:
     - `requests`: number of incoming batches of metrics, logs, traces (the most performant option);

--- a/exporter/exporterhelper/internal/queue/memory_queue.go
+++ b/exporter/exporterhelper/internal/queue/memory_queue.go
@@ -6,8 +6,10 @@ package queue // import "go.opentelemetry.io/collector/exporter/exporterhelper/i
 import (
 	"context"
 	"errors"
+	"strconv"
 	"sync"
 
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 )
@@ -32,26 +34,28 @@ type memoryQueue[T request.Request] struct {
 	sizer      request.Sizer
 	cap        int64
 
-	mu              sync.Mutex
-	hasMoreElements *sync.Cond
-	hasMoreSpace    *cond
-	items           *linkedQueue[T]
-	size            int64
-	stopped         bool
-	waitForResult   bool
-	blockOnOverflow bool
+	mu                       sync.Mutex
+	hasMoreElements          *sync.Cond
+	hasMoreSpace             *cond
+	items                    *linkedQueue[T]
+	size                     int64
+	stopped                  bool
+	waitForResult            bool
+	waitForResultMetadataKey string
+	blockOnOverflow          bool
 }
 
 // newMemoryQueue creates a sized elements channel. Each element is assigned a size by the provided sizer.
 // capacity is the capacity of the queue.
 func newMemoryQueue[T request.Request](set Settings[T]) readableQueue[T] {
 	sq := &memoryQueue[T]{
-		refCounter:      set.ReferenceCounter,
-		sizer:           request.NewSizer(set.SizerType),
-		cap:             set.Capacity,
-		items:           &linkedQueue[T]{},
-		waitForResult:   set.WaitForResult,
-		blockOnOverflow: set.BlockOnOverflow,
+		refCounter:               set.ReferenceCounter,
+		sizer:                    request.NewSizer(set.SizerType),
+		cap:                      set.Capacity,
+		items:                    &linkedQueue[T]{},
+		waitForResult:            set.WaitForResult,
+		waitForResultMetadataKey: set.WaitForResultMetadataKey,
+		blockOnOverflow:          set.BlockOnOverflow,
 	}
 	sq.hasMoreElements = sync.NewCond(&sq.mu)
 	sq.hasMoreSpace = newCond(&sq.mu)
@@ -89,7 +93,7 @@ func (mq *memoryQueue[T]) Offer(ctx context.Context, el T) error {
 		return err
 	}
 
-	if mq.waitForResult {
+	if done.waitForResult {
 		// Only re-add the blockingDone instance back to the pool if successfully received the
 		// message from the consumer which guarantees consumer will not use that anymore,
 		// otherwise no guarantee about when the consumer will add the message to the channel so cannot reuse or close.
@@ -102,6 +106,21 @@ func (mq *memoryQueue[T]) Offer(ctx context.Context, el T) error {
 		}
 	}
 	return nil
+}
+
+func (mq *memoryQueue[T]) shouldWaitForResult(ctx context.Context) bool {
+	if mq.waitForResult {
+		return true
+	}
+	if mq.waitForResultMetadataKey == "" {
+		return false
+	}
+	vals := client.FromContext(ctx).Metadata.Get(mq.waitForResultMetadataKey)
+	if len(vals) == 0 {
+		return false
+	}
+	wait, err := strconv.ParseBool(vals[0])
+	return err == nil && wait
 }
 
 func (mq *memoryQueue[T]) add(ctx context.Context, el T, elSize int64) (*blockingDone, error) {
@@ -119,10 +138,11 @@ func (mq *memoryQueue[T]) add(ctx context.Context, el T, elSize int64) (*blockin
 	}
 
 	mq.size += elSize
+	wait := mq.shouldWaitForResult(ctx)
 	done := blockingDonePool.Get().(*blockingDone)
-	done.reset(elSize, mq)
+	done.reset(elSize, mq, wait)
 
-	if !mq.waitForResult {
+	if !wait {
 		// Prevent cancellation and deadline to propagate to the context stored in the queue.
 		// The grpc/http based receivers will cancel the request context after this function returns.
 		ctx = context.WithoutCancel(ctx)
@@ -163,7 +183,7 @@ func (mq *memoryQueue[T]) onDone(bd *blockingDone, err error) {
 	defer mq.mu.Unlock()
 	mq.size -= bd.elSize
 	mq.hasMoreSpace.Signal()
-	if mq.waitForResult {
+	if bd.waitForResult {
 		// In this case the done will be added back to the queue by the waiter.
 		bd.ch <- err
 		return
@@ -233,13 +253,15 @@ type blockingDone struct {
 	queue interface {
 		onDone(*blockingDone, error)
 	}
-	elSize int64
-	ch     chan error
+	elSize        int64
+	ch            chan error
+	waitForResult bool
 }
 
-func (bd *blockingDone) reset(elSize int64, queue interface{ onDone(*blockingDone, error) }) {
+func (bd *blockingDone) reset(elSize int64, queue interface{ onDone(*blockingDone, error) }, waitForResult bool) {
 	bd.elSize = elSize
 	bd.queue = queue
+	bd.waitForResult = waitForResult
 }
 
 func (bd *blockingDone) OnDone(err error) {

--- a/exporter/exporterhelper/internal/queue/memory_queue_test.go
+++ b/exporter/exporterhelper/internal/queue/memory_queue_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 )
@@ -201,6 +202,88 @@ func TestMemoryQueueWaitForResultSizeAndCapacity(t *testing.T) {
 	close(stop)
 	require.NoError(t, q.Shutdown(context.Background()))
 	wg.Wait()
+}
+
+func TestMemoryQueueWaitForResultMetadataKey(t *testing.T) {
+	const metaKey = "x-wait-for-result"
+	myErr := errors.New("test error")
+
+	set := newSettings(request.SizerTypeItems, 100)
+	set.WaitForResultMetadataKey = metaKey
+	q := newMemoryQueue[intRequest](set)
+	require.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, q.Shutdown(context.Background()))
+	})
+
+	t.Run("metadata true waits and returns error", func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Go(func() {
+			_, req, done, ok := q.Read(context.Background())
+			assert.True(t, ok)
+			assert.EqualValues(t, 1, req)
+			done.OnDone(myErr)
+		})
+		ctx := client.NewContext(context.Background(), client.Info{
+			Metadata: client.NewMetadata(map[string][]string{metaKey: {"true"}}),
+		})
+		require.ErrorIs(t, q.Offer(ctx, intRequest(1)), myErr)
+		wg.Wait()
+	})
+
+	t.Run("metadata false does not wait", func(t *testing.T) {
+		consumed := make(chan struct{})
+		wg := sync.WaitGroup{}
+		wg.Go(func() {
+			_, req, done, ok := q.Read(context.Background())
+			assert.True(t, ok)
+			assert.EqualValues(t, 2, req)
+			done.OnDone(myErr)
+			close(consumed)
+		})
+		ctx := client.NewContext(context.Background(), client.Info{
+			Metadata: client.NewMetadata(map[string][]string{metaKey: {"false"}}),
+		})
+		require.NoError(t, q.Offer(ctx, intRequest(2)))
+		<-consumed
+		wg.Wait()
+	})
+
+	t.Run("missing metadata does not wait", func(t *testing.T) {
+		consumed := make(chan struct{})
+		wg := sync.WaitGroup{}
+		wg.Go(func() {
+			_, req, done, ok := q.Read(context.Background())
+			assert.True(t, ok)
+			assert.EqualValues(t, 3, req)
+			done.OnDone(myErr)
+			close(consumed)
+		})
+		require.NoError(t, q.Offer(context.Background(), intRequest(3)))
+		<-consumed
+		wg.Wait()
+	})
+
+	t.Run("wait_for_result overrides missing metadata", func(t *testing.T) {
+		setAlways := newSettings(request.SizerTypeItems, 100)
+		setAlways.WaitForResult = true
+		setAlways.WaitForResultMetadataKey = metaKey
+		qAlways := newMemoryQueue[intRequest](setAlways)
+		require.NoError(t, qAlways.Start(context.Background(), componenttest.NewNopHost()))
+		t.Cleanup(func() {
+			require.NoError(t, qAlways.Shutdown(context.Background()))
+		})
+
+		wg := sync.WaitGroup{}
+		wg.Go(func() {
+			_, req, done, ok := qAlways.Read(context.Background())
+			assert.True(t, ok)
+			assert.EqualValues(t, 4, req)
+			done.OnDone(myErr)
+		})
+		require.ErrorIs(t, qAlways.Offer(context.Background(), intRequest(4)), myErr)
+		wg.Wait()
+	})
 }
 
 func BenchmarkMemoryQueueWaitForResult(b *testing.B) {

--- a/exporter/exporterhelper/internal/queue/queue.go
+++ b/exporter/exporterhelper/internal/queue/queue.go
@@ -65,17 +65,18 @@ type Queue[T any] interface {
 
 // Settings define internal parameters for a new Queue creation.
 type Settings[T request.Request] struct {
-	SizerType        request.SizerType
-	Capacity         int64
-	NumConsumers     int
-	WaitForResult    bool
-	BlockOnOverflow  bool
-	Signal           pipeline.Signal
-	StorageID        *component.ID
-	ReferenceCounter ReferenceCounter[T]
-	Encoding         Encoding[T]
-	ID               component.ID
-	Telemetry        component.TelemetrySettings
+	SizerType                request.SizerType
+	Capacity                 int64
+	NumConsumers             int
+	WaitForResult            bool
+	WaitForResultMetadataKey string
+	BlockOnOverflow          bool
+	Signal                   pipeline.Signal
+	StorageID                *component.ID
+	ReferenceCounter         ReferenceCounter[T]
+	Encoding                 Encoding[T]
+	ID                       component.ID
+	Telemetry                component.TelemetrySettings
 }
 
 func NewQueue[T request.Request](set Settings[T], next ConsumeFunc[T]) (Queue[T], error) {

--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -21,6 +21,13 @@ type Config struct {
 	// Currently, this option is not available when persistent queue is configured using the storage configuration.
 	WaitForResult bool `mapstructure:"wait_for_result"`
 
+	// WaitForResultMetadataKey is a client.Metadata key used to decide per request whether to wait
+	// for the result. When WaitForResult is false and this key is set, a request waits only if the
+	// metadata value parses as true (e.g. "true" or "1"). When WaitForResult is true, all requests
+	// wait and this key is ignored. Requires the receiver to enable include_metadata so headers are
+	// propagated. Not available with a persistent queue configured using storage.
+	WaitForResultMetadataKey string `mapstructure:"wait_for_result_metadata_key"`
+
 	// Sizer determines the type of size measurement used by this component.
 	// It accepts "requests", "items", or "bytes".
 	Sizer request.SizerType `mapstructure:"sizer"`
@@ -76,6 +83,9 @@ func (cfg *Config) Validate() error {
 	// Only support request sizer for persistent queue at this moment.
 	if cfg.StorageID != nil && cfg.WaitForResult {
 		return errors.New("`wait_for_result` is not supported with a persistent queue configured with `storage`")
+	}
+	if cfg.StorageID != nil && cfg.WaitForResultMetadataKey != "" {
+		return errors.New("`wait_for_result_metadata_key` is not supported with a persistent queue configured with `storage`")
 	}
 
 	if cfg.Batch.HasValue() && cfg.Batch.Get().Sizer == cfg.Sizer {

--- a/exporter/exporterhelper/internal/queuebatch/config.schema.yaml
+++ b/exporter/exporterhelper/internal/queuebatch/config.schema.yaml
@@ -65,3 +65,6 @@ $defs:
       wait_for_result:
         description: WaitForResult determines if incoming requests are blocked until the request is processed or not. Currently, this option is not available when persistent queue is configured using the storage configuration.
         type: boolean
+      wait_for_result_metadata_key:
+        description: WaitForResultMetadataKey is a client.Metadata key used to decide per request whether to wait for the result. When wait_for_result is false and this key is set, a request waits only if the metadata value parses as true (e.g. "true" or "1"). When wait_for_result is true, all requests wait and this key is ignored. Requires the receiver to enable include_metadata. Not available with a persistent queue configured using storage.
+        type: string

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -40,6 +40,15 @@ func TestConfig_Validate(t *testing.T) {
 	require.EqualError(t, confmap.Validate(cfg), "`wait_for_result` is not supported with a persistent queue configured with `storage`")
 
 	cfg = newTestConfig()
+	cfg.WaitForResultMetadataKey = "x-wait-for-result"
+	cfg.StorageID = &storageID
+	require.EqualError(t, confmap.Validate(cfg), "`wait_for_result_metadata_key` is not supported with a persistent queue configured with `storage`")
+
+	cfg = newTestConfig()
+	cfg.WaitForResultMetadataKey = "x-wait-for-result"
+	require.NoError(t, confmap.Validate(cfg))
+
+	cfg = newTestConfig()
 	cfg.QueueSize = cfg.Batch.Get().MinSize - 1
 	require.EqualError(t, confmap.Validate(cfg), "`min_size` must be less than or equal to `queue_size`")
 

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch.go
@@ -57,17 +57,18 @@ func NewQueueBatch(
 	}
 
 	q, err := queue.NewQueue(queue.Settings[request.Request]{
-		SizerType:        cfg.Sizer,
-		Capacity:         cfg.QueueSize,
-		NumConsumers:     cfg.NumConsumers,
-		WaitForResult:    cfg.WaitForResult,
-		BlockOnOverflow:  cfg.BlockOnOverflow,
-		Signal:           set.Signal,
-		StorageID:        cfg.StorageID,
-		ReferenceCounter: set.ReferenceCounter,
-		Encoding:         set.Encoding,
-		ID:               set.ID,
-		Telemetry:        set.Telemetry,
+		SizerType:                cfg.Sizer,
+		Capacity:                 cfg.QueueSize,
+		NumConsumers:             cfg.NumConsumers,
+		WaitForResult:            cfg.WaitForResult,
+		WaitForResultMetadataKey: cfg.WaitForResultMetadataKey,
+		BlockOnOverflow:          cfg.BlockOnOverflow,
+		Signal:                   set.Signal,
+		StorageID:                cfg.StorageID,
+		ReferenceCounter:         set.ReferenceCounter,
+		Encoding:                 set.Encoding,
+		ID:                       set.ID,
+		Telemetry:                set.Telemetry,
 	}, b.Consume)
 	if err != nil {
 		return nil, err

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
@@ -472,6 +473,56 @@ func TestQueueBatch_Shutdown(t *testing.T) {
 	// shutdown should force sending the batch
 	assert.Equal(t, 1, sink.RequestsCount())
 	assert.Equal(t, 3, sink.ItemsCount())
+}
+
+func TestQueueBatch_WaitForResultMetadataKey(t *testing.T) {
+	const metaKey = "x-wait-for-result"
+	cfg := newTestConfig()
+	cfg.WaitForResult = false
+	cfg.WaitForResultMetadataKey = metaKey
+	cfg.Batch = configoptional.Optional[BatchConfig]{}
+
+	t.Run("metadata true blocks until export finishes", func(t *testing.T) {
+		sink := requesttest.NewSink()
+		qb, err := NewQueueBatch(newFakeRequestSettings(), cfg, sink.Export)
+		require.NoError(t, err)
+		require.NoError(t, qb.Start(context.Background(), componenttest.NewNopHost()))
+		t.Cleanup(func() {
+			require.NoError(t, qb.Shutdown(context.Background()))
+		})
+
+		ctx := client.NewContext(context.Background(), client.Info{
+			Metadata: client.NewMetadata(map[string][]string{metaKey: {"true"}}),
+		})
+		require.NoError(t, qb.Send(ctx, &requesttest.FakeRequest{Items: 1, Delay: 20 * time.Millisecond}))
+		assert.Equal(t, 1, sink.RequestsCount())
+		assert.Equal(t, 1, sink.ItemsCount())
+	})
+
+	t.Run("metadata false returns before export finishes", func(t *testing.T) {
+		exportDone := make(chan struct{})
+		export := func(context.Context, request.Request) error {
+			time.Sleep(50 * time.Millisecond)
+			close(exportDone)
+			return nil
+		}
+		qb, err := NewQueueBatch(newFakeRequestSettings(), cfg, export)
+		require.NoError(t, err)
+		require.NoError(t, qb.Start(context.Background(), componenttest.NewNopHost()))
+		t.Cleanup(func() {
+			require.NoError(t, qb.Shutdown(context.Background()))
+		})
+
+		ctx := client.NewContext(context.Background(), client.Info{
+			Metadata: client.NewMetadata(map[string][]string{metaKey: {"false"}}),
+		})
+		require.NoError(t, qb.Send(ctx, &requesttest.FakeRequest{Items: 1}))
+		select {
+		case <-exportDone:
+			t.Fatal("Send should return before export completes when metadata is false")
+		default:
+		}
+	})
 }
 
 func TestQueueBatch_BatchBlocking(t *testing.T) {

--- a/processor/queuebatchprocessor/README.md
+++ b/processor/queuebatchprocessor/README.md
@@ -40,6 +40,10 @@ block_on_overflow: true
 # or failure.
 wait_for_result: false
 
+# Optional: wait only when this client.Metadata key parses as true.
+# Requires the receiver to enable include_metadata.
+# wait_for_result_metadata_key: x-wait-for-result
+
 # These defaults match both batchprocessor and exporterhelper.
 batch: 
   enabled: true
@@ -126,7 +130,7 @@ service:
 
 When `storage` is set there is no in-memory queue. Each request is
 serialized as it enters the queue and read back from disk before
-export. The `wait_for_result` setting is not supported together with
-`storage`.
+export. The `wait_for_result` and `wait_for_result_metadata_key`
+settings are not supported together with `storage`.
 
 [filestorage]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adding a capability to sending queue where we can block the caller what caller wants explicit result of request. We right not have way to to that by using blocking queue but it makes full queue blocking but my requirement is to block few requests and non block others. And the requests I want to block comes from callers how sends grpc request which a special header key. 

want to get feedback on high level and once looks fine I will create issue and changelog.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
