### PR TITLE
[chore] Add `freebsd/amd64` and `solaris/amd64` to cross-compile

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -282,6 +282,8 @@ jobs:
             goarch: amd64
           - goos: darwin
             goarch: arm64
+          - goos: freebsd
+            goarch: amd64
           - goos: js
             goarch: wasm
           - goos: linux
@@ -299,6 +301,8 @@ jobs:
             goarm: 7
           - goos: linux
             goarch: s390x
+          - goos: solaris
+            goarch: amd64
           - goos: windows
             goarch: 386
           - goos: windows


### PR DESCRIPTION
Initial steps to add `freebsd/amd64` and `solaris/amd64` to tier-3 support, per:

- https://github.com/open-telemetry/opentelemetry-collector/issues/15781
- https://github.com/open-telemetry/opentelemetry-collector/issues/15782

