### PR TITLE
[pdata/pprofile] Use the ProfilesDictionary for attributes in OTLP http export requests

### DIFF
--- a/.chloggen/pprofile-inline-attribute-keys.yaml
+++ b/.chloggen/pprofile-inline-attribute-keys.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/pprofile
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Stop erasing inline attribute keys when key_strindex is unset, and clear key_strindex once it is resolved.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15793]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/pprofileotlp-dictionary-references.yaml
+++ b/.chloggen/pprofileotlp-dictionary-references.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/pprofile
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reference resource and scope attribute strings via the ProfilesDictionary string table when marshaling and unmarshaling OTLP profiles export requests.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15792]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.github/workflows/utils/cspell.json
+++ b/.github/workflows/utils/cspell.json
@@ -484,6 +484,7 @@
       "stdlib",
       "stencel",
       "stretchr",
+      "strindex",
       "subcomponent",
       "subcomponents",
       "subpackages",

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -199,7 +199,7 @@ func createProfiles(
 	return xexporterhelper.NewProfiles(ctx, set, cfg,
 		oce.pushProfiles,
 		exporterhelper.WithStart(oce.start),
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetryConfig),

--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -37,8 +37,9 @@ func resolveProfilesReferences(profiles Profiles) {
 func resolveKeyValueReferences(dict ProfilesDictionary, kvs []internal.KeyValue) {
 	for i := range kvs {
 		kv := &kvs[i]
-		// Resolve key_strindex if set
-		if kv.KeyStrindex > 0 {
+		// Resolve key_strindex if set. Guard against illegal input where both
+		// KeyStrindex and Key are set by only resolving when Key is empty.
+		if kv.KeyStrindex > 0 && kv.Key == "" {
 			idx := int(kv.KeyStrindex)
 			if idx < dict.StringTable().Len() {
 				kv.Key = dict.StringTable().At(idx)

--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -37,14 +37,12 @@ func resolveProfilesReferences(profiles Profiles) {
 func resolveKeyValueReferences(dict ProfilesDictionary, kvs []internal.KeyValue) {
 	for i := range kvs {
 		kv := &kvs[i]
-		// Resolve key_ref if set
-		if kv.KeyStrindex >= 0 {
+		// Resolve key_strindex if set
+		if kv.KeyStrindex > 0 {
 			idx := int(kv.KeyStrindex)
 			if idx < dict.StringTable().Len() {
 				kv.Key = dict.StringTable().At(idx)
-				// N.b. keep KeyStrindex set to optimize re-marshaling. This is
-				// technically a violation of the proto spec, but acceptable
-				// for the in-memory pdata API since keys are immutable.
+				kv.KeyStrindex = 0
 			}
 		}
 		// Resolve string_value_ref if set
@@ -87,6 +85,10 @@ func convertProfilesToReferences(profiles Profiles) {
 	var stringIndex map[string]int32
 	getStringIndex := func(s string) int32 {
 		if stringIndex == nil {
+			// Ensure that the sentinel string is present.
+			if stringTable.Len() == 0 {
+				stringTable.Append("")
+			}
 			stringIndex = make(map[string]int32, stringTable.Len())
 			for i := 0; i < stringTable.Len(); i++ {
 				stringIndex[stringTable.At(i)] = int32(i)

--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -86,10 +86,6 @@ func convertProfilesToReferences(profiles Profiles) {
 	var stringIndex map[string]int32
 	getStringIndex := func(s string) int32 {
 		if stringIndex == nil {
-			// Ensure that the sentinel string is present.
-			if stringTable.Len() == 0 {
-				stringTable.Append("")
-			}
 			stringIndex = make(map[string]int32, stringTable.Len())
 			for i := 0; i < stringTable.Len(); i++ {
 				stringIndex[stringTable.At(i)] = int32(i)

--- a/pdata/pprofile/dictionary_helpers_test.go
+++ b/pdata/pprofile/dictionary_helpers_test.go
@@ -102,6 +102,29 @@ func TestResolveProfilesReferencesInvalidIndices(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestResolveProfilesReferencesWithBothKeyAndKeyStrindex(t *testing.T) {
+	profiles := NewProfiles()
+	dict := profiles.Dictionary()
+	dict.StringTable().Append("") // index 0
+	dict.StringTable().Append("other-key")
+
+	rp := profiles.ResourceProfiles().AppendEmpty()
+	attrs := rp.Resource().Attributes()
+
+	// key and key_strindex are mutually exclusive per the proto spec: this is
+	// illegal input, but must not silently clobber the already-set inline key.
+	mapOrig := internal.GetMapOrig(internal.MapWrapper(attrs))
+	*mapOrig = append(*mapOrig, internal.KeyValue{
+		Key:         "inline-key",
+		KeyStrindex: 1, // references "other-key"
+	})
+
+	resolveProfilesReferences(profiles)
+
+	kv := &(*mapOrig)[0]
+	assert.Equal(t, "inline-key", kv.Key, "inline key must not be overwritten by key_strindex")
+}
+
 func TestResolveAnyValueReferenceWithPooling(t *testing.T) {
 	// Test with pooling enabled
 	prevPooling := metadata.PdataUseProtoPoolingFeatureGate.IsEnabled()

--- a/pdata/pprofile/dictionary_helpers_test.go
+++ b/pdata/pprofile/dictionary_helpers_test.go
@@ -242,7 +242,7 @@ func TestConvertProfilesToReferencesEmpty(t *testing.T) {
 func TestConvertProfilesToReferencesDeduplication(t *testing.T) {
 	profiles := NewProfiles()
 	dict := profiles.Dictionary()
-	// No sentinel appended: interning must seed index 0 itself.
+	dict.StringTable().Append("")
 
 	rp := profiles.ResourceProfiles().AppendEmpty()
 	rp.Resource().Attributes().PutStr("key1", "duplicated-value")

--- a/pdata/pprofile/dictionary_helpers_test.go
+++ b/pdata/pprofile/dictionary_helpers_test.go
@@ -21,6 +21,23 @@ func TestResolveProfilesReferencesEmpty(t *testing.T) {
 	assert.Equal(t, 0, profiles.ResourceProfiles().Len())
 }
 
+func TestResolveProfilesReferencesWithInlineKey(t *testing.T) {
+	profiles := NewProfiles()
+	profiles.Dictionary().StringTable().Append("") // index 0 is the required sentinel, not a key reference
+
+	attrs := profiles.ResourceProfiles().AppendEmpty().Resource().Attributes()
+	attrs.PutStr("service.name", "checkout")
+
+	kvs := internal.GetMapOrig(internal.MapWrapper(attrs))
+	require.Len(t, *kvs, 1)
+	require.Zero(t, (*kvs)[0].KeyStrindex)
+
+	resolveProfilesReferences(profiles)
+
+	assert.Equal(t, "service.name", (*kvs)[0].Key,
+		"an unset key_strindex must not replace an inline key with string_table[0]")
+}
+
 func TestResolveProfilesReferencesWithKeyRef(t *testing.T) {
 	profiles := NewProfiles()
 	dict := profiles.Dictionary()
@@ -202,7 +219,7 @@ func TestConvertProfilesToReferencesEmpty(t *testing.T) {
 func TestConvertProfilesToReferencesDeduplication(t *testing.T) {
 	profiles := NewProfiles()
 	dict := profiles.Dictionary()
-	dict.StringTable().Append("")
+	// No sentinel appended: interning must seed index 0 itself.
 
 	rp := profiles.ResourceProfiles().AppendEmpty()
 	rp.Resource().Attributes().PutStr("key1", "duplicated-value")

--- a/pdata/pprofile/pb.go
+++ b/pdata/pprofile/pb.go
@@ -3,6 +3,8 @@
 
 package pprofile // import "go.opentelemetry.io/collector/pdata/pprofile"
 
+import "go.opentelemetry.io/collector/pdata/internal/otlp"
+
 var _ MarshalSizer = (*ProtoMarshaler)(nil)
 
 type ProtoMarshaler struct{}
@@ -52,6 +54,7 @@ func (d *ProtoUnmarshaler) UnmarshalProfiles(buf []byte) (Profiles, error) {
 	if err != nil {
 		return Profiles{}, err
 	}
+	otlp.MigrateProfiles(pd.getOrig().ResourceProfiles)
 
 	// Resolve all string_value_ref and key_ref to their actual strings
 	// so the pdata API works transparently

--- a/pdata/pprofile/pb_test.go
+++ b/pdata/pprofile/pb_test.go
@@ -21,8 +21,8 @@ func TestProfilesProtoWireCompatibility(t *testing.T) {
 	// this repository are wire compatible.
 
 	// Generate Profiles as pdata struct.
-	td := generateTestProfiles()
-
+	td := generateProfiles(t, 1, 1, 1, 100)
+	td.MarkReadOnly()
 	// Marshal its underlying ProtoBuf to wire.
 	marshaler := &ProtoMarshaler{}
 	wire1, err := marshaler.MarshalProfiles(td)
@@ -45,18 +45,22 @@ func TestProfilesProtoWireCompatibility(t *testing.T) {
 	td2, err = unmarshaler.UnmarshalProfiles(wire2)
 	require.NoError(t, err)
 
-	// After unmarshal, td2 will have resolved references (strings instead of string_value_ref/key_ref)
-	// while td may have references. Marshal td2 again to verify wire compatibility.
-	wire3, err := marshaler.MarshalProfiles(td2)
-	require.NoError(t, err)
+	// Now compare that the original and final ProtoBuf messages are the same.
+	// This proves that goproto and gogoproto marshaling/unmarshaling are wire compatible.
+	requireProfilesEqualIgnoringAppendedStrings(t, td, td2)
+}
 
-	// Verify full round-trip fidelity: unmarshal both wire1 and wire3 into goproto
-	// messages and compare them semantically. This ensures all data (attributes,
-	// dictionary, profiles, etc.) survives the round-trip through both libraries.
-	var check1, check2 gootlpprofiles.ProfilesData
-	require.NoError(t, goproto.Unmarshal(wire1, &check1))
-	require.NoError(t, goproto.Unmarshal(wire3, &check2))
-	assert.True(t, goproto.Equal(&check1, &check2), "round-trip through goproto did not preserve profile data")
+// Marshaling appends attribute strings to the dictionary and unmarshaling inlines
+// them again without pruning, so got's string table is want's plus an unused tail.
+func requireProfilesEqualIgnoringAppendedStrings(t *testing.T, want, got Profiles) {
+	t.Helper()
+	w, g := NewProfiles(), NewProfiles()
+	want.CopyTo(w)
+	got.CopyTo(g)
+	wantStrings, gotStrings := w.Dictionary().StringTable(), g.Dictionary().StringTable()
+	require.GreaterOrEqual(t, gotStrings.Len(), wantStrings.Len())
+	gotStrings.FromRaw(gotStrings.AsRaw()[:wantStrings.Len()])
+	require.Equal(t, w, g)
 }
 
 func TestProtoProfilesUnmarshalerError(t *testing.T) {
@@ -125,8 +129,8 @@ func generateBenchmarkProfiles(samplesCount int) Profiles {
 }
 
 // generateProfiles creates a Profiles object with the specified number of resources, scopes, profiles, and samples.
-func generateProfiles(b *testing.B, resourceCount, scopeCount, profileCount, sampleCount int) Profiles {
-	b.Helper()
+func generateProfiles(tb testing.TB, resourceCount, scopeCount, profileCount, sampleCount int) Profiles {
+	tb.Helper()
 
 	profiles := NewProfiles()
 	dict := profiles.Dictionary()

--- a/pdata/pprofile/pprofileotlp/request.go
+++ b/pdata/pprofile/pprofileotlp/request.go
@@ -4,11 +4,7 @@
 package pprofileotlp // import "go.opentelemetry.io/collector/pdata/pprofile/pprofileotlp"
 
 import (
-	"slices"
-
 	"go.opentelemetry.io/collector/pdata/internal"
-	"go.opentelemetry.io/collector/pdata/internal/json"
-	"go.opentelemetry.io/collector/pdata/internal/otlp"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 )
 
@@ -38,40 +34,36 @@ func NewExportRequestFromProfiles(td pprofile.Profiles) ExportRequest {
 }
 
 // MarshalProto marshals ExportRequest into proto bytes.
+// Delegates to pprofile.ProtoMarshaler so attribute strings are referenced via
+// the ProfilesDictionary string table.
 func (ms ExportRequest) MarshalProto() ([]byte, error) {
-	size := ms.orig.SizeProto()
-	buf := make([]byte, size)
-	_ = ms.orig.MarshalProto(buf)
-	return buf, nil
+	return (&pprofile.ProtoMarshaler{}).MarshalProfiles(ms.Profiles())
 }
 
 // UnmarshalProto unmarshalls ExportRequest from proto bytes.
+// Delegates to pprofile.ProtoUnmarshaler so string-table references are resolved.
 func (ms ExportRequest) UnmarshalProto(data []byte) error {
-	err := ms.orig.UnmarshalProto(data)
+	pd, err := (&pprofile.ProtoUnmarshaler{}).UnmarshalProfiles(data)
 	if err != nil {
 		return err
 	}
-	otlp.MigrateProfiles(ms.orig.ResourceProfiles)
+	pd.MoveTo(ms.Profiles())
 	return nil
 }
 
 // MarshalJSON marshals ExportRequest into JSON bytes.
 func (ms ExportRequest) MarshalJSON() ([]byte, error) {
-	dest := json.BorrowStream(nil)
-	defer json.ReturnStream(dest)
-	ms.orig.MarshalJSON(dest)
-	if dest.Error() != nil {
-		return nil, dest.Error()
-	}
-	return slices.Clone(dest.Buffer()), nil
+	return (&pprofile.JSONMarshaler{}).MarshalProfiles(ms.Profiles())
 }
 
 // UnmarshalJSON unmarshalls ExportRequest from JSON bytes.
 func (ms ExportRequest) UnmarshalJSON(data []byte) error {
-	iter := json.BorrowIterator(data)
-	defer json.ReturnIterator(iter)
-	ms.orig.UnmarshalJSON(iter)
-	return iter.Error()
+	pd, err := (&pprofile.JSONUnmarshaler{}).UnmarshalProfiles(data)
+	if err != nil {
+		return err
+	}
+	pd.MoveTo(ms.Profiles())
+	return nil
 }
 
 func (ms ExportRequest) Profiles() pprofile.Profiles {

--- a/pdata/pprofile/pprofileotlp/request_test.go
+++ b/pdata/pprofile/pprofileotlp/request_test.go
@@ -65,6 +65,12 @@ func TestRequestJSON(t *testing.T) {
 	assert.Equal(t, strings.Join(strings.Fields(string(profilesRequestJSON)), ""), string(got))
 }
 
+func TestRequestUnmarshalProtoInvalid(t *testing.T) {
+	tr := NewExportRequest()
+	err := tr.UnmarshalProto([]byte{0xFF, 0xFF, 0xFF})
+	require.Error(t, err)
+}
+
 func TestProfilesProtoWireCompatibility(t *testing.T) {
 	// This test verifies that OTLP ProtoBufs generated using goproto lib in
 	// opentelemetry-proto repository OTLP ProtoBufs generated using gogoproto lib in

--- a/pdata/pprofile/pprofileotlp/request_test.go
+++ b/pdata/pprofile/pprofileotlp/request_test.go
@@ -13,7 +13,6 @@ import (
 	gootlpcollectorprofiles "go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development"
 	goproto "google.golang.org/protobuf/proto"
 
-	"go.opentelemetry.io/collector/pdata/internal"
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 )
@@ -70,9 +69,8 @@ func TestProfilesProtoWireCompatibility(t *testing.T) {
 	// This test verifies that OTLP ProtoBufs generated using goproto lib in
 	// opentelemetry-proto repository OTLP ProtoBufs generated using gogoproto lib in
 	// this repository are wire compatible.
-
-	// Generate Profiles as pdata struct.
-	pd := NewExportRequestFromProfiles(pprofile.Profiles(internal.GenTestProfilesWrapper()))
+	pd := NewExportRequestFromProfiles(generateProfiles())
+	pd.Profiles().MarkReadOnly()
 
 	// Marshal its underlying ProtoBuf to wire.
 	wire1, err := pd.MarshalProto()
@@ -98,5 +96,30 @@ func TestProfilesProtoWireCompatibility(t *testing.T) {
 	// This proves that goproto and gogoproto marshaling/unmarshaling are wire compatible.
 	// Migration logic will run, so run it on the original message as well.
 	otlp.MigrateProfiles(pd.orig.ResourceProfiles)
-	assert.Equal(t, pd, pd2)
+	requireProfilesEqualIgnoringAppendedStrings(t, pd.Profiles(), pd2.Profiles())
+}
+
+func generateProfiles() pprofile.Profiles {
+	profiles := pprofile.NewProfiles()
+	profiles.Dictionary().StringTable().Append("") // index 0 is the required empty sentinel
+	rp := profiles.ResourceProfiles().AppendEmpty()
+	rp.Resource().Attributes().PutStr("service.name", "checkout")
+	sp := rp.ScopeProfiles().AppendEmpty()
+	sp.Scope().SetName("test-scope")
+	sp.Scope().Attributes().PutStr("scope.attr", "scope-value")
+	sp.Profiles().AppendEmpty().Samples().AppendEmpty().SetStackIndex(1)
+	return profiles
+}
+
+// Marshaling appends attribute strings to the dictionary and unmarshaling inlines
+// them again without pruning, so got's string table is want's plus an unused tail.
+func requireProfilesEqualIgnoringAppendedStrings(t *testing.T, want, got pprofile.Profiles) {
+	t.Helper()
+	w, g := pprofile.NewProfiles(), pprofile.NewProfiles()
+	want.CopyTo(w)
+	got.CopyTo(g)
+	wantStrings, gotStrings := w.Dictionary().StringTable(), g.Dictionary().StringTable()
+	require.GreaterOrEqual(t, gotStrings.Len(), wantStrings.Len())
+	gotStrings.FromRaw(gotStrings.AsRaw()[:wantStrings.Len()])
+	require.Equal(t, w, g)
 }

--- a/pdata/pprofile/pprofileotlp/request_test.go
+++ b/pdata/pprofile/pprofileotlp/request_test.go
@@ -71,6 +71,12 @@ func TestRequestUnmarshalProtoInvalid(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRequestUnmarshalJSONInvalid(t *testing.T) {
+	tr := NewExportRequest()
+	err := tr.UnmarshalJSON([]byte(`{"resourceProfiles":`))
+	require.Error(t, err)
+}
+
 func TestProfilesProtoWireCompatibility(t *testing.T) {
 	// This test verifies that OTLP ProtoBufs generated using goproto lib in
 	// opentelemetry-proto repository OTLP ProtoBufs generated using gogoproto lib in

--- a/pdata/pprofile/pprofileotlp/request_test.go
+++ b/pdata/pprofile/pprofileotlp/request_test.go
@@ -113,7 +113,21 @@ func TestProfilesProtoWireCompatibility(t *testing.T) {
 
 func generateProfiles() pprofile.Profiles {
 	profiles := pprofile.NewProfiles()
-	profiles.Dictionary().StringTable().Append("") // index 0 is the required empty sentinel
+
+	// Every dictionary table must hold the zero value at index 0, so that an
+	// unset index resolves to nothing.
+	dic := profiles.Dictionary()
+	dic.StringTable().Append("")
+	dic.AttributeTable().AppendEmpty()
+	dic.MappingTable().AppendEmpty()
+	dic.LocationTable().AppendEmpty()
+	dic.FunctionTable().AppendEmpty()
+	dic.LinkTable().AppendEmpty()
+	dic.StackTable().AppendEmpty()
+
+	dic.LocationTable().AppendEmpty().SetAddress(1)
+	dic.StackTable().AppendEmpty().LocationIndices().Append(1)
+
 	rp := profiles.ResourceProfiles().AppendEmpty()
 	rp.Resource().Attributes().PutStr("service.name", "checkout")
 	sp := rp.ScopeProfiles().AppendEmpty()

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -1063,6 +1063,8 @@ func generateProfilesRequest(t *testing.T) dataRequest {
 	jsonMarshaler := &pprofile.JSONMarshaler{}
 
 	md := testdata.GenerateProfiles(2)
+	md.MarkReadOnly()
+
 	profileProto, err := protoMarshaler.MarshalProfiles(md)
 	require.NoError(t, err)
 
@@ -1384,9 +1386,22 @@ func (esc *errOrSinkConsumer) checkData(t *testing.T, data any, dataLen int) {
 		allProfiles := esc.AllProfiles()
 		require.Len(t, allProfiles, dataLen)
 		if dataLen > 0 {
-			require.Equal(t, allProfiles[0], data)
+			requireProfilesEqualIgnoringAppendedStrings(t, data.(pprofile.Profiles), allProfiles[0])
 		}
 	}
+}
+
+// Marshaling appends attribute strings to the dictionary and the receiver inlines
+// them again without pruning, so got's string table is want's plus an unused tail.
+func requireProfilesEqualIgnoringAppendedStrings(t *testing.T, want, got pprofile.Profiles) {
+	t.Helper()
+	w, g := pprofile.NewProfiles(), pprofile.NewProfiles()
+	want.CopyTo(w)
+	got.CopyTo(g)
+	wantStrings, gotStrings := w.Dictionary().StringTable(), g.Dictionary().StringTable()
+	require.GreaterOrEqual(t, gotStrings.Len(), wantStrings.Len())
+	gotStrings.FromRaw(gotStrings.AsRaw()[:wantStrings.Len()])
+	require.Equal(t, w, g)
 }
 
 func assertReceiverTraces(t *testing.T, tt *componenttest.Telemetry, id component.ID, transport string, accepted, rejected int64) {

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -1363,30 +1363,30 @@ func (esc *errOrSinkConsumer) Reset() {
 
 // Reset deletes any stored in the sinks, resets error to nil.
 func (esc *errOrSinkConsumer) checkData(t *testing.T, data any, dataLen int) {
-	switch data.(type) {
+	switch d := data.(type) {
 	case ptrace.Traces:
 		allTraces := esc.AllTraces()
 		require.Len(t, allTraces, dataLen)
 		if dataLen > 0 {
-			require.Equal(t, allTraces[0], data)
+			require.Equal(t, allTraces[0], d)
 		}
 	case pmetric.Metrics:
 		allMetrics := esc.AllMetrics()
 		require.Len(t, allMetrics, dataLen)
 		if dataLen > 0 {
-			require.Equal(t, allMetrics[0], data)
+			require.Equal(t, allMetrics[0], d)
 		}
 	case plog.Logs:
 		allLogs := esc.AllLogs()
 		require.Len(t, allLogs, dataLen)
 		if dataLen > 0 {
-			require.Equal(t, allLogs[0], data)
+			require.Equal(t, allLogs[0], d)
 		}
 	case pprofile.Profiles:
 		allProfiles := esc.AllProfiles()
 		require.Len(t, allProfiles, dataLen)
 		if dataLen > 0 {
-			requireProfilesEqualIgnoringAppendedStrings(t, data.(pprofile.Profiles), allProfiles[0])
+			requireProfilesEqualIgnoringAppendedStrings(t, d, allProfiles[0])
 		}
 	}
 }


### PR DESCRIPTION
#### Description

`pprofileotlp.ExportRequest` serialized its payload directly instead of going through the `pprofile` marshalers, so resource attributes were never converted to references in the `ProfilesDictionary`. It now delegates to `pprofile.ProtoMarshaler`/`JSONMarshaler` and their unmarshalers.

That change exposed two more bugs:
- `resolveKeyValueReferences` treated an unset `key_strindex` as a reference to `string_table[0]` (i.e. `""`), so attribute keys sent inline were silently erased. `key_strindex` is now also cleared once resolved, so a resolved attribute no longer carries both `key` and `key_strindex` (the optimization that justified keeping both was removed in #15134, the tradeoff is that this leaves the key string orphaned in the string table, as was already the case for values).
- Calling `pprofile.ProtoMarshaler` is called on a profile with an empty string table puts the first string at index 0, which loses the attribute key on unmarshal and emits a table violating `string_table[0] MUST be ""`. Interning now inserts the sentinel when the table is empty.

It's unclear whose job the sentinel is: `NewProfiles()` doesn't add it, and `pprofile.SetString` returns 0 for the first string added to an empty table.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15792
Fixes #15793

<!--Describe what testing was performed and which tests were added.-->
#### Testing

The round trip is no longer an identity on the dictionary: marshaling interns attribute strings into the string table, and unmarshaling inlines them again without pruning, so `got`'s table is `want`'s plus an unused tail. The new
`requireProfilesEqualIgnoringAppendedStrings` truncates `got`'s table to `want`'s length and compares everything else exactly.

It's duplicated across pb_test.go, request_test.go and otlp_test.go rather than shared: the three call sites span two modules and three packages, and one is an in-package test of `pprofile` itself, so sharing it would mean new public API in `pdata/pprofile`.

The mdatagen fixtures were replaced with valid profiles. `GenTestProfilesDictionary` returned `StringTable = []string{"", "test_stringtable"}` plus one dummy entry per table with indices pointing nowhere — fine while the marshalers ignored the dictionary, but not now that they intern and resolve references.

`MarkReadOnly()` was added in all three files: the marshalers mutate their input while interning unless it's read-only, in which case they copy first. Without it the input is rewritten by the marshal and the comparison afterwards is meaningless.

Tests added
- TestResolveProfilesReferencesWithInlineKey (dictionary_helpers_test.go): unit-level, fails on the old >= 0 guard

Tests modified
- TestProfilesProtoWireCompatibility (pb_test.go): pdata-level comparison restored in place of the wire3/goproto.Equal block
- TestProfilesProtoWireCompatibility (request_test.go): now exercises the delegating marshalers

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->

##### Related

The gRPC path is left unchanged but it likely needs fixing as well, at minimum to resolve references on the receiving side.