### PR TITLE
fix: treat key_strindex==0 as not-set sentinel (inline key erase) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -38,7 +38,8 @@ func resolveKeyValueReferences(dict ProfilesDictionary, kvs []internal.KeyValue)
 	for i := range kvs {
 		kv := &kvs[i]
 		// Resolve key_ref if set
-		if kv.KeyStrindex >= 0 {
+		// Note: 0 is the proto3 default (not set) sentinel, so valid refs start at 1.
+		if kv.KeyStrindex > 0 {
 			idx := int(kv.KeyStrindex)
 			if idx < dict.StringTable().Len() {
 				kv.Key = dict.StringTable().At(idx)

--- a/pdata/pprofile/dictionary_helpers_test.go
+++ b/pdata/pprofile/dictionary_helpers_test.go
@@ -21,6 +21,29 @@ func TestResolveProfilesReferencesEmpty(t *testing.T) {
 	assert.Equal(t, 0, profiles.ResourceProfiles().Len())
 }
 
+func TestResolveProfilesReferencesInlineKey(t *testing.T) {
+	profiles := NewProfiles()
+	dict := profiles.Dictionary()
+	dict.StringTable().Append("") // index 0
+
+	rp := profiles.ResourceProfiles().AppendEmpty()
+	attrs := rp.Resource().Attributes()
+	attrs.PutStr("service.name", "checkout")
+
+	// Verify key is inline (KeyStrindex == 0 means not set)
+	mapOrig := internal.GetMapOrig(internal.MapWrapper(attrs))
+	kv := &(*mapOrig)[0]
+	assert.Equal(t, "service.name", kv.Key)
+	assert.Equal(t, int32(0), kv.KeyStrindex, "inline key should have KeyStrindex==0")
+
+	// Resolve references — should NOT replace inline key with empty string
+	resolveProfilesReferences(profiles)
+
+	// Verify key is still intact
+	assert.Equal(t, "service.name", kv.Key)
+	assert.Equal(t, "checkout", attrs.Get("service.name").AsString())
+}
+
 func TestResolveProfilesReferencesWithKeyRef(t *testing.T) {
 	profiles := NewProfiles()
 	dict := profiles.Dictionary()


### PR DESCRIPTION
#### Description

Fixes the `resolveKeyValueReferences` function in `pdata/pprofile/dictionary_helpers.go` where `key_strindex == 0` (the proto3 default/not-set sentinel) was treated as a valid string table reference. This caused inline attribute keys to be silently replaced with the empty string (`""`) from `string_table[0]`.

#### Link to tracking issue
Fixes #15793

#### Testing
Added `TestResolveProfilesReferencesInlineKey` — verifies that an attribute with inline key (`KeyStrindex == 0`) is not replaced after `resolveProfilesReferences` runs.

#### Documentation
Not needed — bug fix with no API change.