### PR TITLE
fix: bound memory growth in queuebatch split path by flushing incrementally [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/.chloggen/queuebatch-split-memory-limit.yaml
+++ b/.chloggen/queuebatch-split-memory-limit.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix unbounded memory growth in queuebatch split path when flush workers are starved by a slow exporter"
+
+# One or more tracking issues or pull requests related to the change
+issues: [15747]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, ConsumeInternal called MergeSplit which eagerly built the entire split chunk list
+  upfront. When all flush workers were occupied by a slow exporter, the Consume goroutine stalled
+  on the first flush while every remaining chunk remained live in memory, uncounted by queue_size
+  or any other bound. This caused RSS to grow up to 200GB in production.
+  
+  The fix adds a SplitOne method to the concrete request types, and a lazy split loop in the
+  batcher that splits off one chunk at a time and flushes it immediately. This bounds the number
+  of live split chunks to num_consumers + 1 at any time, matching the existing memory contract.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/queuebatch/logs_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_batch.go
@@ -63,6 +63,30 @@ func (req *logsRequest) split(maxSize int, sz sizer.LogsSizer) ([]request.Reques
 	return res, nil
 }
 
+// SplitOne implements the splitOne interface by splitting off at most maxSize
+// items/bytes from this request into a new request, leaving the remainder in the
+// receiver. Returns nil when the receiver already contains at most maxSize items.
+func (req *logsRequest) SplitOne(_ context.Context, maxSize int, szt request.SizerType) (request.Request, error) {
+	var sz sizer.LogsSizer
+	switch szt {
+	case request.SizerTypeItems:
+		sz = &sizer.LogsCountSizer{}
+	case request.SizerTypeBytes:
+		sz = &sizer.LogsBytesSizer{}
+	default:
+		return nil, errors.New("unknown sizer type")
+	}
+	if req.size(sz) <= maxSize {
+		return nil, nil
+	}
+	ld, removedSize := extractLogs(req.ld, maxSize, sz)
+	if ld.LogRecordCount() == 0 {
+		return nil, fmt.Errorf("one log record size is greater than max size, dropping items: %d", req.ld.LogRecordCount())
+	}
+	req.setCachedSize(req.size(sz) - removedSize)
+	return newLogsRequest(ld), nil
+}
+
 // extractLogs extracts logs from the input logs and returns a new logs with the specified number of log records.
 func extractLogs(srcLogs plog.Logs, capacity int, sz sizer.LogsSizer) (plog.Logs, int) {
 	destLogs := plog.NewLogs()

--- a/exporter/exporterhelper/internal/queuebatch/metrics_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_batch.go
@@ -63,6 +63,30 @@ func (req *metricsRequest) split(maxSize int, sz sizer.MetricsSizer) ([]request.
 	return res, nil
 }
 
+// SplitOne implements the splitOne interface by splitting off at most maxSize
+// items/bytes from this request into a new request, leaving the remainder in the
+// receiver. Returns nil when the receiver already contains at most maxSize items.
+func (req *metricsRequest) SplitOne(_ context.Context, maxSize int, szt request.SizerType) (request.Request, error) {
+	var sz sizer.MetricsSizer
+	switch szt {
+	case request.SizerTypeItems:
+		sz = &sizer.MetricsCountSizer{}
+	case request.SizerTypeBytes:
+		sz = &sizer.MetricsBytesSizer{}
+	default:
+		return nil, errors.New("unknown sizer type")
+	}
+	if req.size(sz) <= maxSize {
+		return nil, nil
+	}
+	md, rmSize := extractMetrics(req.md, maxSize, sz)
+	if md.DataPointCount() == 0 {
+		return nil, fmt.Errorf("one datapoint size is greater than max size, dropping items: %d", req.md.DataPointCount())
+	}
+	req.setCachedSize(req.size(sz) - rmSize)
+	return newMetricsRequest(md), nil
+}
+
 // extractMetrics extracts metrics from srcMetrics until capacity is reached.
 func extractMetrics(srcMetrics pmetric.Metrics, capacity int, sz sizer.MetricsSizer) (pmetric.Metrics, int) {
 	destMetrics := pmetric.NewMetrics()

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
@@ -23,6 +23,17 @@ const partitionIdleCycles = 10
 
 var _ Batcher[request.Request] = (*partitionBatcher)(nil)
 
+// splitOne is an optional interface implemented by request types that can be split
+// incrementally, one chunk at a time, so the batcher can bound memory usage when
+// exporting a very large request through a limited worker pool (see #15747).
+type splitOne interface {
+	// SplitOne splits off and returns a new Request that contains at most maxSize
+	// items/bytes from this Request, leaving the remainder in the receiver. Returns
+	// nil when the receiver already contains at most maxSize items. Returns a non-nil
+	// error when the request cannot be split (e.g. a single item exceeds maxSize).
+	SplitOne(ctx context.Context, maxSize int, sizerType request.SizerType) (request.Request, error)
+}
+
 type batch struct {
 	ctx  context.Context
 	req  request.Request
@@ -81,6 +92,15 @@ func (qb *partitionBatcher) consumeInternal(ctx context.Context, req request.Req
 	isActive := qb.active
 	qb.lastDataTime = time.Now()
 	if qb.currentBatch == nil {
+		// Lazy splitting: if the request supports it, split off one chunk at a time
+		// and flush immediately, bounding the number of live split chunks to one
+		// (plus the worker pool's in-flight chunks). This avoids the unbounded memory
+		// growth in the eager path where the entire chunk list is materialized upfront
+		// while flush workers are starved by a slow exporter (see #15747).
+		if sp, ok := req.(splitOne); ok && qb.cfg.MaxSize > 0 {
+			qb.currentBatchMu.Unlock()
+			return qb.consumeSplitLoop(ctx, sp, req, done, isActive)
+		}
 		reqList, mergeSplitErr := req.MergeSplit(ctx, int(qb.cfg.MaxSize), qb.cfg.Sizer, nil)
 		if mergeSplitErr != nil {
 			// Do not return in case of error if there are data, try to export as much as possible.
@@ -202,6 +222,69 @@ func (qb *partitionBatcher) consumeInternal(ctx context.Context, req request.Req
 	for i := 0; i < len(reqList); i++ {
 		qb.flush(ctx, reqList[i], done)
 	}
+	return isActive
+}
+
+// consumeSplitLoop lazily splits the request into chunks and flushes each chunk as soon
+// as it is produced, instead of eagerly materializing the full chunk list upfront.
+// This bounds the memory held by split chunks to at most one chunk at a time (plus the
+// chunks in flight in the worker pool), avoiding the unbounded growth described in #15747.
+func (qb *partitionBatcher) consumeSplitLoop(ctx context.Context, sp splitOne, req request.Request, done queue.Done, isActive bool) bool {
+	maxSize := int(qb.cfg.MaxSize)
+	// done is called once per flushed chunk; use a ref-counted wrapper so the original
+	// done fires exactly once after all pieces complete.
+	rcd := &refCountDone{done: done}
+	var splitErr error
+
+	// Split off and flush chunks one at a time. At most one split chunk is live at a
+	// time in addition to the worker pool's in-flight flushes, bounding memory usage
+	// even when every worker is occupied by a slow exporter.
+	for {
+		chunk, err := sp.SplitOne(ctx, maxSize, qb.cfg.Sizer)
+		if err != nil {
+			splitErr = err
+		}
+		if chunk == nil {
+			break
+		}
+		rcd.AddRef()
+		qb.flush(ctx, chunk, rcd)
+		if splitErr != nil {
+			// Cannot split further; the remainder (which still contains the oversized
+			// item) is dropped, matching the eager path's "dropping items" behavior.
+			break
+		}
+	}
+
+	// Handle the remainder (req now holds at most maxSize items).
+	if splitErr != nil {
+		// Remainder dropped; report the error.
+		rcd.AddRef()
+		rcd.OnDone(splitErr)
+		return isActive
+	}
+
+	// Mirror the eager path: if the remainder is below MinSize, keep it as the
+	// current batch so it can be merged with subsequent requests; otherwise flush it.
+	// We must re-check currentBatchMu because another consumer may have set it
+	// while we were flushing (only possible with multi-partition batching).
+	qb.currentBatchMu.Lock()
+	if qb.currentBatch == nil && qb.sizer.Sizeof(req) < qb.cfg.MinSize {
+		rcd.AddRef()
+		qb.currentBatch = &batch{
+			ctx:  ctx,
+			req:  req,
+			done: multiDone{rcd},
+		}
+		qb.resetTimer()
+		qb.currentBatchMu.Unlock()
+		return isActive
+	}
+	qb.currentBatchMu.Unlock()
+
+	// Flush the remainder (either >= MinSize, or currentBatch was already claimed).
+	rcd.AddRef()
+	qb.flush(ctx, req, rcd)
 	return isActive
 }
 
@@ -337,6 +420,14 @@ func newRefCountDone(done queue.Done, refCount int64) queue.Done {
 		done:     done,
 		refCount: refCount,
 	}
+}
+
+// AddRef increments the reference count. Used when the number of chunks is not known
+// in advance (e.g. lazy splitting).
+func (rcd *refCountDone) AddRef() {
+	rcd.mu.Lock()
+	defer rcd.mu.Unlock()
+	rcd.refCount++
 }
 
 func (rcd *refCountDone) OnDone(err error) {

--- a/exporter/exporterhelper/internal/queuebatch/traces_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_batch.go
@@ -63,6 +63,30 @@ func (req *tracesRequest) split(maxSize int, sz sizer.TracesSizer) ([]request.Re
 	return res, nil
 }
 
+// SplitOne implements the splitOne interface by splitting off at most maxSize
+// items/bytes from this request into a new request, leaving the remainder in the
+// receiver. Returns nil when the receiver already contains at most maxSize items.
+func (req *tracesRequest) SplitOne(_ context.Context, maxSize int, szt request.SizerType) (request.Request, error) {
+	var sz sizer.TracesSizer
+	switch szt {
+	case request.SizerTypeItems:
+		sz = &sizer.TracesCountSizer{}
+	case request.SizerTypeBytes:
+		sz = &sizer.TracesBytesSizer{}
+	default:
+		return nil, errors.New("unknown sizer type")
+	}
+	if req.size(sz) <= maxSize {
+		return nil, nil
+	}
+	td, rmSize := extractTraces(req.td, maxSize, sz)
+	if td.SpanCount() == 0 {
+		return nil, fmt.Errorf("one span size is greater than max size, dropping items: %d", req.td.SpanCount())
+	}
+	req.setCachedSize(req.size(sz) - rmSize)
+	return newTracesRequest(td), nil
+}
+
 // extractTraces extracts a new traces with a maximum number of spans.
 func extractTraces(srcTraces ptrace.Traces, capacity int, sz sizer.TracesSizer) (ptrace.Traces, int) {
 	destTraces := ptrace.NewTraces()


### PR DESCRIPTION
**Fixes #15747**

**Problem:**
`consumeInternal` in `partition_batcher.go` calls `MergeSplit` which eagerly builds the entire chunk list upfront. When all flush workers are occupied by a slow exporter, the `Consume` goroutine stalls on the first `flush()` call while every remaining chunk — each a freshly allocated `plog.Logs` / `ptrace.Traces` / `pmetric.Metrics` — stays live and reachable, **uncounted by `queue_size` or any other bound**. This can lead to unbounded memory growth (RSS exceeding 200GB in production, 36GB+ heap snapshots in the `split` → `extractLogs` → `plog.NewLogs` call chain).

**Root cause:**
`split()` eagerly builds the entire chunk list before returning. `flush()` blocks until a worker is free. When every `num_consumers` worker is occupied by a slow produce call, the loop stalls on chunk 0 while every remaining chunk stays live.

**Fix:**
- Add a `SplitOne` method to `logsRequest`, `tracesRequest`, and `metricsRequest` that splits off **one chunk at a time** from the request, leaving the remainder in the receiver.
- Add an optional `splitOne` interface in `partition_batcher.go` (Go type-assertion pattern, no change to the `request.Request` interface).
- Add `consumeSplitLoop` that calls `SplitOne` in a loop, flushing each chunk immediately, so only **one chunk at a time** is live in memory (plus the worker pool's in-flight chunks).
- Add `AddRef` to `refCountDone` to support dynamic ref-counting when the total number of chunks is not known upfront.

**Memory bound:**
With lazy splitting, at most `num_consumers + 1` chunks are live at any time, instead of the full request-size / max-size count.

**Backward compatibility:**
- The `splitOne` interface is optional; existing `Request` implementations (e.g. `FakeRequest` in tests) continue to use the eager `MergeSplit` path, unchanged.
- All existing tests pass without modification.

**Testing:**
- Manual: verified each chunk is ≤ maxSize, total item count preserved, remainder handling matches eager path.
- CI: all existing `partition_batcher_test.go` tests pass (use `FakeRequest` which doesn't implement `splitOne`).

CLA: CNCF EasyCLA needs signing — added @waterWang as the commit author.