### PR TITLE
[all] Bump go version to 1.26.0

### DIFF
--- a/.chloggen/go-126.yaml
+++ b/.chloggen/go-126.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Bump go version in all go.mod to 1.26.0, drop support on 1.25.0"
+
+# One or more tracking issues or pull requests related to the change
+issues: [15799]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -64,7 +64,7 @@ modernize:
 .PHONY: tidy
 tidy:
 	rm -fr go.sum
-	$(GOCMD) mod tidy -compat=1.25.0
+	$(GOCMD) mod tidy -compat=1.26.0
 
 .PHONY: lint
 lint:

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/client
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -3,7 +3,7 @@
 
 module go.opentelemetry.io/collector/cmd/builder
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/knadh/koanf/parsers/yaml v1.1.1

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/cmd/mdatagen
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/cmd/mdatagen/internal/cfggen/generation_test.go
+++ b/cmd/mdatagen/internal/cfggen/generation_test.go
@@ -1573,7 +1573,7 @@ func TestExtractImports_ErrorsImportForValidators(t *testing.T) {
 			metadata: &ConfigMetadata{
 				Type: "object",
 				Properties: map[string]*ConfigMetadata{
-					"name": {Type: "string", MinLength: Ptr(1)},
+					"name": {Type: "string", MinLength: new(1)},
 				},
 			},
 		},
@@ -1582,7 +1582,7 @@ func TestExtractImports_ErrorsImportForValidators(t *testing.T) {
 			metadata: &ConfigMetadata{
 				Type: "object",
 				Properties: map[string]*ConfigMetadata{
-					"name": {Type: "string", MaxLength: Ptr(64)},
+					"name": {Type: "string", MaxLength: new(64)},
 				},
 			},
 		},
@@ -1601,7 +1601,7 @@ func TestExtractImports_ErrorsImportForValidators(t *testing.T) {
 			metadata: &ConfigMetadata{
 				Type: "object",
 				Properties: map[string]*ConfigMetadata{
-					"count": {Type: "integer", Maximum: Ptr(100.0)},
+					"count": {Type: "integer", Maximum: new(100.0)},
 				},
 			},
 		},
@@ -1646,17 +1646,17 @@ func TestValidationRules_Enabled(t *testing.T) {
 		},
 		{
 			name:     "maxLength only",
-			rules:    ValidationRules{MaxLength: Ptr(64)},
+			rules:    ValidationRules{MaxLength: new(64)},
 			expected: true,
 		},
 		{
 			name:     "minLength only",
-			rules:    ValidationRules{MinLength: Ptr(1)},
+			rules:    ValidationRules{MinLength: new(1)},
 			expected: true,
 		},
 		{
 			name:     "pattern only",
-			rules:    ValidationRules{Pattern: Ptr(`^[a-z]+$`)},
+			rules:    ValidationRules{Pattern: new(`^[a-z]+$`)},
 			expected: true,
 		},
 		{
@@ -1666,7 +1666,7 @@ func TestValidationRules_Enabled(t *testing.T) {
 		},
 		{
 			name:     "required with value rule",
-			rules:    ValidationRules{Required: true, MaxLength: Ptr(64)},
+			rules:    ValidationRules{Required: true, MaxLength: new(64)},
 			expected: true,
 		},
 	}
@@ -1845,7 +1845,7 @@ func TestExtractValidators_StringValidators(t *testing.T) {
 				{
 					FieldName: "name",
 					FieldType: "string",
-					Rules:     ValidationRules{Pattern: Ptr(`^[a-z]+$`)},
+					Rules:     ValidationRules{Pattern: new(`^[a-z]+$`)},
 				},
 			},
 		},
@@ -1861,7 +1861,7 @@ func TestExtractValidators_StringValidators(t *testing.T) {
 				{
 					FieldName: "name",
 					FieldType: "string",
-					Rules:     ValidationRules{MinLength: &minLen, MaxLength: &maxLen, Pattern: Ptr(`^[a-z]+$`)},
+					Rules:     ValidationRules{MinLength: &minLen, MaxLength: &maxLen, Pattern: new(`^[a-z]+$`)},
 				},
 			},
 		},
@@ -1878,7 +1878,7 @@ func TestExtractValidators_StringValidators(t *testing.T) {
 				{
 					FieldName: "name",
 					FieldType: "string",
-					Rules:     ValidationRules{Required: true, MinLength: &minLen, MaxLength: &maxLen, Pattern: Ptr(`^[a-z]+$`)},
+					Rules:     ValidationRules{Required: true, MinLength: &minLen, MaxLength: &maxLen, Pattern: new(`^[a-z]+$`)},
 				},
 			},
 		},
@@ -2198,22 +2198,22 @@ func TestValidationRules_HasValueRule(t *testing.T) {
 		},
 		{
 			name:     "maxLength",
-			rules:    ValidationRules{MaxLength: Ptr(64)},
+			rules:    ValidationRules{MaxLength: new(64)},
 			expected: true,
 		},
 		{
 			name:     "minLength",
-			rules:    ValidationRules{MinLength: Ptr(1)},
+			rules:    ValidationRules{MinLength: new(1)},
 			expected: true,
 		},
 		{
 			name:     "pattern",
-			rules:    ValidationRules{Pattern: Ptr(`^[a-z]+$`)},
+			rules:    ValidationRules{Pattern: new(`^[a-z]+$`)},
 			expected: true,
 		},
 		{
 			name:     "required and pattern",
-			rules:    ValidationRules{Required: true, Pattern: Ptr(`^[a-z]+$`)},
+			rules:    ValidationRules{Required: true, Pattern: new(`^[a-z]+$`)},
 			expected: true,
 		},
 		{
@@ -2223,27 +2223,27 @@ func TestValidationRules_HasValueRule(t *testing.T) {
 		},
 		{
 			name:     "minimum",
-			rules:    ValidationRules{Minimum: Ptr(0.0)},
+			rules:    ValidationRules{Minimum: new(0.0)},
 			expected: true,
 		},
 		{
 			name:     "maximum",
-			rules:    ValidationRules{Maximum: Ptr(100.0)},
+			rules:    ValidationRules{Maximum: new(100.0)},
 			expected: true,
 		},
 		{
 			name:     "exclusiveMinimum",
-			rules:    ValidationRules{ExclusiveMinimum: Ptr(5.0)},
+			rules:    ValidationRules{ExclusiveMinimum: new(5.0)},
 			expected: true,
 		},
 		{
 			name:     "exclusiveMaximum",
-			rules:    ValidationRules{ExclusiveMaximum: Ptr(10.0)},
+			rules:    ValidationRules{ExclusiveMaximum: new(10.0)},
 			expected: true,
 		},
 		{
 			name:     "all numeric validators",
-			rules:    ValidationRules{Minimum: Ptr(0.0), Maximum: Ptr(100.0), ExclusiveMinimum: Ptr(5.0), ExclusiveMaximum: Ptr(10.0)},
+			rules:    ValidationRules{Minimum: new(0.0), Maximum: new(100.0), ExclusiveMinimum: new(5.0), ExclusiveMaximum: new(10.0)},
 			expected: true,
 		},
 		{
@@ -2323,8 +2323,9 @@ func TestNewCfgFns_ExtractValidators(t *testing.T) {
 	require.True(t, result[0].Rules.Required)
 }
 
+//go:fix inline
 func Ptr[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 func TestExternalDefaultCall(t *testing.T) {

--- a/cmd/mdatagen/internal/config_test.go
+++ b/cmd/mdatagen/internal/config_test.go
@@ -71,15 +71,15 @@ exclusions:
 			Exclusions: []ComponentExclusion{
 				{
 					Component:     "go.opentelemetry.io/collector/receiver/foo",
-					LifecycleTest: Toggle{Enabled: boolPtr(false)},
-					ShutdownTest:  Toggle{Enabled: boolPtr(false)},
-					Goleak:        Toggle{Enabled: boolPtr(false)},
+					LifecycleTest: Toggle{Enabled: new(false)},
+					ShutdownTest:  Toggle{Enabled: new(false)},
+					Goleak:        Toggle{Enabled: new(false)},
 				},
 				{
 					Component: "go.opentelemetry.io/collector/service",
 					FeatureGates: []FeatureGateExclusion{
-						{Name: "service.gateOne", Validation: Toggle{Enabled: boolPtr(false)}},
-						{Name: "service.gateTwo", Validation: Toggle{Enabled: boolPtr(false)}},
+						{Name: "service.gateOne", Validation: Toggle{Enabled: new(false)}},
+						{Name: "service.gateTwo", Validation: Toggle{Enabled: new(false)}},
 					},
 				},
 			},
@@ -176,11 +176,11 @@ func TestCentralConfigApplyTo(t *testing.T) {
 			Exclusions: []ComponentExclusion{
 				{
 					Component:     pkg,
-					LifecycleTest: Toggle{Enabled: boolPtr(false)},
-					ShutdownTest:  Toggle{Enabled: boolPtr(false)},
-					Goleak:        Toggle{Enabled: boolPtr(false)},
+					LifecycleTest: Toggle{Enabled: new(false)},
+					ShutdownTest:  Toggle{Enabled: new(false)},
+					Goleak:        Toggle{Enabled: new(false)},
 					FeatureGates: []FeatureGateExclusion{
-						{Name: "foo.gateA", Validation: Toggle{Enabled: boolPtr(false)}},
+						{Name: "foo.gateA", Validation: Toggle{Enabled: new(false)}},
 					},
 				},
 			},
@@ -225,7 +225,7 @@ func TestCentralConfigApplyTo(t *testing.T) {
 			Exclusions: []ComponentExclusion{
 				{Component: pkg, FeatureGates: []FeatureGateExclusion{
 					{Name: "foo.absent"}, // no enabled key
-					{Name: "foo.enabled", Validation: Toggle{Enabled: boolPtr(true)}}, // explicitly enabled
+					{Name: "foo.enabled", Validation: Toggle{Enabled: new(true)}}, // explicitly enabled
 				}},
 			},
 		}
@@ -242,8 +242,8 @@ func TestCentralConfigApplyTo(t *testing.T) {
 		}
 		cfg := &CentralConfig{
 			Exclusions: []ComponentExclusion{
-				{Component: pkg, LifecycleTest: Toggle{Enabled: boolPtr(false)}},
-				{Component: pkg, FeatureGates: []FeatureGateExclusion{{Name: "foo.gateA", Validation: Toggle{Enabled: boolPtr(false)}}}},
+				{Component: pkg, LifecycleTest: Toggle{Enabled: new(false)}},
+				{Component: pkg, FeatureGates: []FeatureGateExclusion{{Name: "foo.gateA", Validation: Toggle{Enabled: new(false)}}}},
 			},
 		}
 		cfg.applyTo(&md)
@@ -261,8 +261,8 @@ func TestCentralConfigApplyTo(t *testing.T) {
 			Exclusions: []ComponentExclusion{
 				{
 					Component:     pkg,
-					LifecycleTest: Toggle{Enabled: boolPtr(false)},
-					FeatureGates:  []FeatureGateExclusion{{Name: "foo.gateA", Validation: Toggle{Enabled: boolPtr(false)}}},
+					LifecycleTest: Toggle{Enabled: new(false)},
+					FeatureGates:  []FeatureGateExclusion{{Name: "foo.gateA", Validation: Toggle{Enabled: new(false)}}},
 				},
 			},
 		}

--- a/cmd/mdatagen/internal/loader.go
+++ b/cmd/mdatagen/internal/loader.go
@@ -140,8 +140,7 @@ func packageName(filePath string) (string, error) {
 	cmd.Dir = filePath
 	output, err := cmd.Output()
 	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			return "", fmt.Errorf("unable to determine package name: %v failed: (stderr) %v", cmd.Args, string(ee.Stderr))
 		}
 

--- a/cmd/mdatagen/internal/loader_test.go
+++ b/cmd/mdatagen/internal/loader_test.go
@@ -16,10 +16,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 func TestTwoPackagesInDirectory(t *testing.T) {
 	contents, err := os.ReadFile("testdata/twopackages.yaml")
 	require.NoError(t, err)
@@ -124,7 +120,7 @@ func TestLoadMetadata(t *testing.T) {
 				ResourceAttributes: map[AttributeName]Attribute{
 					"host.arch": {
 						Description: "The CPU architecture the host system is running on.",
-						EnabledPtr:  boolPtr(false),
+						EnabledPtr:  new(false),
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
@@ -136,7 +132,7 @@ func TestLoadMetadata(t *testing.T) {
 					},
 					"string.resource.attr": {
 						Description: "Resource attribute with any string value.",
-						EnabledPtr:  boolPtr(true),
+						EnabledPtr:  new(true),
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
@@ -145,7 +141,7 @@ func TestLoadMetadata(t *testing.T) {
 					},
 					"string.enum.resource.attr": {
 						Description: "Resource attribute with a known set of string values.",
-						EnabledPtr:  boolPtr(true),
+						EnabledPtr:  new(true),
 						Enum:        []string{"one", "two"},
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
@@ -155,7 +151,7 @@ func TestLoadMetadata(t *testing.T) {
 					},
 					"optional.resource.attr": {
 						Description: "Explicitly disabled ResourceAttribute.",
-						EnabledPtr:  boolPtr(false),
+						EnabledPtr:  new(false),
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
@@ -165,7 +161,7 @@ func TestLoadMetadata(t *testing.T) {
 					},
 					"slice.resource.attr": {
 						Description: "Resource attribute with a slice value.",
-						EnabledPtr:  boolPtr(true),
+						EnabledPtr:  new(true),
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeSlice,
 						},
@@ -175,7 +171,7 @@ func TestLoadMetadata(t *testing.T) {
 					},
 					"map.resource.attr": {
 						Description: "Resource attribute with a map value.",
-						EnabledPtr:  boolPtr(true),
+						EnabledPtr:  new(true),
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeMap,
 						},
@@ -188,7 +184,7 @@ func TestLoadMetadata(t *testing.T) {
 						Warnings: Warnings{
 							IfEnabledNotSet: "This resource_attribute will be disabled by default soon.",
 						},
-						EnabledPtr: boolPtr(true),
+						EnabledPtr: new(true),
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
@@ -200,7 +196,7 @@ func TestLoadMetadata(t *testing.T) {
 						Warnings: Warnings{
 							IfConfigured: "This resource_attribute is deprecated and will be removed soon.",
 						},
-						EnabledPtr: boolPtr(false),
+						EnabledPtr: new(false),
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
@@ -212,7 +208,7 @@ func TestLoadMetadata(t *testing.T) {
 						Warnings: Warnings{
 							IfEnabled: "This resource_attribute is deprecated and will be removed soon.",
 						},
-						EnabledPtr: boolPtr(true),
+						EnabledPtr: new(true),
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
@@ -224,7 +220,7 @@ func TestLoadMetadata(t *testing.T) {
 						Warnings: Warnings{
 							IfEnabled: "This resource_attribute is deprecated and will be removed soon.",
 						},
-						EnabledPtr: boolPtr(false),
+						EnabledPtr: new(false),
 						Type: ValueType{
 							ValueType: pcommon.ValueTypeStr,
 						},
@@ -359,7 +355,7 @@ func TestLoadMetadata(t *testing.T) {
 							},
 							Attributes: []AttributeName{"string_attr", "overridden_int_attr", "enum_attr", "slice_attr", "map_attr", "conditional_int_attr", "conditional_string_attr", "opt_in_bool_attr"},
 						},
-						Unit: strPtr("s"),
+						Unit: new("s"),
 						Sum: &Sum{
 							MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 							AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -377,7 +373,7 @@ func TestLoadMetadata(t *testing.T) {
 							Stability:   component.StabilityLevelBeta,
 							Attributes:  []AttributeName{"string_attr", "boolean_attr"},
 						},
-						Unit: strPtr("1"),
+						Unit: new("1"),
 						Gauge: &Gauge{
 							MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeDouble},
 						},
@@ -389,7 +385,7 @@ func TestLoadMetadata(t *testing.T) {
 							Stability:   component.StabilityLevelBeta,
 							Attributes:  []AttributeName{"required_string_attr", "string_attr", "boolean_attr"},
 						},
-						Unit: strPtr("1"),
+						Unit: new("1"),
 						Gauge: &Gauge{
 							MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeDouble},
 						},
@@ -403,7 +399,7 @@ func TestLoadMetadata(t *testing.T) {
 							ExtendedDocumentation: "The metric will be become optional soon.",
 							Attributes:            []AttributeName{"cpu"},
 						},
-						Unit: strPtr("s"),
+						Unit: new("s"),
 						Sum: &Sum{
 							MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 							AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -417,7 +413,7 @@ func TestLoadMetadata(t *testing.T) {
 							Description: "Bytes of memory in use.",
 							Attributes:  []AttributeName{"state"},
 						},
-						Unit: strPtr("By"),
+						Unit: new("By"),
 						Sum: &Sum{
 							MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 							AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -438,7 +434,7 @@ func TestLoadMetadata(t *testing.T) {
 							Since: "1.0.0",
 							Note:  "This metric will be removed",
 						},
-						Unit: strPtr("1"),
+						Unit: new("1"),
 						Gauge: &Gauge{
 							MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeDouble},
 						},
@@ -457,7 +453,7 @@ func TestLoadMetadata(t *testing.T) {
 							Since: "1.0.0",
 							Note:  "This metric will be removed",
 						},
-						Unit: strPtr(""),
+						Unit: new(""),
 						Gauge: &Gauge{
 							MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeDouble},
 						},
@@ -477,7 +473,7 @@ func TestLoadMetadata(t *testing.T) {
 							Since: "1.0.0",
 							Note:  "This metric will be removed",
 						},
-						Unit: strPtr("s"),
+						Unit: new("s"),
 						Sum: &Sum{
 							MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeDouble},
 							AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityDelta},
@@ -491,7 +487,7 @@ func TestLoadMetadata(t *testing.T) {
 							Stability:   component.StabilityLevelDevelopment,
 							Attributes:  []AttributeName{"string_attr", "overridden_int_attr", "enum_attr", "slice_attr", "map_attr"},
 						},
-						Unit: strPtr("s"),
+						Unit: new("s"),
 						Sum: &Sum{
 							MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 							MetricInputType:        MetricInputType{InputType: "string"},
@@ -546,7 +542,7 @@ func TestLoadMetadata(t *testing.T) {
 								Since: "1.5.0",
 								Note:  "This metric will be removed in favor of batch_send_trigger_size",
 							},
-							Unit: strPtr("{time}"),
+							Unit: new("{time}"),
 							Sum: &Sum{
 								MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeInt},
 								Mono:            Mono{Monotonic: true},
@@ -558,7 +554,7 @@ func TestLoadMetadata(t *testing.T) {
 								Stability:   component.StabilityLevelAlpha,
 								Description: "Duration of request",
 							},
-							Unit: strPtr("s"),
+							Unit: new("s"),
 							Histogram: &Histogram{
 								MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeDouble},
 								Boundaries:      []float64{1, 10, 100},
@@ -570,7 +566,7 @@ func TestLoadMetadata(t *testing.T) {
 								Stability:   component.StabilityLevelStable,
 								Description: "Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')",
 							},
-							Unit: strPtr("By"),
+							Unit: new("By"),
 							Sum: &Sum{
 								Mono: Mono{true},
 								MetricValueType: MetricValueType{
@@ -586,7 +582,7 @@ func TestLoadMetadata(t *testing.T) {
 								Description:           "This metric is optional and therefore not initialized in NewTelemetryBuilder.",
 								ExtendedDocumentation: "For example this metric only exists if feature A is enabled.",
 							},
-							Unit:     strPtr("{item}"),
+							Unit:     new("{item}"),
 							Optional: true,
 							Gauge: &Gauge{
 								MetricValueType: MetricValueType{
@@ -601,7 +597,7 @@ func TestLoadMetadata(t *testing.T) {
 								Description: "Queue capacity - sync gauge example.",
 								Stability:   component.StabilityLevelDevelopment,
 							},
-							Unit: strPtr("{item}"),
+							Unit: new("{item}"),
 							Gauge: &Gauge{
 								MetricValueType: MetricValueType{
 									ValueType: pmetric.NumberDataPointValueTypeInt,
@@ -875,7 +871,7 @@ func TestLoadMetadata(t *testing.T) {
 								SemanticConventionRef: "https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/system/system-metrics.md#metric-systemdiskio_time",
 							},
 						},
-						Unit: strPtr("s"),
+						Unit: new("s"),
 						Sum: &Sum{
 							AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
 							Mono:                   Mono{Monotonic: true},
@@ -954,8 +950,4 @@ func TestVersionedMetricName(t *testing.T) {
 	// Versioned metric - Name should be auto-populated from key
 	versioned := md.Metrics["system.cpu.time@v1"]
 	require.True(t, versioned.Versioned)
-}
-
-func strPtr(s string) *string {
-	return &s
 }

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -443,7 +443,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -482,7 +482,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -507,7 +507,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -546,7 +546,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -577,7 +577,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -602,7 +602,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -635,7 +635,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -660,7 +660,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -693,7 +693,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -718,7 +718,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
@@ -758,7 +758,7 @@ func TestValidateMigrations(t *testing.T) {
 						},
 						Attributes: []AttributeName{"string_attr", "overridden_int_attr"},
 					},
-					Unit: strPtr("s"),
+					Unit: new("s"),
 					Sum: &Sum{
 						MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
 						AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -2,7 +2,7 @@
 
 module go.opentelemetry.io/collector/cmd/otelcorecol
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opentelemetry.io/collector/component v1.65.0

--- a/cmd/schemagen/go.mod
+++ b/cmd/schemagen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/cmd/schemagen
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/iancoleman/strcase v0.3.0

--- a/cmd/schemagen/internal/parser_test.go
+++ b/cmd/schemagen/internal/parser_test.go
@@ -142,6 +142,7 @@ func TestPackageParser(t *testing.T) {
 		Mode:     Package,
 		DirPath:  dir,
 		Mappings: testMappings(),
+		Pattern:  ".",
 	}
 
 	parser := NewParser(cfg)

--- a/cmd/schemagen/internal/resolver.go
+++ b/cmd/schemagen/internal/resolver.go
@@ -24,8 +24,7 @@ func (e *NotFoundError) Error() string {
 }
 
 func isNotFound(err error) (*NotFoundError, bool) {
-	var nf *NotFoundError
-	if errors.As(err, &nf) {
+	if nf, ok := errors.AsType[*NotFoundError](err); ok {
 		return nf, true
 	}
 	return nil, false

--- a/component/componentstatus/go.mod
+++ b/component/componentstatus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component/componentstatus
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/component/componenttest/go.mod
+++ b/component/componenttest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component/componenttest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/component/go.mod
+++ b/component/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/configauth/go.mod
+++ b/config/configauth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configauth
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/configcompression/go.mod
+++ b/config/configcompression/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configcompression
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configgrpc
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/golang/snappy v1.0.0

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confighttp
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/golang/snappy v1.0.0

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confighttp/xconfighttp
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/configmiddleware/go.mod
+++ b/config/configmiddleware/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configmiddleware
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -43,8 +43,7 @@ func TestAddrConfigTimeout(t *testing.T) {
 	}
 	_, err := nac.Dial(context.Background())
 	require.Error(t, err)
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if netErr, ok := errors.AsType[net.Error](err); ok {
 		assert.True(t, netErr.Timeout())
 	} else {
 		assert.Fail(t, "error should be a net.Error")
@@ -60,8 +59,7 @@ func TestTCPAddrConfigTimeout(t *testing.T) {
 	}
 	_, err := nac.Dial(context.Background())
 	require.Error(t, err)
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if netErr, ok := errors.AsType[net.Error](err); ok {
 		assert.True(t, netErr.Timeout())
 	} else {
 		assert.Fail(t, "error should be a net.Error")

--- a/config/confignet/go.mod
+++ b/config/confignet/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/confignet
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/config/configopaque/go.mod
+++ b/config/configopaque/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configopaque
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/configoptional/go.mod
+++ b/config/configoptional/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configoptional
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/configoptional/optional.go
+++ b/config/configoptional/optional.go
@@ -63,8 +63,7 @@ func assertNoEnabledField[T any]() error {
 	}
 
 	// Check if the struct has a field with the name "enabled".
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
+	for field := range t.Fields() {
 		mapstructureTags := strings.SplitN(field.Tag.Get("mapstructure"), ",", 2)
 		if len(mapstructureTags) > 0 && mapstructureTags[0] == "enabled" {
 			return errors.New("configoptional: underlying type cannot have a field with mapstructure tag 'enabled'")

--- a/config/configoptional/optional_test.go
+++ b/config/configoptional/optional_test.go
@@ -78,10 +78,6 @@ var subDefault = Sub{
 	Foo: "foobar",
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 func TestDefaultPanics(t *testing.T) {
 	assert.Panics(t, func() {
 		_ = Default(WithEnabled{})
@@ -122,7 +118,7 @@ func TestDefaultPanics(t *testing.T) {
 	})
 
 	assert.NotPanics(t, func() {
-		_ = Default(ptr(subDefault))
+		_ = Default(new(subDefault))
 	})
 }
 

--- a/config/configretry/go.mod
+++ b/config/configretry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configretry
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/configstorage/go.mod
+++ b/config/configstorage/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configstorage
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/configtelemetry/go.mod
+++ b/config/configtelemetry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtelemetry
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/config/configtls/go.mod
+++ b/config/configtls/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configtls
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250903184740-5d135037bd4d

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/confmap/internal/e2e/go.mod
+++ b/confmap/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/internal/e2e
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/confmap/provider/envprovider/go.mod
+++ b/confmap/provider/envprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/envprovider
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/confmap/provider/fileprovider/go.mod
+++ b/confmap/provider/fileprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/fileprovider
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/confmap/provider/httpprovider/go.mod
+++ b/confmap/provider/httpprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpprovider
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/confmap/provider/httpsprovider/go.mod
+++ b/confmap/provider/httpsprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/httpsprovider
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/confmap/provider/yamlprovider/go.mod
+++ b/confmap/provider/yamlprovider/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/provider/yamlprovider
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/confmap/xconfmap/go.mod
+++ b/confmap/xconfmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap/xconfmap
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/connectortest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/forwardconnector
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/connector/xconnector/go.mod
+++ b/connector/xconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/xconnector
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/consumer/consumererror/error.go
+++ b/consumer/consumererror/error.go
@@ -129,8 +129,7 @@ func (e *Error) IsRetryable() bool {
 // If a http status code cannot be derived from these three sources then 500 is
 // returned.
 func ToHTTPStatus(err error) int {
-	var e *Error
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*Error](err); ok {
 		if e.httpStatus != 0 {
 			return e.httpStatus
 		}

--- a/consumer/consumererror/error_test.go
+++ b/consumer/consumererror/error_test.go
@@ -335,8 +335,7 @@ func TestError_Retryable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, httpStatus := range tt.httpStatuses {
 				err := NewOTLPHTTPError(errTest, httpStatus)
-				var httpErr *Error
-				if errors.As(err, &httpErr) {
+				if httpErr, ok := errors.AsType[*Error](err); ok {
 					require.Equal(t, tt.want, httpErr.IsRetryable(), "Expected %d to be retryable=%t", httpStatus, tt.want)
 				} else {
 					require.Fail(t, "NewOTLPHTTPError didn't return an *Error")
@@ -345,9 +344,8 @@ func TestError_Retryable(t *testing.T) {
 
 			for _, grpcStatus := range tt.grpcStatuses {
 				err := NewOTLPGRPCError(errTest, grpcStatus)
-				var grpcErr *Error
 
-				if errors.As(err, &grpcErr) {
+				if grpcErr, ok := errors.AsType[*Error](err); ok {
 					require.Equal(t, tt.want, grpcErr.IsRetryable(), "Expected %q to be retryable=%t", grpcStatus.Code().String(), tt.want)
 				} else {
 					require.Fail(t, "NewOTLPGRPCError didn't return an *Error")

--- a/consumer/consumererror/go.mod
+++ b/consumer/consumererror/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumererror
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/consumer/consumererror/xconsumererror/go.mod
+++ b/consumer/consumererror/xconsumererror/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumererror/xconsumererror
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/consumer/consumertest/go.mod
+++ b/consumer/consumertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/consumertest
 
-go 1.25.0
+go 1.26.0
 
 replace go.opentelemetry.io/collector/consumer => ../
 

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/consumer/xconsumer/go.mod
+++ b/consumer/xconsumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer/xconsumer
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/debugexporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/exporter/exporterhelper/go.mod
+++ b/exporter/exporterhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/exporterhelper
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cenkalti/backoff/v7 v7.0.0

--- a/exporter/exporterhelper/internal/queuebatch/logs.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs.go
@@ -79,8 +79,7 @@ func (logsReferenceCounter) Unref(req request.Request) {
 }
 
 func (req *logsRequest) OnError(err error) request.Request {
-	var logError consumererror.Logs
-	if errors.As(err, &logError) {
+	if logError, ok := errors.AsType[consumererror.Logs](err); ok {
 		// TODO: Add logic to unref the new request created here.
 		return newLogsRequest(logError.Data())
 	}

--- a/exporter/exporterhelper/internal/queuebatch/metrics.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics.go
@@ -76,8 +76,7 @@ func (metricsReferenceCounter) Unref(req request.Request) {
 }
 
 func (req *metricsRequest) OnError(err error) request.Request {
-	var metricsError consumererror.Metrics
-	if errors.As(err, &metricsError) {
+	if metricsError, ok := errors.AsType[consumererror.Metrics](err); ok {
 		// TODO: Add logic to unref the new request created here.
 		return newMetricsRequest(metricsError.Data())
 	}

--- a/exporter/exporterhelper/internal/queuebatch/traces.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces.go
@@ -79,8 +79,7 @@ func (tracesReferenceCounter) Unref(req request.Request) {
 }
 
 func (req *tracesRequest) OnError(err error) request.Request {
-	var traceError consumererror.Traces
-	if errors.As(err, &traceError) {
+	if traceError, ok := errors.AsType[consumererror.Traces](err); ok {
 		// TODO: Add logic to unref the new request created here.
 		return newTracesRequest(traceError.Data())
 	}

--- a/exporter/exporterhelper/internal/requesttest/request.go
+++ b/exporter/exporterhelper/internal/requesttest/request.go
@@ -33,8 +33,7 @@ type FakeRequest struct {
 }
 
 func (r *FakeRequest) OnError(err error) request.Request {
-	var pErr errorPartial
-	if errors.As(err, &pErr) {
+	if pErr, ok := errors.AsType[errorPartial](err); ok {
 		return pErr.fr
 	}
 	return r

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -88,8 +88,7 @@ func (profilesReferenceCounter) Unref(req request.Request) {
 }
 
 func (req *profilesRequest) OnError(err error) Request {
-	var profileError xconsumererror.Profiles
-	if errors.As(err, &profileError) {
+	if profileError, ok := errors.AsType[xconsumererror.Profiles](err); ok {
 		// TODO: Add logic to unref the new request created here.
 		return newProfilesRequest(profileError.Data())
 	}

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/exportertest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/nopexporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlpexporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlphttpexporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -193,8 +193,7 @@ func (e *baseExporter) export(ctx context.Context, requestURL string, request []
 
 	resp, err := e.client.Do(req)
 	if err != nil {
-		var urlErr *url.Error
-		if errors.As(err, &urlErr) {
+		if urlErr, ok := errors.AsType[*url.Error](err); ok {
 			urlErr.URL = req.URL.String()
 		}
 		return fmt.Errorf("failed to make an HTTP request: %w", err)

--- a/exporter/xexporter/go.mod
+++ b/exporter/xexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/xexporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/extension/extensionauth/extensionauthtest/go.mod
+++ b/extension/extensionauth/extensionauthtest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/extension/extensionauth/go.mod
+++ b/extension/extensionauth/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionauth
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/extension/extensioncapabilities/go.mod
+++ b/extension/extensioncapabilities/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensioncapabilities
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opentelemetry.io/collector/component v1.65.0

--- a/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/extension/extensionmiddleware/go.mod
+++ b/extension/extensionmiddleware/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensionmiddleware
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/extension/extensiontest/go.mod
+++ b/extension/extensiontest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/extensiontest
 
-go 1.25.0
+go 1.26.0
 
 replace go.opentelemetry.io/collector/extension => ..
 

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/memorylimiterextension
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/extension/xextension/go.mod
+++ b/extension/xextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/xextension
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/zpagesextension
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/featuregate/go.mod
+++ b/featuregate/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/featuregate
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/hashicorp/go-version v1.9.0

--- a/filter/go.mod
+++ b/filter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/filter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module go.opentelemetry.io/collector
 // For the OpenTelemetry Collector Core distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/internal/cmd/pdatagen/go.mod
+++ b/internal/cmd/pdatagen/go.mod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/collector/internal/cmd/pdatagen
 
-go 1.25.0
+go 1.26.0
 
 require github.com/ettle/strcase v0.2.0

--- a/internal/componentalias/go.mod
+++ b/internal/componentalias/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/componentalias
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/e2e
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/internal/fanoutconsumer/go.mod
+++ b/internal/fanoutconsumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/fanoutconsumer
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/internal/memorylimiter/go.mod
+++ b/internal/memorylimiter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/memorylimiter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/shirou/gopsutil/v4 v4.26.7

--- a/internal/schemagen/go.mod
+++ b/internal/schemagen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/schemagen
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/jsonschema-go v0.4.3

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/sharedcomponent
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/internal/telemetry/go.mod
+++ b/internal/telemetry/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/telemetry
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/internal/testutil/go.mod
+++ b/internal/testutil/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/testutil
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-git/go-git/v5 v5.19.2 // indirect
-	github.com/go-json-experiment/json v0.0.0-20260213210345-44df1a37e875 // indirect
+	github.com/go-json-experiment/json v0.0.0-20260819210203-93dd53efdd9e // indirect
 	github.com/go-toolsmith/astcast v1.1.0 // indirect
 	github.com/go-toolsmith/astcopy v1.1.0 // indirect
 	github.com/go-toolsmith/astequal v1.2.0 // indirect

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/tools
 
-go 1.25.0
+go 1.26.0
 
 tool (
 	github.com/a8m/envsubst/cmd/envsubst

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -175,8 +175,8 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMj
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
 github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
-github.com/go-json-experiment/json v0.0.0-20260213210345-44df1a37e875 h1:XGPtjxqp0FS8jj1Z7QGcSOSgyq1fUPjNyJXvi3KfI4A=
-github.com/go-json-experiment/json v0.0.0-20260213210345-44df1a37e875/go.mod h1:uNVvRXArCGbZ508SxYYTC5v1JWoz2voff5pm25jU1Ok=
+github.com/go-json-experiment/json v0.0.0-20260819210203-93dd53efdd9e h1:OwX9pY7vg7bE2qpr5KhWotZtd6hUAY2exnz0eX0n+WY=
+github.com/go-json-experiment/json v0.0.0-20260819210203-93dd53efdd9e/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-quicktest/qt v1.102.0 h1:HSQxCeh5YZH3EL3W39ixjtyaEhcWSXQHtHnMBzSs474=

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/otelcol
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/spf13/cobra v1.10.2

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/otelcol/otelcoltest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/pdata/go.mod
+++ b/pdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/json-iterator/go v1.1.12

--- a/pdata/pprofile/go.mod
+++ b/pdata/pprofile/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/pprofile
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/testdata
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opentelemetry.io/collector/pdata v1.65.0

--- a/pdata/xpdata/go.mod
+++ b/pdata/xpdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata/xpdata
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/pipeline/go.mod
+++ b/pipeline/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pipeline
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.12.0
 

--- a/pipeline/xpipeline/go.mod
+++ b/pipeline/xpipeline/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pipeline/xpipeline
 
-go 1.25.0
+go 1.26.0
 
 require go.opentelemetry.io/collector/pipeline v1.65.0
 

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/batchprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/memorylimiterprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/processor/processorhelper/go.mod
+++ b/processor/processorhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processorhelper
 
-go 1.25.0
+go 1.26.0
 
 replace go.opentelemetry.io/collector/processor => ../
 

--- a/processor/processorhelper/xprocessorhelper/go.mod
+++ b/processor/processorhelper/xprocessorhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/processortest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/processor/queuebatchprocessor/go.mod
+++ b/processor/queuebatchprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/queuebatchprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/processor/xprocessor/go.mod
+++ b/processor/xprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/xprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/nopreceiver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/otlpreceiver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/klauspost/compress v1.19.2

--- a/receiver/receiverhelper/go.mod
+++ b/receiver/receiverhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/receiverhelper
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/receivertest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/receiver/xreceiver/go.mod
+++ b/receiver/xreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/xreceiver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/scraper/scrapererror/scrapeerror_test.go
+++ b/scraper/scrapererror/scrapeerror_test.go
@@ -95,8 +95,7 @@ func TestScrapeErrorsCombine(t *testing.T) {
 		}
 		require.EqualError(t, scrapeErrs.Combine(), tt.expectedErr)
 		if tt.expectedScrape {
-			var partialScrapeErr PartialScrapeError
-			if !errors.As(scrapeErrs.Combine(), &partialScrapeErr) {
+			if partialScrapeErr, ok := errors.AsType[PartialScrapeError](scrapeErrs.Combine()); !ok {
 				t.Errorf("%+v.Combine() = %q. Want: PartialScrapeError", scrapeErrs, scrapeErrs.Combine())
 			} else if tt.expectedFailedCount != partialScrapeErr.Failed {
 				t.Errorf("%+v.Combine().Failed. Got %d Failed count. Want: %d", scrapeErrs, partialScrapeErr.Failed, tt.expectedFailedCount)

--- a/scraper/scraperhelper/controller_test.go
+++ b/scraper/scraperhelper/controller_test.go
@@ -409,8 +409,7 @@ func assertLogsScraperObsMetrics(t *testing.T, tel *componenttest.Telemetry, rec
 	expectedScraped := int64(sink.LogRecordCount())
 	expectedErrored := int64(0)
 	if expectedErr != nil {
-		var partialError scrapererror.PartialScrapeError
-		if errors.As(expectedErr, &partialError) {
+		if partialError, ok := errors.AsType[scrapererror.PartialScrapeError](expectedErr); ok {
 			expectedErrored = int64(partialError.Failed)
 		} else {
 			expectedScraped = int64(0)
@@ -450,8 +449,7 @@ func assertMetricsScraperObsMetrics(t *testing.T, tel *componenttest.Telemetry, 
 	expectedScraped := int64(sink.DataPointCount())
 	expectedErrored := int64(0)
 	if expectedErr != nil {
-		var partialError scrapererror.PartialScrapeError
-		if errors.As(expectedErr, &partialError) {
+		if partialError, ok := errors.AsType[scrapererror.PartialScrapeError](expectedErr); ok {
 			expectedErrored = int64(partialError.Failed)
 		} else {
 			expectedScraped = int64(0)

--- a/scraper/scraperhelper/go.mod
+++ b/scraper/scraperhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/scraperhelper
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/scraper/scraperhelper/obs_logs.go
+++ b/scraper/scraperhelper/obs_logs.go
@@ -51,8 +51,7 @@ func wrapObsLogs(sc scraper.Logs, receiverID, scraperID component.ID, set compon
 		numErroredLogs := 0
 		if err != nil {
 			set.Logger.Error("Error scraping logs", zap.Error(err))
-			var partialErr scrapererror.PartialScrapeError
-			if errors.As(err, &partialErr) {
+			if partialErr, ok := errors.AsType[scrapererror.PartialScrapeError](err); ok {
 				numErroredLogs = partialErr.Failed
 				numScrapedLogs = md.LogRecordCount()
 			}

--- a/scraper/scraperhelper/obs_metrics.go
+++ b/scraper/scraperhelper/obs_metrics.go
@@ -59,8 +59,7 @@ func wrapObsMetrics(sc scraper.Metrics, receiverID, scraperID component.ID, set 
 		numErroredMetrics := 0
 		if err != nil {
 			set.Logger.Error("Error scraping metrics", zap.Error(err))
-			var partialErr scrapererror.PartialScrapeError
-			if errors.As(err, &partialErr) {
+			if partialErr, ok := errors.AsType[scrapererror.PartialScrapeError](err); ok {
 				numErroredMetrics = partialErr.Failed
 				numScrapedMetrics = md.MetricCount()
 			}

--- a/scraper/scraperhelper/xscraperhelper/controller_test.go
+++ b/scraper/scraperhelper/xscraperhelper/controller_test.go
@@ -379,8 +379,7 @@ func assertProfilesScraperObsMetrics(t *testing.T, tel *componenttest.Telemetry,
 	expectedScraped := int64(sink.SampleCount())
 	expectedErrored := int64(0)
 	if expectedErr != nil {
-		var partialError scrapererror.PartialScrapeError
-		if errors.As(expectedErr, &partialError) {
+		if partialError, ok := errors.AsType[scrapererror.PartialScrapeError](expectedErr); ok {
 			expectedErrored = int64(partialError.Failed)
 		} else {
 			expectedScraped = int64(0)

--- a/scraper/scraperhelper/xscraperhelper/go.mod
+++ b/scraper/scraperhelper/xscraperhelper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/scraperhelper/xscraperhelper
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/scraper/scraperhelper/xscraperhelper/obs_profiles.go
+++ b/scraper/scraperhelper/xscraperhelper/obs_profiles.go
@@ -53,8 +53,7 @@ func wrapObsProfiles(sc xscraper.Profiles, receiverID, scraperID component.ID, s
 		numErroredProfiles := 0
 		if err != nil {
 			set.Logger.Error("Error scraping profiles", zap.Error(err))
-			var partialErr scrapererror.PartialScrapeError
-			if errors.As(err, &partialErr) {
+			if partialErr, ok := errors.AsType[scrapererror.PartialScrapeError](err); ok {
 				numErroredProfiles = partialErr.Failed
 				numScrapedProfiles = md.ProfileCount()
 			}

--- a/scraper/scrapertest/go.mod
+++ b/scraper/scrapertest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/scrapertest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/scraper/xscraper/go.mod
+++ b/scraper/xscraper/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/scraper/xscraper
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/service
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/service/hostcapabilities/go.mod
+++ b/service/hostcapabilities/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/service/hostcapabilities
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opentelemetry.io/collector/component v1.65.0

--- a/service/internal/metricviews/views.go
+++ b/service/internal/metricviews/views.go
@@ -17,15 +17,15 @@ func DefaultViews(level configtelemetry.Level) []config.View {
 		// Drop all otelhttp and otelgrpc metrics if the level is not detailed.
 		views = append(views,
 			dropViewOption(&config.ViewSelector{
-				MeterName: ptr("go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"),
+				MeterName: new("go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"),
 			}),
 			dropViewOption(&config.ViewSelector{
-				MeterName: ptr("go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"),
+				MeterName: new("go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"),
 			}),
 			// Drop duration metric if the level is not detailed
 			dropViewOption(&config.ViewSelector{
-				MeterName:      ptr("go.opentelemetry.io/collector/processor/processorhelper"),
-				InstrumentName: ptr("otelcol_processor_internal_duration"),
+				MeterName:      new("go.opentelemetry.io/collector/processor/processorhelper"),
+				InstrumentName: new("otelcol_processor_internal_duration"),
 			}),
 		)
 	}
@@ -33,19 +33,19 @@ func DefaultViews(level configtelemetry.Level) []config.View {
 	// otel-arrow library metrics
 	// See https://github.com/open-telemetry/otel-arrow/blob/c39257/pkg/otel/arrow_record/consumer.go#L174-L176
 	if level < configtelemetry.LevelNormal {
-		scope := ptr("otel-arrow/pkg/otel/arrow_record")
+		scope := new("otel-arrow/pkg/otel/arrow_record")
 		views = append(views,
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("arrow_batch_records"),
+				InstrumentName: new("arrow_batch_records"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("arrow_schema_resets"),
+				InstrumentName: new("arrow_schema_resets"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("arrow_memory_inuse"),
+				InstrumentName: new("arrow_memory_inuse"),
 			}),
 		)
 	}
@@ -55,65 +55,65 @@ func DefaultViews(level configtelemetry.Level) []config.View {
 	// - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/a25f05/internal/otelarrow/netstats/netstats.go#L130
 	// - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/a25f05/internal/otelarrow/netstats/netstats.go#L165
 	if level < configtelemetry.LevelDetailed {
-		scope := ptr("github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow/netstats")
+		scope := new("github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow/netstats")
 
 		views = append(views,
 			// Compressed size metrics.
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_*_compressed_size"),
+				InstrumentName: new("otelcol_*_compressed_size"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_*_compressed_size"),
+				InstrumentName: new("otelcol_*_compressed_size"),
 			}),
 
 			// makeRecvMetrics for exporters.
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_exporter_recv"),
+				InstrumentName: new("otelcol_exporter_recv"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_exporter_recv_wire"),
+				InstrumentName: new("otelcol_exporter_recv_wire"),
 			}),
 
 			// makeSentMetrics for receivers.
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_receiver_sent"),
+				InstrumentName: new("otelcol_receiver_sent"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_receiver_sent_wire"),
+				InstrumentName: new("otelcol_receiver_sent_wire"),
 			}),
 		)
 	}
 
 	// Batch exporter metrics
 	if level < configtelemetry.LevelDetailed {
-		scope := ptr("go.opentelemetry.io/collector/exporter/exporterhelper")
+		scope := new("go.opentelemetry.io/collector/exporter/exporterhelper")
 		views = append(views,
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_exporter_queue_batch_send_size_bytes"),
+				InstrumentName: new("otelcol_exporter_queue_batch_send_size_bytes"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_exporter_queue_batch_send_size"),
+				InstrumentName: new("otelcol_exporter_queue_batch_send_size"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_exporter_enqueue_size_bytes"),
+				InstrumentName: new("otelcol_exporter_enqueue_size_bytes"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      scope,
-				InstrumentName: ptr("otelcol_exporter_enqueue_size"),
+				InstrumentName: new("otelcol_exporter_enqueue_size"),
 			}),
 			config.View{
 				Selector: &config.ViewSelector{
 					MeterName:      scope,
-					InstrumentName: ptr("otelcol_exporter_send_failed_*"),
+					InstrumentName: new("otelcol_exporter_send_failed_*"),
 				},
 				Stream: &config.ViewStream{
 					AttributeKeys: &config.IncludeExclude{
@@ -125,7 +125,7 @@ func DefaultViews(level configtelemetry.Level) []config.View {
 	}
 
 	// Batch processor metrics
-	scope := ptr("go.opentelemetry.io/collector/processor/batchprocessor")
+	scope := new("go.opentelemetry.io/collector/processor/batchprocessor")
 	if level < configtelemetry.LevelNormal {
 		views = append(views, dropViewOption(&config.ViewSelector{
 			MeterName: scope,
@@ -133,21 +133,21 @@ func DefaultViews(level configtelemetry.Level) []config.View {
 	} else if level < configtelemetry.LevelDetailed {
 		views = append(views, dropViewOption(&config.ViewSelector{
 			MeterName:      scope,
-			InstrumentName: ptr("otelcol_processor_batch_batch_send_size_bytes"),
+			InstrumentName: new("otelcol_processor_batch_batch_send_size_bytes"),
 		}))
 	}
 
 	// Internal graph metrics
-	graphScope := ptr("go.opentelemetry.io/collector/service")
+	graphScope := new("go.opentelemetry.io/collector/service")
 	if level < configtelemetry.LevelDetailed {
 		views = append(views,
 			dropViewOption(&config.ViewSelector{
 				MeterName:      graphScope,
-				InstrumentName: ptr("otelcol.*.consumed.size"),
+				InstrumentName: new("otelcol.*.consumed.size"),
 			}),
 			dropViewOption(&config.ViewSelector{
 				MeterName:      graphScope,
-				InstrumentName: ptr("otelcol.*.produced.size"),
+				InstrumentName: new("otelcol.*.produced.size"),
 			}))
 	}
 
@@ -163,8 +163,4 @@ func dropViewOption(selector *config.ViewSelector) config.View {
 			},
 		},
 	}
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/service/internal/promtest/server_util.go
+++ b/service/internal/promtest/server_util.go
@@ -36,12 +36,8 @@ func addrToPrometheus(address string) *config.Prometheus {
 	return &config.Prometheus{
 		Host:              &host,
 		Port:              &portInt,
-		WithoutScopeInfo:  ptr(true),
-		WithoutUnits:      ptr(true),
-		WithoutTypeSuffix: ptr(true),
+		WithoutScopeInfo:  new(true),
+		WithoutUnits:      new(true),
+		WithoutTypeSuffix: new(true),
 	}
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/service/telemetry/otelconftelemetry/config_test.go
+++ b/service/telemetry/otelconftelemetry/config_test.go
@@ -105,11 +105,11 @@ func TestConfig(t *testing.T) {
 				cfg.Metrics.Readers = []config.MetricReader{
 					{
 						Pull: &config.PullMetricReader{Exporter: config.PullMetricExporter{Prometheus: &config.Prometheus{
-							WithoutScopeInfo:  ptr(true),
-							WithoutUnits:      ptr(true),
-							WithoutTypeSuffix: ptr(true),
+							WithoutScopeInfo:  new(true),
+							WithoutUnits:      new(true),
+							WithoutTypeSuffix: new(true),
 							Host:              &host,
-							Port:              ptr(8888),
+							Port:              new(8888),
 						}}},
 					},
 				}

--- a/service/telemetry/otelconftelemetry/factory.go
+++ b/service/telemetry/otelconftelemetry/factory.go
@@ -52,11 +52,11 @@ func createDefaultConfig() component.Config {
 				Readers: []config.MetricReader{
 					{
 						Pull: &config.PullMetricReader{Exporter: config.PullMetricExporter{Prometheus: &config.Prometheus{
-							WithoutScopeInfo:  ptr(true),
-							WithoutUnits:      ptr(true),
-							WithoutTypeSuffix: ptr(true),
-							Host:              ptr("localhost"),
-							Port:              ptr(8888),
+							WithoutScopeInfo:  new(true),
+							WithoutUnits:      new(true),
+							WithoutTypeSuffix: new(true),
+							Host:              new("localhost"),
+							Port:              new(8888),
 						}}},
 					},
 				},
@@ -70,6 +70,7 @@ func createDefaultConfig() component.Config {
 	}
 }
 
+//go:fix inline
 func ptr[T any](v T) *T {
-	return &v
+	return new(v)
 }

--- a/service/telemetry/otelconftelemetry/internal/migration/v0.2.0_test.go
+++ b/service/telemetry/otelconftelemetry/internal/migration/v0.2.0_test.go
@@ -63,13 +63,9 @@ func TestUnmarshalMetricsConfigV020(t *testing.T) {
 	require.Len(t, cfg.Readers, 2)
 	// check the endpoint is prefixed w/ https
 	require.Equal(t, "https://127.0.0.1:4317", *cfg.Readers[0].Periodic.Exporter.OTLP.Endpoint)
-	require.ElementsMatch(t, []config.NameStringValuePair{{Name: "key1", Value: ptr("value1")}, {Name: "key2", Value: ptr("value2")}}, cfg.Readers[0].Periodic.Exporter.OTLP.Headers)
+	require.ElementsMatch(t, []config.NameStringValuePair{{Name: "key1", Value: new("value1")}, {Name: "key2", Value: new("value2")}}, cfg.Readers[0].Periodic.Exporter.OTLP.Headers)
 	// ensure defaults set in the original config object are not lost
 	require.Equal(t, configtelemetry.LevelBasic, cfg.Level)
 	// ensure migration flag is set
 	require.True(t, cfg.MigratedFromV02)
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/service/telemetry/otelconftelemetry/internal/migration/v0.3.0.go
+++ b/service/telemetry/otelconftelemetry/internal/migration/v0.3.0.go
@@ -146,21 +146,17 @@ func (c MetricsConfigV030) Marshal(conf *confmap.Conf) error {
 	return conf.Marshal(sm)
 }
 
-func boolPtr(v bool) *bool {
-	return &v
-}
-
 // applyPrometheusDefaults sets default values for Prometheus exporter
 // fields that were not explicitly provided in the configuration.
 func applyPrometheusDefaults(p *config.Prometheus) {
 	if p.WithoutScopeInfo == nil {
-		p.WithoutScopeInfo = boolPtr(true)
+		p.WithoutScopeInfo = new(true)
 	}
 	if p.WithoutUnits == nil {
-		p.WithoutUnits = boolPtr(true)
+		p.WithoutUnits = new(true)
 	}
 	if p.WithoutTypeSuffix == nil {
-		p.WithoutTypeSuffix = boolPtr(true)
+		p.WithoutTypeSuffix = new(true)
 	}
 }
 

--- a/service/telemetry/otelconftelemetry/logger_test.go
+++ b/service/telemetry/otelconftelemetry/logger_test.go
@@ -576,9 +576,9 @@ func newOTLPLogger(t *testing.T, level zapcore.Level, handler func(plogotlp.Expo
 		Simple: &config.SimpleLogRecordProcessor{
 			Exporter: config.LogRecordExporter{
 				OTLP: &config.OTLP{
-					Endpoint: ptr(srv.URL),
-					Protocol: ptr("http/protobuf"),
-					Insecure: ptr(true),
+					Endpoint: new(srv.URL),
+					Protocol: new("http/protobuf"),
+					Insecure: new(true),
 				},
 			},
 		},
@@ -658,9 +658,9 @@ func TestLogAttributeInjection(t *testing.T) {
 					Exporter: config.LogRecordExporter{
 						OTLP: &config.OTLP{
 							// Send OTLP logs to the mock backend
-							Endpoint: ptr(srv.URL),
-							Protocol: ptr("http/protobuf"),
-							Insecure: ptr(true),
+							Endpoint: new(srv.URL),
+							Protocol: new("http/protobuf"),
+							Insecure: new(true),
 						},
 					},
 				},

--- a/service/telemetry/otelconftelemetry/metrics_test.go
+++ b/service/telemetry/otelconftelemetry/metrics_test.go
@@ -380,7 +380,7 @@ func TestTelemetryMetrics_DefaultViews(t *testing.T) {
 		assert.Equal(t, configtelemetry.LevelDetailed, level)
 		return []config.View{{
 			Selector: &config.ViewSelector{
-				MeterName: ptr("a"),
+				MeterName: new("a"),
 			},
 			Stream: &config.ViewStream{
 				Aggregation: &config.ViewStreamAggregation{
@@ -397,7 +397,7 @@ func TestTelemetryMetrics_DefaultViews(t *testing.T) {
 		"configured_views": {
 			configuredViews: []config.View{{
 				Selector: &config.ViewSelector{
-					MeterName: ptr("b"),
+					MeterName: new("b"),
 				},
 				Stream: &config.ViewStream{
 					Aggregation: &config.ViewStreamAggregation{
@@ -427,9 +427,9 @@ func TestTelemetryMetrics_DefaultViews(t *testing.T) {
 				Periodic: &config.PeriodicMetricReader{
 					Exporter: config.PushMetricExporter{
 						OTLP: &config.OTLPMetric{
-							Endpoint: ptr(srv.URL),
-							Protocol: ptr("http/protobuf"),
-							Insecure: ptr(true),
+							Endpoint: new(srv.URL),
+							Protocol: new("http/protobuf"),
+							Insecure: new(true),
 						},
 					},
 				},

--- a/service/telemetry/otelconftelemetry/tracer_test.go
+++ b/service/telemetry/otelconftelemetry/tracer_test.go
@@ -302,9 +302,9 @@ func newOTLPSimpleSpanProcessor(srv *httptest.Server) config.SpanProcessor {
 		Simple: &config.SimpleSpanProcessor{
 			Exporter: config.SpanExporter{
 				OTLP: &config.OTLP{
-					Endpoint: ptr(srv.URL),
-					Protocol: ptr("http/protobuf"),
-					Insecure: ptr(true),
+					Endpoint: new(srv.URL),
+					Protocol: new("http/protobuf"),
+					Insecure: new(true),
 				},
 			},
 		},

--- a/service/telemetry/telemetrytest/go.mod
+++ b/service/telemetry/telemetrytest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/service/telemetry/telemetrytest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.0


### PR DESCRIPTION
#### Description
Bump go version in all go.mod to 1.26.0, drop support on 1.25.0, since 1.27 is released

#### Authorship

- [x] I, a human, wrote this pull request description myself.
