### PR TITLE
exporterhelper: add requests sizer support in the batcher

### DIFF
--- a/.chloggen/exporterhelper-requests-sizer-batcher.yaml
+++ b/.chloggen/exporterhelper-requests-sizer-batcher.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for `requests` sizer in the exporter batcher."
+
+# One or more tracking issues or pull requests related to the change
+issues: [12880]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The batch configuration now accepts `requests` in addition to `items` and `bytes`.
+  Each incoming export call counts as 1. Requests are merged until `min_size` is
+  reached or `flush_timeout` elapses. A request cannot be split.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -55,6 +55,7 @@ If `sending_queue::sizer` is not set, `batch::sizer` defaults to `items`.
 
 Available `batch::sizer` options:
 
+- `requests`: number of incoming export calls. Each call counts as 1 regardless of its payload size. `min_size` is measured in requests. A request cannot be split, so `max_size` does not split a single request;
 - `items`: number of the smallest parts of each signal (spans, metric data points, log records);
 - `bytes`: the size of serialized data in bytes (the least performant option).
 

--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -126,9 +126,8 @@ func (cfg *BatchConfig) Validate() error {
 		return nil
 	}
 
-	// Only support items or bytes sizer for batch at this moment.
-	if cfg.Sizer != request.SizerTypeItems && cfg.Sizer != request.SizerTypeBytes {
-		return fmt.Errorf("`batch` supports only `items` or `bytes` sizer, found %q", cfg.Sizer.String())
+	if cfg.Sizer != request.SizerTypeRequests && cfg.Sizer != request.SizerTypeItems && cfg.Sizer != request.SizerTypeBytes {
+		return fmt.Errorf("`batch` supports only `requests`, `items`, or `bytes` sizer, found %q", cfg.Sizer.String())
 	}
 
 	if cfg.FlushTimeout <= 0 {

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -45,7 +45,7 @@ func TestConfig_Validate(t *testing.T) {
 
 	cfg = newTestConfig()
 	cfg.Batch.Get().Sizer = request.SizerType{}
-	require.EqualError(t, confmap.Validate(cfg), "batch: `batch` supports only `items` or `bytes` sizer, found \"\"")
+	require.EqualError(t, confmap.Validate(cfg), "batch: `batch` supports only `requests`, `items`, or `bytes` sizer, found \"\"")
 
 	cfg = newTestConfig()
 	cfg.Sizer = request.SizerTypeBytes
@@ -109,11 +109,11 @@ func TestBatchConfig_Validate(t *testing.T) {
 
 	cfg = newTestBatchConfig()
 	cfg.Sizer = request.SizerTypeRequests
-	require.EqualError(t, confmap.Validate(cfg), "`batch` supports only `items` or `bytes` sizer, found \"requests\"")
+	require.NoError(t, confmap.Validate(cfg))
 
 	cfg = newTestBatchConfig()
 	cfg.Sizer = request.SizerType{}
-	require.EqualError(t, confmap.Validate(cfg), "`batch` supports only `items` or `bytes` sizer, found \"\"")
+	require.EqualError(t, confmap.Validate(cfg), "`batch` supports only `requests`, `items`, or `bytes` sizer, found \"\"")
 
 	cfg = newTestBatchConfig()
 	cfg.MinSize = 2048

--- a/exporter/exporterhelper/internal/queuebatch/logs.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs.go
@@ -33,19 +33,22 @@ func NewLogsQueueBatchSettings() Settings[request.Request] {
 }
 
 var (
-	_ request.Request      = (*logsRequest)(nil)
-	_ request.ErrorHandler = (*logsRequest)(nil)
+	_ request.Request         = (*logsRequest)(nil)
+	_ request.ErrorHandler    = (*logsRequest)(nil)
+	_ request.RequestsCounter = (*logsRequest)(nil)
 )
 
 type logsRequest struct {
-	ld         plog.Logs
-	cachedSize int
+	ld           plog.Logs
+	cachedSize   int
+	requestCount int
 }
 
 func newLogsRequest(ld plog.Logs) request.Request {
 	return &logsRequest{
-		ld:         ld,
-		cachedSize: -1,
+		ld:           ld,
+		cachedSize:   -1,
+		requestCount: 1,
 	}
 }
 
@@ -88,6 +91,13 @@ func (req *logsRequest) OnError(err error) request.Request {
 
 func (req *logsRequest) ItemsCount() int {
 	return req.ld.LogRecordCount()
+}
+
+func (req *logsRequest) RequestsCount() int {
+	if req.requestCount <= 0 {
+		return 1
+	}
+	return req.requestCount
 }
 
 func (req *logsRequest) size(sizer sizer.LogsSizer) int {

--- a/exporter/exporterhelper/internal/queuebatch/logs_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_batch.go
@@ -16,6 +16,10 @@ import (
 // MergeSplit splits and/or merges the provided logs request and the current request into one or more requests
 // conforming with the MaxSizeConfig.
 func (req *logsRequest) MergeSplit(_ context.Context, maxSize int, szt request.SizerType, r2 request.Request) ([]request.Request, error) {
+	if szt == request.SizerTypeRequests {
+		return mergeSplitLogsRequests(req, maxSize, r2)
+	}
+
 	var sz sizer.LogsSizer
 	switch szt {
 	case request.SizerTypeItems:
@@ -39,6 +43,22 @@ func (req *logsRequest) MergeSplit(_ context.Context, maxSize int, szt request.S
 	}
 
 	return req.split(maxSize, sz)
+}
+
+func mergeSplitLogsRequests(req *logsRequest, maxSize int, r2 request.Request) ([]request.Request, error) {
+	if r2 != nil {
+		req2, ok := r2.(*logsRequest)
+		if !ok {
+			return nil, errors.New("invalid input type")
+		}
+		mergedCount := req.RequestsCount() + req2.RequestsCount()
+		if maxSize > 0 && mergedCount > maxSize {
+			return []request.Request{req, req2}, nil
+		}
+		req2.mergeTo(req, nil)
+		req.requestCount = mergedCount
+	}
+	return []request.Request{req}, nil
 }
 
 func (req *logsRequest) mergeTo(dst *logsRequest, sz sizer.LogsSizer) {

--- a/exporter/exporterhelper/internal/queuebatch/logs_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/logs_batch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/requesttest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
 	"go.opentelemetry.io/collector/internal/testutil"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -323,6 +324,101 @@ func TestLogsMergeSplitUnknownSizerType(t *testing.T) {
 	// Call MergeSplit with invalid sizer
 	_, err := req.MergeSplit(context.Background(), 0, request.SizerType{}, nil)
 	require.EqualError(t, err, "unknown sizer type")
+}
+
+func TestMergeSplitLogsRequestsSizer(t *testing.T) {
+	tests := []struct {
+		name           string
+		lr1            request.Request
+		lr2            request.Request
+		maxSize        int
+		wantLen        int
+		wantItemCounts []int
+		wantReqCounts  []int64
+		wantErr        string
+	}{
+		{
+			name:           "merge_two_requests",
+			lr1:            newLogsRequest(testdata.GenerateLogs(5)),
+			lr2:            newLogsRequest(testdata.GenerateLogs(3)),
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{8},
+			wantReqCounts:  []int64{2},
+		},
+		{
+			name:           "merge_when_under_max_size",
+			lr1:            newLogsRequest(testdata.GenerateLogs(5)),
+			lr2:            newLogsRequest(testdata.GenerateLogs(3)),
+			maxSize:        2,
+			wantLen:        1,
+			wantItemCounts: []int{8},
+			wantReqCounts:  []int64{2},
+		},
+		{
+			name:           "do_not_merge_when_over_max_size",
+			lr1:            newLogsRequest(testdata.GenerateLogs(5)),
+			lr2:            newLogsRequest(testdata.GenerateLogs(3)),
+			maxSize:        1,
+			wantLen:        2,
+			wantItemCounts: []int{5, 3},
+			wantReqCounts:  []int64{1, 1},
+		},
+		{
+			name:           "nil_second_request",
+			lr1:            newLogsRequest(testdata.GenerateLogs(7)),
+			lr2:            nil,
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{7},
+			wantReqCounts:  []int64{1},
+		},
+		{
+			name:           "empty_first_request",
+			lr1:            newLogsRequest(plog.NewLogs()),
+			lr2:            newLogsRequest(testdata.GenerateLogs(4)),
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{4},
+			wantReqCounts:  []int64{2},
+		},
+		{
+			name:    "invalid_input_type",
+			lr1:     newLogsRequest(testdata.GenerateLogs(1)),
+			lr2:     &requesttest.FakeRequest{Items: 1},
+			maxSize: 0,
+			wantErr: "invalid input type",
+		},
+	}
+
+	sz := request.RequestsSizer{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.lr1.MergeSplit(context.Background(), tt.maxSize, request.SizerTypeRequests, tt.lr2)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, res, tt.wantLen)
+			for i, r := range res {
+				assert.Equal(t, tt.wantItemCounts[i], r.ItemsCount())
+				assert.Equal(t, tt.wantReqCounts[i], sz.Sizeof(r))
+			}
+		})
+	}
+}
+
+func TestMergeSplitLogsRequestsSizerAccumulates(t *testing.T) {
+	r := newLogsRequest(testdata.GenerateLogs(1))
+	for range 4 {
+		res, err := r.MergeSplit(context.Background(), 0, request.SizerTypeRequests, newLogsRequest(testdata.GenerateLogs(1)))
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		r = res[0]
+	}
+	assert.Equal(t, 5, r.ItemsCount())
+	assert.EqualValues(t, 5, request.RequestsSizer{}.Sizeof(r))
 }
 
 func BenchmarkSplittingBasedOnItemCountManySmallLogs(b *testing.B) {

--- a/exporter/exporterhelper/internal/queuebatch/metrics.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics.go
@@ -30,19 +30,22 @@ func NewMetricsQueueBatchSettings() Settings[request.Request] {
 }
 
 var (
-	_ request.Request      = (*metricsRequest)(nil)
-	_ request.ErrorHandler = (*metricsRequest)(nil)
+	_ request.Request         = (*metricsRequest)(nil)
+	_ request.ErrorHandler    = (*metricsRequest)(nil)
+	_ request.RequestsCounter = (*metricsRequest)(nil)
 )
 
 type metricsRequest struct {
-	md         pmetric.Metrics
-	cachedSize int
+	md           pmetric.Metrics
+	cachedSize   int
+	requestCount int
 }
 
 func newMetricsRequest(md pmetric.Metrics) request.Request {
 	return &metricsRequest{
-		md:         md,
-		cachedSize: -1,
+		md:           md,
+		cachedSize:   -1,
+		requestCount: 1,
 	}
 }
 
@@ -85,6 +88,13 @@ func (req *metricsRequest) OnError(err error) request.Request {
 
 func (req *metricsRequest) ItemsCount() int {
 	return req.md.DataPointCount()
+}
+
+func (req *metricsRequest) RequestsCount() int {
+	if req.requestCount <= 0 {
+		return 1
+	}
+	return req.requestCount
 }
 
 func (req *metricsRequest) size(sizer sizer.MetricsSizer) int {

--- a/exporter/exporterhelper/internal/queuebatch/metrics_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_batch.go
@@ -16,6 +16,10 @@ import (
 // MergeSplit splits and/or merges the provided metrics request and the current request into one or more requests
 // conforming with the MaxSizeConfig.
 func (req *metricsRequest) MergeSplit(_ context.Context, maxSize int, szt request.SizerType, r2 request.Request) ([]request.Request, error) {
+	if szt == request.SizerTypeRequests {
+		return mergeSplitMetricsRequests(req, maxSize, r2)
+	}
+
 	var sz sizer.MetricsSizer
 	switch szt {
 	case request.SizerTypeItems:
@@ -39,6 +43,22 @@ func (req *metricsRequest) MergeSplit(_ context.Context, maxSize int, szt reques
 		return []request.Request{req}, nil
 	}
 	return req.split(maxSize, sz)
+}
+
+func mergeSplitMetricsRequests(req *metricsRequest, maxSize int, r2 request.Request) ([]request.Request, error) {
+	if r2 != nil {
+		req2, ok := r2.(*metricsRequest)
+		if !ok {
+			return nil, errors.New("invalid input type")
+		}
+		mergedCount := req.RequestsCount() + req2.RequestsCount()
+		if maxSize > 0 && mergedCount > maxSize {
+			return []request.Request{req, req2}, nil
+		}
+		req2.mergeTo(req, nil)
+		req.requestCount = mergedCount
+	}
+	return []request.Request{req}, nil
 }
 
 func (req *metricsRequest) mergeTo(dst *metricsRequest, sz sizer.MetricsSizer) {

--- a/exporter/exporterhelper/internal/queuebatch/metrics_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/metrics_batch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/requesttest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
 	"go.opentelemetry.io/collector/internal/testutil"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -727,6 +728,91 @@ func TestMetricsMergeSplitUnknownSizerType(t *testing.T) {
 	// Call MergeSplit with invalid sizer
 	_, err := req.MergeSplit(context.Background(), 0, request.SizerType{}, nil)
 	require.EqualError(t, err, "unknown sizer type")
+}
+
+func TestMergeSplitMetricsRequestsSizer(t *testing.T) {
+	tests := []struct {
+		name           string
+		mr1            request.Request
+		mr2            request.Request
+		maxSize        int
+		wantLen        int
+		wantItemCounts []int
+		wantReqCounts  []int64
+		wantErr        string
+	}{
+		{
+			// testdata.GenerateMetrics(N) creates N metrics each with 2 data points,
+			// so ItemsCount() == N*2.
+			name:           "merge_two_requests",
+			mr1:            newMetricsRequest(testdata.GenerateMetrics(5)),
+			mr2:            newMetricsRequest(testdata.GenerateMetrics(3)),
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{16},
+			wantReqCounts:  []int64{2},
+		},
+		{
+			name:           "merge_when_under_max_size",
+			mr1:            newMetricsRequest(testdata.GenerateMetrics(5)),
+			mr2:            newMetricsRequest(testdata.GenerateMetrics(3)),
+			maxSize:        2,
+			wantLen:        1,
+			wantItemCounts: []int{16},
+			wantReqCounts:  []int64{2},
+		},
+		{
+			name:           "do_not_merge_when_over_max_size",
+			mr1:            newMetricsRequest(testdata.GenerateMetrics(5)),
+			mr2:            newMetricsRequest(testdata.GenerateMetrics(3)),
+			maxSize:        1,
+			wantLen:        2,
+			wantItemCounts: []int{10, 6},
+			wantReqCounts:  []int64{1, 1},
+		},
+		{
+			name:           "nil_second_request",
+			mr1:            newMetricsRequest(testdata.GenerateMetrics(7)),
+			mr2:            nil,
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{14},
+			wantReqCounts:  []int64{1},
+		},
+		{
+			name:           "empty_first_request",
+			mr1:            newMetricsRequest(pmetric.NewMetrics()),
+			mr2:            newMetricsRequest(testdata.GenerateMetrics(4)),
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{8},
+			wantReqCounts:  []int64{2},
+		},
+		{
+			name:    "invalid_input_type",
+			mr1:     newMetricsRequest(testdata.GenerateMetrics(1)),
+			mr2:     &requesttest.FakeRequest{Items: 1},
+			maxSize: 0,
+			wantErr: "invalid input type",
+		},
+	}
+
+	sz := request.RequestsSizer{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.mr1.MergeSplit(context.Background(), tt.maxSize, request.SizerTypeRequests, tt.mr2)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, res, tt.wantLen)
+			for i, r := range res {
+				assert.Equal(t, tt.wantItemCounts[i], r.ItemsCount())
+				assert.Equal(t, tt.wantReqCounts[i], sz.Sizeof(r))
+			}
+		})
+	}
 }
 
 // mockMetricsSizer implements sizer.MetricsSizer interface for testing

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher_test.go
@@ -627,3 +627,86 @@ func TestPartitionBatcher_OnEmptyNotCalledWithActiveData(t *testing.T) {
 	// But data should have been flushed
 	assert.GreaterOrEqual(t, sink.RequestsCount(), 1)
 }
+
+func TestPartitionBatcher_RequestsSizer_MinSize(t *testing.T) {
+	cfg := BatchConfig{
+		FlushTimeout: 100 * time.Second,
+		Sizer:        request.SizerTypeRequests,
+		MinSize:      3,
+	}
+
+	sink := requesttest.NewSink()
+	ba := newPartitionBatcher(cfg, request.RequestsSizer{}, nil, newWorkerPool(1), sink.Export, zap.NewNop(), nil)
+	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+
+	done := newFakeDone()
+	ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 4}, done)
+	ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 5}, done)
+	assert.Equal(t, 0, sink.RequestsCount())
+
+	ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 6}, done)
+	assert.Eventually(t, func() bool {
+		return sink.RequestsCount() == 1 && sink.ItemsCount() == 15
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, ba.Shutdown(context.Background()))
+	assert.Equal(t, 1, sink.RequestsCount())
+	assert.Equal(t, 15, sink.ItemsCount())
+	assert.EqualValues(t, 3, done.success.Load())
+	assert.EqualValues(t, 0, done.errors.Load())
+}
+
+func TestPartitionBatcher_RequestsSizer_MaxSize(t *testing.T) {
+	cfg := BatchConfig{
+		FlushTimeout: 100 * time.Second,
+		Sizer:        request.SizerTypeRequests,
+		MinSize:      2,
+		MaxSize:      2,
+	}
+
+	sink := requesttest.NewSink()
+	ba := newPartitionBatcher(cfg, request.RequestsSizer{}, nil, newWorkerPool(1), sink.Export, zap.NewNop(), nil)
+	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+
+	done := newFakeDone()
+	for range 5 {
+		ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 1}, done)
+	}
+
+	assert.Eventually(t, func() bool {
+		return sink.RequestsCount() == 2 && sink.ItemsCount() == 4
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, ba.Shutdown(context.Background()))
+	assert.Equal(t, 3, sink.RequestsCount())
+	assert.Equal(t, 5, sink.ItemsCount())
+	assert.EqualValues(t, 5, done.success.Load())
+	assert.EqualValues(t, 0, done.errors.Load())
+}
+
+func TestPartitionBatcher_RequestsSizer_DoesNotMergeOverMaxSize(t *testing.T) {
+	cfg := BatchConfig{
+		FlushTimeout: 100 * time.Second,
+		Sizer:        request.SizerTypeRequests,
+		MinSize:      2,
+		MaxSize:      2,
+	}
+
+	sink := requesttest.NewSink()
+	ba := newPartitionBatcher(cfg, request.RequestsSizer{}, nil, newWorkerPool(1), sink.Export, zap.NewNop(), nil)
+	require.NoError(t, ba.Start(context.Background(), componenttest.NewNopHost()))
+
+	done := newFakeDone()
+	ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 1}, done)
+	ba.Consume(context.Background(), &requesttest.FakeRequest{Items: 10, Requests: 2}, done)
+
+	assert.Eventually(t, func() bool {
+		return sink.RequestsCount() == 2 && sink.ItemsCount() == 11
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, ba.Shutdown(context.Background()))
+	assert.Equal(t, 2, sink.RequestsCount())
+	assert.Equal(t, 11, sink.ItemsCount())
+	assert.EqualValues(t, 2, done.success.Load())
+	assert.EqualValues(t, 0, done.errors.Load())
+}

--- a/exporter/exporterhelper/internal/queuebatch/traces.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces.go
@@ -33,19 +33,22 @@ func NewTracesQueueBatchSettings() Settings[request.Request] {
 }
 
 var (
-	_ request.Request      = (*tracesRequest)(nil)
-	_ request.ErrorHandler = (*tracesRequest)(nil)
+	_ request.Request         = (*tracesRequest)(nil)
+	_ request.ErrorHandler    = (*tracesRequest)(nil)
+	_ request.RequestsCounter = (*tracesRequest)(nil)
 )
 
 type tracesRequest struct {
-	td         ptrace.Traces
-	cachedSize int
+	td           ptrace.Traces
+	cachedSize   int
+	requestCount int
 }
 
 func newTracesRequest(td ptrace.Traces) request.Request {
 	return &tracesRequest{
-		td:         td,
-		cachedSize: -1,
+		td:           td,
+		cachedSize:   -1,
+		requestCount: 1,
 	}
 }
 
@@ -88,6 +91,13 @@ func (req *tracesRequest) OnError(err error) request.Request {
 
 func (req *tracesRequest) ItemsCount() int {
 	return req.td.SpanCount()
+}
+
+func (req *tracesRequest) RequestsCount() int {
+	if req.requestCount <= 0 {
+		return 1
+	}
+	return req.requestCount
 }
 
 func (req *tracesRequest) size(sizer sizer.TracesSizer) int {

--- a/exporter/exporterhelper/internal/queuebatch/traces_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_batch.go
@@ -16,6 +16,10 @@ import (
 // MergeSplit splits and/or merges the provided traces request and the current request into one or more requests
 // conforming with the MaxSizeConfig.
 func (req *tracesRequest) MergeSplit(_ context.Context, maxSize int, szt request.SizerType, r2 request.Request) ([]request.Request, error) {
+	if szt == request.SizerTypeRequests {
+		return mergeSplitTracesRequests(req, maxSize, r2)
+	}
+
 	var sz sizer.TracesSizer
 	switch szt {
 	case request.SizerTypeItems:
@@ -39,6 +43,22 @@ func (req *tracesRequest) MergeSplit(_ context.Context, maxSize int, szt request
 		return []request.Request{req}, nil
 	}
 	return req.split(maxSize, sz)
+}
+
+func mergeSplitTracesRequests(req *tracesRequest, maxSize int, r2 request.Request) ([]request.Request, error) {
+	if r2 != nil {
+		req2, ok := r2.(*tracesRequest)
+		if !ok {
+			return nil, errors.New("invalid input type")
+		}
+		mergedCount := req.RequestsCount() + req2.RequestsCount()
+		if maxSize > 0 && mergedCount > maxSize {
+			return []request.Request{req, req2}, nil
+		}
+		req2.mergeTo(req, nil)
+		req.requestCount = mergedCount
+	}
+	return []request.Request{req}, nil
 }
 
 func (req *tracesRequest) mergeTo(dst *tracesRequest, sz sizer.TracesSizer) {

--- a/exporter/exporterhelper/internal/queuebatch/traces_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/traces_batch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/requesttest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sizer"
 	"go.opentelemetry.io/collector/internal/testutil"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -336,6 +337,89 @@ func TestTracesMergeSplitUnknownSizerType(t *testing.T) {
 	// Call MergeSplit with invalid sizer
 	_, err := req.MergeSplit(context.Background(), 0, request.SizerType{}, nil)
 	require.EqualError(t, err, "unknown sizer type")
+}
+
+func TestMergeSplitTracesRequestsSizer(t *testing.T) {
+	tests := []struct {
+		name           string
+		tr1            request.Request
+		tr2            request.Request
+		maxSize        int
+		wantLen        int
+		wantItemCounts []int
+		wantReqCounts  []int64
+		wantErr        string
+	}{
+		{
+			name:           "merge_two_requests",
+			tr1:            newTracesRequest(testdata.GenerateTraces(5)),
+			tr2:            newTracesRequest(testdata.GenerateTraces(3)),
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{8},
+			wantReqCounts:  []int64{2},
+		},
+		{
+			name:           "merge_when_under_max_size",
+			tr1:            newTracesRequest(testdata.GenerateTraces(5)),
+			tr2:            newTracesRequest(testdata.GenerateTraces(3)),
+			maxSize:        2,
+			wantLen:        1,
+			wantItemCounts: []int{8},
+			wantReqCounts:  []int64{2},
+		},
+		{
+			name:           "do_not_merge_when_over_max_size",
+			tr1:            newTracesRequest(testdata.GenerateTraces(5)),
+			tr2:            newTracesRequest(testdata.GenerateTraces(3)),
+			maxSize:        1,
+			wantLen:        2,
+			wantItemCounts: []int{5, 3},
+			wantReqCounts:  []int64{1, 1},
+		},
+		{
+			name:           "nil_second_request",
+			tr1:            newTracesRequest(testdata.GenerateTraces(7)),
+			tr2:            nil,
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{7},
+			wantReqCounts:  []int64{1},
+		},
+		{
+			name:           "empty_first_request",
+			tr1:            newTracesRequest(ptrace.NewTraces()),
+			tr2:            newTracesRequest(testdata.GenerateTraces(4)),
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{4},
+			wantReqCounts:  []int64{2},
+		},
+		{
+			name:    "invalid_input_type",
+			tr1:     newTracesRequest(testdata.GenerateTraces(1)),
+			tr2:     &requesttest.FakeRequest{Items: 1},
+			maxSize: 0,
+			wantErr: "invalid input type",
+		},
+	}
+
+	sz := request.RequestsSizer{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.tr1.MergeSplit(context.Background(), tt.maxSize, request.SizerTypeRequests, tt.tr2)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, res, tt.wantLen)
+			for i, r := range res {
+				assert.Equal(t, tt.wantItemCounts[i], r.ItemsCount())
+				assert.Equal(t, tt.wantReqCounts[i], sz.Sizeof(r))
+			}
+		})
+	}
 }
 
 func BenchmarkSplittingBasedOnItemCountManySmallTraces(b *testing.B) {

--- a/exporter/exporterhelper/internal/request/sizer.go
+++ b/exporter/exporterhelper/internal/request/sizer.go
@@ -70,10 +70,21 @@ func NewSizer(sizerType SizerType) Sizer {
 	}
 }
 
+// RequestsCounter may be implemented by a Request so that RequestsSizer reports how many
+// original requests were merged into it. If a Request does not implement RequestsCounter,
+// RequestsSizer treats it as size 1.
+type RequestsCounter interface {
+	RequestsCount() int
+}
+
 // RequestsSizer is a Sizer implementation that returns the size of a queue element as one request.
+// If the request implements RequestsCounter, that count is used so merged batches can be measured.
 type RequestsSizer struct{}
 
-func (rs RequestsSizer) Sizeof(Request) int64 {
+func (rs RequestsSizer) Sizeof(req Request) int64 {
+	if rc, ok := req.(RequestsCounter); ok {
+		return int64(rc.RequestsCount())
+	}
 	return 1
 }
 

--- a/exporter/exporterhelper/internal/request/sizer_test.go
+++ b/exporter/exporterhelper/internal/request/sizer_test.go
@@ -4,6 +4,7 @@
 package request_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,23 @@ import (
 func TestItemsSizer(t *testing.T) {
 	sz := request.NewItemsSizer()
 	assert.EqualValues(t, 3, sz.Sizeof(&requesttest.FakeRequest{Items: 3}))
+}
+
+func TestRequestsSizer(t *testing.T) {
+	sz := request.RequestsSizer{}
+	assert.EqualValues(t, 1, sz.Sizeof(&requesttest.FakeRequest{Items: 3}))
+	assert.EqualValues(t, 4, sz.Sizeof(&requesttest.FakeRequest{Items: 3, Requests: 4}))
+	assert.EqualValues(t, 1, sz.Sizeof(plainRequest{}))
+}
+
+type plainRequest struct{}
+
+func (plainRequest) ItemsCount() int { return 0 }
+
+func (plainRequest) BytesSize() int { return 0 }
+
+func (plainRequest) MergeSplit(context.Context, int, request.SizerType, request.Request) ([]request.Request, error) {
+	return []request.Request{plainRequest{}}, nil
 }
 
 func TestSizeTypeUnmarshalText(t *testing.T) {

--- a/exporter/exporterhelper/internal/requesttest/request.go
+++ b/exporter/exporterhelper/internal/requesttest/request.go
@@ -23,9 +23,15 @@ func (e errorPartial) Error() string {
 	return fmt.Sprintf("items: %d", e.fr.Items)
 }
 
+var (
+	_ request.Request         = (*FakeRequest)(nil)
+	_ request.RequestsCounter = (*FakeRequest)(nil)
+)
+
 type FakeRequest struct {
 	Items          int
 	Bytes          int
+	Requests       int
 	Partial        int
 	MergeErr       error
 	MergeErrResult []request.Request
@@ -47,9 +53,20 @@ func (r *FakeRequest) BytesSize() int {
 	return r.Bytes
 }
 
+func (r *FakeRequest) RequestsCount() int {
+	if r.Requests <= 0 {
+		return 1
+	}
+	return r.Requests
+}
+
 func (r *FakeRequest) MergeSplit(_ context.Context, maxSize int, szt request.SizerType, r2 request.Request) ([]request.Request, error) {
 	if r.MergeErr != nil {
 		return r.MergeErrResult, r.MergeErr
+	}
+
+	if szt == request.SizerTypeRequests {
+		return r.mergeSplitRequests(maxSize, r2)
 	}
 
 	if r2 != nil {
@@ -89,6 +106,23 @@ func (r *FakeRequest) MergeSplit(_ context.Context, maxSize int, szt request.Siz
 	}
 
 	return res, nil
+}
+
+func (r *FakeRequest) mergeSplitRequests(maxSize int, r2 request.Request) ([]request.Request, error) {
+	if r2 == nil {
+		return []request.Request{r}, nil
+	}
+	fr2 := r2.(*FakeRequest)
+	if fr2.MergeErr != nil {
+		return fr2.MergeErrResult, fr2.MergeErr
+	}
+	mergedCount := r.RequestsCount() + fr2.RequestsCount()
+	if maxSize > 0 && mergedCount > maxSize {
+		return []request.Request{r, fr2}, nil
+	}
+	fr2.mergeTo(r)
+	r.Requests = mergedCount
+	return []request.Request{r}, nil
 }
 
 func (r *FakeRequest) mergeTo(dst *FakeRequest) {

--- a/exporter/exporterhelper/xexporterhelper/profiles.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles.go
@@ -42,19 +42,22 @@ func NewProfilesQueueBatchSettings() QueueBatchSettings {
 }
 
 var (
-	_ request.Request      = (*profilesRequest)(nil)
-	_ request.ErrorHandler = (*profilesRequest)(nil)
+	_ request.Request         = (*profilesRequest)(nil)
+	_ request.ErrorHandler    = (*profilesRequest)(nil)
+	_ request.RequestsCounter = (*profilesRequest)(nil)
 )
 
 type profilesRequest struct {
-	pd         pprofile.Profiles
-	cachedSize int
+	pd           pprofile.Profiles
+	cachedSize   int
+	requestCount int
 }
 
 func newProfilesRequest(pd pprofile.Profiles) Request {
 	return &profilesRequest{
-		pd:         pd,
-		cachedSize: -1,
+		pd:           pd,
+		cachedSize:   -1,
+		requestCount: 1,
 	}
 }
 
@@ -97,6 +100,13 @@ func (req *profilesRequest) OnError(err error) Request {
 
 func (req *profilesRequest) ItemsCount() int {
 	return req.pd.SampleCount()
+}
+
+func (req *profilesRequest) RequestsCount() int {
+	if req.requestCount <= 0 {
+		return 1
+	}
+	return req.requestCount
 }
 
 func (req *profilesRequest) size(sizer sizer.ProfilesSizer) int {

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch.go
@@ -18,6 +18,10 @@ import (
 // Following the OTLP 1.7.0 upgrade, this is currently a noop.
 // See https://github.com/open-telemetry/opentelemetry-collector/issues/13106
 func (req *profilesRequest) MergeSplit(_ context.Context, maxSize int, szt exporterhelper.RequestSizerType, r2 Request) ([]Request, error) {
+	if szt == exporterhelper.RequestSizerTypeRequests {
+		return mergeSplitProfilesRequests(req, maxSize, r2)
+	}
+
 	var sz sizer.ProfilesSizer
 	switch szt {
 	case exporterhelper.RequestSizerTypeItems:
@@ -44,6 +48,24 @@ func (req *profilesRequest) MergeSplit(_ context.Context, maxSize int, szt expor
 		return []Request{req}, nil
 	}
 	return req.split(maxSize, sz)
+}
+
+func mergeSplitProfilesRequests(req *profilesRequest, maxSize int, r2 Request) ([]Request, error) {
+	if r2 != nil {
+		req2, ok := r2.(*profilesRequest)
+		if !ok {
+			return nil, errors.New("invalid input type")
+		}
+		mergedCount := req.RequestsCount() + req2.RequestsCount()
+		if maxSize > 0 && mergedCount > maxSize {
+			return []Request{req, req2}, nil
+		}
+		if err := req2.mergeTo(req, nil); err != nil {
+			return nil, fmt.Errorf("failed merging profiles; %w", err)
+		}
+		req.requestCount = mergedCount
+	}
+	return []Request{req}, nil
 }
 
 func (req *profilesRequest) mergeTo(dst *profilesRequest, sz sizer.ProfilesSizer) error {

--- a/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
+++ b/exporter/exporterhelper/xexporterhelper/profiles_batch_test.go
@@ -32,6 +32,88 @@ func TestMergeProfilesInvalidInput(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestMergeSplitProfilesRequestsSizer(t *testing.T) {
+	tests := []struct {
+		name           string
+		pr1            Request
+		pr2            Request
+		maxSize        int
+		wantLen        int
+		wantItemCounts []int
+		wantReqCounts  []int
+		wantErr        string
+	}{
+		{
+			name:           "merge_two_requests",
+			pr1:            newProfilesRequest(testdata.GenerateProfiles(5)),
+			pr2:            newProfilesRequest(testdata.GenerateProfiles(3)),
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{8},
+			wantReqCounts:  []int{2},
+		},
+		{
+			name:           "merge_when_under_max_size",
+			pr1:            newProfilesRequest(testdata.GenerateProfiles(5)),
+			pr2:            newProfilesRequest(testdata.GenerateProfiles(3)),
+			maxSize:        2,
+			wantLen:        1,
+			wantItemCounts: []int{8},
+			wantReqCounts:  []int{2},
+		},
+		{
+			name:           "do_not_merge_when_over_max_size",
+			pr1:            newProfilesRequest(testdata.GenerateProfiles(5)),
+			pr2:            newProfilesRequest(testdata.GenerateProfiles(3)),
+			maxSize:        1,
+			wantLen:        2,
+			wantItemCounts: []int{5, 3},
+			wantReqCounts:  []int{1, 1},
+		},
+		{
+			name:           "nil_second_request",
+			pr1:            newProfilesRequest(testdata.GenerateProfiles(7)),
+			pr2:            nil,
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{7},
+			wantReqCounts:  []int{1},
+		},
+		{
+			name:           "empty_first_request",
+			pr1:            newProfilesRequest(pprofile.NewProfiles()),
+			pr2:            newProfilesRequest(testdata.GenerateProfiles(4)),
+			maxSize:        0,
+			wantLen:        1,
+			wantItemCounts: []int{4},
+			wantReqCounts:  []int{2},
+		},
+		{
+			name:    "invalid_input_type",
+			pr1:     newProfilesRequest(testdata.GenerateProfiles(1)),
+			pr2:     &requesttest.FakeRequest{Items: 1},
+			maxSize: 0,
+			wantErr: "invalid input type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.pr1.MergeSplit(context.Background(), tt.maxSize, exporterhelper.RequestSizerTypeRequests, tt.pr2)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, res, tt.wantLen)
+			for i, r := range res {
+				assert.Equal(t, tt.wantItemCounts[i], r.ItemsCount())
+				assert.Equal(t, tt.wantReqCounts[i], r.(*profilesRequest).RequestsCount())
+			}
+		})
+	}
+}
+
 func TestMergeSplitProfiles(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
#### Description

The batcher currently rejects `requests` as a sizer, so enabling batching with the default queue sizer fails validation.

This adds `requests` as a valid `batch::sizer` for traces, metrics, logs, and profiles. Each incoming export call counts as 1. Merged batches keep that count so `min_size` can flush on request count, not only on `flush_timeout`. A request cannot be split; if merging would exceed `max_size`, the two requests are left as-is.

Fixes #12880

#### Testing

- `BatchConfig.Validate` now accepts `requests`
- MergeSplit tests for logs, metrics, traces, and profiles
- Partition batcher tests covering `min_size` and `max_size`
- `RequestsSizer` unit tests

#### Documentation

Updated `exporter/exporterhelper/README.md` with the `requests` batch sizer option.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.