### PR TITLE
fix(mdatagen): Versioned Metrics migration improve documentation template

### DIFF
--- a/cmd/mdatagen/internal/samplemigrationscraper/documentation.md
+++ b/cmd/mdatagen/internal/samplemigrationscraper/documentation.md
@@ -26,7 +26,14 @@ CPU utilization as a ratio.
 - Disable Old Gate: `scraper.samplemigration.DontEmitV0SystemConventions`
 - Enable New Gate: `scraper.samplemigration.EmitV1SystemConventions`
 
-When the disable-old gate is enabled, emission of this metric is suppressed. When the enable-new gate is enabled, the target metric is emitted. If both gates are disabled, only this metric is emitted; if both are enabled, only the target metric is emitted.
+Emission depends on the state of the two migration feature gates:
+
+| `scraper.samplemigration.EmitV1SystemConventions` | `scraper.samplemigration.DontEmitV0SystemConventions` | Emitted metric(s) |
+| --- | --- | --- |
+| disabled | disabled | `system.cpu.utilization` only |
+| enabled | disabled | `system.cpu.utilization` and `system.cpu.utilization@v1` |
+| enabled | enabled | `system.cpu.utilization@v1` only |
+| disabled | enabled | Migrated metrics: none (v0 suppressed, v1 gated off — warnings logged). Non-migrated metrics still emit. No startup error. |
 
 #### Attributes
 
@@ -59,7 +66,14 @@ Legacy Linux available memory estimate.
 - Disable Old Gate: `scraper.samplemigration.DontEmitV0SystemConventions`
 - Enable New Gate: `scraper.samplemigration.EmitV1SystemConventions`
 
-When the disable-old gate is enabled, emission of this metric is suppressed. When the enable-new gate is enabled, the target metric is emitted. If both gates are disabled, only this metric is emitted; if both are enabled, only the target metric is emitted.
+Emission depends on the state of the two migration feature gates:
+
+| `scraper.samplemigration.EmitV1SystemConventions` | `scraper.samplemigration.DontEmitV0SystemConventions` | Emitted metric(s) |
+| --- | --- | --- |
+| disabled | disabled | `linux.memory.available` only |
+| enabled | disabled | `linux.memory.available` and `system.memory.linux.available@v1` |
+| enabled | enabled | `system.memory.linux.available@v1` only |
+| disabled | enabled | Migrated metrics: none (v0 suppressed, v1 gated off — warnings logged). Non-migrated metrics still emit. No startup error. |
 
 ### system.cpu.foo
 

--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -38,7 +38,14 @@ Emitted Name: `{{ $metricName.EmittedName }}`
 - Disable Old Gate: `{{ $metric.Migration.ThroughGates.DisableOld }}`
 - Enable New Gate: `{{ $metric.Migration.ThroughGates.EnableNew }}`
 
-When the disable-old gate is enabled, emission of this metric is suppressed. When the enable-new gate is enabled, the target metric is emitted. If both gates are disabled, only this metric is emitted; if both are enabled, only the target metric is emitted.
+Emission depends on the state of the two migration feature gates:
+
+| `{{ $metric.Migration.ThroughGates.EnableNew }}` | `{{ $metric.Migration.ThroughGates.DisableOld }}` | Emitted metric(s) |
+| --- | --- | --- |
+| disabled | disabled | `{{ $metricName }}` only |
+| enabled | disabled | `{{ $metricName }}` and `{{ $metric.Migration.To }}` |
+| enabled | enabled | `{{ $metric.Migration.To }}` only |
+| disabled | enabled | Migrated metrics: none (v0 suppressed, v1 gated off — warnings logged). Non-migrated metrics still emit. No startup error. |
 
 {{- end }}
 


### PR DESCRIPTION
#### Description

This PR addresses issue #15795 by updating the documentation template for versioned metrics migration paths to use a clear markdown table. The new format makes it much easier to read and understand the behavior of the two migration feature gates (`EnableNew` and `DisableOld`).

The updated output clearly delineates what metrics are emitted for each of the four possible states (disabled/disabled, enabled/disabled, enabled/enabled, disabled/enabled), including detailing the warning states when both gates are improperly configured.

#### Link to tracking issue
Fixes #15795

#### Testing
Generated the updated docs and ran tests in the `cmd/mdatagen` directory to verify that all code generation and tests pass without issues.

#### Documentation
Updated `cmd/mdatagen/internal/templates/documentation.md.tmpl`.
