### PR TITLE
fix(pprofile): ignore KeyStrindex==0 and clear after resolve

### DIFF
--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -38,15 +38,14 @@ func resolveKeyValueReferences(dict ProfilesDictionary, kvs []internal.KeyValue)
 	for i := range kvs {
 		kv := &kvs[i]
 		// Resolve key_ref if set
-		if kv.KeyStrindex >= 0 {
+		if kv.KeyStrindex > 0 {
 			idx := int(kv.KeyStrindex)
 			if idx < dict.StringTable().Len() {
 				kv.Key = dict.StringTable().At(idx)
-				// N.b. keep KeyStrindex set to optimize re-marshaling. This is
-				// technically a violation of the proto spec, but acceptable
-				// for the in-memory pdata API since keys are immutable.
 			}
 		}
+		// Clear KeyStrindex to avoid emitting it if re-marshaled without conversion.
+		kv.KeyStrindex = 0
 		// Resolve string_value_ref if set
 		resolveAnyValueReference(dict, &kv.Value)
 	}


### PR DESCRIPTION
#### Description

This PR addresses issue #15793. `resolveKeyValueReferences` in `pdata/pprofile/dictionary_helpers.go` previously treated `key_strindex == 0` as a valid reference. Since `0` is the "not set" sentinel for index fields in protobuf, any producer that sent attribute keys inline had their key silently replaced with `""` on unmarshal if `string_table[0]` was empty.

Additionally, `key_strindex` was intentionally kept set to optimize re-marshaling, but since optimization #15134 was removed, this was dangerous and caused both fields to be emitted onto the wire by serialization paths that do not run `convertKeyValueToReferences` (such as `pprofileotlp.ExportRequest.MarshalProto`).

This PR:
1. Modifies the condition to `if kv.KeyStrindex > 0` to correctly treat `0` as not set and prevent erasing inline attribute keys.
2. Unconditionally clears `kv.KeyStrindex = 0` after resolution so it does not persist on re-marshaling and corrupt the wire encoding.

#### Link to tracking issue
Fixes #15793

#### Testing
Ran the unit test suite in `pdata/pprofile` and `pdata/pprofile/pprofileotlp`.

#### Documentation
N/A
