### PR TITLE
fix(pprofileotlp): fix ExportRequest marshaling of dictionaries

### DIFF
--- a/pdata/internal/otlp/profiles.go
+++ b/pdata/internal/otlp/profiles.go
@@ -10,3 +10,11 @@ import (
 // MigrateProfiles implements any translation needed due to deprecation in OTLP profiles protocol.
 // Any pprofile.Unmarshaler implementation from OTLP (proto/json) MUST call this, and the gRPC Server implementation.
 func MigrateProfiles(_ []*internal.ResourceProfiles) {}
+
+// PProfileConvertProfilesToReferences is a function pointer that allows pprofileotlp to call
+// convertProfilesToReferences from pprofile without creating a cyclic dependency.
+var PProfileConvertProfilesToReferences func(any)
+
+// PProfileResolveProfilesReferences is a function pointer that allows pprofileotlp to call
+// resolveProfilesReferences from pprofile without creating a cyclic dependency.
+var PProfileResolveProfilesReferences func(any)

--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -6,6 +6,7 @@ package pprofile // import "go.opentelemetry.io/collector/pdata/pprofile"
 import (
 	"go.opentelemetry.io/collector/pdata/internal"
 	"go.opentelemetry.io/collector/pdata/internal/metadata"
+	"go.opentelemetry.io/collector/pdata/internal/otlp"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -156,5 +157,14 @@ func convertAnyValueToReference(getStringIndex func(string) int32, anyValue *int
 		for i := 0; i < len(arrVal.ArrayValue.Values); i++ {
 			convertAnyValueToReference(getStringIndex, &arrVal.ArrayValue.Values[i])
 		}
+	}
+}
+
+func init() {
+	otlp.PProfileConvertProfilesToReferences = func(profiles any) {
+		convertProfilesToReferences(profiles.(Profiles))
+	}
+	otlp.PProfileResolveProfilesReferences = func(profiles any) {
+		resolveProfilesReferences(profiles.(Profiles))
 	}
 }

--- a/pdata/pprofile/pprofileotlp/request.go
+++ b/pdata/pprofile/pprofileotlp/request.go
@@ -39,9 +39,25 @@ func NewExportRequestFromProfiles(td pprofile.Profiles) ExportRequest {
 
 // MarshalProto marshals ExportRequest into proto bytes.
 func (ms ExportRequest) MarshalProto() ([]byte, error) {
-	size := ms.orig.SizeProto()
+	req := ms.orig
+	pd := ms.Profiles()
+	if pd.IsReadOnly() {
+		// Only copy if data is shared/read-only to avoid unnecessary allocation
+		pdCopy := pprofile.NewProfiles()
+		pd.CopyTo(pdCopy)
+		req = internal.GetProfilesOrig(internal.ProfilesWrapper(pdCopy))
+		if otlp.PProfileConvertProfilesToReferences != nil {
+			otlp.PProfileConvertProfilesToReferences(pdCopy)
+		}
+	} else {
+		if otlp.PProfileConvertProfilesToReferences != nil {
+			otlp.PProfileConvertProfilesToReferences(pd)
+		}
+	}
+
+	size := req.SizeProto()
 	buf := make([]byte, size)
-	_ = ms.orig.MarshalProto(buf)
+	_ = req.MarshalProto(buf)
 	return buf, nil
 }
 
@@ -52,14 +68,32 @@ func (ms ExportRequest) UnmarshalProto(data []byte) error {
 		return err
 	}
 	otlp.MigrateProfiles(ms.orig.ResourceProfiles)
+	if otlp.PProfileResolveProfilesReferences != nil {
+		otlp.PProfileResolveProfilesReferences(ms.Profiles())
+	}
 	return nil
 }
 
 // MarshalJSON marshals ExportRequest into JSON bytes.
 func (ms ExportRequest) MarshalJSON() ([]byte, error) {
+	req := ms.orig
+	pd := ms.Profiles()
+	if pd.IsReadOnly() {
+		pdCopy := pprofile.NewProfiles()
+		pd.CopyTo(pdCopy)
+		req = internal.GetProfilesOrig(internal.ProfilesWrapper(pdCopy))
+		if otlp.PProfileConvertProfilesToReferences != nil {
+			otlp.PProfileConvertProfilesToReferences(pdCopy)
+		}
+	} else {
+		if otlp.PProfileConvertProfilesToReferences != nil {
+			otlp.PProfileConvertProfilesToReferences(pd)
+		}
+	}
+
 	dest := json.BorrowStream(nil)
 	defer json.ReturnStream(dest)
-	ms.orig.MarshalJSON(dest)
+	req.MarshalJSON(dest)
 	if dest.Error() != nil {
 		return nil, dest.Error()
 	}
@@ -71,7 +105,14 @@ func (ms ExportRequest) UnmarshalJSON(data []byte) error {
 	iter := json.BorrowIterator(data)
 	defer json.ReturnIterator(iter)
 	ms.orig.UnmarshalJSON(iter)
-	return iter.Error()
+	err := iter.Error()
+	if err != nil {
+		return err
+	}
+	if otlp.PProfileResolveProfilesReferences != nil {
+		otlp.PProfileResolveProfilesReferences(ms.Profiles())
+	}
+	return nil
 }
 
 func (ms ExportRequest) Profiles() pprofile.Profiles {

--- a/pdata/pprofile/pprofileotlp/request_test.go
+++ b/pdata/pprofile/pprofileotlp/request_test.go
@@ -14,7 +14,6 @@ import (
 	goproto "google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/collector/pdata/internal"
-	"go.opentelemetry.io/collector/pdata/internal/otlp"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 )
 
@@ -94,9 +93,14 @@ func TestProfilesProtoWireCompatibility(t *testing.T) {
 	err = pd2.UnmarshalProto(wire2)
 	require.NoError(t, err)
 
-	// Now compare that the original and final ProtoBuf messages are the same.
-	// This proves that goproto and gogoproto marshaling/unmarshaling are wire compatible.
-	// Migration logic will run, so run it on the original message as well.
-	otlp.MigrateProfiles(pd.orig.ResourceProfiles)
-	assert.Equal(t, pd, pd2)
+	// After unmarshal, pd2 will have resolved references while pd may have references.
+	// Marshal pd2 again to verify wire compatibility.
+	wire3, err := pd2.MarshalProto()
+	require.NoError(t, err)
+
+	// Verify full round-trip fidelity: unmarshal both wire1 and wire3 into goproto
+	var check1, check2 gootlpcollectorprofiles.ExportProfilesServiceRequest
+	require.NoError(t, goproto.Unmarshal(wire1, &check1))
+	require.NoError(t, goproto.Unmarshal(wire3, &check2))
+	assert.True(t, goproto.Equal(&check1, &check2), "round-trip through goproto did not preserve profile data")
 }


### PR DESCRIPTION
#### Description

This PR addresses issue #15792. `pprofileotlp.ExportRequest` previously bypassed the `convertProfilesToReferences` conversion on its protobuf and JSON marshaling paths because those helpers were internal to the `pdata/pprofile` package and unexported. This meant that any profile data exported via OTLP gRPC/HTTP had strings encoded inline rather than deduplicated using the dictionary strings table, defeating the wire-size optimization.

This PR introduces function pointers `otlp.PProfileConvertProfilesToReferences` and `otlp.PProfileResolveProfilesReferences` in the `pdata/internal/otlp` package. `pdata/pprofile` registers its dictionary helper implementations to these pointers at `init()`, and `pprofileotlp.ExportRequest` invokes them during `MarshalProto`/`MarshalJSON` and `UnmarshalProto`/`UnmarshalJSON`. 

Now `ExportRequest` behaves identically to `ProtoMarshaler`/`JSONMarshaler` regarding reference conversion. Tests were also updated to properly verify wire-compatibility round trips instead of strict in-memory struct equality, since `MarshalProto` mutates the in-memory string references if the data is not marked read-only.

#### Link to tracking issue
Fixes #15792

#### Testing
Updated and successfully ran the tests in `pdata/pprofile/pprofileotlp`. Added proper round-trip verifications.
