### PR TITLE
exporterhelper: remove legacy persistent queue metadata format (ri/wi/di keys)

### DIFF
--- a/exporter/exporterhelper/internal/queue/persistent_queue.go
+++ b/exporter/exporterhelper/internal/queue/persistent_queue.go
@@ -5,7 +5,6 @@ package queue // import "go.opentelemetry.io/collector/exporter/exporterhelper/i
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
@@ -26,17 +25,12 @@ const (
 	zapErrorCount    = "errorCount"
 	zapNumberOfItems = "numberOfItems"
 
-	legacyReadIndexKey                = "ri"
-	legacyWriteIndexKey               = "wi"
-	legacyCurrentlyDispatchedItemsKey = "di"
-
-	// metadataKey is the new single key for all queue metadata.
+	// metadataKey is the single key for all queue metadata.
 	metadataKey = "qmv0"
 )
 
 var (
 	errValueNotSet        = errors.New("value not set")
-	errInvalidValue       = errors.New("invalid value")
 	errNoStorageClient    = errors.New("no storage client extension found")
 	errWrongExtensionType = errors.New("requested extension is not a storage extension")
 )
@@ -153,18 +147,18 @@ func (pq *persistentQueue[T]) initClient(ctx context.Context, client storage.Cli
 	// Start with a reference 1 which is the reference we use for the producer goroutines and initialization.
 	pq.refClient = 1
 
-	// Try to load from new consolidated metadata first
+	// Load from consolidated metadata
 	err := pq.loadQueueMetadata(ctx)
 	switch {
 	case err == nil:
 		pq.enqueueNotDispatchedReqs(ctx, pq.metadata.CurrentlyDispatchedItems)
 		pq.metadata.CurrentlyDispatchedItems = nil
-	case !errors.Is(err, errValueNotSet):
-		pq.logger.Error("Failed getting metadata, starting with new ones", zap.Error(err))
+	case errors.Is(err, errValueNotSet):
+		pq.logger.Info("Initializing new persistent queue")
 		pq.metadata = PersistentMetadata{}
 	default:
-		pq.logger.Info("New queue metadata key not found, attempting to load legacy format.")
-		pq.loadLegacyMetadata(ctx)
+		pq.logger.Error("Failed getting metadata, starting with new ones", zap.Error(err))
+		pq.metadata = PersistentMetadata{}
 	}
 }
 
@@ -191,55 +185,6 @@ func (pq *persistentQueue[T]) loadQueueMetadata(ctx context.Context) error {
 		zap.Int("dispatchedItems", len(pq.metadata.CurrentlyDispatchedItems)))
 
 	return nil
-}
-
-// TODO: Remove legacy format support after 6 months (target: December 2025)
-func (pq *persistentQueue[T]) loadLegacyMetadata(ctx context.Context) {
-	// Fallback to legacy individual keys for backward compatibility
-	riOp := storage.GetOperation(legacyReadIndexKey)
-	wiOp := storage.GetOperation(legacyWriteIndexKey)
-
-	err := pq.client.Batch(ctx, riOp, wiOp)
-	if err == nil {
-		pq.metadata.ReadIndex, err = bytesToItemIndex(riOp.Value)
-	}
-
-	if err == nil {
-		pq.metadata.WriteIndex, err = bytesToItemIndex(wiOp.Value)
-	}
-
-	if err != nil {
-		if errors.Is(err, errValueNotSet) {
-			pq.logger.Info("Initializing new persistent queue")
-		} else {
-			pq.logger.Error("Failed getting read/write index, starting with new ones", zap.Error(err))
-		}
-		pq.metadata.ReadIndex = 0
-		pq.metadata.WriteIndex = 0
-	}
-
-	pq.retrieveAndEnqueueNotDispatchedReqs(ctx)
-
-	// Save to a new format and clean up legacy keys
-	metadataBytes, err := proto.Marshal(&pq.metadata)
-	if err != nil {
-		pq.logger.Error("Failed to marshal metadata", zap.Error(err))
-		return
-	}
-
-	if err = pq.client.Set(ctx, metadataKey, metadataBytes); err != nil {
-		pq.logger.Error("Failed to persist current metadata to storage", zap.Error(err))
-		return
-	}
-
-	if err = pq.client.Batch(ctx,
-		storage.DeleteOperation(legacyReadIndexKey),
-		storage.DeleteOperation(legacyWriteIndexKey),
-		storage.DeleteOperation(legacyCurrentlyDispatchedItemsKey)); err != nil {
-		pq.logger.Warn("Failed to cleanup legacy metadata keys", zap.Error(err))
-	} else {
-		pq.logger.Info("Successfully migrated to consolidated metadata format")
-	}
 }
 
 func (pq *persistentQueue[T]) Shutdown(ctx context.Context) error {
@@ -425,25 +370,6 @@ func (pq *persistentQueue[T]) onDone(index uint64, itemsSize, bytesSize int64, c
 	pq.hasMoreSpace.Signal()
 }
 
-// retrieveAndEnqueueNotDispatchedReqs gets the items for which sending was not finished, cleans the storage
-// and moves the items at the back of the queue.
-func (pq *persistentQueue[T]) retrieveAndEnqueueNotDispatchedReqs(ctx context.Context) {
-	var dispatchedItems []uint64
-
-	pq.mu.Lock()
-	defer pq.mu.Unlock()
-	pq.logger.Debug("Checking if there are items left for dispatch by consumers")
-	itemKeysBuf, err := pq.client.Get(ctx, legacyCurrentlyDispatchedItemsKey)
-	if err == nil {
-		dispatchedItems, err = bytesToItemIndexArray(itemKeysBuf)
-	}
-	if err != nil {
-		pq.logger.Error("Could not fetch items left for dispatch by consumers", zap.Error(err))
-		return
-	}
-
-	pq.enqueueNotDispatchedReqs(ctx, dispatchedItems)
-}
 
 func (pq *persistentQueue[T]) enqueueNotDispatchedReqs(ctx context.Context, dispatchedItems []uint64) {
 	if len(dispatchedItems) == 0 {
@@ -564,44 +490,6 @@ func getItemKey(index uint64) string {
 	return strconv.FormatUint(index, 10)
 }
 
-func bytesToItemIndex(buf []byte) (uint64, error) {
-	if buf == nil {
-		return uint64(0), errValueNotSet
-	}
-	// The sizeof uint64 in binary is 8.
-	if len(buf) < 8 {
-		return 0, errInvalidValue
-	}
-	return binary.LittleEndian.Uint64(buf), nil
-}
-
-func bytesToItemIndexArray(buf []byte) ([]uint64, error) {
-	if len(buf) == 0 {
-		return nil, nil
-	}
-
-	// The sizeof uint32 in binary is 4.
-	if len(buf) < 4 {
-		return nil, errInvalidValue
-	}
-	size := int(binary.LittleEndian.Uint32(buf))
-	if size == 0 {
-		return nil, nil
-	}
-
-	buf = buf[4:]
-	// The sizeof uint64 in binary is 8, so we need to have size*8 bytes.
-	if len(buf) < size*8 {
-		return nil, errInvalidValue
-	}
-
-	val := make([]uint64, size)
-	for i := range size {
-		val[i] = binary.LittleEndian.Uint64(buf)
-		buf = buf[8:]
-	}
-	return val, nil
-}
 
 type indexDone struct {
 	index     uint64

--- a/exporter/exporterhelper/internal/queue/persistent_queue_test.go
+++ b/exporter/exporterhelper/internal/queue/persistent_queue_test.go
@@ -5,7 +5,6 @@ package queue
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
@@ -808,63 +807,6 @@ func BenchmarkPersistentQueue(b *testing.B) {
 	require.NoError(b, ext.Shutdown(context.Background()))
 }
 
-func TestItemIndexMarshaling(t *testing.T) {
-	cases := []struct {
-		in  uint64
-		out uint64
-	}{
-		{
-			in:  0,
-			out: 0,
-		},
-		{
-			in:  1,
-			out: 1,
-		},
-		{
-			in:  0xFFFFFFFFFFFFFFFF,
-			out: 0xFFFFFFFFFFFFFFFF,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(fmt.Sprintf("#elements:%v", c.in), func(*testing.T) {
-			buf := binary.LittleEndian.AppendUint64([]byte{}, c.in)
-			out, err := bytesToItemIndex(buf)
-			require.NoError(t, err)
-			require.Equal(t, c.out, out)
-		})
-	}
-}
-
-func TestItemIndexArrayMarshaling(t *testing.T) {
-	cases := []struct {
-		in  []uint64
-		out []uint64
-	}{
-		{
-			in:  []uint64{0, 1, 2},
-			out: []uint64{0, 1, 2},
-		},
-		{
-			in:  []uint64{},
-			out: nil,
-		},
-		{
-			in:  nil,
-			out: nil,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(fmt.Sprintf("#elements:%v", c.in), func(_ *testing.T) {
-			buf := itemIndexArrayToBytes(c.in)
-			out, err := bytesToItemIndexArray(buf)
-			require.NoError(t, err)
-			require.Equal(t, c.out, out)
-		})
-	}
-}
 
 func TestPersistentQueue_ShutdownWhileConsuming(t *testing.T) {
 	ps := createTestPersistentQueueWithRequestsSizer(t, storagetest.NewMockStorageExtension(nil), 1000)
@@ -1172,14 +1114,4 @@ func requireCurrentlyDispatchedItemsEqual(t *testing.T, pq *persistentQueue[intR
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	assert.ElementsMatch(t, compare, pq.metadata.CurrentlyDispatchedItems)
-}
-
-func itemIndexArrayToBytes(arr []uint64) []byte {
-	size := len(arr)
-	buf := make([]byte, 0, 4+size*8)
-	buf = binary.LittleEndian.AppendUint32(buf, uint32(size))
-	for _, item := range arr {
-		buf = binary.LittleEndian.AppendUint64(buf, item)
-	}
-	return buf
 }


### PR DESCRIPTION
#### Description

This PR resolves #15640 by removing the deprecated legacy persistent queue metadata format (which used separate keys `ri`, `wi`, and `di`) and all associated migration logic. The metadata was consolidated into a protobuf-serialized key (`qmv0`), and the migration grace period target date has passed.

**Changes included:**
- Removed `loadLegacyMetadata()` method and legacy migration logic from `initClient()`.
- Simplified `initClient()` to directly initialize an empty queue when no metadata is found in storage.
- Removed `retrieveAndEnqueueNotDispatchedReqs()` method.
- Removed legacy constants `legacyReadIndexKey`, `legacyWriteIndexKey`, `legacyCurrentlyDispatchedItemsKey`, and unused error `errInvalidValue`.
- Removed helper functions `bytesToItemIndex()` and `bytesToItemIndexArray()`.
- Removed obsolete tests and test helpers `TestItemIndexMarshaling`, `TestItemIndexArrayMarshaling`, and `itemIndexArrayToBytes()`.

#### Link to tracking issue
Fixes #15640

#### Testing
- Ran all unit tests in `exporter/exporterhelper/internal/queue`: all tests pass.

#### Documentation
N/A (internal package cleanup).
