### PR TITLE
docs(connector): clarify available connectors, distributions, and configuration

### DIFF
--- a/connector/README.md
+++ b/connector/README.md
@@ -32,22 +32,34 @@ used to connect the following types of pipelines.
 | metrics                  | metrics                  |
 | logs                     | logs                     |
 
+## Available Connectors and Distributions
+
+Connectors are modular components compiled into the OpenTelemetry Collector binary. The component name specified in the configuration (e.g. `forward`, `count`, `router`) must correspond to a connector component type available in your Collector distribution:
+
+- **Core Distribution**: The core OpenTelemetry Collector includes the [`forward` connector](./forwardconnector/README.md), which simply passes telemetry unchanged from an exporter pipeline to a receiver pipeline of the same data type.
+- **Contrib Distribution**: Additional connectors (such as `count`, `router`, `spanmetrics`, etc.) are available in the [OpenTelemetry Collector Contrib distribution](https://github.com/open-telemetry/opentelemetry-collector-contrib).
+- **Custom Distributions**: You can build custom Collector distributions that bundle specific connectors using the [OpenTelemetry Collector Builder (OCB)](../cmd/builder/README.md).
+
+> **Note:** If you use a connector type in your configuration that is not included in the Collector distribution you are running, you will encounter an error like `'connectors' unknown type: "<name>" for id: "<name>" (valid values: [...])`. Ensure you are running a distribution (such as `otelcol-contrib`) that includes the desired connector.
+
 ## Configuration
 
 ### Declaration
 
 Connectors are defined within a dedicated `connectors` section at the top level of the collector config.
+The declaration syntax follows the standard Collector component ID format: `<type>` or `<type>/<name>` (e.g., `forward`, `count`, `forward/custom_name`).
 
-The count connector may be used with default settings.
+Connectors can be configured with default settings or with custom parameters defined by each connector's configuration:
 
 ```yaml
 receivers:
-  foo:
+  otlp:
 exporters:
-  bar:
+  otlp:
 connectors:
-  count:
-  router:
+  forward:
+  count: # (Available in Contrib distribution)
+  router: # (Available in Contrib distribution)
 ```
 
 ### Usage
@@ -61,14 +73,14 @@ receivers:
 exporters:
   bar:
 connectors:
-  count:
+  forward:
 service:
   pipelines:
     traces:
       receivers: [foo]
-      exporters: [count]
-    metrics:
-      receivers: [count]
+      exporters: [forward]
+    traces/downstream:
+      receivers: [forward]
       exporters: [bar]
 ```
 


### PR DESCRIPTION
#### Description

This PR resolves #15540 by improving the documentation in `connector/README.md`.

**Details:**
- Added an "Available Connectors and Distributions" section explaining how connector components are compiled into the binary, clarifying that the core distribution includes the `forward` connector, while other connectors like `count`, `router`, and `spanmetrics` are part of the `opentelemetry-collector-contrib` distribution or custom builds with OCB.
- Clarified error messages that occur when attempting to use a contrib connector in a core distribution (`'connectors' unknown type: "<name>" for id: "<name>"`).
- Clarified component declaration syntax (`<type>` or `<type>/<name>`) and updated examples to use the core built-in `forward` connector as the primary example alongside contrib examples.

#### Link to tracking issue
Fixes #15540

#### Testing
Verified markdown formatting and rendering.

#### Documentation
Updated `connector/README.md`.
