### PR TITLE
client: expose TLS SNI server name in client.Info

### DIFF
--- a/.chloggen/client-tls-sni.yaml
+++ b/.chloggen/client-tls-sni.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: client
+note: "Add `TLS` field to `client.Info` and populate TLS SNI server name in `confighttp` and `configgrpc`."
+issues: [15494]
+subtext:
+change_logs: [user, api]

--- a/client/client.go
+++ b/client/client.go
@@ -102,8 +102,17 @@ type Info struct {
 	// Metadata is the request metadata from the client connecting to this connector.
 	Metadata Metadata
 
+	// TLS information from the incoming TLS connection, if available.
+	TLS *TLSInfo
+
 	// prevent unkeyed literal initialization
 	_ struct{}
+}
+
+// TLSInfo contains TLS connection details for the client.
+type TLSInfo struct {
+	// ServerName is the SNI server name requested by the client during TLS handshake.
+	ServerName string
 }
 
 // AuthData represents the authentication data as seen by authenticators tied to

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -25,6 +25,9 @@ func TestNewContext(t *testing.T) {
 				Addr: &net.IPAddr{
 					IP: net.IPv4(1, 2, 3, 4),
 				},
+				TLS: &TLSInfo{
+					ServerName: "example.com",
+				},
 			},
 		},
 		{

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -678,6 +678,11 @@ func contextWithClient(ctx context.Context, includeMetadata bool) context.Contex
 	cl := client.FromContext(ctx)
 	if p, ok := peer.FromContext(ctx); ok {
 		cl.Addr = p.Addr
+		if tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo); ok {
+			cl.TLS = &client.TLSInfo{
+				ServerName: tlsInfo.State.ServerName,
+			}
+		}
 	}
 	if includeMetadata {
 		if md, ok := metadata.FromIncomingContext(ctx); ok {

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -5,6 +5,7 @@ package configgrpc
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -927,6 +929,27 @@ func TestContextWithClient(t *testing.T) {
 			expected: client.Info{
 				Addr: &net.IPAddr{
 					IP: net.IPv4(1, 2, 3, 5),
+				},
+			},
+		},
+		{
+			desc: "peer with TLS information",
+			input: peer.NewContext(context.Background(), &peer.Peer{
+				Addr: &net.IPAddr{
+					IP: net.IPv4(1, 2, 3, 4),
+				},
+				AuthInfo: credentials.TLSInfo{
+					State: tls.ConnectionState{
+						ServerName: "grpc.example.com",
+					},
+				},
+			}),
+			expected: client.Info{
+				Addr: &net.IPAddr{
+					IP: net.IPv4(1, 2, 3, 4),
+				},
+				TLS: &client.TLSInfo{
+					ServerName: "grpc.example.com",
 				},
 			},
 		},

--- a/config/confighttp/clientinfohandler.go
+++ b/config/confighttp/clientinfohandler.go
@@ -36,6 +36,12 @@ func contextWithClient(req *http.Request, includeMetadata bool) context.Context 
 		cl.Addr = ip
 	}
 
+	if req.TLS != nil {
+		cl.TLS = &client.TLSInfo{
+			ServerName: req.TLS.ServerName,
+		}
+	}
+
 	if includeMetadata {
 		md := req.Header.Clone()
 		if md.Get(client.MetadataHostName) == "" && req.Host != "" {

--- a/config/confighttp/clientinfohandler_test.go
+++ b/config/confighttp/clientinfohandler_test.go
@@ -4,11 +4,14 @@
 package confighttp // import "go.opentelemetry.io/collector/config/confighttp"
 
 import (
+	"crypto/tls"
 	"net"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/client"
 )
 
 var _ http.Handler = (*clientInfoHandler)(nil)
@@ -49,4 +52,18 @@ func TestParseIP(t *testing.T) {
 			assert.Equal(t, tt.expected, parseIP(tt.input))
 		})
 	}
+}
+
+func TestContextWithClient_TLS(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/test", nil)
+	assert.NoError(t, err)
+	req.RemoteAddr = "1.2.3.4:1234"
+	req.TLS = &tls.ConnectionState{
+		ServerName: "example.com",
+	}
+
+	ctx := contextWithClient(req, false)
+	cl := client.FromContext(ctx)
+	assert.NotNil(t, cl.TLS)
+	assert.Equal(t, "example.com", cl.TLS.ServerName)
 }


### PR DESCRIPTION
#### Description

This PR resolves #15494 by exposing the TLS SNI server name in `client.Info`.

**Details:**
- Added `TLS *TLSInfo` to `client.Info` and defined `TLSInfo` struct containing `ServerName string`.
- Updated `confighttp` (`clientinfohandler.go`) to populate `cl.TLS` from `req.TLS` when present.
- Updated `configgrpc` (`configgrpc.go`) to extract `credentials.TLSInfo` from `peer.AuthInfo` and populate `cl.TLS`.
- Added unit tests in `client`, `confighttp`, and `configgrpc`.
- Added changelog entry in `.chloggen/client-tls-sni.yaml`.

#### Link to tracking issue
Fixes #15494

#### Testing
- Added test cases in `client/client_test.go`, `config/confighttp/clientinfohandler_test.go`, and `config/configgrpc/configgrpc_test.go`.
- Ran unit tests across all affected modules: all passed cleanly.

#### Documentation
Documented `TLSInfo` in `client/client.go`.
