### PR TITLE
cmd/builder: add Makefile.Common template with development targets to ocb init

### DIFF
--- a/.chloggen/builder-makefile-common.yaml
+++ b/.chloggen/builder-makefile-common.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: cmd/builder
+note: "Add `Makefile.Common` with development targets (`test`, `test-with-cover`, `fmt`, `tidy`, `check-links`, `generate`) to `ocb init` template."
+issues: [14704]
+subtext:
+change_logs: [user]

--- a/cmd/builder/internal/command_init.go
+++ b/cmd/builder/internal/command_init.go
@@ -95,6 +95,11 @@ func run(path string) error {
 		return fmt.Errorf("failed writing Makefile: %w", err)
 	}
 
+	err = writeTemplate(path, "Makefile.Common", meta)
+	if err != nil {
+		return fmt.Errorf("failed writing Makefile.Common: %w", err)
+	}
+
 	err = writeTemplate(path, "config.yaml", meta)
 	if err != nil {
 		return fmt.Errorf("failed writing config.yaml: %w", err)

--- a/cmd/builder/internal/command_init_test.go
+++ b/cmd/builder/internal/command_init_test.go
@@ -98,5 +98,6 @@ func validateCollector(t *testing.T, path string) {
 	require.FileExists(t, filepath.Join(path, "go.mod"))
 	require.FileExists(t, filepath.Join(path, "go.sum"))
 	require.FileExists(t, filepath.Join(path, "Makefile"))
+	require.FileExists(t, filepath.Join(path, "Makefile.Common"))
 	require.FileExists(t, filepath.Join(path, "config.yaml"))
 }

--- a/cmd/builder/internal/init/templates/Makefile.Common.tmpl
+++ b/cmd/builder/internal/init/templates/Makefile.Common.tmpl
@@ -1,0 +1,27 @@
+GOCMD ?= go
+GOTEST_TIMEOUT ?= 240s
+GOTEST_OPT ?= -timeout $(GOTEST_TIMEOUT) -race
+
+.PHONY: test
+test:
+	$(GOCMD) test $(GOTEST_OPT) ./...
+
+.PHONY: test-with-cover
+test-with-cover:
+	$(GOCMD) test $(GOTEST_OPT) -cover ./...
+
+.PHONY: fmt
+fmt:
+	gofmt -w -s ./
+
+.PHONY: tidy
+tidy:
+	$(GOCMD) mod tidy
+
+.PHONY: check-links
+check-links:
+	$(GOCMD) tool go.opentelemetry.io/collector/cmd/builder --help > /dev/null
+
+.PHONY: generate
+generate:
+	$(GOCMD) generate ./...

--- a/cmd/builder/internal/init/templates/Makefile.tmpl
+++ b/cmd/builder/internal/init/templates/Makefile.tmpl
@@ -1,3 +1,5 @@
+include Makefile.Common
+
 GOMODULES := $(shell find . -mindepth 2 \
 							 -type f \
 							 -name "go.mod" \


### PR DESCRIPTION
#### Description

This PR resolves #14704 by adding a `Makefile.Common` template with standard development targets to `ocb init`.

**Details:**
- Added `cmd/builder/internal/init/templates/Makefile.Common.tmpl` containing the following targets:
  - `test`: executes `$(GOCMD) test $(GOTEST_OPT) ./...`
  - `test-with-cover`: executes `$(GOCMD) test $(GOTEST_OPT) -cover ./...`
  - `fmt`: runs `gofmt -w -s ./`
  - `tidy`: runs `$(GOCMD) mod tidy`
  - `check-links`: validates builder tool flags/help
  - `generate`: runs `$(GOCMD) generate ./...`
- Updated `cmd/builder/internal/init/templates/Makefile.tmpl` to import `Makefile.Common`.
- Updated `cmd/builder/internal/command_init.go` to generate `Makefile.Common` upon running `ocb init`.
- Updated tests in `cmd/builder/internal/command_init_test.go` to verify `Makefile.Common` generation.
- Added changelog entry in `.chloggen/builder-makefile-common.yaml`.

#### Link to tracking issue
Fixes #14704

#### Testing
- Added assertion in `TestRunInit` to verify `Makefile.Common` creation.
- Ran tests in `cmd/builder`: all pass.

#### Documentation
`Makefile.Common` is generated alongside `Makefile` in scaffolded collector directories.
