### PR TITLE
featuregate: reject leading, trailing, or consecutive dots in gate IDs

### DIFF
--- a/.chloggen/featuregate-validate-dot-ids.yaml
+++ b/.chloggen/featuregate-validate-dot-ids.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: featuregate
+note: "Disallow leading, trailing, or consecutive dots in feature gate ID validation."
+issues: [15676]
+subtext:
+change_logs: [user]

--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -21,7 +21,7 @@ import (
 const semConvURL = "https://github.com/open-telemetry/semantic-conventions/blob"
 
 var (
-	featureGateIDRegexp       = regexp.MustCompile(`^[0-9a-zA-Z.]*$`)
+	featureGateIDRegexp       = regexp.MustCompile(`^[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*$`)
 	featureGateIssueURLRegexp = regexp.MustCompile(`^https://github\.com/[^/]+/[^/]+/issues/\d+$`)
 )
 
@@ -439,7 +439,7 @@ func (md *Metadata) validateFeatureGates() error {
 
 		// Validate ID follows the allowed character pattern
 		if !featureGateIDRegexp.MatchString(string(gate.ID)) {
-			errs = errors.Join(errs, fmt.Errorf(`feature gate "%v": ID contains invalid characters, must match ^[0-9a-zA-Z.]*$`, gate.ID))
+			errs = errors.Join(errs, fmt.Errorf(`feature gate "%v": ID contains invalid characters, must match ^[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*$`, gate.ID))
 		}
 
 		// Validate ID is prefixed with "<class>.<type>." so gates are namespaced to their component.

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -954,6 +954,39 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 			wantErr: `ID contains invalid characters`,
 		},
+		{
+			name: "invalid leading dot in ID",
+			featureGate: FeatureGate{
+				ID:           ".component.feature",
+				Description:  "Test feature",
+				Stage:        FeatureGateStageAlpha,
+				FromVersion:  "v0.100.0",
+				ReferenceURL: "https://github.com/open-telemetry/opentelemetry-collector/issues/12345",
+			},
+			wantErr: `ID contains invalid characters`,
+		},
+		{
+			name: "invalid trailing dot in ID",
+			featureGate: FeatureGate{
+				ID:           "component.feature.",
+				Description:  "Test feature",
+				Stage:        FeatureGateStageAlpha,
+				FromVersion:  "v0.100.0",
+				ReferenceURL: "https://github.com/open-telemetry/opentelemetry-collector/issues/12345",
+			},
+			wantErr: `ID contains invalid characters`,
+		},
+		{
+			name: "invalid consecutive dots in ID",
+			featureGate: FeatureGate{
+				ID:           "component..feature",
+				Description:  "Test feature",
+				Stage:        FeatureGateStageAlpha,
+				FromVersion:  "v0.100.0",
+				ReferenceURL: "https://github.com/open-telemetry/opentelemetry-collector/issues/12345",
+			},
+			wantErr: `ID contains invalid characters`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -19,8 +19,8 @@ var (
 	globalRegistry = NewRegistry()
 
 	// idRegexp is used to validate the ID of a Gate.
-	// IDs' characters must be alphanumeric or dots.
-	idRegexp = regexp.MustCompile(`^[0-9a-zA-Z.]*$`)
+	// IDs must be dot-separated alphanumeric segments with no leading, trailing, or consecutive dots.
+	idRegexp = regexp.MustCompile(`^[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*$`)
 )
 
 // ErrAlreadyRegistered is returned when adding a Gate that is already registered.

--- a/featuregate/registry_test.go
+++ b/featuregate/registry_test.go
@@ -153,6 +153,30 @@ func TestRegisterGateLifecycle(t *testing.T) {
 			shouldErr: true,
 		},
 		{
+			name:      "Invalid gate leading dot",
+			id:        ".foo",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid gate trailing dot",
+			id:        "foo.",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid gate consecutive dots",
+			id:        "foo..bar",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid gate only dot",
+			id:        ".",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
 			name:      "Invalid empty gate",
 			id:        "",
 			stage:     StageAlpha,


### PR DESCRIPTION
#### Description

This PR resolves #15676 by updating the feature gate ID validation regex in `featuregate/registry.go` and `cmd/mdatagen/internal/metadata.go` from `^[0-9a-zA-Z.]*$` to `^[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*$`.

**Details:**
- Disallows leading dots (e.g. `.foo`), trailing dots (e.g. `foo.`), consecutive dots (e.g. `foo..bar`), and dot-only strings (`.`).
- Requires every dot-separated segment to contain at least one alphanumeric character.
- Updated `featuregate/registry.go` regex and documentation.
- Updated `cmd/mdatagen/internal/metadata.go` regex and validation error message.
- Added test cases in `featuregate/registry_test.go` and `cmd/mdatagen/internal/metadata_test.go`.
- Added changelog entry in `.chloggen/featuregate-validate-dot-ids.yaml`.

#### Link to tracking issue
Fixes #15676

#### Testing
- Added unit tests in `featuregate/registry_test.go` checking rejection of `.foo`, `foo.`, `foo..bar`, `.`.
- Added unit tests in `cmd/mdatagen/internal/metadata_test.go` verifying rejection of leading/trailing/consecutive dots in metadata schemas.
- Ran test suite in `featuregate` and `cmd/mdatagen`: all tests pass.

#### Documentation
Updated comments in `featuregate/registry.go`.
