### PR TITLE
pdata/pprofile: reserve index 0 in destination dictionary tables during MergeTo

### DIFF
--- a/.chloggen/pprofile-mergeto-reserve-zero-values.yaml
+++ b/.chloggen/pprofile-mergeto-reserve-zero-values.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: pdata/pprofile
+note: "Ensure `Profiles.MergeTo` reserves index 0 for table zero values in destination dictionary."
+issues: [15661]
+subtext:
+change_logs: [user]

--- a/pdata/pprofile/profiles_merge.go
+++ b/pdata/pprofile/profiles_merge.go
@@ -13,6 +13,8 @@ func (ms Profiles) MergeTo(dest Profiles) error {
 		return nil
 	}
 
+	reserveDictionaryZeroValues(dest.Dictionary())
+
 	if err := ms.switchDictionary(ms.Dictionary(), dest.Dictionary()); err != nil {
 		return err
 	}
@@ -21,4 +23,30 @@ func (ms Profiles) MergeTo(dest Profiles) error {
 	ms.MarkReadOnly()
 
 	return nil
+}
+
+// reserveDictionaryZeroValues ensures that index 0 of every table in the destination
+// dictionary is reserved for that table's zero value, seeding only tables that are still empty.
+func reserveDictionaryZeroValues(dict ProfilesDictionary) {
+	if dict.StringTable().Len() == 0 {
+		dict.StringTable().Append("")
+	}
+	if dict.MappingTable().Len() == 0 {
+		dict.MappingTable().AppendEmpty()
+	}
+	if dict.LocationTable().Len() == 0 {
+		dict.LocationTable().AppendEmpty()
+	}
+	if dict.FunctionTable().Len() == 0 {
+		dict.FunctionTable().AppendEmpty()
+	}
+	if dict.LinkTable().Len() == 0 {
+		dict.LinkTable().AppendEmpty()
+	}
+	if dict.AttributeTable().Len() == 0 {
+		dict.AttributeTable().AppendEmpty()
+	}
+	if dict.StackTable().Len() == 0 {
+		dict.StackTable().AppendEmpty()
+	}
 }

--- a/pdata/pprofile/profiles_merge_test.go
+++ b/pdata/pprofile/profiles_merge_test.go
@@ -718,3 +718,35 @@ func attrMapToStrings(m pcommon.Map) map[string]string {
 	})
 	return result
 }
+
+func TestProfilesMergeTo_DestinationZeroValueReserved(t *testing.T) {
+	src := NewProfiles()
+	dic := src.Dictionary()
+	dic.StringTable().Append("")
+	dic.AttributeTable().AppendEmpty()
+	dic.StackTable().AppendEmpty()
+	dic.LocationTable().AppendEmpty()
+	dic.FunctionTable().AppendEmpty()
+	dic.MappingTable().AppendEmpty()
+	dic.LinkTable().AppendEmpty()
+	dic.StringTable().Append("inuse_space")
+
+	prof := src.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+	prof.SampleType().SetTypeStrindex(1)
+
+	dest := NewProfiles()
+	require.NoError(t, src.MergeTo(dest))
+
+	// string_table[0] MUST be "" and not the merged string
+	assert.GreaterOrEqual(t, dest.Dictionary().StringTable().Len(), 2)
+	assert.Equal(t, "", dest.Dictionary().StringTable().At(0))
+	assert.Equal(t, "inuse_space", dest.Dictionary().StringTable().At(1))
+
+	// Zero values should be preserved across all tables
+	assert.GreaterOrEqual(t, dest.Dictionary().AttributeTable().Len(), 1)
+	assert.GreaterOrEqual(t, dest.Dictionary().StackTable().Len(), 1)
+	assert.GreaterOrEqual(t, dest.Dictionary().LocationTable().Len(), 1)
+	assert.GreaterOrEqual(t, dest.Dictionary().FunctionTable().Len(), 1)
+	assert.GreaterOrEqual(t, dest.Dictionary().MappingTable().Len(), 1)
+	assert.GreaterOrEqual(t, dest.Dictionary().LinkTable().Len(), 1)
+}


### PR DESCRIPTION
#### Description

This PR resolves #15661 by ensuring that `Profiles.MergeTo` reserves index 0 in the destination dictionary for each table's zero value (e.g. `""` for `StringTable`, `Location{}` for `LocationTable`, etc.) prior to remapping source dictionary entries into destination.

**Details:**
- Defined `reserveDictionaryZeroValues(dict ProfilesDictionary)` in `pdata/pprofile/profiles_merge.go` which checks each table in the destination dictionary (`StringTable`, `MappingTable`, `LocationTable`, `FunctionTable`, `LinkTable`, `AttributeTable`, `StackTable`) and seeds index 0 if the table is currently empty.
- Invoked `reserveDictionaryZeroValues(dest.Dictionary())` at the start of `Profiles.MergeTo`.
- Added unit test `TestProfilesMergeTo_DestinationZeroValueReserved` in `pdata/pprofile/profiles_merge_test.go` verifying that merging a profile with string/location data into an uninitialized `NewProfiles()` preserves `""` and zero elements at index 0 across all dictionary tables.
- Added changelog entry in `.chloggen/pprofile-mergeto-reserve-zero-values.yaml`.

#### Link to tracking issue
Fixes #15661

#### Testing
- Added unit test `TestProfilesMergeTo_DestinationZeroValueReserved` in `profiles_merge_test.go`.
- Ran unit and fuzz test suites in `pdata/pprofile`: all tests pass.

#### Documentation
Preserves protocol compliance as defined in `ProfilesDictionary` proto specification.
