### PR TITLE
[confighttp] accept Content-Encoding: identity

### DIFF
--- a/.chloggen/confighttp-identity-content-encoding.yaml
+++ b/.chloggen/confighttp-identity-content-encoding.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Accept `Content-Encoding: identity` on server requests instead of rejecting it as an unsupported encoding.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15122]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  RFC 9110 defines `identity` as "no transformation applied", the same thing an absent
+  `Content-Encoding` conveys, but the decoder lookup treated it as an unknown algorithm
+  and returned 400. It is now normalized to the empty encoding, so it is accepted exactly
+  when an uncompressed body is accepted — removing `""` from `compression_algorithms` to
+  reject uncompressed payloads rejects `identity` as well.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/confighttp-identity-content-encoding.yaml
+++ b/.chloggen/confighttp-identity-content-encoding.yaml
@@ -4,10 +4,10 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
-component: confighttp
+component: pkg/confighttp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Accept `Content-Encoding: identity` on server requests instead of rejecting it as an unsupported encoding.
+note: "Accept `Content-Encoding: identity` on server requests instead of rejecting it as an unsupported encoding."
 
 # One or more tracking issues or pull requests related to the change
 issues: [15122]

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -25,6 +25,11 @@ import (
 	"go.opentelemetry.io/collector/config/configcompression"
 )
 
+// encodingIdentity is the Content-Encoding token for "no transformation applied"
+// (RFC 9110 section 8.4.1). It is deliberately not a configurable algorithm; see
+// newBodyReader.
+const encodingIdentity = "identity"
+
 func defaultCompressionAlgorithms() []string {
 	return []string{"", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4", "x-snappy-framed"}
 }
@@ -294,6 +299,15 @@ func (d *decompressor) newBodyReader(r *http.Request) (io.ReadCloser, error) {
 		return nil, nil // Signal: don't replace r.Body
 	}
 	encoding := r.Header.Get(headerContentEncoding)
+	if encoding == encodingIdentity {
+		// RFC 9110 section 8.4.1 defines "identity" as "no transformation", which is
+		// exactly what an absent Content-Encoding conveys. Normalise it here rather
+		// than registering it as its own decoder so it is accepted precisely when an
+		// uncompressed body is accepted: an operator who drops "" from
+		// compression_algorithms to reject uncompressed payloads rejects "identity"
+		// too, instead of leaving it as a bypass.
+		encoding = ""
+	}
 
 	decoder, ok := d.decoders[encoding]
 	if !ok {

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -453,12 +453,6 @@ func TestEmptyCompressionAlgorithmsAllowsUncompressed(t *testing.T) {
 		},
 		// Case 3: Explicit list including empty string should accept uncompressed
 		{
-			name:                  "WithEmptyString_Identity_Accepted",
-			compressionAlgorithms: []string{"", "gzip", "zstd"},
-			contentEncoding:       "identity",
-			expectedStatus:        http.StatusOK,
-		},
-		{
 			name:                  "WithEmptyString_NoContentEncoding_Accepted",
 			compressionAlgorithms: []string{"", "gzip", "zstd"},
 			contentEncoding:       "",
@@ -656,14 +650,14 @@ func TestCompressionAlgorithmsEdgeCases(t *testing.T) {
 			wantBodyEcho:          true,
 		},
 		{
-			// BUG: "identity" means no encoding per RFC 7231 §3.1.2.2, but
-			// the decompressor rejects it because "identity" is not registered
-			// in availableDecoders. This should be treated the same as "".
+			// "identity" means no encoding per RFC 9110 §8.4.1, so it is handled
+			// the same as "". It used to be rejected because it was not registered
+			// in availableDecoders.
 			name:                  "Mixed_Identity_ShouldAccept",
 			compressionAlgorithms: []string{"", "gzip", "zstd"},
 			contentEncoding:       "identity",
 			body:                  testBody,
-			wantStatus:            http.StatusBadRequest, // BUG: should be http.StatusOK
+			wantStatus:            http.StatusOK,
 		},
 		{
 			name:                  "Mixed_Snappy_Rejected",

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -243,6 +243,15 @@ func TestHTTPContentDecompressionHandler(t *testing.T) {
 			respCode: http.StatusOK,
 		},
 		{
+			// RFC 9110 section 8.4.1: "identity" means no transformation was applied,
+			// so it must be accepted exactly like an absent Content-Encoding. It was
+			// previously rejected as an unknown algorithm.
+			name:     "ValidIdentity",
+			encoding: "identity",
+			reqBody:  bytes.NewBuffer(testBody),
+			respCode: http.StatusOK,
+		},
+		{
 			name:     "ValidDeflate",
 			encoding: "deflate",
 			reqBody:  compressZlib(t, testBody),
@@ -420,6 +429,16 @@ func TestEmptyCompressionAlgorithmsAllowsUncompressed(t *testing.T) {
 			expectedError:         "unsupported Content-Encoding",
 		},
 		{
+			// "identity" is normalised to the empty encoding, so removing "" from the
+			// allowed list rejects it too. If it were registered as its own decoder it
+			// would survive here and become a way to bypass the restriction.
+			name:                  "OnlyZstd_Identity_Rejected",
+			compressionAlgorithms: []string{"zstd"},
+			contentEncoding:       "identity",
+			expectedStatus:        http.StatusBadRequest,
+			expectedError:         "unsupported Content-Encoding",
+		},
+		{
 			name:                  "OnlyZstd_Zstd_Accepted",
 			compressionAlgorithms: []string{"zstd"},
 			contentEncoding:       "zstd",
@@ -433,6 +452,12 @@ func TestEmptyCompressionAlgorithmsAllowsUncompressed(t *testing.T) {
 			expectedError:         "unsupported Content-Encoding",
 		},
 		// Case 3: Explicit list including empty string should accept uncompressed
+		{
+			name:                  "WithEmptyString_Identity_Accepted",
+			compressionAlgorithms: []string{"", "gzip", "zstd"},
+			contentEncoding:       "identity",
+			expectedStatus:        http.StatusOK,
+		},
 		{
 			name:                  "WithEmptyString_NoContentEncoding_Accepted",
 			compressionAlgorithms: []string{"", "gzip", "zstd"},


### PR DESCRIPTION
#### Description

`Content-Encoding: identity` is rejected by the server with `400 unsupported Content-Encoding: identity`.

RFC 9110 §8.4.1 defines `identity` as "no transformation applied" — the same thing an absent `Content-Encoding` header conveys. But `newBodyReader` looks the header value up directly in the enabled-decoder map, which has an entry for the empty string and none for `identity`, so it falls to the unknown-algorithm branch. A correctly-behaving client that states its body is unencoded gets turned away.

This normalizes `identity` to the empty encoding at the lookup, rather than registering it as its own decoder.

That distinction is deliberate. Registering it as a separate algorithm would make it independently configurable, so an operator who removes `""` from `compression_algorithms` specifically to reject uncompressed payloads would still accept `identity` — a bypass of the restriction they just set. Normalizing couples the two, which matches what the tokens actually mean. Adding `identity` to `defaultCompressionAlgorithms()` would also have expanded the documented default config surface for no benefit.

#### Link to tracking issue

Fixes #15122

**Scope note:** #15122 describes three related bugs — `compression: ""` handling, `identity`/`""` Content-Encoding, and garbage data returning 500 instead of 400. This PR fixes only the `identity` half.

I used a closing reference because `check-pr-issue-link` requires one from non-members, but this should not close the issue. Happy to retarget it at a narrower issue if you'd rather split #15122, or to leave it and have the issue reopened on merge — whichever you prefer.

On the other two, from reading the code before writing this: the 500 looks like a lazy-vs-eager split (`gzip.NewReader` parses its header eagerly so malformed gzip already 400s, while decoders that fail on read surface after `ServeHTTP` has handed off), and `Type.UnmarshalText` currently accepts both `""` and `none`, so the `compression: ""` invalidity is likely on a different path. I asked about both on the issue and would rather agree the approach there than guess here.

#### Testing

Three cases added to the existing tables, all of which fail on `main`:

- `TestHTTPContentDecompressionHandler/ValidIdentity` — an `identity` request with an uncompressed body returns 200. On `main` it returns 400 `unsupported Content-Encoding: identity`.
- `TestEmptyCompressionAlgorithmsAllowsUncompressed/WithEmptyString_Identity_Accepted` — with `["", "gzip", "zstd"]`, `identity` is accepted. Also 400 on `main`.
- `TestEmptyCompressionAlgorithmsAllowsUncompressed/OnlyZstd_Identity_Rejected` — with `["zstd"]`, `identity` is rejected. This one passes before and after, and is there to pin the coupling: if someone later re-implements this as a standalone decoder, this test fails and says why.

`config/confighttp` passes; `gofmt` is clean.

#### Documentation

None beyond the changelog entry. This restores spec-conformant behaviour rather than adding a configurable surface, so there is nothing new to document.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

---

*Disclosure: prepared with AI assistance. Commits carry an `Assisted-by:` trailer per AGENTS.md.*
