### PR TITLE
[chore] Fix CI failure

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,4 +1,4 @@
-include_fragments = true
+include_fragments = "full"
 
 accept = ["200..=299", "429"]
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
lycheeverse/lychee-action is bumped from v2.8.0 to v2.9.0. In the latest version the include_fragments is expected to be string.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #15821

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
