### PR TITLE
docs(pcommon): document Map.Remove invalidating borrowed values

### DIFF
--- a/pdata/pcommon/map.go
+++ b/pdata/pcommon/map.go
@@ -73,7 +73,8 @@ func (m Map) Get(key string) (Value, bool) {
 }
 
 // Remove removes the entry associated with the key and returns true if the key
-// was present in the map, otherwise returns false.
+// was present in the map, otherwise returns false. Removing an entry
+// invalidates any Value previously returned by Get from this Map.
 func (m Map) Remove(key string) bool {
 	m.getState().AssertMutable()
 	for i := range *m.getOrig() {


### PR DESCRIPTION
## Description

Document that `pcommon.Map.Remove` invalidates any `pcommon.Value` previously returned by `Get` from the same map. This makes the existing borrowed-value lifetime behavior visible at the mutating API where it matters.

## Link to tracking issue

Fixes #10366

## Testing

- `git diff --check` passed.
- Go tests were not run because the Go toolchain is unavailable in this environment.

## Documentation

Updated the `pcommon.Map.Remove` GoDoc comment in `pdata/pcommon/map.go`.