### PR TITLE
[chore] sizer is never nil

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/batcher.go
@@ -36,9 +36,6 @@ func NewBatcher(cfg configoptional.Optional[BatchConfig], set batcherSettings[re
 	}
 
 	sizer := request.NewSizer(cfg.Get().Sizer)
-	if sizer == nil {
-		return nil, fmt.Errorf("queue_batch: unsupported sizer %q", cfg.Get().Sizer)
-	}
 
 	if set.partitioner == nil {
 		return newPartitionBatcher(*cfg.Get(), sizer, set.mergeCtx, newWorkerPool(set.maxWorkers), set.next, set.logger, nil), nil


### PR DESCRIPTION
Removing unnecessary check as a struct is always returned

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
