### PR TITLE
Mark confighttp as stable

### DIFF
--- a/.chloggen/confighttp-stable.yaml
+++ b/.chloggen/confighttp-stable.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: pkg/confighttp
+note: Mark confighttp as stable
+issues: [9380]
+subtext:
+change_logs: [api]

--- a/versions.yaml
+++ b/versions.yaml
@@ -21,7 +21,6 @@ module-sets:
       - go.opentelemetry.io/collector/config/configoptional
       - go.opentelemetry.io/collector/config/configcompression
       - go.opentelemetry.io/collector/config/confighttp
-      - go.opentelemetry.io/collector/config/confighttp/xconfighttp
       - go.opentelemetry.io/collector/config/configretry
       - go.opentelemetry.io/collector/config/configtls
       - go.opentelemetry.io/collector/config/confignet
@@ -50,6 +49,7 @@ module-sets:
       - go.opentelemetry.io/collector/component/componentstatus
       - go.opentelemetry.io/collector/component/componenttest
       - go.opentelemetry.io/collector/confmap/xconfmap
+      - go.opentelemetry.io/collector/config/confighttp/xconfighttp
       - go.opentelemetry.io/collector/config/configstorage
       - go.opentelemetry.io/collector/config/configtelemetry
       - go.opentelemetry.io/collector/connector

--- a/versions.yaml
+++ b/versions.yaml
@@ -20,6 +20,8 @@ module-sets:
       - go.opentelemetry.io/collector/config/configopaque
       - go.opentelemetry.io/collector/config/configoptional
       - go.opentelemetry.io/collector/config/configcompression
+      - go.opentelemetry.io/collector/config/confighttp
+      - go.opentelemetry.io/collector/config/confighttp/xconfighttp
       - go.opentelemetry.io/collector/config/configretry
       - go.opentelemetry.io/collector/config/configtls
       - go.opentelemetry.io/collector/config/confignet
@@ -48,8 +50,6 @@ module-sets:
       - go.opentelemetry.io/collector/component/componentstatus
       - go.opentelemetry.io/collector/component/componenttest
       - go.opentelemetry.io/collector/confmap/xconfmap
-      - go.opentelemetry.io/collector/config/confighttp
-      - go.opentelemetry.io/collector/config/confighttp/xconfighttp
       - go.opentelemetry.io/collector/config/configstorage
       - go.opentelemetry.io/collector/config/configtelemetry
       - go.opentelemetry.io/collector/connector


### PR DESCRIPTION
#### Description

As of https://github.com/open-telemetry/opentelemetry-collector/issues/14020, there are no more blockers for marking confighttp as stable. It has no (non-test) dependencies on unstable modules and no potential breaking changes in the pipeline.

#### Link to tracking issue
Closes #9380

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

