### PR TITLE
[chore] enable storing of benchmark results

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -32,14 +32,12 @@ jobs:
       - name: Run benchmark
         run: make gobenchmark
 
-      # Disabling until fine-grained permissions token enabled for the
-      # repository
-      #- name: Store benchmark result
-      #  uses: benchmark-action/github-action-benchmark@v1
-      #  with:
-      #    tool: 'go'
-      #    output-file-path: benchmarks.txt
-      #    gh-pages-branch: gh-pages
-      #    auto-push: true
-      #    github-token: ${{ secrets.GITHUB_TOKEN }}
-      #    benchmark-data-dir-path: "docs/dev/bench"
+      - uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        with:
+            tool: 'go'
+            output-file-path: benchmarks.txt
+            gh-pages-branch: benchmarks
+            max-items-in-chart: 100
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            benchmark-data-dir-path: "docs/benchmarks/loadtests"
+            auto-push: true


### PR DESCRIPTION
#### Description

Saw that this was disabled 3 years ago, but the same job is available in contrib. Possible we'll need to update permissions on this repo to make this work.

The ask from reviewers is to determine whether this workflow should be run at all.

#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
