### PR TITLE
[confighttp] skip unknown compression_algorithms entries instead of storing nil decoders

### DIFF
--- a/.chloggen/confighttp-unknown-algorithm-nil-decoder.yaml
+++ b/.chloggen/confighttp-unknown-algorithm-nil-decoder.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: pkg/confighttp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Skip unrecognised entries in `compression_algorithms` instead of registering them as nil decoders, which panicked the server."
+note: "Skip unrecognized entries in `compression_algorithms` instead of registering them as nil decoders, which panicked the server."
 
 # One or more tracking issues or pull requests related to the change
 issues: [15836]
@@ -16,7 +16,7 @@ issues: [15836]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  An unrecognised name was stored in the enabled-decoder map with a nil value, so a request
+  An unrecognized name was stored in the enabled-decoder map with a nil value, so a request
   whose `Content-Encoding` matched it was treated as supported and the nil decoder was called,
   panicking the handler. Unknown names are now skipped, so such a request falls through to the
   existing `unsupported Content-Encoding` path and returns 400.

--- a/.chloggen/confighttp-unknown-algorithm-nil-decoder.yaml
+++ b/.chloggen/confighttp-unknown-algorithm-nil-decoder.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Skip unrecognised entries in `compression_algorithms` instead of registering them as nil decoders, which panicked the server."
+
+# One or more tracking issues or pull requests related to the change
+issues: [15836]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  An unrecognised name was stored in the enabled-decoder map with a nil value, so a request
+  whose `Content-Encoding` matched it was treated as supported and the nil decoder was called,
+  panicking the handler. Unknown names are now skipped, so such a request falls through to the
+  existing `unsupported Content-Encoding` path and returns 400.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -247,14 +247,27 @@ func httpContentDecompressor(h http.Handler, maxRequestBodySize int64, eh func(w
 
 	enabled := map[string]func(body io.ReadCloser) (io.ReadCloser, error){}
 	for _, dec := range enableDecoders {
-		enabled[dec] = availableDecoders[dec]
+		var decoder func(body io.ReadCloser) (io.ReadCloser, error)
+		switch dec {
+		case "deflate":
+			// "deflate" has no entry of its own; it is served by the zlib reader.
+			decoder = availableDecoders["zlib"]
+		case "snappy":
+			// snappy needs the request-body limit, so it is constructed per server.
+			decoder = newSnappyHandler(maxRequestBodySize)
+		default:
+			decoder = availableDecoders[dec]
+		}
 
-		if dec == "deflate" {
-			enabled["deflate"] = availableDecoders["zlib"]
+		// An unrecognised name would otherwise be stored as a nil decoder. The key
+		// would then be present in the map, so newBodyReader would take it as
+		// supported and call it, panicking on the nil func. Skipping it instead
+		// lets the encoding fall through to the "unsupported Content-Encoding"
+		// path and return 400, which is what an unconfigured algorithm should do.
+		if decoder == nil {
+			continue
 		}
-		if dec == "snappy" {
-			enabled["snappy"] = newSnappyHandler(maxRequestBodySize)
-		}
+		enabled[dec] = decoder
 	}
 
 	d := &decompressor{

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -259,7 +259,7 @@ func httpContentDecompressor(h http.Handler, maxRequestBodySize int64, eh func(w
 			decoder = availableDecoders[dec]
 		}
 
-		// An unrecognised name would otherwise be stored as a nil decoder. The key
+		// An unrecognized name would otherwise be stored as a nil decoder. The key
 		// would then be present in the map, so newBodyReader would take it as
 		// supported and call it, panicking on the nil func. Skipping it instead
 		// lets the encoding fall through to the "unsupported Content-Encoding"

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -420,6 +420,37 @@ func TestEmptyCompressionAlgorithmsAllowsUncompressed(t *testing.T) {
 			expectedError:         "unsupported Content-Encoding",
 		},
 		{
+			// An unrecognised algorithm name used to be stored as a nil decoder, so
+			// newBodyReader found the key present, treated the encoding as supported,
+			// and panicked calling it. It must be skipped instead, leaving the request
+			// to fall through to the unsupported-encoding path.
+			name:                  "UnknownAlgorithm_MatchingEncoding_Rejected",
+			compressionAlgorithms: []string{"", "gzip", "bogus"},
+			contentEncoding:       "bogus",
+			expectedStatus:        http.StatusBadRequest,
+			expectedError:         "unsupported Content-Encoding",
+		},
+		{
+			// A list of only unrecognised names leaves nothing enabled, which takes the
+			// same path as an explicitly empty list: decompression is bypassed rather
+			// than rejected. Pinned so the difference from the mixed case above is
+			// deliberate rather than accidental.
+			name:                  "OnlyUnknownAlgorithms_BypassesDecompression",
+			compressionAlgorithms: []string{"bogus"},
+			contentEncoding:       "bogus",
+			expectedStatus:        http.StatusOK,
+			compressionBypassed:   true,
+		},
+		{
+			// Guards the two names that have no direct availableDecoders entry:
+			// "deflate" is served by the zlib reader and "snappy" is constructed per
+			// server. A naive skip-unknown-names change would drop both.
+			name:                  "Deflate_StillServedByZlib",
+			compressionAlgorithms: []string{"deflate"},
+			contentEncoding:       "deflate",
+			expectedStatus:        http.StatusOK,
+		},
+		{
 			name:                  "OnlyZstd_Zstd_Accepted",
 			compressionAlgorithms: []string{"zstd"},
 			contentEncoding:       "zstd",
@@ -490,6 +521,10 @@ func TestEmptyCompressionAlgorithmsAllowsUncompressed(t *testing.T) {
 					requestBody = compressGzip(t, testBody).Bytes()
 				case "zstd":
 					requestBody = compressZstd(t, testBody).Bytes()
+				case "deflate":
+					// "deflate" is served by the zlib reader, so the body must be
+					// zlib-compressed for the accept case to be meaningful.
+					requestBody = compressZlib(t, testBody).Bytes()
 				}
 			}
 

--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -420,7 +420,7 @@ func TestEmptyCompressionAlgorithmsAllowsUncompressed(t *testing.T) {
 			expectedError:         "unsupported Content-Encoding",
 		},
 		{
-			// An unrecognised algorithm name used to be stored as a nil decoder, so
+			// An unrecognized algorithm name used to be stored as a nil decoder, so
 			// newBodyReader found the key present, treated the encoding as supported,
 			// and panicked calling it. It must be skipped instead, leaving the request
 			// to fall through to the unsupported-encoding path.
@@ -431,7 +431,7 @@ func TestEmptyCompressionAlgorithmsAllowsUncompressed(t *testing.T) {
 			expectedError:         "unsupported Content-Encoding",
 		},
 		{
-			// A list of only unrecognised names leaves nothing enabled, which takes the
+			// A list of only unrecognized names leaves nothing enabled, which takes the
 			// same path as an explicitly empty list: decompression is bypassed rather
 			// than rejected. Pinned so the difference from the mixed case above is
 			// deliberate rather than accidental.


### PR DESCRIPTION
#### Description

An unrecognized entry in `compression_algorithms` is stored in the enabled-decoder map as a **nil function**, because `availableDecoders[dec]` returns the zero value for a missing key. `newBodyReader` then finds the key present, treats the encoding as supported, and calls the nil decoder — panicking the handler. `CompressionAlgorithms` is not validated anywhere, so a typo in operator config plus a matching request header is enough to reach it.

This resolves each name before inserting it and skips anything that does not resolve, so an unknown encoding falls through to the existing `unsupported Content-Encoding` path and returns 400.

**Why the loop is restructured rather than guarded in place:** two supported names have no direct `availableDecoders` entry. `deflate` is served by the `zlib` reader, and `snappy` is constructed per server so it can carry `maxRequestBodySize`. Both currently work only because the old code inserted a nil and then overwrote it on the next line. A naive "skip names that aren't in `availableDecoders`" change would have silently dropped `deflate` from the defaults — there is a regression test for exactly that below.

#### Link to tracking issue

Fixes #15836

#### Testing

Three cases added to `TestEmptyCompressionAlgorithmsAllowsUncompressed`:

- `UnknownAlgorithm_MatchingEncoding_Rejected` — `["", "gzip", "bogus"]` with `Content-Encoding: bogus` now returns 400. On `main` this panics:
  ```
  http: panic serving 127.0.0.1:52782: runtime error: invalid memory address or nil pointer dereference
  ```
- `OnlyUnknownAlgorithms_BypassesDecompression` — a list of *only* unknown names leaves nothing enabled, which takes the same path as an explicitly empty list: decompression is bypassed rather than rejected. Pinned deliberately so the difference from the case above is visible; happy to change that behavior if you'd rather an all-unknown list be an error, but that felt like a separate decision from fixing the panic.
- `Deflate_StillServedByZlib` — guards the `deflate`/`zlib` indirection described above. The test harness now zlib-compresses the body for `deflate`, which it previously only did for `gzip` and `zstd`.

Full `config/confighttp` suite passes; `gofmt` and `make chlog-validate` are clean.

#### Documentation

None beyond the changelog entry — this restores intended behavior rather than adding configuration surface.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

---

*Disclosure: prepared with AI assistance. Commits carry an `Assisted-by:` trailer per AGENTS.md.*

