### PR TITLE
[cmd/mdatagen] remove deprecated func DefaultMetricsBuilderConfig

### DIFF
--- a/.chloggen/codeboten_mdatagen-remove-deprecated-func.yaml
+++ b/.chloggen/codeboten_mdatagen-remove-deprecated-func.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "remove deprecated func DefaultMetricsBuilderConfig"
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_mdatagen-remove-deprecated-func.yaml
+++ b/.chloggen/codeboten_mdatagen-remove-deprecated-func.yaml
@@ -10,7 +10,7 @@ component: cmd/mdatagen
 note: "remove deprecated func DefaultMetricsBuilderConfig"
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [15854]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
@@ -22,4 +22,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [api]

--- a/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/sampleconnector/internal/metadata/generated_config.go
@@ -644,8 +644,3 @@ func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
-
-// Deprecated: Use NewDefaultMetricsBuilderConfig.
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
-	return NewDefaultMetricsBuilderConfig()
-}

--- a/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/internal/metadata/generated_config.go
@@ -323,8 +323,3 @@ func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
-
-// Deprecated: Use NewDefaultMetricsBuilderConfig.
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
-	return NewDefaultMetricsBuilderConfig()
-}

--- a/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplemigrationscraper/internal/metadata/generated_config.go
@@ -209,8 +209,3 @@ func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 		Metrics: DefaultMetricsConfig(),
 	}
 }
-
-// Deprecated: Use NewDefaultMetricsBuilderConfig.
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
-	return NewDefaultMetricsBuilderConfig()
-}

--- a/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/internal/metadata/generated_config.go
@@ -997,11 +997,6 @@ func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	}
 }
 
-// Deprecated: Use NewDefaultMetricsBuilderConfig.
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
-	return NewDefaultMetricsBuilderConfig()
-}
-
 // LogsBuilderConfig is a configuration for sample logs builder.
 type LogsBuilderConfig struct {
 	Events             EventsConfig             `mapstructure:"events"`

--- a/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/internal/metadata/generated_config.go
@@ -668,8 +668,3 @@ func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
-
-// Deprecated: Use NewDefaultMetricsBuilderConfig.
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
-	return NewDefaultMetricsBuilderConfig()
-}

--- a/cmd/mdatagen/internal/templates/config.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config.go.tmpl
@@ -303,10 +303,6 @@ func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	}
 }
 
-// Deprecated: Use NewDefaultMetricsBuilderConfig.
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
-	return NewDefaultMetricsBuilderConfig()
-}
 {{- end }}
 
 {{ if .Events -}}


### PR DESCRIPTION
#### Description

This has been deprecated since v0.151.0, removing

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
