### PR TITLE
[chore] clean up linter warns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,10 @@ formatters:
       simplify: true
 
     gofumpt:
-      # Choose whether to use the extra rules
-      extra-rules: true
+      extra:
+        group-params: true
+        clothe-returns: true
+        balance-calls: true
 
     goimports:
       # put imports beginning with prefix after 3rd-party packages;
@@ -62,9 +64,6 @@ linters:
         linters:
           - gosec
         text: "^G104:"
-
-    # Log a warning if an exclusion rule is unused.
-    warn-unused: true
 
   # all available settings of specific linters
   settings:


### PR DESCRIPTION
#### Description

One is about the extra-rules being deprecated, the other warnings are triggered by modules that don't need the G104 exclusion, it's just noise.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
