### PR TITLE
docs: improve metric migration documentation template

### DIFF
--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -34,11 +34,18 @@ Emitted Name: `{{ $metricName.EmittedName }}`
 
 #### Migration
 
-- Target Metric: `{{ $metric.Migration.To }}`
-- Disable Old Gate: `{{ $metric.Migration.ThroughGates.DisableOld }}`
-- Enable New Gate: `{{ $metric.Migration.ThroughGates.EnableNew }}`
+**Metric Migration:** `{{ $metric.Migration.To }}`
 
-When the disable-old gate is enabled, emission of this metric is suppressed. When the enable-new gate is enabled, the target metric is emitted. If both gates are disabled, only this metric is emitted; if both are enabled, only the target metric is emitted.
+| Enable New Gate | Disable Old Gate | Emitted Metric(s) |
+| --- | --- | --- |
+| disabled | disabled | `{{ $metricName }}` only |
+| enabled | disabled | `{{ $metricName }}` and `{{ $metric.Migration.To }}` |
+| enabled | enabled | `{{ $metric.Migration.To }}` only |
+| disabled | enabled | Migrated metrics: none (v0 suppressed, v1 gated off — warnings logged) |
+
+Gate definitions:
+- Enable New Gate: `{{ $metric.Migration.ThroughGates.EnableNew }}`
+- Disable Old Gate: `{{ $metric.Migration.ThroughGates.DisableOld }}`
 
 {{- end }}
 


### PR DESCRIPTION
Replaces confusing prose explanation with a clear table showing all gate state combinations and their resulting metric emission behavior.

**What Changed:**
- Replaced prose explanation with a 4-row gate state matrix
- Shows exactly which metrics are emitted for each gate combination
- Makes it easier for users to understand enable-new and disable-old gates

**Fixes:** #15795