### PR TITLE
[otelcol] fix deadlock when a fatal error is reported during startup, reload, or shutdown

### DIFF
--- a/.chloggen/otelcol-fatal-error-shutdown-deadlock.yaml
+++ b/.chloggen/otelcol-fatal-error-shutdown-deadlock.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: pkg/otelcol
+
+note: Fix a deadlock when a component reports a fatal error asynchronously while the collector is starting up, reloading its configuration, or shutting down
+
+issues: [9824]
+
+subtext:
+
+change_logs: [user]

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -116,7 +116,14 @@ type Collector struct {
 	// signalsChannel is used to receive termination signals from the OS.
 	signalsChannel chan os.Signal
 	// asyncErrorChannel is used to signal a fatal error from any component.
-	asyncErrorChannel          chan error
+	// It is drained continuously by a background goroutine for the entire
+	// duration of Run, so that a component reporting a fatal error never
+	// blocks indefinitely, even while the control loop below is not actively
+	// selecting on it (e.g. during startup, a configuration reload, or shutdown).
+	asyncErrorChannel chan error
+	// fatalErrChan receives the first fatal error forwarded from
+	// asyncErrorChannel, for the control loop to act on.
+	fatalErrChan               chan error
 	bc                         *bufferedCore
 	updateConfigProviderLogger func(core zapcore.Core)
 
@@ -150,6 +157,7 @@ func NewCollector(set CollectorSettings) (*Collector, error) {
 		// the number of signals getting notified on is recommended.
 		signalsChannel:             make(chan os.Signal, 3),
 		asyncErrorChannel:          make(chan error),
+		fatalErrChan:               make(chan error, 1),
 		configProvider:             configProvider,
 		bc:                         bc,
 		updateConfigProviderLogger: cc.SetCore,
@@ -427,6 +435,28 @@ func (col *Collector) Run(ctx context.Context) error {
 	default:
 	}
 
+	// Drain asyncErrorChannel for the entire lifetime of Run, independently of
+	// the control loop below, so components can always report a fatal error
+	// without blocking. Only the first reported error is forwarded to the
+	// control loop via fatalErrChan; a single fatal error is enough to trigger
+	// shutdown, so subsequent ones are dropped rather than risking a blocked
+	// reporting goroutine.
+	pumpDone := make(chan struct{})
+	defer close(pumpDone)
+	go func() {
+		for {
+			select {
+			case err := <-col.asyncErrorChannel:
+				select {
+				case col.fatalErrChan <- err:
+				default:
+				}
+			case <-pumpDone:
+				return
+			}
+		}
+	}()
+
 	// setupConfigurationComponents is the "main" function responsible for startup
 	if err := col.setupConfigurationComponents(ctx); err != nil {
 		col.setCollectorState(StateClosed)
@@ -470,7 +500,7 @@ LOOP:
 			if err := col.reloadConfiguration(ctx); err != nil {
 				return err
 			}
-		case err := <-col.asyncErrorChannel:
+		case err := <-col.fatalErrChan:
 			col.service.Logger().Error("Asynchronous error received, terminating process", zap.Error(err))
 			break LOOP
 		case s := <-col.signalsChannel:

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -1039,6 +1039,82 @@ func TestCollectorReportError(t *testing.T) {
 	assert.Equal(t, StateClosed, col.GetState())
 }
 
+// slowShutdownExtension signals shutdownStarted as soon as its Shutdown method is called, then
+// blocks until releaseShutdown is closed. It is used to widen the window during which the
+// collector is shutting down but its control loop is no longer selecting on asyncErrorChannel.
+type slowShutdownExtension struct {
+	component.StartFunc
+	shutdownStarted chan struct{}
+	releaseShutdown chan struct{}
+}
+
+func (e *slowShutdownExtension) Shutdown(context.Context) error {
+	close(e.shutdownStarted)
+	<-e.releaseShutdown
+	return nil
+}
+
+// TestCollectorReportErrorDuringShutdown verifies that a fatal error reported asynchronously
+// while the collector is shutting down (i.e. after the control loop has already stopped
+// selecting on asyncErrorChannel) does not block the reporting goroutine indefinitely.
+func TestCollectorReportErrorDuringShutdown(t *testing.T) {
+	shutdownStarted := make(chan struct{})
+	releaseShutdown := make(chan struct{})
+
+	factory := extension.NewFactory(
+		component.MustNewType("slowshutdown"),
+		func() component.Config { return &struct{}{} },
+		func(context.Context, extension.Settings, component.Config) (extension.Extension, error) {
+			return &slowShutdownExtension{shutdownStarted: shutdownStarted, releaseShutdown: releaseShutdown}, nil
+		},
+		component.StabilityLevelStable,
+	)
+
+	factories, err := nopFactories()
+	require.NoError(t, err)
+	factories.Extensions[factory.Type()] = factory
+
+	col, err := NewCollector(CollectorSettings{
+		BuildInfo:              component.NewDefaultBuildInfo(),
+		Factories:              func() (Factories, error) { return factories, nil },
+		ConfigProviderSettings: newDefaultConfigProviderSettings(t, []string{filepath.Join("testdata", "otelcol-slowshutdown.yaml")}),
+	})
+	require.NoError(t, err)
+
+	wg := startCollector(context.Background(), t, col)
+
+	assert.Eventually(t, func() bool {
+		return StateRunning == col.GetState()
+	}, 2*time.Second, 200*time.Millisecond)
+
+	go col.Shutdown()
+
+	select {
+	case <-shutdownStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("extension shutdown did not start in time")
+	}
+
+	// The control loop has already broken out of its select statement at this point, since
+	// shutdown() calls service.Shutdown synchronously and blocks on the extension above.
+	// Reporting an async error here must not block.
+	reported := make(chan struct{})
+	go func() {
+		col.asyncErrorChannel <- errors.New("fatal error during shutdown")
+		close(reported)
+	}()
+
+	select {
+	case <-reported:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reporting an async error during shutdown blocked indefinitely")
+	}
+
+	close(releaseShutdown)
+	wg.Wait()
+	assert.Equal(t, StateClosed, col.GetState())
+}
+
 // NewStatusWatcherExtensionFactory returns a component.ExtensionFactory to construct a status watcher extension.
 func NewStatusWatcherExtensionFactory(
 	onStatusChanged func(source *componentstatus.InstanceID, event *componentstatus.Event),

--- a/otelcol/testdata/otelcol-slowshutdown.yaml
+++ b/otelcol/testdata/otelcol-slowshutdown.yaml
@@ -1,0 +1,19 @@
+receivers:
+  nop:
+
+processors:
+  nop:
+
+exporters:
+  nop:
+
+extensions:
+  slowshutdown:
+
+service:
+  extensions: [slowshutdown]
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]


### PR DESCRIPTION
#### Description

`asyncErrorChannel` was only ever read inside `Run()`'s control-loop `select` statement. A component reporting a fatal error asynchronously (e.g. via `NotifyComponentStatusChange`) outside that window, during `setupConfigurationComponents`, a config reload, or shutdown, would block the reporting goroutine forever, since nothing was listening on the channel.

This adds a background "pump" goroutine that drains `asyncErrorChannel` for the entire lifetime of `Run`, so a send never blocks regardless of what the control loop is doing. The pump forwards only the first error (non-blocking) to a new small buffered `fatalErrChan`, which the control loop reads from instead. One fatal error is enough to trigger shutdown, and the buffering means no error is ever silently dropped, even if the control loop is momentarily elsewhere (e.g. mid-reload). The pump's lifetime is tied to `pumpDone`, which is closed via `defer` when `Run` returns, so `asyncErrorChannel` itself stays unbuffered.

**Relationship to #15428:** this overlaps with #15428, which I commented on Aug 6 with this same drain-goroutine idea; that PR was later reworked around it, but keeps `asyncErrorChannel` itself buffered with a non-blocking send at the call site, rather than a dedicated pump. Close mechanisms, different tradeoffs, deferring to maintainers on which to land.

#### Link to tracking issue
Fixes #9824

#### Testing

- Added `TestCollectorReportErrorDuringShutdown` in `otelcol/collector_test.go`, using a new `slowshutdown` test extension/fixture (`otelcol/testdata/otelcol-slowshutdown.yaml`) whose `Shutdown()` blocks so the test can report a fatal error to `asyncErrorChannel` while the control loop is provably no longer selecting on it.
- Verified the test fails without the fix (times out) and passes with it.
- Ran the full `otelcol` module test suite (`go test ./...`), all passing, no regressions.

#### Documentation

N/A, internal fix, no user-facing config or API changes. Changelog entry added at `.chloggen/otelcol-fatal-error-shutdown-deadlock.yaml`.

#### Authorship

- [x] I, a human, wrote this pull request description myself.