### PR TITLE
[pdata/pprofile] MergeTo: reserve index 0 of destination dictionary tables

### DIFF
--- a/.chloggen/fix-pprofile-mergeto-dictionary-sentinels.yaml
+++ b/.chloggen/fix-pprofile-mergeto-dictionary-sentinels.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/pprofile
+
+# A brief description of the change.  Surround your text with quotes (") if it needs to start with a backtick (`).
+note: "`pprofile.Profiles.MergeTo` now reserves index 0 of each destination dictionary table for the table's zero value, keeping merged dictionaries conformant with the ProfilesDictionary contract"
+
+# One or more tracking issues or pull requests related to the change
+issues: [15661]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, merging into a fresh destination dictionary let the first merged
+  entry take index 0 of each table. Since unset references resolve to index 0,
+  they silently resolved to real data after the merge (e.g. a function with no
+  filename reported the first merged string as its filename).
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pdata/pprofile/dictionary_helpers.go
+++ b/pdata/pprofile/dictionary_helpers.go
@@ -14,6 +14,35 @@ func mapKeyValues(m pcommon.Map) []internal.KeyValue {
 	return *internal.GetMapOrig(internal.MapWrapper(m))
 }
 
+// ensureDictionarySentinels seeds index 0 of each of dst's tables with that
+// table's zero value, but only for tables that are still empty. The
+// ProfilesDictionary contract requires index 0 of every table to hold the
+// zero value for the table's element type, because every unset reference
+// resolves to it. Tables that already hold entries are left untouched.
+func ensureDictionarySentinels(dst ProfilesDictionary) {
+	if dst.StringTable().Len() == 0 {
+		dst.StringTable().Append("")
+	}
+	if dst.AttributeTable().Len() == 0 {
+		dst.AttributeTable().AppendEmpty()
+	}
+	if dst.FunctionTable().Len() == 0 {
+		dst.FunctionTable().AppendEmpty()
+	}
+	if dst.LinkTable().Len() == 0 {
+		dst.LinkTable().AppendEmpty()
+	}
+	if dst.LocationTable().Len() == 0 {
+		dst.LocationTable().AppendEmpty()
+	}
+	if dst.MappingTable().Len() == 0 {
+		dst.MappingTable().AppendEmpty()
+	}
+	if dst.StackTable().Len() == 0 {
+		dst.StackTable().AppendEmpty()
+	}
+}
+
 // resolveProfilesReferences walks through all profiles data after unmarshaling
 // and resolves any string_value_ref and key_ref to their actual string values.
 // This ensures the pdata API works transparently with referenced strings.

--- a/pdata/pprofile/profiles_merge.go
+++ b/pdata/pprofile/profiles_merge.go
@@ -13,6 +13,8 @@ func (ms Profiles) MergeTo(dest Profiles) error {
 		return nil
 	}
 
+	ensureDictionarySentinels(dest.Dictionary())
+
 	if err := ms.switchDictionary(ms.Dictionary(), dest.Dictionary()); err != nil {
 		return err
 	}

--- a/pdata/pprofile/profiles_merge_test.go
+++ b/pdata/pprofile/profiles_merge_test.go
@@ -718,3 +718,137 @@ func attrMapToStrings(m pcommon.Map) map[string]string {
 	})
 	return result
 }
+
+// TestProfilesMergeToEmptyDestination covers
+// https://github.com/open-telemetry/opentelemetry-collector/issues/15661:
+// merging into a fresh destination used to drop the reserved zero-value
+// entries of the source dictionary and let real data take index 0, so unset
+// references silently resolved to real data afterwards.
+func TestProfilesMergeToEmptyDestination(t *testing.T) {
+	src := NewProfiles()
+	dic := src.Dictionary()
+	dic.StringTable().Append("")
+	dic.AttributeTable().AppendEmpty()
+	dic.StackTable().AppendEmpty()
+	dic.LocationTable().AppendEmpty()
+	dic.FunctionTable().AppendEmpty()
+	dic.MappingTable().AppendEmpty()
+	dic.LinkTable().AppendEmpty()
+
+	dic.StringTable().Append("inuse_space")                     // 1
+	dic.StringTable().Append("bytes")                           // 2
+	dic.StringTable().Append("std::rt::lang_start")             // 3
+	dic.StringTable().Append("process.executable.build_id.gnu") // 4
+
+	// A function with an unset filename: only the name is set.
+	fn := dic.FunctionTable().AppendEmpty() // index 1
+	fn.SetNameStrindex(3)
+
+	loc := dic.LocationTable().AppendEmpty() // index 1
+	ln := loc.Lines().AppendEmpty()
+	ln.SetFunctionIndex(1)
+
+	st := dic.StackTable().AppendEmpty() // index 1
+	st.LocationIndices().Append(1)
+
+	// A resource attribute carrying the string that must not end up at
+	// string_table[0] in the destination.
+	attr := dic.AttributeTable().AppendEmpty() // index 1
+	attr.SetKeyStrindex(4)
+	attr.Value().SetStr("abc123")
+
+	prof := src.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+	prof.SampleType().SetTypeStrindex(1)
+	prof.SampleType().SetUnitStrindex(2)
+	sample := prof.Samples().AppendEmpty()
+	sample.SetStackIndex(1)
+	sample.AttributeIndices().Append(1)
+
+	dest := NewProfiles()
+	require.NoError(t, src.MergeTo(dest))
+
+	dd := dest.Dictionary()
+
+	// Every table holds its zero value at index 0.
+	require.Equal(t, "", dd.StringTable().At(0), "string_table[0] must be the empty string")
+	require.GreaterOrEqual(t, dd.AttributeTable().Len(), 1)
+	require.GreaterOrEqual(t, dd.StackTable().Len(), 1)
+	require.GreaterOrEqual(t, dd.LocationTable().Len(), 1)
+	require.GreaterOrEqual(t, dd.FunctionTable().Len(), 1)
+	require.GreaterOrEqual(t, dd.MappingTable().Len(), 1)
+	require.GreaterOrEqual(t, dd.LinkTable().Len(), 1)
+
+	// The merged function kept its name and still has no filename.
+	mergedFn := dd.FunctionTable().At(1)
+	require.Equal(t, "std::rt::lang_start", dd.StringTable().At(int(mergedFn.NameStrindex())))
+	require.Equal(t, int32(0), mergedFn.FilenameStrindex())
+	require.Equal(t, "", dd.StringTable().At(int(mergedFn.FilenameStrindex())),
+		"unset filename must still resolve to the empty string")
+
+	// The attribute key landed at some index > 0.
+	mergedAttr := dd.AttributeTable().At(1)
+	require.Equal(t, "process.executable.build_id.gnu", dd.StringTable().At(int(mergedAttr.KeyStrindex())))
+	require.Greater(t, mergedAttr.KeyStrindex(), int32(0))
+}
+
+// TestProfilesMergeToPartlyPrepopulatedDestination makes sure seeding only
+// happens on tables that are still empty: a destination table that already
+// holds entries must not be shifted, or every existing reference into it
+// would be invalidated.
+func TestProfilesMergeToPartlyPrepopulatedDestination(t *testing.T) {
+	dest := NewProfiles()
+	// Only the string table is populated; everything else is empty.
+	dest.Dictionary().StringTable().Append("")       // 0
+	dest.Dictionary().StringTable().Append("stored") // 1
+
+	src := NewProfiles()
+	src.Dictionary().StringTable().Append("")
+	src.Dictionary().StringTable().Append("nanoseconds") // 1
+	prof := src.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+	prof.PeriodType().SetUnitStrindex(1)
+
+	require.NoError(t, src.MergeTo(dest))
+
+	dd := dest.Dictionary()
+	// Pre-existing entries stay put.
+	require.Equal(t, "", dd.StringTable().At(0))
+	require.Equal(t, "stored", dd.StringTable().At(1))
+	require.Equal(t, "nanoseconds", dd.StringTable().At(2))
+	// All other tables got their zero value reserved.
+	require.Equal(t, 1, dd.AttributeTable().Len())
+	require.Equal(t, 1, dd.StackTable().Len())
+	require.Equal(t, 1, dd.LocationTable().Len())
+	require.Equal(t, 1, dd.FunctionTable().Len())
+	require.Equal(t, 1, dd.MappingTable().Len())
+	require.Equal(t, 1, dd.LinkTable().Len())
+}
+
+// TestProfilesMergeToSequentialMergesStayConformant merges two profiles into
+// the same fresh destination one after another and checks the dictionary
+// contract after each step.
+func TestProfilesMergeToSequentialMergesStayConformant(t *testing.T) {
+	build := func(sampleType string) Profiles {
+		p := NewProfiles()
+		p.Dictionary().StringTable().Append("")
+		p.Dictionary().StringTable().Append(sampleType) // 1
+		prof := p.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+		prof.SampleType().SetTypeStrindex(1)
+		return p
+	}
+
+	dest := NewProfiles()
+	require.NoError(t, build("cpu").MergeTo(dest))
+	require.Equal(t, "", dest.Dictionary().StringTable().At(0))
+	require.NoError(t, build("memory").MergeTo(dest))
+
+	dd := dest.Dictionary()
+	require.Equal(t, "", dd.StringTable().At(0), "string_table[0] clobbered by second merge")
+	require.Equal(t, 3, dd.StringTable().Len())
+	require.Equal(t, 2, dest.ResourceProfiles().Len())
+
+	// Both merged profiles still resolve their sample type correctly.
+	for i, want := range []string{"cpu", "memory"} {
+		prof := dest.ResourceProfiles().At(i).ScopeProfiles().At(0).Profiles().At(0)
+		require.Equal(t, want, dd.StringTable().At(int(prof.SampleType().TypeStrindex())))
+	}
+}

--- a/pdata/pprofile/profiles_merge_test.go
+++ b/pdata/pprofile/profiles_merge_test.go
@@ -770,7 +770,7 @@ func TestProfilesMergeToEmptyDestination(t *testing.T) {
 	dd := dest.Dictionary()
 
 	// Every table holds its zero value at index 0.
-	require.Equal(t, "", dd.StringTable().At(0), "string_table[0] must be the empty string")
+	require.Empty(t, dd.StringTable().At(0), "string_table[0] must be the empty string")
 	require.GreaterOrEqual(t, dd.AttributeTable().Len(), 1)
 	require.GreaterOrEqual(t, dd.StackTable().Len(), 1)
 	require.GreaterOrEqual(t, dd.LocationTable().Len(), 1)
@@ -782,13 +782,13 @@ func TestProfilesMergeToEmptyDestination(t *testing.T) {
 	mergedFn := dd.FunctionTable().At(1)
 	require.Equal(t, "std::rt::lang_start", dd.StringTable().At(int(mergedFn.NameStrindex())))
 	require.Equal(t, int32(0), mergedFn.FilenameStrindex())
-	require.Equal(t, "", dd.StringTable().At(int(mergedFn.FilenameStrindex())),
+	require.Empty(t, dd.StringTable().At(int(mergedFn.FilenameStrindex())),
 		"unset filename must still resolve to the empty string")
 
 	// The attribute key landed at some index > 0.
 	mergedAttr := dd.AttributeTable().At(1)
 	require.Equal(t, "process.executable.build_id.gnu", dd.StringTable().At(int(mergedAttr.KeyStrindex())))
-	require.Greater(t, mergedAttr.KeyStrindex(), int32(0))
+	require.Positive(t, mergedAttr.KeyStrindex())
 }
 
 // TestProfilesMergeToPartlyPrepopulatedDestination makes sure seeding only
@@ -811,7 +811,7 @@ func TestProfilesMergeToPartlyPrepopulatedDestination(t *testing.T) {
 
 	dd := dest.Dictionary()
 	// Pre-existing entries stay put.
-	require.Equal(t, "", dd.StringTable().At(0))
+	require.Empty(t, dd.StringTable().At(0))
 	require.Equal(t, "stored", dd.StringTable().At(1))
 	require.Equal(t, "nanoseconds", dd.StringTable().At(2))
 	// All other tables got their zero value reserved.
@@ -838,11 +838,11 @@ func TestProfilesMergeToSequentialMergesStayConformant(t *testing.T) {
 
 	dest := NewProfiles()
 	require.NoError(t, build("cpu").MergeTo(dest))
-	require.Equal(t, "", dest.Dictionary().StringTable().At(0))
+	require.Empty(t, dest.Dictionary().StringTable().At(0))
 	require.NoError(t, build("memory").MergeTo(dest))
 
 	dd := dest.Dictionary()
-	require.Equal(t, "", dd.StringTable().At(0), "string_table[0] clobbered by second merge")
+	require.Empty(t, dd.StringTable().At(0), "string_table[0] clobbered by second merge")
 	require.Equal(t, 3, dd.StringTable().Len())
 	require.Equal(t, 2, dest.ResourceProfiles().Len())
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

I picked up #15661 and could reproduce it right away with the snippet there: merge a conformant profile into a plain `NewProfiles()` and `string_table[0]` comes back as `"inuse_space"` instead of `""`. The reserved zero-value entries of `function_table`/`location_table`/etc. get dropped along the way too.

Looking at the merge path, `switchDictionary` skips every index-0 reference as unset (which is correct), but nothing ever reserves index 0 in the destination tables. So the first real entry interned into an empty destination table takes the slot that every unset reference resolves to, and unset references silently start pointing at real data after the merge. That's how a function with no filename ends up reporting `process.executable.build_id.gnu` as its filename.

The fix is to seed the zero value of every still-empty destination table before remapping the source indices. Tables that already hold entries are deliberately left untouched, since inserting at index 0 would shift and invalidate every existing reference into them.

#### Link to tracking issue

Fixes #15661

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added three cases to `profiles_merge_test.go`:

- merge into a completely fresh destination: all seven tables end up with their zero value at index 0, and a function with an unset filename still resolves to `""` afterwards (the scenario from the issue)
- merge into a destination where only the string table is populated: pre-existing entries don't shift, the remaining tables get seeded
- two sequential merges into the same destination stay conformant

Ran `go test ./...` and `go test -race .` in `pdata/pprofile` (covers `pprofileotlp` too), plus `go test ./...` in `exporter/exporterhelper/xexporterhelper` since its batch merge calls `Profiles.MergeTo`. All green. `gofmt`/`go vet` clean.

<!--Describe the documentation added.-->
#### Documentation

Changelog entry via chloggen. No other docs changes, the merged dictionary now just matches what the `ProfilesDictionary` contract in profiles.proto already states.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.
