### PR TITLE
mdatagen: add callback-based resource attribute setters

### DIFF
--- a/cmd/mdatagen/internal/metadata.go
+++ b/cmd/mdatagen/internal/metadata.go
@@ -648,6 +648,10 @@ type Attribute struct {
 	SemanticConvention *SemanticConvention `mapstructure:"semantic_convention"`
 	// Stability is the stability level of the resource attribute.
 	Stability component.StabilityLevel `mapstructure:"stability"`
+	// SetterType controls how resource attribute setters are generated.
+	// When set to "callback", mdatagen emits Set*FromCallback methods that invoke
+	// the provided function only when the attribute is enabled.
+	SetterType string `mapstructure:"setter_type"`
 }
 
 // IsConditional returns true if the attribute is conditionally required.
@@ -695,6 +699,11 @@ func (a Attribute) Enabled() bool {
 		panic("Enabled() must not be called on regular attributes, only on resource attributes")
 	}
 	return *a.EnabledPtr
+}
+
+// UseCallbackSetter reports whether mdatagen should generate callback-based setters.
+func (a Attribute) UseCallbackSetter() bool {
+	return a.SetterType == "callback"
 }
 
 // Name returns actual name of the attribute that is set on the metric after applying NameOverride.

--- a/cmd/mdatagen/internal/metadata_test.go
+++ b/cmd/mdatagen/internal/metadata_test.go
@@ -360,6 +360,14 @@ func TestAttributeRequirementLevel(t *testing.T) {
 	}
 }
 
+func TestAttributeUseCallbackSetter(t *testing.T) {
+	attr := Attribute{SetterType: "callback"}
+	assert.True(t, attr.UseCallbackSetter())
+
+	attr.SetterType = ""
+	assert.False(t, attr.UseCallbackSetter())
+}
+
 func TestAttributeRequirementLevelUnmarshalText(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/mdatagen/internal/templates/resource.go.tmpl
+++ b/cmd/mdatagen/internal/templates/resource.go.tmpl
@@ -23,13 +23,25 @@ func NewResourceBuilder(rac ResourceAttributesConfig) *ResourceBuilder {
 
 {{- range $name, $attr := .ResourceAttributes }}
 {{- range $attr.Enum }}
-// Set{{ $name.Render }}{{ . | publicVar }} sets "{{ $name }}={{ . }}" attribute.
+// Set{{ $name.Render }}{{ . | publicVar }} sets "{{ $name }}"="{{ . }}" attribute.
 func (rb *ResourceBuilder) Set{{ $name.Render }}{{ . | publicVar }}() {
 	if rb.config.{{ $name.Render }}.Enabled {
 		rb.res.Attributes().PutStr("{{ $name }}", "{{ . }}")
 	}
 }
 {{- else }}
+{{- if $attr.UseCallbackSetter }}
+// Set{{ $name.Render }}FromCallback sets "{{ $name }}" attribute using cb when enabled.
+func (rb *ResourceBuilder) Set{{ $name.Render }}FromCallback(cb func() {{ $attr.Type.Primitive }}) {
+	if rb.config.{{ $name.Render }}.Enabled {
+		{{- if or (eq $attr.Type.String "Bytes") (eq $attr.Type.String "Slice") (eq $attr.Type.String "Map") }}
+		rb.res.Attributes().PutEmpty{{ $attr.Type }}("{{ $name }}").FromRaw(cb())
+		{{- else }}
+		rb.res.Attributes().Put{{ $attr.Type }}("{{ $name }}", cb())
+		{{- end }}
+	}
+}
+{{- end }}
 // Set{{ $name.Render }} sets provided value as "{{ $name }}" attribute.
 func (rb *ResourceBuilder) Set{{ $name.Render }}(val {{ $attr.Type.Primitive }}) {
 	if rb.config.{{ $name.Render }}.Enabled {

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -168,6 +168,9 @@ resource_attributes:
     type: <string|int|double|bool|bytes|slice|map>
     # Optional: the stability level of the resource attribute.
     stability: <development|alpha|beta|release_candidate|stable>
+    # Optional: controls generated setter style. Use "callback" to emit Set*FromCallback
+    # methods that invoke a user-provided function only when the attribute is enabled.
+    setter_type: <callback>
     # Optional: warnings that will be shown to user under specified conditions.
     warnings:
       # A warning that will be displayed if the resource_attribute is enabled in user config.


### PR DESCRIPTION
Fixes #10901

Adds an optional setter_type: callback field for resource attributes. When set, mdatagen generates Set*FromCallback methods that invoke a user function only if the attribute is enabled.

## Test plan
- [x] go test ./cmd/mdatagen/internal/... -count=1 -run TestAttributeUseCallbackSetter (pass)