### PR TITLE
[chore][cmd/mdatagen] Follow golang conventions when generating doc comments for config fields

### DIFF
--- a/cmd/mdatagen/internal/samplemigrationscraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplemigrationscraper/generated_config.go
@@ -11,7 +11,7 @@ import (
 type Config struct {
 	// MetricsBuilderConfig is a configuration for samplemigration metrics builder.
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
-	// Whether to emit legacy metric names alongside new ones.
+	// EmitLegacyMetrics whether to emit legacy metric names alongside new ones.
 	EmitLegacyMetrics bool `mapstructure:"emit_legacy_metrics"`
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/cmd/mdatagen/internal/samplepkg/generated_config.go
+++ b/cmd/mdatagen/internal/samplepkg/generated_config.go
@@ -10,9 +10,9 @@ import (
 type PortNumber int
 
 type SampleConfig struct {
-	// The host name to connect to.
+	// HostName the host name to connect to.
 	HostName string `mapstructure:"host_name"`
-	// The port to connect to.
+	// Port the port to connect to.
 	Port PortNumber `mapstructure:"port"`
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/cmd/mdatagen/internal/samplereceiver/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/generated_config.go
@@ -16,18 +16,18 @@ import (
 type Config struct {
 	// MetricsBuilderConfig is a configuration for sample metrics builder.
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
-	// API token used to authenticate with the endpoint.
+	// APIToken aPI token used to authenticate with the endpoint.
 	APIToken configopaque.String `mapstructure:"api_token,omitempty"`
-	// Component ID used to identify this receiver instance.
+	// ComponentID component ID used to identify this receiver instance.
 	ComponentID component.ID `mapstructure:"component_id,omitempty"`
-	// The endpoint to scrape metrics from.
+	// Endpoint the endpoint to scrape metrics from.
 	Endpoint string `mapstructure:"endpoint"`
-	// Extra HTTP headers to attach to each request.
+	// Headers extra HTTP headers to attach to each request.
 	Headers configopaque.MapList `mapstructure:"headers,omitempty"`
-	// Maximum number of results to return per scrape.
+	// MaxResults maximum number of results to return per scrape.
 	MaxResults int64                  `mapstructure:"max_results"`
 	SamplePkg  samplepkg.SampleConfig `mapstructure:"sample_pkg"`
-	// Timeout for scraping metrics.
+	// Timeout timeout for scraping metrics.
 	Timeout time.Duration `mapstructure:"timeout"`
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -24,11 +24,11 @@ func NewDefaultSamplePkg() SamplePkg {
 
 type TargetsItem struct {
 	Interval configoptional.Optional[time.Duration] `mapstructure:"interval"`
-	// Static key-value labels attached to all metrics from this target.
+	// Labels static key-value labels attached to all metrics from this target.
 	Labels map[string]string `mapstructure:"labels"`
-	// Number of retry attempts for failed scrapes.
+	// RetryCount number of retry attempts for failed scrapes.
 	RetryCount int `mapstructure:"retry_count"`
-	// Timeout in seconds for each scrape request.
+	// TimeoutSeconds timeout in seconds for each scrape request.
 	TimeoutSeconds float64 `mapstructure:"timeout_seconds"`
 	// prevent unkeyed literal initialization
 	_ struct{}
@@ -75,13 +75,13 @@ type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 	// MetricsBuilderConfig is a configuration for sample metrics builder.
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
-	// Identifies the scraper, used for telemetry and logging.
+	// ComponentID identifies the scraper, used for telemetry and logging.
 	ComponentID component.ID `mapstructure:"component,omitempty"`
-	// Name of the scrape job, used to identify the source in telemetry.
+	// JobName name of the scrape job, used to identify the source in telemetry.
 	JobName string `mapstructure:"job_name"`
-	// Logging level for the scraper.
+	// LogLevel logging level for the scraper.
 	LogLevel string `mapstructure:"log_level"`
-	// List of targets to scrape metrics from.
+	// Targets list of targets to scrape metrics from.
 	Targets *[]TargetsItem `mapstructure:"targets"`
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -30,7 +30,7 @@ import (
     {{- end }}
     {{- range $propName, $prop := .Properties | namedProps }}
         {{- if $prop.Description }}
-            // {{ $prop.Description }}
+            // {{ $prop.GoStruct.FieldName | publicVar }} {{ $prop.Description | uncapitalize }}
         {{- end }}
         {{ $prop.GoStruct.FieldName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}{{ if shouldOmitEmpty . $propName $prop }},omitempty{{ end }}"`
     {{- end }}

--- a/config/configauth/generated_config.go
+++ b/config/configauth/generated_config.go
@@ -8,7 +8,7 @@ import (
 
 // Config defines the auth settings for the receiver.
 type Config struct {
-	// Specifies the name of the extension to use in order to authenticate the incoming data point.
+	// AuthenticatorID specifies the name of the extension to use in order to authenticate the incoming data point.
 	AuthenticatorID component.ID `mapstructure:"authenticator,omitempty"`
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/config/configretry/generated_config.go
+++ b/config/configretry/generated_config.go
@@ -9,17 +9,17 @@ import (
 
 // BackOffConfig defines configuration for retrying batches in case of export failure. The current supported strategy is exponential backoff.
 type BackOffConfig struct {
-	// Indicates whether to not retry sending batches in case of export failure.
+	// Enabled indicates whether to not retry sending batches in case of export failure.
 	Enabled bool `mapstructure:"enabled"`
-	// The time to wait after the first failure before retrying.
+	// InitialInterval the time to wait after the first failure before retrying.
 	InitialInterval time.Duration `mapstructure:"initial_interval"`
-	// The maximum amount of time (including retries) spent trying to send a request/batch. Once this value is reached, the data is discarded. If set to 0, the retries are never stopped.
+	// MaxElapsedTime the maximum amount of time (including retries) spent trying to send a request/batch. Once this value is reached, the data is discarded. If set to 0, the retries are never stopped.
 	MaxElapsedTime time.Duration `mapstructure:"max_elapsed_time"`
-	// The upper bound on backoff interval. Once this value is reached the delay between consecutive retries will always be `MaxInterval`.
+	// MaxInterval the upper bound on backoff interval. Once this value is reached the delay between consecutive retries will always be `MaxInterval`.
 	MaxInterval time.Duration `mapstructure:"max_interval"`
-	// The value multiplied by the backoff interval bounds
+	// Multiplier the value multiplied by the backoff interval bounds
 	Multiplier float64 `mapstructure:"multiplier"`
-	// A random factor used to calculate next backoffs Randomized interval = RetryInterval * (1 ± RandomizationFactor)
+	// RandomizationFactor a random factor used to calculate next backoffs Randomized interval = RetryInterval * (1 ± RandomizationFactor)
 	RandomizationFactor float64 `mapstructure:"randomization_factor"`
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/config/configtls/generated_config.go
+++ b/config/configtls/generated_config.go
@@ -12,11 +12,11 @@ import (
 type ClientConfig struct {
 	// Exposes the common client and server TLS configurations. Note: Since there isn't anything specific to a server connection. Components with server connections should use Config.
 	Config `mapstructure:",squash"`
-	// In gRPC and HTTP when set to true, this is used to disable the client transport security. See https://godoc.org/google.golang.org/grpc#WithInsecure for gRPC. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)
+	// Insecure in gRPC and HTTP when set to true, this is used to disable the client transport security. See https://godoc.org/google.golang.org/grpc#WithInsecure for gRPC. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)
 	Insecure bool `mapstructure:"insecure,omitempty"`
-	// Enables TLS but not verify the certificate.
+	// InsecureSkipVerify enables TLS but not verify the certificate.
 	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify,omitempty"`
-	// Server name requested by client for virtual hosting. This sets the ServerName in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
+	// ServerName server name requested by client for virtual hosting. This sets the ServerName in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
 	ServerName string `mapstructure:"server_name_override,omitempty"`
 	// prevent unkeyed literal initialization
 	_ struct{}
@@ -31,33 +31,33 @@ func NewDefaultClientConfig() ClientConfig {
 
 // Config exposes the common client and server TLS configurations. Note: Since there isn't anything specific to a server connection. Components with server connections should use Config.
 type Config struct {
-	// Path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)
+	// CAFile path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)
 	CAFile string `mapstructure:"ca_file,omitempty"`
-	// In memory PEM encoded cert. (optional)
+	// CAPem in memory PEM encoded cert. (optional)
 	CAPem configopaque.String `mapstructure:"ca_pem,omitempty"`
-	// Path to the TLS cert to use for TLS required connections. (optional)
+	// CertFile path to the TLS cert to use for TLS required connections. (optional)
 	CertFile string `mapstructure:"cert_file,omitempty"`
-	// In memory PEM encoded TLS cert to use for TLS required connections. (optional)
+	// CertPem in memory PEM encoded TLS cert to use for TLS required connections. (optional)
 	CertPem configopaque.String `mapstructure:"cert_pem,omitempty"`
-	// A list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.
+	// CipherSuites a list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.
 	CipherSuites []string `mapstructure:"cipher_suites,omitempty"`
-	// Contains the elliptic curves that will be used in an ECDHE handshake, in preference order Defaults to empty list and "crypto/tls" defaults are used, internally.
+	// CurvePreferences contains the elliptic curves that will be used in an ECDHE handshake, in preference order Defaults to empty list and "crypto/tls" defaults are used, internally.
 	CurvePreferences []string `mapstructure:"curve_preferences,omitempty"`
-	// Enables support for insecure cipher suites. When set to true, cipher suites returned by tls.InsecureCipherSuites() will be available for selection in addition to the secure ones. This should only be used when working with legacy systems that require insecure cipher suites. (optional, default false)
+	// IncludeInsecureCipherSuites enables support for insecure cipher suites. When set to true, cipher suites returned by tls.InsecureCipherSuites() will be available for selection in addition to the secure ones. This should only be used when working with legacy systems that require insecure cipher suites. (optional, default false)
 	IncludeInsecureCipherSuites bool `mapstructure:"include_insecure_cipher_suites,omitempty"`
-	// If true, load system CA certificates pool in addition to the certificates configured in this struct.
+	// IncludeSystemCACertsPool if true, load system CA certificates pool in addition to the certificates configured in this struct.
 	IncludeSystemCACertsPool bool `mapstructure:"include_system_ca_certs_pool,omitempty"`
-	// Path to the TLS key to use for TLS required connections. (optional)
+	// KeyFile path to the TLS key to use for TLS required connections. (optional)
 	KeyFile string `mapstructure:"key_file,omitempty"`
-	// In memory PEM encoded TLS key to use for TLS required connections. (optional)
+	// KeyPem in memory PEM encoded TLS key to use for TLS required connections. (optional)
 	KeyPem configopaque.String `mapstructure:"key_pem,omitempty"`
-	// Sets the maximum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)
+	// MaxVersion sets the maximum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)
 	MaxVersion string `mapstructure:"max_version,omitempty"`
-	// Sets the minimum TLS version that is acceptable. If not set, TLS 1.2 will be used. (optional)
+	// MinVersion sets the minimum TLS version that is acceptable. If not set, TLS 1.2 will be used. (optional)
 	MinVersion string `mapstructure:"min_version,omitempty"`
-	// Specifies the duration after which the certificate will be reloaded If not set, it will never be reloaded (optional)
+	// ReloadInterval specifies the duration after which the certificate will be reloaded If not set, it will never be reloaded (optional)
 	ReloadInterval time.Duration `mapstructure:"reload_interval,omitempty"`
-	// Trusted platform module configuration
+	// TPMConfig trusted platform module configuration
 	TPMConfig TPMConfig `mapstructure:"tpm,omitempty"`
 	// prevent unkeyed literal initialization
 	_ struct{}
@@ -72,9 +72,9 @@ func NewDefaultConfig() Config {
 type ServerConfig struct {
 	// Exposes the common client and server TLS configurations. Note: Since there isn't anything specific to a server connection. Components with server connections should use Config.
 	Config `mapstructure:",squash"`
-	// Path to the TLS cert to use by the server to verify a client certificate. (optional) This sets the ClientCAs and ClientAuth to RequireAndVerifyClientCert in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
+	// ClientCAFile path to the TLS cert to use by the server to verify a client certificate. (optional) This sets the ClientCAs and ClientAuth to RequireAndVerifyClientCert in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
 	ClientCAFile string `mapstructure:"client_ca_file,omitempty"`
-	// Reload the ClientCAs file when it is modified (optional, default false)
+	// ReloadClientCAFile reload the ClientCAs file when it is modified (optional, default false)
 	ReloadClientCAFile bool `mapstructure:"client_ca_file_reload,omitempty"`
 	// prevent unkeyed literal initialization
 	_ struct{}
@@ -92,7 +92,7 @@ type TPMConfig struct {
 	Auth      string `mapstructure:"auth,omitempty"`
 	Enabled   bool   `mapstructure:"enabled,omitempty"`
 	OwnerAuth string `mapstructure:"owner_auth,omitempty"`
-	// The path to the TPM device or Unix domain socket. For instance /dev/tpm0 or /dev/tpmrm0.
+	// Path the path to the TPM device or Unix domain socket. For instance /dev/tpm0 or /dev/tpmrm0.
 	Path string `mapstructure:"path,omitempty"`
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/exporter/exporterhelper/internal/generated_config.go
+++ b/exporter/exporterhelper/internal/generated_config.go
@@ -9,7 +9,7 @@ import (
 
 // TimeoutConfig a timeout configuration. The timeout applies to individual attempts to send data to the backend.
 type TimeoutConfig struct {
-	// Defines the timeout for every attempt to send data to the backend. A zero timeout means no timeout.
+	// Timeout defines the timeout for every attempt to send data to the backend. A zero timeout means no timeout.
 	Timeout time.Duration `mapstructure:"timeout"`
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/scraper/scraperhelper/internal/controller/generated_config.go
+++ b/scraper/scraperhelper/internal/controller/generated_config.go
@@ -9,11 +9,11 @@ import (
 
 // ControllerConfig defines common settings for a scraper controller configuration. Scraper controller receivers can embed this struct, instead of receiver.Settings, and extend it with more fields if needed.
 type ControllerConfig struct {
-	// Sets how frequently the scraper is scheduled.
+	// CollectionInterval sets how frequently the scraper is scheduled.
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
-	// Sets the initial start delay for the scraper, any non positive value is assumed to be immediately.
+	// InitialDelay sets the initial start delay for the scraper, any non positive value is assumed to be immediately.
 	InitialDelay time.Duration `mapstructure:"initial_delay"`
-	// An optional value used to set scraper's context deadline.
+	// Timeout an optional value used to set scraper's context deadline.
 	Timeout time.Duration `mapstructure:"timeout"`
 	// prevent unkeyed literal initialization
 	_ struct{}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This change fixes `mdatagen` config generator issue with creating struct field doc comments. Now they should follow golang convention:
```go
type TargetsItem struct {
  // FieldName <description>
  FieldName int `mapstructure:"field_name"`
}
```
Follow up to comment: https://github.com/open-telemetry/opentelemetry-collector/pull/15706#discussion_r3895621929

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
