### PR TITLE
fix(confmap): expand URI after escaped URI

### DIFF
--- a/.chloggen/fix-confmap-escaped-uri-expansion.yaml
+++ b/.chloggen/fix-confmap-escaped-uri-expansion.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where an escaped URI appearing before a valid URI prevented the subsequent URI from being expanded.
+
+# One or more tracking issues or pull requests related to the change
+issues: [15867]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  URI scanning now continues after an escaped URI while preserving the escaped expression as literal text.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/confmap/expand.go
+++ b/confmap/expand.go
@@ -137,7 +137,10 @@ func (mr *Resolver) findURI(input string) string {
 	}
 	// if we found an odd number of immediately $ preceding ${, then the expansion is escaped
 	if count%2 == 1 {
-		return ""
+		if !strings.Contains(remaining, "}") {
+			return ""
+		}
+		return mr.findURI(remaining)
 	}
 
 	return input[openIndex : closeIndex+1]

--- a/confmap/expand_test.go
+++ b/confmap/expand_test.go
@@ -197,6 +197,27 @@ func TestResolverExpandStringValues(t *testing.T) {
 			input:  "test_${env:BOOL}_test_${env:BOOL}",
 			output: "test_true_test_true",
 		},
+		{
+			name:   "EscapedBeforeValidURI",
+			input:  "$${env:ESCAPED}:${env:PORT}",
+			output: "${env:ESCAPED}:3044",
+		},
+		{
+			name:            "EscapedBeforeValidURIDefaultScheme",
+			input:           "$${ESCAPED}:${PORT}",
+			output:          "${ESCAPED}:3044",
+			defaultProvider: true,
+		},
+		{
+			name:   "MultipleEscapedBeforeValidURI",
+			input:  "$${env:FIRST}_$${env:SECOND}_${env:PORT}",
+			output: "${env:FIRST}_${env:SECOND}_3044",
+		},
+		{
+			name:   "ValidBeforeEscapedURI",
+			input:  "${env:PORT}:$${env:ESCAPED}",
+			output: "3044:${env:ESCAPED}",
+		},
 
 		// Nested.
 		{

--- a/confmap/internal/e2e/expand_test.go
+++ b/confmap/internal/e2e/expand_test.go
@@ -51,6 +51,7 @@ func Test_EscapedEnvVars_NoDefaultScheme(t *testing.T) {
 			"key20": "some expanded value came from nested expansion",
 			"key21": "default_value",
 			"key22": "${env:UNDEFINED_KEY:-${env:UNDEFINED_KEY}}",
+			"key23": "${env:ESCAPED}_" + expandedValue,
 		},
 	}
 
@@ -101,6 +102,7 @@ func Test_EscapedEnvVars_DefaultScheme(t *testing.T) {
 			"key20": "some expanded value came from nested expansion",
 			"key21": "default_value",
 			"key22": "${env:UNDEFINED_KEY:-${env:UNDEFINED_KEY}}",
+			"key23": "${env:ESCAPED}_" + expandedValue,
 		},
 	}
 

--- a/confmap/internal/e2e/testdata/expand-escaped-env.yaml
+++ b/confmap/internal/e2e/testdata/expand-escaped-env.yaml
@@ -43,3 +43,5 @@ test_map:
   key21: "${env:UNDEFINED_KEY:-default_value}"
   # escaped default value
   key22: "${env:UNDEFINED_KEY:-$${env:UNDEFINED_KEY}}"
+  # escaped uri followed by expanded env var
+  key23: "$${env:ESCAPED}_${env:ENV_VALUE}"


### PR DESCRIPTION
#### Description

An escaped URI at the start of a value could prevent subsequent valid URIs from being expanded. This updates the URI scanner to continue searching after an escaped expression while keeping the escaped expression unchanged.

#### Link to tracking issue

Fixes #15867

#### Testing

Added regression tests covering escaped URIs before and after valid URIs, multiple escaped URIs, and default scheme expansion. Unit and E2E tests, `go vet`, `gofmt`, and `git diff --check` all pass.

#### Documentation

No documentation changes are required.


- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
