### PR TITLE
[featuregate] reject malformed dot-separated IDs

### DIFF
--- a/.chloggen/robinjohri_featuregate-reject-malformed-dot-separated-ids.yaml
+++ b/.chloggen/robinjohri_featuregate-reject-malformed-dot-separated-ids.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject feature gate IDs with leading, trailing, or consecutive dots
+
+# One or more tracking issues or pull requests related to the change
+issues: [15676]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -19,8 +19,9 @@ var (
 	globalRegistry = NewRegistry()
 
 	// idRegexp is used to validate the ID of a Gate.
-	// IDs' characters must be alphanumeric or dots.
-	idRegexp = regexp.MustCompile(`^[0-9a-zA-Z.]*$`)
+	// IDs must be a dot-separated list of non-empty alphanumeric segments,
+	// so leading, trailing, or consecutive dots are rejected.
+	idRegexp = regexp.MustCompile(`^[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*$`)
 )
 
 // ErrAlreadyRegistered is returned when adding a Gate that is already registered.

--- a/featuregate/registry_test.go
+++ b/featuregate/registry_test.go
@@ -153,6 +153,24 @@ func TestRegisterGateLifecycle(t *testing.T) {
 			shouldErr: true,
 		},
 		{
+			name:      "Invalid gate name with leading dot",
+			id:        ".invalid.gate.name",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid gate name with trailing dot",
+			id:        "invalid.gate.name.",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid gate name with consecutive dots",
+			id:        "invalid..gate.name",
+			stage:     StageAlpha,
+			shouldErr: true,
+		},
+		{
 			name:      "Invalid empty gate",
 			id:        "",
 			stage:     StageAlpha,


### PR DESCRIPTION
#### Description

The regex was too permissive, it now requires each dot-separated segment to be non-empty after which the solution will work correctly

#### Link to tracking issue
Fixes #15676

#### Testing

I added 3 table driven test cases after running the full featuregate package suite and ensured that no existing registered gate ID breaks as a part of my regression testing.

#### Documentation

No specific documentation required specifically for this PR.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
