### PR TITLE
[chore] Fix flaky TestExporterFailureAttributesDetailed

### DIFF
--- a/internal/e2e/exporter_failure_attributes_test.go
+++ b/internal/e2e/exporter_failure_attributes_test.go
@@ -144,14 +144,10 @@ func startFailureAttributeCollector(t *testing.T, exporterEndpoint string) (stri
 		}
 	}()
 
-	require.Eventually(t, func() bool {
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/metrics", metricsPort))
-		if err != nil {
-			return false
-		}
-		resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
-	}, 5*time.Second, 100*time.Millisecond, "collector failed to start")
+	// Waiting on the telemetry /metrics endpoint alone is not enough: it comes up before
+	// the OTLP receiver is listening, which races sendTestMetrics into a connection refused.
+	waitCollectorRunning(t, collector)
+	waitMetricsReady(t, metricsPort)
 
 	return otelPort, metricsPort
 }


### PR DESCRIPTION
#### Description
Fix flaky TestExporterFailureAttributesDetailed by waiting for the collector to reach the running state before sending test metrics.

#### Link to tracking issue
Fixes #

#### Testing

#### Documentation

#### Authorship

- [ ] I, a human, wrote this pull request description myself.