### PR TITLE
[chore] [cmd/builder] Increase test timeout to 420s

### DIFF
--- a/cmd/builder/Makefile
+++ b/cmd/builder/Makefile
@@ -1,5 +1,10 @@
 include ../../Makefile.Common
 
+# TestGenerateAndCompile runs the builder end-to-end, compiling a full collector
+# distribution once per subtest. This can be slow on shared CI runners (macOS
+# arm, Windows), so give this module a larger budget.
+GOTEST_TIMEOUT = 420s
+
 .PHONY: ocb
 ocb:
 	CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/ocb_$(GOOS)_$(GOARCH) .


### PR DESCRIPTION
The cmd/builder package compiles a full collector distribution once per TestGenerateAndCompile subtest, which intermittently exceeds the shared 240s test timeout on slow CI runners (macOS arm, Windows), so this overrides `GOTEST_TIMEOUT` to 420s for this module only.

Fixes test flakines, examples:
- https://github.com/open-telemetry/opentelemetry-collector/actions/runs/33561653904/job/100035326227
- https://github.com/open-telemetry/opentelemetry-collector/actions/runs/33569108627/job/100058933850

- [x] I, a human, wrote this pull request description myself.