### PR TITLE
[chore][cmd/mdatagen] Improve formatting of doc comments in generated configs

### DIFF
--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -109,6 +109,17 @@ func NewCfgFns(rootPackage, componentPackage string) map[string]any {
 		"shouldOmitEmpty": func(md *ConfigMetadata, propName string, prop *ConfigMetadata) bool {
 			return !isRequired(md, propName) && !hasNonZeroDefault(prop)
 		},
+		"goComment": func(s string) string {
+			lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+			for i, l := range lines {
+				if l == "" {
+					lines[i] = "//"
+				} else {
+					lines[i] = "// " + l
+				}
+			}
+			return strings.Join(lines, "\n")
+		},
 	}
 }
 

--- a/cmd/mdatagen/internal/samplemigrationscraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplemigrationscraper/generated_config.go
@@ -11,8 +11,10 @@ import (
 type Config struct {
 	// MetricsBuilderConfig is a configuration for samplemigration metrics builder.
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+
 	// EmitLegacyMetrics whether to emit legacy metric names alongside new ones.
 	EmitLegacyMetrics bool `mapstructure:"emit_legacy_metrics"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/cmd/mdatagen/internal/samplepkg/generated_config.go
+++ b/cmd/mdatagen/internal/samplepkg/generated_config.go
@@ -12,8 +12,10 @@ type PortNumber int
 type SampleConfig struct {
 	// HostName the host name to connect to.
 	HostName string `mapstructure:"host_name"`
+
 	// Port the port to connect to.
 	Port PortNumber `mapstructure:"port"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/cmd/mdatagen/internal/samplereceiver/generated_config.go
+++ b/cmd/mdatagen/internal/samplereceiver/generated_config.go
@@ -16,19 +16,27 @@ import (
 type Config struct {
 	// MetricsBuilderConfig is a configuration for sample metrics builder.
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+
 	// APIToken aPI token used to authenticate with the endpoint.
 	APIToken configopaque.String `mapstructure:"api_token,omitempty"`
+
 	// ComponentID component ID used to identify this receiver instance.
 	ComponentID component.ID `mapstructure:"component_id,omitempty"`
+
 	// Endpoint the endpoint to scrape metrics from.
 	Endpoint string `mapstructure:"endpoint"`
+
 	// Headers extra HTTP headers to attach to each request.
 	Headers configopaque.MapList `mapstructure:"headers,omitempty"`
+
 	// MaxResults maximum number of results to return per scrape.
-	MaxResults int64                  `mapstructure:"max_results"`
-	SamplePkg  samplepkg.SampleConfig `mapstructure:"sample_pkg"`
+	MaxResults int64 `mapstructure:"max_results"`
+
+	SamplePkg samplepkg.SampleConfig `mapstructure:"sample_pkg"`
+
 	// Timeout timeout for scraping metrics.
 	Timeout time.Duration `mapstructure:"timeout"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -24,12 +24,16 @@ func NewDefaultSamplePkg() SamplePkg {
 
 type TargetsItem struct {
 	Interval configoptional.Optional[time.Duration] `mapstructure:"interval"`
+
 	// Labels static key-value labels attached to all metrics from this target.
 	Labels map[string]string `mapstructure:"labels"`
+
 	// RetryCount number of retry attempts for failed scrapes.
 	RetryCount int `mapstructure:"retry_count"`
+
 	// TimeoutSeconds timeout in seconds for each scrape request.
 	TimeoutSeconds float64 `mapstructure:"timeout_seconds"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -73,16 +77,22 @@ func NewDefaultTargetsItem() TargetsItem {
 type Config struct {
 	// Defines common settings for a scraper controller configuration. Scraper controller receivers can embed this struct, instead of receiver.Settings, and extend it with more fields if needed.
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
+
 	// MetricsBuilderConfig is a configuration for sample metrics builder.
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+
 	// ComponentID identifies the scraper, used for telemetry and logging.
 	ComponentID component.ID `mapstructure:"component,omitempty"`
+
 	// JobName name of the scrape job, used to identify the source in telemetry.
 	JobName string `mapstructure:"job_name"`
+
 	// LogLevel logging level for the scraper.
 	LogLevel string `mapstructure:"log_level"`
+
 	// Targets list of targets to scrape metrics from.
 	Targets *[]TargetsItem `mapstructure:"targets"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
+++ b/cmd/mdatagen/internal/templates/config_from_cfggen.go.tmpl
@@ -19,21 +19,20 @@ import (
 {{ define "struct" }}
     {{- range $propName, $prop := .Properties | embeddedProps }}
         {{- if $prop.Description }}
-    // {{ $prop.Description }}
+        {{ $prop.Description | goComment }}
         {{- end }}
         {{- if $prop.GoStruct.Anonymous }}
             {{ $prop.Ref | publicType }} `mapstructure:",squash"`
         {{- else }}
             {{ $prop.GoStruct.FieldName | publicVar }} {{ $prop.Ref | publicType }} `mapstructure:",squash"`
         {{- end }}
-
-    {{- end }}
+    {{ end }}
     {{- range $propName, $prop := .Properties | namedProps }}
         {{- if $prop.Description }}
-            // {{ $prop.GoStruct.FieldName | publicVar }} {{ $prop.Description | uncapitalize }}
+            {{ printf "%s %s" ($prop.GoStruct.FieldName | publicVar) ($prop.Description | uncapitalize) | goComment }}
         {{- end }}
         {{ $prop.GoStruct.FieldName | publicVar }} {{ mapGoType $prop $propName }} `mapstructure:"{{ $propName }}{{ if shouldOmitEmpty . $propName $prop }},omitempty{{ end }}"`
-    {{- end }}
+    {{ end }}
     // prevent unkeyed literal initialization
     _ struct{}
 {{ end }}
@@ -41,7 +40,7 @@ import (
 {{- $defs := extractDefs .Metadata.ConfigsMetadata }}
 {{ range $defName, $def := $defs }}
     {{- if $def.Description }}
-        // {{ $defName | publicVar }} {{ $def.Description | uncapitalize }}
+        {{ printf "%s %s" ($defName | publicVar) ($def.Description | uncapitalize) | goComment }}
     {{- end }}
     {{- $typeName := $defName | publicVar }}
     {{- if isExternalRef $def.Ref }}

--- a/config/configauth/generated_config.go
+++ b/config/configauth/generated_config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	// AuthenticatorID specifies the name of the extension to use in order to authenticate the incoming data point.
 	AuthenticatorID component.ID `mapstructure:"authenticator,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/config/configcompression/generated_config.go
+++ b/config/configcompression/generated_config.go
@@ -4,6 +4,7 @@ package configcompression
 
 type CompressionParams struct {
 	Level Level `mapstructure:"level,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/config/confignet/config.schema.json
+++ b/config/confignet/config.schema.json
@@ -19,11 +19,11 @@
         },
         "endpoint": {
           "type": "string",
-          "description": "Configures the address for this network connection. For TCP and UDP networks, the address has the form \"host:port\". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in \"[2001:db8::1]:80\" or \"[fe80::1%zone]:80\". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007."
+          "description": "Configures the address for this network connection. For TCP and UDP networks, \nthe address has the form \"host:port\". The host must be a literal IP address, \nor a host name that can be resolved to IP addresses. The port must \nbe a literal port number or a service name. If the host is a literal IPv6 address \nit must be enclosed in square brackets, as in \"[2001:db8::1]:80\" or \"[fe80::1%zone]:80\". \nThe zone specifies the scope of the literal IPv6 address as defined in RFC 4007.\n"
         },
         "transport": {
           "type": "string",
-          "description": "Defines the type of transport protocol used. Allowed protocols are \"tcp\", \"tcp4\" (IPv4-only), \"tcp6\" (IPv6-only), \"udp\", \"udp4\" (IPv4-only), \"udp6\" (IPv6-only), \"ip\", \"ip4\" (IPv4-only), \"ip6\" (IPv6-only), \"unix\", \"unixgram\", \"unixpacket\" and \"npipe\" (Windows named pipes, Windows-only)."
+          "description": "Defines the type of transport protocol used. Allowed protocols are \"tcp\", \"tcp4\" (IPv4-only), \n\"tcp6\" (IPv6-only), \"udp\", \"udp4\" (IPv4-only), \"udp6\" (IPv6-only), \"ip\", \"ip4\" (IPv4-only), \n\"ip6\" (IPv6-only), \"unix\", \"unixgram\", \"unixpacket\" and \"npipe\" (Windows named pipes, Windows-only).\n"
         }
       },
       "description": "Represents a network endpoint address."
@@ -57,7 +57,7 @@
         },
         "endpoint": {
           "type": "string",
-          "description": "Configures the address for this network connection. The address has the form \"host:port\". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in \"[2001:db8::1]:80\" or \"[fe80::1%zone]:80\". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007."
+          "description": "Configures the address for this network connection. The address has the form \"host:port\". \nThe host must be a literal IP address, or a host name that can be resolved to IP addresses. \nThe port must be a literal port number or a service name. If the host is a literal IPv6 address \nit must be enclosed in square brackets, as in \"[2001:db8::1]:80\" or \"[fe80::1%zone]:80\". \nThe zone specifies the scope of the literal IPv6 address as defined in RFC 4007.\n"
         }
       },
       "description": "Represents a TCP endpoint address."

--- a/config/confignet/generated_config.go
+++ b/config/confignet/generated_config.go
@@ -10,10 +10,20 @@ import (
 type AddrConfig struct {
 	// DialerConfig contains options for connecting to an address.
 	DialerConfig DialerConfig `mapstructure:"dialer,omitempty"`
-	// Endpoint configures the address for this network connection. For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
+
+	// Endpoint configures the address for this network connection. For TCP and UDP networks,
+	// the address has the form "host:port". The host must be a literal IP address,
+	// or a host name that can be resolved to IP addresses. The port must
+	// be a literal port number or a service name. If the host is a literal IPv6 address
+	// it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80".
+	// The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
 	Endpoint string `mapstructure:"endpoint,omitempty"`
-	// Transport defines the type of transport protocol used. Allowed protocols are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only), "ip6" (IPv6-only), "unix", "unixgram", "unixpacket" and "npipe" (Windows named pipes, Windows-only).
+
+	// Transport defines the type of transport protocol used. Allowed protocols are "tcp", "tcp4" (IPv4-only),
+	// "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only),
+	// "ip6" (IPv6-only), "unix", "unixgram", "unixpacket" and "npipe" (Windows named pipes, Windows-only).
 	Transport TransportType `mapstructure:"transport,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -29,6 +39,7 @@ func NewDefaultAddrConfig() AddrConfig {
 type DialerConfig struct {
 	// Timeout the maximum amount of time a dial will wait for a connect to complete. The default is no timeout.
 	Timeout time.Duration `mapstructure:"timeout,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -42,8 +53,14 @@ func NewDefaultDialerConfig() DialerConfig {
 type TCPAddrConfig struct {
 	// DialerConfig contains options for connecting to an address.
 	DialerConfig DialerConfig `mapstructure:"dialer,omitempty"`
-	// Endpoint configures the address for this network connection. The address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
+
+	// Endpoint configures the address for this network connection. The address has the form "host:port".
+	// The host must be a literal IP address, or a host name that can be resolved to IP addresses.
+	// The port must be a literal port number or a service name. If the host is a literal IPv6 address
+	// it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80".
+	// The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
 	Endpoint string `mapstructure:"endpoint,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/config/confignet/metadata.yaml
+++ b/config/confignet/metadata.yaml
@@ -15,10 +15,19 @@ exported_configs:
         go_struct:
           field_name: DialerConfig
       endpoint:
-        description: Configures the address for this network connection. For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
+        description: |
+          Configures the address for this network connection. For TCP and UDP networks, 
+          the address has the form "host:port". The host must be a literal IP address, 
+          or a host name that can be resolved to IP addresses. The port must 
+          be a literal port number or a service name. If the host is a literal IPv6 address 
+          it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". 
+          The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
         type: string
       transport:
-        description: Defines the type of transport protocol used. Allowed protocols are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only), "ip6" (IPv6-only), "unix", "unixgram", "unixpacket" and "npipe" (Windows named pipes, Windows-only).
+        description: |
+          Defines the type of transport protocol used. Allowed protocols are "tcp", "tcp4" (IPv4-only), 
+          "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only), 
+          "ip6" (IPv6-only), "unix", "unixgram", "unixpacket" and "npipe" (Windows named pipes, Windows-only).
         $ref: transport_type
   dialer_config:
     description: Contains options for connecting to an address.
@@ -35,7 +44,12 @@ exported_configs:
         go_struct:
           field_name: DialerConfig
       endpoint:
-        description: Configures the address for this network connection. The address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
+        description: |
+          Configures the address for this network connection. The address has the form "host:port". 
+          The host must be a literal IP address, or a host name that can be resolved to IP addresses. 
+          The port must be a literal port number or a service name. If the host is a literal IPv6 address 
+          it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". 
+          The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
         type: string
   transport_type:
     description: Represents a type of network transport protocol

--- a/config/configretry/config.schema.json
+++ b/config/configretry/config.schema.json
@@ -19,14 +19,14 @@
         },
         "max_elapsed_time": {
           "type": "string",
-          "description": "The maximum amount of time (including retries) spent trying to send a request/batch. Once this value is reached, the data is discarded. If set to 0, the retries are never stopped.",
+          "description": "The maximum amount of time (including retries) spent trying to send a request/batch. \nOnce this value is reached, the data is discarded. If set to 0, the retries are never stopped.\n",
           "default": "5m",
           "minimum": 0,
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
         },
         "max_interval": {
           "type": "string",
-          "description": "The upper bound on backoff interval. Once this value is reached the delay between consecutive retries will always be `MaxInterval`.",
+          "description": "The upper bound on backoff interval. Once this value is reached the delay \nbetween consecutive retries will always be `MaxInterval`.\n",
           "default": "30s",
           "minimum": 0,
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
@@ -39,13 +39,13 @@
         },
         "randomization_factor": {
           "type": "number",
-          "description": "A random factor used to calculate next backoffs Randomized interval = RetryInterval * (1 ± RandomizationFactor)",
+          "description": "A random factor used to calculate next backoffs \nRandomized interval = RetryInterval * (1 ± RandomizationFactor)\n",
           "default": 0.5,
           "minimum": 0,
           "maximum": 1
         }
       },
-      "description": "Defines configuration for retrying batches in case of export failure. The current supported strategy is exponential backoff."
+      "description": "Defines configuration for retrying batches in case of export failure. \nThe current supported strategy is exponential backoff.\n"
     }
   },
   "title": "pkg/config/configretry"

--- a/config/configretry/generated_config.go
+++ b/config/configretry/generated_config.go
@@ -7,20 +7,30 @@ import (
 	"time"
 )
 
-// BackOffConfig defines configuration for retrying batches in case of export failure. The current supported strategy is exponential backoff.
+// BackOffConfig defines configuration for retrying batches in case of export failure.
+// The current supported strategy is exponential backoff.
 type BackOffConfig struct {
 	// Enabled indicates whether to not retry sending batches in case of export failure.
 	Enabled bool `mapstructure:"enabled"`
+
 	// InitialInterval the time to wait after the first failure before retrying.
 	InitialInterval time.Duration `mapstructure:"initial_interval"`
-	// MaxElapsedTime the maximum amount of time (including retries) spent trying to send a request/batch. Once this value is reached, the data is discarded. If set to 0, the retries are never stopped.
+
+	// MaxElapsedTime the maximum amount of time (including retries) spent trying to send a request/batch.
+	// Once this value is reached, the data is discarded. If set to 0, the retries are never stopped.
 	MaxElapsedTime time.Duration `mapstructure:"max_elapsed_time"`
-	// MaxInterval the upper bound on backoff interval. Once this value is reached the delay between consecutive retries will always be `MaxInterval`.
+
+	// MaxInterval the upper bound on backoff interval. Once this value is reached the delay
+	// between consecutive retries will always be `MaxInterval`.
 	MaxInterval time.Duration `mapstructure:"max_interval"`
+
 	// Multiplier the value multiplied by the backoff interval bounds
 	Multiplier float64 `mapstructure:"multiplier"`
-	// RandomizationFactor a random factor used to calculate next backoffs Randomized interval = RetryInterval * (1 ± RandomizationFactor)
+
+	// RandomizationFactor a random factor used to calculate next backoffs
+	// Randomized interval = RetryInterval * (1 ± RandomizationFactor)
 	RandomizationFactor float64 `mapstructure:"randomization_factor"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/config/configretry/metadata.yaml
+++ b/config/configretry/metadata.yaml
@@ -8,7 +8,9 @@ status:
 
 exported_configs:
   back_off_config:
-    description: Defines configuration for retrying batches in case of export failure. The current supported strategy is exponential backoff.
+    description: |
+      Defines configuration for retrying batches in case of export failure. 
+      The current supported strategy is exponential backoff.
     type: object
     go_struct:
       custom_validator:
@@ -24,12 +26,16 @@ exported_configs:
         default: 5s
         minimum: 0
       max_elapsed_time:
-        description: The maximum amount of time (including retries) spent trying to send a request/batch. Once this value is reached, the data is discarded. If set to 0, the retries are never stopped.
+        description: |
+          The maximum amount of time (including retries) spent trying to send a request/batch. 
+          Once this value is reached, the data is discarded. If set to 0, the retries are never stopped.
         type: duration
         default: 5m
         minimum: 0
       max_interval:
-        description: The upper bound on backoff interval. Once this value is reached the delay between consecutive retries will always be `MaxInterval`.
+        description: |
+          The upper bound on backoff interval. Once this value is reached the delay 
+          between consecutive retries will always be `MaxInterval`.
         type: duration
         default: 30s
         minimum: 0
@@ -39,7 +45,9 @@ exported_configs:
         default: 1.5
         minimum: 0
       randomization_factor:
-        description: A random factor used to calculate next backoffs Randomized interval = RetryInterval * (1 ± RandomizationFactor)
+        description: |
+          A random factor used to calculate next backoffs 
+          Randomized interval = RetryInterval * (1 ± RandomizationFactor)
         type: double
         default: 0.5
         minimum: 0

--- a/config/configtls/config.schema.json
+++ b/config/configtls/config.schema.json
@@ -7,7 +7,7 @@
       "properties": {
         "insecure": {
           "type": "boolean",
-          "description": "In gRPC and HTTP when set to true, this is used to disable the client transport security. See https://godoc.org/google.golang.org/grpc#WithInsecure for gRPC. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)"
+          "description": "In gRPC and HTTP when set to true, this is used to disable the client transport security. \nSee https://godoc.org/google.golang.org/grpc#WithInsecure for gRPC. \nPlease refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)\n"
         },
         "insecure_skip_verify": {
           "type": "boolean",
@@ -15,17 +15,17 @@
         },
         "server_name_override": {
           "type": "string",
-          "description": "Server name requested by client for virtual hosting. This sets the ServerName in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)"
+          "description": "Server name requested by client for virtual hosting. This sets the ServerName in the TLSConfig. \nPlease refer to https://godoc.org/crypto/tls#Config for more information. (optional)\n"
         }
       },
-      "description": "Contains TLS configurations that are specific to client connections in addition to the common configurations. This should be used by components configuring TLS client connections.",
+      "description": "Contains TLS configurations that are specific to client connections in addition to the common configurations. \nThis should be used by components configuring TLS client connections.\n",
       "allOf": [
         {
           "type": "object",
           "properties": {
             "ca_file": {
               "type": "string",
-              "description": "Path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)"
+              "description": "Path to the CA cert. For a client this verifies the server certificate. \nFor a server this verifies client certificates. If empty uses system root CA. (optional)\n"
             },
             "ca_pem": {
               "type": "string",
@@ -44,18 +44,18 @@
               "items": {
                 "type": "string"
               },
-              "description": "A list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites."
+              "description": "A list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. \nSee https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.\n"
             },
             "curve_preferences": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "Contains the elliptic curves that will be used in an ECDHE handshake, in preference order Defaults to empty list and \"crypto/tls\" defaults are used, internally."
+              "description": "Contains the elliptic curves that will be used in an ECDHE handshake, \nin preference order Defaults to empty list and \"crypto/tls\" defaults are used, internally.\n"
             },
             "include_insecure_cipher_suites": {
               "type": "boolean",
-              "description": "Enables support for insecure cipher suites. When set to true, cipher suites returned by tls.InsecureCipherSuites() will be available for selection in addition to the secure ones. This should only be used when working with legacy systems that require insecure cipher suites. (optional, default false)"
+              "description": "Enables support for insecure cipher suites. When set to true, cipher suites returned by \ntls.InsecureCipherSuites() will be available for selection in addition to the secure ones. \nThis should only be used when working with legacy systems that require insecure cipher suites. \n(optional, default false)\n"
             },
             "include_system_ca_certs_pool": {
               "type": "boolean",
@@ -102,7 +102,7 @@
               "description": "Trusted platform module configuration"
             }
           },
-          "description": "Exposes the common client and server TLS configurations. Note: Since there isn't anything specific to a server connection. Components with server connections should use Config.",
+          "description": "Exposes the common client and server TLS configurations. \nNote: Since there isn''t anything specific to a server connection. Components with server connections should use Config.\n",
           "default": {}
         }
       ]
@@ -112,7 +112,7 @@
       "properties": {
         "ca_file": {
           "type": "string",
-          "description": "Path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)"
+          "description": "Path to the CA cert. For a client this verifies the server certificate. \nFor a server this verifies client certificates. If empty uses system root CA. (optional)\n"
         },
         "ca_pem": {
           "type": "string",
@@ -131,18 +131,18 @@
           "items": {
             "type": "string"
           },
-          "description": "A list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites."
+          "description": "A list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. \nSee https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.\n"
         },
         "curve_preferences": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Contains the elliptic curves that will be used in an ECDHE handshake, in preference order Defaults to empty list and \"crypto/tls\" defaults are used, internally."
+          "description": "Contains the elliptic curves that will be used in an ECDHE handshake, \nin preference order Defaults to empty list and \"crypto/tls\" defaults are used, internally.\n"
         },
         "include_insecure_cipher_suites": {
           "type": "boolean",
-          "description": "Enables support for insecure cipher suites. When set to true, cipher suites returned by tls.InsecureCipherSuites() will be available for selection in addition to the secure ones. This should only be used when working with legacy systems that require insecure cipher suites. (optional, default false)"
+          "description": "Enables support for insecure cipher suites. When set to true, cipher suites returned by \ntls.InsecureCipherSuites() will be available for selection in addition to the secure ones. \nThis should only be used when working with legacy systems that require insecure cipher suites. \n(optional, default false)\n"
         },
         "include_system_ca_certs_pool": {
           "type": "boolean",
@@ -189,7 +189,7 @@
           "description": "Trusted platform module configuration"
         }
       },
-      "description": "Exposes the common client and server TLS configurations. Note: Since there isn't anything specific to a server connection. Components with server connections should use Config.",
+      "description": "Exposes the common client and server TLS configurations. \nNote: Since there isn''t anything specific to a server connection. Components with server connections should use Config.\n",
       "default": {}
     },
     "server_config": {
@@ -197,21 +197,21 @@
       "properties": {
         "client_ca_file": {
           "type": "string",
-          "description": "Path to the TLS cert to use by the server to verify a client certificate. (optional) This sets the ClientCAs and ClientAuth to RequireAndVerifyClientCert in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)"
+          "description": "Path to the TLS cert to use by the server to verify a client certificate. (optional) \nThis sets the ClientCAs and ClientAuth to RequireAndVerifyClientCert in the TLSConfig. \nPlease refer to https://godoc.org/crypto/tls#Config for more information. (optional)\n"
         },
         "client_ca_file_reload": {
           "type": "boolean",
           "description": "Reload the ClientCAs file when it is modified (optional, default false)"
         }
       },
-      "description": "Contains TLS configurations that are specific to server connections in addition to the common configurations. This should be used by components configuring TLS server connections.",
+      "description": "Contains TLS configurations that are specific to server connections in addition to the common configurations. \nThis should be used by components configuring TLS server connections.\n",
       "allOf": [
         {
           "type": "object",
           "properties": {
             "ca_file": {
               "type": "string",
-              "description": "Path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)"
+              "description": "Path to the CA cert. For a client this verifies the server certificate. \nFor a server this verifies client certificates. If empty uses system root CA. (optional)\n"
             },
             "ca_pem": {
               "type": "string",
@@ -230,18 +230,18 @@
               "items": {
                 "type": "string"
               },
-              "description": "A list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites."
+              "description": "A list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. \nSee https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.\n"
             },
             "curve_preferences": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "Contains the elliptic curves that will be used in an ECDHE handshake, in preference order Defaults to empty list and \"crypto/tls\" defaults are used, internally."
+              "description": "Contains the elliptic curves that will be used in an ECDHE handshake, \nin preference order Defaults to empty list and \"crypto/tls\" defaults are used, internally.\n"
             },
             "include_insecure_cipher_suites": {
               "type": "boolean",
-              "description": "Enables support for insecure cipher suites. When set to true, cipher suites returned by tls.InsecureCipherSuites() will be available for selection in addition to the secure ones. This should only be used when working with legacy systems that require insecure cipher suites. (optional, default false)"
+              "description": "Enables support for insecure cipher suites. When set to true, cipher suites returned by \ntls.InsecureCipherSuites() will be available for selection in addition to the secure ones. \nThis should only be used when working with legacy systems that require insecure cipher suites. \n(optional, default false)\n"
             },
             "include_system_ca_certs_pool": {
               "type": "boolean",
@@ -288,7 +288,7 @@
               "description": "Trusted platform module configuration"
             }
           },
-          "description": "Exposes the common client and server TLS configurations. Note: Since there isn't anything specific to a server connection. Components with server connections should use Config.",
+          "description": "Exposes the common client and server TLS configurations. \nNote: Since there isn''t anything specific to a server connection. Components with server connections should use Config.\n",
           "default": {}
         }
       ]

--- a/config/configtls/generated_config.go
+++ b/config/configtls/generated_config.go
@@ -8,16 +8,25 @@ import (
 	"go.opentelemetry.io/collector/config/configopaque"
 )
 
-// ClientConfig contains TLS configurations that are specific to client connections in addition to the common configurations. This should be used by components configuring TLS client connections.
+// ClientConfig contains TLS configurations that are specific to client connections in addition to the common configurations.
+// This should be used by components configuring TLS client connections.
 type ClientConfig struct {
-	// Exposes the common client and server TLS configurations. Note: Since there isn't anything specific to a server connection. Components with server connections should use Config.
+	// Exposes the common client and server TLS configurations.
+	// Note: Since there isn''t anything specific to a server connection. Components with server connections should use Config.
 	Config `mapstructure:",squash"`
-	// Insecure in gRPC and HTTP when set to true, this is used to disable the client transport security. See https://godoc.org/google.golang.org/grpc#WithInsecure for gRPC. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)
+
+	// Insecure in gRPC and HTTP when set to true, this is used to disable the client transport security.
+	// See https://godoc.org/google.golang.org/grpc#WithInsecure for gRPC.
+	// Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)
 	Insecure bool `mapstructure:"insecure,omitempty"`
+
 	// InsecureSkipVerify enables TLS but not verify the certificate.
 	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify,omitempty"`
-	// ServerName server name requested by client for virtual hosting. This sets the ServerName in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
+
+	// ServerName server name requested by client for virtual hosting. This sets the ServerName in the TLSConfig.
+	// Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
 	ServerName string `mapstructure:"server_name_override,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -29,36 +38,57 @@ func NewDefaultClientConfig() ClientConfig {
 	}
 }
 
-// Config exposes the common client and server TLS configurations. Note: Since there isn't anything specific to a server connection. Components with server connections should use Config.
+// Config exposes the common client and server TLS configurations.
+// Note: Since there isn”t anything specific to a server connection. Components with server connections should use Config.
 type Config struct {
-	// CAFile path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)
+	// CAFile path to the CA cert. For a client this verifies the server certificate.
+	// For a server this verifies client certificates. If empty uses system root CA. (optional)
 	CAFile string `mapstructure:"ca_file,omitempty"`
+
 	// CAPem in memory PEM encoded cert. (optional)
 	CAPem configopaque.String `mapstructure:"ca_pem,omitempty"`
+
 	// CertFile path to the TLS cert to use for TLS required connections. (optional)
 	CertFile string `mapstructure:"cert_file,omitempty"`
+
 	// CertPem in memory PEM encoded TLS cert to use for TLS required connections. (optional)
 	CertPem configopaque.String `mapstructure:"cert_pem,omitempty"`
-	// CipherSuites a list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.
+
+	// CipherSuites a list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used.
+	// See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.
 	CipherSuites []string `mapstructure:"cipher_suites,omitempty"`
-	// CurvePreferences contains the elliptic curves that will be used in an ECDHE handshake, in preference order Defaults to empty list and "crypto/tls" defaults are used, internally.
+
+	// CurvePreferences contains the elliptic curves that will be used in an ECDHE handshake,
+	// in preference order Defaults to empty list and "crypto/tls" defaults are used, internally.
 	CurvePreferences []string `mapstructure:"curve_preferences,omitempty"`
-	// IncludeInsecureCipherSuites enables support for insecure cipher suites. When set to true, cipher suites returned by tls.InsecureCipherSuites() will be available for selection in addition to the secure ones. This should only be used when working with legacy systems that require insecure cipher suites. (optional, default false)
+
+	// IncludeInsecureCipherSuites enables support for insecure cipher suites. When set to true, cipher suites returned by
+	// tls.InsecureCipherSuites() will be available for selection in addition to the secure ones.
+	// This should only be used when working with legacy systems that require insecure cipher suites.
+	// (optional, default false)
 	IncludeInsecureCipherSuites bool `mapstructure:"include_insecure_cipher_suites,omitempty"`
+
 	// IncludeSystemCACertsPool if true, load system CA certificates pool in addition to the certificates configured in this struct.
 	IncludeSystemCACertsPool bool `mapstructure:"include_system_ca_certs_pool,omitempty"`
+
 	// KeyFile path to the TLS key to use for TLS required connections. (optional)
 	KeyFile string `mapstructure:"key_file,omitempty"`
+
 	// KeyPem in memory PEM encoded TLS key to use for TLS required connections. (optional)
 	KeyPem configopaque.String `mapstructure:"key_pem,omitempty"`
+
 	// MaxVersion sets the maximum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)
 	MaxVersion string `mapstructure:"max_version,omitempty"`
+
 	// MinVersion sets the minimum TLS version that is acceptable. If not set, TLS 1.2 will be used. (optional)
 	MinVersion string `mapstructure:"min_version,omitempty"`
+
 	// ReloadInterval specifies the duration after which the certificate will be reloaded If not set, it will never be reloaded (optional)
 	ReloadInterval time.Duration `mapstructure:"reload_interval,omitempty"`
+
 	// TPMConfig trusted platform module configuration
 	TPMConfig TPMConfig `mapstructure:"tpm,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -68,14 +98,21 @@ func NewDefaultConfig() Config {
 	return Config{}
 }
 
-// ServerConfig contains TLS configurations that are specific to server connections in addition to the common configurations. This should be used by components configuring TLS server connections.
+// ServerConfig contains TLS configurations that are specific to server connections in addition to the common configurations.
+// This should be used by components configuring TLS server connections.
 type ServerConfig struct {
-	// Exposes the common client and server TLS configurations. Note: Since there isn't anything specific to a server connection. Components with server connections should use Config.
+	// Exposes the common client and server TLS configurations.
+	// Note: Since there isn''t anything specific to a server connection. Components with server connections should use Config.
 	Config `mapstructure:",squash"`
-	// ClientCAFile path to the TLS cert to use by the server to verify a client certificate. (optional) This sets the ClientCAs and ClientAuth to RequireAndVerifyClientCert in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
+
+	// ClientCAFile path to the TLS cert to use by the server to verify a client certificate. (optional)
+	// This sets the ClientCAs and ClientAuth to RequireAndVerifyClientCert in the TLSConfig.
+	// Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
 	ClientCAFile string `mapstructure:"client_ca_file,omitempty"`
+
 	// ReloadClientCAFile reload the ClientCAs file when it is modified (optional, default false)
 	ReloadClientCAFile bool `mapstructure:"client_ca_file_reload,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -89,11 +126,15 @@ func NewDefaultServerConfig() ServerConfig {
 
 // TPMConfig defines trusted platform module configuration for storing TLS keys.
 type TPMConfig struct {
-	Auth      string `mapstructure:"auth,omitempty"`
-	Enabled   bool   `mapstructure:"enabled,omitempty"`
+	Auth string `mapstructure:"auth,omitempty"`
+
+	Enabled bool `mapstructure:"enabled,omitempty"`
+
 	OwnerAuth string `mapstructure:"owner_auth,omitempty"`
+
 	// Path the path to the TPM device or Unix domain socket. For instance /dev/tpm0 or /dev/tpmrm0.
 	Path string `mapstructure:"path,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/config/configtls/metadata.yaml
+++ b/config/configtls/metadata.yaml
@@ -8,16 +8,23 @@ status:
 
 exported_configs:
   client_config:
-    description: Contains TLS configurations that are specific to client connections in addition to the common configurations. This should be used by components configuring TLS client connections.
+    description: |
+      Contains TLS configurations that are specific to client connections in addition to the common configurations. 
+      This should be used by components configuring TLS client connections.
     properties:
       insecure:
-        description: In gRPC and HTTP when set to true, this is used to disable the client transport security. See https://godoc.org/google.golang.org/grpc#WithInsecure for gRPC. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)
+        description: |
+          In gRPC and HTTP when set to true, this is used to disable the client transport security. 
+          See https://godoc.org/google.golang.org/grpc#WithInsecure for gRPC. 
+          Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)
         type: bool
       insecure_skip_verify:
         description: Enables TLS but not verify the certificate.
         type: bool
       server_name_override:
-        description: Server name requested by client for virtual hosting. This sets the ServerName in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
+        description: |
+          Server name requested by client for virtual hosting. This sets the ServerName in the TLSConfig. 
+          Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
         type: string
         go_struct:
           field_name: ServerName
@@ -27,10 +34,14 @@ exported_configs:
         go_struct:
           anonymous: true
   config:
-    description: 'Exposes the common client and server TLS configurations. Note: Since there isn''t anything specific to a server connection. Components with server connections should use Config.'
+    description: | 
+      Exposes the common client and server TLS configurations. 
+      Note: Since there isn''t anything specific to a server connection. Components with server connections should use Config.
     properties:
       ca_file:
-        description: Path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)
+        description: |
+          Path to the CA cert. For a client this verifies the server certificate. 
+          For a server this verifies client certificates. If empty uses system root CA. (optional)
         type: string
       ca_pem:
         description: In memory PEM encoded cert. (optional)
@@ -42,15 +53,23 @@ exported_configs:
         description: In memory PEM encoded TLS cert to use for TLS required connections. (optional)
         type: opaque_string
       cipher_suites:
-        description: A list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.
+        description: |
+          A list of TLS cipher suites that the TLS transport can use. If left blank, a safe default list is used. 
+          See https://go.dev/src/crypto/tls/cipher_suites.go for a list of supported cipher suites.
         type: slice
         values:
           type: string
       include_insecure_cipher_suites:
-        description: Enables support for insecure cipher suites. When set to true, cipher suites returned by tls.InsecureCipherSuites() will be available for selection in addition to the secure ones. This should only be used when working with legacy systems that require insecure cipher suites. (optional, default false)
+        description: |
+          Enables support for insecure cipher suites. When set to true, cipher suites returned by 
+          tls.InsecureCipherSuites() will be available for selection in addition to the secure ones. 
+          This should only be used when working with legacy systems that require insecure cipher suites. 
+          (optional, default false)
         type: bool
       curve_preferences:
-        description: Contains the elliptic curves that will be used in an ECDHE handshake, in preference order Defaults to empty list and "crypto/tls" defaults are used, internally.
+        description: | 
+          Contains the elliptic curves that will be used in an ECDHE handshake, 
+          in preference order Defaults to empty list and "crypto/tls" defaults are used, internally.
         type: slice
         values:
           type: string
@@ -79,10 +98,15 @@ exported_configs:
           field_name: TPMConfig
     default: {}
   server_config:
-    description: Contains TLS configurations that are specific to server connections in addition to the common configurations. This should be used by components configuring TLS server connections.
+    description: | 
+      Contains TLS configurations that are specific to server connections in addition to the common configurations. 
+      This should be used by components configuring TLS server connections.
     properties:
       client_ca_file:
-        description: Path to the TLS cert to use by the server to verify a client certificate. (optional) This sets the ClientCAs and ClientAuth to RequireAndVerifyClientCert in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
+        description: | 
+          Path to the TLS cert to use by the server to verify a client certificate. (optional) 
+          This sets the ClientCAs and ClientAuth to RequireAndVerifyClientCert in the TLSConfig. 
+          Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)
         type: string
       client_ca_file_reload:
         description: Reload the ClientCAs file when it is modified (optional, default false)

--- a/exporter/exporterhelper/internal/generated_config.go
+++ b/exporter/exporterhelper/internal/generated_config.go
@@ -11,6 +11,7 @@ import (
 type TimeoutConfig struct {
 	// Timeout defines the timeout for every attempt to send data to the backend. A zero timeout means no timeout.
 	Timeout time.Duration `mapstructure:"timeout"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/scraper/scraperhelper/internal/controller/generated_config.go
+++ b/scraper/scraperhelper/internal/controller/generated_config.go
@@ -11,10 +11,13 @@ import (
 type ControllerConfig struct {
 	// CollectionInterval sets how frequently the scraper is scheduled.
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+
 	// InitialDelay sets the initial start delay for the scraper, any non positive value is assumed to be immediately.
 	InitialDelay time.Duration `mapstructure:"initial_delay"`
+
 	// Timeout an optional value used to set scraper's context deadline.
 	Timeout time.Duration `mapstructure:"timeout"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Added two readability improvements for doc comments in go config files generated by `mdatagen`:
1. Allow multiline comments
2. Add empty line between struct fields

Follow up to [#15706](https://github.com/open-telemetry/opentelemetry-collector/pull/15706#discussion_r3916461664)

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Regenerated configs for sample components and already migrated core types.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
