### PR TITLE
[chore] Remove usages of x<kind>.Factory on public return types

### DIFF
--- a/cmd/mdatagen/internal/sampleentityreceiver/factory.go
+++ b/cmd/mdatagen/internal/sampleentityreceiver/factory.go
@@ -10,15 +10,14 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
-	"go.opentelemetry.io/collector/receiver/xreceiver"
 )
 
 // NewFactory returns a receiver.Factory for sample entity receiver.
-func NewFactory() xreceiver.Factory {
-	return xreceiver.NewFactory(
+func NewFactory() receiver.Factory {
+	return receiver.NewFactory(
 		metadata.Type,
 		func() component.Config { return &struct{}{} },
-		xreceiver.WithMetrics(createMetrics, metadata.MetricsStability),
+		receiver.WithMetrics(createMetrics, metadata.MetricsStability),
 	)
 }
 

--- a/cmd/mdatagen/internal/samplefactoryreceiver/factory.go
+++ b/cmd/mdatagen/internal/samplefactoryreceiver/factory.go
@@ -19,7 +19,7 @@ import (
 )
 
 // NewFactory returns a receiver.Factory for sample receiver.
-func NewFactory() xreceiver.Factory {
+func NewFactory() receiver.Factory {
 	return xreceiver.NewFactory(
 		metadata.Type,
 		func() component.Config { return &struct{}{} },

--- a/cmd/mdatagen/internal/samplereceiver/factory.go
+++ b/cmd/mdatagen/internal/samplereceiver/factory.go
@@ -17,7 +17,7 @@ import (
 )
 
 // NewFactory returns a receiver.Factory for sample receiver.
-func NewFactory() xreceiver.Factory {
+func NewFactory() receiver.Factory {
 	return xreceiver.NewFactory(
 		metadata.Type,
 		createDefaultConfig,

--- a/connector/forwardconnector/forward.go
+++ b/connector/forwardconnector/forward.go
@@ -15,7 +15,7 @@ import (
 )
 
 // NewFactory returns a connector.Factory.
-func NewFactory() xconnector.Factory {
+func NewFactory() connector.Factory {
 	return xconnector.NewFactory(
 		metadata.Type,
 		createDefaultConfig,

--- a/connector/forwardconnector/forward_test.go
+++ b/connector/forwardconnector/forward_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/connector/connectortest"
+	"go.opentelemetry.io/collector/connector/xconnector"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -43,7 +44,7 @@ func TestForward(t *testing.T) {
 	assert.NotNil(t, logsToLogs)
 
 	profilesSink := new(consumertest.ProfilesSink)
-	profilesToProfiles, err := f.CreateProfilesToProfiles(ctx, set, cfg, profilesSink)
+	profilesToProfiles, err := f.(xconnector.Factory).CreateProfilesToProfiles(ctx, set, cfg, profilesSink)
 	require.NoError(t, err)
 	assert.NotNil(t, profilesToProfiles)
 

--- a/processor/memorylimiterprocessor/factory.go
+++ b/processor/memorylimiterprocessor/factory.go
@@ -31,7 +31,7 @@ type factory struct {
 }
 
 // NewFactory returns a new factory for the Memory Limiter processor.
-func NewFactory() xprocessor.Factory {
+func NewFactory() processor.Factory {
 	f := &factory{
 		memoryLimiters: map[component.Config]*memoryLimiterProcessor{},
 	}

--- a/processor/memorylimiterprocessor/factory_test.go
+++ b/processor/memorylimiterprocessor/factory_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/internal/telemetry"
 	"go.opentelemetry.io/collector/internal/telemetry/telemetrytest"
 	"go.opentelemetry.io/collector/processor/processortest"
+	"go.opentelemetry.io/collector/processor/xprocessor"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -60,7 +61,7 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NotNil(t, lp)
 	require.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))
 
-	pp, err := factory.CreateProfiles(context.Background(), set, cfg, consumertest.NewNop())
+	pp, err := factory.(xprocessor.Factory).CreateProfiles(context.Background(), set, cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.NotNil(t, pp)
 	require.NoError(t, pp.Start(context.Background(), componenttest.NewNopHost()))

--- a/receiver/nopreceiver/nop_receiver.go
+++ b/receiver/nopreceiver/nop_receiver.go
@@ -15,7 +15,7 @@ import (
 )
 
 // NewFactory returns a receiver.Factory that constructs nop receivers.
-func NewFactory() xreceiver.Factory {
+func NewFactory() receiver.Factory {
 	return xreceiver.NewFactory(
 		metadata.Type,
 		func() component.Config { return &struct{}{} },

--- a/receiver/nopreceiver/nop_receiver_test.go
+++ b/receiver/nopreceiver/nop_receiver_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.opentelemetry.io/collector/receiver/xreceiver"
 )
 
 func TestNewNopFactory(t *testing.T) {
@@ -38,7 +39,7 @@ func TestNewNopFactory(t *testing.T) {
 	assert.NoError(t, logs.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, logs.Shutdown(context.Background()))
 
-	profiles, err := factory.CreateProfiles(context.Background(), receivertest.NewNopSettings(receivertest.NopType), cfg, consumertest.NewNop())
+	profiles, err := factory.(xreceiver.Factory).CreateProfiles(context.Background(), receivertest.NewNopSettings(receivertest.NopType), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.NoError(t, profiles.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, profiles.Shutdown(context.Background()))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Removes uses of `xreceiver.Factory` and similar on public return types.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
