### PR TITLE
[chore][cmd/mdatagen] Fix custom validators in go configs generated by mdatagen

### DIFF
--- a/cmd/mdatagen/internal/cfggen/generation.go
+++ b/cmd/mdatagen/internal/cfggen/generation.go
@@ -573,11 +573,11 @@ func collectValidators(md *ConfigMetadata, validators *[]Validator) {
 
 		if prop.GoStruct.CustomValidator != nil {
 			*validators = append(*validators, Validator{
-				FieldName:       propName,
+				FieldName:       fieldName,
 				FieldType:       resolveType(prop),
 				IsPointer:       prop.IsPointer,
 				IsOptional:      prop.IsOptional,
-				CustomValidator: generateValidatorName(propName, prop.GoStruct.CustomValidator),
+				CustomValidator: generateValidatorName(fieldName, prop.GoStruct.CustomValidator),
 			})
 		}
 	}

--- a/cmd/mdatagen/internal/samplescraper/config_custom.go
+++ b/cmd/mdatagen/internal/samplescraper/config_custom.go
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package samplescraper // import "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplescraper"
+import "go.opentelemetry.io/collector/component"
 
 func validateJobName(_ string) error {
+	return nil
+}
+
+func validateComponentID(_ component.ID) error {
 	return nil
 }

--- a/cmd/mdatagen/internal/samplescraper/generated_config.go
+++ b/cmd/mdatagen/internal/samplescraper/generated_config.go
@@ -91,6 +91,10 @@ type Config struct {
 func (c *Config) Validate() error {
 	var err error
 
+	if inner_err := validateComponentID(c.ComponentID); inner_err != nil {
+		err = errors.Join(err, inner_err)
+	}
+
 	if c.JobName == "" {
 		err = errors.Join(err, errors.New("job_name is required"))
 	}

--- a/cmd/mdatagen/internal/samplescraper/metadata.yaml
+++ b/cmd/mdatagen/internal/samplescraper/metadata.yaml
@@ -44,6 +44,7 @@ config:
       description: Identifies the scraper, used for telemetry and logging.
       go_struct:
         field_name: ComponentID
+        custom_validator:
     job_name:
       description: Name of the scrape job, used to identify the source in telemetry.
       type: string


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes issue with custom validators in go configs generated by mdatagen. When field name is also custom it should use it to pass a property value to custom function.

**Example**

For definition:
```yaml
    component:
      type: component_id
      go_struct:
        field_name: ComponentID
        custom_validator:
```

if should generated following validator:
```go
func (c *Config) Validate() error {
  var err error

  if inner_err := validateComponentID(c.ComponentID); inner_err != nil {
    err = errors.Join(err, inner_err)
  }

  return err
```

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added example in `samplescraper` component.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
