### PR TITLE
[exporterhelper] Add `fast_track` support for persistent sending queues

### DIFF
--- a/.chloggen/exporterhelper-fast-track.yaml
+++ b/.chloggen/exporterhelper-fast-track.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `fast_track` option to bypass persistent queue when consumers are available
+
+# One or more tracking issues or pull requests related to the change
+issues: [13355]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `fast_track` is enabled on a persistent queue, incoming requests are exported directly
+  in-memory when a consumer slot is immediately available, bypassing the disk round-trip.
+  When all consumer slots are busy, requests fall back to the persistent queue as usual.
+  Durability is maintained by blocking the caller until export completes (wait-for-result semantics).
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -42,6 +42,13 @@ type Config struct {
 	// This applies across all different optional configurations from above (e.g. wait_for_result, block_on_overflow, storage, etc.).
 	NumConsumers int `mapstructure:"num_consumers"`
 
+	// FastTrack determines whether the component tries to export data directly before falling back to
+	// the queue. When a consumer slot is immediately available, the request is exported in-memory on
+	// the caller's goroutine, bypassing the persistent queue entirely. When all consumer slots are busy,
+	// the request is enqueued normally via the persistent queue.
+	// This option is only supported when a persistent queue is configured with storage.
+	FastTrack bool `mapstructure:"fast_track"`
+
 	// BatchConfig it configures how the requests are consumed from the queue and batch together during consumption.
 	Batch configoptional.Optional[BatchConfig] `mapstructure:"batch"`
 }
@@ -76,6 +83,14 @@ func (cfg *Config) Validate() error {
 	// Only support request sizer for persistent queue at this moment.
 	if cfg.StorageID != nil && cfg.WaitForResult {
 		return errors.New("`wait_for_result` is not supported with a persistent queue configured with `storage`")
+	}
+
+	if cfg.FastTrack && cfg.StorageID == nil {
+		return errors.New("`fast_track` is only supported with a persistent queue configured with `storage`")
+	}
+
+	if cfg.FastTrack && cfg.WaitForResult {
+		return errors.New("`fast_track` and `wait_for_result` are mutually exclusive")
 	}
 
 	if cfg.Batch.HasValue() && cfg.Batch.Get().Sizer == cfg.Sizer {

--- a/exporter/exporterhelper/internal/queuebatch/config.go
+++ b/exporter/exporterhelper/internal/queuebatch/config.go
@@ -89,10 +89,6 @@ func (cfg *Config) Validate() error {
 		return errors.New("`fast_track` is only supported with a persistent queue configured with `storage`")
 	}
 
-	if cfg.FastTrack && cfg.WaitForResult {
-		return errors.New("`fast_track` and `wait_for_result` are mutually exclusive")
-	}
-
 	if cfg.Batch.HasValue() && cfg.Batch.Get().Sizer == cfg.Sizer {
 		// Avoid situations where the queue is not able to hold any data.
 		if cfg.Batch.Get().MinSize > cfg.QueueSize {

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -50,6 +50,27 @@ func TestConfig_Validate(t *testing.T) {
 	cfg = newTestConfig()
 	cfg.Sizer = request.SizerTypeBytes
 	require.NoError(t, confmap.Validate(cfg))
+
+	cfg = newTestConfig()
+	cfg.FastTrack = true
+	require.EqualError(t, confmap.Validate(cfg), "`fast_track` is only supported with a persistent queue configured with `storage`")
+
+	cfg = newTestConfig()
+	cfg.FastTrack = true
+	cfg.StorageID = &storageID
+	require.NoError(t, confmap.Validate(cfg))
+
+	cfg = newTestConfig()
+	cfg.FastTrack = true
+	cfg.WaitForResult = true
+	cfg.StorageID = &storageID
+	require.EqualError(t, confmap.Validate(cfg), "`wait_for_result` is not supported with a persistent queue configured with `storage`")
+
+	// FastTrack without StorageID fails before the mutual exclusion check with WaitForResult.
+	cfg = newTestConfig()
+	cfg.FastTrack = true
+	cfg.WaitForResult = true
+	require.EqualError(t, confmap.Validate(cfg), "`fast_track` is only supported with a persistent queue configured with `storage`")
 }
 
 func TestBatchConfig_Validate_MetadataKeys(t *testing.T) {

--- a/exporter/exporterhelper/internal/queuebatch/config_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/config_test.go
@@ -60,17 +60,6 @@ func TestConfig_Validate(t *testing.T) {
 	cfg.StorageID = &storageID
 	require.NoError(t, confmap.Validate(cfg))
 
-	cfg = newTestConfig()
-	cfg.FastTrack = true
-	cfg.WaitForResult = true
-	cfg.StorageID = &storageID
-	require.EqualError(t, confmap.Validate(cfg), "`wait_for_result` is not supported with a persistent queue configured with `storage`")
-
-	// FastTrack without StorageID fails before the mutual exclusion check with WaitForResult.
-	cfg = newTestConfig()
-	cfg.FastTrack = true
-	cfg.WaitForResult = true
-	require.EqualError(t, confmap.Validate(cfg), "`fast_track` is only supported with a persistent queue configured with `storage`")
 }
 
 func TestBatchConfig_Validate_MetadataKeys(t *testing.T) {

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch.go
@@ -31,8 +31,11 @@ type AllSettings[T any] struct {
 }
 
 type QueueBatch struct {
-	queue   queue.Queue[request.Request]
-	batcher Batcher[request.Request]
+	queue      queue.Queue[request.Request]
+	batcher    Batcher[request.Request]
+	fastTrack  bool
+	directSem  chan struct{}
+	exportFunc sender.SendFunc[request.Request]
 }
 
 func NewQueueBatch(
@@ -73,7 +76,13 @@ func NewQueueBatch(
 		return nil, err
 	}
 
-	return &QueueBatch{queue: q, batcher: b}, nil
+	qb := &QueueBatch{queue: q, batcher: b}
+	if cfg.FastTrack {
+		qb.fastTrack = true
+		qb.directSem = make(chan struct{}, cfg.NumConsumers)
+		qb.exportFunc = next
+	}
+	return qb, nil
 }
 
 // Start is invoked during service startup.
@@ -95,6 +104,18 @@ func (qs *QueueBatch) Shutdown(ctx context.Context) error {
 }
 
 // Send implements the requestSender interface. It puts the request in the queue.
+// When FastTrack is enabled, it first attempts to export directly if a consumer slot
+// is available, bypassing the persistent queue. If all slots are busy, it falls back
+// to the queue.
 func (qs *QueueBatch) Send(ctx context.Context, req request.Request) error {
+	if qs.fastTrack {
+		select {
+		case qs.directSem <- struct{}{}:
+			defer func() { <-qs.directSem }()
+			return qs.exportFunc(ctx, req)
+		default:
+			// all consumer slots busy, fall through to queue.
+		}
+	}
 	return qs.queue.Offer(ctx, req)
 }

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch.go
@@ -43,10 +43,25 @@ func NewQueueBatch(
 	cfg Config,
 	next sender.SendFunc[request.Request],
 ) (*QueueBatch, error) {
+	qb := &QueueBatch{}
+
+	exportFunc := next
+	if cfg.FastTrack {
+		qb.fastTrack = true
+		qb.directSem = make(chan struct{}, cfg.NumConsumers)
+		qb.exportFunc = next
+		// Wrap the export function so queue consumers also acquire a slot from the shared semaphore.
+		exportFunc = func(ctx context.Context, req request.Request) error {
+			qb.directSem <- struct{}{}
+			defer func() { <-qb.directSem }()
+			return next(ctx, req)
+		}
+	}
+
 	b, err := NewBatcher(cfg.Batch, batcherSettings[request.Request]{
 		partitioner: set.Partitioner,
 		mergeCtx:    set.MergeCtx,
-		next:        next,
+		next:        exportFunc,
 		maxWorkers:  cfg.NumConsumers,
 		logger:      set.Telemetry.Logger,
 	})
@@ -76,12 +91,8 @@ func NewQueueBatch(
 		return nil, err
 	}
 
-	qb := &QueueBatch{queue: q, batcher: b}
-	if cfg.FastTrack {
-		qb.fastTrack = true
-		qb.directSem = make(chan struct{}, cfg.NumConsumers)
-		qb.exportFunc = next
-	}
+	qb.queue = q
+	qb.batcher = b
 	return qb, nil
 }
 

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch_test.go
@@ -599,6 +599,77 @@ func TestQueueBatchTimerFlush(t *testing.T) {
 	require.NoError(t, qb.Shutdown(context.Background()))
 }
 
+func TestQueueBatch_FastTrack_ConsumerAvailable(t *testing.T) {
+	sink := requesttest.NewSink()
+	storageID := component.MustNewIDWithName("file_storage", "storage")
+	cfg := newTestConfig()
+	cfg.StorageID = &storageID
+	cfg.FastTrack = true
+	cfg.NumConsumers = 4
+	cfg.Batch = configoptional.Optional[BatchConfig]{}
+	qb, err := NewQueueBatch(newFakeRequestSettings(), cfg, sink.Export)
+	require.NoError(t, err)
+
+	host := hosttest.NewHost(map[component.ID]component.Component{
+		storageID: storagetest.NewMockStorageExtension(nil),
+	})
+	require.NoError(t, qb.Start(context.Background(), host))
+
+	// send requests when consumers are available and must go the direct path.
+	for range 4 {
+		require.NoError(t, qb.Send(context.Background(), &requesttest.FakeRequest{Items: 10}))
+	}
+
+	// Direct path is synchronous, so all requests should be exported immediately.
+	assert.Equal(t, 4, sink.RequestsCount())
+	assert.Equal(t, 40, sink.ItemsCount())
+	// nothing should have been enqueued to the persistent queue.
+	assert.Zero(t, qb.queue.Size())
+
+	require.NoError(t, qb.Shutdown(context.Background()))
+}
+
+func TestQueueBatch_FastTrack_ConsumerBusy(t *testing.T) {
+	sink := requesttest.NewSink()
+	storageID := component.MustNewIDWithName("file_storage", "storage")
+	cfg := newTestConfig()
+	cfg.StorageID = &storageID
+	cfg.FastTrack = true
+	cfg.NumConsumers = 2
+	cfg.Batch = configoptional.Optional[BatchConfig]{}
+
+	// set up encoding to deserialize requests with 7 items, matching the queued request.
+	queuedReq := &requesttest.FakeRequest{Items: 7}
+	qSet := newFakeRequestSettings()
+	qSet.Encoding = newFakeEncoding(queuedReq)
+	qb, err := NewQueueBatch(qSet, cfg, sink.Export)
+	require.NoError(t, err)
+
+	host := hosttest.NewHost(map[component.ID]component.Component{
+		storageID: storagetest.NewMockStorageExtension(nil),
+	})
+	require.NoError(t, qb.Start(context.Background(), host))
+
+	wg := sync.WaitGroup{}
+	for range 2 {
+		wg.Go(func() {
+			assert.NoError(t, qb.Send(context.Background(), &requesttest.FakeRequest{Items: 5, Delay: 200 * time.Millisecond}))
+		})
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	require.NoError(t, qb.Send(context.Background(), &requesttest.FakeRequest{Items: 7}))
+	assert.Greater(t, qb.queue.Size(), int64(0))
+
+	wg.Wait()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 3, sink.RequestsCount())
+		assert.Equal(c, 17, sink.ItemsCount())
+	}, 1*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, qb.Shutdown(context.Background()))
+}
+
 func newTestConfig() Config {
 	return Config{
 		WaitForResult:   false,

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch_test.go
@@ -659,7 +659,7 @@ func TestQueueBatch_FastTrack_ConsumerBusy(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	require.NoError(t, qb.Send(context.Background(), &requesttest.FakeRequest{Items: 7}))
-	assert.Greater(t, qb.queue.Size(), int64(0))
+	assert.Positive(t, qb.queue.Size())
 
 	wg.Wait()
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR add support for support for `fast_track` requests when a persistent sending queue is configured.

for now requests are always written to and read from persistent storage before being consumed, even when a queue consumer is immediately available. This introduces unnecessary storage i/o and serialization overhead when the exporter is able to keep up with incoming data(mentioned in the issue). 
the new code changes adds an opt-in fast-track path that sends a request directly to an available consumer. When no consumer is immediately available, the request falls back to the configured persistent queue as usual (default behavior).

NOTE: The existing behavior remains unchanged when `fast_track` is false.

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #13355 

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
