### PR TITLE
test: add coverage for multiple --config flags resolution

### DIFF
--- a/otelcol/command_test.go
+++ b/otelcol/command_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -68,12 +69,37 @@ func TestAddFlagToSettings(t *testing.T) {
 		},
 	}
 	flgs := flags(featuregate.NewRegistry())
-	err := flgs.Parse([]string{"--config=otelcol-nop.yaml"})
+	err := flgs.Parse([]string{"--config=a.yaml", "--config=b.yaml"})
 	require.NoError(t, err)
 
 	err = updateSettingsUsingFlags(&set, flgs)
 	require.NoError(t, err)
-	require.Len(t, set.ConfigProviderSettings.ResolverSettings.URIs, 1)
+	require.Equal(t, []string{"a.yaml", "b.yaml"}, set.ConfigProviderSettings.ResolverSettings.URIs)
+}
+
+func TestNewCommandMultipleConfigs(t *testing.T) {
+	fileProvider := newFakeProvider("file", func(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
+		path := strings.TrimPrefix(uri, "file:")
+		return confmap.NewRetrieved(newConfFromFile(t, path))
+	})
+	set := CollectorSettings{
+		Factories: nopFactories,
+		ConfigProviderSettings: ConfigProviderSettings{
+			ResolverSettings: confmap.ResolverSettings{
+				ProviderFactories: []confmap.ProviderFactory{fileProvider},
+				DefaultScheme:     "file",
+			},
+		},
+	}
+	cmd := NewCommand(set)
+	otelRunE := cmd.RunE
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		require.NoError(t, c.Flag("config").Value.Set(filepath.Join("testdata", "otelcol-nop.yaml")))
+		require.NoError(t, c.Flag("config").Value.Set(filepath.Join("testdata", "otelcol-invalid.yaml")))
+
+		return otelRunE(cmd, args)
+	}
+	require.ErrorContains(t, cmd.Execute(), "references processor \"invalid\" which is not configured")
 }
 
 func TestInvalidCollectorSettings(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds test coverage for passing multiple --config flags to the Collector command and verifies that the resulting configuration is resolved correctly.

This ensures the command path correctly handles multiple configuration URIs and helps prevent regressions in multi-config resolution.

#### Link to tracking issue
Fixes #

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added TestNewCommandMultipleConfigs to verify multiple --config values through the Collector command.

Tests were run with:
```
go test -v -run TestNewCommandMultipleConfigs
go test -v -run TestAddFlagToSettings
```


<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
