### PR TITLE
[chore] parallelize windows unittests

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           & ${{ github.workspace }}\.github\workflows\scripts\win-required-ports.ps1
       - name: Run Unit Tests
-        run: make gotest
+        run: make -j4 gotest
 
   windows-service-test:
     strategy:


### PR DESCRIPTION
#### Description

Windows runners have 4 cores, test out parallelizing the unit tests as is done on other operating systems.


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
