### PR TITLE
[chore][cmd/mdatagen] Adds `check-stability` subcommand

### DIFF
--- a/.mdatagen.yaml
+++ b/.mdatagen.yaml
@@ -34,3 +34,8 @@ exclusions:
       - name: telemetry.newPipelineTelemetry
         validation:
           enabled: false
+
+stability:
+  coverage:
+    beta: 35
+    stable: 80

--- a/cmd/mdatagen/README.md
+++ b/cmd/mdatagen/README.md
@@ -64,6 +64,21 @@ You can run `cd cmd/mdatagen && $(GOCMD) install .` to install the `mdatagen` to
 
 This is used for skipping validation and configuring project-level hooks.
 
+### Stability
+
+`mdatagen check-stability --profile <coverage profile> metadata.yaml` checks a component against the stability criteria.
+
+#### Code coverage targets
+
+The `stability` section sets a minimum coverage target per stability level:
+
+```yaml
+stability:
+  coverage:
+    beta: 60
+    stable: 80
+```
+
 ### Component Config Documentation
 
 The metadata generator supports automatic generation of configuration schemas for components.

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -47,6 +47,7 @@ require (
 	go.uber.org/zap v1.28.0
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/text v0.41.0
+	golang.org/x/tools v0.49.0
 )
 
 require (
@@ -80,7 +81,6 @@ require (
 	golang.org/x/mod v0.41.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.48.0 // indirect
-	golang.org/x/tools v0.49.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/grpc v1.83.2 // indirect
 	google.golang.org/protobuf v1.36.12 // indirect

--- a/cmd/mdatagen/internal/command.go
+++ b/cmd/mdatagen/internal/command.go
@@ -72,7 +72,43 @@ func NewCommand() (*cobra.Command, error) {
 			return run(args[0])
 		},
 	}
+
+	var profile string
+	checkStabilityCmd := &cobra.Command{
+		Use:          "check-stability",
+		Short:        "Check a component fulfills stability criteria",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runCheckStability(args[0], profile)
+		},
+	}
+	checkStabilityCmd.Flags().StringVar(&profile, "profile", "", "path to a Go coverage profile")
+	if err := checkStabilityCmd.MarkFlagRequired("profile"); err != nil {
+		return nil, err
+	}
+	rootCmd.AddCommand(checkStabilityCmd)
+
 	return rootCmd, nil
+}
+
+func runCheckStability(ymlPath, profilePath string) error {
+	ymlPath, err := filepath.Abs(ymlPath)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path for %v: %w", ymlPath, err)
+	}
+
+	md, err := LoadMetadata(ymlPath)
+	if err != nil {
+		return fmt.Errorf("failed loading %v: %w", ymlPath, err)
+	}
+
+	central, err := loadCentralConfig(filepath.Dir(ymlPath))
+	if err != nil {
+		return fmt.Errorf("unable to load central mdatagen config: %w", err)
+	}
+
+	return checkCoverage(md, central.Stability.Coverage, profilePath)
 }
 
 func run(ymlPath string) error {

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -59,6 +59,55 @@ func TestCommandErrorOutputOnce(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(out, msg), out)
 }
 
+func TestCheckStability(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "checkstabilitytest")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module checkstabilitytest\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "component.go"), []byte("package checkstabilitytest\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "metadata.yaml"), []byte(`type: sample
+status:
+  class: receiver
+  stability:
+    stable: [metrics]
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, centralConfigFileName), []byte("stability:\n  coverage:\n    stable: 80\n"), 0o600))
+	metadataFile := filepath.Join(dir, "metadata.yaml")
+
+	t.Run("passes above target", func(t *testing.T) {
+		profile := filepath.Join(dir, "cover_high.out")
+		require.NoError(t, os.WriteFile(profile, []byte("mode: atomic\ncheckstabilitytest/foo.go:1.1,10.2 8 1\n"), 0o600))
+
+		cmd, err := NewCommand()
+		require.NoError(t, err)
+		cmd.SetArgs([]string{"check-stability", "--profile", profile, metadataFile})
+		require.NoError(t, cmd.Execute())
+	})
+
+	t.Run("fails below target", func(t *testing.T) {
+		profile := filepath.Join(dir, "cover_low.out")
+		require.NoError(t, os.WriteFile(profile, []byte("mode: atomic\ncheckstabilitytest/foo.go:1.1,10.2 8 0\n"), 0o600))
+
+		cmd, err := NewCommand()
+		require.NoError(t, err)
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs([]string{"check-stability", "--profile", profile, metadataFile})
+		err = cmd.Execute()
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "below the 80% target")
+	})
+
+	t.Run("requires --profile", func(t *testing.T) {
+		cmd, err := NewCommand()
+		require.NoError(t, err)
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs([]string{"check-stability", metadataFile})
+		require.Error(t, cmd.Execute())
+	})
+}
+
 func TestRunContents(t *testing.T) {
 	tests := []struct {
 		yml                             string

--- a/cmd/mdatagen/internal/command_test.go
+++ b/cmd/mdatagen/internal/command_test.go
@@ -95,7 +95,7 @@ status:
 		cmd.SetArgs([]string{"check-stability", "--profile", profile, metadataFile})
 		err = cmd.Execute()
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "below the 80% target")
+		assert.ErrorContains(t, err, "below the 80.0% target")
 	})
 
 	t.Run("requires --profile", func(t *testing.T) {

--- a/cmd/mdatagen/internal/config.go
+++ b/cmd/mdatagen/internal/config.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 
 	"go.yaml.in/yaml/v3"
+
+	"go.opentelemetry.io/collector/component"
 )
 
 const centralConfigFileName = ".mdatagen.yaml"
@@ -20,6 +22,12 @@ const centralConfigFileName = ".mdatagen.yaml"
 // CentralConfig is the repository-level configuration for mdatagen.
 type CentralConfig struct {
 	Exclusions []ComponentExclusion `yaml:"exclusions"`
+	Stability  StabilityConfig      `yaml:"stability"`
+}
+
+type StabilityConfig struct {
+	// Coverage maps a stability level to the minimum required component coverage.
+	Coverage map[component.StabilityLevel]float64 `yaml:"coverage"`
 }
 
 type ComponentExclusion struct {

--- a/cmd/mdatagen/internal/config_test.go
+++ b/cmd/mdatagen/internal/config_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
 )
 
 // captureWarnings redirects warnings to a buffer for the test.
@@ -84,6 +86,32 @@ exclusions:
 				},
 			},
 		}, cfg)
+	})
+
+	t.Run("coverage targets are parsed", func(t *testing.T) {
+		dir := t.TempDir()
+		contents := "stability:\n  coverage:\n    beta: 60\n    stable: 80\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, centralConfigFileName), []byte(contents), 0o600))
+
+		cfg, err := loadCentralConfig(dir)
+		require.NoError(t, err)
+		assert.Equal(t, &CentralConfig{
+			Stability: StabilityConfig{
+				Coverage: map[component.StabilityLevel]float64{
+					component.StabilityLevelBeta:   60,
+					component.StabilityLevelStable: 80,
+				},
+			},
+		}, cfg)
+	})
+
+	t.Run("unknown stability level is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, centralConfigFileName), []byte("stability:\n  coverage:\n    stabel: 80\n"), 0o600))
+
+		_, err := loadCentralConfig(dir)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `unsupported stability level: "stabel"`)
 	})
 
 	t.Run("unknown field is rejected", func(t *testing.T) {

--- a/cmd/mdatagen/internal/coverage.go
+++ b/cmd/mdatagen/internal/coverage.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/cmd/mdatagen/internal"
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"golang.org/x/tools/cover"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+func highestStability(ms StabilityMap) component.StabilityLevel {
+	if len(ms) == 0 {
+		return component.StabilityLevelUndefined
+	}
+	return slices.Max(slices.Collect(maps.Keys(ms)))
+}
+
+// checkCoverage in profilePath and error if it is below the target for its highest stability level.
+func checkCoverage(md Metadata, targets map[component.StabilityLevel]float64, profilePath string) error {
+	if md.Status == nil || slices.Contains(nonComponents, md.Status.Class) {
+		return nil
+	}
+
+	level := highestStability(md.Status.Stability)
+	target, ok := targets[level]
+	if !ok {
+		return nil
+	}
+
+	profiles, err := cover.ParseProfiles(profilePath)
+	if err != nil {
+		return fmt.Errorf("failed parsing coverage profile %v: %w", profilePath, err)
+	}
+
+	// Same as:
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/cmd/cover/func.go;l=149
+	prefix := md.PackageName + "/"
+	var covered, total int64
+	for _, p := range profiles {
+		if p.FileName != md.PackageName && !strings.HasPrefix(p.FileName, prefix) {
+			continue
+		}
+		for _, b := range p.Blocks {
+			total += int64(b.NumStmt)
+			if b.Count > 0 {
+				covered += int64(b.NumStmt)
+			}
+		}
+	}
+	if total == 0 {
+		return fmt.Errorf("no coverage data for %v in %v", md.PackageName, profilePath)
+	}
+
+	pct := 100 * float64(covered) / float64(total)
+	if pct < target {
+		return fmt.Errorf("coverage %.1f%% for %v is below the %v%% target for %v", pct, md.PackageName, target, level)
+	}
+	return nil
+}

--- a/cmd/mdatagen/internal/coverage.go
+++ b/cmd/mdatagen/internal/coverage.go
@@ -59,7 +59,7 @@ func checkCoverage(md Metadata, targets map[component.StabilityLevel]float64, pr
 
 	pct := 100 * float64(covered) / float64(total)
 	if pct < target {
-		return fmt.Errorf("coverage %.1f%% for %v is below the %v%% target for %v", pct, md.PackageName, target, level)
+		return fmt.Errorf("coverage %.1f%% for %v is below the %.1f%% target for %v", pct, md.PackageName, target, level)
 	}
 	return nil
 }

--- a/cmd/mdatagen/internal/coverage_test.go
+++ b/cmd/mdatagen/internal/coverage_test.go
@@ -53,7 +53,7 @@ func TestCheckCoverage(t *testing.T) {
 			pkg+"/foo.go:11.1,20.2 2 0\n")
 		err := checkCoverage(stableMD(), map[component.StabilityLevel]float64{component.StabilityLevelStable: 90}, profile)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "coverage 80.0% for "+pkg+" is below the 90% target for Stable")
+		assert.ErrorContains(t, err, "coverage 80.0% for "+pkg+" is below the 90.0% target for Stable")
 	})
 
 	t.Run("at target passes", func(t *testing.T) {

--- a/cmd/mdatagen/internal/coverage_test.go
+++ b/cmd/mdatagen/internal/coverage_test.go
@@ -1,0 +1,133 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+func writeProfile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cover.out")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestHighestStability(t *testing.T) {
+	assert.Equal(t, component.StabilityLevelUndefined, highestStability(nil))
+	assert.Equal(t, component.StabilityLevelBeta, highestStability(StabilityMap{
+		component.StabilityLevelBeta: []string{"traces"},
+	}))
+	assert.Equal(t, component.StabilityLevelStable, highestStability(StabilityMap{
+		component.StabilityLevelBeta:   []string{"traces"},
+		component.StabilityLevelStable: []string{"metrics"},
+	}))
+}
+
+// Go coverage profile format available here:
+// https://github.com/golang/tools/blob/v0.49.0/cover/profile.go#L55-L58.
+func TestCheckCoverage(t *testing.T) {
+	const pkg = "go.opentelemetry.io/collector/receiver/foo"
+
+	stableMD := func() Metadata {
+		return Metadata{
+			PackageName: pkg,
+			Status: &Status{
+				Class:     "receiver",
+				Stability: StabilityMap{component.StabilityLevelStable: []string{"metrics"}},
+			},
+		}
+	}
+
+	t.Run("below target fails", func(t *testing.T) {
+		profile := writeProfile(t, "mode: atomic\n"+
+			pkg+"/foo.go:1.1,10.2 8 1\n"+
+			pkg+"/foo.go:11.1,20.2 2 0\n")
+		err := checkCoverage(stableMD(), map[component.StabilityLevel]float64{component.StabilityLevelStable: 90}, profile)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "coverage 80.0% for "+pkg+" is below the 90% target for Stable")
+	})
+
+	t.Run("at target passes", func(t *testing.T) {
+		profile := writeProfile(t, "mode: atomic\n"+
+			pkg+"/foo.go:1.1,10.2 8 1\n"+
+			pkg+"/foo.go:11.1,20.2 2 0\n")
+		err := checkCoverage(stableMD(), map[component.StabilityLevel]float64{component.StabilityLevelStable: 80}, profile)
+		require.NoError(t, err)
+	})
+
+	t.Run("subpackage statements are counted", func(t *testing.T) {
+		profile := writeProfile(t, "mode: atomic\n"+
+			pkg+"/foo.go:1.1,10.2 5 1\n"+
+			pkg+"/internal/bar.go:1.1,10.2 5 1\n")
+		err := checkCoverage(stableMD(), map[component.StabilityLevel]float64{component.StabilityLevelStable: 100}, profile)
+		require.NoError(t, err)
+	})
+
+	t.Run("a sibling package with a shared prefix is not counted", func(t *testing.T) {
+		profile := writeProfile(t, "mode: atomic\n"+
+			pkg+"/foo.go:1.1,10.2 5 0\n"+
+			pkg+"other/bar.go:1.1,10.2 5 1\n")
+		err := checkCoverage(stableMD(), map[component.StabilityLevel]float64{component.StabilityLevelStable: 100}, profile)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "coverage 0.0%")
+	})
+
+	t.Run("no target for the level passes", func(t *testing.T) {
+		profile := writeProfile(t, "mode: atomic\n"+pkg+"/foo.go:1.1,10.2 5 0\n")
+		err := checkCoverage(stableMD(), map[component.StabilityLevel]float64{component.StabilityLevelBeta: 100}, profile)
+		require.NoError(t, err)
+	})
+
+	t.Run("component absent from the profile errors", func(t *testing.T) {
+		profile := writeProfile(t, "mode: atomic\n"+"go.opentelemetry.io/collector/receiver/other/foo.go:1.1,10.2 5 1\n")
+		err := checkCoverage(stableMD(), map[component.StabilityLevel]float64{component.StabilityLevelStable: 10}, profile)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "no coverage data for "+pkg)
+	})
+
+	t.Run("nonComponents class passes without checking", func(t *testing.T) {
+		md := Metadata{
+			PackageName: "go.opentelemetry.io/collector/pkg/foo",
+			Status:      &Status{Class: "pkg"},
+		}
+		profile := writeProfile(t, "mode: atomic\n"+"unrelated/foo.go:1.1,10.2 5 0\n")
+		err := checkCoverage(md, map[component.StabilityLevel]float64{component.StabilityLevelStable: 100}, profile)
+		require.NoError(t, err)
+	})
+
+	t.Run("missing status passes without checking", func(t *testing.T) {
+		md := Metadata{PackageName: pkg}
+		profile := writeProfile(t, "mode: atomic\n"+pkg+"/foo.go:1.1,10.2 5 0\n")
+		err := checkCoverage(md, map[component.StabilityLevel]float64{component.StabilityLevelStable: 100}, profile)
+		require.NoError(t, err)
+	})
+
+	t.Run("highest of several declared levels is applied", func(t *testing.T) {
+		md := Metadata{
+			PackageName: pkg,
+			Status: &Status{
+				Class: "receiver",
+				Stability: StabilityMap{
+					component.StabilityLevelBeta:   []string{"traces"},
+					component.StabilityLevelStable: []string{"metrics"},
+				},
+			},
+		}
+		profile := writeProfile(t, "mode: atomic\n"+pkg+"/foo.go:1.1,10.2 5 0\n")
+		err := checkCoverage(md, map[component.StabilityLevel]float64{
+			component.StabilityLevelBeta:   10, // would pass
+			component.StabilityLevelStable: 90, // must fail: highest level wins
+		}, profile)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "target for Stable")
+	})
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds `check-stability` subcommand. This subcommand is intended to automatically check the component fulfills criteria set out on the [component stability documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#stable).

For this first PR, it only checks code coverage.

Code coverage is checked in the same way as the Go tooling does it, which seems to be slightly different (within a few percentage points from CodeCov). I think this is okay.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
