### PR TITLE
[chore] clean up deprecated funcs in generated code

### DIFF
--- a/cmd/mdatagen/internal/samplefactoryreceiver/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/samplefactoryreceiver/internal/metadata/generated_config.go
@@ -183,11 +183,6 @@ func NewDefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	}
 }
 
-// Deprecated: Use NewDefaultMetricsBuilderConfig.
-func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
-	return NewDefaultMetricsBuilderConfig()
-}
-
 // LogsBuilderConfig is a configuration for sample logs builder.
 type LogsBuilderConfig struct {
 	Events             EventsConfig             `mapstructure:"events"`
@@ -200,9 +195,4 @@ func NewDefaultLogsBuilderConfig() LogsBuilderConfig {
 		Events:             DefaultEventsConfig(),
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
-}
-
-// Deprecated: Use NewDefaultLogsBuilderConfig.
-func DefaultLogsBuilderConfig() LogsBuilderConfig {
-	return NewDefaultLogsBuilderConfig()
 }


### PR DESCRIPTION
#### Description

Still need to figure out why this file isn't regenerated correctly, but those funcs have been deprecated for a while and can be removed.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
