### PR TITLE
[pkg/service] remove deprecated ZapOptions

### DIFF
--- a/.chloggen/codeboten_rm-zapoptions.yaml
+++ b/.chloggen/codeboten_rm-zapoptions.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated ZapOptions
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_rm-zapoptions.yaml
+++ b/.chloggen/codeboten_rm-zapoptions.yaml
@@ -10,7 +10,7 @@ component: pkg/service
 note: Remove deprecated ZapOptions
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [15935]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -1691,7 +1691,6 @@ func TestCollectorLoggingOptions(t *testing.T) {
 			func(_ context.Context, set telemetry.LoggerSettings, _ component.Config) (
 				*zap.Logger, component.ShutdownFunc, error,
 			) {
-				require.Empty(t, set.ZapOptions) // injected through BuidlZapLogger
 				logger, buildErr := set.BuildZapLogger(zap.NewDevelopmentConfig())
 				return logger, nil, buildErr
 			},

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -111,7 +111,6 @@ func TestServiceTelemetryLogging_Settings(t *testing.T) {
 				*zap.Logger, component.ShutdownFunc, error,
 			) {
 				require.NotNil(t, set.BuildZapLogger)
-				require.Empty(t, set.ZapOptions)
 				logger, err := set.BuildZapLogger(zapConfig)
 				return logger, nil, err
 			},

--- a/service/telemetry/otelconftelemetry/logger.go
+++ b/service/telemetry/otelconftelemetry/logger.go
@@ -56,7 +56,7 @@ func createLogger(
 		// if set.BuildZapLogger is not provided.
 		buildZapLogger = zap.Config.Build
 	}
-	logger, err := buildZapLogger(zapCfg, set.ZapOptions...)
+	logger, err := buildZapLogger(zapCfg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/service/telemetry/otelconftelemetry/logger_test.go
+++ b/service/telemetry/otelconftelemetry/logger_test.go
@@ -516,47 +516,6 @@ func TestCreateLoggerSetsOpenTelemetryErrorHandler(t *testing.T) {
 	assert.Contains(t, entries[0].ContextMap()["error"], "failed to upload metrics")
 }
 
-func TestCreateLoggerZapOptions(t *testing.T) {
-	buildInfo := component.BuildInfo{}
-	factory := NewFactory()
-	cfg := &Config{
-		Logs: LogsConfig{
-			Level:    zapcore.InfoLevel,
-			Encoding: "json",
-		},
-	}
-	resource, _, err := factory.CreateResource(
-		context.Background(), telemetry.Settings{BuildInfo: buildInfo}, cfg,
-	)
-	require.NoError(t, err)
-
-	core, observedLogs := observer.New(zapcore.DebugLevel)
-	set := telemetry.LoggerSettings{
-		Settings: telemetry.Settings{BuildInfo: buildInfo, Resource: &resource},
-
-		// Test deprecated behavior: no BuildZapLogger, but ZapOptions provided.
-		BuildZapLogger: nil,
-		ZapOptions: []zap.Option{
-			zap.WrapCore(func(zapcore.Core) zapcore.Core { return core }),
-		},
-	}
-
-	logger, provider, err := factory.CreateLogger(context.Background(), set, cfg)
-	require.NoError(t, err)
-	require.NotNil(t, provider)
-	defer func() {
-		assert.NoError(t, provider.Shutdown(context.Background()))
-	}()
-
-	testMessage := "Test deprecated zap options"
-	logger.Info(testMessage)
-
-	require.Len(t, observedLogs.All(), 1)
-	logEntry := observedLogs.All()[0]
-	assert.Equal(t, testMessage, logEntry.Message)
-	assert.Equal(t, zapcore.InfoLevel, logEntry.Level)
-}
-
 func TestLogger_OTLP(t *testing.T) {
 	// Create a backend to receive the logs and assert the content
 	receivedLogs := 0

--- a/service/telemetry/telemetry.go
+++ b/service/telemetry/telemetry.go
@@ -22,13 +22,6 @@ import (
 type LoggerSettings struct {
 	Settings
 
-	// ZapOptions contains options for creating the zap logger.
-	//
-	// Deprecated [v0.142.0]: use BuildZapLogger instead.
-	// This field will be removed in the future, and options
-	// must be injected through BuildZapLogger.
-	ZapOptions []zap.Option
-
 	// BuildZapLogger holds a function for building a *zap.Logger
 	// from a zap.Config and options.
 	//


### PR DESCRIPTION
Deprecated since v0.142.0, use BuildZapLogger instead.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
