### PR TITLE
fix(debugexporter): handle known sync errors on AIX

### DIFF
--- a/.chloggen/avinashgoud2000_aix-debugexporter-sync.yaml
+++ b/.chloggen/avinashgoud2000_aix-debugexporter-sync.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: exporter/debugexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support known sync error handling on AIX
+
+# One or more tracking issues or pull requests related to the change
+issues: [15939]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+subtext: |
+  Enable the debug exporter to handle known synchronous errors on AIX.
+
+# Optional: The change log or logs in which this entry should be included.
+change_logs: [user]

--- a/exporter/debugexporter/internal/otlptext/known_sync_error.go
+++ b/exporter/debugexporter/internal/otlptext/known_sync_error.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build linux || darwin
+//go:build linux || darwin || aix
 
 package otlptext // import "go.opentelemetry.io/collector/exporter/debugexporter/internal/otlptext"
 
@@ -22,7 +22,7 @@ var knownSyncErrors = []error{
 }
 
 // knownSyncError returns true if the given error is one of the known
-// non-actionable errors returned by Sync on Linux and macOS.
+// non-actionable errors returned by Sync on Linux, macOS and AIX.
 func knownSyncError(err error) bool {
 	for _, syncError := range knownSyncErrors {
 		if errors.Is(err, syncError) {

--- a/exporter/debugexporter/internal/otlptext/known_sync_error_other.go
+++ b/exporter/debugexporter/internal/otlptext/known_sync_error_other.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !linux && !darwin && !windows
+//go:build !linux && !darwin && !aix && !windows
 
 package otlptext // import "go.opentelemetry.io/collector/exporter/debugexporter/internal/otlptext"
 


### PR DESCRIPTION
the fix is just the build-tag change so AIX uses the same known-sync-error handling as the other Unix platforms. Fixes #15924