### PR TITLE
[exporterhelper] Fix queue deadlock when blocked offers are cancelled

### DIFF
--- a/.chloggen/fix-15700-cond-cancellation.yaml
+++ b/.chloggen/fix-15700-cond-cancellation.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pkg/exporterhelper
+note: Fix sending queue deadlocks when blocked offers are cancelled with block_on_overflow enabled.
+issues: [15700]
+change_logs: [user]

--- a/exporter/exporterhelper/internal/queue/cond.go
+++ b/exporter/exporterhelper/internal/queue/cond.go
@@ -4,6 +4,7 @@
 package queue // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue"
 
 import (
+	"container/list"
 	"context"
 	"sync"
 )
@@ -12,51 +13,61 @@ import (
 // Which means Wait() will return if context is done before any signal is received.
 // Also, it requires the caller to hold the c.L during all calls.
 type cond struct {
-	L       sync.Locker
-	ch      chan struct{}
-	waiting int64
+	L sync.Locker
+	// Each waiter has a private buffered channel. A true notification is a Signal
+	// that must be forwarded if cancellation wins; a false one is a Broadcast.
+	waiters list.List // of chan bool, guarded by L
 }
 
 func newCond(l sync.Locker) *cond {
-	return &cond{L: l, ch: make(chan struct{}, 1)}
+	return &cond{L: l}
 }
 
 // Signal wakes one goroutine waiting on c, if there is any.
 // It requires for the caller to hold c.L during the call.
 func (c *cond) Signal() {
-	if c.waiting == 0 {
-		return
-	}
-	c.waiting--
-	c.ch <- struct{}{}
+	c.notify(true)
 }
 
 // Broadcast wakes all goroutines waiting on c.
 // It requires for the caller to hold c.L during the call.
 func (c *cond) Broadcast() {
-	for ; c.waiting > 0; c.waiting-- {
-		c.ch <- struct{}{}
+	for c.waiters.Len() > 0 {
+		c.notify(false)
 	}
+}
+
+func (c *cond) notify(signal bool) {
+	e := c.waiters.Front()
+	if e == nil {
+		return
+	}
+	c.waiters.Remove(e)
+	// Retirement under L ensures this is the only send to this buffered channel,
+	// so it cannot block even if the waiter has already selected cancellation.
+	e.Value.(chan bool) <- signal
 }
 
 // Wait atomically unlocks c.L and suspends execution of the calling goroutine. After later resuming execution, Wait locks c.L before returning.
 func (c *cond) Wait(ctx context.Context) error {
-	c.waiting++
+	ch := make(chan bool, 1)
+	e := c.waiters.PushBack(ch)
 	c.L.Unlock()
 	select {
 	case <-ctx.Done():
 		c.L.Lock()
-		if c.waiting == 0 {
-			// If waiting is 0, it means that there was a signal sent and nobody else waits for it.
-			// Consume it, so that we don't unblock other consumer unnecessary,
-			// or we don't block the producer because the channel buffer is full.
-			<-c.ch
-		} else {
-			// Decrease the number of waiting routines.
-			c.waiting--
+		select {
+		case signal := <-ch:
+			if signal {
+				// This waiter was selected while cancellation waited for L. Pass
+				// its unused signal on so another waiter can recheck its predicate.
+				c.Signal()
+			}
+		default:
+			c.waiters.Remove(e)
 		}
 		return ctx.Err()
-	case <-c.ch:
+	case <-ch:
 		c.L.Lock()
 		return nil
 	}

--- a/exporter/exporterhelper/internal/queue/cond_test.go
+++ b/exporter/exporterhelper/internal/queue/cond_test.go
@@ -1,0 +1,291 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCondSignalDoesNotBlockBehindCanceledWaiters(t *testing.T) {
+	t.Parallel()
+	locker := &observedLocker{lockAttempts: make(chan struct{}, 2)}
+	c := newCond(locker)
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	waiter1 := startCondWaiter(ctx1, c)
+	waiter2 := startCondWaiter(ctx2, c)
+
+	locked := make(chan struct{})
+	notify := make(chan struct{})
+	notified := make(chan struct{})
+	go func() {
+		locker.Lock()
+		close(locked)
+		<-notify
+		c.Signal()
+		c.Signal()
+		locker.Unlock()
+		close(notified)
+	}()
+
+	<-locked
+	locker.observe.Store(true)
+	cancel1()
+	cancel2()
+	<-locker.lockAttempts
+	<-locker.lockAttempts
+	locker.observe.Store(false)
+	close(notify)
+
+	select {
+	case <-notified:
+	case <-time.After(time.Second):
+		t.Fatal("Signal blocked while holding the condition lock")
+	}
+
+	for _, waiter := range []<-chan error{waiter1, waiter2} {
+		select {
+		case err := <-waiter:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(time.Second):
+			t.Fatal("condition waiter did not return")
+		}
+	}
+}
+
+type observedLocker struct {
+	mu           sync.Mutex
+	observe      atomic.Bool
+	lockAttempts chan struct{}
+}
+
+func (l *observedLocker) Lock() {
+	if l.observe.Load() {
+		l.lockAttempts <- struct{}{}
+	}
+	l.mu.Lock()
+}
+
+func (l *observedLocker) Unlock() {
+	l.mu.Unlock()
+}
+
+func startCondWaiter(ctx context.Context, c *cond) <-chan error {
+	l := c.L
+	entered := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		l.Lock()
+		close(entered)
+		done <- c.Wait(ctx)
+		l.Unlock()
+	}()
+
+	<-entered
+	l.Lock()
+	defer l.Unlock()
+	return done
+}
+
+func TestCondSignalAccounting(t *testing.T) {
+	t.Parallel()
+	for _, signals := range []int{1, 3} {
+		t.Run(strconv.Itoa(signals), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				c := newCond(&sync.Mutex{})
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				waiters := make([]<-chan error, 3)
+				for i := range waiters {
+					waiters[i] = startCondWaiter(ctx, c)
+				}
+				c.L.Lock()
+				for range signals {
+					c.Signal()
+				}
+				c.L.Unlock()
+				synctest.Wait()
+				woken := 0
+				var pending []<-chan error
+				for _, waiter := range waiters {
+					select {
+					case err := <-waiter:
+						require.NoError(t, err)
+						woken++
+					default:
+						pending = append(pending, waiter)
+					}
+				}
+				require.Equal(t, signals, woken)
+				cancel()
+				for _, waiter := range pending {
+					require.ErrorIs(t, <-waiter, context.Canceled)
+				}
+				checkCondReuse(t, c)
+			})
+		})
+	}
+}
+
+func TestCondCancellationNotification(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name        string
+		broadcast   bool
+		notifyFirst bool
+		interleaved bool
+	}{
+		{name: "cancel_then_signal"},
+		{name: "signal_then_cancel", notifyFirst: true},
+		{name: "mixed_cancel_then_signal", interleaved: true},
+		{name: "cancel_then_broadcast", broadcast: true},
+		{name: "broadcast_then_cancel", broadcast: true, notifyFirst: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				locker := &observedLocker{lockAttempts: make(chan struct{}, 6)}
+				c := newCond(locker)
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				var cancelled, live []<-chan error
+				for range 3 {
+					cancelled = append(cancelled, startCondWaiter(ctx, c))
+					if tt.interleaved {
+						live = append(live, startCondWaiter(t.Context(), c))
+					}
+				}
+				if !tt.interleaved {
+					for range 3 {
+						live = append(live, startCondWaiter(t.Context(), c))
+					}
+				}
+				notify := func() {
+					if tt.broadcast {
+						c.Broadcast()
+					} else {
+						for range 3 {
+							c.Signal()
+						}
+					}
+				}
+				c.L.Lock()
+				locker.observe.Store(true)
+				if tt.notifyFirst {
+					notify()
+				} else {
+					cancel()
+				}
+				attempts := 3
+				if tt.notifyFirst && tt.broadcast {
+					attempts = 6
+				}
+				// With L held, these attempts prove which select branch won.
+				for range attempts {
+					<-locker.lockAttempts
+				}
+				locker.observe.Store(false)
+				if tt.notifyFirst {
+					cancel()
+				} else {
+					notify()
+				}
+				c.L.Unlock()
+				for _, waiter := range cancelled {
+					if tt.notifyFirst {
+						require.NoError(t, <-waiter)
+					} else {
+						require.ErrorIs(t, <-waiter, context.Canceled)
+					}
+				}
+				if tt.notifyFirst && !tt.broadcast {
+					// These signals were consumed, so must not also wake live waiters.
+					synctest.Wait()
+					for _, waiter := range live {
+						select {
+						case <-waiter:
+							t.Fatal("notification was duplicated")
+						default:
+						}
+					}
+					c.L.Lock()
+					notify()
+					c.L.Unlock()
+				}
+				for _, waiter := range live {
+					require.NoError(t, <-waiter)
+				}
+				checkCondReuse(t, c)
+			})
+		})
+	}
+}
+
+func TestCondBroadcastDoesNotWakeLaterWaiter(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		locker := &observedLocker{lockAttempts: make(chan struct{}, 1)}
+		c := newCond(locker)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		cancelled := startCondWaiter(ctx, c)
+		c.L.Lock()
+		locker.observe.Store(true)
+		cancel()
+		<-locker.lockAttempts
+		locker.observe.Store(false)
+		c.Broadcast()
+		// Register after Broadcast, before the cancelled waiter can retire.
+		// Wait releases L and lets cancellation finish; no notification is due
+		// to this waiter until the explicit Signal below.
+		later := make(chan error, 1)
+		go func() { later <- c.Wait(t.Context()); c.L.Unlock() }()
+		require.ErrorIs(t, <-cancelled, context.Canceled)
+		synctest.Wait()
+		select {
+		case <-later:
+			t.Fatal("broadcast reached a waiter registered after the broadcast")
+		default:
+		}
+		c.L.Lock()
+		c.Signal()
+		c.L.Unlock()
+		require.NoError(t, <-later)
+		checkCondReuse(t, c)
+	})
+}
+
+// checkCondReuse verifies empty notifications leave no token for the next waiter,
+// then verifies that the same condition still supports a fresh broadcast.
+func checkCondReuse(t *testing.T, c *cond) {
+	t.Helper()
+	c.L.Lock()
+	require.Zero(t, c.waiters.Len())
+	c.Signal()
+	c.Signal()
+	c.Broadcast()
+	c.L.Unlock()
+	waiter := startCondWaiter(t.Context(), c)
+	synctest.Wait()
+	select {
+	case <-waiter:
+		t.Fatal("waiter consumed a stale notification")
+	default:
+	}
+	c.L.Lock()
+	c.Broadcast()
+	c.L.Unlock()
+	require.NoError(t, <-waiter)
+	c.L.Lock()
+	require.Zero(t, c.waiters.Len())
+	c.L.Unlock()
+}

--- a/exporter/exporterhelper/internal/queue/queue_cancellation_test.go
+++ b/exporter/exporterhelper/internal/queue/queue_cancellation_test.go
@@ -1,0 +1,158 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/hosttest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/storagetest"
+)
+
+func TestBlockedOfferCancellationDoesNotConsumeCapacityNotification(t *testing.T) {
+	tests := []struct {
+		name string
+		new  func() (readableQueue[intRequest], *cond, sync.Locker, component.Host)
+	}{
+		{
+			name: "memory",
+			new: func() (readableQueue[intRequest], *cond, sync.Locker, component.Host) {
+				set := newSettings(request.SizerTypeRequests, 2)
+				set.BlockOnOverflow = true
+				q := newMemoryQueue[intRequest](set).(*memoryQueue[intRequest])
+				return q, q.hasMoreSpace, &q.mu, componenttest.NewNopHost()
+			},
+		},
+		{
+			name: "persistent",
+			new: func() (readableQueue[intRequest], *cond, sync.Locker, component.Host) {
+				set := newSettingsWithStorage(request.SizerTypeRequests, 2)
+				set.BlockOnOverflow = true
+				q := newPersistentQueue[intRequest](set).(*persistentQueue[intRequest])
+				host := hosttest.NewHost(map[component.ID]component.Component{
+					{}: storagetest.NewMockStorageExtension(nil),
+				})
+				return q, q.hasMoreSpace, &q.mu, host
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				q, hasMoreSpace, queueLock, host := tt.new()
+				lockBarrier := newLockAttemptBarrier(queueLock, 3)
+				hasMoreSpace.L = lockBarrier
+				require.NoError(t, q.Start(context.Background(), host))
+
+				require.NoError(t, q.Offer(context.Background(), 1))
+				require.NoError(t, q.Offer(context.Background(), 2))
+				_, _, firstDone, ok := q.Read(context.Background())
+				require.True(t, ok)
+				_, _, secondDone, ok := q.Read(context.Background())
+				require.True(t, ok)
+
+				firstCtx, cancelFirst := context.WithCancel(context.Background())
+				secondCtx, cancelSecond := context.WithCancel(context.Background())
+
+				firstResult := offerAsync(firstCtx, q, 3)
+				synctest.Wait()
+				secondResult := offerAsync(secondCtx, q, 4)
+				synctest.Wait()
+				firstLiveResult := offerAsync(context.Background(), q, 5)
+				synctest.Wait()
+				secondLiveResult := offerAsync(context.Background(), q, 6)
+				synctest.Wait()
+
+				lockBarrier.block.Store(true)
+				cancelFirst()
+				cancelSecond()
+				<-lockBarrier.attempts
+				<-lockBarrier.attempts
+
+				completionReturned := make(chan struct{})
+				go func() {
+					firstDone.OnDone(nil)
+					secondDone.OnDone(nil)
+					close(completionReturned)
+				}()
+
+				synctest.Wait()
+				assertClosed(t, completionReturned)
+				lockBarrier.block.Store(false)
+				close(lockBarrier.release)
+				synctest.Wait()
+				require.ErrorIs(t, <-firstResult, context.Canceled)
+				require.ErrorIs(t, <-secondResult, context.Canceled)
+				require.NoError(t, <-firstLiveResult)
+				require.NoError(t, <-secondLiveResult)
+
+				assert.EqualValues(t, 2, q.Size())
+				consumed := make([]intRequest, 0, 2)
+				for range 2 {
+					_, req, done, readOK := q.Read(context.Background())
+					require.True(t, readOK)
+					consumed = append(consumed, req)
+					done.OnDone(nil)
+				}
+				assert.ElementsMatch(t, []intRequest{5, 6}, consumed)
+				assert.EqualValues(t, 0, q.Size())
+
+				require.NoError(t, q.Shutdown(context.Background()))
+				_, _, _, ok = q.Read(context.Background())
+				assert.False(t, ok)
+			})
+		})
+	}
+}
+
+type lockAttemptBarrier struct {
+	sync.Locker
+	block    atomic.Bool
+	attempts chan struct{}
+	release  chan struct{}
+}
+
+func newLockAttemptBarrier(locker sync.Locker, attempts int) *lockAttemptBarrier {
+	return &lockAttemptBarrier{
+		Locker:   locker,
+		attempts: make(chan struct{}, attempts),
+		release:  make(chan struct{}),
+	}
+}
+
+func (b *lockAttemptBarrier) Lock() {
+	if b.block.Load() {
+		b.attempts <- struct{}{}
+		<-b.release
+	}
+	b.Locker.Lock()
+}
+
+func offerAsync(ctx context.Context, q readableQueue[intRequest], req intRequest) <-chan error {
+	result := make(chan error, 1)
+	go func() {
+		result <- q.Offer(ctx, req)
+	}()
+	return result
+}
+
+func assertClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	default:
+		t.Fatal("completion callbacks did not return")
+	}
+}


### PR DESCRIPTION
#### Description

Fixes a sending queue deadlock when blocked offers are cancelled while block_on_overflow is enabled

The problem is that a cancelled condition waiter can stop receiving notifications before it gets the queue mutex back and updates the waiter count. If this happens repeatedly, Signal can fill the shared notification channel and then block while still holding the mutex. At that point the cancelled waiter cannot clean itself up and the queue can stop making progress

This replaces the shared notification channel and waiter count with a FIFO list of private buffered channels, one per waiter, protected by the mutex

Signal and Broadcast remove the waiter from the list before sending the notification, so neither of them needs to wait for the receiver while holding the mutex

There is one extra case around cancellation. If Signal has already selected a waiter but cancellation wins before that waiter uses the notification, the notification is passed to another waiter that is still registered

Broadcast is different and is not forwarded. All waiters that belonged to that Broadcast have already been selected, and a waiter registered afterwards should not receive an old broadcast

The production change is only to the internal condition implementation. Queue storage, batching, configuration and shutdown behaviour are unchanged

PR #15737 also explored using private waiter channels. This version separates Signal and Broadcast behaviour and adds coverage for notification accounting and the actual sending queue behaviour

#### Link to tracking issue

Fixes #15700

#### Testing

The unchanged reproduction from the issue deadlocked on the base revision and passes with this fix

Added deterministic tests covering:

* Signal notification accounting
* cancellation racing with Signal
* cancellation racing with Broadcast
* multiple live and cancelled waiters
* reusing the condition after cancellation
* making sure a Broadcast does not reach waiters registered afterwards
* blocked offer progress in both the memory and persistent queues

Local validation on Go 1.26.0, macOS arm64:

* all 514 exporterhelper tests passed with the race detector
* new condition and blocked offer regression tests passed 100 race-enabled repetitions
* focused queue and queuebatch race tests passed
* nested xexporterhelper tests passed
* formatting, lint, import ordering, changelog validation, licence checks and diff checks passed

The persistent queue test uses the repository mock storage extension, so this was not tested against external file storage

#### Documentation

Added a bug fix changelog entry for pkg/exporterhelper

No configuration or public API changes

#### Authorship

- [x] I, a human, wrote this pull request description myself.
