### PR TITLE
[exporterhelper][queuebatch] Pass through request deadlines

### DIFF
--- a/.chloggen/exporterhelper-deadline-passthrough.yaml
+++ b/.chloggen/exporterhelper-deadline-passthrough.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/otlp)
+component: pkg/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Propagate the maximum deadline from batched request contexts to the merged batch context.
+
+# One or more tracking issues or pull requests related to the change
+issues: [12809]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/internal/queuebatch/batch_context.go
+++ b/exporter/exporterhelper/internal/queuebatch/batch_context.go
@@ -5,13 +5,17 @@ package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhel
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/otel/trace"
 )
 
 type traceContextKeyType int
 
-const batchSpanLinksKey traceContextKeyType = iota
+const (
+	batchSpanLinksKey traceContextKeyType = iota
+	batchMaxDeadlineKey
+)
 
 // LinksFromContext returns a list of trace links registered in the context.
 func LinksFromContext(ctx context.Context) []trace.Link {
@@ -37,4 +41,55 @@ func contextWithMergedLinks(mergedCtx, ctx1, ctx2 context.Context) context.Conte
 		batchSpanLinksKey,
 		append(parentsFromContext(ctx1), parentsFromContext(ctx2)...),
 	)
+}
+
+// deadlineFromContext return the maximum deadline stored during batch context
+// merging, and a boolean indicating whether a deadline was stored.
+func deadlineFromContext(ctx context.Context) (time.Time, bool) {
+	if ctx == nil {
+		return time.Time{}, false
+	}
+	if deadline, ok := ctx.Value(batchMaxDeadlineKey).(time.Time); ok {
+		return deadline, true
+	}
+	return time.Time{}, false
+}
+
+// deadlineOf return the effective deadline of a context. It checks the stored
+// batch max deadline value first, falling back to the native context deadline
+func deadlineOf(ctx context.Context) (time.Time, bool) {
+	if ctx == nil {
+		return time.Time{}, false
+	}
+	if d, ok := ctx.Value(batchMaxDeadlineKey).(time.Time); ok {
+		return d, true
+	}
+	return ctx.Deadline()
+}
+
+// contextWithMergedDeadline computes the maximum deadline from ctx1 and ctx2,
+// and stores it as a context value on mergedCtx.
+func contextWithMergedDeadline(mergedCtx, ctx1, ctx2 context.Context) context.Context {
+	d1, ok1 := deadlineOf(ctx1)
+	d2, ok2 := deadlineOf(ctx2)
+
+	if !ok1 && !ok2 {
+		return mergedCtx
+	}
+
+	var maxDeadline time.Time
+	switch {
+	case ok1 && ok2:
+		if d1.After(d2) {
+			maxDeadline = d1
+		} else {
+			maxDeadline = d2
+		}
+	case ok1:
+		maxDeadline = d1
+	default:
+		maxDeadline = d2
+	}
+
+	return context.WithValue(mergedCtx, batchMaxDeadlineKey, maxDeadline)
 }

--- a/exporter/exporterhelper/internal/queuebatch/batch_context_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/batch_context_test.go
@@ -6,6 +6,7 @@ package queuebatch
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
@@ -69,4 +70,83 @@ func TestMergedContext_GetValue(t *testing.T) {
 	ctx2 := context.WithValue(context.Background(), testTimestampKey, 2345)
 	batchContext := mergeContextHelper(ctx1, ctx2)
 	require.Equal(t, 2345, batchContext.Value(testTimestampKey))
+}
+
+func TestContextWithMergedDeadline_BothHaveDeadlines(t *testing.T) {
+	now := time.Now()
+	d1 := now.Add(5 * time.Second)
+	d2 := now.Add(10 * time.Second)
+
+	ctx1, cancel1 := context.WithDeadline(context.Background(), d1)
+	defer cancel1()
+	ctx2, cancel2 := context.WithDeadline(context.Background(), d2)
+	defer cancel2()
+
+	merged := contextWithMergedDeadline(context.Background(), ctx1, ctx2)
+	deadline, ok := deadlineFromContext(merged)
+	require.True(t, ok)
+	require.Equal(t, d2, deadline) // max of the two
+}
+
+func TestContextWithMergedDeadline_OnlyFirstHasDeadline(t *testing.T) {
+	now := time.Now()
+	d1 := now.Add(5 * time.Second)
+
+	ctx1, cancel1 := context.WithDeadline(context.Background(), d1)
+	defer cancel1()
+	ctx2 := context.Background()
+
+	merged := contextWithMergedDeadline(context.Background(), ctx1, ctx2)
+	deadline, ok := deadlineFromContext(merged)
+	require.True(t, ok)
+	require.Equal(t, d1, deadline)
+}
+
+func TestContextWithMergedDeadline_OnlySecondHasDeadline(t *testing.T) {
+	now := time.Now()
+	d2 := now.Add(10 * time.Second)
+
+	ctx1 := context.Background()
+	ctx2, cancel2 := context.WithDeadline(context.Background(), d2)
+	defer cancel2()
+
+	merged := contextWithMergedDeadline(context.Background(), ctx1, ctx2)
+	deadline, ok := deadlineFromContext(merged)
+	require.True(t, ok)
+	require.Equal(t, d2, deadline)
+}
+
+func TestContextWithMergedDeadline_NeitherHasDeadline(t *testing.T) {
+	ctx1 := context.Background()
+	ctx2 := context.Background()
+
+	merged := contextWithMergedDeadline(context.Background(), ctx1, ctx2)
+	_, ok := deadlineFromContext(merged)
+	require.False(t, ok)
+}
+
+func TestContextWithMergedDeadline_AccumulatedAcrossMultipleMerges(t *testing.T) {
+	now := time.Now()
+	d1 := now.Add(5 * time.Second)
+	d2 := now.Add(3 * time.Second)
+	d3 := now.Add(10 * time.Second)
+
+	ctx1, cancel1 := context.WithDeadline(context.Background(), d1)
+	defer cancel1()
+	ctx2, cancel2 := context.WithDeadline(context.Background(), d2)
+	defer cancel2()
+	ctx3, cancel3 := context.WithDeadline(context.Background(), d3)
+	defer cancel3()
+
+	// First merge: ctx1 + ctx2 → max is d1 (5s > 3s)
+	merged := contextWithMergedDeadline(context.Background(), ctx1, ctx2)
+	deadline, ok := deadlineFromContext(merged)
+	require.True(t, ok)
+	require.Equal(t, d1, deadline)
+
+	// Second merge: merged (stored d1) + ctx3 → max is d3 (10s > 5s)
+	merged = contextWithMergedDeadline(context.Background(), merged, ctx3)
+	deadline, ok = deadlineFromContext(merged)
+	require.True(t, ok)
+	require.Equal(t, d3, deadline)
 }

--- a/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
+++ b/exporter/exporterhelper/internal/queuebatch/partition_batcher.go
@@ -167,7 +167,8 @@ func (qb *partitionBatcher) consumeInternal(ctx context.Context, req request.Req
 	if qb.mergeCtx != nil {
 		mergedCtx = qb.mergeCtx(qb.currentBatch.ctx, ctx)
 	}
-	qb.currentBatch.ctx = contextWithMergedLinks(mergedCtx, qb.currentBatch.ctx, ctx)
+	mergedCtx = contextWithMergedLinks(mergedCtx, qb.currentBatch.ctx, ctx)
+	qb.currentBatch.ctx = contextWithMergedDeadline(mergedCtx, qb.currentBatch.ctx, ctx)
 
 	// Save the "currentBatch" if we need to flush it, because we want to execute flush without holding the lock, and
 	// cannot unlock and re-lock because we are not done processing all the responses.
@@ -291,6 +292,11 @@ func (qb *partitionBatcher) flush(ctx context.Context, req request.Request, done
 	qb.stopWG.Add(1)
 	qb.wp.execute(func() {
 		defer qb.stopWG.Done()
+		if deadline, ok := deadlineFromContext(ctx); ok {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithDeadline(ctx, deadline)
+			defer cancel()
+		}
 		done.OnDone(qb.consumeFunc(ctx, req))
 	})
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When multiple export requests are batched together, the merged context is based on `context.Background()` which drops all deadlines from the original request contexts. This change propagates deadlines through the batching process by:

- Computing the maximum  deadline across all batched requests during pairwise context merging
- Storing the max deadline as a context valu
- Applying `context.WithDeadline` at flush time so downstream senders (retry, timeout) can honor the original callers deadline constraints

<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #12809

<!--Describe what testing was performed and which tests were added.-->
#### Testing
ADDED

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
