### PR TITLE
docs(coding-guidelines): explain how component metrics reach the Prometheus endpoint

### DIFF
--- a/cmd/mdatagen/internal/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/internal/templates/documentation.md.tmpl
@@ -34,11 +34,18 @@ Emitted Name: `{{ $metricName.EmittedName }}`
 
 #### Migration
 
-- Target Metric: `{{ $metric.Migration.To }}`
-- Disable Old Gate: `{{ $metric.Migration.ThroughGates.DisableOld }}`
-- Enable New Gate: `{{ $metric.Migration.ThroughGates.EnableNew }}`
+**Metric Migration:** `{{ $metric.Migration.To }}`
 
-When the disable-old gate is enabled, emission of this metric is suppressed. When the enable-new gate is enabled, the target metric is emitted. If both gates are disabled, only this metric is emitted; if both are enabled, only the target metric is emitted.
+| Enable New Gate | Disable Old Gate | Emitted Metric(s) |
+| --- | --- | --- |
+| disabled | disabled | `{{ $metricName }}` only |
+| enabled | disabled | `{{ $metricName }}` and `{{ $metric.Migration.To }}` |
+| enabled | enabled | `{{ $metric.Migration.To }}` only |
+| disabled | enabled | Migrated metrics: none (v0 suppressed, v1 gated off — warnings logged) |
+
+Gate definitions:
+- Enable New Gate: `{{ $metric.Migration.ThroughGates.EnableNew }}`
+- Disable Old Gate: `{{ $metric.Migration.ThroughGates.DisableOld }}`
 
 {{- end }}
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -287,6 +287,21 @@ The following limitations are recommended:
 Out of the box, your users should be able to observe the state of your
 component. See [observability.md](observability.md) for more details.
 
+### Component metrics and the Prometheus endpoint
+
+Collector components do not start their own Prometheus endpoint. Instead, each
+component receives `component.TelemetrySettings` from the Collector service, and
+its `MeterProvider` is wired to the Collector's internal telemetry pipeline.
+Any instrument created through that `MeterProvider` is exported to the endpoint
+configured under `service::telemetry::metrics` (default `:8888`) or to any other
+configured reader.
+
+When you use `mdatagen`, the generated `TelemetryBuilder` creates instruments
+from this shared `MeterProvider` automatically. If you are not using code
+generation, create instruments directly from
+`settings.TelemetrySettings.MeterProvider` in your factory or component
+constructor.
+
 When using the regular helpers, you should have some metrics added around key
 events automatically. For instance, exporters should have
 `otelcol_exporter_sent_spans` tracked without your exporter doing anything.


### PR DESCRIPTION
Closes #7960\n\nAdds a short section to the component coding guidelines explaining that components use the shared MeterProvider from component.TelemetrySettings, which is wired to the collector's internal Prometheus endpoint. This addresses the documentation gap around how receivers, processors, exporters, etc. can expose metrics on the default :8888 endpoint.\n\nNo code changes; documentation only.